### PR TITLE
CHECKOUT-3027: Bump `@bigcommerce/data-store` to v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "validate-dependencies": "yarn install --check-files --frozen-lockfile"
   },
   "dependencies": {
-    "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.2",
+    "@bigcommerce/bigpay-client": "git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#2.10.1",
+    "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.3",
+    "@bigcommerce/form-poster": "git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.1",
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.1",
     "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.2",
     "@types/lodash": "^4.14.92",
-    "@bigcommerce/bigpay-client": "git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#2.10.1",
-    "@bigcommerce/form-poster": "git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.1",
     "lodash": "^4.17.4",
     "memoizee": "^0.4.11",
     "messageformat": "0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
     form-poster "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1"
     object-assign "^4.1.0"
 
-"@bigcommerce/data-store@git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.2":
-  version "0.1.2"
-  resolved "git+ssh://git@github.com/bigcommerce/data-store-js.git#f6488acd70540958017879020fc372ca0235f50c"
+"@bigcommerce/data-store@git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.3":
+  version "0.1.3"
+  resolved "git+ssh://git@github.com/bigcommerce/data-store-js.git#7376b3bc76fb30201272fd0003dccf8c9986b74e"
   dependencies:
     "@types/lodash" "^4.14.92"
     lodash "^4.17.4"


### PR DESCRIPTION
## What?
* Bump `@bigcommerce/data-store` to `0.1.3`
* Sort `package.json` dependencies.

## Why?
* Update to include the following [changes](https://github.com/bigcommerce/data-store-js/releases/tag/v0.1.3).

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
