### PR TITLE
CHECKOUT-2419: Only trigger subscribers if values have changed

### DIFF
--- a/src/data-store/data-store.js
+++ b/src/data-store/data-store.js
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -35,7 +36,7 @@ export default class DataStore {
 
         this._dispatchQueue$
             .scan((state, action) => reducer(state, action), initialState)
-            .distinctUntilChanged()
+            .distinctUntilChanged(isEqual)
             .map(stateTransformer)
             .subscribe(this._state$);
 
@@ -82,7 +83,7 @@ export default class DataStore {
 
         if (filters.length > 0) {
             state$ = state$.distinctUntilChanged((stateA, stateB) =>
-                filters.every((filter) => filter(stateA) === filter(stateB))
+                filters.every((filter) => isEqual(filter(stateA), filter(stateB)))
             );
         }
 

--- a/src/data-store/data-store.spec.js
+++ b/src/data-store/data-store.spec.js
@@ -174,6 +174,20 @@ describe('DataStore', () => {
             expect(subscriber.mock.calls.length).toEqual(1);
         });
 
+        it('does not notify subscribers if current state has changed in reference but not value', () => {
+            const store = new DataStore(
+                (state) => ({ ...state }),
+                { foobar: 'foobar' }
+            );
+
+            const subscriber = jest.fn();
+
+            store.subscribe(subscriber);
+            store.dispatch({ type: 'ACTION' });
+
+            expect(subscriber.mock.calls.length).toEqual(1);
+        });
+
         it('notifies subscribers with the tranformed state', () => {
             const initialState = { foobar: 'foobar' };
             const store = new DataStore(
@@ -387,6 +401,19 @@ describe('DataStore', () => {
             store.dispatch({ type: 'INCREMENT' });
 
             expect(store.getState()).toEqual({ foobar: 'foobar x2' });
+        });
+
+        it('does not return different reference if values are equal after reduction', () => {
+            const store = new DataStore(
+                (state) => ({ ...state }),
+                { foobar: 'foobar' }
+            );
+
+            const oldState = store.getState();
+
+            store.dispatch({ type: 'ACTION' });
+
+            expect(store.getState()).toBe(oldState);
         });
 
         it('applies the state transformer before returning the current state', () => {


### PR DESCRIPTION
## What?
* Add a custom comparator to `distinctUntilChanged`.

## Why?
* Make sure we compare the previous and new state by value instead of by reference. Otherwise, we could be notifying subscribers more times than we need to.
* For example, previously, if we have a reducer returning a copy of the current state (`return { ...state }`), subscribers get notified even though there are no changes.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
