### PR TITLE
CHECKOUT-2749: Throw error if required data is missing

### DIFF
--- a/src/core/checkout/checkout-service.js
+++ b/src/core/checkout/checkout-service.js
@@ -1,3 +1,5 @@
+import { isEmpty } from 'lodash';
+
 export default class CheckoutService {
     /**
      * @constructor
@@ -142,7 +144,7 @@ export default class CheckoutService {
         const method = checkout.getPaymentMethod(payment.name, payment.gateway);
 
         if (!method) {
-            throw new Error(`Unable to submit order because payment method ${payment.name} is either not available or not loaded`);
+            throw new Error('Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
         }
 
         return this._paymentStrategyRegistry.getStrategyByMethod(method).execute(payload, options);
@@ -166,11 +168,20 @@ export default class CheckoutService {
      */
     finalizeOrderIfNeeded(options) {
         const { checkout } = this._store.getState();
-        const { payment = {} } = checkout.getOrder();
-        const method = checkout.getPaymentMethod(payment.id, payment.gateway, options);
+        const order = checkout.getOrder();
+
+        if (isEmpty(order)) {
+            throw new Error('Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
+        }
+
+        if (!order.payment || !order.payment.id) {
+            return Promise.reject(this._store.getState());
+        }
+
+        const method = checkout.getPaymentMethod(order.payment.id, order.payment.gateway);
 
         if (!method) {
-            return Promise.reject(this._store.getState());
+            throw new Error('Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
         }
 
         return this._paymentStrategyRegistry.getStrategyByMethod(method).finalize(options);
@@ -208,7 +219,7 @@ export default class CheckoutService {
         const method = checkout.getPaymentMethod(methodId, gatewayId);
 
         if (!method) {
-            throw new Error(`Unable to initialize method because ${methodId} is either not available or not loaded`);
+            throw new Error('Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
         }
 
         return this._paymentStrategyRegistry.getStrategyByMethod(method).initialize(options);
@@ -224,7 +235,7 @@ export default class CheckoutService {
         const method = checkout.getPaymentMethod(methodId, gatewayId);
 
         if (!method) {
-            throw new Error(`Unable to deinitialize method because ${methodId} is either not available or not loaded`);
+            throw new Error('Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
         }
 
         return this._paymentStrategyRegistry.getStrategyByMethod(method).deinitialize();
@@ -365,6 +376,11 @@ export default class CheckoutService {
      */
     loadInstruments() {
         const { checkout } = this._store.getState();
+
+        if (isEmpty(checkout.getConfig()) || isEmpty(checkout.getCustomer())) {
+            throw new Error('Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
+        }
+
         const { storeId } = checkout.getConfig();
         const { customerId } = checkout.getCustomer();
 
@@ -379,6 +395,11 @@ export default class CheckoutService {
      */
     vaultInstrument(instrument) {
         const { checkout } = this._store.getState();
+
+        if (isEmpty(checkout.getConfig()) || isEmpty(checkout.getCustomer())) {
+            throw new Error('Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
+        }
+
         const { storeId } = checkout.getConfig();
         const { customerId } = checkout.getCustomer();
 
@@ -393,6 +414,11 @@ export default class CheckoutService {
      */
     deleteInstrument(instrumentId) {
         const { checkout } = this._store.getState();
+
+        if (isEmpty(checkout.getConfig()) || isEmpty(checkout.getCustomer())) {
+            throw new Error('Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
+        }
+
         const { storeId } = checkout.getConfig();
         const { customerId } = checkout.getCustomer();
 

--- a/src/core/order/place-order-service.spec.js
+++ b/src/core/order/place-order-service.spec.js
@@ -81,6 +81,12 @@ describe('PlaceOrderService', () => {
 
             expect(output).toEqual(store.getState());
         });
+
+        it('throws error if cart data is missing', () => {
+            jest.spyOn(store.getState().checkout, 'getCart').mockReturnValue();
+
+            expect(() => placeOrderService.submitOrder(getOrderRequestBody())).toThrow();
+        });
     });
 
     describe('#finalizeOrder()', () => {
@@ -181,6 +187,12 @@ describe('PlaceOrderService', () => {
             expect(checkout.isPaymentDataRequired).toHaveBeenCalledWith(true);
             expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
         });
+
+        it('throws error if cart data is missing', () => {
+            jest.spyOn(store.getState().checkout, 'getCart').mockReturnValue();
+
+            expect(() => placeOrderService.submitPayment(getPayment())).toThrow();
+        });
     });
 
     describe('#initializeOffsitePayment()', () => {
@@ -210,6 +222,12 @@ describe('PlaceOrderService', () => {
 
             expect(checkout.isPaymentDataRequired).toHaveBeenCalledWith(true);
             expect(paymentActionCreator.initializeOffsitePayment).not.toHaveBeenCalled();
+        });
+
+        it('throws error if cart data is missing', () => {
+            jest.spyOn(store.getState().checkout, 'getCart').mockReturnValue();
+
+            expect(() => placeOrderService.initializeOffsitePayment(getPayment())).toThrow();
         });
     });
 });


### PR DESCRIPTION
## What?
* Explicitly throw an error if calling a method missing the data required for the call.

## Why?
* Instead of throwing a `TypeError` (i.e.: cannot ready property `xyz` of `undefined`), we now throw an error with a clearer message, telling the developer that certain data is missing and they need to check the documentation to resolve the issue.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments

  
  