### PR TITLE
refactor(payment): PAYMENTS-2909 Move store querying to instrument action creator

### DIFF
--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -13,7 +13,6 @@ import { PaymentMethodActionCreator, PaymentStrategyActionCreator } from '../pay
 import { InstrumentActionCreator } from '../payment/instrument';
 import { QuoteActionCreator } from '../quote';
 import { createShippingStrategyRegistry, ShippingCountryActionCreator, ShippingOptionActionCreator, ShippingStrategyActionCreator } from '../shipping';
-import { MissingDataError } from '../common/error/errors';
 import { getConfig, getConfigState } from '../config/configs.mock';
 import { getBillingAddress, getBillingAddressResponseBody } from '../billing/internal-billing-addresses.mock';
 import { getCartResponseBody } from '../cart/internal-carts.mock';
@@ -787,59 +786,41 @@ describe('CheckoutService', () => {
 
     describe('#loadInstruments()', () => {
         it('loads instruments', async () => {
-            const { storeId } = getConfig().storeConfig.storeProfile;
-            const { customerId } = getGuestCustomer();
-            const { vaultAccessToken } = getInstrumentsMeta();
-
             await checkoutService.signInCustomer();
             await checkoutService.loadInstruments();
 
             expect(checkoutClient.getInstruments)
-                .toHaveBeenCalledWith(storeId, customerId, vaultAccessToken);
-        });
-
-        it('throws error if customer data is missing', () => {
-            expect(() => checkoutService.loadInstruments()).toThrow(MissingDataError);
+                .toHaveBeenCalled();
         });
     });
 
     describe('#vaultInstrument()', () => {
         it('vaults an instrument', async () => {
+            const instrument = vaultInstrumentRequestBody();
             const { storeId } = getConfig().storeConfig.storeProfile;
             const { customerId } = getGuestCustomer();
             const { vaultAccessToken } = getInstrumentsMeta();
-            const instrument = vaultInstrumentRequestBody();
 
             await checkoutService.signInCustomer();
             await checkoutService.vaultInstrument(instrument);
 
             expect(checkoutClient.vaultInstrument)
-                .toHaveBeenCalledWith(storeId, customerId, vaultAccessToken, instrument);
-        });
-
-        it('throws error if customer data is missing', () => {
-            const instrument = vaultInstrumentRequestBody();
-
-            expect(() => checkoutService.vaultInstrument(instrument)).toThrow(MissingDataError);
+                .toHaveBeenCalledWith(storeId, customerId, instrument, vaultAccessToken);
         });
     });
 
     describe('#deleteInstrument()', () => {
         it('deletes an instrument', async () => {
+            const instrumentId = '456';
             const { storeId } = getConfig().storeConfig.storeProfile;
             const { customerId } = getGuestCustomer();
             const { vaultAccessToken } = getInstrumentsMeta();
-            const instrumentId = '456';
 
             await checkoutService.signInCustomer();
             await checkoutService.deleteInstrument(instrumentId);
 
             expect(checkoutClient.deleteInstrument)
                 .toHaveBeenCalledWith(storeId, customerId, vaultAccessToken, instrumentId);
-        });
-
-        it('throws error if customer data is missing', () => {
-            expect(() => checkoutService.deleteInstrument(456)).toThrow(MissingDataError);
         });
     });
 });

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -1,7 +1,6 @@
 import { InternalAddress } from '../address';
 import { BillingAddressActionCreator } from '../billing';
 import { CartActionCreator } from '../cart';
-import { MissingDataError } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 import { ConfigActionCreator } from '../config';
 import { CouponActionCreator, GiftCertificateActionCreator } from '../coupon';
@@ -9,7 +8,7 @@ import { CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions,
 import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
 import { PaymentInitializeOptions, PaymentMethodActionCreator, PaymentRequestOptions, PaymentStrategyActionCreator } from '../payment';
-import { InstrumentActionCreator } from '../payment/instrument';
+import { Instrument, InstrumentActionCreator } from '../payment/instrument';
 import { QuoteActionCreator } from '../quote';
 import {
     ShippingCountryActionCreator,
@@ -24,10 +23,6 @@ import CheckoutStore from './checkout-store';
 import createCheckoutSelectors from './create-checkout-selectors';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
-/**
- * TODO: Convert this file into TypeScript properly
- * i.e.: Instrument, InitializePaymentOptions etc...
- */
 export default class CheckoutService {
     private _state: CheckoutSelectors;
 
@@ -278,66 +273,23 @@ export default class CheckoutService {
     }
 
     loadInstruments(): Promise<CheckoutSelectors> {
-        const { storeId, customerId, token } = this._getInstrumentState();
-
-        const action = this._instrumentActionCreator.loadInstruments(
-            storeId,
-            customerId,
-            token
-        );
+        const action = this._instrumentActionCreator.loadInstruments();
 
         return this._store.dispatch(action)
             .then(() => this.getState());
     }
 
-    vaultInstrument(instrument: any): Promise<CheckoutSelectors> {
-        const { storeId, customerId, token } = this._getInstrumentState();
-
-        const action = this._instrumentActionCreator.vaultInstrument(
-            storeId,
-            customerId,
-            token,
-            instrument
-        );
+    vaultInstrument(instrument: Instrument): Promise<CheckoutSelectors> {
+        const action = this._instrumentActionCreator.vaultInstrument(instrument);
 
         return this._store.dispatch(action)
             .then(() => this.getState());
     }
 
     deleteInstrument(instrumentId: string): Promise<CheckoutSelectors> {
-        const { storeId, customerId, token } = this._getInstrumentState();
-
-        const action = this._instrumentActionCreator.deleteInstrument(
-            storeId,
-            customerId,
-            token,
-            instrumentId
-        );
+        const action = this._instrumentActionCreator.deleteInstrument(instrumentId);
 
         return this._store.dispatch(action)
             .then(() => this.getState());
-    }
-
-    private _getInstrumentState(): any {
-        const state = this._store.getState();
-        const config = state.config.getStoreConfig();
-        const customer = state.customer.getCustomer();
-
-        if (!config || !customer) {
-            throw new MissingDataError('Unable to proceed because "config" or "customer" data is missing.');
-        }
-
-        const { customerId } = customer;
-        const { storeId } = config.storeProfile;
-        const { vaultAccessToken = null, vaultAccessExpiry = null } = state.instruments.getInstrumentsMeta() || {};
-
-        return {
-            customerId,
-            storeId,
-            token: {
-                vaultAccessToken,
-                vaultAccessExpiry,
-            },
-        };
     }
 }

--- a/src/payment/instrument/index.ts
+++ b/src/payment/instrument/index.ts
@@ -1,4 +1,5 @@
+export { default as Instrument } from './instrument';
 export { default as InstrumentActionCreator } from './instrument-action-creator';
-export { default as instrumentReducer } from './instrument-reducer';
 export { default as InstrumentRequestSender } from './instrument-request-sender';
 export { default as InstrumentSelector } from './instrument-selector';
+export { default as instrumentReducer } from './instrument-reducer';

--- a/src/payment/instrument/instrument-action-creator.spec.js
+++ b/src/payment/instrument/instrument-action-creator.spec.js
@@ -1,5 +1,8 @@
 import { Observable } from 'rxjs';
-import { addMinutes } from '../../common/date-time';
+import { createCheckoutStore } from '../../checkout';
+import { getConfigState } from '../../config/configs.mock';
+import { getCustomerState } from '../../customer/internal-customers.mock';
+import { getInstrumentsState, getInstrumentsMeta } from './instrument.mock';
 import { getErrorResponse, getResponse } from '../../common/http-request/responses.mock';
 import * as actionTypes from './instrument-action-types';
 import InstrumentActionCreator from './instrument-action-creator';
@@ -18,11 +21,15 @@ describe('InstrumentActionCreator', () => {
     let vaultInstrumentResponse;
     let deleteInstrumentResponse;
     let errorResponse;
+    let store;
     let storeId;
-    let shopperId;
+    let customerId;
     let instrumentId;
     let vaultAccessExpiry;
     let vaultAccessToken;
+    let configState;
+    let customerState;
+    let instrumentsState;
 
     beforeEach(() => {
         errorResponse = getErrorResponse();
@@ -40,33 +47,54 @@ describe('InstrumentActionCreator', () => {
 
         instrumentActionCreator = new InstrumentActionCreator(checkoutClient);
 
-        storeId = '1';
-        shopperId = '2';
+        configState = getConfigState();
+        customerState = getCustomerState();
+        instrumentsState = getInstrumentsState();
+
+        store = createCheckoutStore({
+            config: configState,
+            customer: customerState,
+            instruments: instrumentsState,
+        });
+
+        storeId = configState.data.storeConfig.storeProfile.storeId;
+        customerId = customerState.data.customerId;
         instrumentId = '123';
-        vaultAccessExpiry = getVaultAccessTokenResponse.body.data.expires_at;
-        vaultAccessToken = getVaultAccessTokenResponse.body.data.token;
+
+        const instrumentsMeta = getInstrumentsMeta();
+        vaultAccessToken = instrumentsMeta.vaultAccessToken;
+        vaultAccessExpiry = instrumentsMeta.vaultAccessExpiry;
     });
 
     describe('#getInstruments()', () => {
         it('sends a request to get a list of instruments', async () => {
-            await instrumentActionCreator.loadInstruments(storeId, shopperId).toPromise();
+            await instrumentActionCreator.loadInstruments()(store).toPromise();
 
             expect(checkoutClient.getVaultAccessToken).toHaveBeenCalled();
-            expect(checkoutClient.getInstruments).toHaveBeenCalledWith(storeId, shopperId, vaultAccessToken);
+            expect(checkoutClient.getInstruments).toHaveBeenCalledWith(storeId, customerId, vaultAccessToken);
         });
 
         it('does not send a request to get a list of instruments if valid token is supplied', async () => {
-            await instrumentActionCreator.loadInstruments(storeId, shopperId, {
-                vaultAccessToken: '321',
-                vaultAccessExpiry: addMinutes(new Date(), 5),
-            }).toPromise();
+            store = createCheckoutStore({
+                config: configState,
+                customer: customerState,
+                instruments: {
+                    ...getInstrumentsState(),
+                    meta: {
+                        ...getInstrumentsMeta(),
+                        vaultAccessExpiry: 1816097476098,
+                    },
+                },
+            });
+
+            await instrumentActionCreator.loadInstruments()(store).toPromise();
 
             expect(checkoutClient.getVaultAccessToken).not.toHaveBeenCalled();
-            expect(checkoutClient.getInstruments).toHaveBeenCalledWith(storeId, shopperId, '321');
+            expect(checkoutClient.getInstruments).toHaveBeenCalledWith(storeId, customerId, vaultAccessToken);
         });
 
         it('emits actions if able to load instruments', async () => {
-            const actions = await instrumentActionCreator.loadInstruments()
+            const actions = await instrumentActionCreator.loadInstruments()(store)
                 .toArray()
                 .toPromise();
 
@@ -86,7 +114,7 @@ describe('InstrumentActionCreator', () => {
             checkoutClient.getInstruments.mockReturnValue(Promise.reject(errorResponse));
 
             const errorHandler = jest.fn((action) => Observable.of(action));
-            const actions = await instrumentActionCreator.loadInstruments()
+            const actions = await instrumentActionCreator.loadInstruments()(store)
                 .catch(errorHandler)
                 .toArray()
                 .toPromise();
@@ -97,38 +125,61 @@ describe('InstrumentActionCreator', () => {
                 { type: actionTypes.LOAD_INSTRUMENTS_FAILED, payload: errorResponse, error: true },
             ]);
         });
+
+        it('emits Missing Data Error if data is missing from the date', async () => {
+            store = createCheckoutStore();
+
+            try {
+                await instrumentActionCreator.loadInstruments()(store)
+                    .toArray()
+                    .toPromise();
+            } catch (e) {
+                expect(e.type).toEqual('missing_data');
+            }
+        });
     });
 
     describe('#vaultInstrument()', () => {
         it('post a new instrument', async () => {
-            await instrumentActionCreator.vaultInstrument(storeId, shopperId, null, {}).toPromise();
+            await instrumentActionCreator.vaultInstrument({})(store)
+                .toPromise();
 
             expect(checkoutClient.getVaultAccessToken).toHaveBeenCalled();
             expect(checkoutClient.vaultInstrument).toHaveBeenCalledWith(
                 storeId,
-                shopperId,
-                vaultAccessToken,
-                expect.any(Object)
+                customerId,
+                expect.any(Object),
+                vaultAccessToken
             );
         });
 
         it('does not send a request to get a list of instruments if valid token is supplied', async () => {
-            await instrumentActionCreator.vaultInstrument(storeId, shopperId, {
-                vaultAccessToken: '321',
-                vaultAccessExpiry: addMinutes(new Date(), 5),
-            }, {}).toPromise();
+            store = createCheckoutStore({
+                config: configState,
+                customer: customerState,
+                instruments: {
+                    ...getInstrumentsState(),
+                    meta: {
+                        ...getInstrumentsMeta(),
+                        vaultAccessExpiry: 1816097476098,
+                    },
+                },
+            });
+
+            await instrumentActionCreator.vaultInstrument({})(store)
+                .toPromise();
 
             expect(checkoutClient.getVaultAccessToken).not.toHaveBeenCalled();
             expect(checkoutClient.vaultInstrument).toHaveBeenCalledWith(
                 storeId,
-                shopperId,
-                '321',
-                expect.any(Object)
+                customerId,
+                expect.any(Object),
+                vaultAccessToken
             );
         });
 
         it('emits actions if able to post instrument', async () => {
-            const actions = await instrumentActionCreator.vaultInstrument()
+            const actions = await instrumentActionCreator.vaultInstrument()(store)
                 .toArray()
                 .toPromise();
 
@@ -148,7 +199,7 @@ describe('InstrumentActionCreator', () => {
             checkoutClient.vaultInstrument.mockReturnValue(Promise.reject(errorResponse));
 
             const errorHandler = jest.fn((action) => Observable.of(action));
-            const actions = await instrumentActionCreator.vaultInstrument()
+            const actions = await instrumentActionCreator.vaultInstrument()(store)
                 .catch(errorHandler)
                 .toArray()
                 .toPromise();
@@ -159,38 +210,60 @@ describe('InstrumentActionCreator', () => {
                 { type: actionTypes.VAULT_INSTRUMENT_FAILED, payload: errorResponse, error: true },
             ]);
         });
+
+        it('emits Missing Data Error if data is missing from the date', async () => {
+            store = createCheckoutStore();
+
+            try {
+                await instrumentActionCreator.vaultInstrument()(store)
+                    .toArray()
+                    .toPromise();
+            } catch (e) {
+                expect(e.type).toEqual('missing_data');
+            }
+        });
     });
 
     describe('#deleteInstrument()', () => {
         it('deletes an instrument', async () => {
-            await instrumentActionCreator.deleteInstrument(storeId, shopperId, vaultAccessToken, instrumentId).toPromise();
+            await instrumentActionCreator.deleteInstrument(instrumentId)(store)
+                .toPromise();
 
             expect(checkoutClient.getVaultAccessToken).toHaveBeenCalled();
             expect(checkoutClient.deleteInstrument).toHaveBeenCalledWith(
                 storeId,
-                shopperId,
+                customerId,
                 vaultAccessToken,
                 instrumentId,
             );
         });
 
         it('does not send a request to get a list of instruments if valid token is supplied', async () => {
-            await instrumentActionCreator.deleteInstrument(storeId, shopperId, {
-                vaultAccessToken: '321',
-                vaultAccessExpiry: addMinutes(new Date(), 5),
-            }, instrumentId).toPromise();
+            store = createCheckoutStore({
+                config: configState,
+                customer: customerState,
+                instruments: {
+                    ...getInstrumentsState(),
+                    meta: {
+                        ...getInstrumentsMeta(),
+                        vaultAccessExpiry: 1816097476098,
+                    },
+                },
+            });
+
+            await instrumentActionCreator.deleteInstrument(instrumentId)(store).toPromise();
 
             expect(checkoutClient.getVaultAccessToken).not.toHaveBeenCalled();
             expect(checkoutClient.deleteInstrument).toHaveBeenCalledWith(
                 storeId,
-                shopperId,
-                '321',
+                customerId,
+                vaultAccessToken,
                 instrumentId
             );
         });
 
         it('emits actions if able to delete an instrument', async () => {
-            const actions = await instrumentActionCreator.deleteInstrument(storeId, shopperId, vaultAccessToken, instrumentId)
+            const actions = await instrumentActionCreator.deleteInstrument(instrumentId)(store)
                 .toArray()
                 .toPromise();
 
@@ -211,7 +284,7 @@ describe('InstrumentActionCreator', () => {
             checkoutClient.deleteInstrument.mockReturnValue(Promise.reject(errorResponse));
 
             const errorHandler = jest.fn((action) => Observable.of(action));
-            const actions = await instrumentActionCreator.deleteInstrument(storeId, shopperId, vaultAccessToken, instrumentId)
+            const actions = await instrumentActionCreator.deleteInstrument(instrumentId)(store)
                 .catch(errorHandler)
                 .toArray()
                 .toPromise();
@@ -225,6 +298,18 @@ describe('InstrumentActionCreator', () => {
                     type: actionTypes.DELETE_INSTRUMENT_FAILED, meta: { instrumentId }, payload: errorResponse, error: true,
                 },
             ]);
+        });
+
+        it('emits Missing Data Error if data is missing from the date', async () => {
+            store = createCheckoutStore();
+
+            try {
+                await instrumentActionCreator.deleteInstrument()(store)
+                    .toArray()
+                    .toPromise();
+            } catch (e) {
+                expect(e.type).toEqual('missing_data');
+            }
         });
     });
 });

--- a/src/payment/instrument/instrument-action-creator.ts
+++ b/src/payment/instrument/instrument-action-creator.ts
@@ -1,126 +1,127 @@
-import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+import { createAction, createErrorAction, Action, ThunkAction } from '@bigcommerce/data-store';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
+import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../../checkout';
 import { addMinutes, isFuture } from '../../common/date-time';
+import { MissingDataError } from '../../common/error/errors';
 
+import Instrument, { InstrumentRequestContext, VaultAccessToken } from './instrument';
 import * as actionTypes from './instrument-action-types';
 import InstrumentRequestSender from './instrument-request-sender';
 
-/**
- * @todo Convert this file into TypeScript properly
- */
 export default class InstrumentActionCreator {
     constructor(
         private _instrumentRequestSender: InstrumentRequestSender
     ) {}
 
-    /**
-     * @param {string} storeId
-     * @param {number} shopperId
-     * @param {?VaultAccessToken} accessToken
-     * @return {Observable<Action>}
-     */
-    loadInstruments(storeId: string, shopperId: number, accessToken: any): Observable<Action> {
-        return Observable.create((observer: Observer<Action>) => {
-            observer.next(createAction(actionTypes.LOAD_INSTRUMENTS_REQUESTED));
+    loadInstruments(): ThunkAction<Action, InternalCheckoutSelectors> {
+        return store =>
+            Observable.create((observer: Observer<Action>) => {
+                observer.next(createAction(actionTypes.LOAD_INSTRUMENTS_REQUESTED));
 
-            this._getValidAccessToken(accessToken)
-                .then(currentToken =>
-                    this._instrumentRequestSender.getInstruments(storeId, shopperId, currentToken.vaultAccessToken)
-                        .then(({ body }) => {
-                            observer.next(createAction(actionTypes.LOAD_INSTRUMENTS_SUCCEEDED, body, currentToken));
-                            observer.complete();
-                        })
-                )
-                .catch(response => {
-                    observer.error(createErrorAction(actionTypes.LOAD_INSTRUMENTS_FAILED, response));
-                });
-        });
+                const { token, storeId, customerId } = this._getInstrumentState(store);
+
+                return this._getValidAccessToken(token)
+                    .then(currentToken =>
+                        this._instrumentRequestSender.getInstruments(storeId, customerId, currentToken.vaultAccessToken)
+                            .then(({ body }) => {
+                                observer.next(createAction(actionTypes.LOAD_INSTRUMENTS_SUCCEEDED, body, currentToken));
+                                observer.complete();
+                            })
+                    )
+                    .catch(response => {
+                        observer.error(createErrorAction(actionTypes.LOAD_INSTRUMENTS_FAILED, response));
+                    });
+            });
     }
 
-    /**
-     * @param {string} storeId
-     * @param {string} shopperId
-     * @param {?VaultAccessToken} accessToken
-     * @param {InstrumentRequestBody} instrument
-     * @return {Observable<Action>}
-     */
-    vaultInstrument(storeId: string, shopperId: number, accessToken: any, instrument: any): Observable<Action> {
-        return Observable.create((observer: Observer<Action>) => {
-            observer.next(createAction(actionTypes.VAULT_INSTRUMENT_REQUESTED));
+    vaultInstrument(instrument: Instrument): ThunkAction<Action, InternalCheckoutSelectors> {
+        return store =>
+            Observable.create((observer: Observer<Action>) => {
+                observer.next(createAction(actionTypes.VAULT_INSTRUMENT_REQUESTED));
 
-            this._getValidAccessToken(accessToken)
-                .then(currentToken =>
-                    this._instrumentRequestSender.vaultInstrument(storeId, shopperId, currentToken.vaultAccessToken, instrument)
-                        .then(({ body }) => {
-                            observer.next(createAction(actionTypes.VAULT_INSTRUMENT_SUCCEEDED, body, currentToken));
-                            observer.complete();
-                        })
-                )
-                .catch(response => {
-                    observer.error(createErrorAction(actionTypes.VAULT_INSTRUMENT_FAILED, response));
-                });
-        });
+                const { token, storeId, customerId } = this._getInstrumentState(store);
+
+                return this._getValidAccessToken(token)
+                    .then(currentToken =>
+                        this._instrumentRequestSender.vaultInstrument(storeId, customerId, instrument, currentToken.vaultAccessToken)
+                            .then(({ body }) => {
+                                observer.next(createAction(actionTypes.VAULT_INSTRUMENT_SUCCEEDED, body, currentToken));
+                                observer.complete();
+                            })
+                    )
+                    .catch(response => {
+                        observer.error(createErrorAction(actionTypes.VAULT_INSTRUMENT_FAILED, response));
+                    });
+            });
     }
 
-    /**
-     * @param {string} storeId
-     * @param {string} shopperId
-     * @param {?VaultAccessToken} accessToken
-     * @param {string} instrumentId
-     * @return {Observable<Action>}
-     */
-    deleteInstrument(storeId: string, shopperId: number, accessToken: any, instrumentId: string): Observable<Action> {
-        return Observable.create((observer: Observer<Action>) => {
-            observer.next(createAction(actionTypes.DELETE_INSTRUMENT_REQUESTED, undefined, { instrumentId }));
+    deleteInstrument(instrumentId: string): ThunkAction<Action, InternalCheckoutSelectors> {
+        return store =>
+            Observable.create((observer: Observer<Action>) => {
+                observer.next(createAction(actionTypes.DELETE_INSTRUMENT_REQUESTED, undefined, { instrumentId }));
 
-            this._getValidAccessToken(accessToken)
-                .then(currentToken =>
-                    this._instrumentRequestSender.deleteInstrument(storeId, shopperId, currentToken.vaultAccessToken, instrumentId)
-                        .then(() => {
-                            observer.next(createAction(actionTypes.DELETE_INSTRUMENT_SUCCEEDED, undefined, {
-                                instrumentId,
-                                ...currentToken,
-                            }));
-                            observer.complete();
-                        })
-                )
-                .catch(response => {
-                    observer.error(createErrorAction(actionTypes.DELETE_INSTRUMENT_FAILED, response, { instrumentId }));
-                });
-        });
+                const { token, storeId, customerId } = this._getInstrumentState(store);
+
+                return this._getValidAccessToken(token)
+                    .then(currentToken =>
+                        this._instrumentRequestSender.deleteInstrument(storeId, customerId, currentToken.vaultAccessToken, instrumentId)
+                            .then(() => {
+                                observer.next(createAction(actionTypes.DELETE_INSTRUMENT_SUCCEEDED, undefined, {
+                                    instrumentId,
+                                    ...currentToken,
+                                }));
+                                observer.complete();
+                            })
+                    )
+                    .catch(response => {
+                        observer.error(createErrorAction(actionTypes.DELETE_INSTRUMENT_FAILED, response, { instrumentId }));
+                    });
+            });
     }
 
-    /**
-     * @private
-     * @param {VaultAccessToken} accessToken
-     * @return {boolean}
-     */
-    private _isValidVaultAccessToken(accessToken: any): boolean {
-        if (!accessToken || !accessToken.vaultAccessToken) {
+    private _isValidVaultAccessToken(token: VaultAccessToken): boolean {
+        if (!token || !token.vaultAccessToken) {
             return false;
         }
 
         const expiryBuffer = 2;
-        const expiry = addMinutes(new Date(accessToken.vaultAccessExpiry), expiryBuffer);
+        const expiry = addMinutes(new Date(token.vaultAccessExpiry), expiryBuffer);
 
         return isFuture(expiry);
     }
 
-    /**
-     * Requests a new vault access token if one is not supplied
-     * @private
-     * @param {VaultAccessToken} [accessToken]
-     * @return {Promise<VaultAccessToken>}
-     */
-    private _getValidAccessToken(accessToken: any): Promise<any> {
-        return this._isValidVaultAccessToken(accessToken)
-            ? Promise.resolve(accessToken)
+    private _getValidAccessToken(token: VaultAccessToken): Promise<VaultAccessToken> {
+        return this._isValidVaultAccessToken(token)
+            ? Promise.resolve(token)
             : this._instrumentRequestSender.getVaultAccessToken()
                 .then(({ body = {} }: any) => ({
                     vaultAccessToken: body.data.token,
                     vaultAccessExpiry: body.data.expires_at,
                 }));
+    }
+
+    private _getInstrumentState(store: ReadableCheckoutStore): InstrumentRequestContext {
+        const state = store.getState();
+        const config = state.config.getStoreConfig();
+        const customer = state.customer.getCustomer();
+
+        if (!config || !customer) {
+            throw new MissingDataError('Unable to proceed because "config" or "customer" data is missing.');
+        }
+
+        const { customerId } = customer;
+        const { storeId } = config.storeProfile;
+        const { vaultAccessToken = null, vaultAccessExpiry = null } = state.instruments.getInstrumentsMeta() || {};
+
+        return {
+            customerId,
+            storeId,
+            token: {
+                vaultAccessToken,
+                vaultAccessExpiry,
+            },
+        };
     }
 }

--- a/src/payment/instrument/instrument.ts
+++ b/src/payment/instrument/instrument.ts
@@ -1,0 +1,21 @@
+export default interface Instrument {
+    bigpay_token: string;
+    provider: string;
+    iin: string;
+    last_4: string;
+    expiry_month: string;
+    expiry_year: string;
+    brand: string;
+    default_instrument: boolean;
+}
+
+export interface VaultAccessToken {
+    vaultAccessToken: string;
+    vaultAccessExpiry: number;
+}
+
+export interface InstrumentRequestContext {
+    customerId: number;
+    storeId: string;
+    token: VaultAccessToken;
+}


### PR DESCRIPTION
## What?
- Moves and refactor the `_getInstrumentState` function into the `instrument-action-creator`
- Ensure the appropriate unit tests are refactored/added to support the above
- Instrument type definitions are created to support

## Why?
To tidy a few things up and TS support for typescript

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
