### PR TITLE
CHECKOUT-3007: Set private field to true to prevent publishing to npm accidentally

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.15.1",
   "description": "BigCommerce Checkout JavaScript SDK",
   "license": "MIT",
+  "private": true,
   "main": "lib/index.js",
   "files": [
     "dist/",


### PR DESCRIPTION
## What?
* Setting `private` field to `true`.

## Why?
* To prevent us from accidentally publishing the package to `npm`. We can remove this field once we can publish it to `npm`.

## Testing / Proof
* Manual

@bigcommerce/checkout @bigcommerce/payments
