### PR TITLE
CHECKOUT-3051: Include API version in request header

### DIFF
--- a/src/billing/billing-address-request-sender.spec.js
+++ b/src/billing/billing-address-request-sender.spec.js
@@ -1,6 +1,7 @@
 import { createTimeout } from '@bigcommerce/request-sender';
 
 import { getCheckout } from '../checkout/checkouts.mock';
+import { ContentType } from '../common/http-request';
 import BillingAddressRequestSender from './billing-address-request-sender';
 import { getBillingAddress } from './internal-billing-addresses.mock';
 
@@ -32,6 +33,9 @@ describe('BillingAddressRequestSender', () => {
 
             expect(requestSender.put).toHaveBeenCalledWith(`/api/storefront/checkouts/foo/billing-address/${id}`, {
                 body: address,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
 
@@ -43,6 +47,9 @@ describe('BillingAddressRequestSender', () => {
             expect(requestSender.put).toHaveBeenCalledWith(`/api/storefront/checkouts/foo/billing-address/${id}`, {
                 ...options,
                 body: address,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
     });
@@ -55,6 +62,9 @@ describe('BillingAddressRequestSender', () => {
 
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/foo/billing-address', {
                 body: address,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
 
@@ -66,6 +76,9 @@ describe('BillingAddressRequestSender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/foo/billing-address', {
                 ...options,
                 body: address,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
     });

--- a/src/billing/billing-address-request-sender.ts
+++ b/src/billing/billing-address-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Address } from '../address';
 import { Checkout } from '../checkout';
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
 export default class BillingAddressRequestSender {
     constructor(
@@ -11,14 +11,16 @@ export default class BillingAddressRequestSender {
 
     createAddress(checkoutId: string, address: Address, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/billing-address`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.post(url, { body: address, timeout });
+        return this._requestSender.post(url, { body: address, headers, timeout });
     }
 
     updateAddress(checkoutId: string, address: Address, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const { id, ...body } = address;
         const url = `/api/storefront/checkouts/${checkoutId}/billing-address/${id}`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.put(url, { body, timeout });
+        return this._requestSender.put(url, { body, headers, timeout });
     }
 }

--- a/src/cart/cart-request-sender.ts
+++ b/src/cart/cart-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
 /**
  * @todo Convert this file into TypeScript properly
@@ -18,7 +18,8 @@ export default class CartRequestSender {
 
     loadCarts({ timeout }: RequestOptions = {}): Promise<Response> {
         const url = '/api/storefront/carts';
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.get(url, { timeout });
+        return this._requestSender.get(url, { headers, timeout });
     }
 }

--- a/src/checkout/checkout-request-sender.spec.js
+++ b/src/checkout/checkout-request-sender.spec.js
@@ -1,5 +1,6 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { getCheckout } from './checkouts.mock';
+import { ContentType } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 import CheckoutRequestSender from './checkout-request-sender';
 
@@ -25,10 +26,15 @@ describe('CheckoutRequestSender', () => {
 
         await checkoutRequestSender.loadCheckout('6cb62bfc-c92d-45f5-869b-d3d9681a58d4');
 
-        expect(requestSender.get).toHaveBeenCalledWith(
-            '/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4',
-            { params: { include: 'customer', timeout: undefined } },
-        );
+        expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
+            headers: {
+                Accept: ContentType.JsonV1,
+            },
+            params: {
+                include: 'customer',
+            },
+            timeout: undefined,
+        });
     });
 
     it('appends passed params when loading checkout', async () => {
@@ -40,9 +46,14 @@ describe('CheckoutRequestSender', () => {
             },
         });
 
-        expect(requestSender.get).toHaveBeenCalledWith(
-            '/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4',
-            { params: { include: 'customer,foo', timeout: undefined } },
-        );
+        expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
+            headers: {
+                Accept: ContentType.JsonV1,
+            },
+            params: {
+                include: 'customer,foo',
+                timeout: undefined,
+            },
+        });
     });
 });

--- a/src/checkout/checkout-request-sender.ts
+++ b/src/checkout/checkout-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
 import { Checkout } from '.';
 import { CheckoutParams } from './checkout-params';
@@ -13,11 +13,13 @@ export default class CheckoutRequestSender {
     loadCheckout(id: string, { params: { include = [] } = {}, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkout/${id}`;
         const defaultIncludes = ['customer'];
+        const headers = { Accept: ContentType.JsonV1 };
 
         return this._requestSender.get(url, {
             params: {
                 include: defaultIncludes.concat(include).join(','),
             },
+            headers,
             timeout,
         });
     }

--- a/src/common/http-request/content-type.ts
+++ b/src/common/http-request/content-type.ts
@@ -1,0 +1,6 @@
+enum ContentType {
+    Json = 'application/json',
+    JsonV1 = 'application/vnd.bc.v1+json',
+}
+
+export default ContentType;

--- a/src/common/http-request/index.ts
+++ b/src/common/http-request/index.ts
@@ -1,1 +1,2 @@
+export { default as ContentType } from './content-type';
 export { default as RequestOptions } from './request-options';

--- a/src/config/config-request-sender.spec.js
+++ b/src/config/config-request-sender.spec.js
@@ -1,5 +1,6 @@
 import { createTimeout } from '@bigcommerce/request-sender';
 import { getAppConfig } from './configs.mock';
+import { ContentType } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 import ConfigRequestSender from './config-request-sender';
 
@@ -30,6 +31,7 @@ describe('ConfigRequestSender', () => {
             expect(output).toEqual(response);
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout-settings', {
                 headers: {
+                    'Accept': ContentType.JsonV1,
                     'X-API-INTERNAL': 'This API endpoint is for internal use only and may change in the future',
                 },
             });
@@ -43,6 +45,7 @@ describe('ConfigRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout-settings', {
                 ...options,
                 headers: {
+                    'Accept': ContentType.JsonV1,
                     'X-API-INTERNAL': 'This API endpoint is for internal use only and may change in the future',
                 },
             });

--- a/src/config/config-request-sender.ts
+++ b/src/config/config-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
 /**
  * @todo Convert this file into TypeScript properly
@@ -16,6 +16,7 @@ export default class ConfigRequestSender {
         return this._requestSender.get(url, {
             timeout,
             headers: {
+                Accept: ContentType.JsonV1,
                 'X-API-INTERNAL': 'This API endpoint is for internal use only and may change in the future',
             },
         });

--- a/src/coupon/coupon-request-sender.spec.js
+++ b/src/coupon/coupon-request-sender.spec.js
@@ -1,5 +1,6 @@
 import { createTimeout } from '@bigcommerce/request-sender';
 import { getCouponResponseBody } from './internal-coupons.mock';
+import { ContentType } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 import CouponRequestSender from './coupon-request-sender';
 
@@ -33,6 +34,9 @@ describe('Coupon Request Sender', () => {
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons', {
                 body: { couponCode },
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
 
@@ -47,6 +51,9 @@ describe('Coupon Request Sender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons', {
                 ...options,
                 body: { couponCode },
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
     });
@@ -59,7 +66,11 @@ describe('Coupon Request Sender', () => {
             const output = await couponRequestSender.removeCoupon(checkoutId, couponCode);
 
             expect(output).toEqual(response);
-            expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons/myCouponCode1234', {});
+            expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons/myCouponCode1234', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+            });
         });
 
         it('removes coupon code with timeout', async () => {
@@ -70,7 +81,12 @@ describe('Coupon Request Sender', () => {
             const output = await couponRequestSender.removeCoupon(checkoutId, couponCode, options);
 
             expect(output).toEqual(response);
-            expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons/myCouponCode1234', options);
+            expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons/myCouponCode1234', {
+                ...options,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+            });
         });
     });
 });

--- a/src/coupon/coupon-request-sender.ts
+++ b/src/coupon/coupon-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
 /**
  * @todo Convert this file into TypeScript properly
@@ -12,13 +12,15 @@ export default class CouponRequestSender {
 
     applyCoupon(checkoutId: string, couponCode: string, { timeout }: RequestOptions = {}): Promise<Response> {
         const url = `/api/storefront/checkouts/${checkoutId}/coupons`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.post(url, { timeout, body: { couponCode } });
+        return this._requestSender.post(url, { headers, timeout, body: { couponCode } });
     }
 
     removeCoupon(checkoutId: string, couponCode: string, { timeout }: RequestOptions = {}): Promise<Response> {
         const url = `/api/storefront/checkouts/${checkoutId}/coupons/${couponCode}`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.delete(url, { timeout });
+        return this._requestSender.delete(url, { headers, timeout });
     }
 }

--- a/src/coupon/gift-certificate-request-sender.spec.js
+++ b/src/coupon/gift-certificate-request-sender.spec.js
@@ -1,4 +1,5 @@
 import { createTimeout } from '@bigcommerce/request-sender';
+import { ContentType } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 import { getGiftCertificateResponseBody } from './internal-gift-certificates.mock';
 import GiftCertificateRequestSender from './gift-certificate-request-sender';
@@ -33,6 +34,9 @@ describe('Gift Certificate Request Sender', () => {
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/gift-certificates', {
                 body: { giftCertificateCode },
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
 
@@ -48,6 +52,9 @@ describe('Gift Certificate Request Sender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/gift-certificates', {
                 ...options,
                 body: { giftCertificateCode },
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
     });
@@ -60,7 +67,11 @@ describe('Gift Certificate Request Sender', () => {
             const output = await giftCertificateRequestSender.removeGiftCertificate(checkoutId, giftCertificateCode);
 
             expect(output).toEqual(response);
-            expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/gift-certificates/myGiftCertificate1234', {});
+            expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/gift-certificates/myGiftCertificate1234', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+            });
         });
 
         it('removes gift certificate code with timeout', async () => {
@@ -73,6 +84,9 @@ describe('Gift Certificate Request Sender', () => {
             expect(output).toEqual(response);
             expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/gift-certificates/myGiftCertificate1234', {
                 ...options,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
             });
         });
     });

--- a/src/coupon/gift-certificate-request-sender.ts
+++ b/src/coupon/gift-certificate-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
 /**
  * @todo Convert this file into TypeScript properly
@@ -12,13 +12,15 @@ export default class GiftCertificateRequestSender {
 
     applyGiftCertificate(checkoutId: string, giftCertificateCode: string, { timeout }: RequestOptions = {}): Promise<Response> {
         const url = `/api/storefront/checkouts/${checkoutId}/gift-certificates`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.post(url, { timeout, body: { giftCertificateCode } });
+        return this._requestSender.post(url, { headers, timeout, body: { giftCertificateCode } });
     }
 
     removeGiftCertificate(checkoutId: string, giftCertificateCode: string, { timeout }: RequestOptions = {}): Promise<Response> {
         const url = `/api/storefront/checkouts/${checkoutId}/gift-certificates/${giftCertificateCode}`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.delete(url, { timeout });
+        return this._requestSender.delete(url, { headers, timeout });
     }
 }

--- a/src/order/order-request-sender.spec.js
+++ b/src/order/order-request-sender.spec.js
@@ -1,6 +1,7 @@
 import { createTimeout } from '@bigcommerce/request-sender';
-import { getCompleteOrderResponseBody } from './internal-orders.mock';
+import { ContentType } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
+import { getCompleteOrderResponseBody } from './internal-orders.mock';
 import OrderRequestSender from './order-request-sender';
 
 describe('OrderRequestSender', () => {
@@ -29,7 +30,12 @@ describe('OrderRequestSender', () => {
             const output = await orderRequestSender.loadOrder(295);
 
             expect(output).toEqual(response);
-            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', { timeout: undefined });
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+                timeout: undefined,
+            });
         });
 
         it('loads order with timeout', async () => {
@@ -37,7 +43,12 @@ describe('OrderRequestSender', () => {
             const output = await orderRequestSender.loadOrder(295, options);
 
             expect(output).toEqual(response);
-            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', options);
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
+                ...options,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+            });
         });
     });
 
@@ -86,7 +97,9 @@ describe('OrderRequestSender', () => {
             const output = await orderRequestSender.finalizeOrder(295);
 
             expect(output).toEqual(response);
-            expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order/295', { timeout: undefined });
+            expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order/295', {
+                timeout: undefined,
+            });
         });
 
         it('finalizes order and returns response with timeout', async () => {

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
 import OrderRequestBody from './order-request-body';
 
@@ -8,18 +8,15 @@ import OrderRequestBody from './order-request-body';
  * @todo Convert this file into TypeScript properly
  */
 export default class OrderRequestSender {
-    /**
-     * @constructor
-     * @param {RequestSender} requestSender
-     */
     constructor(
         private _requestSender: RequestSender
     ) {}
 
     loadOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response> {
         const url = `/api/storefront/orders/${orderId}`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.get(url, { timeout });
+        return this._requestSender.get(url, { headers, timeout });
     }
 
     loadInternalOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response> {

--- a/src/shipping/consignment-request-sender.spec.js
+++ b/src/shipping/consignment-request-sender.spec.js
@@ -1,4 +1,5 @@
 import { createTimeout } from '@bigcommerce/request-sender';
+import { ContentType } from '../common/http-request';
 import ConsignmentRequestSender from './consignment-request-sender';
 import { getConsignmentRequestBody } from './consignments.mock';
 import { getCheckout } from '../checkout/checkouts.mock';
@@ -27,6 +28,9 @@ describe('ConsignmentRequestSender', () => {
 
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/foo/consignments', {
                 body: consignments,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
                 params: {
                     include: 'consignments.availableShippingOptions',
                 },
@@ -39,6 +43,9 @@ describe('ConsignmentRequestSender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/foo/consignments', {
                 ...options,
                 body: consignments,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
                 params: {
                     include: 'consignments.availableShippingOptions',
                 },
@@ -54,6 +61,9 @@ describe('ConsignmentRequestSender', () => {
 
             expect(requestSender.put).toHaveBeenCalledWith(`/api/storefront/checkouts/foo/consignments/${id}`, {
                 body,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
                 params: {
                     include: 'consignments.availableShippingOptions',
                 },
@@ -66,6 +76,9 @@ describe('ConsignmentRequestSender', () => {
             expect(requestSender.put).toHaveBeenCalledWith(`/api/storefront/checkouts/foo/consignments/${id}`, {
                 ...options,
                 body,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
                 params: {
                     include: 'consignments.availableShippingOptions',
                 },

--- a/src/shipping/consignment-request-sender.ts
+++ b/src/shipping/consignment-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Checkout } from '../checkout';
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
 import { ConsignmentsRequestBody, ConsignmentRequestBody } from './consignment';
 
@@ -16,14 +16,16 @@ export default class ConsignmentRequestSender {
 
     createConsignments(checkoutId: string, consignments: ConsignmentsRequestBody, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/consignments`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.post(url, { body: consignments, params: DEFAULT_PARAMS, timeout });
+        return this._requestSender.post(url, { body: consignments, params: DEFAULT_PARAMS, headers, timeout });
     }
 
     updateConsignment(checkoutId: string, consignment: ConsignmentRequestBody, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const { id, ...body } = consignment;
         const url = `/api/storefront/checkouts/${checkoutId}/consignments/${id}`;
+        const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.put(url, { body, params: DEFAULT_PARAMS, timeout });
+        return this._requestSender.put(url, { params: DEFAULT_PARAMS, body, headers, timeout });
     }
 }


### PR DESCRIPTION
## What?
* Include `Accept: application/vnd.bc.v1+json` header in Storefront API requests

## Why?
* To lock to a version

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
