### PR TITLE
CHECKOUT-3091: Prefer method signature

### DIFF
--- a/src/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.ts
@@ -139,7 +139,7 @@ export interface InitializeWidgetOptions {
     container: string;
     color?: string;
     size?: string;
-    onError?: (error: Error) => void;
+    onError?(error: Error): void;
 }
 
 interface AuthorizationOptions {

--- a/src/payment/strategies/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.ts
@@ -197,7 +197,7 @@ export interface InitializeOptions extends InitializeWidgetOptions {
 export interface InitializeWidgetOptions {
     container: string;
     amazonOrderReferenceId?: string;
-    onPaymentSelect?: (address?: InternalAddress) => void;
-    onError?: (error: Error) => void;
-    onReady?: () => void;
+    onPaymentSelect?(address?: InternalAddress): void;
+    onError?(error: Error): void;
+    onReady?(): void;
 }

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -126,7 +126,7 @@ export interface BraintreeCreditCardInitializeOptions extends InitializeOptions 
 }
 
 export interface ModalHandler {
-    addFrame: () => {};
-    removeFrame: () => {};
-    onRemoveFrame: (callback: () => void) => void;
+    addFrame(): void;
+    removeFrame(): void;
+    onRemoveFrame(callback: () => void): void;
 }

--- a/src/payment/strategies/braintree/braintree.d.ts
+++ b/src/payment/strategies/braintree/braintree.d.ts
@@ -9,7 +9,7 @@ declare namespace Braintree {
     }
 
     interface ModuleCreator<T> {
-        create: (config: ModuleCreatorConfig) => Promise<T>;
+        create(config: ModuleCreatorConfig): Promise<T>;
     }
 
     interface ModuleCreatorConfig {
@@ -24,25 +24,25 @@ declare namespace Braintree {
     interface PaypalCreator extends ModuleCreator<Paypal> {}
 
     interface Module {
-        teardown: () => Promise<void>;
+        teardown(): Promise<void>;
     }
 
     interface Client {
-        request: (payload: RequestData) => Promise<TokenizeResponse>;
-        getVersion: () => string | void;
+        request(payload: RequestData): Promise<TokenizeResponse>;
+        getVersion(): string | void;
     }
 
     interface ThreeDSecure extends Module {
-        verifyCard: (options: ThreeDSecureOptions, callback?: () => void) => Promise<TokenizedCreditCard>;
-        cancelVerifyCard: (callback?: () => void) => Promise<void>;
+        verifyCard(options: ThreeDSecureOptions, callback?: () => void): Promise<TokenizedCreditCard>;
+        cancelVerifyCard(callback?: () => void): Promise<void>;
     }
 
     interface ThreeDSecureOptions {
         nonce: string;
         amount: number;
-        addFrame: () => void;
-        removeFrame: () => void;
         showLoader?: boolean;
+        addFrame(): void;
+        removeFrame(): void;
     }
 
     interface DataCollector extends Module {
@@ -50,14 +50,14 @@ declare namespace Braintree {
     }
 
     interface Paypal {
-        closeWindow: () => void;
-        focusWindow: () => void;
-        tokenize: (options: PaypalRequest) => Promise<TokenizePayload>;
+        closeWindow(): void;
+        focusWindow(): void;
+        tokenize(options: PaypalRequest): Promise<TokenizePayload>;
     }
 
     interface TokenizeReturn {
-        close: () => void;
-        focus: () => void;
+        close(): void;
+        focus(): void;
     }
 
     interface HostWindow extends Window {

--- a/src/payment/strategies/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna-payment-strategy.ts
@@ -113,7 +113,7 @@ export default class KlarnaPaymentStrategy extends PaymentStrategy {
 
 export interface InitializeWidgetOptions {
     container: string;
-    loadCallback?: () => Klarna.LoadResponse;
+    loadCallback?(): Klarna.LoadResponse;
 }
 
 export interface InitializeOptions extends InitializeWidgetOptions {

--- a/src/payment/strategies/square/square-form.d.ts
+++ b/src/payment/strategies/square/square-form.d.ts
@@ -33,8 +33,8 @@ declare namespace Square {
     }
 
     interface FormCallbacks {
-        paymentFormLoaded?: (form: Square.PaymentForm) => void;
-        unsupportedBrowserDetected?: () => void;
-        cardNonceResponseReceived?: (errors: any, nonce: string) => void;
+        paymentFormLoaded?(form: Square.PaymentForm): void;
+        unsupportedBrowserDetected?(): void;
+        cardNonceResponseReceived?(errors: any, nonce: string): void;
     }
 }

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -101,8 +101,8 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
 }
 
 export interface DeferredPromise {
-    resolve: (resolution?: any) => void;
-    reject: (reason?: any) => void;
+    resolve(resolution?: any): void;
+    reject(reason?: any): void;
 }
 
 export interface InitializeOptions {

--- a/src/remote-checkout/methods/amazon-pay/amazon-login.d.ts
+++ b/src/remote-checkout/methods/amazon-pay/amazon-login.d.ts
@@ -15,6 +15,6 @@ declare namespace amazon {
         amazon?: {
             Login: Login,
         };
-        onAmazonLoginReady?: () => void;
+        onAmazonLoginReady?(): void;
     }
 }

--- a/src/remote-checkout/methods/amazon-pay/off-amazon-payments-widgets.d.ts
+++ b/src/remote-checkout/methods/amazon-pay/off-amazon-payments-widgets.d.ts
@@ -16,10 +16,10 @@ declare namespace OffAmazonPayments.Widgets {
         };
         scope: string;
         sellerId: string;
-        onAddressSelect: (orderReference: OrderReference) => void;
-        onError: (error: WidgetError) => void;
-        onReady: (orderReference: OrderReference) => void;
-        onOrderReferenceCreate: (orderReference: OrderReference) => void;
+        onAddressSelect(orderReference: OrderReference): void;
+        onError(error: WidgetError): void;
+        onReady(orderReference: OrderReference): void;
+        onOrderReferenceCreate(orderReference: OrderReference): void;
     }
 
     interface WalletOptions {
@@ -28,11 +28,11 @@ declare namespace OffAmazonPayments.Widgets {
         };
         scope: string;
         sellerId: string;
-        onError: (error: WidgetError) => void;
-        onReady: (orderReference: OrderReference) => void;
-        onPaymentSelect: (orderReference: OrderReference) => void;
         amazonOrderReferenceId?: string;
-        onOrderReferenceCreate?: (orderReference: OrderReference) => void;
+        onError(error: WidgetError): void;
+        onReady(orderReference: OrderReference): void;
+        onPaymentSelect(orderReference: OrderReference): void;
+        onOrderReferenceCreate?(orderReference: OrderReference): void;
     }
 
     interface OrderReference {

--- a/src/remote-checkout/methods/amazon-pay/off-amazon-payments.d.ts
+++ b/src/remote-checkout/methods/amazon-pay/off-amazon-payments.d.ts
@@ -8,8 +8,8 @@ declare namespace OffAmazonPayments {
         color: string;
         size: string;
         useAmazonAddressBook: boolean;
-        authorization?: () => void;
-        onError?: (error: ButtonError) => void;
+        authorization?(): void;
+        onError?(error: ButtonError): void;
     }
 
     interface ButtonError extends Error {
@@ -17,9 +17,9 @@ declare namespace OffAmazonPayments {
     }
 
     interface HostWindow extends Window {
-        onAmazonPaymentsReady?: () => void;
         OffAmazonPayments?: {
             Button: Button,
         };
+        onAmazonPaymentsReady?(): void;
     }
 }

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.ts
@@ -201,7 +201,7 @@ export interface InitializeOptions extends InitializeWidgetOptions {
 
 export interface InitializeWidgetOptions {
     container: string;
-    onAddressSelect?: (address: InternalAddress) => void;
-    onError?: (error: Error) => void;
-    onReady?: () => void;
+    onAddressSelect?(address: InternalAddress): void;
+    onError?(error: Error): void;
+    onReady?(): void;
 }

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
         "no-reference": false,
         "no-shadowed-variable": false,
         "no-unused-variable": true,
-        "object-literal-sort-keys": false
+        "object-literal-sort-keys": false,
+        "prefer-method-signature": true
     }
 }


### PR DESCRIPTION
## What?
* Prefer `foo(): void` over `foo: () => void` in interfaces and types.
* Used the auto fixer provided by TSLint to fix the issues.

## Why?
* Better consistency.

## Testing / Proof
* Linter

@bigcommerce/checkout @bigcommerce/payments
