### PR TITLE
feat(payments): INT-275 Add Cryptogram like a new payment instrument 

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -4,7 +4,7 @@ export default interface Payment {
     paymentData: PaymentInstrument & PaymentInstrumentMeta;
 }
 
-export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument;
+export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument;
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
@@ -31,4 +31,15 @@ export interface NonceInstrument {
 export interface VaultedInstrument {
     instrumentId: string;
     cvv?: number;
+}
+
+export interface CryptogramInstrument {
+    cryptogramId: string;
+    eci: string;
+    transactionId?: string;
+    ccExpiry: {
+        month: string,
+        year: string,
+    };
+    ccNumber: string;
 }


### PR DESCRIPTION
## What?
Create a new payment instrument called Cryptogram

## Why?
Chasepay needs to send more data (to bigPay) that  is not supported by the credit card Instrument

## Testing / Proof
<img width="297" alt="screen shot 2018-05-14 at 5 25 46 pm" src="https://user-images.githubusercontent.com/38794472/40026739-3a33bb4e-579c-11e8-8547-f2778f782513.png">
<img width="287" alt="screen shot 2018-05-14 at 5 27 09 pm" src="https://user-images.githubusercontent.com/38794472/40026750-453e6aca-579c-11e8-99b9-1777db246d18.png">

NOTE: This PR has a dependency with [https://github.com/rodna-bc/bigpay-client-js/tree/INT-275](url) of @rodna-bc because we need to create the mapper in bigpay-client-js to have the complete flow

@bigcommerce/checkout @bigcommerce/payments
