### PR TITLE
CHECKOUT-2274: Fix exported interfaces using private interfaces

### DIFF
--- a/src/core/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/core/customer/strategies/amazon-pay-customer-strategy.ts
@@ -136,7 +136,7 @@ export interface InitializeOptions extends InitializeWidgetOptions {
     paymentMethod: PaymentMethod;
 }
 
-interface InitializeWidgetOptions {
+export interface InitializeWidgetOptions {
     container: string;
     color?: string;
     size?: string;

--- a/src/core/payment/payment-strategy-registry.ts
+++ b/src/core/payment/payment-strategy-registry.ts
@@ -53,6 +53,6 @@ export default class PaymentStrategyRegistry extends Registry<PaymentStrategy> {
     }
 }
 
-interface RegistryOptions {
+export interface RegistryOptions {
     clientSidePaymentProviders?: string[];
 }

--- a/src/core/payment/payment.ts
+++ b/src/core/payment/payment.ts
@@ -5,7 +5,7 @@ export default interface Payment {
     source?: string;
 }
 
-interface CreditCard {
+export interface CreditCard {
     ccExpiry: {
         month: number,
         year: number,
@@ -18,7 +18,7 @@ interface CreditCard {
     shouldSaveInstrument?: boolean;
 }
 
-interface TokenizedCreditCard {
+export interface TokenizedCreditCard {
     nonce: string;
     deviceSessionId?: string;
 }


### PR DESCRIPTION
## What?
* Export private interfaces that are actually part of public interfaces.

## Why?
* Otherwise, we'll get a warning when we eventually set `declaration` to `true` in `tsconfig`

## Testing / Proof
* Manual

@bigcommerce/checkout @bigcommerce/payments
