### PR TITLE
CHECKOUT-3007: Remove unexpected injections

### DIFF
--- a/src/checkout/checkout-error-selector.js
+++ b/src/checkout/checkout-error-selector.js
@@ -18,7 +18,6 @@ export default class CheckoutErrorSelector {
      * @param {PaymentMethodSelector} paymentMethods
      * @param {PaymentStrategySelector} paymentStrategy
      * @param {QuoteSelector} quote
-     * @param {RemoteCheckout} remoteCheckout
      * @param {ShippingAddressSelector} shippingAddress
      * @param {ShippingCountrySelector} shippingCountries
      * @param {ShippingOptionSelector} shippingOptions
@@ -38,7 +37,6 @@ export default class CheckoutErrorSelector {
         paymentMethods,
         paymentStrategy,
         quote,
-        remoteCheckout,
         shippingAddress,
         shippingCountries,
         shippingOptions,
@@ -57,7 +55,6 @@ export default class CheckoutErrorSelector {
         this._paymentMethods = paymentMethods;
         this._paymentStrategy = paymentStrategy;
         this._quote = quote;
-        this._remoteCheckout = remoteCheckout;
         this._shippingAddress = shippingAddress;
         this._shippingCountries = shippingCountries;
         this._shippingOptions = shippingOptions;

--- a/src/checkout/checkout-error-selector.spec.js
+++ b/src/checkout/checkout-error-selector.spec.js
@@ -8,7 +8,6 @@ import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { QuoteSelector } from '../quote';
-import { RemoteCheckoutSelector } from '../remote-checkout';
 import { ShippingAddressSelector, ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 import CheckoutErrorSelector from './checkout-error-selector';
@@ -29,7 +28,6 @@ describe('CheckoutErrorSelector', () => {
     let paymentMethods;
     let paymentStrategy;
     let quote;
-    let remoteCheckout;
     let shippingAddress;
     let shippingCountries;
     let shippingOptions;
@@ -49,7 +47,6 @@ describe('CheckoutErrorSelector', () => {
         paymentMethods = new PaymentMethodSelector();
         paymentStrategy = new PaymentStrategySelector();
         quote = new QuoteSelector();
-        remoteCheckout = new RemoteCheckoutSelector();
         shippingAddress = new ShippingAddressSelector();
         shippingCountries = new ShippingCountrySelector();
         shippingOptions = new ShippingOptionSelector();
@@ -69,7 +66,6 @@ describe('CheckoutErrorSelector', () => {
             paymentMethods,
             paymentStrategy,
             quote,
-            remoteCheckout,
             shippingAddress,
             shippingCountries,
             shippingOptions,

--- a/src/checkout/checkout-status-selector.js
+++ b/src/checkout/checkout-status-selector.js
@@ -18,7 +18,6 @@ export default class CheckoutStatusSelector {
      * @param {PaymentMethodSelector} paymentMethods
      * @param {PaymentStrategySelector} paymentStrategy
      * @param {QuoteSelector} quote
-     * @param {RemoteCheckoutSelector} remoteCheckout
      * @param {ShippingAddressSelector} shippingAddress
      * @param {ShippingCountrySelector} shippingCountries
      * @param {ShippingOptionSelector} shippingOptions
@@ -38,7 +37,6 @@ export default class CheckoutStatusSelector {
         paymentMethods,
         paymentStrategy,
         quote,
-        remoteCheckout,
         shippingAddress,
         shippingCountries,
         shippingOptions,
@@ -57,7 +55,6 @@ export default class CheckoutStatusSelector {
         this._paymentMethods = paymentMethods;
         this._paymentStrategy = paymentStrategy;
         this._quote = quote;
-        this._remoteCheckout = remoteCheckout;
         this._shippingAddress = shippingAddress;
         this._shippingCountries = shippingCountries;
         this._shippingOptions = shippingOptions;

--- a/src/checkout/checkout-status-selector.spec.js
+++ b/src/checkout/checkout-status-selector.spec.js
@@ -8,7 +8,6 @@ import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { QuoteSelector } from '../quote';
-import { RemoteCheckoutSelector } from '../remote-checkout';
 import { ShippingCountrySelector, ShippingAddressSelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 import CheckoutStatusSelector from './checkout-status-selector';
 import CustomerStrategySelector from '../customer/customer-strategy-selector';
@@ -27,7 +26,6 @@ describe('CheckoutStatusSelector', () => {
     let paymentMethods;
     let paymentStrategy;
     let quote;
-    let remoteCheckout;
     let shippingAddress;
     let shippingCountries;
     let shippingOption;
@@ -48,7 +46,6 @@ describe('CheckoutStatusSelector', () => {
         paymentStrategy = new PaymentStrategySelector();
         instruments = new InstrumentSelector();
         quote = new QuoteSelector();
-        remoteCheckout = new RemoteCheckoutSelector();
         shippingAddress = new ShippingAddressSelector();
         shippingCountries = new ShippingCountrySelector();
         shippingOption = new ShippingOptionSelector();
@@ -68,7 +65,6 @@ describe('CheckoutStatusSelector', () => {
             paymentMethods,
             paymentStrategy,
             quote,
-            remoteCheckout,
             shippingAddress,
             shippingCountries,
             shippingOption,

--- a/src/checkout/create-checkout-store.js
+++ b/src/checkout/create-checkout-store.js
@@ -138,7 +138,6 @@ function createCheckoutSelectors(state, options) {
         paymentMethods,
         paymentStrategy,
         quote,
-        remoteCheckout,
         shippingAddress,
         shippingCountries,
         shippingOptions,


### PR DESCRIPTION
## What?
* `RemoteCheckoutSelector` shouldn't be injected into `CheckoutErrorSelector` and `CheckoutStatusSelector` anymore.

## Why?
* Currently `CheckoutErrorSelector` constructor expects more than it actually receives. Therefore, it throws an error when you try to use it.
* `CheckoutStatusSelector` also has a similar problem.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
