### PR TITLE
CHECKOUT-3050: Load checkout using checkout id

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import { createCheckoutService } from '@bigcommerce/checkout-sdk';
 
 const service = createCheckoutService();
 
-service.loadConfig();
+await service.loadConfig();
 ```
 
 ### Initialize state
@@ -65,8 +65,11 @@ service.loadConfig();
 Once the service has been initialized, you can either initialize the checkout or the order state.
 
 ```js
-service.loadCheckout();
-service.loadOrder();
+const checkoutId = '0cfd6c06-57c3-4e29-8d7a-de55cc8a9052';
+const orderId = 123;
+
+await service.loadCheckout(checkoutId);
+await service.loadOrder(orderId);
 ```
 
 ### Subscribe to data changes

--- a/src/cart/errors/cart-unavailable-error.ts
+++ b/src/cart/errors/cart-unavailable-error.ts
@@ -1,9 +1,0 @@
-import { StandardError } from '../../common/error/errors';
-
-export default class CartUnavailableError extends StandardError {
-    constructor() {
-        super('There is no available shopping cart.');
-
-        this.type = 'cart_unavailable';
-    }
-}

--- a/src/cart/errors/index.ts
+++ b/src/cart/errors/index.ts
@@ -1,2 +1,1 @@
 export { default as CartChangedError } from './cart-changed-error';
-export { default as CartUnavailableError } from './cart-unavailable-error';

--- a/src/checkout/checkout-action-creator.ts
+++ b/src/checkout/checkout-action-creator.ts
@@ -2,8 +2,7 @@ import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
-import { Cart, CartRequestSender } from '../cart';
-import { CartUnavailableError } from '../cart/errors';
+import { CartRequestSender } from '../cart';
 
 import { CheckoutAction, CheckoutActionType } from './checkout-actions';
 import CheckoutClient from './checkout-client';
@@ -14,19 +13,11 @@ export default class CheckoutActionCreator {
         private _cartRequestSender: CartRequestSender
     ) {}
 
-    loadCheckout(options?: any): Observable<CheckoutAction> {
+    loadCheckout(id: string, options?: any): Observable<CheckoutAction> {
         return Observable.create((observer: Observer<CheckoutAction>) => {
             observer.next(createAction(CheckoutActionType.LoadCheckoutRequested));
 
-            this._cartRequestSender.loadCarts(options)
-                .then(({ body: [cart] }: { body: Cart[] }) => {
-                    if (!cart) {
-                        throw new CartUnavailableError();
-                    }
-
-                    return cart.id;
-                })
-                .then(id => this._checkoutClient.loadCheckout(id, options))
+            this._checkoutClient.loadCheckout(id, options)
                 .then(({ body }) => {
                     observer.next(createAction(CheckoutActionType.LoadCheckoutSucceeded, body));
                     observer.complete();

--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -216,15 +216,17 @@ describe('CheckoutService', () => {
     });
 
     describe('#loadCheckout()', () => {
+        const { id } = getCheckout();
+
         it('loads quote data', async () => {
-            const { checkout } = await checkoutService.loadCheckout();
+            const { checkout } = await checkoutService.loadCheckout(id);
 
             expect(checkoutClient.loadQuote).toHaveBeenCalled();
             expect(checkout.getQuote()).toEqual(getQuoteResponseBody().data.quote);
         });
 
         it('loads checkout data', async () => {
-            const { checkout } = await checkoutService.loadCheckout();
+            const { checkout } = await checkoutService.loadCheckout(id);
 
             expect(checkoutClient.loadCheckout).toHaveBeenCalled();
             expect(checkout.getCheckout()).toEqual(getCheckout());

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -63,10 +63,10 @@ export default class CheckoutService {
         );
     }
 
-    loadCheckout(options?: RequestOptions): Promise<CheckoutSelectors> {
+    loadCheckout(id: string, options?: RequestOptions): Promise<CheckoutSelectors> {
         return Promise.all([
             this._store.dispatch(this._quoteActionCreator.loadQuote(options)),
-            this._store.dispatch(this._checkoutActionCreator.loadCheckout(options)),
+            this._store.dispatch(this._checkoutActionCreator.loadCheckout(id, options)),
         ]).then(() => this._store.getState());
     }
 


### PR DESCRIPTION
## What?
* **BREAKING CHANGE**: You now need to pass in checkout ID in order to load checkout

## Why?
* We now expose `checkoutId` as a template variable. So we no longer need to make an additional AJAX request to query the current checkout ID.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
