### PR TITLE
CHECKOUT-2915: Add support for thunk actions

### DIFF
--- a/src/data-store/data-store.spec.ts
+++ b/src/data-store/data-store.spec.ts
@@ -41,6 +41,24 @@ describe('DataStore', () => {
             }
         });
 
+        it('dispatches thunk actions', async () => {
+            const thunk = (store) => Observable.of({
+                type: 'UPDATE',
+                payload: `${store.getState().message}!!!`,
+            });
+
+            const store = new DataStore(
+                (state, action) => (
+                    action.type === 'UPDATE' ?
+                        { ...state, message: action.payload } :
+                        state
+                ),
+                { message: 'foobar' }
+            );
+
+            expect(await store.dispatch(thunk)).toEqual({ message: 'foobar!!!' });
+        });
+
         it('dispatches observable actions and resolves promise with current state', async () => {
             const store = new DataStore((state, action) => {
                 if (action.type === 'APPEND') {

--- a/src/data-store/index.ts
+++ b/src/data-store/index.ts
@@ -2,6 +2,7 @@ export { default as Action } from './action';
 export { default as DataStore } from './data-store';
 export { default as DispatchableDataStore } from './dispatchable-data-store';
 export { default as ReadableDataStore } from './readable-data-store';
+export { default as ThunkAction } from './thunk-action';
 export { default as combineReducers } from './combine-reducers';
 export { default as composeReducers } from './compose-reducers';
 export { default as createAction } from './create-action';

--- a/src/data-store/thunk-action.ts
+++ b/src/data-store/thunk-action.ts
@@ -1,0 +1,6 @@
+import { Observable } from 'rxjs/Observable';
+import ReadableDataStore from './readable-data-store';
+
+type ThunkAction<TAction, TTransformedState> = (store: ReadableDataStore<TTransformedState>) => Observable<TAction>;
+
+export default ThunkAction;


### PR DESCRIPTION
## What?
* `DataStore` is now able to dispatch thunk actions.
* In other words, action creators can create three types of actions - regular action, observable action, and thunk action.

## Why?
* Previously, actions don't know about the store that's used to dispatch them. Therefore, they cannot directly retrieve data from the store. If they need additional data from the store, their factories need to have additional parameters.
* With thunks, the store (`ReadableDataStore`) gets injected into them, allowing you to grab any cached data you want. i.e.: You might want to use cached data instead of dispatching a new action to grab data remotely etc... i.e.:

```js
const action = (store) => Observable.create((observer) => {
    const { foobar } = store.getState();

    Observable
        .fromPromise(
            foobar ? Promise.resolve(foobar) : loadFoobar()
        )
        .map((payload) => ({
            type: 'LOADED',
            payload,
        }));
});
```

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
