### PR TITLE
CHECKOUT-3007: Bump `@bigcommerce/data-store` to v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "validate-dependencies": "yarn install --check-files --frozen-lockfile"
   },
   "dependencies": {
-    "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.1",
+    "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.2",
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.1",
     "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.2",
     "@types/lodash": "^4.14.92",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@bigcommerce/data-store@git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.1":
-  version "0.1.1"
-  resolved "git+ssh://git@github.com/bigcommerce/data-store-js.git#1ab98e71d19a2f0f7509e7de601074f79fae5b2d"
+"@bigcommerce/data-store@git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.2":
+  version "0.1.2"
+  resolved "git+ssh://git@github.com/bigcommerce/data-store-js.git#f6488acd70540958017879020fc372ca0235f50c"
   dependencies:
     "@types/lodash" "^4.14.92"
     lodash "^4.17.4"


### PR DESCRIPTION
## What?
* Bump `@bigcommerce/data-store` to v0.1.2

## Why?
* Please see the [release note](https://github.com/bigcommerce/data-store-js/releases/tag/v0.1.2).

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
