### PR TITLE
CHECKOUT-2749: Fix error message concatenation

### DIFF
--- a/src/core/common/error/errors/request-error.js
+++ b/src/core/common/error/errors/request-error.js
@@ -27,7 +27,15 @@ function joinErrors(errors) {
         return;
     }
 
-    return errors.map(error =>
-        typeof error === 'object' ? error.message : error
-    ).join(' ');
+    return errors.reduce((result, error) => {
+        if (typeof error === 'string' && error) {
+            return [...result, error];
+        }
+
+        if (error && error.message) {
+            return [...result, error.message];
+        }
+
+        return result;
+    }, []).join(' ');
 }

--- a/src/core/common/error/errors/request-error.spec.js
+++ b/src/core/common/error/errors/request-error.spec.js
@@ -28,6 +28,20 @@ describe('RequestError', () => {
         expect(error.message).toEqual('Invalid CVV. Invalid account.');
     });
 
+    it('does not concatenate error messages if they are blank', () => {
+        const error = new RequestError(getErrorResponse({
+            ...getErrorResponseBody(),
+            errors: [
+                null,
+                { code: 'invalid_cvv', message: null },
+                { code: 'invalid_number', message: '' },
+                { code: 'invalid_account', message: 'Invalid account.' },
+            ],
+        }));
+
+        expect(error.message).toEqual('Invalid account.');
+    });
+
     it('sets error message with detail contained in response', () => {
         const response = getErrorResponse({
             ...getErrorResponseBody(),


### PR DESCRIPTION
## What?
* Ignore blank error messages when concatenating them.

## Why?
* The API could potentially return errors as null or `''`. i.e.:
<img width="557" alt="screen shot 2018-01-17 at 1 50 11 pm" src="https://user-images.githubusercontent.com/667603/35023854-b0256702-fb90-11e7-9065-cb8ccb27873f.png">

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
