### PR TITLE
refactor(payment): PAYMENTS-2672 Use trusted shipping address endpoint to request instruments

### DIFF
--- a/src/checkout/checkout-service.js
+++ b/src/checkout/checkout-service.js
@@ -400,11 +400,13 @@ export default class CheckoutService {
      */
     loadInstruments() {
         const { storeId, customerId, token } = this._getInstrumentState();
+        const shippingAddress = this._getShippingAddress();
 
         const action = this._instrumentActionCreator.loadInstruments(
             storeId,
             customerId,
-            token
+            token,
+            shippingAddress
         );
 
         return this._store.dispatch(action);
@@ -442,6 +444,17 @@ export default class CheckoutService {
         );
 
         return this._store.dispatch(action);
+    }
+
+    _getShippingAddress() {
+        const { checkout } = this._store.getState();
+        const shippingAddress = checkout.getShippingAddress()
+
+        if (!shippingAddress) {
+            throw new MissingDataError();
+        }
+
+        return shippingAddress;
     }
 
     /**

--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -724,6 +724,7 @@ describe('CheckoutService', () => {
 
     describe('#loadInstruments()', () => {
         it('loads instruments', async () => {
+            const address = getShippingAddress();
             const { storeId } = getAppConfig();
             const { customerId } = getGuestCustomer();
             const { vaultAccessToken } = getInstrumentsMeta();
@@ -732,7 +733,7 @@ describe('CheckoutService', () => {
             await checkoutService.loadInstruments();
 
             expect(checkoutClient.getInstruments)
-                .toHaveBeenCalledWith(storeId, customerId, vaultAccessToken);
+                .toHaveBeenCalledWith(storeId, customerId, vaultAccessToken, address);
         });
 
         it('throws error if customer data is missing', () => {

--- a/src/payment/instrument/instrument-action-creator.js
+++ b/src/payment/instrument/instrument-action-creator.js
@@ -16,15 +16,16 @@ export default class InstrumentActionCreator {
      * @param {string} storeId
      * @param {string} shopperId
      * @param {?VaultAccessToken} accessToken
+     * @param {InternalAddress} shippingAddress
      * @return {Observable<Action>}
      */
-    loadInstruments(storeId, shopperId, accessToken) {
+    loadInstruments(storeId, shopperId, accessToken, shippingAddress) {
         return Observable.create((observer) => {
             observer.next(createAction(actionTypes.LOAD_INSTRUMENTS_REQUESTED));
 
             this._getValidAccessToken(accessToken)
                 .then(currentToken =>
-                    this._instrumentRequestSender.getInstruments(storeId, shopperId, currentToken.vaultAccessToken)
+                    this._instrumentRequestSender.getInstruments(storeId, shopperId, currentToken.vaultAccessToken, shippingAddress)
                         .then(({ body } = {}) => {
                             observer.next(createAction(actionTypes.LOAD_INSTRUMENTS_SUCCEEDED, body, currentToken));
                             observer.complete();

--- a/src/payment/instrument/instrument-action-creator.spec.js
+++ b/src/payment/instrument/instrument-action-creator.spec.js
@@ -1,6 +1,7 @@
 import { Observable } from 'rxjs';
 import { addMinutes } from '../../common/date-time';
 import { getErrorResponse, getResponse } from '../../common/http-request/responses.mock';
+import { getShippingAddress } from '../../shipping/internal-shipping-addresses.mock';
 import * as actionTypes from './instrument-action-types';
 import InstrumentActionCreator from './instrument-action-creator';
 import {
@@ -22,6 +23,7 @@ describe('InstrumentActionCreator', () => {
     let shopperId;
     let instrumentId;
     let vaultAccessToken;
+    let shippingAddress;
 
     beforeEach(() => {
         errorResponse = getErrorResponse();
@@ -43,24 +45,27 @@ describe('InstrumentActionCreator', () => {
         shopperId = '2';
         instrumentId = '123';
         vaultAccessToken = getVaultAccessTokenResponse.body.data.token;
+        shippingAddress = getShippingAddress();
     });
 
     describe('#getInstruments()', () => {
         it('sends a request to get a list of instruments', async () => {
-            await instrumentActionCreator.loadInstruments(storeId, shopperId).toPromise();
+            await instrumentActionCreator.loadInstruments(storeId, shopperId, null, shippingAddress).toPromise();
 
             expect(checkoutClient.getVaultAccessToken).toHaveBeenCalled();
-            expect(checkoutClient.getInstruments).toHaveBeenCalledWith(storeId, shopperId, vaultAccessToken);
+            expect(checkoutClient.getInstruments).toHaveBeenCalledWith(storeId, shopperId, vaultAccessToken, shippingAddress);
         });
 
         it('does not send a request to get a list of instruments if valid token is supplied', async () => {
-            await instrumentActionCreator.loadInstruments(storeId, shopperId, {
+            const vaultAccessToken = {
                 vaultAccessToken: '321',
                 vaultAccessExpiry: addMinutes(new Date(), 5),
-            }).toPromise();
+            };
+
+            await instrumentActionCreator.loadInstruments(storeId, shopperId, vaultAccessToken, shippingAddress).toPromise();
 
             expect(checkoutClient.getVaultAccessToken).not.toHaveBeenCalled();
-            expect(checkoutClient.getInstruments).toHaveBeenCalledWith(storeId, shopperId, '321');
+            expect(checkoutClient.getInstruments).toHaveBeenCalledWith(storeId, shopperId, '321', shippingAddress);
         });
 
         it('emits actions if able to load instruments', () => {

--- a/src/payment/instrument/instrument-request-sender.js
+++ b/src/payment/instrument/instrument-request-sender.js
@@ -23,13 +23,19 @@ export default class InstrumentRequestSender {
      * @param {string} storeId
      * @param {string} shopperId
      * @param {string} authToken
+     * @param {InternalAddress} shippingAddress
      * @return {Promise<Response<InstrumentsResponseBody>>}
      */
-    getInstruments(storeId, shopperId, authToken) {
-        const payload = { storeId, shopperId, authToken };
+    getInstruments(storeId, shopperId, authToken, shippingAddress) {
+        const payload = {
+            storeId,
+            shopperId,
+            authToken,
+            shippingAddress,
+        };
 
         return new Promise((resolve, reject) => {
-            this._client.getShopperInstruments(payload, (error, response) => {
+            this._client.postTrustedShippingAddress(payload, (error, response) => {
                 if (error) {
                     reject(this._transformResponse(error));
                 } else {

--- a/src/payment/instrument/instrument-request-sender.spec.js
+++ b/src/payment/instrument/instrument-request-sender.spec.js
@@ -21,7 +21,7 @@ describe('InstrumentMethodRequestSender', () => {
 
         client = {
             getVaultAccessToken: jest.fn((payload, callback) => callback()),
-            getShopperInstruments: jest.fn((payload, callback) => callback()),
+            postTrustedShippingAddress: jest.fn((payload, callback) => callback()),
             postShopperInstrument: jest.fn((payload, callback) => callback()),
             deleteShopperInstrument: jest.fn((payload, callback) => callback()),
         };
@@ -56,7 +56,7 @@ describe('InstrumentMethodRequestSender', () => {
 
     describe('#getInstruments()', () => {
         it('returns instruments if request is successful', async () => {
-            client.getShopperInstruments = jest.fn((payload, callback) => callback(null, {
+            client.postTrustedShippingAddress = jest.fn((payload, callback) => callback(null, {
                 data: getInstrumentsResponseBody(),
                 status: 200,
                 statusText: 'OK',
@@ -73,7 +73,7 @@ describe('InstrumentMethodRequestSender', () => {
         });
 
         it('returns error response if request is unsuccessful', async () => {
-            client.getShopperInstruments = jest.fn((payload, callback) => callback({
+            client.postTrustedShippingAddress = jest.fn((payload, callback) => callback({
                 data: getErrorInstrumentResponseBody(),
                 status: 400,
                 statusText: 'Bad Request',

--- a/src/payment/instrument/instrument.mock.js
+++ b/src/payment/instrument/instrument.mock.js
@@ -15,6 +15,7 @@ export function getInstrument() {
         expiry_year: '2020',
         brand: 'test',
         default_instrument: true,
+        trusted_shipping_address: true,
     };
 }
 
@@ -29,6 +30,7 @@ export function getInstruments() {
             expiry_year: '2020',
             brand: 'test',
             default_instrument: true,
+            trusted_shipping_address: true,
         },
         {
             bigpay_token: '111',
@@ -39,6 +41,7 @@ export function getInstruments() {
             expiry_year: '2024',
             brand: 'test',
             default_instrument: true,
+            trusted_shipping_address: true,
         },
     ];
 }
@@ -128,6 +131,5 @@ export function vaultInstrumentResponseBody() {
 }
 
 export function deleteInstrumentResponseBody() {
-    return {
-    };
+    return {};
 }

--- a/src/payment/instrument/instrument.typedef.js
+++ b/src/payment/instrument/instrument.typedef.js
@@ -8,6 +8,7 @@
  * @property {string} expiry_year
  * @property {string} brand
  * @property {boolean} default_instrument
+ * @property {boolean} trusted_shipping_address
  */
 
  /**


### PR DESCRIPTION
## What?
Replace `client.getInstruments` with `client.postTrustedShippingAddress` to allow the SDK to determine if an instrument has been used with that shipping address before. 

- Related `bigpay-client-js` pr: https://github.com/bigcommerce/bigpay-client-js/pull/62
- Related `Bigpay api contract`: https://github.com/bigcommerce/api-schema/blob/master/bigpay/v2/docs/payments.yaml

## Why?
This is security feature intended to allow shoppers to checkout without having to enter their CVV.

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
