### PR TITLE
fix(PAYMENTS): PAYMENTS-2590 Release bigpay-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.1",
     "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.1",
     "@types/lodash": "^4.14.92",
-    "bigpay-client": "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.10.0",
+    "bigpay-client": "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.10.1",
     "form-poster": "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1",
     "lodash": "^4.17.4",
     "memoizee": "^0.4.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,9 +499,9 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
-"bigpay-client@git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.10.0":
-  version "2.10.0"
-  resolved "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#8db3d716e25d0d36e8de26d63da4345d9f5e7158"
+"bigpay-client@git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.10.1":
+  version "2.10.1"
+  resolved "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#9beabf90cb3674b6d18f31d45912aef7dc1757ae"
   dependencies:
     deep-assign "^2.0.0"
     form-poster "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1"


### PR DESCRIPTION
## What?
- Releasing bipay client 

## Why?
- dependency

@bigcommerce/checkout @bigcommerce/payments @danieldelcore 
