### PR TITLE
CHECKOUT-2274: Add `Registry` as base class for `PaymentStrategyRegistry` and `ShippingStrategyRegistry`

### DIFF
--- a/src/core/common/error/errors/index.js
+++ b/src/core/common/error/errors/index.js
@@ -1,3 +1,4 @@
+export { default as InvalidArgumentError } from './invalid-argument-error';
 export { default as MissingDataError } from './missing-data-error';
 export { default as NotImplementedError } from './not-implemented-error';
 export { default as RequestError } from './request-error';

--- a/src/core/common/error/errors/invalid-argument-error.js
+++ b/src/core/common/error/errors/invalid-argument-error.js
@@ -1,0 +1,13 @@
+import StandardError from './standard-error';
+
+export default class InvalidArgumentError extends StandardError {
+    /**
+     * @constructor
+     * @param {string} [message]
+     */
+    constructor(message) {
+        super(message || 'Invalid arguments have been provided.');
+
+        this.type = 'invalid_argument';
+    }
+}

--- a/src/core/common/registry/index.ts
+++ b/src/core/common/registry/index.ts
@@ -1,0 +1,1 @@
+export { default as Registry, Factory } from './registry';

--- a/src/core/common/registry/registry.spec.ts
+++ b/src/core/common/registry/registry.spec.ts
@@ -1,0 +1,36 @@
+import { InvalidArgumentError } from '../error/errors';
+import Registry from './registry';
+
+describe('Registry', () => {
+    it('returns registered instance', () => {
+        const registry = new Registry<{ name: string }>();
+
+        registry.register('foo', () => ({ name: 'Foo' }));
+        registry.register('bar', () => ({ name: 'Bar' }));
+
+        expect(registry.get('foo')).toEqual({ name: 'Foo' });
+        expect(registry.get('bar')).toEqual({ name: 'Bar' });
+    });
+
+    it('returns cached instance', () => {
+        const registry = new Registry();
+
+        registry.register('foo', () => ({ name: 'Foo' }));
+
+        expect(registry.get('foo')).toBe(registry.get('foo'));
+    });
+
+    it('throws error if not able to return instance', () => {
+        const registry = new Registry();
+
+        expect(() => registry.get('foo')).toThrow(InvalidArgumentError);
+    });
+
+    it('throws error if already registered', () => {
+        const registry = new Registry();
+
+        registry.register('foo', () => ({ name: 'Foo' }));
+
+        expect(() => registry.register('foo', () => ({ name: 'Foo' }))).toThrow(InvalidArgumentError);
+    });
+});

--- a/src/core/common/registry/registry.ts
+++ b/src/core/common/registry/registry.ts
@@ -1,0 +1,35 @@
+import { InvalidArgumentError } from '../error/errors';
+
+export default class Registry<T> {
+    private _factories: { [key: string]: Factory<T> };
+    private _instances: { [key: string]: T };
+
+    constructor() {
+        this._factories = {};
+        this._instances = {};
+    }
+
+    get(token: string): T {
+        if (!this._instances[token]) {
+            const factory = this._factories[token];
+
+            if (!factory) {
+                throw new InvalidArgumentError();
+            }
+
+            this._instances[token] = factory();
+        }
+
+        return this._instances[token];
+    }
+
+    register(token: string, factory: Factory<T>): void {
+        if (this._factories[token]) {
+            throw new InvalidArgumentError();
+        }
+
+        this._factories[token] = factory;
+    }
+}
+
+export type Factory<T> = () => T;


### PR DESCRIPTION
## What?
* Add `Registry` class, which can register factories and create instances using these factories.

## Why?
* It will be used as a base class for `PaymentStrategyRegistry` and `ShippingStrategyRegistry`

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
