### PR TITLE
CHECKOUT-2098: Remove JS suffix from package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "checkout-sdk-js",
+  "name": "checkout-sdk",
   "version": "0.0.0",
   "description": "BigCommerce storefront checkout JavaScript SDK",
   "main": "lib/index.js",


### PR DESCRIPTION
## What?
* Rename package name from `checkout-sdk-js` to `checkout-sdk`.

## Why?
* It is not really necessary to have the JS suffix because people already know it is a JS/npm package.
* In the future, it's probably going to be called `@bigcommerce/checkout-sdk`.

## Testing / Proof
* None

@bigcommerce/checkout @bigcommerce/payments
