### PR TITLE
CHECKOUT-2098 Remove 'allowSyntheticDefaultImports' from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "allowJs": true,
-        "allowSyntheticDefaultImports": true,
         "declaration": false,
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## What?
* Remove `allowSyntheticDefaultImports` from `tsconfig.json`

## Why?
* It turns out TypeScript [doesn't actually transform](https://www.typescriptlang.org/docs/handbook/compiler-options.html) the emitted code. It is only used for type checking. We need to run an additional transformer, i.e.: Babel, if we want to support the transformation. As we don't plan to do so, we don't need this flag.

## Testing / Proof
* None

@bigcommerce/checkout @bigcommerce/payments
