### PR TITLE
CHECKOUT-2875: Return `OrderFinalizationNotRequiredError` if not required to finalize when using SagePay or Offsite payment method

### DIFF
--- a/src/core/payment/strategies/offsite-payment-strategy.js
+++ b/src/core/payment/strategies/offsite-payment-strategy.js
@@ -29,6 +29,6 @@ export default class OffsitePaymentStrategy extends PaymentStrategy {
             return this._placeOrderService.finalizeOrder(orderId, options);
         }
 
-        return Promise.resolve(this._store.getState());
+        return super.finalize();
     }
 }

--- a/src/core/payment/strategies/offsite-payment-strategy.spec.js
+++ b/src/core/payment/strategies/offsite-payment-strategy.spec.js
@@ -1,6 +1,7 @@
+import { merge, omit } from 'lodash';
 import { getOrderRequestBody, getIncompleteOrder, getSubmittedOrder } from '../../order/orders.mock';
 import { getPaymentMethod } from '../payment-methods.mock';
-import { merge, omit } from 'lodash';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import * as paymentStatusTypes from '../payment-status-types';
 import createCheckoutStore from '../../create-checkout-store';
 import OffsitePaymentStrategy from './offsite-payment-strategy';
@@ -85,9 +86,12 @@ describe('OffsitePaymentStrategy', () => {
 
         jest.spyOn(checkout, 'getOrder').mockReturnValue(getIncompleteOrder());
 
-        await strategy.finalize();
-
-        expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+        }
     });
 
     it('does not finalize order if order is not finalized or acknowledged', async () => {
@@ -99,9 +103,12 @@ describe('OffsitePaymentStrategy', () => {
             },
         }));
 
-        await strategy.finalize();
-
-        expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+        }
     });
 
     it('returns checkout state', async () => {

--- a/src/core/payment/strategies/sage-pay-payment-strategy.js
+++ b/src/core/payment/strategies/sage-pay-payment-strategy.js
@@ -52,6 +52,6 @@ export default class SagePayPaymentStrategy extends PaymentStrategy {
             return this._placeOrderService.finalizeOrder(orderId, options);
         }
 
-        return Promise.resolve(this._store.getState());
+        return super.finalize();
     }
 }

--- a/src/core/payment/strategies/sage-pay-payment-strategy.spec.js
+++ b/src/core/payment/strategies/sage-pay-payment-strategy.spec.js
@@ -3,6 +3,7 @@ import { getErrorPaymentResponseBody } from '../payments.mock';
 import { getOrderRequestBody, getIncompleteOrder, getSubmittedOrder } from '../../order/orders.mock';
 import { getPaymentMethod } from '../payment-methods.mock';
 import { getResponse } from '../../common/http-request/responses.mock';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import * as paymentStatusTypes from '../payment-status-types';
 import createCheckoutStore from '../../create-checkout-store';
 import SagePayPaymentStrategy from './sage-pay-payment-strategy';
@@ -113,9 +114,12 @@ describe('SagePayPaymentStrategy', () => {
 
         jest.spyOn(checkout, 'getOrder').mockReturnValue(getIncompleteOrder());
 
-        await strategy.finalize();
-
-        expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
     });
 
     it('does not finalize order if order is not finalized', async () => {
@@ -127,8 +131,11 @@ describe('SagePayPaymentStrategy', () => {
             },
         }));
 
-        await strategy.finalize();
-
-        expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
     });
 });


### PR DESCRIPTION
## What?
* Return `OrderFinalizationNotRequiredError` if order finalisation is not required when paying with SagePay or other offsite payment methods.

## Why?
* If order finalisation is not required, we should do the default thing, which is returning a rejection error when calling `finalize` method.
* This bug affects SagePay3DS. If you enter an incorrect 3DS password, you'll be redirected to the order confirmation page instead of staying on the checkout page because the method currently returns a resolved promise.

## Testing / Proof
* Unit / manual

@bigcommerce/checkout @bigcommerce/payments
