### PR TITLE
CHECKOUT-2274: Use POST instead of GET for tracking remote checkout authorization event

### DIFF
--- a/src/core/remote-checkout/remote-checkout-request-sender.js
+++ b/src/core/remote-checkout/remote-checkout-request-sender.js
@@ -74,6 +74,6 @@ export default class RemoteCheckoutRequestSender {
     trackAuthorizationEvent({ timeout } = {}) {
         const url = '/remote-checkout/events/shopper-checkout-service-provider-authorization-requested';
 
-        return this._requestSender.get(url, { timeout });
+        return this._requestSender.post(url, { timeout });
     }
 }

--- a/src/core/remote-checkout/remote-checkout-request-sender.spec.js
+++ b/src/core/remote-checkout/remote-checkout-request-sender.spec.js
@@ -79,11 +79,11 @@ describe('RemoteCheckoutRequestSender', () => {
         const response = getResponse();
         const options = { timeout: createTimeout() };
 
-        jest.spyOn(requestSender, 'get').mockReturnValue(response);
+        jest.spyOn(requestSender, 'post').mockReturnValue(response);
 
         const output = await remoteCheckoutRequestSender.trackAuthorizationEvent(options);
 
         expect(output).toEqual(response);
-        expect(requestSender.get).toHaveBeenCalledWith('/remote-checkout/events/shopper-checkout-service-provider-authorization-requested', options);
+        expect(requestSender.post).toHaveBeenCalledWith('/remote-checkout/events/shopper-checkout-service-provider-authorization-requested', options);
     });
 });


### PR DESCRIPTION
## What?
* Send `POST` instead of `GET` request to track remote checkout authorization event.

## Why?
* `/remote-checkout/events/shopper-checkout-service-provider-authorization-requested` is a POST endpoint.

## Testing / Proof
* Unit / Manual

@bigcommerce/checkout @bigcommerce/payments
