### PR TITLE
PAYMENTS-2275: Skip payment submission if payment is already acknowledged or finalized

### DIFF
--- a/src/core/order/place-order-service.spec.js
+++ b/src/core/order/place-order-service.spec.js
@@ -4,12 +4,13 @@ import { createTimeout } from '../../http-request';
 import { getCartState } from '../cart/carts.mock';
 import { getConfigState } from '../config/configs.mock';
 import { getCustomerState } from '../customer/customers.mock';
-import { getCompleteOrder, getOrderRequestBody } from './orders.mock';
+import { getCompleteOrder, getIncompleteOrder, getOrderRequestBody } from './orders.mock';
 import { getPayment, getPaymentRequestBody } from '../payment/payments.mock';
 import { getPaymentMethodsState } from '../payment/payment-methods.mock';
 import { getQuoteState } from '../quote/quotes.mock';
 import { getShippingOptionsState } from '../shipping/shipping-options.mock';
 import { getSubmittedOrderState } from '../order/orders.mock';
+import * as paymentStatusTypes from '../payment/payment-status-types';
 import createCheckoutStore from '../create-checkout-store';
 import PlaceOrderService from './place-order-service';
 
@@ -179,6 +180,38 @@ describe('PlaceOrderService', () => {
             await placeOrderService.submitPayment(getPayment(), true);
 
             expect(checkout.isPaymentDataRequired).toHaveBeenCalledWith(true);
+            expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
+        });
+
+        it('does not submit payment data if payment is acknowledged', async () => {
+            const { checkout } = store.getState();
+
+            jest.spyOn(checkout, 'isPaymentDataRequired').mockReturnValue(true);
+            jest.spyOn(checkout, 'getOrder').mockReturnValue({
+                ...getIncompleteOrder(),
+                payment: {
+                    status: paymentStatusTypes.ACKNOWLEDGE,
+                },
+            });
+
+            await placeOrderService.submitPayment(getPayment(), true);
+
+            expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
+        });
+
+        it('does not submit payment data if payment is finalized', async () => {
+            const { checkout } = store.getState();
+
+            jest.spyOn(checkout, 'isPaymentDataRequired').mockReturnValue(true);
+            jest.spyOn(checkout, 'getOrder').mockReturnValue({
+                ...getIncompleteOrder(),
+                payment: {
+                    status: paymentStatusTypes.FINALIZE,
+                },
+            });
+
+            await placeOrderService.submitPayment(getPayment(), true);
+
             expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
## What?
* Skip payment submission if payment is already acknowledged or finalized.
* This is the same patch as https://github.com/bigcommerce-labs/ng-checkout/pull/698

## Why?
* Otherwise, you'll get an error. This problem currently affects PayPal Website Payments Pro.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
