### PR TITLE
CHECKOUT-2951: Validate commit messages on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ dist: trusty
 sudo: false
 
 script:
+    - yarn validate-commits
     - yarn lint
     - yarn test:series --coverage


### PR DESCRIPTION
## What?
* Validate commit messages on Travis.

## Why?
* It wasn't enabled for some reason.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
