### PR TITLE
CHECKOUT-2725: Convert `CreditCardPaymentStrategy` to TypeScript

### DIFF
--- a/src/core/payment/strategies/credit-card-payment-strategy.spec.ts
+++ b/src/core/payment/strategies/credit-card-payment-strategy.spec.ts
@@ -1,22 +1,34 @@
 import { omit } from 'lodash';
+import { createClient as createPaymentClient } from 'bigpay-client';
+import { CheckoutStore } from '../../checkout';
 import { getOrderRequestBody } from '../../order/orders.mock';
+import { PlaceOrderService } from '../../order';
+import createCheckoutClient from '../../create-checkout-client';
 import createCheckoutStore from '../../create-checkout-store';
+import createPlaceOrderService from '../../create-place-order-service';
 import CreditCardPaymentStrategy from './credit-card-payment-strategy';
 
 describe('CreditCardPaymentStrategy', () => {
-    let placeOrderService;
-    let store;
-    let strategy;
+    let placeOrderService: PlaceOrderService;
+    let store: CheckoutStore;
+    let strategy: CreditCardPaymentStrategy;
 
     beforeEach(() => {
-        placeOrderService = {
-            submitOrder: jest.fn(() => Promise.resolve(store.getState())),
-            submitPayment: jest.fn(() => Promise.resolve(store.getState())),
-        };
-
         store = createCheckoutStore();
 
+        placeOrderService = createPlaceOrderService(
+            store,
+            createCheckoutClient(),
+            createPaymentClient()
+        );
+
         strategy = new CreditCardPaymentStrategy(store, placeOrderService);
+
+        jest.spyOn(placeOrderService, 'submitOrder')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(placeOrderService, 'submitPayment')
+            .mockReturnValue(Promise.resolve(store.getState()));
     });
 
     it('submits order without payment data', async () => {

--- a/src/core/payment/strategies/credit-card-payment-strategy.ts
+++ b/src/core/payment/strategies/credit-card-payment-strategy.ts
@@ -1,11 +1,10 @@
 import { omit } from 'lodash';
+import { CheckoutSelectors } from '../../checkout';
+import { OrderRequestBody } from '../../order';
 import PaymentStrategy from './payment-strategy';
 
 export default class CreditCardPaymentStrategy extends PaymentStrategy {
-    /**
-     * @inheritdoc
-     */
-    execute(payload, options) {
+    execute(payload: OrderRequestBody, options?: any): Promise<CheckoutSelectors> {
         return this._placeOrderService.submitOrder(omit(payload, 'payment'), options)
             .then(() =>
                 this._placeOrderService.submitPayment(payload.payment, payload.useStoreCredit, options)

--- a/src/core/payment/strategies/payment-strategy.ts
+++ b/src/core/payment/strategies/payment-strategy.ts
@@ -13,9 +13,9 @@ export default abstract class PaymentStrategy {
         protected _placeOrderService: any
     ) {}
 
-    abstract execute(payload: OrderRequestBody, options: any): Promise<CheckoutSelectors>;
+    abstract execute(payload: OrderRequestBody, options?: any): Promise<CheckoutSelectors>;
 
-    finalize(options: any): Promise<CheckoutSelectors> {
+    finalize(options?: any): Promise<CheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
@@ -26,7 +26,7 @@ export default abstract class PaymentStrategy {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options: any): Promise<CheckoutSelectors> {
+    deinitialize(options?: any): Promise<CheckoutSelectors> {
         this._isInitialized = false;
         this._paymentMethod = undefined;
 


### PR DESCRIPTION
## What?
* Add type annotation to `CreditCardPaymentStrategy`

## Why?
* Static type checking

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
