### PR TITLE
CHECKOUT-2900: Restore 'allow-parens' rule

### DIFF
--- a/src/checkout/checkout-action-creator.ts
+++ b/src/checkout/checkout-action-creator.ts
@@ -32,7 +32,7 @@ export default class CheckoutActionCreator {
                     observer.next(createAction(CheckoutActionType.LoadCheckoutSucceeded, body));
                     observer.complete();
                 })
-                .catch(response => {
+                .catch((response) => {
                     observer.error(createErrorAction(CheckoutActionType.LoadCheckoutFailed, response));
                 });
         });

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -26,7 +26,7 @@ export default class BraintreePaymentProcessor {
         const requestData = this._mapToCreditCard(paymentData as CreditCard, billingAddress);
 
         return this._braintreeSDKCreator.getClient()
-            .then(client => client.request(requestData))
+            .then((client) => client.request(requestData))
             .then(({ creditCards }) => ({
                 nonce: creditCards[0].nonce,
             }));

--- a/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -24,7 +24,7 @@ export default class BraintreeSDKCreator {
 
         if (!this._client) {
             this._client = this._braintreeScriptLoader.loadClient()
-                .then(client => client.create({ authorization: this._clientToken }));
+                .then((client) => client.create({ authorization: this._clientToken }));
         }
 
         return this._client;

--- a/src/payment/strategies/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna-payment-strategy.ts
@@ -25,7 +25,7 @@ export default class KlarnaPaymentStrategy extends PaymentStrategy {
 
     initialize(options: InitializeOptions): Promise<CheckoutSelectors> {
         return this._klarnaScriptLoader.load()
-            .then(klarnaSdk => { this._klarnaSdk = klarnaSdk; })
+            .then((klarnaSdk) => { this._klarnaSdk = klarnaSdk; })
             .then(() => {
                 this._unsubscribe = this._store.subscribe(() => this._loadWidget(options),
                     ({ checkout }) => checkout.getCart() && checkout.getCart().grandTotal

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -81,7 +81,7 @@ describe('SquarePaymentStrategy', () => {
                 };
 
                 strategy.initialize({ paymentMethod })
-                    .catch(error => expect(error.type).toEqual('payment_method_missing_data'));
+                    .catch((error) => expect(error.type).toEqual('payment_method_missing_data'));
             });
         });
 
@@ -103,7 +103,7 @@ describe('SquarePaymentStrategy', () => {
                 };
 
                 strategy.initialize(initOptions)
-                    .catch(e => expect(e.type).toEqual('unsupported_browser'));
+                    .catch((e) => expect(e.type).toEqual('unsupported_browser'));
 
                 expect(scriptLoader.load).toHaveBeenCalledTimes(1);
                 expect(squareForm.build).toHaveBeenCalledTimes(0);
@@ -115,7 +115,7 @@ describe('SquarePaymentStrategy', () => {
         describe('when form has not been initialized', () => {
             it('rejects the promise', () => {
                 strategy.execute()
-                    .catch(e => expect(e.type).toEqual('payment_method_uninitialized'));
+                    .catch((e) => expect(e.type).toEqual('payment_method_uninitialized'));
 
                 expect(squareForm.requestCardNonce).toHaveBeenCalledTimes(0);
             });
@@ -140,7 +140,7 @@ describe('SquarePaymentStrategy', () => {
 
             it('cancels the first request', async () => {
                 strategy.execute({})
-                    .catch(e => expect(e.type).toEqual('timeout'));
+                    .catch((e) => expect(e.type).toEqual('timeout'));
 
                 setTimeout(() => {
                     callbacks.cardNonceResponseReceived(null, 'nonce');
@@ -162,7 +162,7 @@ describe('SquarePaymentStrategy', () => {
                 });
 
                 it('resolves to what is returned by submitOrder', async () => {
-                    await promise.then(response => expect(response).toMatchObject({ foo: 'bar' }));
+                    await promise.then((response) => expect(response).toMatchObject({ foo: 'bar' }));
                 });
             });
 
@@ -179,7 +179,7 @@ describe('SquarePaymentStrategy', () => {
                 });
 
                 it('rejects the promise', async () => {
-                    await promise.catch(error => expect(error).toBeTruthy());
+                    await promise.catch((error) => expect(error).toBeTruthy());
                 });
             });
         });

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -48,7 +48,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
             this._deferredRequestNonce = { resolve, reject };
             this._paymentForm.requestCardNonce();
         })
-        .then(paymentData => this._placeOrderService.submitOrder(
+        .then((paymentData) => this._placeOrderService.submitOrder(
             omit(payload, 'payment'), true, options)
         );
     }

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,6 @@
 {
     "extends": "tslint:recommended",
     "rules": {
-        "arrow-parens": false,
         "interface-name": [true, "never-prefix"],
         "max-line-length": false,
         "member-access": [true, "no-public"],


### PR DESCRIPTION
## What?
* Restore `allow-parens` rule

## Why?
* The rule was turned off temporarily. It has an auto-fixer so the errors can be fixed easily.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
