### PR TITLE
CHECKOUT-2274: Properly handle `/remote-checkout` responses

### DIFF
--- a/src/core/remote-checkout/remote-checkout-action-creator.js
+++ b/src/core/remote-checkout/remote-checkout-action-creator.js
@@ -23,8 +23,8 @@ export default class RemoteCheckoutActionCreator {
             observer.next(createAction(actionTypes.INITIALIZE_REMOTE_BILLING_REQUESTED));
 
             this._remoteCheckoutRequestSender.initializeBilling(methodName, params, options)
-                .then(({ body: { data } = {} }) => {
-                    observer.next(createAction(actionTypes.INITIALIZE_REMOTE_BILLING_SUCCEEDED, data));
+                .then(({ body = {} }) => {
+                    observer.next(createAction(actionTypes.INITIALIZE_REMOTE_BILLING_SUCCEEDED, body));
                     observer.complete();
                 })
                 .catch(response => {
@@ -45,8 +45,8 @@ export default class RemoteCheckoutActionCreator {
             observer.next(createAction(actionTypes.INITIALIZE_REMOTE_SHIPPING_REQUESTED));
 
             this._remoteCheckoutRequestSender.initializeShipping(methodName, params, options)
-                .then(({ body: { data } = {} }) => {
-                    observer.next(createAction(actionTypes.INITIALIZE_REMOTE_SHIPPING_SUCCEEDED, data));
+                .then(({ body = {} }) => {
+                    observer.next(createAction(actionTypes.INITIALIZE_REMOTE_SHIPPING_SUCCEEDED, body));
                     observer.complete();
                 })
                 .catch(response => {
@@ -69,8 +69,8 @@ export default class RemoteCheckoutActionCreator {
             observer.next(createAction(actionTypes.INITIALIZE_REMOTE_PAYMENT_REQUESTED));
 
             this._remoteCheckoutRequestSender.initializePayment(methodName, params, options)
-                .then(({ body: { data } = {} }) => {
-                    observer.next(createAction(actionTypes.INITIALIZE_REMOTE_PAYMENT_SUCCEEDED, data));
+                .then(({ body = {} }) => {
+                    observer.next(createAction(actionTypes.INITIALIZE_REMOTE_PAYMENT_SUCCEEDED, body));
                     observer.complete();
                 })
                 .catch(response => {

--- a/src/core/remote-checkout/remote-checkout-action-creator.spec.js
+++ b/src/core/remote-checkout/remote-checkout-action-creator.spec.js
@@ -31,7 +31,7 @@ describe('RemoteCheckoutActionCreator', () => {
         expect(requestSender.initializeBilling).toHaveBeenCalledWith('amazon', params, options);
         expect(actions).toEqual([
             { type: actionTypes.INITIALIZE_REMOTE_BILLING_REQUESTED },
-            { type: actionTypes.INITIALIZE_REMOTE_BILLING_SUCCEEDED, payload: response.body.data },
+            { type: actionTypes.INITIALIZE_REMOTE_BILLING_SUCCEEDED, payload: response.body },
         ]);
     });
 
@@ -71,7 +71,7 @@ describe('RemoteCheckoutActionCreator', () => {
         expect(requestSender.initializeShipping).toHaveBeenCalledWith('amazon', params, options);
         expect(actions).toEqual([
             { type: actionTypes.INITIALIZE_REMOTE_SHIPPING_REQUESTED },
-            { type: actionTypes.INITIALIZE_REMOTE_SHIPPING_SUCCEEDED, payload: response.body.data },
+            { type: actionTypes.INITIALIZE_REMOTE_SHIPPING_SUCCEEDED, payload: response.body },
         ]);
     });
 
@@ -111,7 +111,7 @@ describe('RemoteCheckoutActionCreator', () => {
         expect(requestSender.initializePayment).toHaveBeenCalledWith('amazon', params, options);
         expect(actions).toEqual([
             { type: actionTypes.INITIALIZE_REMOTE_PAYMENT_REQUESTED },
-            { type: actionTypes.INITIALIZE_REMOTE_PAYMENT_SUCCEEDED, payload: response.body.data },
+            { type: actionTypes.INITIALIZE_REMOTE_PAYMENT_SUCCEEDED, payload: response.body },
         ]);
     });
 

--- a/src/core/remote-checkout/remote-checkout-reducer.spec.js
+++ b/src/core/remote-checkout/remote-checkout-reducer.spec.js
@@ -8,13 +8,13 @@ describe('remoteCheckoutReducer', () => {
         const response = getResponse(getRemoteBillingResponseBody());
         const action = {
             type: actionTypes.INITIALIZE_REMOTE_BILLING_SUCCEEDED,
-            payload: response.body.data,
+            payload: response.body,
         };
 
         expect(remoteCheckoutReducer({}, action))
             .toEqual(expect.objectContaining({
                 data: {
-                    billingAddress: response.body.data.address,
+                    billingAddress: response.body.address,
                 },
                 errors: {
                     initializeBillingError: undefined,
@@ -62,13 +62,13 @@ describe('remoteCheckoutReducer', () => {
         const response = getResponse(getRemoteShippingResponseBody());
         const action = {
             type: actionTypes.INITIALIZE_REMOTE_SHIPPING_SUCCEEDED,
-            payload: response.body.data,
+            payload: response.body,
         };
 
         expect(remoteCheckoutReducer({}, action))
             .toEqual(expect.objectContaining({
                 data: {
-                    shippingAddress: response.body.data.address,
+                    shippingAddress: response.body.address,
                 },
                 errors: {
                     initializeShippingError: undefined,
@@ -116,13 +116,13 @@ describe('remoteCheckoutReducer', () => {
         const response = getResponse(getRemotePaymentResponseBody());
         const action = {
             type: actionTypes.INITIALIZE_REMOTE_PAYMENT_SUCCEEDED,
-            payload: response.body.data,
+            payload: response.body,
         };
 
         expect(remoteCheckoutReducer({}, action))
             .toEqual(expect.objectContaining({
                 data: {
-                    isPaymentInitialized: response.body.data.payment,
+                    isPaymentInitialized: response.body.payment,
                 },
                 errors: {
                     initializePaymentError: undefined,

--- a/src/core/remote-checkout/remote-checkout.mock.ts
+++ b/src/core/remote-checkout/remote-checkout.mock.ts
@@ -34,27 +34,18 @@ export function getRemoteCheckoutMeta(): RemoteCheckoutMeta {
 
 export function getRemoteBillingResponseBody(): any {
     return {
-        data: {
-            address: getBillingAddress(),
-        },
-        meta: {},
+        address: getBillingAddress(),
     };
 }
 
 export function getRemoteShippingResponseBody(): any {
     return {
-        data: {
-            address: getShippingAddress(),
-        },
-        meta: {},
+        address: getShippingAddress(),
     };
 }
 
 export function getRemotePaymentResponseBody(): any {
     return {
-        data: {
-            payment: true,
-        },
-        meta: {},
+        payment: true,
     };
 }


### PR DESCRIPTION
## What?
* Properly handle `/remote-checkout` responses.

## Why?
* `/remote-checkout` endpoints don't use the standard transformers we use for other internal API endpoints. In other words, they don't have the `meta/data` data containers.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
