### PR TITLE
CHECKOUT-2951: Don't include links to source file in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bundle:analyze": "yarn --silent bundle -- --profile --json > webpack-stats.json && webpack-bundle-analyzer webpack-stats.json dist --default-sizes gzip",
     "bundle:watch": "yarn bundle -- --watch",
     "bundle-dts": "tsc --outDir temp --declaration && api-extractor run && rm -rf temp",
-    "docs": "typedoc --theme markdown --mode file --module commonjs --readme none --out docs --includeDeclarations --excludeExternals --excludePrivate --excludeProtected dist/checkout-sdk.d.ts",
+    "docs": "typedoc --theme markdown --mode file --module commonjs --readme none --out docs --includeDeclarations --excludeExternals --excludePrivate --excludeProtected --mdHideSources dist/checkout-sdk.d.ts",
     "lint": "yarn lint:js && yarn lint:ts",
     "lint:js": "eslint src --config eslintrc.json",
     "lint:ts": "tslint 'src/**/*.ts' --config tslint.json && tsc --noEmit",


### PR DESCRIPTION
## What?
* Don't include links to source file in docs

## Why?
* Otherwise, each release commit can be pretty noisy as each documentation file needs to be updated with a new commit hash. (i.e.: https://github.com/bigcommerce/checkout-sdk-js/commit/4c24192f59f696877769ce58e3284898e9e4c914)

## Testing / Proof
* Manual

@bigcommerce/checkout @bigcommerce/payments
