### PR TITLE
CHECKOUT-3089: Remove unused variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "docs": "typedoc --theme markdown --mode file --module commonjs --readme none --out docs --includeDeclarations --excludeExternals --excludePrivate --excludeProtected --mdHideSources dist/checkout-sdk.d.ts",
     "lint": "yarn lint:js && yarn lint:ts",
     "lint:js": "eslint src --config eslintrc.json",
-    "lint:ts": "tslint 'src/**/*.ts' --config tslint.json && tsc --noEmit",
+    "lint:ts": "tslint 'src/**/*.ts' --config tslint.json --project tsconfig.json && tsc --noEmit",
     "prerelease": "git fetch --tags && yarn validate-dependencies && yarn validate-commits && yarn build && yarn docs",
     "release": "git add dist docs && standard-version -a",
     "test": "jest --config jest-config.js",

--- a/src/address/map-to-internal-address.ts
+++ b/src/address/map-to-internal-address.ts
@@ -1,4 +1,3 @@
-import { Checkout } from '../checkout';
 
 import Address from './address';
 import InternalAddress from './internal-address';

--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -1,7 +1,7 @@
-import { combineReducers, Action } from '@bigcommerce/data-store';
+import { combineReducers } from '@bigcommerce/data-store';
 
 import { Address } from '../address';
-import { Checkout, CheckoutAction, CheckoutActionType } from '../checkout';
+import { CheckoutAction, CheckoutActionType } from '../checkout';
 
 import BillingAddressState from './billing-address-state';
 

--- a/src/checkout/checkout-error-selector.spec.js
+++ b/src/checkout/checkout-error-selector.spec.js
@@ -3,12 +3,12 @@ import { CartSelector } from '../cart';
 import { ConfigSelector } from '../config';
 import { CountrySelector } from '../geography';
 import { CouponSelector, GiftCertificateSelector } from '../coupon';
-import { CustomerSelector, CustomerStrategySelector } from '../customer';
+import { CustomerStrategySelector } from '../customer';
 import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { QuoteSelector } from '../quote';
-import { ShippingAddressSelector, ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
+import { ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 import CheckoutErrorSelector from './checkout-error-selector';
 
@@ -18,7 +18,6 @@ describe('CheckoutErrorSelector', () => {
     let config;
     let countries;
     let coupon;
-    let customer;
     let customerStrategy;
     let giftCertificate;
     let instruments;
@@ -28,7 +27,6 @@ describe('CheckoutErrorSelector', () => {
     let paymentMethods;
     let paymentStrategy;
     let quote;
-    let shippingAddress;
     let shippingCountries;
     let shippingOptions;
     let shippingStrategy;
@@ -39,7 +37,6 @@ describe('CheckoutErrorSelector', () => {
         config = new ConfigSelector();
         countries = new CountrySelector();
         coupon = new CouponSelector();
-        customer = new CustomerSelector();
         customerStrategy = new CustomerStrategySelector();
         giftCertificate = new GiftCertificateSelector();
         instruments = new InstrumentSelector();
@@ -47,7 +44,6 @@ describe('CheckoutErrorSelector', () => {
         paymentMethods = new PaymentMethodSelector();
         paymentStrategy = new PaymentStrategySelector();
         quote = new QuoteSelector();
-        shippingAddress = new ShippingAddressSelector();
         shippingCountries = new ShippingCountrySelector();
         shippingOptions = new ShippingOptionSelector();
         shippingStrategy = new ShippingStrategySelector();
@@ -58,7 +54,6 @@ describe('CheckoutErrorSelector', () => {
             config,
             countries,
             coupon,
-            customer,
             customerStrategy,
             giftCertificate,
             instruments,
@@ -66,7 +61,6 @@ describe('CheckoutErrorSelector', () => {
             paymentMethods,
             paymentStrategy,
             quote,
-            shippingAddress,
             shippingCountries,
             shippingOptions,
             shippingStrategy

--- a/src/checkout/checkout-error-selector.ts
+++ b/src/checkout/checkout-error-selector.ts
@@ -3,14 +3,13 @@ import { CartSelector } from '../cart';
 import { selectorDecorator as selector } from '../common/selector';
 import { ConfigSelector } from '../config';
 import { CouponSelector, GiftCertificateSelector } from '../coupon';
-import { CustomerSelector, CustomerStrategySelector } from '../customer';
+import { CustomerStrategySelector } from '../customer';
 import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { QuoteSelector } from '../quote';
-import { RemoteCheckoutSelector } from '../remote-checkout';
-import { ShippingAddressSelector, ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
+import { ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 
 @selector
 export default class CheckoutErrorSelector {
@@ -23,7 +22,6 @@ export default class CheckoutErrorSelector {
         private _config: ConfigSelector,
         private _countries: CountrySelector,
         private _coupon: CouponSelector,
-        private _customer: CustomerSelector,
         private _customerStrategy: CustomerStrategySelector,
         private _giftCertificate: GiftCertificateSelector,
         private _instruments: InstrumentSelector,
@@ -31,7 +29,6 @@ export default class CheckoutErrorSelector {
         private _paymentMethods: PaymentMethodSelector,
         private _paymentStrategy: PaymentStrategySelector,
         private _quote: QuoteSelector,
-        private _shippingAddress: ShippingAddressSelector,
         private _shippingCountries: ShippingCountrySelector,
         private _shippingOptions: ShippingOptionSelector,
         private _shippingStrategy: ShippingStrategySelector

--- a/src/checkout/checkout-reducer.ts
+++ b/src/checkout/checkout-reducer.ts
@@ -1,6 +1,4 @@
-import { combineReducers, Action } from '@bigcommerce/data-store';
-
-import { Address } from '../address';
+import { combineReducers } from '@bigcommerce/data-store';
 
 import Checkout from './checkout';
 import { CheckoutAction, CheckoutActionType } from './checkout-actions';

--- a/src/checkout/checkout-selector.spec.js
+++ b/src/checkout/checkout-selector.spec.js
@@ -45,7 +45,7 @@ describe('CheckoutSelector', () => {
             shippingCountries: getShippingCountriesState(),
         };
 
-        orderSelector = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+        orderSelector = new OrderSelector(state.order, state.customer, state.cart);
         formSelector = new FormSelector(state.config);
 
         selector = new CheckoutSelector(

--- a/src/checkout/checkout-status-selector.spec.js
+++ b/src/checkout/checkout-status-selector.spec.js
@@ -3,12 +3,11 @@ import { CartSelector } from '../cart';
 import { ConfigSelector } from '../config';
 import { CountrySelector } from '../geography';
 import { CouponSelector, GiftCertificateSelector } from '../coupon';
-import { CustomerSelector } from '../customer';
 import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { QuoteSelector } from '../quote';
-import { ShippingCountrySelector, ShippingAddressSelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
+import { ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 import CheckoutStatusSelector from './checkout-status-selector';
 import CustomerStrategySelector from '../customer/customer-strategy-selector';
 
@@ -18,7 +17,6 @@ describe('CheckoutStatusSelector', () => {
     let config;
     let countries;
     let coupon;
-    let customer;
     let customerStrategy;
     let giftCertificate;
     let instruments;
@@ -26,7 +24,6 @@ describe('CheckoutStatusSelector', () => {
     let paymentMethods;
     let paymentStrategy;
     let quote;
-    let shippingAddress;
     let shippingCountries;
     let shippingOption;
     let shippingStrategy;
@@ -38,7 +35,6 @@ describe('CheckoutStatusSelector', () => {
         config = new ConfigSelector();
         countries = new CountrySelector();
         coupon = new CouponSelector();
-        customer = new CustomerSelector();
         customerStrategy = new CustomerStrategySelector();
         giftCertificate = new GiftCertificateSelector();
         order = new OrderSelector();
@@ -46,7 +42,6 @@ describe('CheckoutStatusSelector', () => {
         paymentStrategy = new PaymentStrategySelector();
         instruments = new InstrumentSelector();
         quote = new QuoteSelector();
-        shippingAddress = new ShippingAddressSelector();
         shippingCountries = new ShippingCountrySelector();
         shippingOption = new ShippingOptionSelector();
         shippingStrategy = new ShippingStrategySelector();
@@ -57,7 +52,6 @@ describe('CheckoutStatusSelector', () => {
             config,
             countries,
             coupon,
-            customer,
             customerStrategy,
             giftCertificate,
             instruments,
@@ -65,7 +59,6 @@ describe('CheckoutStatusSelector', () => {
             paymentMethods,
             paymentStrategy,
             quote,
-            shippingAddress,
             shippingCountries,
             shippingOption,
             shippingStrategy

--- a/src/checkout/checkout-status-selector.ts
+++ b/src/checkout/checkout-status-selector.ts
@@ -3,13 +3,13 @@ import { CartSelector } from '../cart';
 import { selectorDecorator as selector } from '../common/selector';
 import { ConfigSelector } from '../config';
 import { CouponSelector, GiftCertificateSelector } from '../coupon';
-import { CustomerSelector, CustomerStrategySelector } from '../customer';
+import { CustomerStrategySelector } from '../customer';
 import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { QuoteSelector } from '../quote';
-import { ShippingAddressSelector, ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
+import { ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 
 @selector
 export default class CheckoutStatusSelector {
@@ -22,7 +22,6 @@ export default class CheckoutStatusSelector {
         private _config: ConfigSelector,
         private _countries: CountrySelector,
         private _coupon: CouponSelector,
-        private _customer: CustomerSelector,
         private _customerStrategy: CustomerStrategySelector,
         private _giftCertificate: GiftCertificateSelector,
         private _instruments: InstrumentSelector,
@@ -30,7 +29,6 @@ export default class CheckoutStatusSelector {
         private _paymentMethods: PaymentMethodSelector,
         private _paymentStrategy: PaymentStrategySelector,
         private _quote: QuoteSelector,
-        private _shippingAddress: ShippingAddressSelector,
         private _shippingCountries: ShippingCountrySelector,
         private _shippingOptions: ShippingOptionSelector,
         private _shippingStrategy: ShippingStrategySelector

--- a/src/checkout/create-checkout-store.ts
+++ b/src/checkout/create-checkout-store.ts
@@ -88,7 +88,7 @@ function createCheckoutSelectors(state: any, options: CheckoutStoreOptions = {})
     const form = new FormSelector(state.config);
     const giftCertificate = new GiftCertificateSelector(state.giftCertificates);
     const instruments = new InstrumentSelector(state.instruments);
-    const order = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+    const order = new OrderSelector(state.order, state.customer, state.cart);
     const paymentMethods = new PaymentMethodSelector(state.paymentMethods, state.order);
     const paymentStrategy = new PaymentStrategySelector(state.paymentStrategy);
     const quote = new QuoteSelector(state.quote);
@@ -121,7 +121,6 @@ function createCheckoutSelectors(state: any, options: CheckoutStoreOptions = {})
         config,
         countries,
         coupon,
-        customer,
         customerStrategy,
         giftCertificate,
         instruments,
@@ -129,7 +128,6 @@ function createCheckoutSelectors(state: any, options: CheckoutStoreOptions = {})
         paymentMethods,
         paymentStrategy,
         quote,
-        shippingAddress,
         shippingCountries,
         shippingOptions,
         shippingStrategy
@@ -141,7 +139,6 @@ function createCheckoutSelectors(state: any, options: CheckoutStoreOptions = {})
         config,
         countries,
         coupon,
-        customer,
         customerStrategy,
         giftCertificate,
         instruments,
@@ -149,7 +146,6 @@ function createCheckoutSelectors(state: any, options: CheckoutStoreOptions = {})
         paymentMethods,
         paymentStrategy,
         quote,
-        shippingAddress,
         shippingCountries,
         shippingOptions,
         shippingStrategy

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -3,7 +3,7 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import { CheckoutClient, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
-import { PaymentMethod, PaymentMethodActionCreator } from '../payment';
+import { PaymentMethodActionCreator } from '../payment';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
 

--- a/src/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.ts
@@ -2,7 +2,6 @@
 /// <reference path="../../remote-checkout/methods/amazon-pay/off-amazon-payments.d.ts" />
 
 import 'rxjs/add/observable/empty';
-import { Observable } from 'rxjs/Observable';
 
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
 import { NotImplementedError, NotInitializedError } from '../../common/error/errors';
@@ -16,8 +15,6 @@ import CustomerStrategy from './customer-strategy';
 
 export default class AmazonPayCustomerStrategy extends CustomerStrategy {
     private _paymentMethod?: PaymentMethod;
-    private _signInButton?: OffAmazonPayments.Button;
-    private _window: OffAmazonPayments.HostWindow;
 
     constructor(
         store: CheckoutStore,
@@ -27,8 +24,6 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
         private _scriptLoader: AmazonPayScriptLoader
     ) {
         super(store);
-
-        this._window = window;
     }
 
     initialize(options: InitializeOptions): Promise<CheckoutSelectors> {
@@ -42,7 +37,7 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
 
                 const { onError = () => {} } = options;
                 const onReady = () => {
-                    this._signInButton = this._createSignInButton({
+                    this._createSignInButton({
                         ...options as InitializeWidgetOptions,
                         onError: error => {
                             reject(error);
@@ -64,7 +59,6 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
             return super.deinitialize(options);
         }
 
-        this._signInButton = undefined;
         this._paymentMethod = undefined;
 
         return super.deinitialize(options);

--- a/src/order/create-place-order-service.ts
+++ b/src/order/create-place-order-service.ts
@@ -1,5 +1,3 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
-
 import { CartActionCreator } from '../cart';
 import { CheckoutClient, CheckoutStore } from '../checkout';
 import { PaymentActionCreator, PaymentMethodActionCreator, PaymentRequestSender } from '../payment';
@@ -12,8 +10,6 @@ export default function createPlaceOrderService(
     client: CheckoutClient,
     paymentClient: any
 ): PlaceOrderService {
-    const requestSender = createRequestSender();
-
     return new PlaceOrderService(
         store,
         new CartActionCreator(client),

--- a/src/order/map-to-internal-incomplete-order.ts
+++ b/src/order/map-to-internal-incomplete-order.ts
@@ -1,7 +1,6 @@
 import { Checkout } from '../checkout';
 
 import InternalIncompleteOrder from './internal-incomplete-order';
-import InternalOrder from './internal-order';
 
 export default function mapToInternalIncompleteOrder(checkout: Checkout, existingOrder: InternalIncompleteOrder): InternalIncompleteOrder {
     return {

--- a/src/order/map-to-internal-order.ts
+++ b/src/order/map-to-internal-order.ts
@@ -1,6 +1,6 @@
 import { find } from 'lodash';
 
-import { mapToInternalCart, mapToInternalLineItems } from '../cart';
+import { mapToInternalLineItems } from '../cart';
 import { Checkout } from '../checkout';
 import { mapToInternalCoupon, mapToInternalGiftCertificate } from '../coupon';
 

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -2,7 +2,6 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
 
-import InternalOrder from './internal-order';
 import OrderRequestBody from './order-request-body';
 
 /**

--- a/src/order/order-selector.spec.js
+++ b/src/order/order-selector.spec.js
@@ -25,7 +25,7 @@ describe('OrderSelector', () => {
 
     describe('#getOrder()', () => {
         it('returns the current order', () => {
-            orderSelector = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
 
             expect(orderSelector.getOrder()).toEqual(order);
         });
@@ -33,7 +33,7 @@ describe('OrderSelector', () => {
 
     describe('#getOrderMeta()', () => {
         it('returns order meta', () => {
-            orderSelector = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
 
             expect(orderSelector.getOrderMeta()).toEqual({
                 deviceFingerprint: 'a084205e-1b1f-487d-9087-e072d20747e5',
@@ -54,7 +54,7 @@ describe('OrderSelector', () => {
         });
 
         it('does not returns error if able to load', () => {
-            orderSelector = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
 
             expect(orderSelector.getLoadError()).toBeUndefined();
         });
@@ -71,7 +71,7 @@ describe('OrderSelector', () => {
         });
 
         it('returns false if not loading order', () => {
-            orderSelector = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
 
             expect(orderSelector.isLoading()).toEqual(false);
         });
@@ -79,13 +79,13 @@ describe('OrderSelector', () => {
 
     describe('#isPaymentDataRequired()', () => {
         it('returns true if payment is required', () => {
-            orderSelector = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
 
             expect(orderSelector.isPaymentDataRequired()).toEqual(true);
         });
 
         it('returns false if store credit exceeds grand total', () => {
-            orderSelector = new OrderSelector(state.order, state.payment, merge({}, state.customer, {
+            orderSelector = new OrderSelector(state.order, merge({}, state.customer, {
                 data: { storeCredit: 100000000000 },
             }), state.cart);
 
@@ -93,7 +93,7 @@ describe('OrderSelector', () => {
         });
 
         it('returns true if store credit exceeds grand total but not using store credit', () => {
-            orderSelector = new OrderSelector(state.order, state.payment, merge({}, state.customer, {
+            orderSelector = new OrderSelector(state.order, merge({}, state.customer, {
                 data: { storeCredit: 100000000000 },
             }), state.cart);
 
@@ -105,7 +105,7 @@ describe('OrderSelector', () => {
         it('returns true if payment is tokenized', () => {
             const paymentMethod = { ...getPaymentMethod(), nonce: '8903d867-6f7b-475c-8ab2-0b47ec6e000d' };
 
-            orderSelector = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
 
             expect(orderSelector.isPaymentDataSubmitted(paymentMethod)).toEqual(true);
         });
@@ -127,7 +127,7 @@ describe('OrderSelector', () => {
         });
 
         it('returns false if payment is not tokenized, acknowledged or finalized', () => {
-            orderSelector = new OrderSelector(state.order, state.payment, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
 
             expect(orderSelector.isPaymentDataSubmitted(getPaymentMethod())).toEqual(false);
         });

--- a/src/order/order-selector.ts
+++ b/src/order/order-selector.ts
@@ -11,13 +11,11 @@ export default class OrderSelector {
     /**
      * @constructor
      * @param {OrderState} order
-     * @param {PaymentState} payment
      * @param {CustomerState} customer
      * @param {CartState} cart
      */
     constructor(
         private _order: any = {},
-        private _payment: any = {},
         private _customer: any = {},
         private _cart: any = {}
     ) {}

--- a/src/payment/create-payment-client.ts
+++ b/src/payment/create-payment-client.ts
@@ -2,7 +2,6 @@
 import { createClient as createBigpayClient } from '@bigcommerce/bigpay-client';
 
 import { CheckoutStore } from '../checkout';
-import Config from '../config/config';
 import LegacyConfig from '../config/legacy-config';
 
 export default function createPaymentClient(store: CheckoutStore): any {

--- a/src/payment/is-credit-card.ts
+++ b/src/payment/is-credit-card.ts
@@ -1,5 +1,5 @@
 import isVaultedInstrument from './is-vaulted-instrument';
-import { CreditCard, PaymentInstrument, VaultedInstrument } from './payment';
+import { CreditCard, PaymentInstrument } from './payment';
 
 export default function isCreditCardLike(creditCard: PaymentInstrument): creditCard is CreditCard {
     const card = creditCard as CreditCard;

--- a/src/payment/strategies/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.ts
@@ -14,9 +14,7 @@ import PaymentMethod from '../payment-method';
 import PaymentStrategy from './payment-strategy';
 
 export default class AmazonPayPaymentStrategy extends PaymentStrategy {
-    private _wallet?: OffAmazonPayments.Widgets.Wallet;
     private _walletOptions?: InitializeWidgetOptions;
-    private _window: OffAmazonPayments.HostWindow;
 
     constructor(
         store: CheckoutStore,
@@ -26,8 +24,6 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
         private _scriptLoader: AmazonPayScriptLoader
     ) {
         super(store, placeOrderService);
-
-        this._window = window;
     }
 
     initialize(options: InitializeOptions): Promise<CheckoutSelectors> {
@@ -41,10 +37,7 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
         return new Promise((resolve, reject) => {
             const onReady = () => {
                 this._createWallet(options)
-                    .then(wallet => {
-                        this._wallet = wallet;
-                        resolve();
-                    })
+                    .then(resolve)
                     .catch(reject);
             };
 
@@ -59,7 +52,6 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
             return super.deinitialize(options);
         }
 
-        this._wallet = undefined;
         this._walletOptions = undefined;
 
         return super.deinitialize(options);
@@ -85,11 +77,7 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
             .catch(error => {
                 if (error instanceof RequestError && error.body.type === 'provider_widget_error' && this._walletOptions) {
                     return this._createWallet(this._walletOptions)
-                        .then(wallet => {
-                            this._wallet = wallet;
-
-                            return Promise.reject(error);
-                        });
+                        .then(() => Promise.reject(error));
                 }
 
                 return Promise.reject(error);

--- a/src/payment/strategies/wepay-payment-strategy.ts
+++ b/src/payment/strategies/wepay-payment-strategy.ts
@@ -1,4 +1,3 @@
-import { ReadableDataStore } from '@bigcommerce/data-store';
 
 import { CheckoutSelectors, CheckoutStore } from '../../checkout';
 import { OrderRequestBody, PlaceOrderService } from '../../order';
@@ -6,7 +5,7 @@ import { WepayRiskClient } from '../../remote-checkout/methods/wepay';
 import { CreditCard } from '../payment';
 
 import { CreditCardPaymentStrategy } from '.';
-import PaymentStrategy, { InitializeOptions } from './payment-strategy';
+import { InitializeOptions } from './payment-strategy';
 
 export default class WepayPaymentStrategy extends CreditCardPaymentStrategy {
 

--- a/src/remote-checkout/methods/klarna/klarna-script-loader.ts
+++ b/src/remote-checkout/methods/klarna/klarna-script-loader.ts
@@ -2,8 +2,6 @@
 
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { PaymentMethod } from '../../../payment';
-
 const SDK_URL = '//credit.klarnacdn.net/lib/v1/api.js';
 
 export default class KlarnaScriptLoader {

--- a/src/shipping/consignment-reducer.ts
+++ b/src/shipping/consignment-reducer.ts
@@ -1,6 +1,6 @@
-import { combineReducers, Action } from '@bigcommerce/data-store';
+import { combineReducers } from '@bigcommerce/data-store';
 
-import { Checkout, CheckoutAction, CheckoutActionType } from '../checkout';
+import { CheckoutAction, CheckoutActionType } from '../checkout';
 
 import Consignment from './consignment';
 import ConsignmentState from './consignment-state';

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.ts
@@ -20,9 +20,7 @@ import { ShippingStrategyActionType } from '../shipping-strategy-actions';
 import ShippingStrategy from './shipping-strategy';
 
 export default class AmazonPayShippingStrategy extends ShippingStrategy {
-    private _addressBook?: OffAmazonPayments.Widgets.AddressBook;
     private _paymentMethod?: PaymentMethod;
-    private _window: OffAmazonPayments.HostWindow;
 
     constructor(
         store: CheckoutStore,
@@ -33,8 +31,6 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
         private _scriptLoader: AmazonPayScriptLoader
     ) {
         super(store);
-
-        this._window = window;
     }
 
     initialize(options: InitializeOptions): Promise<CheckoutSelectors> {
@@ -48,10 +44,7 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
 
                 const onReady = () => {
                     this._createAddressBook(options)
-                        .then(addressBook => {
-                            this._addressBook = addressBook;
-                            resolve();
-                        })
+                        .then(resolve)
                         .catch(reject);
                 };
 
@@ -66,7 +59,6 @@ export default class AmazonPayShippingStrategy extends ShippingStrategy {
             return super.deinitialize(options);
         }
 
-        this._addressBook = undefined;
         this._paymentMethod = undefined;
 
         return super.deinitialize(options);

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
         "no-empty": false,
         "no-reference": false,
         "no-shadowed-variable": false,
+        "no-unused-variable": true,
         "object-literal-sort-keys": false
     }
 }


### PR DESCRIPTION
## What?
* Enable `no-unused-variable` rule. It is currently an override but should eventually be [merged](https://github.com/bigcommerce/tslint-config/pull/8) with the shared config.
* Fix linter errors.

## Why?
* To improve code maintainability.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
