### PR TITLE
CHECKOUT-2449 Add missing `v` to RequestSender version

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "validate-dependencies": "yarn install --check-files --frozen-lockfile"
   },
   "dependencies": {
-    "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#0.1.0",
+    "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.0",
     "@types/jest": "^21.1.10",
     "@types/lodash": "^4.14.92",
     "@types/node": "^9.4.0",


### PR DESCRIPTION
## What?
- RequestSender version does include a `v`, `npm` will fail to install if the `v` is missing.

## Why?
- When used in cornerstone, we use `npm` for managing dependencies and it does require the `v` to be present.

## Testing / Proof
- Unit

@bigcommerce/checkout @bigcommerce/payments
