### PR TITLE
CHECKOUT-2926 Do not cache failure when loading scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.1",
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.1",
-    "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.1",
+    "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.2",
     "@types/lodash": "^4.14.92",
     "bigpay-client": "git+ssh://git@github.com/bigcommerce-labs/bigpay-client-js.git#2.10.1",
     "form-poster": "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,9 +20,9 @@
     query-string "^5.0.0"
     tslib "^1.8.0"
 
-"@bigcommerce/script-loader@git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.1":
-  version "0.1.1"
-  resolved "git+ssh://git@github.com/bigcommerce/script-loader-js.git#2b6c98bb0b36e788bc645a339c7b3cdd1e59972a"
+"@bigcommerce/script-loader@git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.2":
+  version "0.1.2"
+  resolved "git+ssh://git@github.com/bigcommerce/script-loader-js.git#a98ae63523e247e19c8907f2111cb9e3f91a541b"
   dependencies:
     tslib "^1.8.0"
 


### PR DESCRIPTION
## What?
When loading a script, do not cache failures.

## Why?
So consecutive calls to `load()` re-try to load the script instead of returning a failure.

## Testing / Proof
- [x] unit
