### PR TITLE
CHECKOUT-2749: Fix SagePay 3DS payment flow

### DIFF
--- a/src/core/payment/strategies/sage-pay-payment-strategy.js
+++ b/src/core/payment/strategies/sage-pay-payment-strategy.js
@@ -23,11 +23,11 @@ export default class SagePayPaymentStrategy extends PaymentStrategy {
             .then(() =>
                 this._placeOrderService.submitPayment(payload.payment, payload.useStoreCredit, options)
             )
-            .catch((state) => {
-                const { body } = state.errors.getSubmitOrderError();
+            .catch((error) => {
+                const { body } = error;
 
                 if (!some(body.errors, { code: 'three_d_secure_required' })) {
-                    return Promise.reject(state);
+                    return Promise.reject(error);
                 }
 
                 return new Promise(() => {

--- a/src/core/payment/strategies/sage-pay-payment-strategy.spec.js
+++ b/src/core/payment/strategies/sage-pay-payment-strategy.spec.js
@@ -53,10 +53,7 @@ describe('SagePayPaymentStrategy', () => {
     });
 
     it('posts 3ds data to Sage if 3ds is enabled', async () => {
-        const state = store.getState();
-
-        jest.spyOn(placeOrderService, 'submitPayment').mockReturnValue(Promise.reject(state));
-        jest.spyOn(state.errors, 'getSubmitOrderError').mockReturnValue(getResponse({
+        const error = getResponse({
             ...getErrorPaymentResponseBody(),
             errors: [
                 { code: 'three_d_secure_required' },
@@ -68,7 +65,9 @@ describe('SagePayPaymentStrategy', () => {
                 merchant_data: 'merchant_data',
             },
             status: 'error',
-        }));
+        });
+
+        jest.spyOn(placeOrderService, 'submitPayment').mockReturnValue(Promise.reject(error));
 
         strategy.execute(getOrderRequestBody());
 


### PR DESCRIPTION
## What?
* Get error responses directly from the error handler instead of calling `getSubmitOrderError`.

## Why?
* Fix an issue where `SagePayPaymentStrategy` is not catching error responses properly, causing 3DS payment to fail.
* The bug was introduced by #25.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
