### PR TITLE
fix(payment): PAYMENTS-2122 Ensure store config used when initialising the payment client

### DIFF
--- a/src/payment/create-payment-client.ts
+++ b/src/payment/create-payment-client.ts
@@ -5,7 +5,7 @@ import { CheckoutStore } from '../checkout';
 import LegacyConfig from '../config/legacy-config';
 
 export default function createPaymentClient(store: CheckoutStore): any {
-    const paymentClient: any = createBigpayClient();
+    const paymentClient: any = createBigpayClient(store);
 
     store.subscribe(
         ({ checkout: { getConfig } }) => {


### PR DESCRIPTION
## What?
Fixes an issue where the "host url" not being sent to `bigpay-client-js`

## Why?
Seems that this was missed during some recent refactoring ? 

## Testing / Proof
N/A Please help

@bigcommerce/checkout @bigcommerce/payments
