### PR TITLE
CHECKOUT-3032 Create a no payment strategy

### DIFF
--- a/src/checkout/checkout-service.js
+++ b/src/checkout/checkout-service.js
@@ -137,11 +137,15 @@ export default class CheckoutService {
      */
     submitOrder(payload, options) {
         const { checkout } = this._store.getState();
-        const { payment = {} } = payload;
+        const { payment = {}, useStoreCredit } = payload;
         const method = checkout.getPaymentMethod(payment.name, payment.gateway);
 
         if (!method) {
             throw new MissingDataError();
+        }
+
+        if (!checkout.isPaymentDataRequired(useStoreCredit)) {
+            return this._paymentStrategyRegistry.get('nopaymentdatarequired').execute(payload, options);
         }
 
         return this._paymentStrategyRegistry.getByMethod(method).execute(payload, options);

--- a/src/order/place-order-service.js
+++ b/src/order/place-order-service.js
@@ -69,10 +69,6 @@ export default class PlaceOrderService {
      * @return {Promise<CheckoutSelectors>}
      */
     submitPayment(payment, useStoreCredit = false, options) {
-        if (!this._shouldSubmitPayment(useStoreCredit)) {
-            return Promise.resolve(this._store.getState());
-        }
-
         const payload = this._getPaymentRequestBody(payment);
 
         return this._store.dispatch(this._paymentActionCreator.submitPayment(payload, options))
@@ -90,10 +86,6 @@ export default class PlaceOrderService {
      * @return {Promise<CheckoutSelectors>}
      */
     initializeOffsitePayment(payment, useStoreCredit = false, options) {
-        if (!this._shouldSubmitPayment(useStoreCredit)) {
-            return Promise.resolve(this._store.getState());
-        }
-
         const payload = this._getPaymentRequestBody(payment);
 
         return this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment(payload, options));
@@ -120,17 +112,6 @@ export default class PlaceOrderService {
         const action = this._paymentMethodActionCreator.loadPaymentMethod(methodId, options);
 
         return this._store.dispatch(action, { queueId: 'paymentMethods' });
-    }
-
-    /**
-     * @private
-     * @param {boolean} useStoreCredit
-     * @return {boolean}
-     */
-    _shouldSubmitPayment(useStoreCredit) {
-        const { checkout } = this._store.getState();
-
-        return checkout.isPaymentDataRequired(useStoreCredit);
     }
 
     /**

--- a/src/order/place-order-service.spec.js
+++ b/src/order/place-order-service.spec.js
@@ -202,17 +202,6 @@ describe('PlaceOrderService', () => {
 
             expect(output).toEqual(store.getState());
         });
-
-        it('does not submit payment data if payment is not required', async () => {
-            const { checkout } = store.getState();
-
-            jest.spyOn(checkout, 'isPaymentDataRequired').mockReturnValue(false);
-
-            await placeOrderService.submitPayment(getPayment(), true);
-
-            expect(checkout.isPaymentDataRequired).toHaveBeenCalledWith(true);
-            expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
-        });
     });
 
     describe('#initializeOffsitePayment()', () => {
@@ -231,17 +220,6 @@ describe('PlaceOrderService', () => {
             const output = await placeOrderService.initializeOffsitePayment(getPayment(), false);
 
             expect(output).toEqual(store.getState());
-        });
-
-        it('does not submit payment data if payment is not required', async () => {
-            const { checkout } = store.getState();
-
-            jest.spyOn(checkout, 'isPaymentDataRequired').mockReturnValue(false);
-
-            await placeOrderService.initializeOffsitePayment(getPayment(), true);
-
-            expect(checkout.isPaymentDataRequired).toHaveBeenCalledWith(true);
-            expect(paymentActionCreator.initializeOffsitePayment).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/payment/create-payment-strategy-registry.js
+++ b/src/payment/create-payment-strategy-registry.js
@@ -5,6 +5,7 @@ import {
     AmazonPayPaymentStrategy,
     CreditCardPaymentStrategy,
     KlarnaPaymentStrategy,
+    NoPaymentDataRequiredPaymentStrategy,
     LegacyPaymentStrategy,
     OfflinePaymentStrategy,
     OffsitePaymentStrategy,
@@ -89,6 +90,10 @@ export default function createPaymentStrategyRegistry(store, client, paymentClie
 
     registry.register('squarev2', () =>
         new SquarePaymentStrategy(store, placeOrderService, squareScriptLoader)
+    );
+
+    registry.register('nopaymentdatarequired', () =>
+        new NoPaymentDataRequiredPaymentStrategy(store, placeOrderService)
     );
 
     return registry;

--- a/src/payment/strategies/index.js
+++ b/src/payment/strategies/index.js
@@ -9,4 +9,5 @@ export { default as PaymentStrategy } from './payment-strategy';
 export { default as PaypalExpressPaymentStrategy } from './paypal-express-payment-strategy';
 export { default as PaypalProPaymentStrategy } from './paypal-pro-payment-strategy';
 export { default as SagePayPaymentStrategy } from './sage-pay-payment-strategy';
+export { NoPaymentDataRequiredPaymentStrategy } from './no-payment-data-required-strategy';
 export { SquarePaymentStrategy } from './square';

--- a/src/payment/strategies/no-payment-data-required-strategy.spec.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.spec.ts
@@ -1,0 +1,47 @@
+import { omit } from 'lodash';
+
+import { createCheckoutStore } from '../../checkout';
+import { getOrderRequestBody } from '../../order/internal-orders.mock';
+import NoPaymentDataRequiredPaymentStrategy from './no-payment-data-required-strategy';
+
+describe('NoPaymentDataRequiredPaymentStrategy', () => {
+    let store;
+    let placeOrderService;
+    let noPaymentDataRequiredPaymentStrategy;
+    beforeEach(() => {
+        store = createCheckoutStore();
+        placeOrderService = {
+            submitOrder: jest.fn(() => Promise.resolve(store.getState())),
+            submitPayment: jest.fn(() => Promise.resolve(store.getState())),
+        };
+
+        noPaymentDataRequiredPaymentStrategy = new NoPaymentDataRequiredPaymentStrategy(store, placeOrderService);
+    });
+
+    describe('#execute()', () => {
+        it('calls submit order with the right data', async () => {
+            await noPaymentDataRequiredPaymentStrategy.execute(getOrderRequestBody(), undefined);
+
+            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(omit(getOrderRequestBody(), 'payment'), false, undefined);
+        });
+
+        it('does not call submit payment', async () => {
+            await noPaymentDataRequiredPaymentStrategy.execute(getOrderRequestBody(), undefined);
+
+            expect(placeOrderService.submitPayment).not.toHaveBeenCalled();
+        });
+
+        it('passes the options to submitOrder', async () => {
+            const options = { myOptions: 'option1' };
+            await noPaymentDataRequiredPaymentStrategy.execute(getOrderRequestBody(), options);
+
+            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(expect.any(Object), false, options);
+        });
+
+        it('passes useStoreCredit to submitOrder', async () => {
+            await noPaymentDataRequiredPaymentStrategy.execute({ ...getOrderRequestBody(), useStoreCredit: true });
+
+            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(expect.any(Object), true, undefined);
+        });
+    });
+});

--- a/src/payment/strategies/no-payment-data-required-strategy.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.ts
@@ -1,0 +1,12 @@
+import { omit } from 'lodash';
+
+import { CheckoutSelectors } from '../../checkout';
+import { OrderRequestBody } from '../../order';
+import PaymentStrategy from './payment-strategy';
+
+export default class NoPaymentRequiredPaymentStrategy extends PaymentStrategy {
+    execute(orderRequest: OrderRequestBody, options?: any): Promise<CheckoutSelectors> {
+        const { useStoreCredit } = orderRequest;
+        return this._placeOrderService.submitOrder(omit(orderRequest, 'payment'), useStoreCredit, options);
+    }
+}


### PR DESCRIPTION
## What?
- Add a NoPaymentRequiredStrategy

## Why?
- So we don't have to handle the case of no payment in every other strategy

## Testing / Proof
- Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
