### PR TITLE
CHECKOUT-2955: `isInitializingPaymentMethod` should return true while waiting for initialization to complete

### DIFF
--- a/src/core/payment/strategies/afterpay-payment-strategy.ts
+++ b/src/core/payment/strategies/afterpay-payment-strategy.ts
@@ -28,12 +28,14 @@ export default class AfterpayPaymentStrategy extends PaymentStrategy {
             return super.initialize(options);
         }
 
-        return this._afterpayScriptLoader.load(options.paymentMethod)
-            .then((afterpaySdk) => {
-                this._afterpaySdk = afterpaySdk;
-
-                return super.initialize(options);
-            });
+        return this._placeOrderService
+            .initializePaymentMethod(options.paymentMethod.id, () =>
+                this._afterpayScriptLoader.load(options.paymentMethod)
+                    .then((afterpaySdk) => {
+                        this._afterpaySdk = afterpaySdk;
+                    })
+            )
+            .then(() => super.initialize(options));
     }
 
     deinitialize(options: any): Promise<CheckoutSelectors> {

--- a/src/core/payment/strategies/paypal-express-payment-strategy.js
+++ b/src/core/payment/strategies/paypal-express-payment-strategy.js
@@ -25,20 +25,22 @@ export default class PaypalExpressPaymentStrategy extends PaymentStrategy {
             return super.initialize(options);
         }
 
-        return this._scriptLoader.loadScript('//www.paypalobjects.com/api/checkout.min.js')
-            .then(() => {
-                this._paypalSdk = window.paypal;
+        return this._placeOrderService
+            .initializePaymentMethod(this._paymentMethod.id, () =>
+                this._scriptLoader.loadScript('//www.paypalobjects.com/api/checkout.min.js')
+                    .then(() => {
+                        this._paypalSdk = window.paypal;
 
-                const { merchantId, testMode } = this._paymentMethod.config;
-                const environment = testMode ? 'sandbox' : 'production';
+                        const { merchantId, testMode } = this._paymentMethod.config;
+                        const environment = testMode ? 'sandbox' : 'production';
 
-                this._paypalSdk.checkout.setup(merchantId, {
-                    button: 'paypal-button',
-                    environment,
-                });
-
-                return super.initialize(options);
-            });
+                        this._paypalSdk.checkout.setup(merchantId, {
+                            button: 'paypal-button',
+                            environment,
+                        });
+                    })
+            )
+            .then(() => super.initialize(options));
     }
 
     /**

--- a/src/core/payment/strategies/paypal-express-payment-strategy.spec.js
+++ b/src/core/payment/strategies/paypal-express-payment-strategy.spec.js
@@ -20,6 +20,9 @@ describe('PaypalExpressPaymentStrategy', () => {
             verifyCart: jest.fn(() => Promise.resolve(store.getState())),
             submitOrder: jest.fn(() => Promise.resolve(store.getState())),
             submitPayment: jest.fn(() => Promise.resolve(store.getState())),
+            initializePaymentMethod: jest.fn((id, initializer) =>
+                initializer().then(() => store.getState())
+            ),
         };
 
         paypalSdk = {
@@ -87,6 +90,13 @@ describe('PaypalExpressPaymentStrategy', () => {
                 const output = await strategy.initialize({ paymentMethod });
 
                 expect(output).toEqual(store.getState());
+            });
+
+            it('toggles the initialization flag', async () => {
+                await strategy.initialize({ paymentMethod });
+
+                expect(placeOrderService.initializePaymentMethod)
+                    .toHaveBeenCalledWith(paymentMethod.id, expect.any(Function));
             });
         });
 


### PR DESCRIPTION
## What?
* `isInitializingPaymentMethod` should return true while waiting for initialization to complete

## Why?
* So developers can subscribe to that value and display a loading spinner or disable the submit button

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
