### PR TITLE
CHECKOUT-2896: Upgrade TypeScript to 2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ts-jest": "^21.2.3",
     "ts-loader": "^3.2.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.6.2",
+    "typescript": "^2.7.1",
     "typescript-eslint-parser": "^9.0.1",
     "uglifyjs-webpack-plugin": "^1.1.1",
     "validate-commits": "git+ssh://git@github.com/bigcommerce-labs/validate-commits.git#1.1.0",

--- a/src/core/customer/strategies/customer-strategy.ts
+++ b/src/core/customer/strategies/customer-strategy.ts
@@ -4,7 +4,7 @@ import CustomerCredentials from '../customer-credentials';
 import SignInCustomerService from '../sign-in-customer-service';
 
 export default abstract class CustomerStrategy {
-    protected _isInitialized: boolean;
+    protected _isInitialized = false;
 
     constructor(
         protected _store: ReadableDataStore<CheckoutSelectors>,

--- a/src/core/shipping/strategies/shipping-strategy.ts
+++ b/src/core/shipping/strategies/shipping-strategy.ts
@@ -4,7 +4,7 @@ import { ReadableDataStore } from '../../../data-store';
 import UpdateShippingService from '../update-shipping-service';
 
 export default abstract class ShippingStrategy {
-    protected _isInitialized: boolean;
+    protected _isInitialized = false;
 
     constructor(
         protected _store: ReadableDataStore<CheckoutSelectors>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4533,9 +4533,9 @@ typescript-eslint-parser@^9.0.1:
     lodash.unescape "4.0.1"
     semver "5.4.1"
 
-typescript@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 uglify-es@^3.1.3:
   version "3.2.0"


### PR DESCRIPTION
## What?
* Upgrade TypeScript to `2.7.1`.

## Why?
* Better `strict` mode. i.e.: The compiler now throws an error if there are uninitialised properties.
* Plus other features. Please see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
