### PR TITLE
CHECKOUT-2851: Catch reducer error and keep subscription alive

### DIFF
--- a/src/data-store/data-store.ts
+++ b/src/data-store/data-store.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import { isEqual, merge } from 'lodash';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -17,22 +17,26 @@ import 'rxjs/add/operator/concatMap';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/first';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/scan';
 
 export default class DataStore<TState, TAction extends Action, TTransformedState = TState> implements ReadableDataStore<TTransformedState>, DispatchableDataStore<TTransformedState, TAction> {
+    private _reducer: Reducer<Partial<TState>, TAction>;
     private _options: DataStoreOptions<TState, TAction, TTransformedState>;
     private _notification$: Subject<TTransformedState>;
     private _dispatchers: { [key: string]: Dispatcher<TAction> };
     private _dispatchQueue$: Subject<Dispatcher<TAction>>;
     private _state$: BehaviorSubject<TTransformedState>;
+    private _errors: { [key: string]: Subject<Error> };
 
     constructor(
         reducer: Reducer<Partial<TState>, TAction>,
         initialState: Partial<TState> = {},
         options?: DataStoreOptions<TState, TAction, TTransformedState>
     ) {
+        this._reducer = reducer;
         this._options = {
             shouldWarnMutation: true,
             stateTransformer: noopStateTransformer,
@@ -43,14 +47,17 @@ export default class DataStore<TState, TAction extends Action, TTransformedState
         this._notification$ = new Subject();
         this._dispatchers = {};
         this._dispatchQueue$ = new Subject();
+        this._errors = {};
 
         this._dispatchQueue$
             .mergeMap((dispatcher$) => dispatcher$.concatMap((action$) => action$))
             .filter((action) => !!action.type)
-            .scan((state, action) => reducer(state, action), initialState)
+            .scan(
+                (states, action) => this._transformStates(states, action),
+                { state: initialState, transformedState: this._state$.getValue() }
+            )
+            .map(({ transformedState }) => transformedState)
             .distinctUntilChanged(isEqual)
-            .map((state) => this._options.shouldWarnMutation === false ? state : deepFreeze(state))
-            .map((state) => this._options.stateTransformer(state))
             .subscribe(this._state$);
 
         this.dispatch({ type: 'INIT' } as TAction);
@@ -95,6 +102,26 @@ export default class DataStore<TState, TAction extends Action, TTransformedState
         return () => subscriptions.forEach((subscription) => subscription.unsubscribe());
     }
 
+    private _transformStates(
+        states: StateTuple<Partial<TState>, TTransformedState>,
+        action: TAction
+    ): StateTuple<Partial<TState>, TTransformedState> {
+        const { state, transformedState } = states;
+
+        try {
+            const newState = this._reducer(state, action);
+            const transformedState = this._options.shouldWarnMutation === false ?
+                this._options.stateTransformer(newState) :
+                this._options.stateTransformer(deepFreeze(newState));
+
+            return { state: newState, transformedState };
+        } catch (error) {
+            this._getDispatchError(action.meta && action.meta.queueId).next(error);
+
+            return { state, transformedState };
+        }
+    }
+
     private _dispatchAction<TDispatchAction extends TAction>(
         action: TDispatchAction
     ): Promise<TTransformedState> {
@@ -110,28 +137,34 @@ export default class DataStore<TState, TAction extends Action, TTransformedState
         options: DispatchOptions = {}
     ): Promise<TTransformedState> {
         return new Promise((resolve, reject) => {
-            let action: TDispatchAction;
-            let error: any;
+            const error$ = this._getDispatchError(options.queueId);
+            const transformedAction$ = this._options.actionTransformer(
+                action$.map((action) =>
+                    options.queueId ? merge({}, action, { meta: { queueId: options.queueId } }) : action
+                )
+            );
 
             this._getDispatcher(options.queueId).next(
-                this._options.actionTransformer(action$)
-                    .catch((value) => {
-                        error = value;
+                transformedAction$
+                    .map((action, index) => {
+                        if (index === 0) {
+                            error$.first().subscribe(reject);
+                        }
 
-                        return Observable.of(value);
+                        if (action.error) {
+                            reject(action.payload);
+                        }
+
+                        return action;
+                    })
+                    .catch((action) => {
+                        reject(action instanceof Error ? action : action.payload);
+
+                        return Observable.of(action);
                     })
                     .do({
-                        next: (value) => {
-                            action = value;
-                        },
                         complete: () => {
-                            if (error) {
-                                reject(error instanceof Error ? error : error.payload);
-                            } else if (action.error) {
-                                reject(action.payload);
-                            } else {
-                                resolve(this.getState());
-                            }
+                            resolve(this.getState());
                         },
                     })
             );
@@ -147,12 +180,25 @@ export default class DataStore<TState, TAction extends Action, TTransformedState
 
         return this._dispatchers[queueId];
     }
+
+    private _getDispatchError(queueId: string = 'default'): Subject<Error> {
+        if (!this._errors[queueId]) {
+            this._errors[queueId] = new Subject();
+        }
+
+        return this._errors[queueId];
+    }
 }
 
 export interface DataStoreOptions<TState, TAction, TTransformedState> {
     shouldWarnMutation?: boolean;
     actionTransformer?: (action: Observable<TAction>) => Observable<TAction>;
     stateTransformer?: (state: Partial<TState>) => TTransformedState;
+}
+
+interface StateTuple<TState, TTransformedState> {
+    state: TState;
+    transformedState: TTransformedState;
 }
 
 type Dispatcher<TAction> = Subject<Observable<TAction>>;


### PR DESCRIPTION
## What?
* Keep subscription with `DataStore` alive when there's an error.

## Why?
* Otherwise, if a reducer or state transformer throws an error, `DataStore` will unsubscribe from all events. In other words, you cannot dispatch another action again. With this fix, `DataStore` stays alive and you can continue to dispatch actions even if one of them fails.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
