### PR TITLE
CHECKOUT-2851: Use Lodash instead of `Object.assign` to support older browsers

### DIFF
--- a/src/data-store/combine-reducers.ts
+++ b/src/data-store/combine-reducers.ts
@@ -1,3 +1,4 @@
+import { assign } from 'lodash';
 import Action from './action';
 import Reducer from './reducer';
 
@@ -14,7 +15,7 @@ export default function combineReducers<TState, TAction extends Action>(
                 return result;
             }
 
-            return Object.assign({}, result, { [key]: newState });
+            return assign({}, result, { [key]: newState });
         }, state);
 }
 


### PR DESCRIPTION
## What?
* Use `_.assign` instead of `Object.assign`

## Why?
* To support older browsers. A quick fix is made last week: https://github.com/bigcommerce-labs/ng-checkout/pull/722. But we shouldn't require external clients to polyfill a method used internally in this library (we only ask people to polyfill things that get returned externally, i.e.: `Promise`).

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
