### PR TITLE
chore(payment): PAYMENTS-2009 Bump bigpay-client-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "validate-dependencies": "yarn install --check-files --frozen-lockfile"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#2.11.0",
+    "@bigcommerce/bigpay-client": "git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#2.11.1",
     "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.3",
     "@bigcommerce/form-poster": "git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.2",
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@bigcommerce/bigpay-client@git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#2.11.0":
-  version "2.11.0"
-  resolved "git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#1e8102eeeb6756b0c99da3cf8155e3a394232f96"
+"@bigcommerce/bigpay-client@git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#2.11.1":
+  version "2.11.1"
+  resolved "git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#bc0e3dc919561af15dd618f0b7410d0a8bed1799"
   dependencies:
     "@bigcommerce/form-poster" "git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.2"
     deep-assign "^2.0.0"


### PR DESCRIPTION
## What?
Bump bigpay-client-js to v2.11.1

## Why?
To surface a [bug fix](https://github.com/bigcommerce/bigpay-client-js/pull/63)

## Testing / Proof
n/a

@bigcommerce/checkout @bigcommerce/payments
