### PR TITLE
CHECKOUT-2951: Throw error if missing required data

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,3 +1,3 @@
-beforeAll(() => {
+beforeEach(() => {
     expect.hasAssertions();
 });

--- a/src/address/is-address-equal.ts
+++ b/src/address/is-address-equal.ts
@@ -4,11 +4,11 @@ import { omitPrivate } from '../common/utility';
 
 import InternalAddress from './internal-address';
 
-export default function isAddressEqual(addressA: InternalAddress, addressB: InternalAddress): boolean {
+export default function isAddressEqual(addressA: Partial<InternalAddress>, addressB: Partial<InternalAddress>): boolean {
     return isEqual(normalize(addressA), normalize(addressB));
 }
 
-function normalize(address: InternalAddress): Partial<InternalAddress> {
+function normalize(address: Partial<InternalAddress>): Partial<InternalAddress> {
     const ignoredKeys = ['id', 'provinceCode'];
 
     return (Object.keys(omitPrivate(address) || {}) as Array<keyof InternalAddress>)

--- a/src/cart/map-to-internal-cart.ts
+++ b/src/cart/map-to-internal-cart.ts
@@ -17,6 +17,7 @@ export default function mapToInternalCart(checkout: Checkout, existingCart: Inte
             coupons: checkout.cart.coupons.map(coupon =>
                 mapToInternalCoupon(
                     coupon,
+                    // tslint:disable-next-line:no-non-null-assertion
                     find(existingCart.coupon.coupons, { code: coupon.code })!
                 )
             ),
@@ -31,6 +32,7 @@ export default function mapToInternalCart(checkout: Checkout, existingCart: Inte
             appliedGiftCertificates: checkout.giftCertificates.map(giftCertificate =>
                 mapToInternalGiftCertificate(
                     giftCertificate,
+                    // tslint:disable-next-line:no-non-null-assertion
                     find(existingCart.giftCertificate.appliedGiftCertificates, { code: giftCertificate.code })!
                 )
             ),

--- a/src/cart/map-to-internal-line-items.ts
+++ b/src/cart/map-to-internal-line-items.ts
@@ -10,6 +10,7 @@ export default function mapToInternalLineItems(itemMap: LineItemMap, existingIte
         .reduce((result, key) => [
             ...result,
             ...(itemMap[key] as LineItem[]).map(item => {
+                // tslint:disable-next-line:no-non-null-assertion
                 const existingItem = find(existingItems, { id: item.id })!;
 
                 return mapToInternalLineItem(item, existingItem, mapToInternalLineItemType(key));

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -288,13 +288,15 @@ export default class CheckoutService {
 
     private _getInstrumentState(): any {
         const { checkout } = this._store.getState();
+        const config = checkout.getConfig();
+        const customer = checkout.getCustomer();
 
-        if (!checkout.getConfig() || !checkout.getCustomer() || !checkout.getCheckoutMeta()) {
-            throw new MissingDataError();
+        if (!config || !customer) {
+            throw new MissingDataError('Unable to proceed because "config" or "customer" data is missing.');
         }
 
-        const { customerId } = checkout.getCustomer()!;
-        const { storeId } = checkout.getConfig()!;
+        const { customerId } = customer;
+        const { storeId } = config;
         const { vaultAccessToken, vaultAccessExpiry } = checkout.getCheckoutMeta();
 
         return {

--- a/src/common/error/errors/missing-data-error.ts
+++ b/src/common/error/errors/missing-data-error.ts
@@ -2,7 +2,7 @@ import StandardError from './standard-error';
 
 export default class MissingDataError extends StandardError {
     constructor(message?: string) {
-        super(message || 'Unable to call this method because the data required for the call is not available. Please refer to the documentation to see what you need to do in order to obtain the required data.');
+        super(message || 'Unable to proceed because required data is missing.');
 
         this.type = 'missing_data';
     }

--- a/src/common/error/errors/not-initialized-error.ts
+++ b/src/common/error/errors/not-initialized-error.ts
@@ -2,7 +2,7 @@ import StandardError from './standard-error';
 
 export default class NotInitializedError extends StandardError {
     constructor(message?: string) {
-        super(message || 'Not initialized.');
+        super(message || 'Unable to proceed because the required component has not been initialized.');
 
         this.type = 'not_initialized';
     }

--- a/src/common/selector/cache-key-resolver.ts
+++ b/src/common/selector/cache-key-resolver.ts
@@ -5,10 +5,10 @@ export default class CacheKeyResolver {
     getKey(...args: any[]): string {
         const { index, map, parentMaps } = this._resolveMap(...args);
 
-        if (map) {
+        if (map && map.cacheKey) {
             map.usedCount++;
 
-            return map.cacheKey!;
+            return map.cacheKey;
         }
 
         return this._generateKey(parentMaps, args.slice(index));

--- a/src/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.ts
@@ -4,7 +4,7 @@
 import 'rxjs/add/observable/empty';
 
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
-import { NotImplementedError, NotInitializedError } from '../../common/error/errors';
+import { MissingDataError, NotImplementedError } from '../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../remote-checkout';
 import { RemoteCheckoutCustomerError } from '../../remote-checkout/errors';
@@ -35,6 +35,10 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
             .then(({ checkout }) => new Promise((resolve, reject) => {
                 this._paymentMethod = checkout.getPaymentMethod(options.methodId);
 
+                if (!this._paymentMethod) {
+                    throw new MissingDataError(`Unable to initialize because "paymentMethod (${options.methodId})" data is missing.`);
+                }
+
                 const { onError = () => {} } = options;
                 const onReady = () => {
                     this._createSignInButton({
@@ -48,7 +52,7 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
                     resolve();
                 };
 
-                this._scriptLoader.loadWidget(this._paymentMethod!, onReady)
+                this._scriptLoader.loadWidget(this._paymentMethod, onReady)
                     .catch(reject);
             }))
             .then(() => super.initialize(options));
@@ -84,14 +88,14 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
     }
 
     private _createSignInButton(options: InitializeWidgetOptions): OffAmazonPayments.Button {
-        if (!this._paymentMethod) {
-            throw new NotInitializedError();
+        if (!this._paymentMethod || !this._paymentMethod.config.merchantId) {
+            throw new MissingDataError('Unable to create sign-in button because "paymentMethod.config.merchantId" field is missing.');
         }
 
         const { onError = () => {} } = options;
-        const { config, initializationData } = this._paymentMethod;
+        const { initializationData } = this._paymentMethod;
 
-        return new OffAmazonPayments.Button(options.container, config.merchantId!, {
+        return new OffAmazonPayments.Button(options.container, this._paymentMethod.config.merchantId, {
             color: options.color || 'Gold',
             size: options.size || 'small',
             type: 'PwA',

--- a/src/order/map-to-internal-order.ts
+++ b/src/order/map-to-internal-order.ts
@@ -24,6 +24,7 @@ export default function mapToInternalOrder(checkout: Checkout, order: Order, exi
             coupons: checkout.cart.coupons.map(coupon =>
                 mapToInternalCoupon(
                     coupon,
+                    // tslint:disable-next-line:no-non-null-assertion
                     find(existingOrder.coupon.coupons, { code: coupon.code })!
                 )
             ),
@@ -38,6 +39,7 @@ export default function mapToInternalOrder(checkout: Checkout, order: Order, exi
             appliedGiftCertificates: checkout.giftCertificates.map(giftCertificate =>
                 mapToInternalGiftCertificate(
                     giftCertificate,
+                    // tslint:disable-next-line:no-non-null-assertion
                     find(existingOrder.giftCertificate.appliedGiftCertificates, { code: giftCertificate.code })!
                 )
             ),

--- a/src/order/order-action-creator.spec.js
+++ b/src/order/order-action-creator.spec.js
@@ -106,21 +106,20 @@ describe('OrderActionCreator', () => {
                 });
         });
 
-        it('emits error actions if unable to submit order', () => {
+        it('emits error actions if unable to submit order', async () => {
             checkoutClient.submitOrder.mockReturnValue(Promise.reject(errorResponse));
 
             const errorHandler = jest.fn((action) => Observable.of(action));
-
-            orderActionCreator.submitOrder(getOrderRequestBody())
+            const actions = await orderActionCreator.submitOrder(getOrderRequestBody())
                 .catch(errorHandler)
                 .toArray()
-                .subscribe((actions) => {
-                    expect(errorHandler).toHaveBeenCalled();
-                    expect(actions).toEqual([
-                        { type: actionTypes.SUBMIT_ORDER_REQUESTED },
-                        { type: actionTypes.SUBMIT_ORDER_FAILED, payload: errorResponse, error: true },
-                    ]);
-                });
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: actionTypes.SUBMIT_ORDER_REQUESTED },
+                { type: actionTypes.SUBMIT_ORDER_FAILED, payload: errorResponse, error: true },
+            ]);
         });
 
         it('verifies cart content', async () => {

--- a/src/order/place-order-service.ts
+++ b/src/order/place-order-service.ts
@@ -30,7 +30,7 @@ export default class PlaceOrderService {
         const cart = checkout.getCart();
 
         if (!cart) {
-            throw new MissingDataError();
+            throw new MissingDataError('Unable to submit order because "cart" data is missing.');
         }
 
         const action = this._orderActionCreator.submitOrder(
@@ -93,12 +93,16 @@ export default class PlaceOrderService {
             ? `${checkoutMeta.paymentAuthToken}, ${checkoutMeta.vaultAccessToken}`
             : checkoutMeta.paymentAuthToken;
 
+        if (!paymentMethod) {
+            throw new MissingDataError(`Unable to submit payment because "paymentMethod (${payment.name})" data is missing.`);
+        }
+
         return {
             billingAddress,
             cart,
             customer,
             order,
-            paymentMethod: this._getRequestPaymentMethod(paymentMethod!),
+            paymentMethod: this._getRequestPaymentMethod(paymentMethod),
             shippingAddress,
             shippingOption,
             authToken,

--- a/src/payment/create-payment-client.ts
+++ b/src/payment/create-payment-client.ts
@@ -2,14 +2,13 @@
 import { createClient as createBigpayClient } from '@bigcommerce/bigpay-client';
 
 import { CheckoutStore } from '../checkout';
-import LegacyConfig from '../config/legacy-config';
 
 export default function createPaymentClient(store: CheckoutStore): any {
     const paymentClient: any = createBigpayClient();
 
     store.subscribe(
         ({ checkout: { getConfig } }) => {
-            const config: LegacyConfig = getConfig()!;
+            const config = getConfig();
 
             if (config) {
                 paymentClient.setHost(config.bigpayBaseUrl);

--- a/src/payment/errors/index.ts
+++ b/src/payment/errors/index.ts
@@ -1,6 +1,2 @@
-export { default as PaymentMethodUninitializedError } from './payment-method-uninitialized-error';
-export { default as PaymentMethodNotRegistrableError } from './payment-method-not-registrable-error';
 export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';
-export { default as PaymentMethodUnsupportedError } from './payment-method-unsupported-error';
-export { default as PaymentMethodMissingDataError } from './payment-method-missing-data-error';
 export { default as PaymentMethodCancelledError } from './payment-method-cancelled-error';

--- a/src/payment/errors/payment-method-invalid-error.ts
+++ b/src/payment/errors/payment-method-invalid-error.ts
@@ -3,7 +3,7 @@ import { Response } from '@bigcommerce/request-sender';
 import { RequestError } from '../../common/error/errors';
 
 export default class PaymentMethodInvalidError extends RequestError {
-    constructor(response: Response) {
+    constructor(response?: Response) {
         super(response, 'There is a problem processing your payment. Please try again later.');
 
         this.type = 'payment_method_invalid';

--- a/src/payment/errors/payment-method-missing-data-error.ts
+++ b/src/payment/errors/payment-method-missing-data-error.ts
@@ -1,9 +1,0 @@
-import { StandardError } from '../../common/error/errors';
-
-export default class PaymentMethodMissingDataError extends StandardError {
-    constructor(field: string) {
-        super(`Failed to proceed because payment method misses "${field}" data`);
-
-        this.type = 'payment_method_missing_data';
-    }
-}

--- a/src/payment/errors/payment-method-not-registrable-error.ts
+++ b/src/payment/errors/payment-method-not-registrable-error.ts
@@ -1,9 +1,0 @@
-import { StandardError } from '../../common/error/errors';
-
-export default class PaymentMethodNotRegistrableError extends StandardError {
-    constructor(name: string) {
-        super(`Failed to register "${name}" as a payment strategy.`);
-
-        this.type = 'payment_method_not_registrable';
-    }
-}

--- a/src/payment/errors/payment-method-uninitialized-error.ts
+++ b/src/payment/errors/payment-method-uninitialized-error.ts
@@ -1,9 +1,0 @@
-import { StandardError } from '../../common/error/errors';
-
-export default class PaymentMethodUninitializedError extends StandardError {
-    constructor(name: string) {
-        super(`Failed to proceed because "${name}" has not been initialized.`);
-
-        this.type = 'payment_method_uninitialized';
-    }
-}

--- a/src/payment/errors/payment-method-unsupported-error.ts
+++ b/src/payment/errors/payment-method-unsupported-error.ts
@@ -1,9 +1,0 @@
-import { StandardError } from '../../common/error/errors';
-
-export default class PaymentMethodUnsupportedError extends StandardError {
-    constructor(name: string) {
-        super(`Failed to proceed because "${name}" is not supported.`);
-
-        this.type = 'payment_method_unsupported';
-    }
-}

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -34,7 +34,7 @@ export default class PaymentStrategyActionCreator {
                 const method = checkout.getPaymentMethod(payment.name, payment.gateway);
 
                 if (!method) {
-                    throw new MissingDataError();
+                    throw new MissingDataError(`Unable to submit payment because "paymentMethod (${payment.name})" data is missing.`);
                 }
 
                 strategy = this._strategyRegistry.getByMethod(method);
@@ -62,7 +62,7 @@ export default class PaymentStrategyActionCreator {
             const order = checkout.getOrder();
 
             if (!order) {
-                throw new MissingDataError();
+                throw new MissingDataError('Unable to finalize order because "order" data is missing.');
             }
 
             if (!order.payment || !order.payment.id) {
@@ -92,7 +92,7 @@ export default class PaymentStrategyActionCreator {
             const method = checkout.getPaymentMethod(methodId, gatewayId);
 
             if (!method) {
-                throw new MissingDataError();
+                throw new MissingDataError(`Unable to initialize because "paymentMethod (${methodId})" data is missing.`);
             }
 
             observer.next(createAction(PaymentStrategyActionType.InitializeRequested, undefined, { methodId }));
@@ -115,7 +115,7 @@ export default class PaymentStrategyActionCreator {
             const method = checkout.getPaymentMethod(methodId, gatewayId);
 
             if (!method) {
-                throw new MissingDataError();
+                throw new MissingDataError(`Unable to deinitialize because "paymentMethod (${methodId})" data is missing.`);
             }
 
             observer.next(createAction(PaymentStrategyActionType.DeinitializeRequested, undefined, { methodId }));

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -2,7 +2,7 @@ import { omit } from 'lodash';
 
 import { Payment } from '../..';
 import { CheckoutSelectors, CheckoutStore } from '../../../checkout';
-import { StandardError } from '../../../common/error/errors';
+import { MissingDataError, StandardError } from '../../../common/error/errors';
 import { OrderRequestBody, PlaceOrderService } from '../../../order';
 import isCreditCardLike from '../../is-credit-card';
 import isVaultedInstrument from '../../is-vaulted-instrument';
@@ -27,9 +27,14 @@ export default class BraintreeCreditCardPaymentStrategy extends PaymentStrategy 
 
         return this._placeOrderService.loadPaymentMethod(paymentId)
             .then(({ checkout }: CheckoutSelectors) => {
-                const { clientToken, config } = checkout.getPaymentMethod(paymentId)!;
-                this._braintreePaymentProcessor.initialize(clientToken!, options);
-                this._is3dsEnabled = config.is3dsEnabled;
+                this._paymentMethod = checkout.getPaymentMethod(paymentId);
+
+                if (!this._paymentMethod || !this._paymentMethod.clientToken) {
+                    throw new MissingDataError('Unable to initialize because "paymentMethod.clientToken" field is missing.');
+                }
+
+                this._braintreePaymentProcessor.initialize(this._paymentMethod.clientToken, options);
+                this._is3dsEnabled = this._paymentMethod.config.is3dsEnabled;
 
                 return super.initialize(options);
             })
@@ -58,7 +63,7 @@ export default class BraintreeCreditCardPaymentStrategy extends PaymentStrategy 
         .then(() => super.deinitialize(options));
     }
 
-    private _handleError(error: Error): void {
+    private _handleError(error: Error): never {
         if (error.name === 'BraintreeError') {
             throw new StandardError(error.message);
         }
@@ -82,12 +87,16 @@ export default class BraintreeCreditCardPaymentStrategy extends PaymentStrategy 
             return Promise.resolve(payment);
         }
 
-        const { amount } = checkout.getCart()!.grandTotal;
+        const cart = checkout.getCart();
         const billingAddress = checkout.getBillingAddress();
 
+        if (!cart || !billingAddress) {
+            throw new MissingDataError('Unable to prepare payment data because "cart" and "billingAddress" data is missing.');
+        }
+
         const tokenizedCard = this._is3dsEnabled ?
-            this._braintreePaymentProcessor.verifyCard(payment, billingAddress!, amount) :
-            this._braintreePaymentProcessor.tokenizeCard(payment, billingAddress!);
+            this._braintreePaymentProcessor.verifyCard(payment, billingAddress, cart.grandTotal.amount) :
+            this._braintreePaymentProcessor.tokenizeCard(payment, billingAddress);
 
         return this._braintreePaymentProcessor.appendSessionId(tokenizedCard)
             .then(paymentData => ({ ...payment, paymentData }));

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -1,7 +1,8 @@
 import { Payment } from '../..';
 import { InternalAddress } from '../../../address';
+import { NotInitializedError } from '../../../common/error/errors';
 import { CancellablePromise } from '../../../common/utility';
-import { PaymentMethodCancelledError, PaymentMethodUninitializedError } from '../../errors';
+import { PaymentMethodCancelledError } from '../../errors';
 import { CreditCard, TokenizedCreditCard } from '../../payment';
 import PaymentMethod from '../../payment-method';
 import { InitializeOptions } from '../payment-strategy';
@@ -51,7 +52,7 @@ export default class BraintreePaymentProcessor {
 
     verifyCard(payment: Payment, billingAddress: InternalAddress, amount: number): Promise<TokenizedCreditCard> {
         if (!this._modalHandler) {
-            throw new PaymentMethodUninitializedError('A modal handler is required for 3ds payments');
+            throw new NotInitializedError('Unable to verify card because the choosen payment method has not been initialized.');
         }
 
         const { onRemoveFrame, ...modalHandler} = this._modalHandler;

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -3,7 +3,7 @@ import { omit } from 'lodash';
 import { getBillingAddress } from '../../../billing/internal-billing-addresses.mock';
 import { getCart } from '../../../cart/internal-carts.mock';
 import { CheckoutSelector, CheckoutStore } from '../../../checkout';
-import { StandardError } from '../../../common/error/errors';
+import { MissingDataError, StandardError } from '../../../common/error/errors';
 import { getLegacyAppConfig } from '../../../config/configs.mock.js';
 import { OrderRequestBody } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
@@ -77,6 +77,17 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
             expect(braintreePaymentProcessorMock.preloadPaypal).not.toHaveBeenCalled();
             expect(braintreePaymentProcessorMock.initialize).not.toHaveBeenCalled();
+        });
+
+        it('throws error if unable to initialize', async () => {
+            const paymentMethod = getBraintreePaypal();
+            checkoutMock.getPaymentMethod = jest.fn(() => paymentMethod);
+
+            try {
+                await braintreePaypalPaymentStrategy.initialize({ paymentMethod });
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
         });
     });
 

--- a/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -1,5 +1,7 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
+import { StandardError } from '../../../common/error/errors';
+
 import { Braintree } from './braintree';
 
 export default class BraintreeScriptLoader {
@@ -11,24 +13,48 @@ export default class BraintreeScriptLoader {
     loadClient(): Promise<Braintree.ClientCreator> {
         return this._scriptLoader
             .loadScript('//js.braintreegateway.com/web/3.15.0/js/client.min.js')
-            .then(() => this._window.braintree!.client!);
+            .then(() => {
+                if (!this._window.braintree || !this._window.braintree.client) {
+                    throw new StandardError();
+                }
+
+                return this._window.braintree.client;
+            });
     }
 
     load3DS(): Promise<Braintree.ThreeDSecureCreator> {
         return this._scriptLoader
             .loadScript('//js.braintreegateway.com/web/3.15.0/js/three-d-secure.min.js')
-            .then(() => this._window.braintree!.threeDSecure!);
+            .then(() => {
+                if (!this._window.braintree || !this._window.braintree.threeDSecure) {
+                    throw new StandardError();
+                }
+
+                return this._window.braintree.threeDSecure;
+            });
     }
 
     loadDataCollector(): Promise<Braintree.DataCollectorCreator> {
         return this._scriptLoader
             .loadScript('//js.braintreegateway.com/web/3.15.0/js/data-collector.min.js')
-            .then(() => this._window.braintree!.dataCollector!);
+            .then(() => {
+                if (!this._window.braintree || !this._window.braintree.dataCollector) {
+                    throw new StandardError();
+                }
+
+                return this._window.braintree.dataCollector;
+            });
     }
 
     loadPaypal(): Promise<Braintree.PaypalCreator> {
         return this._scriptLoader
             .loadScript('//js.braintreegateway.com/web/3.15.0/js/paypal.min.js')
-            .then(() => this._window.braintree!.paypal!);
+            .then(() => {
+                if (!this._window.braintree || !this._window.braintree.paypal) {
+                    throw new StandardError();
+                }
+
+                return this._window.braintree.paypal;
+            });
     }
 }

--- a/src/payment/strategies/offsite-payment-strategy.spec.js
+++ b/src/payment/strategies/offsite-payment-strategy.spec.js
@@ -1,5 +1,6 @@
 import { merge, omit } from 'lodash';
 import { createCheckoutStore } from '../../checkout';
+import { MissingDataError } from '../../common/error/errors';
 import { getOrderRequestBody, getIncompleteOrder, getSubmittedOrder } from '../../order/internal-orders.mock';
 import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import * as paymentStatusTypes from '../payment-status-types';
@@ -107,6 +108,14 @@ describe('OffsitePaymentStrategy', () => {
         } catch (error) {
             expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
             expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
+        }
+    });
+
+    it('throws error if unable to finalize due to missing data', async () => {
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(MissingDataError);
         }
     });
 

--- a/src/payment/strategies/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite-payment-strategy.ts
@@ -1,6 +1,7 @@
 import { omit } from 'lodash';
 
 import { CheckoutSelectors } from '../../checkout';
+import { MissingDataError } from '../../common/error/errors';
 import { OrderRequestBody } from '../../order';
 import * as paymentStatusTypes from '../payment-status-types';
 
@@ -19,7 +20,13 @@ export default class OffsitePaymentStrategy extends PaymentStrategy {
 
     finalize(options: any): Promise<CheckoutSelectors> {
         const { checkout } = this._store.getState();
-        const { orderId, payment = {} } = checkout.getOrder()!;
+        const order = checkout.getOrder();
+
+        if (!order) {
+            throw new MissingDataError('Unable to finalize order because "order" data is missing.');
+        }
+
+        const { orderId, payment = {} } = order;
 
         if (orderId &&
             payment.status === paymentStatusTypes.ACKNOWLEDGE ||

--- a/src/payment/strategies/paypal-pro-payment-strategy.ts
+++ b/src/payment/strategies/paypal-pro-payment-strategy.ts
@@ -1,6 +1,7 @@
 import { omit, pick } from 'lodash';
 
 import { CheckoutSelectors } from '../../checkout';
+import { MissingDataError } from '../../common/error/errors';
 import { OrderRequestBody } from '../../order';
 import * as paymentStatusTypes from '../payment-status-types';
 
@@ -23,8 +24,12 @@ export default class PaypalProPaymentStrategy extends PaymentStrategy {
 
     private _isPaymentAcknowledged(): boolean {
         const { checkout } = this._store.getState();
-        const { payment = {} } = checkout.getOrder()!;
+        const order = checkout.getOrder();
 
-        return payment.status === paymentStatusTypes.ACKNOWLEDGE;
+        if (!order) {
+            throw new MissingDataError('Unable to determine payment status because "order" data is missing.');
+        }
+
+        return order.payment && order.payment.status === paymentStatusTypes.ACKNOWLEDGE;
     }
 }

--- a/src/payment/strategies/sage-pay-payment-strategy.spec.js
+++ b/src/payment/strategies/sage-pay-payment-strategy.spec.js
@@ -1,5 +1,6 @@
 import { merge, omit } from 'lodash';
 import { createCheckoutStore } from '../../checkout';
+import { MissingDataError } from '../../common/error/errors';
 import { getErrorPaymentResponseBody } from '../payments.mock';
 import { getOrderRequestBody, getIncompleteOrder, getSubmittedOrder } from '../../order/internal-orders.mock';
 import { getResponse } from '../../common/http-request/responses.mock';
@@ -135,6 +136,18 @@ describe('SagePayPaymentStrategy', () => {
         } catch (error) {
             expect(placeOrderService.finalizeOrder).not.toHaveBeenCalled();
             expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
+    });
+
+    it('throws error if order is missing', async () => {
+        const { checkout } = store.getState();
+
+        jest.spyOn(checkout, 'getOrder').mockReturnValue();
+
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(MissingDataError);
         }
     });
 });

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -73,15 +73,18 @@ describe('SquarePaymentStrategy', () => {
                 expect(scriptLoader.load).toHaveBeenCalledTimes(1);
             });
 
-            it('fails to initialize when widget config is missing', () => {
+            it('fails to initialize when widget config is missing', async () => {
                 const initOptions = {
                     paymentMethod: { ...paymentMethod,
                         initializationData: { locationId: 'foo', env: 'bar', applicationId: 'test' },
                     },
                 };
 
-                strategy.initialize({ paymentMethod })
-                    .catch(error => expect(error.type).toEqual('payment_method_missing_data'));
+                try {
+                    await strategy.initialize({ paymentMethod });
+                } catch (error) {
+                    expect(error.type).toEqual('invalid_argument');
+                }
             });
         });
 
@@ -115,7 +118,7 @@ describe('SquarePaymentStrategy', () => {
         describe('when form has not been initialized', () => {
             it('rejects the promise', () => {
                 strategy.execute()
-                    .catch(e => expect(e.type).toEqual('payment_method_uninitialized'));
+                    .catch(e => expect(e.type).toEqual('not_initialized'));
 
                 expect(squareForm.requestCardNonce).toHaveBeenCalledTimes(0);
             });

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -2,9 +2,8 @@
 import { omit } from 'lodash';
 
 import { CheckoutSelectors, CheckoutStore } from '../../../checkout';
-import { TimeoutError, UnsupportedBrowserError } from '../../../common/error/errors';
+import { InvalidArgumentError, NotInitializedError, StandardError, TimeoutError, UnsupportedBrowserError } from '../../../common/error/errors';
 import { OrderRequestBody, PlaceOrderService } from '../../../order';
-import { PaymentMethodMissingDataError, PaymentMethodUninitializedError } from '../../errors';
 import PaymentMethod from '../../payment-method';
 import PaymentStrategy from '../payment-strategy';
 
@@ -29,6 +28,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                     this._paymentForm = createSquareForm(
                         this._getFormOptions(options, { resolve, reject })
                     );
+
                     this._paymentForm.build();
                 }))
             .then(() => super.initialize(options));
@@ -37,7 +37,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
     execute(payload: OrderRequestBody, options?: any): Promise<CheckoutSelectors> {
         return new Promise((resolve, reject) => {
             if (!this._paymentForm) {
-                throw new PaymentMethodUninitializedError('Square');
+                throw new NotInitializedError('Unable to submit payment because the choosen payment method has not been initialized.');
             }
 
             if (this._deferredRequestNonce) {
@@ -47,8 +47,8 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
             this._deferredRequestNonce = { resolve, reject };
             this._paymentForm.requestCardNonce();
         })
-        .then(paymentData => this._placeOrderService.submitOrder(
-            omit(payload, 'payment'), true, options)
+        .then(paymentData =>
+            this._placeOrderService.submitOrder(omit(payload, 'payment') as OrderRequestBody, true, options)
         );
     }
 
@@ -56,7 +56,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
         const { paymentMethod, widgetConfig } = options;
 
         if (!widgetConfig) {
-            throw new PaymentMethodMissingDataError('widgetConfig');
+            throw new InvalidArgumentError('Unable to proceed because "options.widgetConfig" argument is not provided.');
         }
 
         return {
@@ -66,12 +66,15 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                 paymentFormLoaded: () => {
                     deferred.resolve();
 
-                    const state = this._store.getState();
+                    const { checkout } = this._store.getState();
+                    const billingAddress = checkout.getBillingAddress();
 
-                    const billingAddress = state.checkout.getBillingAddress();
+                    if (!this._paymentForm) {
+                        throw new NotInitializedError();
+                    }
 
                     if (billingAddress && billingAddress.postCode) {
-                        this._paymentForm!.setPostalCode(billingAddress.postCode);
+                        this._paymentForm.setPostalCode(billingAddress.postCode);
                     }
                 },
                 unsupportedBrowserDetected: () => {
@@ -85,10 +88,14 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
     }
 
     private _cardNonceResponseReceived(errors: any, nonce: string): void {
+        if (!this._deferredRequestNonce) {
+            throw new StandardError();
+        }
+
         if (errors) {
-            this._deferredRequestNonce!.reject(errors);
+            this._deferredRequestNonce.reject(errors);
         } else {
-            this._deferredRequestNonce!.resolve({ nonce });
+            this._deferredRequestNonce.resolve({ nonce });
         }
     }
 }

--- a/src/remote-checkout/methods/wepay/wepay-risk-client.ts
+++ b/src/remote-checkout/methods/wepay/wepay-risk-client.ts
@@ -8,11 +8,12 @@ const SCRIPT_SRC = '//static.wepay.com/min/js/risk.1.latest.js';
 export default class WepayRiskClient {
     private _riskClient?: WePay.Risk;
 
-    constructor(private _scriptLoader: ScriptLoader) {}
+    constructor(
+        private _scriptLoader: ScriptLoader
+    ) {}
 
     initialize(): Promise<WepayRiskClient> {
-        return this
-            ._scriptLoader
+        return this._scriptLoader
             .loadScript(SCRIPT_SRC)
             .then(() => this._riskClient = (window as any).WePay.risk as WePay.Risk)
             .then(() => this);
@@ -23,7 +24,8 @@ export default class WepayRiskClient {
             throw new NotInitializedError();
         }
 
-        this._riskClient!.generate_risk_token();
-        return this._riskClient!.get_risk_token();
+        this._riskClient.generate_risk_token();
+
+        return this._riskClient.get_risk_token();
     }
 }

--- a/src/shipping/map-to-internal-shipping-options.ts
+++ b/src/shipping/map-to-internal-shipping-options.ts
@@ -8,6 +8,7 @@ export default function mapToInternalShippingOptions(consignments: Consignment[]
     return consignments.reduce((result, consignment) => ({
         ...result,
         [consignment.shippingAddress.id]: (consignment.availableShippingOptions || []).map(option =>
+            // tslint:disable-next-line:no-non-null-assertion
             mapToInternalShippingOption(option, find(existingOptions[consignment.shippingAddress.id], { id: option.id })!)
         ),
     }), {});

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
@@ -131,7 +131,10 @@ describe('AmazonPayShippingStrategy', () => {
 
     it('rejects with error if initialization fails', async () => {
         const strategy = new AmazonPayShippingStrategy(store, addressActionCreator, optionActionCreator, paymentMethodActionCreator, remoteCheckoutActionCreator, scriptLoader);
-        const paymentMethod = { ...getAmazonPay(), config: {} };
+        const paymentMethod = { ...getAmazonPay(), config: { merchantId: undefined } };
+
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+            .mockReturnValue(Observable.of(createAction(LOAD_PAYMENT_METHOD_SUCCEEDED, { paymentMethod })));
 
         try {
             await strategy.initialize({ container: 'addressBook', methodId: paymentMethod.id });
@@ -145,7 +148,7 @@ describe('AmazonPayShippingStrategy', () => {
         const paymentMethod = getAmazonPay();
 
         try {
-            await strategy.initialize({ container: 'addressBook', methodId: paymentMethod.id });
+            await strategy.initialize({ container: 'addressBook123', methodId: paymentMethod.id });
         } catch (error) {
             expect(error).toBeInstanceOf(NotInitializedError);
         }

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.ts
@@ -3,7 +3,7 @@ import { createAction, createErrorAction } from '@bigcommerce/data-store';
 
 import { isAddressEqual, InternalAddress } from '../../address';
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
-import { NotInitializedError } from '../../common/error/errors';
+import { MissingDataError, NotInitializedError } from '../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
 import { RemoteCheckoutActionCreator } from '../../remote-checkout';
 import {
@@ -42,13 +42,17 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
             .then(({ checkout }) => new Promise((resolve, reject) => {
                 this._paymentMethod = checkout.getPaymentMethod(options.methodId);
 
+                if (!this._paymentMethod) {
+                    throw new MissingDataError(`Unable to initialize because "paymentMethod (${options.methodId})" data is missing.`);
+                }
+
                 const onReady = () => {
                     this._createAddressBook(options)
                         .then(resolve)
                         .catch(reject);
                 };
 
-                this._scriptLoader.loadWidget(this._paymentMethod!, onReady)
+                this._scriptLoader.loadWidget(this._paymentMethod, onReady)
                     .catch(reject);
             }))
             .then(() => super.initialize(options));
@@ -128,12 +132,13 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
             ))
             .then(({ checkout }) => {
                 const { remoteCheckout = {} } = checkout.getCheckoutMeta();
+                const address = checkout.getShippingAddress();
 
                 if (remoteCheckout.shippingAddress === false) {
                     throw new RemoteCheckoutSynchronizationError();
                 }
 
-                if (isAddressEqual(remoteCheckout.shippingAddress, checkout.getShippingAddress()!)) {
+                if (isAddressEqual(remoteCheckout.shippingAddress, address || {})) {
                     return this._store.getState();
                 }
 
@@ -156,7 +161,11 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
     ): void {
         this._synchronizeShippingAddress()
             .then(({ checkout }: CheckoutSelectors) => {
-                callback(checkout.getShippingAddress()!);
+                const address = checkout.getShippingAddress();
+
+                if (address) {
+                    callback(address);
+                }
             })
             .catch((error: Error) => {
                 errorCallback(error);

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "max-line-length": false,
         "no-empty": false,
+        "no-non-null-assertion": true,
         "no-reference": false,
         "no-shadowed-variable": false,
         "no-unused-variable": true,


### PR DESCRIPTION
## What?
* Enable `no-non-null-assertion` to make sure we're actively checking for possible `null` values. I currently have a local override but the rule will be [enable](https://github.com/bigcommerce/tslint-config/pull/4) in the shared config soon.
* Throw the appropriate error type, i.e.:
  * `MissingDataError` - we're in an invalid state because the required data has not been retrieved.
  * `InvalidArgumentError` - we haven't supplied expected arguments.
* Provide more descriptive error messages.
* Remove some redundant error types. For example, `PaymentMethodMissingDataError` could be replaced with `MissingDataError`.

## Why?
* To reduce the chance of encountering null access error.
* If there is an error due to incorrect usage, we should throw more descriptive error messages so the consumer of the library can catch and fix.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
