### PR TITLE
CHECKOUT-2274: Enable `strictNullChecks`

### DIFF
--- a/src/data-store/combine-reducers.ts
+++ b/src/data-store/combine-reducers.ts
@@ -20,5 +20,5 @@ export default function combineReducers<TState, TAction extends Action>(
 }
 
 export type ReducerMap<TState, TAction extends Action> = {
-    [Key in keyof TState]: Reducer<TState[Key], TAction>;
+    [Key in keyof TState]: Reducer<TState[Key] | undefined, TAction>;
 };

--- a/src/data-store/data-store.ts
+++ b/src/data-store/data-store.ts
@@ -34,7 +34,7 @@ export default class DataStore<TState, TAction extends Action, TTransformedState
     constructor(
         reducer: Reducer<Partial<TState>, TAction>,
         initialState: Partial<TState> = {},
-        options?: DataStoreOptions<TState, TAction, TTransformedState>
+        options?: Partial<DataStoreOptions<TState, TAction, TTransformedState>>
     ) {
         this._reducer = reducer;
         this._options = {
@@ -191,9 +191,9 @@ export default class DataStore<TState, TAction extends Action, TTransformedState
 }
 
 export interface DataStoreOptions<TState, TAction, TTransformedState> {
-    shouldWarnMutation?: boolean;
-    actionTransformer?: (action: Observable<TAction>) => Observable<TAction>;
-    stateTransformer?: (state: Partial<TState>) => TTransformedState;
+    shouldWarnMutation: boolean;
+    actionTransformer: (action: Observable<TAction>) => Observable<TAction>;
+    stateTransformer: (state: Partial<TState>) => TTransformedState;
 }
 
 interface StateTuple<TState, TTransformedState> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,
-        "strictNullChecks": false,
+        "strictNullChecks": true,
         "stripInternal": true,
         "target": "es5"
     },


### PR DESCRIPTION
## What?
* Enable `strictNullChecks`.

## Why?
* Please see https://basarat.gitbooks.io/typescript/docs/options/strictNullChecks.html
* i.e.: With this option enabled, optional properties, such as `foobar?: string`, would require a null check (i.e.: returning `string | undefined` instead of `string`).

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
