### PR TITLE
CHECKOUT-2749: Reject with error instead of state

### DIFF
--- a/src/core/checkout/checkout-service.js
+++ b/src/core/checkout/checkout-service.js
@@ -175,7 +175,7 @@ export default class CheckoutService {
         }
 
         if (!order.payment || !order.payment.id) {
-            return Promise.reject(this._store.getState());
+            return Promise.reject(new Error('Skipping order finalization as it is not required'));
         }
 
         const method = checkout.getPaymentMethod(order.payment.id, order.payment.gateway);

--- a/src/core/checkout/checkout-service.spec.js
+++ b/src/core/checkout/checkout-service.spec.js
@@ -289,7 +289,7 @@ describe('CheckoutService', () => {
             try {
                 await checkoutService.finalizeOrderIfNeeded();
             } catch (error) {
-                expect(error).toBeDefined();
+                expect(error).toBeInstanceOf(Error);
             }
         });
     });

--- a/src/core/payment/strategies/payment-strategy.js
+++ b/src/core/payment/strategies/payment-strategy.js
@@ -27,7 +27,7 @@ export default class PaymentStrategy {
      * @return {Promise<CheckoutSelectors>}
      */
     finalize() {
-        return Promise.reject(this._store.getState());
+        return Promise.reject(new Error('Not required'));
     }
 
     /**

--- a/src/core/payment/strategies/paypal-express-payment-strategy.spec.js
+++ b/src/core/payment/strategies/paypal-express-payment-strategy.spec.js
@@ -316,8 +316,8 @@ describe('PaypalExpressPaymentStrategy', () => {
 
             try {
                 await strategy.finalize();
-            } catch ({ errors }) {
-                expect(errors.getFinalizeOrderError()).toBeUndefined();
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
                 expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
             }
         });
@@ -325,8 +325,8 @@ describe('PaypalExpressPaymentStrategy', () => {
         it('does not finalize order if order is not finalized or acknowledged', async () => {
             try {
                 await strategy.finalize();
-            } catch ({ errors }) {
-                expect(errors.getFinalizeOrderError()).toBeUndefined();
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
                 expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
             }
         });

--- a/src/data-store/data-store.js
+++ b/src/data-store/data-store.js
@@ -136,10 +136,18 @@ export default class DataStore {
                         return Observable.of(value);
                     })
                     .do({
-                        next: (value) => { action = value; },
-                        complete: () => error || action.error ?
-                            reject(this.getState()) :
-                            resolve(this.getState()),
+                        next: (value) => {
+                            action = value;
+                        },
+                        complete: () => {
+                            if (error) {
+                                reject(error instanceof Error ? error : error.payload);
+                            } else if (action.error) {
+                                reject(action.payload);
+                            } else {
+                                resolve(this.getState());
+                            }
+                        },
                     })
             );
         });


### PR DESCRIPTION
## What?
* **BREAKING CHANGE:** Return with a rejected promise with the thrown error instead of the current state so that clients can inspect the error directly.

## Why?
* This makes it easier to catch errors. Now, if you do `try/catch`, you can catch the exact error that's been thrown. Previously, you have to call `getState` to retrieve it.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
