### PR TITLE
fix(payment): PAYMENTS-1983 Increment PATCH version of bigpay-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#0.1.0",
-    "bigpay-client": "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.9.0",
+    "bigpay-client": "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.9.1",
     "form-poster": "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1",
     "lodash": "^4.17.4",
     "memoizee": "^0.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,9 +472,9 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
-"bigpay-client@git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.9.0":
-  version "2.9.0"
-  resolved "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#038f316ab8db11e47ac862145788da68d68d77af"
+"bigpay-client@git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.9.1":
+  version "2.9.1"
+  resolved "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#513a3ea6657259ce215a39513944c3159a5afc89"
   dependencies:
     deep-assign "^2.0.0"
     form-poster "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1"


### PR DESCRIPTION
## What?
Updates the patch version of `bigpay-client-js` to expose a minor bug fix.

## Why?
Because a small error was blocking the card vaulting functionality. 

Please see for more information: https://github.com/bigcommerce-labs/bigpay-client-js/pull/54

> Injects the storeRequestSender at the correct position of the Client class.

## Testing / Proof
Unit tests 
Manual tests

@bigcommerce/checkout 
@bigcommerce/payments
@davidchin 


  