### PR TITLE
CHECKOUT-2098: Use scoped package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "checkout-sdk",
+  "name": "@bigcommerce/checkout-sdk",
   "version": "0.0.0",
   "description": "BigCommerce Checkout JavaScript SDK",
   "main": "lib/index.js",


### PR DESCRIPTION
## What?
* Use scoped package name

## Why?
* We use `@bigcommerce` scope for npm packages.

## Testing / Proof
* None

@bigcommerce/checkout @bigcommerce/payments
