### PR TITLE
CHECKOUT-3053: Upgrade data-store dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bigcommerce/bigpay-client": "git+ssh://git@github.com/bigcommerce/bigpay-client-js.git#2.11.1",
-    "@bigcommerce/data-store": "git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.4",
+    "@bigcommerce/data-store": "^0.1.7",
     "@bigcommerce/form-poster": "git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.2",
     "@bigcommerce/request-sender": "git+ssh://git@github.com/bigcommerce/request-sender-js.git#v0.1.2",
     "@bigcommerce/script-loader": "git+ssh://git@github.com/bigcommerce/script-loader-js.git#v0.1.2",

--- a/src/checkout/create-action-transformer.ts
+++ b/src/checkout/create-action-transformer.ts
@@ -1,7 +1,6 @@
-import 'rxjs/add/observable/from';
-import 'rxjs/add/operator/catch';
-
 import { Action } from '@bigcommerce/data-store';
+import { from } from 'rxjs/observable/from';
+import { catchError } from 'rxjs/operators';
 import { Observable, Subscribable } from 'rxjs/Observable';
 
 import { RequestErrorFactory } from '../common/error';
@@ -9,7 +8,7 @@ import { RequestErrorFactory } from '../common/error';
 export default function createActionTransformer(
     requestErrorFactory: RequestErrorFactory
 ): (action: Subscribable<Action>) => Observable<Action> {
-    return action$ => Observable.from(action$).catch<Action, never>(action => {
+    return action$ => from(action$).pipe(catchError<Action, never>(action => {
         if (action instanceof Error || action.payload instanceof Error) {
             throw action;
         }
@@ -19,7 +18,7 @@ export default function createActionTransformer(
         }
 
         throw action;
-    });
+    }));
 }
 
 function isResponse(object: any) {

--- a/src/config/config-actions.ts
+++ b/src/config/config-actions.ts
@@ -9,7 +9,6 @@ export enum ConfigActionType {
 }
 
 export type LoadConfigAction =
-    Action |
     LoadConfigRequestedAction |
     LoadConfigSucceededAction |
     LoadConfigFailedAction;

--- a/src/customer/customer-strategy-action-creator.spec.ts
+++ b/src/customer/customer-strategy-action-creator.spec.ts
@@ -1,8 +1,4 @@
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/toArray';
-import 'rxjs/add/operator/toPromise';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 
 import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';

--- a/src/customer/customer-strategy-actions.ts
+++ b/src/customer/customer-strategy-actions.ts
@@ -16,7 +16,6 @@ export enum CustomerStrategyActionType {
 }
 
 export type CustomerStrategyAction =
-    Action |
     CustomerStrategySignInAction |
     CustomerStrategySignOutAction |
     CustomerStrategyInitializeAction |

--- a/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
@@ -1,9 +1,7 @@
-import 'rxjs/add/observable/of';
-
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 
 import { createCheckoutClient, createCheckoutStore, CheckoutStore } from '../../checkout';
 import { MissingDataError } from '../../common/error/errors';

--- a/src/customer/strategies/default-customer-strategy.spec.ts
+++ b/src/customer/strategies/default-customer-strategy.spec.ts
@@ -1,6 +1,5 @@
 import { createAction } from '@bigcommerce/data-store';
-import 'rxjs/add/observable/of';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 
 import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../checkout';
 import { getQuote } from '../../quote/internal-quotes.mock';

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -1,11 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { merge } from 'lodash';
-import 'rxjs/add/observable/from';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/toArray';
-import 'rxjs/add/operator/toPromise';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 
 import { getCartState } from '../cart/internal-carts.mock';
 import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../checkout';

--- a/src/payment/payment-strategy-actions.ts
+++ b/src/payment/payment-strategy-actions.ts
@@ -16,7 +16,6 @@ export enum PaymentStrategyActionType {
 }
 
 export type PaymentStrategyAction =
-    Action |
     PaymentStrategyExecuteAction |
     PaymentStrategyFinalizeAction |
     PaymentStrategyInitializeAction |

--- a/src/remote-checkout/remote-checkout-action-creator.spec.js
+++ b/src/remote-checkout/remote-checkout-action-creator.spec.js
@@ -1,11 +1,10 @@
 import { createRequestSender, createTimeout } from '@bigcommerce/request-sender';
+import { Observable } from 'rxjs';
 import { getRemoteBillingResponseBody, getRemoteShippingResponseBody, getRemotePaymentResponseBody } from './remote-checkout.mock';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import * as actionTypes from './remote-checkout-action-types';
 import RemoteCheckoutActionCreator from './remote-checkout-action-creator';
 import RemoteCheckoutRequestSender from './remote-checkout-request-sender';
-import 'rxjs/add/operator/toArray';
-import 'rxjs/add/operator/toPromise';
 
 describe('RemoteCheckoutActionCreator', () => {
     let actionCreator;
@@ -37,23 +36,21 @@ describe('RemoteCheckoutActionCreator', () => {
 
     it('emits error action if unable to initialize billing', async () => {
         const response = getErrorResponse();
+        const errorHandler = jest.fn(action => Observable.of(action));
 
         jest.spyOn(requestSender, 'initializeBilling')
             .mockReturnValue(Promise.reject(response));
 
-        try {
-            const actions = await actionCreator.initializeBilling('amazon')
-                .toArray()
-                .toPromise();
+        const actions = await actionCreator.initializeBilling('amazon')
+            .catch(errorHandler)
+            .toArray()
+            .toPromise();
 
-            expect(actions).toEqual([
-                { type: actionTypes.INITIALIZE_REMOTE_BILLING_REQUESTED, meta: { methodId: 'amazon' } },
-            ]);
-        } catch (error) {
-            expect(error).toEqual(
-                { type: actionTypes.INITIALIZE_REMOTE_BILLING_FAILED, error: true, payload: response, meta: { methodId: 'amazon' } }
-            );
-        }
+        expect(errorHandler).toHaveBeenCalled();
+        expect(actions).toEqual([
+            { type: actionTypes.INITIALIZE_REMOTE_BILLING_REQUESTED, meta: { methodId: 'amazon' } },
+            { type: actionTypes.INITIALIZE_REMOTE_BILLING_FAILED, error: true, payload: response, meta: { methodId: 'amazon' } },
+        ]);
     });
 
     it('initializes shipping and emits actions to notify progress', async () => {
@@ -77,23 +74,20 @@ describe('RemoteCheckoutActionCreator', () => {
 
     it('emits error action if unable to initialize shipping', async () => {
         const response = getErrorResponse();
+        const errorHandler = jest.fn(action => Observable.of(action));
 
         jest.spyOn(requestSender, 'initializeShipping')
             .mockReturnValue(Promise.reject(response));
 
-        try {
-            const actions = await actionCreator.initializeShipping('amazon')
-                .toArray()
-                .toPromise();
+        const actions = await actionCreator.initializeShipping('amazon')
+            .catch(errorHandler)
+            .toArray()
+            .toPromise();
 
-            expect(actions).toEqual([
-                { type: actionTypes.INITIALIZE_REMOTE_SHIPPING_REQUESTED, meta: { methodId: 'amazon' } },
-            ]);
-        } catch (error) {
-            expect(error).toEqual(
-                { type: actionTypes.INITIALIZE_REMOTE_SHIPPING_FAILED, error: true, payload: response, meta: { methodId: 'amazon' } }
-            );
-        }
+        expect(actions).toEqual([
+            { type: actionTypes.INITIALIZE_REMOTE_SHIPPING_REQUESTED, meta: { methodId: 'amazon' } },
+            { type: actionTypes.INITIALIZE_REMOTE_SHIPPING_FAILED, error: true, payload: response, meta: { methodId: 'amazon' } },
+        ]);
     });
 
     it('initializes payment and emits actions to notify progress', async () => {
@@ -117,23 +111,20 @@ describe('RemoteCheckoutActionCreator', () => {
 
     it('emits error action if unable to initialize payment', async () => {
         const response = getErrorResponse();
+        const errorHandler = jest.fn(action => Observable.of(action));
 
         jest.spyOn(requestSender, 'initializePayment')
             .mockReturnValue(Promise.reject(response));
 
-        try {
-            const actions = await actionCreator.initializePayment('amazon')
-                .toArray()
-                .toPromise();
+        const actions = await actionCreator.initializePayment('amazon')
+            .catch(errorHandler)
+            .toArray()
+            .toPromise();
 
-            expect(actions).toEqual([
-                { type: actionTypes.INITIALIZE_REMOTE_PAYMENT_REQUESTED, meta: { methodId: 'amazon' } },
-            ]);
-        } catch (error) {
-            expect(error).toEqual(
-                { type: actionTypes.INITIALIZE_REMOTE_PAYMENT_FAILED, error: true, payload: response, meta: { methodId: 'amazon' } }
-            );
-        }
+        expect(actions).toEqual([
+            { type: actionTypes.INITIALIZE_REMOTE_PAYMENT_REQUESTED, meta: { methodId: 'amazon' } },
+            { type: actionTypes.INITIALIZE_REMOTE_PAYMENT_FAILED, error: true, payload: response, meta: { methodId: 'amazon' } },
+        ]);
     });
 
     it('signs out and emits actions to notify progress', async () => {
@@ -156,23 +147,20 @@ describe('RemoteCheckoutActionCreator', () => {
 
     it('emits error action if unable to sign out', async () => {
         const response = getErrorResponse();
+        const errorHandler = jest.fn(action => Observable.of(action));
 
         jest.spyOn(requestSender, 'signOut')
             .mockReturnValue(Promise.reject(response));
 
-        try {
-            const actions = await actionCreator.signOut('amazon')
-                .toArray()
-                .toPromise();
+        const actions = await actionCreator.signOut('amazon')
+            .catch(errorHandler)
+            .toArray()
+            .toPromise();
 
-            expect(actions).toEqual([
-                { type: actionTypes.SIGN_OUT_REMOTE_CUSTOMER_REQUESTED },
-            ]);
-        } catch (error) {
-            expect(error).toEqual(
-                { type: actionTypes.SIGN_OUT_REMOTE_CUSTOMER_FAILED, error: true, payload: response }
-            );
-        }
+        expect(actions).toEqual([
+            { type: actionTypes.SIGN_OUT_REMOTE_CUSTOMER_REQUESTED },
+            { type: actionTypes.SIGN_OUT_REMOTE_CUSTOMER_FAILED, error: true, payload: response },
+        ]);
     });
 
     it('returns action to set meta for provider', () => {

--- a/src/shipping/shipping-strategy-action-creator.spec.ts
+++ b/src/shipping/shipping-strategy-action-creator.spec.ts
@@ -1,9 +1,4 @@
-import 'rxjs/add/observable/from';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/toArray';
-import 'rxjs/add/operator/toPromise';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 
 import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';

--- a/src/shipping/shipping-strategy-actions.ts
+++ b/src/shipping/shipping-strategy-actions.ts
@@ -16,7 +16,6 @@ export enum ShippingStrategyActionType {
 }
 
 export type ShippingStrategyAction =
-    Action |
     ShippingStrategyUpdateAddressAction |
     ShippingStrategySelectOptionAction |
     ShippingStrategyInitializeAction |

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
     deep-assign "^2.0.0"
     object-assign "^4.1.0"
 
-"@bigcommerce/data-store@git+ssh://git@github.com/bigcommerce/data-store-js.git#v0.1.4":
-  version "0.1.4"
-  resolved "git+ssh://git@github.com/bigcommerce/data-store-js.git#92647d7485f9a09a824f963aee07b976eac9c591"
+"@bigcommerce/data-store@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@bigcommerce/data-store/-/data-store-0.1.7.tgz#9cde00cc3939e6448603d3b2764bb579d466e962"
   dependencies:
     "@types/lodash" "^4.14.92"
     lodash "^4.17.4"


### PR DESCRIPTION
## What?
* Upgrade `data-store` dependency

## Why?
* It fixes several [issues](https://github.com/bigcommerce/data-store-js/releases)

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
