### PR TITLE
CHECKOUT-2274: Use session information to sign out from AmazonPay

### DIFF
--- a/src/core/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/core/customer/strategies/amazon-pay-customer-strategy.ts
@@ -78,11 +78,14 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
     }
 
     signOut(options?: any): Promise<CheckoutSelectors> {
-        if (!this._isInitialized) {
-            throw new NotInitializedError();
+        const { checkout } = this._store.getState();
+        const { remote = {} } = checkout.getCustomer() || {};
+
+        if (!remote.provider) {
+            return Promise.resolve(this._store.getState());
         }
 
-        return this._signInCustomerService.remoteSignOut(this._paymentMethod!.id, options);
+        return this._signInCustomerService.remoteSignOut(remote.provider, options);
     }
 
     private _createSignInButton(options: InitializeWidgetOptions): OffAmazonPayments.Button {


### PR DESCRIPTION
## What?
* Use `order.remote` data to determine if shopper can log out from AmazonPay.

## Why?
* It more accurately reflects the shopper status. There's no need to sign out if shopper is not signed in.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
