### PR TITLE
CHECKOUT-2842: Don't need to check for missing data when constructing payload for payment service

### DIFF
--- a/src/core/order/place-order-service.js
+++ b/src/core/order/place-order-service.js
@@ -113,11 +113,6 @@ export default class PlaceOrderService {
         const shippingOption = checkout.getSelectedShippingOption();
         const config = checkout.getConfig();
 
-        if (!checkoutMeta || !billingAddress || !cart || !customer || !order ||
-            !paymentMethod || !shippingAddress || !shippingOption || !config) {
-            throw new MissingDataError();
-        }
-
         const authToken = payment.paymentData && payment.paymentData.instrumentId
             ? `${checkoutMeta.paymentAuthToken}, ${checkoutMeta.vaultAccessToken}`
             : checkoutMeta.paymentAuthToken;

--- a/src/core/order/place-order-service.spec.js
+++ b/src/core/order/place-order-service.spec.js
@@ -1,7 +1,6 @@
 import { createTimeout } from '@bigcommerce/request-sender';
 import { merge } from 'lodash';
 import { createAction } from '../../data-store';
-import { MissingDataError } from '../common/error/errors';
 import { getCartState } from '../cart/carts.mock';
 import { getConfigState } from '../config/configs.mock';
 import { getCustomerState } from '../customer/customers.mock';
@@ -83,12 +82,6 @@ describe('PlaceOrderService', () => {
             const output = await placeOrderService.submitOrder(getOrderRequestBody());
 
             expect(output).toEqual(store.getState());
-        });
-
-        it('throws error if cart data is missing', () => {
-            jest.spyOn(store.getState().checkout, 'getCart').mockReturnValue();
-
-            expect(() => placeOrderService.submitOrder(getOrderRequestBody())).toThrow(MissingDataError);
         });
     });
 
@@ -210,12 +203,6 @@ describe('PlaceOrderService', () => {
             expect(checkout.isPaymentDataRequired).toHaveBeenCalledWith(true);
             expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
         });
-
-        it('throws error if cart data is missing', () => {
-            jest.spyOn(store.getState().checkout, 'getCart').mockReturnValue();
-
-            expect(() => placeOrderService.submitPayment(getPayment())).toThrow(MissingDataError);
-        });
     });
 
     describe('#initializeOffsitePayment()', () => {
@@ -245,12 +232,6 @@ describe('PlaceOrderService', () => {
 
             expect(checkout.isPaymentDataRequired).toHaveBeenCalledWith(true);
             expect(paymentActionCreator.initializeOffsitePayment).not.toHaveBeenCalled();
-        });
-
-        it('throws error if cart data is missing', () => {
-            jest.spyOn(store.getState().checkout, 'getCart').mockReturnValue();
-
-            expect(() => placeOrderService.initializeOffsitePayment(getPayment())).toThrow(MissingDataError);
         });
     });
 });


### PR DESCRIPTION
## What?
* Don't need to check for missing data when constructing payload for payment service.
* Reverting parts of this PR https://github.com/bigcommerce/checkout-sdk-js/pull/27

## Why?
* We're not using the data directly (we're simply passing it to the server), so we don't actually need to do any null checks.
* This is required to fix `CHECKOUT-2842`, because when a shopper checks out with only digital products, he doesn't have a shipping option set. So we shouldn't check for it.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
