### PR TITLE
CHECKOUT-2647 Afterpay: send storeCredit flag and verify cart

### DIFF
--- a/src/core/create-place-order-service.ts
+++ b/src/core/create-place-order-service.ts
@@ -1,4 +1,5 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { CartActionCreator } from './cart';
 import { CheckoutClient, CheckoutStore } from './checkout';
 import { PlaceOrderService, OrderActionCreator } from './order';
 import { PaymentActionCreator, PaymentMethodActionCreator, PaymentRequestSender } from './payment';
@@ -12,6 +13,7 @@ export default function createPlaceOrderService(
 
     return new PlaceOrderService(
         store,
+        new CartActionCreator(client),
         new OrderActionCreator(client),
         new PaymentActionCreator(new PaymentRequestSender(paymentClient)),
         new PaymentMethodActionCreator(client)

--- a/src/core/order/place-order-service.js
+++ b/src/core/order/place-order-service.js
@@ -5,12 +5,14 @@ export default class PlaceOrderService {
     /**
      * @constructor
      * @param {DataStore} store
+     * @param {CartActionCreator} cartActionCreator
      * @param {OrderActionCreator} orderActionCreator
      * @param {PaymentActionCreator} paymentActionCreator
      * @param {PaymentMethodActionCreator} paymentMethodActionCreator
      */
-    constructor(store, orderActionCreator, paymentActionCreator, paymentMethodActionCreator) {
+    constructor(store, cartActionCreator, orderActionCreator, paymentActionCreator, paymentMethodActionCreator) {
         this._store = store;
+        this._cartActionCreator = cartActionCreator;
         this._orderActionCreator = orderActionCreator;
         this._paymentActionCreator = paymentActionCreator;
         this._paymentMethodActionCreator = paymentMethodActionCreator;
@@ -36,6 +38,17 @@ export default class PlaceOrderService {
             shouldVerifyCart ? cart : undefined,
             options
         );
+
+        return this._store.dispatch(action);
+    }
+
+    /**
+     * @param {RequestOptions} [options]
+     * @return {Promise<CheckoutSelectors>}
+     */
+    verifyCart(options) {
+        const { checkout } = this._store.getState();
+        const action = this._cartActionCreator.verifyCart(checkout.getCart(), options);
 
         return this._store.dispatch(action);
     }

--- a/src/core/order/place-order-service.spec.js
+++ b/src/core/order/place-order-service.spec.js
@@ -15,6 +15,7 @@ import createCheckoutStore from '../create-checkout-store';
 import PlaceOrderService from './place-order-service';
 
 describe('PlaceOrderService', () => {
+    let cartActionCreator;
     let orderActionCreator;
     let paymentActionCreator;
     let paymentMethodActionCreator;
@@ -37,6 +38,10 @@ describe('PlaceOrderService', () => {
             initializePaymentMethod: jest.fn(() => createAction('INITALIZE_PAYMENT_METHOD')),
         };
 
+        cartActionCreator = {
+            verifyCart: jest.fn(() => createAction('VERIFY_CART_SUCCEEDED')),
+        };
+
         store = createCheckoutStore({
             cart: getCartState(),
             config: getConfigState(),
@@ -48,7 +53,7 @@ describe('PlaceOrderService', () => {
             shippingOptions: getShippingOptionsState(),
         });
 
-        placeOrderService = new PlaceOrderService(store, orderActionCreator, paymentActionCreator, paymentMethodActionCreator);
+        placeOrderService = new PlaceOrderService(store, cartActionCreator, orderActionCreator, paymentActionCreator, paymentMethodActionCreator);
     });
 
     describe('#submitOrder()', () => {

--- a/src/core/payment/strategies/afterpay-payment-strategy.spec.ts
+++ b/src/core/payment/strategies/afterpay-payment-strategy.spec.ts
@@ -48,6 +48,7 @@ describe('AfterpayPaymentStrategy', () => {
             scriptLoader
         );
 
+        jest.spyOn(placeOrderService, 'verifyCart').mockImplementation(() => {});
         jest.spyOn(placeOrderService, 'loadPaymentMethod').mockImplementation(() => {
             return Promise.resolve({
                 checkout: {
@@ -106,13 +107,17 @@ describe('AfterpayPaymentStrategy', () => {
             });
         });
 
-        it('notifies store credit usage to remote checkout service', () => {
+        it('displays the afterpay modal', () => {
             expect(afterpaySdk.init).toHaveBeenCalled();
             expect(afterpaySdk.display).toHaveBeenCalledWith({ token: clientToken });
         });
 
-        it('notifies displays the afterpay modal', () => {
+        it('notifies store credit usage to remote checkout service', () => {
             expect(remoteCheckoutService.initializePayment).toHaveBeenCalledWith( paymentMethod.gateway, { useStoreCredit: false });
+        });
+
+        it('verifies the cart', () => {
+            expect(placeOrderService.verifyCart).toHaveBeenCalled();
         });
     });
 
@@ -126,6 +131,11 @@ describe('AfterpayPaymentStrategy', () => {
                     payment: {
                         id: paymentMethod.id,
                     },
+                });
+
+            jest.spyOn(store.getState().checkout, 'getCustomer')
+                .mockReturnValue({
+                    remote: { useStoreCredit: false }
                 });
 
             await strategy.initialize({ paymentMethod });


### PR DESCRIPTION
## What?
When callling `execute()`, verifyCart();
When calling `finalize()`, send `useStoreCredit` flag;

## Why?
Because we need to verify cart and appropriately send `useStoreCredit` flag when submitting the order.

## Test
- [x] unit
- [x] manual
  - [x] Pay using store credit
  - [x] Pay without store credit

@bigcommerce/checkout @bigcommerce/payments
