### PR TITLE
fix(payment): PAYMENTS-2122 Ensure instrument Id is accessed via the meta object

### DIFF
--- a/src/payment/instrument/instrument-reducer.spec.js
+++ b/src/payment/instrument/instrument-reducer.spec.js
@@ -1,4 +1,11 @@
-import { getInstruments, getInstrumentsMeta, getInstrumentsResponseBody, vaultInstrumentResponseBody } from './instrument.mock';
+import {
+    deleteInstrumentResponseBody,
+    getInstruments,
+    getInstrumentsMeta,
+    getInstrumentsResponseBody,
+    vaultInstrumentResponseBody,
+} from './instrument.mock';
+
 import { getErrorResponse } from '../../common/http-request/responses.mock';
 import instrumentReducer from './instrument-reducer';
 import * as actionTypes from './instrument-action-types';
@@ -122,10 +129,11 @@ describe('instrumentReducer()', () => {
 
         const action = {
             type: actionTypes.DELETE_INSTRUMENT_SUCCEEDED,
-            meta: getInstrumentsMeta(),
-            payload: {
+            meta: {
+                ...getInstrumentsMeta(),
                 instrumentId: initialInstruments[0].bigpay_token,
             },
+            payload: deleteInstrumentResponseBody(),
         };
 
         expect(instrumentReducer(initialState, action)).toEqual({

--- a/src/payment/instrument/instrument-reducer.ts
+++ b/src/payment/instrument/instrument-reducer.ts
@@ -35,7 +35,7 @@ function dataReducer(data: any, action: Action): any {
 
     case actionTypes.DELETE_INSTRUMENT_SUCCEEDED:
         return (data || []).filter((instrument: any) =>
-            instrument.bigpay_token !== action.payload.instrumentId
+            instrument.bigpay_token !== action.meta.instrumentId
         );
 
     default:


### PR DESCRIPTION
## What?
When determining the new state when the `DELETE_INSTRUMENT_SUCCEEDED` action is dispatched, ensure `instrumentId` is being accessed from the `meta` and not `payload` so that the correct instrument is removed from the store.

## Why?
Previously the `instrumentId` was null because we accessed it from the wrong object (payload not meta), which caused an error. 

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
