### PR TITLE
CHECKOUT-3006: Allow support for newer version of Yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ dist: trusty
 
 sudo: false
 
-before_install:
-    - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
-    - export PATH=$HOME/.yarn/bin:$PATH
-
 script:
     - yarn lint
-    - yarn test:series -- --coverage
+    - yarn test:series --coverage

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "lib/"
   ],
   "engines": {
-    "node": "^6.10.0",
-    "yarn": "^0.27.5"
+    "node": "^6.10.0"
   },
   "repository": {
     "type": "git",
@@ -45,7 +44,7 @@
   },
   "dependencies": {
     "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.1",
-    "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.0",
+    "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.1",
     "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.0",
     "@types/lodash": "^4.14.92",
     "bigpay-client": "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.10.0",


### PR DESCRIPTION
## What?
- As per title

## Why?
- Checkout will start supporting Yarn 1.X, this check prevents us from using the SDK within UCO

## Testing / Proof
- Travis

@bigcommerce/checkout @bigcommerce/payments
