### PR TITLE
CHECKOUT-2098: Remove MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,0 @@
-(The MIT License)
-Copyright (C) 2015-2017 BigCommerce Inc.
-All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "url": "git://github.com/bigcommerce/checkout-sdk-js.git"
   },
   "author": "BigCommerce",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/bigcommerce/checkout-sdk-js/issues"
   },


### PR DESCRIPTION
## What?
* Remove MIT license for now

## Why?
* Need approvals from Brain and Jeff before we can have open source license. I'm filling out the request form right now. We can revert this PR once we are ready.

## Testing / Proof
* None

@bigcommerce/checkout @bigcommerce/payments
