### PR TITLE
refactor(shipping): CHECKOUT-3049 Update mapToInternalShippingOption mapper to use type field

### DIFF
--- a/src/shipping/map-to-internal-shipping-option.spec.ts
+++ b/src/shipping/map-to-internal-shipping-option.spec.ts
@@ -4,7 +4,7 @@ import { getShippingOption } from './shipping-options.mock';
 
 describe('mapToInternalShippingOption()', () => {
     it('maps to internal shipping option', () => {
-        expect(mapToInternalShippingOption(getShippingOption(), true, getInternalShippingOption()))
+        expect(mapToInternalShippingOption(getShippingOption(), true))
             .toEqual(getInternalShippingOption());
     });
 });

--- a/src/shipping/map-to-internal-shipping-option.ts
+++ b/src/shipping/map-to-internal-shipping-option.ts
@@ -1,10 +1,10 @@
 import InternalShippingOption from './internal-shipping-option';
 import ShippingOption from './shipping-option';
 
-export default function mapToInternalShippingOption(option: ShippingOption, isSelected: boolean, existingOption: InternalShippingOption): InternalShippingOption {
+export default function mapToInternalShippingOption(option: ShippingOption, isSelected: boolean): InternalShippingOption {
     return {
         description: option.description,
-        module: existingOption.module,
+        module: option.type,
         price: option.price,
         id: option.id,
         selected: isSelected,

--- a/src/shipping/map-to-internal-shipping-options.ts
+++ b/src/shipping/map-to-internal-shipping-options.ts
@@ -1,5 +1,3 @@
-import { find } from 'lodash';
-
 import Consignment from './consignment';
 import InternalShippingOption from './internal-shipping-option';
 import mapToInternalShippingOption from './map-to-internal-shipping-option';
@@ -10,8 +8,7 @@ export default function mapToInternalShippingOptions(consignments: Consignment[]
         [consignment.shippingAddress.id]: (consignment.availableShippingOptions || []).map((option) =>
             mapToInternalShippingOption(
                 option,
-                option.id === consignment.selectedShippingOptionId,
-                find(existingOptions[consignment.shippingAddress.id], { id: option.id })!
+                option.id === consignment.selectedShippingOptionId
             )
         ),
     }), {});

--- a/src/shipping/shipping-option.ts
+++ b/src/shipping/shipping-option.ts
@@ -5,4 +5,5 @@ export default interface ShippingOption {
     imageUrl: string;
     price: number;
     transitTime: string;
+    type: string;
 }

--- a/src/shipping/shipping-options.mock.ts
+++ b/src/shipping/shipping-options.mock.ts
@@ -8,5 +8,6 @@ export function getShippingOption(): ShippingOption {
         isRecommended: true,
         price: 0,
         transitTime: '',
+        type: 'shipping_flatrate',
     };
 }


### PR DESCRIPTION
## What?
* Use the new `type` field provided by storefront API.
* Remove the temporary backfill.

## Why?
* Required for transitioning to storefront API

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
