### PR TITLE
CHECKOUT-2274: Add `AmazonPayPaymentStrategy`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#0.1.0",
     "@types/jest": "^21.1.10",
     "@types/lodash": "^4.14.92",
+    "@types/node": "^9.4.0",
     "bigpay-client": "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.10.0",
     "form-poster": "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1",
     "lodash": "^4.17.4",

--- a/src/core/payment/payment-methods.mock.js
+++ b/src/core/payment/payment-methods.mock.js
@@ -180,6 +180,33 @@ export function getBankDeposit() {
     };
 }
 
+export function getAmazonPay() {
+    return {
+        id: 'amazon',
+        gateway: null,
+        logoUrl: '',
+        method: 'widget',
+        supportedCards: [],
+        config: {
+            displayName: 'AmazonPay',
+            cardCode: null,
+            helpText: null,
+            enablePaypal: null,
+            merchantId: 'A3F5ZS4DL0H261',
+            is3dsEnabled: null,
+            testMode: false,
+            isVisaCheckoutEnabled: null,
+        },
+        type: 'PAYMENT_TYPE_API',
+        nonce: null,
+        initializationData: {
+            region: 'US',
+        },
+        clientToken: null,
+        returnUrl: null,
+    };
+}
+
 export function getPaymentMethod() {
     return getAuthorizenet();
 }

--- a/src/core/payment/strategies/amazon-pay-payment-strategy.spec.ts
+++ b/src/core/payment/strategies/amazon-pay-payment-strategy.spec.ts
@@ -1,0 +1,172 @@
+import { createClient as createPaymentClient } from 'bigpay-client';
+import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay';
+import { CartActionCreator } from '../../cart';
+import { CheckoutStore } from '../../checkout';
+import { PlaceOrderService } from '../../order';
+import { RemoteCheckoutPaymentError, RemoteCheckoutSessionError } from '../../remote-checkout/errors';
+import { RemoteCheckoutService } from '../../remote-checkout';
+import { createScriptLoader } from '../../../script-loader';
+import { getAmazonPay } from '../../payment/payment-methods.mock';
+import { getCart, getCartResponseBody } from '../../cart/carts.mock';
+import { getCheckoutMeta } from '../../checkout/checkout.mock';
+import { getResponse } from '../../common/http-request/responses.mock';
+import AmazonPayPaymentStrategy from './amazon-pay-payment-strategy';
+import CheckoutClient from '../../checkout/checkout-client';
+import PaymentMethod from '../payment-method';
+import createCheckoutClient from '../../create-checkout-client';
+import createCheckoutStore from '../../create-checkout-store';
+import createPlaceOrderService from '../../create-place-order-service';
+import createRemoteCheckoutService from '../../create-remote-checkout-service';
+
+describe('AmazonPayPaymentStrategy', () => {
+    let client: CheckoutClient;
+    let container: HTMLDivElement;
+    let scriptLoader: AmazonPayScriptLoader;
+    let store: CheckoutStore;
+    let strategy: AmazonPayPaymentStrategy;
+    let remoteCheckoutService: RemoteCheckoutService;
+    let paymentMethod: PaymentMethod;
+    let placeOrderService: PlaceOrderService;
+
+    class Wallet implements Widgets.Wallet {
+        constructor(public options: Widgets.WalletOptions) { }
+
+        bind(id: string) {
+            const element = document.getElementById(id);
+
+            element.addEventListener('paymentSelect', () => {
+                this.options.onPaymentSelect({
+                    getAmazonOrderReferenceId: () => getCheckoutMeta().remoteCheckout.amazon.referenceId,
+                });
+            });
+
+            element.addEventListener('error', (event: CustomEvent) => {
+                this.options.onError(Object.assign(new Error(), {
+                    getErrorCode: () => event.detail.code,
+                }));
+            });
+        }
+    }
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        client = createCheckoutClient();
+        store = createCheckoutStore();
+        placeOrderService = createPlaceOrderService(store, client, createPaymentClient());
+        remoteCheckoutService = createRemoteCheckoutService(store, client);
+        paymentMethod = getAmazonPay();
+        scriptLoader = new AmazonPayScriptLoader(createScriptLoader());
+        strategy = new AmazonPayPaymentStrategy(paymentMethod,
+            store,
+            placeOrderService,
+            remoteCheckoutService,
+            scriptLoader
+        );
+
+        container.setAttribute('id', 'wallet');
+        document.body.appendChild(container);
+
+        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation(() => {
+            (window as any).Widgets = { Wallet };
+
+            return Promise.resolve();
+        });
+
+        jest.spyOn(client, 'loadCart')
+            .mockReturnValue(Promise.resolve(getResponse(getCartResponseBody())));
+
+        jest.spyOn(remoteCheckoutService, 'initializePayment')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(remoteCheckoutService, 'synchronizeBillingAddress')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        remoteCheckoutService.setCheckoutMeta('amazon', getCheckoutMeta().remoteCheckout.amazon);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('loads widget script', async () => {
+        await strategy.initialize({
+            container: 'wallet',
+            paymentMethod,
+        });
+
+        expect(scriptLoader.loadWidget).toHaveBeenCalledWith(paymentMethod);
+    });
+
+    it('initializes payment when selecting new payment method', async () => {
+        await strategy.initialize({
+            container: 'wallet',
+            paymentMethod,
+        });
+
+        document.getElementById('wallet').dispatchEvent(new CustomEvent('paymentSelect'));
+
+        expect(remoteCheckoutService.initializePayment)
+            .toHaveBeenCalledWith(paymentMethod.id, getCheckoutMeta().remoteCheckout.amazon);
+    });
+
+    it('synchronizes address when selecting new payment method', async () => {
+        await strategy.initialize({
+            container: 'wallet',
+            paymentMethod,
+        });
+
+        document.getElementById('wallet').dispatchEvent(new CustomEvent('paymentSelect'));
+
+        await new Promise((resolve) => process.nextTick(resolve));
+
+        expect(remoteCheckoutService.initializePayment).toHaveBeenCalled();
+
+        expect(remoteCheckoutService.synchronizeBillingAddress)
+            .toHaveBeenCalledWith(paymentMethod.id, getCheckoutMeta().remoteCheckout.amazon);
+    });
+
+    it('passes error to callback when wallet widget encounters error', async () => {
+        const onError = jest.fn();
+
+        await strategy.initialize({
+            container: 'wallet',
+            onError,
+            paymentMethod,
+        });
+
+        const element = document.getElementById('wallet');
+
+        element.dispatchEvent(new CustomEvent('error', { detail: { code: 'BuyerSessionExpired' } }));
+        expect(onError).toHaveBeenCalledWith(expect.any(RemoteCheckoutSessionError));
+
+        element.dispatchEvent(new CustomEvent('error', { detail: { code: 'PeriodicAmountExceeded' } }));
+        expect(onError).toHaveBeenCalledWith(expect.any(RemoteCheckoutPaymentError));
+    });
+
+    it('reinitializes payment method when cart total changes', async () => {
+        await strategy.initialize({
+            container: 'wallet',
+            paymentMethod,
+        });
+
+        await store.dispatch(new CartActionCreator(client).loadCart());
+
+        expect(remoteCheckoutService.initializePayment)
+            .toHaveBeenCalledWith(paymentMethod.id, getCheckoutMeta().remoteCheckout.amazon);
+
+        expect(remoteCheckoutService.initializePayment).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not reinitialize payment method if cart total remains the same', async () => {
+        await store.dispatch(new CartActionCreator(client).loadCart());
+
+        await strategy.initialize({
+            container: 'wallet',
+            paymentMethod,
+        });
+
+        await store.dispatch(new CartActionCreator(client).loadCart());
+
+        expect(remoteCheckoutService.initializePayment).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/core/payment/strategies/amazon-pay-payment-strategy.ts
+++ b/src/core/payment/strategies/amazon-pay-payment-strategy.ts
@@ -1,0 +1,127 @@
+/// <reference path="../../remote-checkout/methods/amazon-pay/amazon-pay-widgets.d.ts" />
+
+import { noop, omit } from 'lodash';
+import { Address } from '../../address';
+import { OrderRequestBody } from '../../order';
+import { RemoteCheckoutPaymentError, RemoteCheckoutSessionError } from '../../remote-checkout/errors';
+import Payment from '../payment';
+import PaymentStrategy from './payment-strategy';
+import PaymentMethod from '../payment-method';
+import ReadableDataStore from '../../../data-store/readable-data-store';
+import CheckoutSelectors from '../../checkout/checkout-selectors';
+import AmazonPayScriptLoader from '../../remote-checkout/methods/amazon-pay/amazon-pay-script-loader';
+
+export default class AmazonPayPaymentStrategy extends PaymentStrategy {
+    private _unsubscribe: (() => void) | undefined;
+    private _wallet: Widgets.Wallet | undefined;
+
+    constructor(
+        paymentMethod: PaymentMethod,
+        store: ReadableDataStore<CheckoutSelectors>,
+        placeOrderService: any,
+        private _remoteCheckoutService: any,
+        private _scriptLoader: AmazonPayScriptLoader
+    ) {
+        super(paymentMethod, store, placeOrderService);
+    }
+
+    initialize(options: any): Promise<CheckoutSelectors> {
+        return this._scriptLoader.loadWidget(this._paymentMethod)
+            .then(() => {
+                this._wallet = this._createWallet(options);
+
+                this._unsubscribe = this._store.subscribe(
+                    this._handleGrandTotalChange.bind(this),
+                    ({ checkout }) => checkout.getCart() && checkout.getCart().grandTotal
+                );
+
+                return super.initialize(options);
+            });
+    }
+
+    deinitialize(options: any): Promise<CheckoutSelectors> {
+        if (this._unsubscribe) {
+            this._unsubscribe();
+        }
+
+        this._wallet = undefined;
+
+        return super.deinitialize(options);
+    }
+
+    execute(payload: OrderRequestBody, options: any): Promise<CheckoutSelectors> {
+        const { id } = this._paymentMethod;
+        const { checkout } = this._store.getState();
+        const { remoteCheckout: { amazon: { referenceId } } } = checkout.getCheckoutMeta();
+
+        return this._remoteCheckoutService.initializePayment(id, { referenceId })
+            .then(() => this._placeOrderService.submitOrder({
+                ...payload,
+                payment: omit(payload.payment, 'paymentData'),
+            }, options));
+    }
+
+    private _createWallet(options: InitializeWidgetOptions): Widgets.Wallet {
+        const { container, onError = noop, onPaymentSelect = noop } = options;
+        const { merchantId } = this._paymentMethod.config;
+
+        const widget = new Widgets.Wallet({
+            design: { designMode: 'responsive' },
+            scope: 'payments:billing_address payments:shipping_address payments:widget profile',
+            sellerId: merchantId!,
+            onError: (error) => {
+                this._handleError(error, onError);
+            },
+            onPaymentSelect: (orderReference) => {
+                this._handlePaymentSelect(orderReference, onPaymentSelect);
+            },
+        });
+
+        widget.bind(container);
+
+        return widget;
+    }
+
+    private _handlePaymentSelect(orderReference: Widgets.OrderReference, callback: (address: Address) => void): void {
+        const { id } = this._paymentMethod;
+        const { checkout } = this._store.getState();
+        const { remoteCheckout: { amazon: { referenceId } } } = checkout.getCheckoutMeta();
+
+        callback(checkout.getBillingAddress());
+
+        this._remoteCheckoutService.initializePayment(id, { referenceId })
+            .then(() => this._remoteCheckoutService.synchronizeBillingAddress(id, { referenceId }))
+            .then(({ checkout }: CheckoutSelectors) => callback(checkout.getBillingAddress()));
+    }
+
+    private _handleGrandTotalChange({ checkout }: CheckoutSelectors): void {
+        const { id } = this._paymentMethod;
+        const { remoteCheckout } = checkout.getCheckoutMeta();
+
+        if (!remoteCheckout || !remoteCheckout.amazon || !remoteCheckout.amazon.referenceId) {
+            return;
+        }
+
+        this._remoteCheckoutService.initializePayment(id, {
+            referenceId: remoteCheckout.amazon.referenceId,
+        });
+    }
+
+    private _handleError(error: Widgets.WidgetError, callback: (error: Error) => void): void {
+        if (!error) {
+            return;
+        }
+
+        if (error.getErrorCode() === 'BuyerSessionExpired') {
+            callback(new RemoteCheckoutSessionError(error));
+        } else {
+            callback(new RemoteCheckoutPaymentError(error));
+        }
+    }
+}
+
+export interface InitializeWidgetOptions {
+    container: string;
+    onPaymentSelect?: (address: Address) => void;
+    onError?: (error: Error) => void;
+}

--- a/src/core/payment/strategies/index.js
+++ b/src/core/payment/strategies/index.js
@@ -1,3 +1,4 @@
+export { default as AmazonPayPaymentStrategy } from './amazon-pay-payment-strategy';
 export { default as CreditCardPaymentStrategy } from './credit-card-payment-strategy';
 export { default as LegacyPaymentStrategy } from './legacy-payment-strategy';
 export { default as OfflinePaymentStrategy } from './offline-payment-strategy';

--- a/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.spec.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.spec.ts
@@ -1,0 +1,44 @@
+import { merge } from 'lodash';
+import { getAmazonPay } from '../../../payment/payment-methods.mock';
+import AmazonPayScriptLoader from './amazon-pay-script-loader';
+import ScriptLoader from '../../../../script-loader/script-loader';
+
+describe('AmazonPayScriptLoader', () => {
+    const scriptLoader = new ScriptLoader(document);
+    const amazonPayScriptLoader = new AmazonPayScriptLoader(scriptLoader);
+
+    beforeEach(() => {
+        jest.spyOn(scriptLoader, 'loadScript')
+            .mockReturnValue(Promise.resolve(new Event('load')));
+    });
+
+    it('loads widget script', () => {
+        const method = getAmazonPay();
+
+        amazonPayScriptLoader.loadWidget(method);
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            `https://static-na.payments-amazon.com/OffAmazonPayments/us/Widgets.js?sellerId=${method.config.merchantId}`
+        );
+    });
+
+    it('loads widget script for different region', () => {
+        const method = merge({}, getAmazonPay(), { initializationData: { region: 'EU' } });
+
+        amazonPayScriptLoader.loadWidget(method);
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            `https://static-na.payments-amazon.com/OffAmazonPayments/eu/Widgets.js?sellerId=${method.config.merchantId}`
+        );
+    });
+
+    it('loads sandbox widget script if in test mode', () => {
+        const method = merge({}, getAmazonPay(), { config: { testMode: true } });
+
+        amazonPayScriptLoader.loadWidget(method);
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            `https://static-na.payments-amazon.com/OffAmazonPayments/us/sandbox/Widgets.js?sellerId=${method.config.merchantId}`
+        );
+    });
+});

--- a/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
@@ -1,0 +1,22 @@
+import { PaymentMethod } from '../../../payment';
+import ScriptLoader from '../../../../script-loader/script-loader';
+
+export default class AmazonPayScriptLoader {
+    constructor(
+        private _scriptLoader: ScriptLoader
+    ) {}
+
+    loadWidget(method: PaymentMethod): Promise<Event> {
+        const {
+            config: { merchantId, testMode },
+            initializationData: { region = 'us' } = {},
+        } = method;
+
+        const url = 'https://static-na.payments-amazon.com/OffAmazonPayments/' +
+            `${region.toLowerCase()}/` +
+            `${testMode ? 'sandbox/' : ''}` +
+            `Widgets.js?sellerId=${merchantId}`;
+
+        return this._scriptLoader.loadScript(url);
+    }
+}

--- a/src/core/remote-checkout/methods/amazon-pay/amazon-pay-widgets.d.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/amazon-pay-widgets.d.ts
@@ -1,0 +1,44 @@
+declare namespace Widgets {
+    class AddressBook {
+        constructor(options: AddressBookOptions);
+        bind(container: string): void;
+    }
+
+    class Wallet {
+        constructor(options: WalletOptions);
+        bind(container: string): void;
+    }
+
+    interface AddressBookOptions {
+        scope: string;
+        sellerId: string;
+        design: {
+            designMode: string;
+        };
+        onAddressSelect: (billingAgreement: BillingAgreement) => void;
+        onError: (error: WidgetError) => void;
+        onOrderReferenceCreate: (orderReference: OrderReference) => void;
+    }
+
+    interface WalletOptions {
+        scope: string;
+        sellerId: string;
+        design: {
+            designMode: string;
+        };
+        onError: (error: WidgetError) => void;
+        onPaymentSelect: (orderReference: OrderReference) => void;
+    }
+
+    interface BillingAgreement {
+        getAmazonBillingAgreementId(): string;
+    }
+
+    interface OrderReference {
+        getAmazonOrderReferenceId(): string;
+    }
+
+    interface WidgetError extends Error {
+        getErrorCode(): string;
+    }
+}

--- a/src/core/remote-checkout/methods/amazon-pay/index.js
+++ b/src/core/remote-checkout/methods/amazon-pay/index.js
@@ -1,0 +1,1 @@
+export { default as AmazonPayScriptLoader } from './amazon-pay-script-loader';

--- a/src/core/remote-checkout/remote-checkout-service.js
+++ b/src/core/remote-checkout/remote-checkout-service.js
@@ -107,7 +107,7 @@ export default class RemoteCheckoutService {
 
     /**
      * @param {string} methodId
-     * @param {string} meta
+     * @param {any} meta
      * @return {Promise<CheckoutSelectors>}
      */
     setCheckoutMeta(methodId, meta) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,10 @@
   version "4.14.92"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.92.tgz#6e3cb0b71a1e12180a47a42a744e856c3ae99a57"
 
+"@types/node@^9.4.0":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.0.tgz#b85a0bcf1e1cc84eb4901b7e96966aedc6f078d1"
+
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"


### PR DESCRIPTION
## What?
* Add `AmazonPayPaymentStrategy`, which does the following
  * Load Amazon Widgets script and initialise wallet widget
  * Synchronise billing information when changing payment detail
  * Reinitialise payment method when the cart total changes

## Why?
* This is required to support Amazon Pay.
* Please note that this strategy is not registered yet, therefore it's not active.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
