### PR TITLE
fix(payment): CHECKOUT-2905 Hold execution to avoid unwanted redirect

### DIFF
--- a/src/payment/strategies/paypal-express-payment-strategy.js
+++ b/src/payment/strategies/paypal-express-payment-strategy.js
@@ -70,7 +70,8 @@ export default class PaypalExpressPaymentStrategy extends PaymentStrategy {
                 .then((state) => {
                     window.location.assign(state.checkout.getOrder().payment.redirectUrl);
 
-                    return this._resolveBeforeUnload(state);
+                    // We need to hold execution so the consumer does not redirect us somewhere else
+                    return new Promise(() => {});
                 });
         }
 
@@ -80,7 +81,8 @@ export default class PaypalExpressPaymentStrategy extends PaymentStrategy {
             .then((state) => {
                 this._paypalSdk.checkout.startFlow(state.checkout.getOrder().payment.redirectUrl);
 
-                return this._resolveBeforeUnload(state);
+                // We need to hold execution so the consumer does not redirect us somewhere else
+                return new Promise(() => {});
             })
             .catch((state) => {
                 this._paypalSdk.checkout.closeFlow();
@@ -122,22 +124,5 @@ export default class PaypalExpressPaymentStrategy extends PaymentStrategy {
      */
     _isInContextEnabled() {
         return !!this._paymentMethod.config.merchantId;
-    }
-
-    /**
-     * @private
-     * @param {CheckoutSelectors} state
-     * @return {Promise<CheckoutSelectors>}
-     */
-    _resolveBeforeUnload(state) {
-        return new Promise((resolve) => {
-            const handleUnload = () => {
-                window.removeEventListener('unload', handleUnload);
-
-                resolve(state);
-            };
-
-            window.addEventListener('unload', handleUnload);
-        });
     }
 }

--- a/src/payment/strategies/paypal-express-payment-strategy.spec.js
+++ b/src/payment/strategies/paypal-express-payment-strategy.spec.js
@@ -26,14 +26,7 @@ describe('PaypalExpressPaymentStrategy', () => {
             checkout: {
                 setup: jest.fn(),
                 initXO: jest.fn(),
-                startFlow: jest.fn(() => {
-                    setTimeout(() => {
-                        const event = document.createEvent('Event');
-
-                        event.initEvent('unload', true, false);
-                        document.body.dispatchEvent(event);
-                    });
-                }),
+                startFlow: jest.fn(),
                 closeFlow: jest.fn(),
             },
         };
@@ -50,14 +43,7 @@ describe('PaypalExpressPaymentStrategy', () => {
 
         paymentMethod = getPaypalExpress();
 
-        jest.spyOn(window.location, 'assign').mockImplementation(() => {
-            setTimeout(() => {
-                const event = document.createEvent('Event');
-
-                event.initEvent('unload', true, false);
-                document.body.dispatchEvent(event);
-            });
-        });
+        jest.spyOn(window.location, 'assign').mockImplementation(() => {});
 
         strategy = new PaypalExpressPaymentStrategy(store, placeOrderService, scriptLoader);
     });
@@ -140,13 +126,15 @@ describe('PaypalExpressPaymentStrategy', () => {
             });
 
             it('opens in-context modal', async () => {
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalSdk.checkout.initXO).toHaveBeenCalled();
             });
 
             it('starts in-context payment flow', async () => {
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalSdk.checkout.startFlow).toHaveBeenCalledWith(order.payment.redirectUrl);
             });
@@ -154,7 +142,8 @@ describe('PaypalExpressPaymentStrategy', () => {
             it('does not open in-context modal if payment is already acknowledged', async () => {
                 order.payment.status = paymentStatusTypes.ACKNOWLEDGE;
 
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalSdk.checkout.initXO).not.toHaveBeenCalled();
                 expect(paypalSdk.checkout.startFlow).not.toHaveBeenCalled();
@@ -163,7 +152,8 @@ describe('PaypalExpressPaymentStrategy', () => {
             it('does not open in-context modal if payment is already finalized', async () => {
                 order.payment.status = paymentStatusTypes.FINALIZE;
 
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalSdk.checkout.initXO).not.toHaveBeenCalled();
                 expect(paypalSdk.checkout.startFlow).not.toHaveBeenCalled();
@@ -172,7 +162,8 @@ describe('PaypalExpressPaymentStrategy', () => {
             it('submits order with payment data', async () => {
                 const options = {};
 
-                await strategy.execute(payload, options);
+                strategy.execute(payload, options);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(placeOrderService.submitOrder).toHaveBeenCalledWith(payload, true, options);
             });
@@ -180,21 +171,17 @@ describe('PaypalExpressPaymentStrategy', () => {
             it('does not submit payment data separately', async () => {
                 const options = {};
 
-                await strategy.execute(payload, options);
+                strategy.execute(payload, options);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(placeOrderService.submitPayment).not.toHaveBeenCalledWith(options);
             });
 
             it('does not redirect shopper directly if order submission is successful', async () => {
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(window.location.assign).not.toHaveBeenCalled();
-            });
-
-            it('returns checkout state', async () => {
-                const output = await strategy.execute(payload);
-
-                expect(output).toEqual(store.getState());
             });
         });
 
@@ -206,13 +193,15 @@ describe('PaypalExpressPaymentStrategy', () => {
             });
 
             it('does not open in-context modal', async () => {
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalSdk.checkout.initXO).not.toHaveBeenCalled();
             });
 
             it('does not start in-context payment flow', async () => {
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalSdk.checkout.startFlow).not.toHaveBeenCalled();
             });
@@ -220,19 +209,22 @@ describe('PaypalExpressPaymentStrategy', () => {
             it('submits order with payment data', async () => {
                 const options = {};
 
-                await strategy.execute(payload, options);
+                strategy.execute(payload, options);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(placeOrderService.submitOrder).toHaveBeenCalledWith(payload, true, options);
             });
 
             it('does not submit payment data separately', async () => {
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(placeOrderService.submitPayment).not.toHaveBeenCalled();
             });
 
             it('redirects shopper directly if order submission is successful', async () => {
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(window.location.assign).toHaveBeenCalledWith(order.payment.redirectUrl);
             });
@@ -240,7 +232,8 @@ describe('PaypalExpressPaymentStrategy', () => {
             it('does not redirect shopper if payment is already acknowledged', async () => {
                 order.payment.status = paymentStatusTypes.ACKNOWLEDGE;
 
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(window.location.assign).not.toHaveBeenCalled();
             });
@@ -248,15 +241,10 @@ describe('PaypalExpressPaymentStrategy', () => {
             it('does not redirect shopper if payment is already finalized', async () => {
                 order.payment.status = paymentStatusTypes.FINALIZE;
 
-                await strategy.execute(payload);
+                strategy.execute(payload);
+                await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(window.location.assign).not.toHaveBeenCalled();
-            });
-
-            it('returns checkout state', async () => {
-                const output = await strategy.execute(payload);
-
-                expect(output).toEqual(store.getState());
             });
         });
     });


### PR DESCRIPTION
## What?
- Hold the `#execute()` promise so no side effects occur.

## Why?
- In some cases, the resolution of the promise causes the consumer to
continue execution even when a redirect has already started. This can
cause some side effects. It is better to never resolve the promise so
the consumer stays put until the redirect is done.

## Testing / Proof
Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
