### PR TITLE
CHECKOUT-2926 Verify cart for Square

### DIFF
--- a/src/payment/strategies/no-payment-data-required-strategy.spec.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.spec.ts
@@ -22,7 +22,7 @@ describe('NoPaymentDataRequiredPaymentStrategy', () => {
         it('calls submit order with the right data', async () => {
             await noPaymentDataRequiredPaymentStrategy.execute(getOrderRequestBody(), undefined);
 
-            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(omit(getOrderRequestBody(), 'payment'), false, undefined);
+            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(omit(getOrderRequestBody(), 'payment'), true, undefined);
         });
 
         it('does not call submit payment', async () => {
@@ -35,13 +35,7 @@ describe('NoPaymentDataRequiredPaymentStrategy', () => {
             const options = { myOptions: 'option1' };
             await noPaymentDataRequiredPaymentStrategy.execute(getOrderRequestBody(), options);
 
-            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(expect.any(Object), false, options);
-        });
-
-        it('passes useStoreCredit to submitOrder', async () => {
-            await noPaymentDataRequiredPaymentStrategy.execute({ ...getOrderRequestBody(), useStoreCredit: true });
-
-            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(expect.any(Object), true, undefined);
+            expect(placeOrderService.submitOrder).toHaveBeenCalledWith(expect.any(Object), true, options);
         });
     });
 });

--- a/src/payment/strategies/no-payment-data-required-strategy.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.ts
@@ -6,7 +6,6 @@ import PaymentStrategy from './payment-strategy';
 
 export default class NoPaymentDataRequiredPaymentStrategy extends PaymentStrategy {
     execute(orderRequest: OrderRequestBody, options?: any): Promise<CheckoutSelectors> {
-        const { useStoreCredit } = orderRequest;
-        return this._placeOrderService.submitOrder(omit(orderRequest, 'payment'), useStoreCredit, options);
+        return this._placeOrderService.submitOrder(omit(orderRequest, 'payment'), true, options);
     }
 }

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -151,12 +151,12 @@ describe('SquarePaymentStrategy', () => {
                 let promise;
 
                 beforeEach(() => {
-                    promise = strategy.execute({});
+                    promise = strategy.execute({ payment: '', x: 'y' }, { b: 'f' });
                     callbacks.cardNonceResponseReceived(null, 'nonce');
                 });
 
-                it('places the order', () => {
-                    expect(placeOrderService.submitOrder).toHaveBeenCalledTimes(1);
+                it('places the order with the right arguments', () => {
+                    expect(placeOrderService.submitOrder).toHaveBeenCalledWith({ x: 'y' }, true, { b: 'f' });
                 });
 
                 it('resolves to what is returned by submitOrder', async () => {

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -1,6 +1,7 @@
 /// <reference path="./square-form.d.ts" />
 
 import { ReadableDataStore } from '@bigcommerce/data-store';
+import { omit } from 'lodash';
 import { CheckoutSelectors } from '../../../checkout';
 import { TimeoutError, UnsupportedBrowserError } from '../../../common/error/errors';
 import { OrderRequestBody, PlaceOrderService } from '../../../order';
@@ -46,7 +47,9 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
             this._deferredRequestNonce = { resolve, reject };
             this._paymentForm.requestCardNonce();
         })
-        .then(paymentData => this._placeOrderService.submitOrder(payload, paymentData));
+        .then(paymentData => this._placeOrderService.submitOrder(
+            omit(payload, 'payment'), true, options)
+        );
     }
 
     private _getFormOptions(options: InitializeOptions, deferred: DeferredPromise): Square.FormOptions {


### PR DESCRIPTION
## What?
When paying with Square, verify cart and also remove unrequired payload.

## Why?
To make checkout more robust.

## Testing / Proof
- [x] unit
- [x] manual
- [x] functional
