### PR TITLE
CHECKOUT-3035 Use storefront checkout-settings endpoint

### DIFF
--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -14,7 +14,7 @@ import { InstrumentActionCreator } from '../payment/instrument';
 import { QuoteActionCreator } from '../quote';
 import { createShippingStrategyRegistry, ShippingCountryActionCreator, ShippingOptionActionCreator, ShippingStrategyActionCreator } from '../shipping';
 import { MissingDataError } from '../common/error/errors';
-import { getAppConfig } from '../config/configs.mock';
+import { getAppConfig, getLegacyAppConfig } from '../config/configs.mock';
 import { getBillingAddress, getBillingAddressResponseBody } from '../billing/internal-billing-addresses.mock';
 import { getCartResponseBody } from '../cart/internal-carts.mock';
 import { getCountriesResponseBody } from '../geography/countries.mock';
@@ -141,7 +141,14 @@ describe('CheckoutService', () => {
         };
 
         store = createCheckoutStore({
-            config: { data: getAppConfig() },
+            config: {
+                data: {
+                    ...getLegacyAppConfig(),
+                    storeConfig: {
+                        formFields: getAppConfig().storeConfig.formFields,
+                    },
+                },
+            },
         });
 
         paymentStrategy = {
@@ -207,7 +214,12 @@ describe('CheckoutService', () => {
             const { checkout } = await checkoutService.loadConfig();
 
             expect(checkoutClient.loadConfig).toHaveBeenCalled();
-            expect(checkout.getConfig()).toEqual(getAppConfig());
+            expect(checkout.getConfig()).toEqual({
+                ...getLegacyAppConfig(),
+                storeConfig: {
+                    formFields: getAppConfig().storeConfig.formFields,
+                },
+            });
         });
 
         it('dispatches load config action with queue id', async () => {
@@ -742,7 +754,7 @@ describe('CheckoutService', () => {
 
     describe('#loadInstruments()', () => {
         it('loads instruments', async () => {
-            const { storeId } = getAppConfig();
+            const { storeId } = getAppConfig().storeConfig.storeProfile;
             const { customerId } = getGuestCustomer();
             const { vaultAccessToken } = getInstrumentsMeta();
 
@@ -760,7 +772,7 @@ describe('CheckoutService', () => {
 
     describe('#vaultInstrument()', () => {
         it('vaults an instrument', async () => {
-            const { storeId } = getAppConfig();
+            const { storeId } = getAppConfig().storeConfig.storeProfile;
             const { customerId } = getGuestCustomer();
             const { vaultAccessToken } = getInstrumentsMeta();
             const instrument = vaultInstrumentRequestBody();
@@ -781,7 +793,7 @@ describe('CheckoutService', () => {
 
     describe('#deleteInstrument()', () => {
         it('deletes an instrument', async () => {
-            const { storeId } = getAppConfig();
+            const { storeId } = getAppConfig().storeConfig.storeProfile;
             const { customerId } = getGuestCustomer();
             const { vaultAccessToken } = getInstrumentsMeta();
             const instrumentId = '456';

--- a/src/config/config-action-creator.spec.js
+++ b/src/config/config-action-creator.spec.js
@@ -28,7 +28,7 @@ describe('ConfigActionCreator', () => {
                 .subscribe((actions) => {
                     expect(actions).toEqual([
                         { type: actionTypes.LOAD_CONFIG_REQUESTED },
-                        { type: actionTypes.LOAD_CONFIG_SUCCEEDED, payload: response.body.data },
+                        { type: actionTypes.LOAD_CONFIG_SUCCEEDED, payload: response.body },
                     ]);
                 });
         });

--- a/src/config/config-action-creator.ts
+++ b/src/config/config-action-creator.ts
@@ -21,7 +21,7 @@ export default class ConfigActionCreator {
 
             this._checkoutClient.loadConfig(options)
                 .then(({ body = {} }) => {
-                    observer.next(createAction(actionTypes.LOAD_CONFIG_SUCCEEDED, body.data));
+                    observer.next(createAction(actionTypes.LOAD_CONFIG_SUCCEEDED, body));
                     observer.complete();
                 })
                 .catch(response => {

--- a/src/config/config-request-sender.spec.js
+++ b/src/config/config-request-sender.spec.js
@@ -28,7 +28,11 @@ describe('ConfigRequestSender', () => {
             const output = await configRequestSender.loadConfig();
 
             expect(output).toEqual(response);
-            expect(requestSender.get).toHaveBeenCalledWith('/internalapi/v1/checkout/configuration', {});
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkoutsettings', {
+                headers: {
+                    'X-API-INTERNAL': 'This API endpoint is for internal use only and changes',
+                },
+            });
         });
 
         it('loads config with timeout', async () => {
@@ -36,7 +40,12 @@ describe('ConfigRequestSender', () => {
             const output = await configRequestSender.loadConfig(options);
 
             expect(output).toEqual(response);
-            expect(requestSender.get).toHaveBeenCalledWith('/internalapi/v1/checkout/configuration', options);
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkoutsettings', {
+                ...options,
+                headers: {
+                    'X-API-INTERNAL': 'This API endpoint is for internal use only and changes',
+                },
+            });
         });
     });
 });

--- a/src/config/config-request-sender.ts
+++ b/src/config/config-request-sender.ts
@@ -11,8 +11,13 @@ export default class ConfigRequestSender {
     ) {}
 
     loadConfig({ timeout }: RequestOptions = {}): Promise<Response> {
-        const url = '/internalapi/v1/checkout/configuration';
+        const url = '/api/storefront/checkoutsettings';
 
-        return this._requestSender.get(url, { timeout });
+        return this._requestSender.get(url, {
+            timeout,
+            headers: {
+                'X-API-INTERNAL': 'This API endpoint is for internal use only and changes',
+            },
+        });
     }
 }


### PR DESCRIPTION
## What?
Use storefront endpoint for checkout settings.

## Why?
Because internal endpoint is buggy.

## Testing / Proof
- unit
- manual

@bigcommerce/checkout 
