### PR TITLE
CHECKOUT-3138: Fix Braintree Paypal cart flow initialisation

### DIFF
--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -118,11 +118,10 @@ describe('BraintreePaypalPaymentStrategy', () => {
             checkoutMock.getCart = jest.fn(() => getCart());
             checkoutMock.getBillingAddress = jest.fn(() => getBillingAddress());
             checkoutMock.getConfig = jest.fn(() => getAppConfig().storeConfig);
-
-            return braintreePaypalPaymentStrategy.initialize(options);
         });
 
         it('calls submit order with the order request information', async () => {
+            await braintreePaypalPaymentStrategy.initialize(options);
             await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
 
             expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(orderRequestBody, 'payment'), expect.any(Boolean), expect.any(Object));
@@ -130,12 +129,14 @@ describe('BraintreePaypalPaymentStrategy', () => {
         });
 
         it('asks for cart verification', async () => {
+            await braintreePaypalPaymentStrategy.initialize(options);
             await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
 
             expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(expect.any(Object), true, expect.any(Object));
         });
 
         it('pass the options to submitOrder', async () => {
+            await braintreePaypalPaymentStrategy.initialize(options);
             await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
 
             expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(expect.any(Object), expect.any(Boolean), options);
@@ -151,6 +152,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 },
             };
 
+            await braintreePaypalPaymentStrategy.initialize(options);
             await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
 
             expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith(190, 'en_US', 'USD', false);
@@ -179,6 +181,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
         it('converts any error returned by braintree in a StandardError', async () => {
             braintreePaymentProcessorMock.paypal = () => Promise.reject({ name: 'BraintreeError', message: 'my_message'});
 
+            await braintreePaypalPaymentStrategy.initialize(options);
             await expect(braintreePaypalPaymentStrategy.execute(orderRequestBody, options)).rejects.toEqual(expect.any(StandardError));
         });
 

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -26,9 +26,10 @@ export default class BraintreePaypalPaymentStrategy extends PaymentStrategy {
 
     initialize(options: PaymentInitializeOptions): Promise<CheckoutSelectors> {
         const { braintree: braintreeOptions, methodId } = options;
-        const { nonce } = this._store.getState().checkout.getPaymentMethod(methodId) || { nonce: undefined };
 
-        if (nonce) {
+        this._paymentMethod = this._store.getState().checkout.getPaymentMethod(methodId);
+
+        if (this._paymentMethod && this._paymentMethod.nonce) {
             return super.initialize(options);
         }
 


### PR DESCRIPTION
## What?
* Fix Braintree Paypal cart flow initialization.
* Move the `initialize` call from `beforeEach` into each test.

## Why?
* Before the fix, `execute` method assumes `paymentMethod` property gets set in `initialize` call. However, the property doesn't get set if the payment method has `nonce` defined.
* The tests are unable to pick up the error because they are all initialised without a nonce. By moving the call into each test instead of `beforeEach`, we can properly test each scenario (with and without a nonce).

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
