### PR TITLE
CHECKOUT-3012: Always override `onAmazonLoginReady` and `onAmazonPaymentReady`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.1",
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.1",
-    "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.0",
+    "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.1",
     "@types/lodash": "^4.14.92",
     "bigpay-client": "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.10.0",
     "form-poster": "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1",

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -1,5 +1,5 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { createScriptLoader } from '@bigcommerce/script-loader';
+import { getScriptLoader } from '@bigcommerce/script-loader';
 import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
 import { AmazonPayCustomerStrategy, DefaultCustomerStrategy, CustomerStrategy } from './strategies';
 import { CheckoutClient, CheckoutStore } from '../checkout';
@@ -20,7 +20,7 @@ export default function createCustomerStrategyRegistry(
             store,
             signInCustomerService,
             new RemoteCheckoutRequestSender(createRequestSender()),
-            new AmazonPayScriptLoader(createScriptLoader())
+            new AmazonPayScriptLoader(getScriptLoader())
         )
     );
 

--- a/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
@@ -65,10 +65,11 @@ describe('AmazonPayCustomerStrategy', () => {
         container.setAttribute('id', 'login');
         document.body.appendChild(container);
 
-        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation(() => {
+        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((method, onReady) => {
             hostWindow.OffAmazonPayments = { Button };
             hostWindow.amazon = { Login };
-            hostWindow.onAmazonPaymentsReady();
+
+            onReady();
 
             return Promise.resolve();
         });
@@ -87,7 +88,7 @@ describe('AmazonPayCustomerStrategy', () => {
     it('loads widget script', async () => {
         await strategy.initialize({ container: 'login', paymentMethod });
 
-        expect(scriptLoader.loadWidget).toHaveBeenCalledWith(paymentMethod);
+        expect(scriptLoader.loadWidget).toHaveBeenCalledWith(paymentMethod, expect.any(Function));
     });
 
     it('creates login button', async () => {

--- a/src/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.ts
@@ -34,14 +34,13 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
             return super.initialize(options);
         }
 
+        this._paymentMethod = options.paymentMethod;
+
         return this._signInCustomerService
             .initializeCustomer(options.paymentMethod.id, () =>
                 new Promise((resolve, reject) => {
                     const { onError = noop } = options;
-
-                    this._paymentMethod = options.paymentMethod;
-
-                    this._window.onAmazonPaymentsReady = () => {
+                    const onReady = () => {
                         this._signInButton = this._createSignInButton({
                             ...options as InitializeWidgetOptions,
                             onError: (error) => {
@@ -53,7 +52,7 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
                         resolve();
                     };
 
-                    this._scriptLoader.loadWidget(this._paymentMethod)
+                    this._scriptLoader.loadWidget(options.paymentMethod, onReady)
                         .catch(reject);
                 })
             )

--- a/src/payment/create-payment-strategy-registry.js
+++ b/src/payment/create-payment-strategy-registry.js
@@ -1,5 +1,5 @@
 import { createFormPoster } from 'form-poster';
-import { createScriptLoader } from '@bigcommerce/script-loader';
+import { getScriptLoader } from '@bigcommerce/script-loader';
 import {
     AfterpayPaymentStrategy,
     AmazonPayPaymentStrategy,
@@ -31,7 +31,7 @@ export default function createPaymentStrategyRegistry(store, client, paymentClie
     const registry = new PaymentStrategyRegistry(checkout.getConfig());
     const placeOrderService = createPlaceOrderService(store, client, paymentClient);
     const remoteCheckoutService = createRemoteCheckoutService(store, client);
-    const scriptLoader = createScriptLoader();
+    const scriptLoader = getScriptLoader();
     const afterpayScriptLoader = createAfterpayScriptLoader();
     const klarnaScriptLoader = new KlarnaScriptLoader(scriptLoader);
 

--- a/src/payment/strategies/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.spec.ts
@@ -87,9 +87,10 @@ describe('AmazonPayPaymentStrategy', () => {
         container.setAttribute('id', 'wallet');
         document.body.appendChild(container);
 
-        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation(() => {
+        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((method, onReady) => {
             hostWindow.OffAmazonPayments = { Widgets: { Wallet } };
-            hostWindow.onAmazonPaymentsReady();
+
+            onReady();
 
             return Promise.resolve();
         });
@@ -116,7 +117,7 @@ describe('AmazonPayPaymentStrategy', () => {
     it('loads widget script', async () => {
         await strategy.initialize({ container: 'wallet', paymentMethod });
 
-        expect(scriptLoader.loadWidget).toHaveBeenCalledWith(paymentMethod);
+        expect(scriptLoader.loadWidget).toHaveBeenCalledWith(paymentMethod, expect.any(Function));
     });
 
     it('creates wallet widget with required properties', async () => {

--- a/src/payment/strategies/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.ts
@@ -40,7 +40,7 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
         return this._placeOrderService
             .initializePaymentMethod(this._paymentMethod.id, () =>
                 new Promise((resolve, reject) => {
-                    this._window.onAmazonPaymentsReady = () => {
+                    const onReady = () => {
                         this._createWallet(options)
                             .then((wallet) => {
                                 this._wallet = wallet;
@@ -49,7 +49,7 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
                             .catch(reject);
                     };
 
-                    this._scriptLoader.loadWidget(options.paymentMethod)
+                    this._scriptLoader.loadWidget(options.paymentMethod, onReady)
                         .catch(reject);
                 })
             )

--- a/src/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
+++ b/src/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
@@ -1,10 +1,11 @@
 /// <reference path="./amazon-login.d.ts" />
+/// <reference path="./off-amazon-payments.d.ts" />
 
 import { ScriptLoader } from '@bigcommerce/script-loader';
 import { PaymentMethod } from '../../../payment';
 
 export default class AmazonPayScriptLoader {
-    private _window: amazon.HostWindow;
+    private _window: amazon.HostWindow & OffAmazonPayments.HostWindow;
 
     constructor(
         private _scriptLoader: ScriptLoader
@@ -12,7 +13,7 @@ export default class AmazonPayScriptLoader {
         this._window = window;
     }
 
-    loadWidget(method: PaymentMethod): Promise<Event> {
+    loadWidget(method: PaymentMethod, onPaymentReady?: () => void): Promise<Event> {
         const {
             config: { merchantId, testMode },
             initializationData: { region = 'us' } = {},
@@ -26,19 +27,27 @@ export default class AmazonPayScriptLoader {
             (region.toLowerCase() !== 'us' ? 'lpa/' : '') +
             `js/Widgets.js?sellerId=${merchantId}`;
 
-        this._configureWidget(method);
+        this._configureWidget(method, onPaymentReady);
 
         return this._scriptLoader.loadScript(url);
     }
 
-    private _configureWidget(method: PaymentMethod): void {
-        if (this._window.onAmazonLoginReady) {
-            return;
-        }
-
-        this._window.onAmazonLoginReady = () => {
+    private _configureWidget(method: PaymentMethod, onPaymentReady?: () => void): void {
+        const onLoginReady = () => {
             amazon.Login.setClientId(method.initializationData.clientId);
             amazon.Login.setUseCookie(true);
         };
+
+        if (this._window.amazon && this._window.amazon.Login) {
+            onLoginReady();
+        } else {
+            this._window.onAmazonLoginReady = onLoginReady;
+        }
+
+        if (this._window.OffAmazonPayments && onPaymentReady) {
+            onPaymentReady();
+        } else {
+            this._window.onAmazonPaymentsReady = onPaymentReady;
+        }
     }
 }

--- a/src/shipping/create-shipping-strategy-registry.ts
+++ b/src/shipping/create-shipping-strategy-registry.ts
@@ -1,4 +1,4 @@
-import { createScriptLoader } from '@bigcommerce/script-loader';
+import { getScriptLoader } from '@bigcommerce/script-loader';
 import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
 import { AmazonPayShippingStrategy, DefaultShippingStrategy, ShippingStrategy } from './strategies';
 import { CheckoutClient, CheckoutStore } from '../checkout';
@@ -19,7 +19,7 @@ export default function createShippingStrategyRegistry(
             store,
             updateShippingService,
             remoteCheckoutService,
-            new AmazonPayScriptLoader(createScriptLoader())
+            new AmazonPayScriptLoader(getScriptLoader())
         )
     );
 

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
@@ -75,9 +75,10 @@ describe('AmazonPayShippingStrategy', () => {
         container.setAttribute('id', 'addressBook');
         document.body.appendChild(container);
 
-        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation(() => {
+        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((method, onReady) => {
             hostWindow.OffAmazonPayments = { Widgets: { AddressBook } };
-            hostWindow.onAmazonPaymentsReady();
+
+            onReady();
 
             return Promise.resolve();
         });
@@ -96,7 +97,7 @@ describe('AmazonPayShippingStrategy', () => {
             paymentMethod,
         });
 
-        expect(scriptLoader.loadWidget).toHaveBeenCalledWith(paymentMethod);
+        expect(scriptLoader.loadWidget).not.toHaveBeenCalledWith(paymentMethod);
     });
 
     it('only initializes widget once until deinitialization', async () => {

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.ts
@@ -41,7 +41,7 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
         return this._updateShippingService
             .initializeShipping(options.paymentMethod.id, () =>
                 new Promise((resolve, reject) => {
-                    this._window.onAmazonPaymentsReady = () => {
+                    const onReady = () => {
                         this._createAddressBook(options)
                             .then((addressBook) => {
                                 this._addressBook = addressBook;
@@ -50,7 +50,7 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
                             .catch(reject);
                     };
 
-                    this._scriptLoader.loadWidget(options.paymentMethod)
+                    this._scriptLoader.loadWidget(options.paymentMethod, onReady)
                         .catch(reject);
                 })
             )

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,9 +20,9 @@
     query-string "^5.0.0"
     tslib "^1.8.0"
 
-"@bigcommerce/script-loader@git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.0":
-  version "0.1.0"
-  resolved "git+ssh://git@github.com/bigcommerce/script-loader-js.git#13fd8a427494c4be459ff03baab235b58669dce1"
+"@bigcommerce/script-loader@git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.1":
+  version "0.1.1"
+  resolved "git+ssh://git@github.com/bigcommerce/script-loader-js.git#2b6c98bb0b36e788bc645a339c7b3cdd1e59972a"
   dependencies:
     tslib "^1.8.0"
 


### PR DESCRIPTION
## What?
* Always override `onAmazonLoginReady` and `onAmazonPaymentReady` callbacks.
* Only set these Amazon callbacks if there is a need. If the Amazon Widget script is already loaded, there's no need to set these callbacks. We can just initialize Amazon Widgets directly.

## Why?
* Otherwise, if `window.onAmazonLoginReady` is already defined elsewhere, Amazon-related strategies are not able to configure the widget script as expected.
* Also, if the Amazon script is already loaded, `onAmazonLoginReady` and `onAmazonPaymentReady` callback don't get triggered again. So in order to trigger the required procedures, we need to trigger them manually.

## Testing / Proof
* Unit
* Related PR: https://github.com/bigcommerce/script-loader-js/pull/2

@bigcommerce/checkout @bigcommerce/payments
