### PR TITLE
CHECKOUT-2274: Add type annotation to ScriptLoader

### DIFF
--- a/src/script-loader/index.ts
+++ b/src/script-loader/index.ts
@@ -1,8 +1,5 @@
 import ScriptLoader from './script-loader';
 
-/**
- * @return {ScriptLoader}
- */
-export function createScriptLoader() {
+export function createScriptLoader(): ScriptLoader {
     return new ScriptLoader(document);
 }

--- a/src/script-loader/script-loader.spec.ts
+++ b/src/script-loader/script-loader.spec.ts
@@ -1,23 +1,22 @@
 import ScriptLoader from './script-loader';
 
 describe('ScriptLoader', () => {
-    let document;
-    let loader;
-    let script;
+    let loader: ScriptLoader;
+    let script: HTMLScriptElement;
 
     beforeEach(() => {
-        script = {};
+        script = document.createElement('script');
 
-        document = {
-            createElement: jest.fn(() => script),
-            body: {
-                appendChild: jest.fn((element) =>
-                    element.onreadystatechange(new Event('readystatechange'))
-                ),
-            },
-        };
+        jest.spyOn(document, 'createElement').mockImplementation(() => script);
+        jest.spyOn(document.body, 'appendChild').mockImplementation((element) =>
+            element.onreadystatechange(new Event('readystatechange'))
+        );
 
         loader = new ScriptLoader(document);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     it('attaches script tag to document', async () => {

--- a/src/script-loader/script-loader.ts
+++ b/src/script-loader/script-loader.ts
@@ -1,19 +1,11 @@
 export default class ScriptLoader {
-    /**
-     * @constructor
-     * @param {Document} document
-     */
-    constructor(document) {
-        this._document = document;
-    }
+    constructor(
+        private _document: Document
+    ) {}
 
-    /**
-     * @param {string} src
-     * @return {Promise<Event>}
-     */
-    loadScript(src) {
+    loadScript(src: string): Promise<Event> {
         return new Promise((resolve, reject) => {
-            const script = this._document.createElement('script');
+            const script = this._document.createElement('script') as LegacyHTMLScriptElement;
 
             script.onload = (event) => resolve(event);
             script.onreadystatechange = (event) => resolve(event);
@@ -24,4 +16,9 @@ export default class ScriptLoader {
             this._document.body.appendChild(script);
         });
     }
+}
+
+interface LegacyHTMLScriptElement extends HTMLScriptElement {
+    // `onreadystatechange` is needed to support legacy IE
+    onreadystatechange: (this: HTMLElement, event: Event) => any;
 }


### PR DESCRIPTION
## What?
* Add type annotation to `ScriptLoader`

## Why?
* We'll need to use it soon (i.e.: AmazonPay)

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
