### PR TITLE
CHECKOUT-3124: Return same state object unless it is different

### DIFF
--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -192,6 +192,16 @@ describe('CheckoutService', () => {
                 statuses: expect.any(CheckoutStatusSelector),
             });
         });
+
+        it('returns same state unless it is changed', () => {
+            const state = checkoutService.getState();
+
+            expect(state).toBe(checkoutService.getState());
+
+            checkoutService.loadPaymentMethods();
+
+            expect(state).not.toBe(checkoutService.getState());
+        });
     });
 
     describe('#subscribe()', () => {

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -29,6 +29,8 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
  * i.e.: Instrument, InitializePaymentOptions etc...
  */
 export default class CheckoutService {
+    private _state: CheckoutSelectors;
+
     /**
      * @internal
      */
@@ -49,10 +51,16 @@ export default class CheckoutService {
         private _shippingCountryActionCreator: ShippingCountryActionCreator,
         private _shippingOptionActionCreator: ShippingOptionActionCreator,
         private _shippingStrategyActionCreator: ShippingStrategyActionCreator
-    ) {}
+    ) {
+        this._state = createCheckoutSelectors(this._store.getState());
+
+        this._store.subscribe(state => {
+            this._state = createCheckoutSelectors(state);
+        });
+    }
 
     getState(): CheckoutSelectors {
-        return createCheckoutSelectors(this._store.getState());
+        return this._state;
     }
 
     notifyState(): void {
@@ -64,7 +72,7 @@ export default class CheckoutService {
         ...filters: Array<(state: CheckoutSelectors) => any>
     ): () => void {
         return this._store.subscribe(
-            state => subscriber(createCheckoutSelectors(state)),
+            () => subscriber(this.getState()),
             ...filters.map(filter => (state: InternalCheckoutSelectors) => filter(createCheckoutSelectors(state)))
         );
     }


### PR DESCRIPTION
## What?
* Only transform state if different

## Why?
* Instead of creating a new one every time `getState` / `subscribe` gets called.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
