### PR TITLE
fix(payment): CHECKOUT-2926 Unregister Square v2

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.js
+++ b/src/payment/create-payment-strategy-registry.spec.js
@@ -15,7 +15,6 @@ import {
     PaypalExpressPaymentStrategy,
     PaypalProPaymentStrategy,
     SagePayPaymentStrategy,
-    SquarePaymentStrategy,
 } from './strategies';
 
 describe('CreatePaymentStrategyRegistry', () => {
@@ -85,11 +84,6 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instanciate sagepay', () => {
         const paymentStrategy = registry.get('sagepay');
         expect(paymentStrategy).toBeInstanceOf(SagePayPaymentStrategy);
-    });
-
-    it('can instanciate squarev2', () => {
-        const paymentStrategy = registry.get('squarev2');
-        expect(paymentStrategy).toBeInstanceOf(SquarePaymentStrategy);
     });
 
     it('can instanciate nopaymentdatarequired', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -26,10 +26,8 @@ import {
     PaypalExpressPaymentStrategy,
     PaypalProPaymentStrategy,
     SagePayPaymentStrategy,
-    SquarePaymentStrategy,
 } from './strategies';
 import { createBraintreePaymentProcessor } from './strategies/braintree';
-import { SquareScriptLoader } from './strategies/square';
 
 export default function createPaymentStrategyRegistry(
     store: CheckoutStore,
@@ -92,10 +90,6 @@ export default function createPaymentStrategyRegistry(
 
     registry.register('sagepay', () =>
         new SagePayPaymentStrategy(store, placeOrderService, createFormPoster())
-    );
-
-    registry.register('squarev2', () =>
-        new SquarePaymentStrategy(store, placeOrderService, new SquareScriptLoader(scriptLoader))
     );
 
     registry.register('nopaymentdatarequired', () =>


### PR DESCRIPTION
## What?
- Unregistering Square v2 until some issues with the integration get resolved

## Why?
- There are some changes in the Square APIs and we can't test it properly at the moment.

## Testing / Proof
- Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
