### PR TITLE
CHECKOUT-2844: Fix `Object.setPrototypeOf` not available in some browsers

### DIFF
--- a/src/core/common/error/errors/standard-error.js
+++ b/src/core/common/error/errors/standard-error.js
@@ -1,3 +1,5 @@
+import { setPrototypeOf } from '../../utility';
+
 export default class StandardError extends Error {
     /**
      * @constructor
@@ -6,7 +8,7 @@ export default class StandardError extends Error {
     constructor(message) {
         super(message || 'An unexpected error has occurred.');
 
-        Object.setPrototypeOf(this, new.target.prototype);
+        setPrototypeOf(this, new.target.prototype);
 
         if (typeof Error.captureStackTrace === 'function') {
             Error.captureStackTrace(this, new.target);

--- a/src/core/common/utility/index.js
+++ b/src/core/common/utility/index.js
@@ -2,3 +2,4 @@ export { default as createFreezeProxy } from './create-freeze-proxy';
 export { default as mergeOrPush } from './merge-or-push';
 export { default as omitDeep } from './omit-deep';
 export { default as omitPrivate } from './omit-private';
+export { default as setPrototypeOf } from './set-prototype-of';

--- a/src/core/common/utility/set-prototype-of.js
+++ b/src/core/common/utility/set-prototype-of.js
@@ -1,0 +1,14 @@
+/**
+ * @param {Object} object
+ * @param {Object} prototype
+ */
+export default function setPrototypeOf(object, prototype) {
+    if (Object.setPrototypeOf) {
+        Object.setPrototypeOf(object, prototype);
+    } else {
+        // eslint-disable-next-line no-proto
+        object.__proto__ = prototype;
+    }
+
+    return object;
+}

--- a/src/core/common/utility/set-prototype-of.spec.js
+++ b/src/core/common/utility/set-prototype-of.spec.js
@@ -1,0 +1,15 @@
+import setPrototypeOf from './set-prototype-of';
+
+describe('setPrototypeOf', () => {
+    it('assigns prototype to object', () => {
+        class CustomError extends Error {}
+
+        const error = new CustomError();
+
+        expect(error instanceof CustomError).toBeFalsy();
+
+        setPrototypeOf(error, CustomError.prototype);
+
+        expect(error instanceof CustomError).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## What?
* Create a helper function for setting the prototype of an object.

## Why?
* `Object.setPrototypeOf` is not available in some browsers, i.e.: IE10.
* We need to call it because some classes, i.e.: `Error`, cannot be extended properly. The recommended workaround, outlined in [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error), is to manually assign prototypes.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
