### PR TITLE
CHECKOUT-2749: Fix `TimeoutError` not inheriting members of `RequestError`

### DIFF
--- a/src/core/common/error/errors/timeout-error.js
+++ b/src/core/common/error/errors/timeout-error.js
@@ -1,12 +1,12 @@
-import StandardError from './standard-error';
+import RequestError from './request-error';
 
-export default class TimeoutError extends StandardError {
+export default class TimeoutError extends RequestError {
     /**
      * @constructor
      * @param {Response} [response]
      */
     constructor(response) {
-        super('The request has timed out or aborted.', response);
+        super(response, 'The request has timed out or aborted.');
 
         this.type = 'timeout';
     }

--- a/src/core/common/error/request-error-factory.spec.js
+++ b/src/core/common/error/request-error-factory.spec.js
@@ -39,7 +39,9 @@ describe('RequestErrorFactory', () => {
 
     it('creates `TimeoutError` if XHR is aborted', () => {
         const factory = new RequestErrorFactory();
+        const error = factory.createError(getTimeoutResponse());
 
-        expect(factory.createError(getTimeoutResponse())).toBeInstanceOf(TimeoutError);
+        expect(error).toBeInstanceOf(TimeoutError);
+        expect(error.status).toEqual(0);
     });
 });


### PR DESCRIPTION
## What?
* Extend `TimeoutError` with `RequestError` instead of `StandardError`

## Why?
* Otherwise, the error object won't contain details of the timed out response. i.e.: `status` code.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
