### PR TITLE
CHECKOUT-2647 Add Afterpay Payment strategy

### DIFF
--- a/src/core/create-checkout-service.js
+++ b/src/core/create-checkout-service.js
@@ -15,9 +15,7 @@ import { ShippingCountryActionCreator, ShippingOptionActionCreator } from './shi
 import createCheckoutClient from './create-checkout-client';
 import createCheckoutStore from './create-checkout-store';
 import createCustomerStrategyRegistry from './create-customer-strategy-registry';
-import createPlaceOrderService from './create-place-order-service';
 import createPaymentStrategyRegistry from './create-payment-strategy-registry';
-import createRemoteCheckoutService from './create-remote-checkout-service';
 import createShippingStrategyRegistry from './create-shipping-strategy-registry';
 
 /**
@@ -36,11 +34,7 @@ export default function createCheckoutService(options = {}) {
     return new CheckoutService(
         store,
         createCustomerStrategyRegistry(store, client),
-        createPaymentStrategyRegistry(
-            store,
-            createPlaceOrderService(store, client, paymentClient),
-            createRemoteCheckoutService(store, client)
-        ),
+        createPaymentStrategyRegistry(store, client, paymentClient),
         createShippingStrategyRegistry(store, client),
         new BillingAddressActionCreator(client),
         new CartActionCreator(client),

--- a/src/core/create-place-order-service.ts
+++ b/src/core/create-place-order-service.ts
@@ -1,15 +1,19 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
 import { CheckoutClient, CheckoutStore } from './checkout';
 import { PlaceOrderService, OrderActionCreator } from './order';
-import { PaymentActionCreator, PaymentRequestSender } from './payment';
+import { PaymentActionCreator, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender } from './payment';
 
 export default function createPlaceOrderService(
     store: CheckoutStore,
     client: CheckoutClient,
     paymentClient: any
 ): PlaceOrderService {
+    const requestSender = createRequestSender();
+
     return new PlaceOrderService(
         store,
         new OrderActionCreator(client),
-        new PaymentActionCreator(new PaymentRequestSender(paymentClient))
+        new PaymentActionCreator(new PaymentRequestSender(paymentClient)),
+        new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender))
     );
 }

--- a/src/core/payment/errors/index.js
+++ b/src/core/payment/errors/index.js
@@ -2,3 +2,4 @@ export { default as PaymentMethodUninitializedError } from './payment-method-uni
 export { default as PaymentMethodNotRegistrableError } from './payment-method-not-registrable-error';
 export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';
 export { default as PaymentMethodUnsupportedError } from './payment-method-unsupported-error';
+export { default as PaymentMethodMissingDataError } from './payment-method-missing-data-error';

--- a/src/core/payment/errors/payment-method-missing-data-error.js
+++ b/src/core/payment/errors/payment-method-missing-data-error.js
@@ -1,0 +1,13 @@
+import { StandardError } from '../../common/error/errors';
+
+export default class PaymentMethodMissingDataError extends StandardError {
+    /**
+     * @constructor
+     * @param {string} name
+     */
+    constructor(field) {
+        super(`Failed to proceed because payment method misses "${field}" data`);
+
+        this.type = 'payment_method_missing_data';
+    }
+}

--- a/src/core/payment/payment-methods.mock.js
+++ b/src/core/payment/payment-methods.mock.js
@@ -180,6 +180,31 @@ export function getBankDeposit() {
     };
 }
 
+export function getAfterpay() {
+    return {
+        id: 'PAY_BY_INSTALLMENT',
+        gateway: 'afterpay',
+        logoUrl: '',
+        method: 'multi-option',
+        supportedCards: [],
+        config: {
+            displayName: 'Pay over time',
+            cardCode: null,
+            helpText: null,
+            enablePaypal: null,
+            merchantId: '33133',
+            is3dsEnabled: null,
+            testMode: false,
+            isVisaCheckoutEnabled: null,
+        },
+        type: 'PAYMENT_TYPE_API',
+        nonce: null,
+        initializationData: null,
+        clientToken: null,
+        returnUrl: null,
+    };
+}
+
 export function getAmazonPay() {
     return {
         id: 'amazon',

--- a/src/core/payment/payment-strategy-registry.js
+++ b/src/core/payment/payment-strategy-registry.js
@@ -1,4 +1,4 @@
-import { compact, some } from 'lodash';
+import { some } from 'lodash';
 import { PaymentMethodNotRegistrableError, PaymentMethodUnsupportedError } from './errors';
 import * as paymentMethodTypes from './payment-method-types';
 
@@ -91,7 +91,7 @@ export default class PaymentStrategyRegistry {
      * @return {string}
      */
     _getKey(paymentMethod) {
-        return compact([paymentMethod.gateway, paymentMethod.id]).join('_');
+        return paymentMethod.gateway || paymentMethod.id;
     }
 
     /**

--- a/src/core/payment/strategies/afterpay-payment-strategy.spec.ts
+++ b/src/core/payment/strategies/afterpay-payment-strategy.spec.ts
@@ -1,0 +1,129 @@
+import { merge } from 'lodash';
+import { createClient as createPaymentClient } from 'bigpay-client';
+import AfterpayScriptLoader from '../../remote-checkout/methods/afterpay';
+import { CartActionCreator } from '../../cart';
+import { CheckoutStore } from '../../checkout';
+import { PlaceOrderService } from '../../order';
+import { RemoteCheckoutPaymentError, RemoteCheckoutSessionError } from '../../remote-checkout/errors';
+import { RemoteCheckoutService } from '../../remote-checkout';
+import { createScriptLoader } from '../../../script-loader';
+import { getAfterpay } from '../../payment/payment-methods.mock';
+import { getOrderRequestBody } from '../../order/orders.mock';
+import { getResponse } from '../../common/http-request/responses.mock';
+import AfterpayPaymentStrategy from './afterpay-payment-strategy';
+import CheckoutClient from '../../checkout/checkout-client';
+import PaymentMethod from '../payment-method';
+import createCheckoutClient from '../../create-checkout-client';
+import createCheckoutStore from '../../create-checkout-store';
+import createPlaceOrderService from '../../create-place-order-service';
+import createRemoteCheckoutService from '../../create-remote-checkout-service';
+import { OrderRequestBody, PlaceOrderService } from '../../order';
+
+describe('AfterpayPaymentStrategy', () => {
+    let client: CheckoutClient;
+    let scriptLoader: AfterpayScriptLoader;
+    let store: CheckoutStore;
+    let strategy: AfterpayPaymentStrategy;
+    let remoteCheckoutService: RemoteCheckoutService;
+    let paymentMethod: PaymentMethod;
+    let placeOrderService: PlaceOrderService;
+    let payload: OrderRequestBody;
+    let clientToken: string = 'foo';
+    let afterpaySdk = {
+        init: () => {},
+        display: () => {},
+    };
+
+    beforeEach(() => {
+        client = createCheckoutClient();
+        store = createCheckoutStore();
+        placeOrderService = createPlaceOrderService(store, client, createPaymentClient());
+        remoteCheckoutService = createRemoteCheckoutService(store, client);
+        paymentMethod = getAfterpay();
+        scriptLoader = new AfterpayScriptLoader(createScriptLoader());
+        strategy = new AfterpayPaymentStrategy(paymentMethod,
+            store,
+            placeOrderService,
+            remoteCheckoutService,
+            scriptLoader
+        );
+
+        jest.spyOn(placeOrderService, 'loadPaymentMethod').mockImplementation(() => {
+            return Promise.resolve({
+                checkout: {
+                    getPaymentMethod: () => {
+                        return { clientToken };
+                    },
+                },
+            });
+        });
+
+        jest.spyOn(placeOrderService, 'submitOrder').mockImplementation(() => {
+            return Promise.resolve();
+        });
+
+        jest.spyOn(placeOrderService, 'submitPayment').mockImplementation(() => {
+            return Promise.resolve();
+        });
+
+        jest.spyOn(scriptLoader, 'load').mockImplementation(() => {
+            return Promise.resolve(afterpaySdk);
+        });
+
+        jest.spyOn(afterpaySdk, 'init').mockImplementation(() => {});
+        jest.spyOn(afterpaySdk, 'display').mockImplementation(() => {});
+
+        jest.spyOn(remoteCheckoutService, 'initializePayment').mockImplementation(() => {
+            return Promise.resolve({});
+        });
+
+        payload = merge({}, getOrderRequestBody(), {
+            payment: {
+                name: paymentMethod.id,
+                gateway: paymentMethod.gateway,
+            },
+        });
+    });
+
+    describe('#initialize()', () => {
+        it('loads script when initializing strategy', async () => {
+            await strategy.initialize();
+            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod);
+        });
+    });
+
+    describe('#execute()', () => {
+        beforeEach(async () => {
+            await strategy.initialize();
+            strategy.execute(payload);
+
+            setTimeout(() => {
+                const event = document.createEvent('Event');
+                event.initEvent('unload', true, false);
+                document.body.dispatchEvent(event);
+            });
+        });
+
+        it('notifies store credit usage to remote checkout service', () => {
+            expect(afterpaySdk.init).toHaveBeenCalled();
+            expect(afterpaySdk.display).toHaveBeenCalledWith({ token: clientToken });
+        });
+
+        it('notifies displays the afterpay modal', () => {
+            expect(remoteCheckoutService.initializePayment).toHaveBeenCalledWith( paymentMethod.gateway, { useStoreCredit: false });
+        });
+    });
+
+    describe('#finalize()', () => {
+        const nonce = 'bar';
+
+        it('submits the order and the payment', async () => {
+            await strategy.finalize({ nonce });
+            expect(placeOrderService.submitOrder).toHaveBeenCalled();
+            expect(placeOrderService.submitPayment).toHaveBeenCalledWith({
+                name: paymentMethod.id,
+                paymentData: { nonce },
+            }, false, {});
+        });
+    });
+});

--- a/src/core/payment/strategies/afterpay-payment-strategy.ts
+++ b/src/core/payment/strategies/afterpay-payment-strategy.ts
@@ -1,0 +1,110 @@
+/// <reference path="../../remote-checkout/methods/afterpay/afterpay-sdk.d.ts" />
+
+import { omit } from 'lodash';
+import PaymentStrategy from './payment-strategy';
+import PaymentMethod from '../payment-method';
+import { RemoteCheckoutService } from '../../remote-checkout';
+import { ReadableDataStore } from '../../../data-store';
+import { CheckoutSelectors } from '../../checkout';
+import { OrderRequestBody, PlaceOrderService } from '../../order';
+import { PaymentMethodUninitializedError, PaymentMethodMissingDataError } from '../errors';
+import AfterpayScriptLoader from '../../remote-checkout/methods/afterpay';
+
+/** Class that provides utility methods for checking out using Afterpay SDK */
+export default class AfterpayPaymentStrategy extends PaymentStrategy {
+    private _afterpaySdk?: Afterpay.Sdk;
+
+    constructor(
+        paymentMethod: PaymentMethod,
+        store: ReadableDataStore<CheckoutSelectors>,
+        placeOrderService: PlaceOrderService,
+        private _remoteCheckoutService: RemoteCheckoutService,
+        private _afterpayScriptLoader: AfterpayScriptLoader
+    ) {
+        super(paymentMethod, store, placeOrderService);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    initialize(options: any): Promise<CheckoutSelectors> {
+        return this._afterpayScriptLoader.load(this._paymentMethod)
+            .then((afterpaySdk) => {
+                this._afterpaySdk = afterpaySdk;
+                return super.initialize(options);
+            });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    deinitialize(options: any): Promise<CheckoutSelectors> {
+        if (this._afterpaySdk) {
+            this._afterpaySdk = undefined;
+        }
+
+        return super.deinitialize(options);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    execute(payload: OrderRequestBody, options: any): Promise<any> {
+        const paymentId = payload.payment.gateway;
+        const useStoreCredit = !!payload.useStoreCredit;
+
+        if (!paymentId) {
+            throw new PaymentMethodMissingDataError('gateway');
+        }
+
+        return this._remoteCheckoutService.initializePayment(paymentId, { useStoreCredit })
+            .then(() => this._placeOrderService.loadPaymentMethod(paymentId))
+            .then((resp: any) => this._displayModal(resp.checkout.getPaymentMethod(paymentId).clientToken))
+            // Afterpay will handle the rest of the flow so return a promise that doesn't really resolve
+            .then(() => this._resolveBeforeUnload());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    finalize(options: any): Promise<CheckoutSelectors> {
+        const payload = {
+            payment: {
+                name: this._paymentMethod.id,
+                paymentData: { nonce: options.nonce },
+            },
+        };
+
+        return this._placeOrderService.submitOrder(omit(payload, 'payment'), true, options)
+            .then(() =>
+                this._placeOrderService.submitPayment(payload.payment, false, omit(options, 'nonce'))
+            );
+    }
+
+    /**
+     * Displays an Afterpay modal box.
+     * @param token the token returned by afterpay API
+     */
+    private _displayModal(token: string): void {
+        if (!this._afterpaySdk || !token) {
+            throw new PaymentMethodUninitializedError(this._paymentMethod.gateway!);
+        }
+
+        this._afterpaySdk.init();
+        this._afterpaySdk.display({ token });
+    }
+
+    /**
+     * Returns a promise that resolves when the window unloads.
+     */
+    private _resolveBeforeUnload(): Promise<void> {
+        return new Promise((resolve) => {
+            const handleUnload = () => {
+                window.removeEventListener('unload', handleUnload);
+                resolve();
+            };
+
+            window.addEventListener('unload', handleUnload);
+        });
+    }
+}

--- a/src/core/payment/strategies/index.js
+++ b/src/core/payment/strategies/index.js
@@ -1,3 +1,4 @@
+export { default as AfterpayPaymentStrategy } from './afterpay-payment-strategy';
 export { default as AmazonPayPaymentStrategy } from './amazon-pay-payment-strategy';
 export { default as CreditCardPaymentStrategy } from './credit-card-payment-strategy';
 export { default as LegacyPaymentStrategy } from './legacy-payment-strategy';

--- a/src/core/remote-checkout/methods/afterpay/afterpay-script-loader.spec.ts
+++ b/src/core/remote-checkout/methods/afterpay/afterpay-script-loader.spec.ts
@@ -1,0 +1,34 @@
+import { merge } from 'lodash';
+import { getAfterpay } from '../../../payment/payment-methods.mock';
+import AfterpayScriptLoader from './afterpay-script-loader';
+import ScriptLoader from '../../../../script-loader/script-loader';
+
+describe('AfterpayScriptLoader', () => {
+    const scriptLoader = new ScriptLoader(document);
+    const afterpayScriptLoader = new AfterpayScriptLoader(scriptLoader);
+
+    beforeEach(() => {
+        jest.spyOn(scriptLoader, 'loadScript')
+            .mockReturnValue(Promise.resolve(new Event('load')));
+    });
+
+    it('loads widget script', () => {
+        const method = getAfterpay();
+
+        afterpayScriptLoader.load(method);
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            '//www.secure-afterpay.com.au/afterpay-async.js'
+        );
+    });
+
+    it('loads sandbox widget script if in test mode', () => {
+        const method = merge({}, getAfterpay(), { config: { testMode: true } });
+
+        afterpayScriptLoader.load(method);
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            '//www-sandbox.secure-afterpay.com.au/afterpay-async.js'
+        );
+    });
+});

--- a/src/core/remote-checkout/methods/afterpay/afterpay-script-loader.ts
+++ b/src/core/remote-checkout/methods/afterpay/afterpay-script-loader.ts
@@ -1,0 +1,29 @@
+/// <reference path="./afterpay-sdk.d.ts" />
+
+import { PaymentMethod } from '../../../payment';
+import ScriptLoader from '../../../../script-loader/script-loader';
+
+const SCRIPT_PROD = '//www.secure-afterpay.com.au/afterpay-async.js';
+const SCRIPT_SANDBOX = '//www-sandbox.secure-afterpay.com.au/afterpay-async.js';
+
+/** Class responsible for loading the Afterpay SDK */
+export default class AfterpayScriptLoader {
+    /**
+     * @param _scriptLoader 
+     */
+    constructor(
+        private _scriptLoader: ScriptLoader
+    ) {}
+
+    /**
+     * Loads the appropriate Afterpay SDK depending on the payment method data.
+     * @param method the payment method data
+     */
+    load(method: PaymentMethod): Promise<Afterpay.Sdk> {
+        const testMode = method.config.testMode;
+        const scriptURI = testMode ? SCRIPT_SANDBOX : SCRIPT_PROD;
+
+        return this._scriptLoader.loadScript(scriptURI)
+            .then(() => (window as any).AfterPay as Afterpay.Sdk);
+    }
+}

--- a/src/core/remote-checkout/methods/afterpay/afterpay-sdk.d.ts
+++ b/src/core/remote-checkout/methods/afterpay/afterpay-sdk.d.ts
@@ -1,0 +1,10 @@
+declare namespace Afterpay {
+    interface DisplayOptions {
+        token: string;
+    }
+
+    interface Sdk {
+        init(): void;
+        display(token: DisplayOptions): void;
+    }
+}

--- a/src/core/remote-checkout/methods/afterpay/index.ts
+++ b/src/core/remote-checkout/methods/afterpay/index.ts
@@ -1,0 +1,9 @@
+import { createScriptLoader } from '../../../../script-loader';
+import AfterpayScriptLoader from './afterpay-script-loader';
+
+export default AfterpayScriptLoader;
+
+export function createAfterpayScriptLoader(): AfterpayScriptLoader {
+    const scriptLoader = createScriptLoader();
+    return new AfterpayScriptLoader(scriptLoader);
+}


### PR DESCRIPTION
## What?
as above

## Why?
move logic to SDK
Refer to https://github.com/bigcommerce-labs/ng-checkout/pull/736 for the ng-checkout counterpart

## Testing / Proof
- [x] manual testing
- [x] unit test

@bigcommerce/checkout @bigcommerce/payments
