### PR TITLE
CHECKOUT-2902 Submit order comments when using Afterpay

### DIFF
--- a/src/core/payment/strategies/afterpay-payment-strategy.spec.ts
+++ b/src/core/payment/strategies/afterpay-payment-strategy.spec.ts
@@ -113,7 +113,7 @@ describe('AfterpayPaymentStrategy', () => {
         });
 
         it('notifies store credit usage to remote checkout service', () => {
-            expect(remoteCheckoutService.initializePayment).toHaveBeenCalledWith( paymentMethod.gateway, { useStoreCredit: false });
+            expect(remoteCheckoutService.initializePayment).toHaveBeenCalledWith( paymentMethod.gateway, { useStoreCredit: false, customerMessage: '' });
         });
 
         it('verifies the cart', () => {
@@ -135,13 +135,17 @@ describe('AfterpayPaymentStrategy', () => {
 
             jest.spyOn(store.getState().checkout, 'getCustomer')
                 .mockReturnValue({
-                    remote: { useStoreCredit: false }
+                    remote: { useStoreCredit: false, customerMessage: 'foo' }
                 });
 
             await strategy.initialize({ paymentMethod });
             await strategy.finalize({ nonce });
 
-            expect(placeOrderService.submitOrder).toHaveBeenCalled();
+            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(
+                { useStoreCredit: false, customerMessage: 'foo' },
+                true,
+                { nonce }
+            );
             expect(placeOrderService.submitPayment).toHaveBeenCalledWith({
                 name: paymentMethod.id,
                 paymentData: { nonce },

--- a/src/core/remote-checkout/remote-checkout-service.js
+++ b/src/core/remote-checkout/remote-checkout-service.js
@@ -51,6 +51,7 @@ export default class RemoteCheckoutService {
      * @param {string} methodId
      * @param {Object} params
      * @param {?string} [params.referenceId]
+     * @param {?string} [params.customerMessage]
      * @param {?boolean} [params.useStoreCredit]
      * @param {?boolean} [params.authorizationToken]
      * @param {RequestOptions} [options]


### PR DESCRIPTION
## What?
Submit order comments when using afterpay. Blocked by https://github.com/bc-marquis-ong/bigcommerce/tree/Afterpay-HandleCustomerMessage

## Why?
So order comments are not lost

## Testing / Proof
- [x] unit
- [x] manual
