### PR TITLE
CHECKOUT-2900: Restore import order rule

### DIFF
--- a/src/address/is-address-equal.spec.ts
+++ b/src/address/is-address-equal.spec.ts
@@ -1,4 +1,5 @@
 import { getShippingAddress } from '../shipping/internal-shipping-addresses.mock';
+
 import isAddressEqual from './is-address-equal';
 
 describe('isAddressEqual', () => {

--- a/src/address/is-address-equal.ts
+++ b/src/address/is-address-equal.ts
@@ -1,5 +1,7 @@
 import { isEqual } from 'lodash';
+
 import { omitPrivate } from '../common/utility';
+
 import InternalAddress from './internal-address';
 
 export default function isAddressEqual(addressA: InternalAddress, addressB: InternalAddress): boolean {

--- a/src/address/map-to-internal-address.spec.ts
+++ b/src/address/map-to-internal-address.spec.ts
@@ -1,5 +1,6 @@
-import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 import { getShippingAddress as getInternalShippingAddress } from '../shipping/internal-shipping-addresses.mock';
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
+
 import mapToInternalAddress from './map-to-internal-address';
 
 describe('mapToInternalAddress()', () => {

--- a/src/address/map-to-internal-address.ts
+++ b/src/address/map-to-internal-address.ts
@@ -1,4 +1,5 @@
 import { Checkout } from '../checkout';
+
 import Address from './address';
 import InternalAddress from './internal-address';
 

--- a/src/billing/billing-address-reducer.spec.ts
+++ b/src/billing/billing-address-reducer.spec.ts
@@ -1,6 +1,8 @@
 import { createAction } from '@bigcommerce/data-store';
-import { getCheckout } from '../checkout/checkouts.mock';
+
 import { CheckoutActionType } from '../checkout';
+import { getCheckout } from '../checkout/checkouts.mock';
+
 import billingAddressReducer from './billing-address-reducer';
 
 describe('billingAddressReducer', () => {

--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -1,6 +1,8 @@
-import { Action, combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, Action } from '@bigcommerce/data-store';
+
 import { Address } from '../address';
 import { Checkout, CheckoutAction, CheckoutActionType } from '../checkout';
+
 import BillingAddressState from './billing-address-state';
 
 const DEFAULT_STATE: BillingAddressState = {};

--- a/src/cart/cart.ts
+++ b/src/cart/cart.ts
@@ -1,6 +1,7 @@
 import { Coupon } from '../coupon';
 import { Currency } from '../currency';
 import { Discount } from '../discount';
+
 import LineItemMap from './line-item-map';
 
 export default interface Cart {

--- a/src/cart/carts.mock.ts
+++ b/src/cart/carts.mock.ts
@@ -1,7 +1,8 @@
 import { Cart } from '../cart';
-import { getCurrency } from '../currency/currencies.mock';
 import { getCoupon } from '../coupon/coupons.mock';
+import { getCurrency } from '../currency/currencies.mock';
 import { getDiscount } from '../discount/discounts.mock';
+
 import { getPhysicalItem } from './line-items.mock';
 
 export function getCart(): Cart {

--- a/src/cart/internal-cart.ts
+++ b/src/cart/internal-cart.ts
@@ -1,5 +1,6 @@
-import { DiscountNotification } from '../discount';
 import { InternalCoupon, InternalGiftCertificate } from '../coupon';
+import { DiscountNotification } from '../discount';
+
 import InternalLineItem from './internal-line-item';
 
 export default interface InternalCart {

--- a/src/cart/map-to-internal-cart.spec.ts
+++ b/src/cart/map-to-internal-cart.spec.ts
@@ -1,5 +1,6 @@
-import { getCheckout } from '../checkout/checkouts.mock';
 import { getCart as getInternalCart } from '../cart/internal-carts.mock';
+import { getCheckout } from '../checkout/checkouts.mock';
+
 import mapToInternalCart from './map-to-internal-cart';
 
 describe('mapToInternalLineItems()', () => {

--- a/src/cart/map-to-internal-cart.ts
+++ b/src/cart/map-to-internal-cart.ts
@@ -1,6 +1,8 @@
 import { find } from 'lodash';
+
 import { Checkout } from '../checkout';
 import { mapToInternalCoupon, mapToInternalGiftCertificate } from '../coupon';
+
 import InternalCart from './internal-cart';
 import mapToInternalLineItems from './map-to-internal-line-items';
 

--- a/src/cart/map-to-internal-line-item.ts
+++ b/src/cart/map-to-internal-line-item.ts
@@ -1,5 +1,5 @@
-import { LineItem } from './line-item';
 import InternalLineItem from './internal-line-item';
+import { LineItem } from './line-item';
 
 export default function mapToInternalLineItem(item: LineItem, existingItem: InternalLineItem, type: string): InternalLineItem {
     return {

--- a/src/cart/map-to-internal-line-items.spec.ts
+++ b/src/cart/map-to-internal-line-items.spec.ts
@@ -1,5 +1,6 @@
 import { getCart } from '../cart/carts.mock';
 import { getCart as getInternalCart } from '../cart/internal-carts.mock';
+
 import mapToInternalLineItems from './map-to-internal-line-items';
 
 describe('mapToInternalLineItems()', () => {

--- a/src/cart/map-to-internal-line-items.ts
+++ b/src/cart/map-to-internal-line-items.ts
@@ -1,6 +1,7 @@
-import { LineItem } from './line-item';
 import { find } from 'lodash';
+
 import InternalLineItem from './internal-line-item';
+import { LineItem } from './line-item';
 import LineItemMap from './line-item-map';
 import mapToInternalLineItem from './map-to-internal-line-item';
 

--- a/src/checkout/checkout-action-creator.spec.ts
+++ b/src/checkout/checkout-action-creator.spec.ts
@@ -1,13 +1,15 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { CartRequestSender } from '../cart';
-import { CheckoutActionType } from './checkout-actions';
-import { getCart } from '../cart/carts.mock';
-import { getCheckout } from './checkouts.mock';
-import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
-import CheckoutActionCreator from './checkout-action-creator';
-import CheckoutRequestSender from './checkout-request-sender';
 import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/toPromise';
+
+import { CartRequestSender } from '../cart';
+import { getCart } from '../cart/carts.mock';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+
+import CheckoutActionCreator from './checkout-action-creator';
+import { CheckoutActionType } from './checkout-actions';
+import CheckoutRequestSender from './checkout-request-sender';
+import { getCheckout } from './checkouts.mock';
 
 describe('CheckoutActionCreator', () => {
     let checkoutRequestSender;

--- a/src/checkout/checkout-action-creator.ts
+++ b/src/checkout/checkout-action-creator.ts
@@ -1,10 +1,12 @@
+import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
-import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+
 import { CartRequestSender } from '../cart';
 import { CartUnavailableError } from '../cart/errors';
-import { CheckoutAction, CheckoutActionType } from './checkout-actions';
+
 import Checkout from './checkout';
+import { CheckoutAction, CheckoutActionType } from './checkout-actions';
 import CheckoutRequestSender from './checkout-request-sender';
 
 export default class CheckoutActionCreator {

--- a/src/checkout/checkout-actions.ts
+++ b/src/checkout/checkout-actions.ts
@@ -1,4 +1,5 @@
 import { Action } from '@bigcommerce/data-store';
+
 import Checkout from './checkout';
 
 export enum CheckoutActionType {

--- a/src/checkout/checkout-reducer.spec.ts
+++ b/src/checkout/checkout-reducer.spec.ts
@@ -1,10 +1,12 @@
 import { createAction } from '@bigcommerce/data-store';
+
 import { CheckoutActionType } from '../checkout';
-import { RequestError } from '../common/error/errors';
 import { getCheckout } from '../checkout/checkouts.mock';
+import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
-import CheckoutState from './checkout-state';
+
 import checkoutReducer from './checkout-reducer';
+import CheckoutState from './checkout-state';
 
 describe('checkoutReducer', () => {
     let initialState: CheckoutState;

--- a/src/checkout/checkout-reducer.ts
+++ b/src/checkout/checkout-reducer.ts
@@ -1,7 +1,9 @@
-import { Action, combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, Action } from '@bigcommerce/data-store';
+
 import { Address } from '../address';
-import { CheckoutAction, CheckoutActionType } from './checkout-actions';
+
 import Checkout from './checkout';
+import { CheckoutAction, CheckoutActionType } from './checkout-actions';
 import CheckoutState, { CheckoutErrorsState, CheckoutStatusesState } from './checkout-state';
 
 const DEFAULT_STATE: CheckoutState = {

--- a/src/checkout/checkout-selectors.ts
+++ b/src/checkout/checkout-selectors.ts
@@ -1,6 +1,6 @@
+import CheckoutErrorSelector from './checkout-error-selector';
 import CheckoutSelector from './checkout-selector';
 import CheckoutStatusSelector from './checkout-status-selector';
-import CheckoutErrorSelector from './checkout-error-selector';
 
 export default interface CheckoutSelectors {
     checkout: CheckoutSelector;

--- a/src/checkout/checkout-store.ts
+++ b/src/checkout/checkout-store.ts
@@ -1,4 +1,5 @@
 import { DataStore } from '@bigcommerce/data-store';
+
 import CheckoutSelectors from './checkout-selectors';
 
 type CheckoutStore = DataStore<CheckoutSelectors>;

--- a/src/checkout/checkout.ts
+++ b/src/checkout/checkout.ts
@@ -1,9 +1,9 @@
 import { Address } from '../address';
 import { Cart } from '../cart';
-import { Consignment } from '../shipping';
 import { Coupon, GiftCertificate } from '../coupon';
-import { Discount } from '../discount';
 import { Shopper } from '../customer';
+import { Discount } from '../discount';
+import { Consignment } from '../shipping';
 import { Tax } from '../tax';
 
 export default interface Checkout {

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -1,7 +1,8 @@
-import { getRemoteCheckoutMeta } from '../remote-checkout/remote-checkout.mock';
 import { getBillingAddress } from '../billing/billing-addresses.mock';
 import { getCart } from '../cart/carts.mock';
+import { getRemoteCheckoutMeta } from '../remote-checkout/remote-checkout.mock';
 import { getConsignment } from '../shipping/consignments.mock';
+
 import Checkout from './checkout';
 
 export function getCheckout(): Checkout {

--- a/src/common/registry/registry.spec.ts
+++ b/src/common/registry/registry.spec.ts
@@ -1,4 +1,5 @@
 import { InvalidArgumentError } from '../error/errors';
+
 import Registry from './registry';
 
 describe('Registry', () => {

--- a/src/common/selector/selector-decorator.ts
+++ b/src/common/selector/selector-decorator.ts
@@ -1,7 +1,8 @@
 import { isEqual, memoize } from 'lodash';
-import CacheKeyResolver from './cache-key-resolver';
 
 import { bindDecorator } from '../utility';
+
+import CacheKeyResolver from './cache-key-resolver';
 
 /**
  * Decorates a class by patching all of its methods to cache their return values

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -1,13 +1,15 @@
 /// <reference path="../common/http-request/request-sender.d.ts" />
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
-import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
-import { AmazonPayCustomerStrategy, DefaultCustomerStrategy, CustomerStrategy } from './strategies';
+
 import { CheckoutClient, CheckoutStore } from '../checkout';
-import { PaymentMethod, PaymentMethodActionCreator } from '../payment';
 import { Registry } from '../common/registry';
+import { PaymentMethod, PaymentMethodActionCreator } from '../payment';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
+import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
+
 import CustomerActionCreator from './customer-action-creator';
+import { AmazonPayCustomerStrategy, CustomerStrategy, DefaultCustomerStrategy } from './strategies';
 
 export default function createCustomerStrategyRegistry(
     store: CheckoutStore,

--- a/src/customer/customer-strategy-action-creator.spec.ts
+++ b/src/customer/customer-strategy-action-creator.spec.ts
@@ -2,11 +2,11 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/toPromise';
-
 import { Observable } from 'rxjs/Observable';
 
-import { CheckoutClient, CheckoutStore, createCheckoutClient, createCheckoutStore } from '../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
+
 import createCustomerStrategyRegistry from './create-customer-strategy-registry';
 import CustomerActionCreator from './customer-action-creator';
 import CustomerStrategyActionCreator from './customer-strategy-action-creator';

--- a/src/customer/customer-strategy-action-creator.ts
+++ b/src/customer/customer-strategy-action-creator.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
 import { Registry } from '../common/registry';
+
 import CustomerCredentials from './customer-credentials';
 import {
     CustomerStrategyActionType,

--- a/src/customer/customer-strategy-selector.spec.ts
+++ b/src/customer/customer-strategy-selector.spec.ts
@@ -1,7 +1,8 @@
-import { getCustomerStrategyState } from './internal-customers.mock';
 import { getErrorResponse } from '../common/http-request/responses.mock';
+
 import CustomerStrategySelector from './customer-strategy-selector';
 import CustomerStrategyState from './customer-strategy-state';
+import { getCustomerStrategyState } from './internal-customers.mock';
 
 describe('CustomerStrategySelector', () => {
     let selector: CustomerStrategySelector;

--- a/src/customer/map-to-internal-customer.ts
+++ b/src/customer/map-to-internal-customer.ts
@@ -1,4 +1,5 @@
 import { Checkout } from '../checkout';
+
 import InternalCustomer from './internal-customer';
 
 export default function mapToInternalCustomer(checkout: Checkout, existingCustomer: InternalCustomer): InternalCustomer {

--- a/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
@@ -6,16 +6,18 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import 'rxjs/add/observable/of';
 import { Observable } from 'rxjs/Observable';
-import { CheckoutStore, createCheckoutClient, createCheckoutStore } from '../../checkout';
+
+import { createCheckoutClient, createCheckoutStore, CheckoutStore } from '../../checkout';
 import { getResponse } from '../../common/http-request/responses.mock';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
 import { LOAD_PAYMENT_METHOD_SUCCEEDED } from '../../payment/payment-method-action-types';
-import { SIGN_OUT_REMOTE_CUSTOMER_SUCCEEDED } from '../../remote-checkout/remote-checkout-action-types';
 import { getAmazonPay } from '../../payment/payment-methods.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../remote-checkout';
 import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay';
+import { SIGN_OUT_REMOTE_CUSTOMER_SUCCEEDED } from '../../remote-checkout/remote-checkout-action-types';
 import { getRemoteTokenResponseBody } from '../../remote-checkout/remote-checkout.mock';
 import { getGuestCustomer } from '../internal-customers.mock';
+
 import AmazonPayCustomerStrategy from './amazon-pay-customer-strategy';
 
 describe('AmazonPayCustomerStrategy', () => {

--- a/src/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.ts
@@ -3,6 +3,7 @@
 
 import 'rxjs/add/observable/empty';
 import { Observable } from 'rxjs/Observable';
+
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
 import { NotImplementedError, NotInitializedError } from '../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
@@ -10,6 +11,7 @@ import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../
 import { RemoteCheckoutCustomerError } from '../../remote-checkout/errors';
 import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay';
 import CustomerCredentials from '../customer-credentials';
+
 import CustomerStrategy from './customer-strategy';
 
 export default class AmazonPayCustomerStrategy extends CustomerStrategy {

--- a/src/customer/strategies/default-customer-strategy.spec.ts
+++ b/src/customer/strategies/default-customer-strategy.spec.ts
@@ -1,10 +1,12 @@
 import { createAction } from '@bigcommerce/data-store';
 import 'rxjs/add/observable/of';
 import { Observable } from 'rxjs/Observable';
-import { CheckoutClient, CheckoutStore, createCheckoutClient, createCheckoutStore } from '../../checkout';
+
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../checkout';
 import { getQuote } from '../../quote/internal-quotes.mock';
 import CustomerActionCreator from '../customer-action-creator';
 import { SIGN_IN_CUSTOMER_SUCCEEDED, SIGN_OUT_CUSTOMER_SUCCEEDED } from '../customer-action-types';
+
 import DefaultCustomerStrategy from './default-customer-strategy';
 
 describe('DefaultCustomerStrategy', () => {

--- a/src/customer/strategies/default-customer-strategy.ts
+++ b/src/customer/strategies/default-customer-strategy.ts
@@ -1,7 +1,8 @@
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
-import CustomerCredentials from '../customer-credentials';
-import CustomerStrategy from './customer-strategy';
 import CustomerActionCreator from '../customer-action-creator';
+import CustomerCredentials from '../customer-credentials';
+
+import CustomerStrategy from './customer-strategy';
 
 export default class DefaultCustomerStrategy extends CustomerStrategy {
     constructor(

--- a/src/order/create-place-order-service.ts
+++ b/src/order/create-place-order-service.ts
@@ -1,7 +1,9 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
+
 import { CartActionCreator } from '../cart';
 import { CheckoutClient, CheckoutStore } from '../checkout';
 import { PaymentActionCreator, PaymentMethodActionCreator, PaymentRequestSender } from '../payment';
+
 import OrderActionCreator from './order-action-creator';
 import PlaceOrderService from './place-order-service';
 

--- a/src/order/internal-order.ts
+++ b/src/order/internal-order.ts
@@ -1,5 +1,6 @@
 import { InternalLineItem } from '../cart';
 import { InternalCoupon, InternalGiftCertificate } from '../coupon';
+
 import InternalIncompleteOrder from './internal-incomplete-order';
 
 export default interface InternalOrder extends InternalIncompleteOrder {

--- a/src/order/map-to-internal-incomplete-order.ts
+++ b/src/order/map-to-internal-incomplete-order.ts
@@ -1,6 +1,7 @@
 import { Checkout } from '../checkout';
-import InternalOrder from './internal-order';
+
 import InternalIncompleteOrder from './internal-incomplete-order';
+import InternalOrder from './internal-order';
 
 export default function mapToInternalIncompleteOrder(checkout: Checkout, existingOrder: InternalIncompleteOrder): InternalIncompleteOrder {
     return {

--- a/src/order/map-to-internal-order.spec.ts
+++ b/src/order/map-to-internal-order.spec.ts
@@ -1,7 +1,8 @@
 import { getCheckout } from '../checkout/checkouts.mock';
-import { getOrder } from './orders.mock';
+
 import { getCompleteOrder as getInternalOrder } from './internal-orders.mock';
 import mapToInternalOrder from './map-to-internal-order';
+import { getOrder } from './orders.mock';
 
 describe('mapToInternalOrder()', () => {
     it('maps to internal line items', () => {

--- a/src/order/map-to-internal-order.ts
+++ b/src/order/map-to-internal-order.ts
@@ -1,10 +1,12 @@
 import { find } from 'lodash';
-import { Checkout } from '../checkout';
-import { default as InternalOrder } from './internal-order';
+
 import { mapToInternalCart, mapToInternalLineItems } from '../cart';
+import { Checkout } from '../checkout';
 import { mapToInternalCoupon, mapToInternalGiftCertificate } from '../coupon';
-import Order from './order';
+
+import { default as InternalOrder } from './internal-order';
 import mapToInternalIncompleteOrder from './map-to-internal-incomplete-order';
+import Order from './order';
 
 export default function mapToInternalOrder(checkout: Checkout, order: Order, existingOrder: InternalOrder): InternalOrder {
     return {

--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -1,6 +1,6 @@
 import { Address } from '../address';
-import { Currency } from '../currency';
 import { DigitalItem, GiftCertificateItem, PhysicalItem } from '../cart';
+import { Currency } from '../currency';
 
 export default interface Order {
     baseAmount: number;

--- a/src/order/orders.mock.ts
+++ b/src/order/orders.mock.ts
@@ -1,8 +1,9 @@
 import { getBillingAddress } from '../billing/billing-addresses.mock';
-import { getCurrency } from '../currency/currencies.mock';
-import { getCoupon } from '../coupon/coupons.mock';
-import { getDiscount } from '../discount/discounts.mock';
 import { getPhysicalItem } from '../cart/line-items.mock';
+import { getCoupon } from '../coupon/coupons.mock';
+import { getCurrency } from '../currency/currencies.mock';
+import { getDiscount } from '../discount/discounts.mock';
+
 import Order from './order';
 
 export function getOrder(): Order {

--- a/src/payment/is-credit-card.ts
+++ b/src/payment/is-credit-card.ts
@@ -1,5 +1,5 @@
-import { CreditCard, PaymentInstrument, VaultedInstrument } from './payment';
 import isVaultedInstrument from './is-vaulted-instrument';
+import { CreditCard, PaymentInstrument, VaultedInstrument } from './payment';
 
 export default function isCreditCardLike(creditCard: PaymentInstrument): creditCard is CreditCard {
     const card = creditCard as CreditCard;

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -1,20 +1,20 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { merge } from 'lodash';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/toPromise';
-
-import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
-import { merge } from 'lodash';
 import { Observable } from 'rxjs/Observable';
 
 import { getCartState } from '../cart/internal-carts.mock';
-import { CheckoutClient, CheckoutStore, createCheckoutClient, createCheckoutStore } from '../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../checkout';
 import { MissingDataError } from '../common/error/errors';
 import { getCustomerState } from '../customer/internal-customers.mock';
 import { createPlaceOrderService } from '../order';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 import { getCompleteOrderState, getIncompleteOrderState, getOrderRequestBody } from '../order/internal-orders.mock';
+
 import createPaymentStrategyRegistry from './create-payment-strategy-registry';
 import { getPaymentMethod, getPaymentMethodsState } from './payment-methods.mock';
 import PaymentStrategyActionCreator from './payment-strategy-action-creator';

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -5,6 +5,7 @@ import { Observer } from 'rxjs/Observer';
 import { MissingDataError } from '../common/error/errors';
 import { OrderRequestBody } from '../order';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
+
 import Payment from './payment';
 import {
     PaymentStrategyActionType,

--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -1,7 +1,9 @@
 import { some } from 'lodash';
+
 import { Registry } from '../common/registry';
-import * as paymentMethodTypes from './payment-method-types';
+
 import PaymentMethod from './payment-method';
+import * as paymentMethodTypes from './payment-method-types';
 import PaymentStrategy from './strategies/payment-strategy';
 
 export default class PaymentStrategyRegistry extends Registry<PaymentStrategy> {

--- a/src/payment/payment-strategy-selector.spec.ts
+++ b/src/payment/payment-strategy-selector.spec.ts
@@ -1,4 +1,5 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
+
 import PaymentStrategySelector from './payment-strategy-selector';
 import { DEFAULT_STATE } from './payment-strategy-state';
 

--- a/src/payment/strategies/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay-payment-strategy.spec.ts
@@ -5,7 +5,7 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
 import { Observable } from 'rxjs';
 
-import { CheckoutStore, createCheckoutClient, createCheckoutStore } from '../../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutStore } from '../../checkout';
 import CheckoutClient from '../../checkout/checkout-client';
 import { createPlaceOrderService, OrderRequestBody, PlaceOrderService } from '../../order';
 import { getIncompleteOrder, getOrderRequestBody } from '../../order/internal-orders.mock';
@@ -14,6 +14,7 @@ import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../
 import AfterpayScriptLoader from '../../remote-checkout/methods/afterpay';
 import { INITIALIZE_REMOTE_PAYMENT_REQUESTED } from '../../remote-checkout/remote-checkout-action-types';
 import PaymentMethod from '../payment-method';
+
 import AfterpayPaymentStrategy from './afterpay-payment-strategy';
 
 describe('AfterpayPaymentStrategy', () => {

--- a/src/payment/strategies/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay-payment-strategy.ts
@@ -6,6 +6,7 @@ import { OrderRequestBody, PlaceOrderService } from '../../order';
 import { RemoteCheckoutActionCreator } from '../../remote-checkout';
 import AfterpayScriptLoader from '../../remote-checkout/methods/afterpay';
 import { PaymentMethodMissingDataError, PaymentMethodUninitializedError } from '../errors';
+
 import PaymentStrategy, { InitializeOptions } from './payment-strategy';
 
 export default class AfterpayPaymentStrategy extends PaymentStrategy {

--- a/src/payment/strategies/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../remote-checkout/methods/amazon-pay/off-amazon-payments.d.ts" />
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
-import { Action, createAction } from '@bigcommerce/data-store';
+import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
@@ -10,7 +10,7 @@ import { BillingAddressActionCreator } from '../../billing';
 import { UPDATE_BILLING_ADDRESS_REQUESTED } from '../../billing/billing-address-action-types';
 import { getBillingAddress } from '../../billing/internal-billing-addresses.mock';
 import { getCartResponseBody } from '../../cart/internal-carts.mock';
-import { CheckoutClient, CheckoutStore, createCheckoutClient, createCheckoutStore } from '../../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../checkout';
 import { getCheckoutMeta } from '../../checkout/checkouts.mock';
 import { NotInitializedError, RequestError } from '../../common/error/errors';
 import { getErrorResponse, getResponse } from '../../common/http-request/responses.mock';
@@ -25,6 +25,7 @@ import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay'
 import { INITIALIZE_REMOTE_BILLING_REQUESTED, INITIALIZE_REMOTE_PAYMENT_REQUESTED } from '../../remote-checkout/remote-checkout-action-types';
 import { getRemoteCheckoutState } from '../../remote-checkout/remote-checkout.mock';
 import PaymentMethod from '../payment-method';
+
 import AmazonPayPaymentStrategy from './amazon-pay-payment-strategy';
 
 describe('AmazonPayPaymentStrategy', () => {

--- a/src/payment/strategies/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../remote-checkout/methods/amazon-pay/off-amazon-payments-widgets.d.ts" />
 import { noop, omit } from 'lodash';
 
-import { InternalAddress, isAddressEqual } from '../../address';
+import { isAddressEqual, InternalAddress } from '../../address';
 import { BillingAddressActionCreator } from '../../billing';
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
 import { NotInitializedError, RequestError } from '../../common/error/errors';
@@ -10,6 +10,7 @@ import { RemoteCheckoutActionCreator } from '../../remote-checkout';
 import { RemoteCheckoutPaymentError, RemoteCheckoutSessionError, RemoteCheckoutSynchronizationError } from '../../remote-checkout/errors';
 import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay';
 import PaymentMethod from '../payment-method';
+
 import PaymentStrategy from './payment-strategy';
 
 export default class AmazonPayPaymentStrategy extends PaymentStrategy {

--- a/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
@@ -1,4 +1,5 @@
 import { NotInitializedError } from '../../../common/error/errors';
+
 import BraintreeScriptLoader from './braintree-script-loader';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 import {

--- a/src/payment/strategies/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card-payment-strategy.spec.ts
@@ -1,8 +1,10 @@
-import { omit } from 'lodash';
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { omit } from 'lodash';
+
 import { createCheckoutClient, createCheckoutStore, CheckoutStore } from '../../checkout';
 import { createPlaceOrderService, PlaceOrderService } from '../../order';
 import { getOrderRequestBody } from '../../order/internal-orders.mock';
+
 import CreditCardPaymentStrategy from './credit-card-payment-strategy';
 
 describe('CreditCardPaymentStrategy', () => {

--- a/src/payment/strategies/credit-card-payment-strategy.ts
+++ b/src/payment/strategies/credit-card-payment-strategy.ts
@@ -1,6 +1,8 @@
 import { omit } from 'lodash';
+
 import { CheckoutSelectors } from '../../checkout';
 import { OrderRequestBody } from '../../order';
+
 import PaymentStrategy from './payment-strategy';
 
 export default class CreditCardPaymentStrategy extends PaymentStrategy {

--- a/src/payment/strategies/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna-payment-strategy.spec.ts
@@ -5,7 +5,7 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
 import { Observable } from 'rxjs';
 
-import { CheckoutClient, CheckoutStore, createCheckoutClient, createCheckoutStore } from '../../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../checkout';
 import { createPlaceOrderService, OrderRequestBody, PlaceOrderService } from '../../order';
 import { getOrderRequestBody } from '../../order/internal-orders.mock';
 import { getKlarna } from '../../payment/payment-methods.mock';
@@ -13,6 +13,7 @@ import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../
 import { KlarnaScriptLoader } from '../../remote-checkout/methods/klarna';
 import { INITIALIZE_REMOTE_PAYMENT_REQUESTED } from '../../remote-checkout/remote-checkout-action-types';
 import PaymentMethod from '../payment-method';
+
 import KlarnaPaymentStrategy from './klarna-payment-strategy';
 
 describe('KlarnaPaymentStrategy', () => {

--- a/src/payment/strategies/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna-payment-strategy.ts
@@ -1,11 +1,13 @@
 /// <reference path="../../remote-checkout/methods/klarna/klarna-sdk.d.ts" />
 
 import { omit } from 'lodash';
+
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
-import { KlarnaScriptLoader } from '../../remote-checkout/methods/klarna';
 import { OrderRequestBody, PlaceOrderService } from '../../order';
 import { RemoteCheckoutActionCreator } from '../../remote-checkout';
+import { KlarnaScriptLoader } from '../../remote-checkout/methods/klarna';
 import PaymentMethod from '../payment-method';
+
 import PaymentStrategy from './payment-strategy';
 
 export default class KlarnaPaymentStrategy extends PaymentStrategy {

--- a/src/payment/strategies/no-payment-data-required-strategy.spec.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.spec.ts
@@ -2,6 +2,7 @@ import { omit } from 'lodash';
 
 import { createCheckoutStore } from '../../checkout';
 import { getOrderRequestBody } from '../../order/internal-orders.mock';
+
 import { NoPaymentDataRequiredPaymentStrategy } from '.';
 
 describe('NoPaymentDataRequiredPaymentStrategy', () => {

--- a/src/payment/strategies/no-payment-data-required-strategy.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.ts
@@ -2,6 +2,7 @@ import { omit } from 'lodash';
 
 import { CheckoutSelectors } from '../../checkout';
 import { OrderRequestBody } from '../../order';
+
 import PaymentStrategy from './payment-strategy';
 
 export default class NoPaymentDataRequiredPaymentStrategy extends PaymentStrategy {

--- a/src/payment/strategies/payment-strategy.ts
+++ b/src/payment/strategies/payment-strategy.ts
@@ -1,6 +1,6 @@
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
-import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import { OrderRequestBody } from '../../order';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import PaymentMethod from '../payment-method';
 
 export default abstract class PaymentStrategy {

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -2,12 +2,14 @@
 
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createScriptLoader } from '@bigcommerce/script-loader';
+
 import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../../checkout';
 import { createPlaceOrderService } from '../../../order';
 import { getSquare } from '../../../payment/payment-methods.mock';
+import PaymentMethod from '../../payment-method';
+
 import SquarePaymentStrategy from './square-payment-strategy';
 import SquareScriptLoader from './square-script-loader';
-import PaymentMethod from '../../payment-method';
 
 describe('SquarePaymentStrategy', () => {
     let client: CheckoutClient;

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -1,13 +1,15 @@
 /// <reference path="./square-form.d.ts" />
 
 import { omit } from 'lodash';
+
 import { CheckoutSelectors, CheckoutStore } from '../../../checkout';
 import { TimeoutError, UnsupportedBrowserError } from '../../../common/error/errors';
 import { OrderRequestBody, PlaceOrderService } from '../../../order';
-import { PaymentMethodUninitializedError, PaymentMethodMissingDataError } from '../../errors';
-import SquareScriptLoader from './square-script-loader';
+import { PaymentMethodMissingDataError, PaymentMethodUninitializedError } from '../../errors';
 import PaymentMethod from '../../payment-method';
 import PaymentStrategy from '../payment-strategy';
+
+import SquareScriptLoader from './square-script-loader';
 
 export default class SquarePaymentStrategy extends PaymentStrategy {
     private _paymentForm?: Square.PaymentForm;

--- a/src/payment/strategies/square/square-script-loader.spec.ts
+++ b/src/payment/strategies/square/square-script-loader.spec.ts
@@ -1,5 +1,6 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
+
 import SquareScriptLoader from './square-script-loader';
 
 describe('SquareScriptLoader', () => {

--- a/src/quote/map-to-internal-quote.spec.ts
+++ b/src/quote/map-to-internal-quote.spec.ts
@@ -1,4 +1,5 @@
 import { getCheckout } from '../checkout/checkouts.mock';
+
 import { getQuote as getInternalQuote } from './internal-quotes.mock';
 import mapToInternalQuote from './map-to-internal-quote';
 

--- a/src/quote/map-to-internal-quote.ts
+++ b/src/quote/map-to-internal-quote.ts
@@ -1,5 +1,6 @@
-import { Checkout } from '../checkout';
 import { mapToInternalAddress } from '../address';
+import { Checkout } from '../checkout';
+
 import InternalQuote from './internal-quote';
 
 export default function mapToInternalQuote(checkout: Checkout, existingQuote: InternalQuote): InternalQuote {

--- a/src/remote-checkout/methods/afterpay/afterpay-script-loader.spec.ts
+++ b/src/remote-checkout/methods/afterpay/afterpay-script-loader.spec.ts
@@ -1,6 +1,8 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
+
 import { getAfterpay } from '../../../payment/payment-methods.mock';
+
 import AfterpayScriptLoader from './afterpay-script-loader';
 
 describe('AfterpayScriptLoader', () => {

--- a/src/remote-checkout/methods/afterpay/afterpay-script-loader.ts
+++ b/src/remote-checkout/methods/afterpay/afterpay-script-loader.ts
@@ -1,6 +1,7 @@
 /// <reference path="./afterpay-sdk.d.ts" />
 
 import { ScriptLoader } from '@bigcommerce/script-loader';
+
 import { PaymentMethod } from '../../../payment';
 
 const SCRIPT_PROD = '//www.secure-afterpay.com.au/afterpay-async.js';

--- a/src/remote-checkout/methods/afterpay/index.ts
+++ b/src/remote-checkout/methods/afterpay/index.ts
@@ -1,4 +1,5 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
+
 import AfterpayScriptLoader from './afterpay-script-loader';
 
 export default AfterpayScriptLoader;

--- a/src/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.spec.ts
+++ b/src/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.spec.ts
@@ -3,7 +3,9 @@
 
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
+
 import { getAmazonPay } from '../../../payment/payment-methods.mock';
+
 import AmazonPayScriptLoader from './amazon-pay-script-loader';
 
 describe('AmazonPayScriptLoader', () => {

--- a/src/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
+++ b/src/remote-checkout/methods/amazon-pay/amazon-pay-script-loader.ts
@@ -2,6 +2,7 @@
 /// <reference path="./off-amazon-payments.d.ts" />
 
 import { ScriptLoader } from '@bigcommerce/script-loader';
+
 import { PaymentMethod } from '../../../payment';
 
 export default class AmazonPayScriptLoader {

--- a/src/remote-checkout/methods/klarna/klarna-script-loader.spec.ts
+++ b/src/remote-checkout/methods/klarna/klarna-script-loader.spec.ts
@@ -1,5 +1,6 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
+
 import KlarnaScriptLoader from './klarna-script-loader';
 
 describe('KlarnaScriptLoader', () => {

--- a/src/remote-checkout/methods/klarna/klarna-script-loader.ts
+++ b/src/remote-checkout/methods/klarna/klarna-script-loader.ts
@@ -1,6 +1,7 @@
 /// <reference path="./klarna-sdk.d.ts" />
 
 import { ScriptLoader } from '@bigcommerce/script-loader';
+
 import { PaymentMethod } from '../../../payment';
 
 const SDK_URL = '//credit.klarnacdn.net/lib/v1/api.js';

--- a/src/remote-checkout/remote-checkout-selector.spec.ts
+++ b/src/remote-checkout/remote-checkout-selector.spec.ts
@@ -1,6 +1,7 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
-import { getRemoteCheckoutState, getEmptyRemoteCheckoutState } from './remote-checkout.mock';
+
 import RemoteCheckoutSelector from './remote-checkout-selector';
+import { getEmptyRemoteCheckoutState, getRemoteCheckoutState } from './remote-checkout.mock';
 
 describe('RemoteCheckoutSelector', () => {
     it('returns remote checkout data', () => {

--- a/src/remote-checkout/remote-checkout-selector.ts
+++ b/src/remote-checkout/remote-checkout-selector.ts
@@ -1,6 +1,6 @@
-import RemoteCheckoutState from './remote-checkout-state';
 import RemoteCheckout from './remote-checkout';
 import RemoteCheckoutMeta from './remote-checkout-meta';
+import RemoteCheckoutState from './remote-checkout-state';
 
 export default class RemoteCheckoutSelector {
     constructor(

--- a/src/remote-checkout/remote-checkout.mock.ts
+++ b/src/remote-checkout/remote-checkout.mock.ts
@@ -1,8 +1,9 @@
 import { getBillingAddress } from '../billing/internal-billing-addresses.mock';
 import { getShippingAddress } from '../shipping/internal-shipping-addresses.mock';
-import RemoteCheckoutState from './remote-checkout-state';
+
 import RemoteCheckout from './remote-checkout';
 import RemoteCheckoutMeta from './remote-checkout-meta';
+import RemoteCheckoutState from './remote-checkout-state';
 
 export function getRemoteCheckoutState(): RemoteCheckoutState {
     return {

--- a/src/shipping/consignment-reducer.spec.ts
+++ b/src/shipping/consignment-reducer.spec.ts
@@ -1,6 +1,8 @@
 import { createAction } from '@bigcommerce/data-store';
-import { getCheckout } from '../checkout/checkouts.mock';
+
 import { CheckoutActionType } from '../checkout';
+import { getCheckout } from '../checkout/checkouts.mock';
+
 import consignmentReducer from './consignment-reducer';
 
 describe('consignmentReducer', () => {

--- a/src/shipping/consignment-reducer.ts
+++ b/src/shipping/consignment-reducer.ts
@@ -1,5 +1,7 @@
-import { Action, combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, Action } from '@bigcommerce/data-store';
+
 import { Checkout, CheckoutAction, CheckoutActionType } from '../checkout';
+
 import Consignment from './consignment';
 import ConsignmentState from './consignment-state';
 

--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -1,4 +1,5 @@
 import { Address } from '../address';
+
 import ShippingOption from './shipping-option';
 
 export default interface Consignment {

--- a/src/shipping/create-shipping-strategy-registry.ts
+++ b/src/shipping/create-shipping-strategy-registry.ts
@@ -7,6 +7,7 @@ import { Registry } from '../common/registry';
 import { PaymentMethodActionCreator } from '../payment';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
+
 import ShippingAddressActionCreator from './shipping-address-action-creator';
 import ShippingOptionActionCreator from './shipping-option-action-creator';
 import { AmazonPayShippingStrategy, DefaultShippingStrategy, ShippingStrategy } from './strategies';

--- a/src/shipping/map-to-internal-shipping-option.spec.ts
+++ b/src/shipping/map-to-internal-shipping-option.spec.ts
@@ -1,6 +1,6 @@
-import { getShippingOption } from './shipping-options.mock';
 import { getFlatRateOption as getInternalShippingOption } from './internal-shipping-options.mock';
 import mapToInternalShippingOption from './map-to-internal-shipping-option';
+import { getShippingOption } from './shipping-options.mock';
 
 describe('mapToInternalShippingOption()', () => {
     it('maps to internal shipping option', () => {

--- a/src/shipping/map-to-internal-shipping-options.ts
+++ b/src/shipping/map-to-internal-shipping-options.ts
@@ -1,4 +1,5 @@
 import { find } from 'lodash';
+
 import Consignment from './consignment';
 import InternalShippingOption from './internal-shipping-option';
 import mapToInternalShippingOption from './map-to-internal-shipping-option';

--- a/src/shipping/shipping-strategy-action-creator.spec.ts
+++ b/src/shipping/shipping-strategy-action-creator.spec.ts
@@ -3,13 +3,13 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/toPromise';
-
 import { Observable } from 'rxjs/Observable';
 
-import { CheckoutClient, CheckoutStore, createCheckoutClient, createCheckoutStore } from '../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
 import { getCustomerState, getGuestCustomer } from '../customer/internal-customers.mock';
 import { getPaymentMethod } from '../payment/payment-methods.mock';
+
 import createShippingStrategyRegistry from './create-shipping-strategy-registry';
 import { getShippingAddress } from './internal-shipping-addresses.mock';
 import { getShippingOptions } from './internal-shipping-options.mock';

--- a/src/shipping/shipping-strategy-action-creator.ts
+++ b/src/shipping/shipping-strategy-action-creator.ts
@@ -4,6 +4,7 @@ import { Observer } from 'rxjs/Observer';
 
 import { InternalAddress } from '../address';
 import { Registry } from '../common/registry';
+
 import {
     ShippingStrategyActionType,
     ShippingStrategyDeinitializeAction,

--- a/src/shipping/shipping-strategy-reducer.ts
+++ b/src/shipping/shipping-strategy-reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
 import { ShippingStrategyAction, ShippingStrategyActionType } from './shipping-strategy-actions';
-import ShippingStrategyState, { ShippingStrategyErrorsState, ShippingStrategyStatusesState, DEFAULT_STATE } from './shipping-strategy-state';
+import ShippingStrategyState, { DEFAULT_STATE, ShippingStrategyErrorsState, ShippingStrategyStatusesState } from './shipping-strategy-state';
 
 export default function shippingStrategyReducer(
     state: ShippingStrategyState = DEFAULT_STATE,

--- a/src/shipping/shipping-strategy-selector.spec.ts
+++ b/src/shipping/shipping-strategy-selector.spec.ts
@@ -1,4 +1,5 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
+
 import ShippingStrategySelector from './shipping-strategy-selector';
 import { DEFAULT_STATE } from './shipping-strategy-state';
 

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
@@ -5,7 +5,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { Observable } from 'rxjs';
 
-import { CheckoutStore, createCheckoutClient, createCheckoutStore } from '../../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutStore } from '../../checkout';
 import { getCheckoutMeta } from '../../checkout/checkouts.mock';
 import { NotInitializedError } from '../../common/error/errors';
 import { getRemoteCustomer } from '../../customer/internal-customers.mock';
@@ -24,6 +24,7 @@ import { UPDATE_SHIPPING_ADDRESS_REQUESTED } from '../shipping-address-action-ty
 import ShippingOptionActionCreator from '../shipping-option-action-creator';
 import { SELECT_SHIPPING_OPTION_REQUESTED } from '../shipping-option-action-types';
 import { ShippingStrategyActionType } from '../shipping-strategy-actions';
+
 import AmazonPayShippingStrategy from './amazon-pay-shipping-strategy';
 
 describe('AmazonPayShippingStrategy', () => {

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../remote-checkout/methods/amazon-pay/off-amazon-payments-widgets.d.ts" />
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 
-import { InternalAddress, isAddressEqual } from '../../address';
+import { isAddressEqual, InternalAddress } from '../../address';
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
 import { NotInitializedError } from '../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
@@ -16,6 +16,7 @@ import { AmazonPayScriptLoader } from '../../remote-checkout/methods/amazon-pay'
 import ShippingAddressActionCreator from '../shipping-address-action-creator';
 import ShippingOptionActionCreator from '../shipping-option-action-creator';
 import { ShippingStrategyActionType } from '../shipping-strategy-actions';
+
 import ShippingStrategy from './shipping-strategy';
 
 export default class AmazonPayShippingStrategy extends ShippingStrategy {

--- a/src/shipping/strategies/default-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/default-shipping-strategy.spec.ts
@@ -1,14 +1,15 @@
 import { createAction } from '@bigcommerce/data-store';
 import { Observable } from 'rxjs';
 
-import { CheckoutClient, CheckoutStore, createCheckoutClient, createCheckoutStore } from '../../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../checkout';
 import { getShippingAddress } from '../internal-shipping-addresses.mock';
 import { getFlatRateOption } from '../internal-shipping-options.mock';
 import ShippingAddressActionCreator from '../shipping-address-action-creator';
 import { UPDATE_SHIPPING_ADDRESS_REQUESTED } from '../shipping-address-action-types';
 import ShippingOptionActionCreator from '../shipping-option-action-creator';
-import DefaultShippingStrategy from './default-shipping-strategy';
 import { SELECT_SHIPPING_OPTION_REQUESTED } from '../shipping-option-action-types';
+
+import DefaultShippingStrategy from './default-shipping-strategy';
 
 describe('DefaultShippingStrategy', () => {
     let client: CheckoutClient;

--- a/src/shipping/strategies/default-shipping-strategy.ts
+++ b/src/shipping/strategies/default-shipping-strategy.ts
@@ -2,6 +2,7 @@ import { InternalAddress } from '../../address';
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
 import ShippingAddressActionCreator from '../shipping-address-action-creator';
 import ShippingOptionActionCreator from '../shipping-option-action-creator';
+
 import ShippingStrategy from './shipping-strategy';
 
 export default class DefaultShippingStrategy extends ShippingStrategy {

--- a/src/shipping/strategies/shipping-strategy.spec.ts
+++ b/src/shipping/strategies/shipping-strategy.spec.ts
@@ -1,6 +1,8 @@
 import { DataStore } from '@bigcommerce/data-store';
+
 import { InternalAddress } from '../../address';
 import { createCheckoutClient, createCheckoutStore, CheckoutSelectors } from '../../checkout';
+
 import ShippingStrategy from './shipping-strategy';
 
 describe('ShippingStrategy', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,6 @@
     "extends": "tslint:recommended",
     "rules": {
         "arrow-parens": false,
-        "grouped-imports": false,
         "interface-name": [true, "never-prefix"],
         "max-line-length": false,
         "member-access": [true, "no-public"],
@@ -11,7 +10,14 @@
         "no-reference": false,
         "no-shadowed-variable": false,
         "object-literal-sort-keys": false,
-        "ordered-imports": false,
+        "ordered-imports": [
+            true,
+            {
+                "grouped-imports": true,
+                "import-sources-order": "lowercase-first",
+                "named-imports-order": "lowercase-first"
+            }
+        ],
         "quotemark": [true, "single"],
         "trailing-comma": [
             true,


### PR DESCRIPTION
## What?
* Re-enabled `ordered-imports`.
* Use `tslint 'src/**/*.ts' --fix` to automatically fix the errors.

## Why?
* It was turned off temporarily.

## Testing / Proof
* Linter

@bigcommerce/checkout @bigcommerce/payments
