### PR TITLE
CHECKOUT-2926 Add support for Square Payments

### DIFF
--- a/src/common/error/errors/index.js
+++ b/src/common/error/errors/index.js
@@ -6,3 +6,4 @@ export { default as RequestError } from './request-error';
 export { default as StandardError } from './standard-error';
 export { default as TimeoutError } from './timeout-error';
 export { default as UnrecoverableError } from './unrecoverable-error';
+export { default as UnsupportedBrowserError } from './unsupported-browser-error';

--- a/src/common/error/errors/request-error.js
+++ b/src/common/error/errors/request-error.js
@@ -6,7 +6,7 @@ export default class RequestError extends StandardError {
      * @param {Response} response
      * @param {string} [message] - Fallback message
      */
-    constructor({ body = {}, headers, status, statusText }, message) {
+    constructor({ body = {}, headers, status, statusText } = {}, message) {
         super(joinErrors(body.errors) || body.detail || body.title || message || 'An unexpected error has occurred.');
 
         this.type = 'request';

--- a/src/common/error/errors/unsupported-browser-error.js
+++ b/src/common/error/errors/unsupported-browser-error.js
@@ -1,0 +1,13 @@
+import StandardError from './standard-error';
+
+export default class UnsupportedBrowserError extends StandardError {
+    /**
+     * @constructor
+     * @param {string} [message]
+     */
+    constructor(message) {
+        super(message || 'Unsupported browser error');
+
+        this.type = 'unsupported_browser';
+    }
+}

--- a/src/payment/create-payment-strategy-registry.js
+++ b/src/payment/create-payment-strategy-registry.js
@@ -11,12 +11,14 @@ import {
     PaypalExpressPaymentStrategy,
     PaypalProPaymentStrategy,
     SagePayPaymentStrategy,
+    SquarePaymentStrategy,
 } from './strategies';
 import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
 import { KlarnaScriptLoader } from '../remote-checkout/methods/klarna';
 import { createAfterpayScriptLoader } from '../remote-checkout/methods/afterpay';
 import { createRemoteCheckoutService } from '../remote-checkout';
 import { createPlaceOrderService } from '../order';
+import { SquareScriptLoader } from './strategies/square';
 import PaymentStrategyRegistry from './payment-strategy-registry';
 
 /**
@@ -34,6 +36,7 @@ export default function createPaymentStrategyRegistry(store, client, paymentClie
     const scriptLoader = getScriptLoader();
     const afterpayScriptLoader = createAfterpayScriptLoader();
     const klarnaScriptLoader = new KlarnaScriptLoader(scriptLoader);
+    const squareScriptLoader = new SquareScriptLoader(scriptLoader);
 
     registry.register('afterpay', () =>
         new AfterpayPaymentStrategy(store, placeOrderService, remoteCheckoutService, afterpayScriptLoader)
@@ -82,6 +85,10 @@ export default function createPaymentStrategyRegistry(store, client, paymentClie
 
     registry.register('sagepay', () =>
         new SagePayPaymentStrategy(store, placeOrderService, createFormPoster())
+    );
+
+    registry.register('squarev2', () =>
+        new SquarePaymentStrategy(store, placeOrderService, squareScriptLoader)
     );
 
     return registry;

--- a/src/payment/payment-methods.mock.js
+++ b/src/payment/payment-methods.mock.js
@@ -261,6 +261,38 @@ export function getAmazonPay() {
     };
 }
 
+export function getSquare() {
+    return {
+        id: 'square',
+        gateway: null,
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: [
+            'VISA',
+            'MC',
+            'AMEX',
+            'DISCOVER',
+            'JCB',
+            'DINERS',
+        ],
+        config: {
+            displayName: 'Credit Card',
+            cardCode: true,
+            helpText: null,
+            enablePaypal: true,
+            merchantId: '',
+            is3dsEnabled: null,
+            testMode: true,
+            isVisaCheckoutEnabled: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        nonce: null,
+        initializationData: null,
+        clientToken: null,
+        returnUrl: null,
+    };
+}
+
 export function getPaymentMethod() {
     return getAuthorizenet();
 }

--- a/src/payment/strategies/index.js
+++ b/src/payment/strategies/index.js
@@ -9,3 +9,4 @@ export { default as PaymentStrategy } from './payment-strategy';
 export { default as PaypalExpressPaymentStrategy } from './paypal-express-payment-strategy';
 export { default as PaypalProPaymentStrategy } from './paypal-pro-payment-strategy';
 export { default as SagePayPaymentStrategy } from './sage-pay-payment-strategy';
+export { SquarePaymentStrategy } from './square';

--- a/src/payment/strategies/square/index.ts
+++ b/src/payment/strategies/square/index.ts
@@ -1,0 +1,2 @@
+export { default as SquarePaymentStrategy } from './square-payment-strategy';
+export { default as SquareScriptLoader } from './square-script-loader';

--- a/src/payment/strategies/square/square-form.d.ts
+++ b/src/payment/strategies/square/square-form.d.ts
@@ -1,0 +1,40 @@
+declare namespace Square {
+    interface PaymentFormConstructor {
+        new(options: FormOptions): PaymentForm;
+    }
+
+    type FormFactory = (options: FormOptions) => PaymentForm;
+
+    class PaymentForm {
+        build(): void;
+        requestCardNonce(): void;
+        setPostalCode(postalCode: string): void;
+    }
+
+    interface HostWindow extends Window {
+        SqPaymentForm: PaymentFormConstructor
+    }
+
+    interface FormOptions {
+        applicationId: string;
+        env: string;
+        locationId: string;
+        inputClass?: string;
+        inputStyles?: string[];
+        callbacks?: FormCallbacks;
+        cardNumber: FormElement;
+        cvv: FormElement;
+        expirationDate: FormElement;
+        postalCode: FormElement;
+    }
+
+    interface FormElement {
+        elementId: string;
+    }
+
+    interface FormCallbacks {
+        paymentFormLoaded?: (form: Square.PaymentForm) => void;
+        unsupportedBrowserDetected?: () => void;
+        cardNonceResponseReceived?: (errors: any, nonce: string) => void;
+    }
+}

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -1,0 +1,185 @@
+/// <reference path="./square-form.d.ts" />
+
+import { createClient as createPaymentClient } from 'bigpay-client';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../../checkout';
+import { createPlaceOrderService } from '../../../order';
+import { getSquare } from '../../../payment/payment-methods.mock';
+import SquarePaymentStrategy from './square-payment-strategy';
+import SquareScriptLoader from './square-script-loader';
+import PaymentMethod from '../../payment-method';
+
+describe('SquarePaymentStrategy', () => {
+    let client: CheckoutClient;
+    let scriptLoader: SquareScriptLoader;
+    let store: CheckoutStore;
+    let strategy: SquarePaymentStrategy;
+    let paymentMethod: PaymentMethod;
+    let placeOrderService: PlaceOrderService;
+    let callbacks: Square.FormCallbacks;
+
+    const formFactory = (options) => {
+        callbacks = options.callbacks;
+        return squareForm;
+    };
+
+    const squareForm = {
+        build: () => callbacks.paymentFormLoaded(),
+        requestCardNonce: () => {},
+    };
+
+    beforeEach(() => {
+        client = createCheckoutClient();
+        store = createCheckoutStore();
+        placeOrderService = createPlaceOrderService(store, client, createPaymentClient());
+        paymentMethod = getSquare();
+        scriptLoader = new SquareScriptLoader(createScriptLoader());
+        strategy = new SquarePaymentStrategy(store, placeOrderService, scriptLoader);
+
+        jest.spyOn(placeOrderService, 'submitOrder')
+            .mockImplementation(() => Promise.resolve({ foo: 'bar' }));
+
+        jest.spyOn(store, 'getState')
+            .mockImplementation(() => {
+                return {
+                    getBillingAddress: () => {},
+                };
+            });
+
+        jest.spyOn(scriptLoader, 'load')
+            .mockImplementation(() => Promise.resolve(formFactory));
+
+        jest.spyOn(squareForm, 'build');
+        jest.spyOn(squareForm, 'requestCardNonce');
+
+        scriptLoader.load.mockClear();
+        squareForm.build.mockClear();
+    });
+
+    describe('#initialize()', () => {
+        describe('when form loads successfully', () => {
+            it('loads script when initializing strategy with required params', async () => {
+                const initOptions = {
+                    paymentMethod: { ...paymentMethod,
+                        initializationData: { locationId: 'foo', env: 'bar', applicationId: 'test' },
+                    },
+                    widgetConfig: {},
+                };
+
+                await strategy.initialize(initOptions);
+
+                expect(scriptLoader.load).toHaveBeenCalledTimes(1);
+            });
+
+            it('fails to initialize when widget config is missing', () => {
+                const initOptions = {
+                    paymentMethod: { ...paymentMethod,
+                        initializationData: { locationId: 'foo', env: 'bar', applicationId: 'test' },
+                    },
+                };
+
+                strategy.initialize({ paymentMethod })
+                    .catch(error => expect(error.type).toEqual('payment_method_missing_data'));
+            });
+        });
+
+        describe('when form fails to load', () => {
+            beforeEach(() => {
+                jest.spyOn(squareForm, 'build').mockImplementation(() => {
+                    callbacks.unsupportedBrowserDetected();
+                });
+            });
+
+            afterEach(() => squareForm.build.mockRestore());
+
+            it('rejects the promise', () => {
+                const initOptions = {
+                    paymentMethod: { ...paymentMethod,
+                        initializationData: { locationId: 'foo', env: 'bar', applicationId: 'test' },
+                    },
+                    widgetConfig: {},
+                };
+
+                strategy.initialize(initOptions)
+                    .catch(e => expect(e.type).toEqual('unsupported_browser'));
+
+                expect(scriptLoader.load).toHaveBeenCalledTimes(1);
+                expect(squareForm.build).toHaveBeenCalledTimes(0);
+            });
+        });
+    });
+
+    describe('#execute()', () => {
+        describe('when form has not been initialized', () => {
+            it('rejects the promise', () => {
+                strategy.execute()
+                    .catch(e => expect(e.type).toEqual('payment_method_uninitialized'));
+
+                expect(squareForm.requestCardNonce).toHaveBeenCalledTimes(0);
+            });
+        });
+
+        describe('when the form has been initialized', () => {
+            beforeEach(async () => {
+                const initOptions = {
+                    paymentMethod: { ...paymentMethod,
+                        initializationData: { locationId: 'foo', env: 'bar', applicationId: 'test' },
+                    },
+                    widgetConfig: {},
+                };
+
+                await strategy.initialize(initOptions);
+            });
+
+            it('requests the nonce', () => {
+                strategy.execute({});
+                expect(squareForm.requestCardNonce).toHaveBeenCalledTimes(1);
+            });
+
+            it('cancels the first request', async () => {
+                strategy.execute({})
+                    .catch(e => expect(e.type).toEqual('timeout'));
+
+                setTimeout(() => {
+                    callbacks.cardNonceResponseReceived(null, 'nonce');
+                }, 0);
+
+                await strategy.execute({});
+            });
+
+            describe('when the nonce is received', () => {
+                let promise;
+
+                beforeEach(() => {
+                    promise = strategy.execute({});
+                    callbacks.cardNonceResponseReceived(null, 'nonce');
+                });
+
+                it('places the order', () => {
+                    expect(placeOrderService.submitOrder).toHaveBeenCalledTimes(1);
+                });
+
+                it('resolves to what is returned by submitOrder', async () => {
+                    await promise.then(response => expect(response).toMatchObject({ foo: 'bar' }));
+                });
+            });
+
+            describe('when a failure happens receiving the nonce', () => {
+                let promise;
+
+                beforeEach(() => {
+                    promise = strategy.execute({});
+                    callbacks.cardNonceResponseReceived({}, 'nonce');
+                });
+
+                it('does not place the order', () => {
+                    expect(placeOrderService.submitOrder).toHaveBeenCalledTimes(0);
+                });
+
+                it('rejects the promise', async () => {
+                    await promise.catch(error => expect(error).toBeTruthy());
+                });
+            });
+        });
+    });
+});

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -1,0 +1,101 @@
+/// <reference path="./square-form.d.ts" />
+
+import { ReadableDataStore } from '@bigcommerce/data-store';
+import { CheckoutSelectors } from '../../../checkout';
+import { TimeoutError, UnsupportedBrowserError } from '../../../common/error/errors';
+import { OrderRequestBody, PlaceOrderService } from '../../../order';
+import { PaymentMethodUninitializedError, PaymentMethodMissingDataError } from '../../errors';
+import SquareScriptLoader from './square-script-loader';
+import PaymentMethod from '../../payment-method';
+import PaymentStrategy from '../payment-strategy';
+
+export default class SquarePaymentStrategy extends PaymentStrategy {
+    private _paymentForm?: Square.PaymentForm;
+    private _deferredRequestNonce?: DeferredPromise;
+
+    constructor(
+        store: ReadableDataStore<CheckoutSelectors>,
+        placeOrderService: PlaceOrderService,
+        private _scriptLoader: SquareScriptLoader
+    ) {
+        super(store, placeOrderService);
+    }
+
+    initialize(options: InitializeOptions): Promise<CheckoutSelectors> {
+        return this._scriptLoader.load()
+            .then((createSquareForm) =>
+                new Promise((resolve, reject) => {
+                    this._paymentForm = createSquareForm(
+                        this._getFormOptions(options, { resolve, reject })
+                    );
+                    this._paymentForm.build();
+                }))
+            .then(() => super.initialize(options));
+    }
+
+    execute(payload: OrderRequestBody, options?: any): Promise<CheckoutSelectors> {
+        return new Promise((resolve, reject) => {
+            if (!this._paymentForm) {
+                throw new PaymentMethodUninitializedError('Square');
+            }
+
+            if (this._deferredRequestNonce) {
+                this._deferredRequestNonce.reject(new TimeoutError());
+            };
+
+            this._deferredRequestNonce = { resolve, reject };
+            this._paymentForm.requestCardNonce();
+        })
+        .then(paymentData => this._placeOrderService.submitOrder(payload, paymentData));
+    }
+
+    private _getFormOptions(options: InitializeOptions, deferred: DeferredPromise): Square.FormOptions {
+        const { paymentMethod, widgetConfig } = options;
+
+        if (!widgetConfig) {
+            throw new PaymentMethodMissingDataError('widgetConfig');
+        }
+        
+        return {
+            ...widgetConfig,
+            ...paymentMethod.initializationData,
+            callbacks: {
+                paymentFormLoaded: () => {
+                    deferred.resolve();
+
+                    const state = this._store.getState();
+
+                    const billingAddress = state.checkout.getBillingAddress();
+
+                    if (billingAddress && billingAddress.postCode) {
+                        this._paymentForm!.setPostalCode(billingAddress.postCode);
+                    }
+                },
+                unsupportedBrowserDetected: () => {
+                    deferred.reject(new UnsupportedBrowserError());
+                },
+                cardNonceResponseReceived: (errors, nonce) => {
+                    this._cardNonceResponseReceived(errors, nonce);
+                },
+            }
+        }
+    }
+
+    private _cardNonceResponseReceived(errors: any, nonce: string): void {
+        if (errors) {
+            this._deferredRequestNonce!.reject(errors);
+        } else {
+            this._deferredRequestNonce!.resolve({ nonce });
+        }
+    }
+}
+
+export interface DeferredPromise {
+    resolve: (resolution?: any) => void;
+    reject: (reason?: any) => void;
+}
+
+export interface InitializeOptions {
+    paymentMethod: PaymentMethod;
+    widgetConfig?: Square.FormOptions;
+}

--- a/src/payment/strategies/square/square-script-loader.spec.ts
+++ b/src/payment/strategies/square/square-script-loader.spec.ts
@@ -1,0 +1,27 @@
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { merge } from 'lodash';
+import SquareScriptLoader from './square-script-loader';
+
+describe('SquareScriptLoader', () => {
+    const scriptLoader = createScriptLoader();
+    const squareScriptLoader = new SquareScriptLoader(scriptLoader);
+
+    beforeEach(() => {
+        jest.spyOn(scriptLoader, 'loadScript').mockReturnValue(Promise.resolve(true));
+    });
+
+    it('loads widget script', () => {
+        squareScriptLoader.load();
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            '//js.squareup.com/v2/paymentform'
+        );
+    });
+
+    it('loads widget only once', () => {
+        squareScriptLoader.load();
+        squareScriptLoader.load();
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/payment/strategies/square/square-script-loader.ts
+++ b/src/payment/strategies/square/square-script-loader.ts
@@ -1,0 +1,24 @@
+/// <reference path="./square-form.d.ts" />
+
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+export default class SquareScriptLoader {
+    private _loadPromise?: Promise<Square.FormFactory>;
+
+    constructor(
+        private _scriptLoader: ScriptLoader
+    ) {}
+
+    load(): Promise<Square.FormFactory> {
+        const scriptURI = '//js.squareup.com/v2/paymentform';
+
+        if (!this._loadPromise) {
+            this._loadPromise = this._scriptLoader.loadScript(scriptURI)
+                .then(() => (options: Square.FormOptions) =>
+                    new (window as Square.HostWindow).SqPaymentForm(options)
+                );
+        }
+
+        return this._loadPromise;
+    }
+}


### PR DESCRIPTION
## What?
Add support for Square payments in SDK.

## Why?
For feature parity with ng-checkout

## Testing / Proof
- [x] unit
- [x] manual