### PR TITLE
CHECKOUT-2964 Allow making phone number required

### DIFF
--- a/src/form/form-selector.js
+++ b/src/form/form-selector.js
@@ -18,7 +18,6 @@ export default class FormSelector {
         const selectedCountry = find(countries, { code: countryCode });
 
         return this._config.storeConfig.formFields.shippingAddressFields
-            .map((field) => field.name === 'phone' ? { ...field, required: false } : field)
             .map((field) => this._processField(field, countries, selectedCountry));
     }
 

--- a/src/form/form-selector.spec.js
+++ b/src/form/form-selector.spec.js
@@ -82,14 +82,6 @@ describe('FormSelector', () => {
 
             expect(postCode.required).toBe(false);
         });
-
-        it('makes phone number NOT required', () => {
-            const forms = formSelector.getShippingAddressFields(countries, 'JP');
-            const phone = find(forms, { name: 'phone' });
-
-            expect(find(getFormFields(), { name: 'phone' }).required).toBe(true);
-            expect(phone.required).toBe(false);
-        });
     });
 
     describe('#getBillingAddressFields()', () => {
@@ -159,13 +151,6 @@ describe('FormSelector', () => {
             const postCode = find(forms, { name: 'postCode' });
 
             expect(postCode.required).toBe(false);
-        });
-
-        it('does not modify the required value for phone number', () => {
-            const forms = formSelector.getBillingAddressFields(countries, 'JP');
-            const phone = find(forms, { name: 'phone' });
-
-            expect(phone.required).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## What?
Honor CP setting when making phone number required.

## Why?
Because it's required by merchants.

## Testing / Proof
- [x] unit
- [x] manual
