### PR TITLE
fix(checkout): CHECKOUT-2932 Fix line items mapping for cart

### DIFF
--- a/src/cart/internal-carts.mock.js
+++ b/src/cart/internal-carts.mock.js
@@ -3,7 +3,7 @@ export function getCart() {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         items: [
             {
-                id: 103,
+                id: '666',
                 type: 'ItemPhysicalEntity',
                 name: 'Canvas Laundry Cart',
                 imageUrl: '/images/canvas-laundry-cart.jpg',

--- a/src/cart/internal-line-item.ts
+++ b/src/cart/internal-line-item.ts
@@ -3,7 +3,7 @@ export default interface InternalLineItem {
     amountAfterDiscount: number;
     attributes: Array<{ name: string, value: string }>;
     discount: number;
-    id: number;
+    id: string | number;
     imageUrl: string;
     integerAmount: number;
     integerAmountAfterDiscount: number;

--- a/src/cart/line-item.ts
+++ b/src/cart/line-item.ts
@@ -32,7 +32,7 @@ export interface GiftCertificateItem {
 }
 
 export interface LineItem {
-    id: number;
+    id: string | number;
     variantId: number;
     productId: number;
     sku: string;

--- a/src/cart/line-items.mock.ts
+++ b/src/cart/line-items.mock.ts
@@ -2,7 +2,7 @@ import { PhysicalItem } from '../cart';
 
 export function getPhysicalItem(): PhysicalItem {
     return {
-        id: 666,
+        id: '666',
         variantId: 71,
         productId: 103,
         sku: 'CLC',

--- a/src/cart/map-to-internal-line-item.ts
+++ b/src/cart/map-to-internal-line-item.ts
@@ -1,13 +1,18 @@
 import { LineItem } from './line-item';
 import InternalLineItem from './internal-line-item';
 
-export default function mapToInternalLineItem(item: LineItem, existingItem: InternalLineItem, type: string): InternalLineItem {
+export default function mapToInternalLineItem(
+    item: LineItem,
+    existingItem: InternalLineItem,
+    type: string,
+    idKey: keyof LineItem = 'id'
+): InternalLineItem {
     return {
         amount: existingItem.amount,
         amountAfterDiscount: existingItem.amountAfterDiscount,
         attributes: existingItem.attributes,
         discount: item.discountAmount,
-        id: item.productId,
+        id: (item[idKey] as string | number),
         imageUrl: item.imageUrl,
         integerAmount: existingItem.integerAmount,
         integerAmountAfterDiscount: existingItem.integerAmountAfterDiscount,

--- a/src/cart/map-to-internal-line-items.ts
+++ b/src/cart/map-to-internal-line-items.ts
@@ -4,14 +4,23 @@ import InternalLineItem from './internal-line-item';
 import LineItemMap from './line-item-map';
 import mapToInternalLineItem from './map-to-internal-line-item';
 
-export default function mapToInternalLineItems(itemMap: LineItemMap, existingItems: InternalLineItem[]): InternalLineItem[] {
+export default function mapToInternalLineItems(
+    itemMap: LineItemMap,
+    existingItems: InternalLineItem[],
+    idKey: keyof LineItem = 'id'
+): InternalLineItem[] {
     return (Object.keys(itemMap) as Array<keyof LineItemMap>)
         .reduce((result, key) => [
             ...result,
-            ...(itemMap[key] as LineItem[]).map((item) => {
-                const existingItem = find(existingItems, { id: item.productId })!;
+            ...(itemMap[key] as LineItem[]).map((item: any) => {
+                const existingItem = find(existingItems, { id: item[idKey] })!;
 
-                return mapToInternalLineItem(item, existingItem, mapToInternalLineItemType(key));
+                return mapToInternalLineItem(
+                    item,
+                    existingItem,
+                    mapToInternalLineItemType(key),
+                    idKey
+                );
             }),
         ], [] as InternalLineItem[]);
 }

--- a/src/order/line-items.mock.ts
+++ b/src/order/line-items.mock.ts
@@ -1,0 +1,9 @@
+import { PhysicalItem } from '../cart';
+import { getPhysicalItem as getCartPhysicalItem } from '../cart/line-items.mock';
+
+export function getPhysicalItem(): PhysicalItem {
+    return {
+        ...getCartPhysicalItem(),
+        id: 5,
+    };
+}

--- a/src/order/map-from-order-to-internal.ts
+++ b/src/order/map-from-order-to-internal.ts
@@ -8,7 +8,7 @@ export default function mapFromOrderToInternal(order: Order, fallbackOrder: Inte
     return {
         id: order.orderId,
         orderId: order.orderId,
-        items: mapToInternalLineItems(order.lineItems, fallbackOrder.items),
+        items: mapToInternalLineItems(order.lineItems, fallbackOrder.items, 'productId'),
         currency: order.currency.code,
         customerCanBeCreated: fallbackOrder.customerCanBeCreated,
         token: fallbackOrder.token,

--- a/src/order/map-to-internal-order.ts
+++ b/src/order/map-to-internal-order.ts
@@ -10,7 +10,7 @@ export default function mapToInternalOrder(checkout: Checkout, order: Order, exi
     return {
         ...mapToInternalIncompleteOrder(checkout, existingOrder),
         id: order.orderId,
-        items: mapToInternalLineItems(order.lineItems, existingOrder.items),
+        items: mapToInternalLineItems(order.lineItems, existingOrder.items, 'productId'),
         currency: order.currency.code,
         customerCanBeCreated: existingOrder.customerCanBeCreated,
         subtotal: {

--- a/src/order/orders.mock.ts
+++ b/src/order/orders.mock.ts
@@ -2,7 +2,7 @@ import { getBillingAddress } from '../billing/billing-addresses.mock';
 import { getCurrency } from '../currency/currencies.mock';
 import { getCoupon } from '../coupon/coupons.mock';
 import { getDiscount } from '../discount/discounts.mock';
-import { getPhysicalItem } from '../cart/line-items.mock';
+import { getPhysicalItem } from './line-items.mock';
 import Order from './order';
 
 export function getOrder(): Order {


### PR DESCRIPTION
## What?
 - Allow line item ID to be either number or string.
 - Allow a `field ID` mapper for line items (temporary). Can be removed once we don't need to backfill using internal data.

## Why?
Because a previous PR changed mappings to accomodate the needs of `orders`. However:
 - Order/Cart items IDs have different types. 
 - The way to map line items differ for `order` and `cart`.

## Testing / Proof
- [x] unit
- [x] manual

@bigcommerce/checkout @bigcommerce/payments
