### PR TITLE
CHECKOUT-2274: Refresh AmazonPay wallet

### DIFF
--- a/src/core/payment/payment.ts
+++ b/src/core/payment/payment.ts
@@ -1,6 +1,6 @@
 export default interface Payment {
     name: string;
-    paymentData: CreditCard | TokenizedCreditCard;
+    paymentData?: CreditCard | TokenizedCreditCard;
     gateway?: string;
     source?: string;
 }

--- a/src/core/payment/payments.mock.js
+++ b/src/core/payment/payments.mock.js
@@ -18,7 +18,7 @@ export function getPayment() {
             ccName: 'BigCommerce',
             ccNumber: '4111111111111111',
             ccType: 'visa',
-            ccCvv: '123',
+            ccCvv: 123,
         },
     };
 }


### PR DESCRIPTION
## What?
* Refresh Amazon wallet widget after receiving `provider_widget` error.

## Why?
* It's a solution recommended by Amazon (https://pay.amazon.com/us/developer/documentation/lpwa/201953730).

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
