### PR TITLE
CHECKOUT-2274: Fix AmazonPay widget script path

### DIFF
--- a/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.spec.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.spec.ts
@@ -18,7 +18,7 @@ describe('AmazonPayScriptLoader', () => {
         amazonPayScriptLoader.loadWidget(method);
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            `https://static-na.payments-amazon.com/OffAmazonPayments/us/Widgets.js?sellerId=${method.config.merchantId}`
+            `https://static-na.payments-amazon.com/OffAmazonPayments/us/js/Widgets.js?sellerId=${method.config.merchantId}`
         );
     });
 
@@ -28,7 +28,7 @@ describe('AmazonPayScriptLoader', () => {
         amazonPayScriptLoader.loadWidget(method);
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            `https://static-na.payments-amazon.com/OffAmazonPayments/eu/Widgets.js?sellerId=${method.config.merchantId}`
+            `https://static-na.payments-amazon.com/OffAmazonPayments/eu/lpa/js/Widgets.js?sellerId=${method.config.merchantId}`
         );
     });
 
@@ -38,7 +38,7 @@ describe('AmazonPayScriptLoader', () => {
         amazonPayScriptLoader.loadWidget(method);
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            `https://static-na.payments-amazon.com/OffAmazonPayments/us/sandbox/Widgets.js?sellerId=${method.config.merchantId}`
+            `https://static-na.payments-amazon.com/OffAmazonPayments/us/sandbox/js/Widgets.js?sellerId=${method.config.merchantId}`
         );
     });
 });

--- a/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
@@ -14,8 +14,9 @@ export default class AmazonPayScriptLoader {
 
         const url = 'https://static-na.payments-amazon.com/OffAmazonPayments/' +
             `${region.toLowerCase()}/` +
-            `${testMode ? 'sandbox/' : ''}` +
-            `Widgets.js?sellerId=${merchantId}`;
+            (testMode ? 'sandbox/' : '') +
+            (region.toLowerCase() !== 'us' ? 'lpa/' : '') +
+            `js/Widgets.js?sellerId=${merchantId}`;
 
         return this._scriptLoader.loadScript(url);
     }


### PR DESCRIPTION
## What?
* Fix Amazon widget script path.

## Why?
* It's currently missing `/js/` directory.
* Also, add `/lpa/` directory to non-US regions.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
