### PR TITLE
CHECKOUT-2274: Add type definition for AmazonPay event hooks

### DIFF
--- a/src/core/customer/strategies/amazon-pay-customer-strategy.spec.ts
+++ b/src/core/customer/strategies/amazon-pay-customer-strategy.spec.ts
@@ -1,3 +1,6 @@
+/// <reference path="../../remote-checkout/methods/amazon-pay/amazon-login.d.ts" />
+/// <reference path="../../remote-checkout/methods/amazon-pay/off-amazon-payments.d.ts" />
+
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay';
 import { CheckoutStore } from '../../checkout';
@@ -17,6 +20,7 @@ describe('AmazonPayCustomerStrategy', () => {
     let authorizeSpy: jest.Mock;
     let buttonConstructorSpy: jest.Mock;
     let container: HTMLDivElement;
+    let hostWindow: OffAmazonPayments.HostWindow & amazon.HostWindow;
     let paymentMethod: PaymentMethod;
     let requestSender: RemoteCheckoutRequestSender;
     let scriptLoader: AmazonPayScriptLoader;
@@ -51,6 +55,7 @@ describe('AmazonPayCustomerStrategy', () => {
         authorizeSpy = jest.fn();
         buttonConstructorSpy = jest.fn();
         container = document.createElement('div');
+        hostWindow = window;
         paymentMethod = getAmazonPay();
         requestSender = new RemoteCheckoutRequestSender(createRequestSender());
         store = createCheckoutStore();
@@ -62,9 +67,9 @@ describe('AmazonPayCustomerStrategy', () => {
         document.body.appendChild(container);
 
         jest.spyOn(scriptLoader, 'loadWidget').mockImplementation(() => {
-            (window as any).OffAmazonPayments = { Button };
-            (window as any).amazon = { Login };
-            (window as any).onAmazonPaymentsReady();
+            hostWindow.OffAmazonPayments = { Button };
+            hostWindow.amazon = { Login };
+            hostWindow.onAmazonPaymentsReady();
 
             return Promise.resolve();
         });

--- a/src/core/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/core/customer/strategies/amazon-pay-customer-strategy.ts
@@ -14,6 +14,7 @@ import SignInCustomerService from '../sign-in-customer-service';
 export default class AmazonPayCustomerStrategy extends CustomerStrategy {
     private _paymentMethod: PaymentMethod | undefined;
     private _signInButton: OffAmazonPayments.Button | undefined;
+    private _window: OffAmazonPayments.HostWindow;
 
     constructor(
         store: ReadableDataStore<CheckoutSelectors>,
@@ -22,6 +23,8 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
         private _scriptLoader: AmazonPayScriptLoader
     ) {
         super(store, signInCustomerService);
+
+        this._window = window;
     }
 
     initialize(options: InitializeOptions): Promise<CheckoutSelectors> {
@@ -31,7 +34,7 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
 
         this._paymentMethod = options.paymentMethod;
 
-        (window as any).onAmazonPaymentsReady = () => {
+        this._window.onAmazonPaymentsReady = () => {
             this._signInButton = this._createSignInButton(options);
         };
 

--- a/src/core/payment/strategies/amazon-pay-payment-strategy.spec.ts
+++ b/src/core/payment/strategies/amazon-pay-payment-strategy.spec.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../remote-checkout/methods/amazon-pay/off-amazon-payments.d.ts" />
+
 import { omit } from 'lodash';
 import { createClient as createPaymentClient } from 'bigpay-client';
 import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay';
@@ -23,6 +25,7 @@ import createRemoteCheckoutService from '../../create-remote-checkout-service';
 describe('AmazonPayPaymentStrategy', () => {
     let client: CheckoutClient;
     let container: HTMLDivElement;
+    let hostWindow: OffAmazonPayments.HostWindow;
     let scriptLoader: AmazonPayScriptLoader;
     let store: CheckoutStore;
     let strategy: AmazonPayPaymentStrategy;
@@ -68,13 +71,14 @@ describe('AmazonPayPaymentStrategy', () => {
             scriptLoader
         );
         walletSpy = jest.fn();
+        hostWindow = window;
 
         container.setAttribute('id', 'wallet');
         document.body.appendChild(container);
 
         jest.spyOn(scriptLoader, 'loadWidget').mockImplementation(() => {
-            (window as any).OffAmazonPayments = { Widgets: { Wallet } };
-            (window as any).onAmazonPaymentsReady();
+            hostWindow.OffAmazonPayments = { Widgets: { Wallet } };
+            hostWindow.onAmazonPaymentsReady();
 
             return Promise.resolve();
         });

--- a/src/core/payment/strategies/amazon-pay-payment-strategy.ts
+++ b/src/core/payment/strategies/amazon-pay-payment-strategy.ts
@@ -16,6 +16,7 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
     private _unsubscribe: (() => void) | undefined;
     private _wallet: OffAmazonPayments.Widgets.Wallet | undefined;
     private _walletOptions: InitializeWidgetOptions | undefined;
+    private _window: OffAmazonPayments.HostWindow;
 
     constructor(
         paymentMethod: PaymentMethod,
@@ -25,12 +26,14 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
         private _scriptLoader: AmazonPayScriptLoader
     ) {
         super(paymentMethod, store, placeOrderService);
+
+        this._window = window;
     }
 
     initialize(options: InitializeWidgetOptions): Promise<CheckoutSelectors> {
         this._walletOptions = options;
 
-        (window as any).onAmazonPaymentsReady = () => {
+        this._window.onAmazonPaymentsReady = () => {
             this._wallet = this._createWallet(options);
         };
 

--- a/src/core/remote-checkout/methods/amazon-pay/amazon-login.d.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/amazon-login.d.ts
@@ -10,4 +10,9 @@ declare namespace amazon {
         scope: string;
         state: string;
     }
+
+    interface HostWindow extends Window {
+        amazon?: amazon;
+        onAmazonLoginReady?: () => void;
+    }
 }

--- a/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.spec.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.spec.ts
@@ -1,3 +1,5 @@
+/// <reference path="./amazon-login.d.ts" />
+
 import { merge } from 'lodash';
 import { getAmazonPay } from '../../../payment/payment-methods.mock';
 import AmazonPayScriptLoader from './amazon-pay-script-loader';
@@ -5,6 +7,7 @@ import ScriptLoader from '../../../../script-loader/script-loader';
 
 describe('AmazonPayScriptLoader', () => {
     let amazonPayScriptLoader: AmazonPayScriptLoader;
+    let hostWindow: amazon.HostWindow;
     let scriptLoader: ScriptLoader;
     let setClientIdSpy: jest.Mock;
     let setUseCookieSpy: jest.Mock;
@@ -24,10 +27,11 @@ describe('AmazonPayScriptLoader', () => {
         amazonPayScriptLoader = new AmazonPayScriptLoader(scriptLoader);
         setClientIdSpy = jest.fn();
         setUseCookieSpy = jest.fn();
+        hostWindow = window;
 
         jest.spyOn(scriptLoader, 'loadScript')
             .mockImplementation(() => {
-                (window as any).amazon = { Login };
+                hostWindow.amazon = { Login };
 
                 Promise.resolve(new Event('load'));
             });

--- a/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
@@ -4,9 +4,13 @@ import { PaymentMethod } from '../../../payment';
 import ScriptLoader from '../../../../script-loader/script-loader';
 
 export default class AmazonPayScriptLoader {
+    private _window: amazon.HostWindow;
+
     constructor(
         private _scriptLoader: ScriptLoader
-    ) {}
+    ) {
+        this._window = window;
+    }
 
     loadWidget(method: PaymentMethod): Promise<Event> {
         const {
@@ -26,13 +30,11 @@ export default class AmazonPayScriptLoader {
     }
 
     private _configureWidget(method: PaymentMethod): void {
-        const global: any = window;
-
-        if (global.onAmazonLoginReady) {
+        if (this._window.onAmazonLoginReady) {
             return;
         }
 
-        global.onAmazonLoginReady = () => {
+        this._window.onAmazonLoginReady = () => {
             amazon.Login.setClientId(method.initializationData.clientId);
             amazon.Login.setUseCookie(true);
         };

--- a/src/core/remote-checkout/methods/amazon-pay/off-amazon-payments.d.ts
+++ b/src/core/remote-checkout/methods/amazon-pay/off-amazon-payments.d.ts
@@ -15,4 +15,9 @@ declare namespace OffAmazonPayments {
     interface ButtonError extends Error {
         getErrorCode(): string;
     }
+
+    interface HostWindow extends Window {
+        onAmazonPaymentsReady?: () => void;
+        OffAmazonPayments?: OffAmazonPayments;
+    }
 }

--- a/src/core/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
+++ b/src/core/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../remote-checkout/methods/amazon-pay/off-amazon-payments-widgets.d.ts" />
+
 import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay';
 import { CheckoutSelectors } from '../../checkout';
 import { createScriptLoader } from '../../../script-loader';
@@ -18,6 +20,7 @@ import createRemoteCheckoutService from '../../create-remote-checkout-service';
 describe('AmazonPayShippingStrategy', () => {
     let addressBookSpy: jest.Mock;
     let container: HTMLDivElement;
+    let hostWindow: OffAmazonPayments.HostWindow;
     let updateShippingService: UpdateShippingService;
     let store: DataStore<CheckoutSelectors>;
     let scriptLoader: AmazonPayScriptLoader;
@@ -54,6 +57,7 @@ describe('AmazonPayShippingStrategy', () => {
     beforeEach(() => {
         addressBookSpy = jest.fn();
         container = document.createElement('div');
+        hostWindow = window;
         store = createCheckoutStore();
         remoteCheckoutService = createRemoteCheckoutService(store, createCheckoutClient());
         updateShippingService = createUpdateShippingService(store, createCheckoutClient());
@@ -63,8 +67,8 @@ describe('AmazonPayShippingStrategy', () => {
         document.body.appendChild(container);
 
         jest.spyOn(scriptLoader, 'loadWidget').mockImplementation(() => {
-            (window as any).OffAmazonPayments = { Widgets: { AddressBook } };
-            (window as any).onAmazonPaymentsReady();
+            hostWindow.OffAmazonPayments = { Widgets: { AddressBook } };
+            hostWindow.onAmazonPaymentsReady();
 
             return Promise.resolve();
         });

--- a/src/core/shipping/strategies/amazon-pay-shipping-strategy.ts
+++ b/src/core/shipping/strategies/amazon-pay-shipping-strategy.ts
@@ -15,6 +15,7 @@ import UpdateShippingService from '../update-shipping-service';
 export default class AmazonPayShippingStrategy extends ShippingStrategy {
     private _addressBook: OffAmazonPayments.Widgets.AddressBook | undefined;
     private _paymentMethod: PaymentMethod | undefined;
+    private _window: OffAmazonPayments.HostWindow;
 
     constructor(
         store: ReadableDataStore<CheckoutSelectors>,
@@ -23,6 +24,8 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
         private _scriptLoader: AmazonPayScriptLoader
     ) {
         super(store, updateShippingService);
+
+        this._window = window;
     }
 
     initialize(options: InitializeOptions): Promise<CheckoutSelectors> {
@@ -32,7 +35,7 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
 
         this._paymentMethod = options.paymentMethod;
 
-        (window as any).onAmazonPaymentsReady = () => {
+        this._window.onAmazonPaymentsReady = () => {
             this._addressBook = this._createAddressBook(options);
         };
 


### PR DESCRIPTION
## What?
* Add type definitions for AmazonPay event hooks (`onAmazonPaymentsReady` and `onAmazonLoginReady`)

## Why?
* So we don't have to cast `window` as `any`.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
