### PR TITLE
CHECKOUT-2274: Run TypeScript compiler without emitting files when linting .ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "compile:watch": "yarn compile -- --watch",
     "lint": "yarn lint:js && yarn lint:ts",
     "lint:js": "eslint src --config eslintrc.json",
-    "lint:ts": "tslint src/**/*.ts --config tslint.json",
+    "lint:ts": "tslint src/**/*.ts --config tslint.json && tsc --noEmit",
     "prerelease": "git fetch --tags && yarn validate-dependencies && yarn validate-commits && yarn build",
     "release": "git add dist lib && standard-version -a",
     "test": "jest --config jest-config.js",


### PR DESCRIPTION
## What?
* Add `tsc --noEmit` in `lint:ts` task.

## Why?
* To ask TypeScript compiler to report errors when linting `.ts` files.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
