### PR TITLE
CHECKOUT-3053: Rename checkout selectors

### DIFF
--- a/src/checkout/checkout-selectors.ts
+++ b/src/checkout/checkout-selectors.ts
@@ -1,9 +1,9 @@
-import CheckoutErrorSelector from './checkout-error-selector';
-import CheckoutSelector from './checkout-selector';
-import CheckoutStatusSelector from './checkout-status-selector';
+import CheckoutStoreErrorSelector from './checkout-store-error-selector';
+import CheckoutStoreSelector from './checkout-store-selector';
+import CheckoutStoreStatusSelector from './checkout-store-status-selector';
 
 export default interface CheckoutSelectors {
-    checkout: CheckoutSelector;
-    errors: CheckoutErrorSelector;
-    statuses: CheckoutStatusSelector;
+    checkout: CheckoutStoreSelector;
+    errors: CheckoutStoreErrorSelector;
+    statuses: CheckoutStoreStatusSelector;
 }

--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -31,9 +31,9 @@ import { getShippingOptionResponseBody } from '../shipping/internal-shipping-opt
 import { getResponse } from '../common/http-request/responses.mock';
 import createCheckoutStore from './create-checkout-store';
 import CheckoutService from './checkout-service';
-import CheckoutSelector from './checkout-selector';
-import CheckoutErrorSelector from './checkout-error-selector';
-import CheckoutStatusSelector from './checkout-status-selector';
+import CheckoutStoreSelector from './checkout-store-selector';
+import CheckoutStoreErrorSelector from './checkout-store-error-selector';
+import CheckoutStoreStatusSelector from './checkout-store-status-selector';
 
 describe('CheckoutService', () => {
     let checkoutClient;
@@ -187,9 +187,9 @@ describe('CheckoutService', () => {
     describe('#getState()', () => {
         it('returns state', () => {
             expect(checkoutService.getState()).toEqual({
-                checkout: expect.any(CheckoutSelector),
-                errors: expect.any(CheckoutErrorSelector),
-                statuses: expect.any(CheckoutStatusSelector),
+                checkout: expect.any(CheckoutStoreSelector),
+                errors: expect.any(CheckoutStoreErrorSelector),
+                statuses: expect.any(CheckoutStoreStatusSelector),
             });
         });
 

--- a/src/checkout/checkout-store-error-selector.spec.js
+++ b/src/checkout/checkout-store-error-selector.spec.js
@@ -1,16 +1,16 @@
 import { getCheckoutStoreState } from './checkouts.mock';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
-import CheckoutErrorSelector from './checkout-error-selector';
+import CheckoutStoreErrorSelector from './checkout-store-error-selector';
 
-describe('CheckoutErrorSelector', () => {
+describe('CheckoutStoreErrorSelector', () => {
     let errorResponse;
     let errors;
     let selectors;
 
     beforeEach(() => {
         selectors = createInternalCheckoutSelectors(getCheckoutStoreState());
-        errors = new CheckoutErrorSelector(selectors);
+        errors = new CheckoutStoreErrorSelector(selectors);
 
         errorResponse = getErrorResponse();
     });

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -14,7 +14,7 @@ import { ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelect
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 @selector
-export default class CheckoutErrorSelector {
+export default class CheckoutStoreErrorSelector {
     private _billingAddress: BillingAddressSelector;
     private _cart: CartSelector;
     private _config: ConfigSelector;

--- a/src/checkout/checkout-store-selector.spec.js
+++ b/src/checkout/checkout-store-selector.spec.js
@@ -4,16 +4,16 @@ import { getFormFields } from '../form/form.mocks';
 import { getUnitedStates } from '../geography/countries.mock';
 import { getBraintree } from '../payment/payment-methods.mock';
 import { getAustralia } from '../shipping/shipping-countries.mock';
-import CheckoutSelector from './checkout-selector';
+import CheckoutStoreSelector from './checkout-store-selector';
 import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
 
-describe('CheckoutSelector', () => {
+describe('CheckoutStoreSelector', () => {
     let selector;
     let state;
 
     beforeEach(() => {
         state = getCheckoutStoreState();
-        selector = new CheckoutSelector(createInternalCheckoutSelectors(state));
+        selector = new CheckoutStoreSelector(createInternalCheckoutSelectors(state));
     });
 
     it('returns order', () => {

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -26,7 +26,7 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
  * i.e.: Instrument
  */
 @selector
-export default class CheckoutSelector {
+export default class CheckoutStoreSelector {
     private _billingAddress: BillingAddressSelector;
     private _cart: CartSelector;
     private _config: ConfigSelector;

--- a/src/checkout/checkout-store-status-selector.spec.js
+++ b/src/checkout/checkout-store-status-selector.spec.js
@@ -1,14 +1,14 @@
 import { getCheckoutStoreState } from './checkouts.mock';
 import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
-import CheckoutStatusSelector from './checkout-status-selector';
+import CheckoutStoreStatusSelector from './checkout-store-status-selector';
 
-describe('CheckoutStatusSelector', () => {
+describe('CheckoutStoreStatusSelector', () => {
     let selectors;
     let statuses;
 
     beforeEach(() => {
         selectors = createInternalCheckoutSelectors(getCheckoutStoreState());
-        statuses = new CheckoutStatusSelector(selectors);
+        statuses = new CheckoutStoreStatusSelector(selectors);
     });
 
     describe('#isLoadingCheckout()', () => {

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -14,7 +14,7 @@ import { ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelect
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 @selector
-export default class CheckoutStatusSelector {
+export default class CheckoutStoreStatusSelector {
     private _billingAddress: BillingAddressSelector;
     private _cart: CartSelector;
     private _config: ConfigSelector;

--- a/src/checkout/create-checkout-selectors.ts
+++ b/src/checkout/create-checkout-selectors.ts
@@ -1,9 +1,15 @@
-import { CheckoutErrorSelector, CheckoutSelector, CheckoutSelectors, CheckoutStatusSelector, InternalCheckoutSelectors } from '../checkout';
+import {
+    CheckoutSelectors,
+    CheckoutStoreErrorSelector,
+    CheckoutStoreSelector,
+    CheckoutStoreStatusSelector,
+    InternalCheckoutSelectors,
+} from '../checkout';
 
 export default function createCheckoutSelectors(selectors: InternalCheckoutSelectors): CheckoutSelectors {
-    const checkout = new CheckoutSelector(selectors);
-    const errors = new CheckoutErrorSelector(selectors);
-    const statuses = new CheckoutStatusSelector(selectors);
+    const checkout = new CheckoutStoreSelector(selectors);
+    const errors = new CheckoutStoreErrorSelector(selectors);
+    const statuses = new CheckoutStoreStatusSelector(selectors);
 
     return {
         checkout,

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -2,11 +2,11 @@ export * from './checkout-actions';
 
 export { default as Checkout } from './checkout';
 export { default as CheckoutClient } from './checkout-client';
-export { default as CheckoutErrorSelector } from './checkout-error-selector';
-export { default as CheckoutSelector } from './checkout-selector';
 export { default as CheckoutSelectors } from './checkout-selectors';
 export { default as CheckoutService } from './checkout-service';
-export { default as CheckoutStatusSelector } from './checkout-status-selector';
+export { default as CheckoutStoreErrorSelector } from './checkout-store-error-selector';
+export { default as CheckoutStoreSelector } from './checkout-store-selector';
+export { default as CheckoutStoreStatusSelector } from './checkout-store-status-selector';
 export { default as CheckoutStore, ReadableCheckoutStore } from './checkout-store';
 export { default as InternalCheckoutSelectors } from './internal-checkout-selectors';
 


### PR DESCRIPTION
## What?
* Rename some files so they are the same as `storefront_api`

## Why?
* So it is easier to merge changes into `storefront_api`

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
