### PR TITLE
CHECKOUT-3016: Add type definitions to responses

### DIFF
--- a/src/checkout/checkout-client.ts
+++ b/src/checkout/checkout-client.ts
@@ -4,12 +4,12 @@ import { InternalAddress } from '../address';
 import { BillingAddressRequestSender } from '../billing';
 import { CartRequestSender } from '../cart';
 import { RequestOptions } from '../common/http-request';
-import { ConfigRequestSender } from '../config';
+import { Config, ConfigRequestSender } from '../config';
 import { CouponRequestSender, GiftCertificateRequestSender } from '../coupon';
 import { CustomerCredentials, CustomerRequestSender } from '../customer';
-import { CountryRequestSender } from '../geography';
-import { OrderRequestBody, OrderRequestSender } from '../order';
-import { PaymentMethodRequestSender } from '../payment';
+import { CountryRequestSender, CountryResponseBody } from '../geography';
+import { InternalOrderResponseBody, OrderRequestBody, OrderRequestSender } from '../order';
+import { PaymentMethodsResponseBody, PaymentMethodRequestSender, PaymentMethodResponseBody } from '../payment';
 import { QuoteRequestSender } from '../quote';
 import { ShippingAddressRequestSender, ShippingCountryRequestSender, ShippingOptionRequestSender } from '../shipping';
 
@@ -43,31 +43,31 @@ export default class CheckoutClient {
         return this._cartRequestSender.loadCart(options);
     }
 
-    loadOrder(orderId: number, options?: RequestOptions): Promise<Response> {
+    loadOrder(orderId: number, options?: RequestOptions): Promise<Response<InternalOrderResponseBody>> {
         return this._orderRequestSender.loadOrder(orderId, options);
     }
 
-    submitOrder(body: OrderRequestBody, options?: RequestOptions): Promise<Response> {
+    submitOrder(body: OrderRequestBody, options?: RequestOptions): Promise<Response<InternalOrderResponseBody>> {
         return this._orderRequestSender.submitOrder(body, options);
     }
 
-    finalizeOrder(orderId: number, options?: RequestOptions): Promise<Response> {
+    finalizeOrder(orderId: number, options?: RequestOptions): Promise<Response<InternalOrderResponseBody>> {
         return this._orderRequestSender.finalizeOrder(orderId, options);
     }
 
-    loadPaymentMethods(options?: RequestOptions): Promise<Response> {
+    loadPaymentMethods(options?: RequestOptions): Promise<Response<PaymentMethodsResponseBody>> {
         return this._paymentMethodRequestSender.loadPaymentMethods(options);
     }
 
-    loadPaymentMethod(methodId: string, options?: RequestOptions): Promise<Response> {
+    loadPaymentMethod(methodId: string, options?: RequestOptions): Promise<Response<PaymentMethodResponseBody>> {
         return this._paymentMethodRequestSender.loadPaymentMethod(methodId, options);
     }
 
-    loadCountries(options?: RequestOptions): Promise<Response> {
+    loadCountries(options?: RequestOptions): Promise<Response<CountryResponseBody>> {
         return this._countryRequestSender.loadCountries(options);
     }
 
-    loadShippingCountries(options?: RequestOptions): Promise<Response> {
+    loadShippingCountries(options?: RequestOptions): Promise<Response<CountryResponseBody>> {
         return this._shippingCountryRequestSender.loadCountries(options);
     }
 
@@ -111,7 +111,7 @@ export default class CheckoutClient {
         return this._giftCertificateRequestSender.removeGiftCertificate(code, options);
     }
 
-    loadConfig(options?: RequestOptions): Promise<Response> {
+    loadConfig(options?: RequestOptions): Promise<Response<Config>> {
         return this._configRequestSender.loadConfig(options);
     }
 }

--- a/src/common/http-request/index.ts
+++ b/src/common/http-request/index.ts
@@ -1,1 +1,2 @@
+export { default as InternalResponseBody } from './internal-response-body';
 export { default as RequestOptions } from './request-options';

--- a/src/common/http-request/internal-response-body.ts
+++ b/src/common/http-request/internal-response-body.ts
@@ -1,0 +1,4 @@
+export default interface InternalResponseBody<TData = {}, TMeta = {}> {
+    data: TData;
+    meta: TMeta;
+}

--- a/src/config/config-action-creator.ts
+++ b/src/config/config-action-creator.ts
@@ -1,4 +1,4 @@
-import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
@@ -7,21 +7,18 @@ import { RequestOptions } from '../common/http-request';
 
 import { ConfigActionType, LoadConfigAction } from './config-actions';
 
-/**
- * @todo Convert this file into TypeScript properly
- */
 export default class ConfigActionCreator {
     constructor(
         private _checkoutClient: CheckoutClient
     ) {}
 
     loadConfig(options?: RequestOptions): Observable<LoadConfigAction> {
-        return Observable.create((observer: Observer<Action>) => {
+        return Observable.create((observer: Observer<LoadConfigAction>) => {
             observer.next(createAction(ConfigActionType.LoadConfigRequested));
 
             this._checkoutClient.loadConfig(options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(ConfigActionType.LoadConfigSucceeded, body));
+                .then(response => {
+                    observer.next(createAction(ConfigActionType.LoadConfigSucceeded, response.body));
                     observer.complete();
                 })
                 .catch(response => {

--- a/src/config/config-request-sender.ts
+++ b/src/config/config-request-sender.ts
@@ -2,15 +2,14 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
 
-/**
- * @todo Convert this file into TypeScript properly
- */
+import Config from './config';
+
 export default class ConfigRequestSender {
     constructor(
         private _requestSender: RequestSender
     ) {}
 
-    loadConfig({ timeout }: RequestOptions = {}): Promise<Response> {
+    loadConfig({ timeout }: RequestOptions = {}): Promise<Response<Config>> {
         const url = '/api/storefront/checkout-settings';
 
         return this._requestSender.get(url, {

--- a/src/geography/country-action-creator.ts
+++ b/src/geography/country-action-creator.ts
@@ -5,6 +5,7 @@ import { Observer } from 'rxjs/Observer';
 import { CheckoutClient } from '../checkout';
 import { RequestOptions } from '../common/http-request';
 
+import Country from './country';
 import * as actionTypes from './country-action-types';
 
 /**
@@ -15,13 +16,13 @@ export default class CountryActionCreator {
         private _checkoutClient: CheckoutClient
     ) {}
 
-    loadCountries(options?: RequestOptions): Observable<Action> {
-        return Observable.create((observer: Observer<Action>) => {
+    loadCountries(options?: RequestOptions): Observable<Action<Country[]>> {
+        return Observable.create((observer: Observer<Action<Country[]>>) => {
             observer.next(createAction(actionTypes.LOAD_COUNTRIES_REQUESTED));
 
             this._checkoutClient.loadCountries(options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(actionTypes.LOAD_COUNTRIES_SUCCEEDED, body.data));
+                .then(response => {
+                    observer.next(createAction(actionTypes.LOAD_COUNTRIES_SUCCEEDED, response.body.data));
                     observer.complete();
                 })
                 .catch(response => {

--- a/src/geography/country-request-sender.ts
+++ b/src/geography/country-request-sender.ts
@@ -2,16 +2,15 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
 
-/**
- * @todo Convert this file into TypeScript properly
- */
+import { CountryResponseBody } from './country-responses';
+
 export default class CountryRequestSender {
     constructor(
         private _requestSender: RequestSender,
         private _config: { locale?: string }
     ) {}
 
-    loadCountries({ timeout }: RequestOptions = {}): Promise<Response> {
+    loadCountries({ timeout }: RequestOptions = {}): Promise<Response<CountryResponseBody>> {
         const url = '/internalapi/v1/store/countries';
         const headers = {
             'Accept-Language': this._config.locale,

--- a/src/geography/country-responses.ts
+++ b/src/geography/country-responses.ts
@@ -1,0 +1,5 @@
+import Country from './country';
+
+export interface CountryResponseBody {
+    data: Country[];
+}

--- a/src/geography/index.ts
+++ b/src/geography/index.ts
@@ -1,3 +1,5 @@
+export * from './country-responses';
+
 export { default as CountryActionCreator } from './country-action-creator';
 export { default as CountryRequestSender } from './country-request-sender';
 export { default as Country } from './country';

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -1,3 +1,5 @@
+export * from './internal-order-responses';
+
 export { default as Order } from './order';
 export { default as InternalOrder } from './internal-order';
 export { default as InternalIncompleteOrder } from './internal-incomplete-order';

--- a/src/order/internal-order-responses.ts
+++ b/src/order/internal-order-responses.ts
@@ -1,0 +1,15 @@
+import { InternalResponseBody } from '../common/http-request';
+import { InternalCustomer } from '../customer';
+
+import InternalOrder from './internal-order';
+
+export type InternalOrderResponseBody = InternalResponseBody<InternalOrderResponseData, InternalOrderResponseMeta>;
+
+export interface InternalOrderResponseData {
+    customer: InternalCustomer;
+    order: InternalOrder;
+}
+
+export interface InternalOrderResponseMeta {
+    deviceFingerprint?: string;
+}

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -8,6 +8,7 @@ import { CheckoutClient, InternalCheckoutSelectors } from '../checkout';
 import { MissingDataError } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
+import { InternalOrderResponseData } from './internal-order-responses';
 import * as actionTypes from './order-action-types';
 import OrderRequestBody from './order-request-body';
 
@@ -23,13 +24,13 @@ export default class OrderActionCreator {
         this._cartComparator = new CartComparator();
     }
 
-    loadOrder(orderId: number, options?: RequestOptions): Observable<Action> {
-        return Observable.create((observer: Observer<Action>) => {
+    loadOrder(orderId: number, options?: RequestOptions): Observable<Action<InternalOrderResponseData>> {
+        return Observable.create((observer: Observer<Action<InternalOrderResponseData>>) => {
             observer.next(createAction(actionTypes.LOAD_ORDER_REQUESTED));
 
             this._checkoutClient.loadOrder(orderId, options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(actionTypes.LOAD_ORDER_SUCCEEDED, body.data));
+                .then(response => {
+                    observer.next(createAction(actionTypes.LOAD_ORDER_SUCCEEDED, response.body.data));
                     observer.complete();
                 })
                 .catch(response => {
@@ -38,8 +39,8 @@ export default class OrderActionCreator {
         });
     }
 
-    submitOrder(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<Action, InternalCheckoutSelectors> {
-        return store => Observable.create((observer: Observer<Action>) => {
+    submitOrder(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<Action<InternalOrderResponseData>, InternalCheckoutSelectors> {
+        return store => Observable.create((observer: Observer<Action<InternalOrderResponseData>>) => {
             observer.next(createAction(actionTypes.SUBMIT_ORDER_REQUESTED));
 
             const state = store.getState();
@@ -51,8 +52,8 @@ export default class OrderActionCreator {
 
             this._verifyCart(cart, options)
                 .then(() => this._checkoutClient.submitOrder(payload, options))
-                .then(({ body = {}, headers = {} }) => {
-                    observer.next(createAction(actionTypes.SUBMIT_ORDER_SUCCEEDED, body.data, { ...body.meta, token: headers.token }));
+                .then(response => {
+                    observer.next(createAction(actionTypes.SUBMIT_ORDER_SUCCEEDED, response.body.data, { ...response.body.meta, token: response.headers.token }));
                     observer.complete();
                 })
                 .catch(response => {
@@ -61,13 +62,13 @@ export default class OrderActionCreator {
         });
     }
 
-    finalizeOrder(orderId: number, options?: RequestOptions): Observable<Action> {
-        return Observable.create((observer: Observer<Action>) => {
+    finalizeOrder(orderId: number, options?: RequestOptions): Observable<Action<InternalOrderResponseData>> {
+        return Observable.create((observer: Observer<Action<InternalOrderResponseData>>) => {
             observer.next(createAction(actionTypes.FINALIZE_ORDER_REQUESTED));
 
             this._checkoutClient.finalizeOrder(orderId, options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(actionTypes.FINALIZE_ORDER_SUCCEEDED, body.data));
+                .then(response => {
+                    observer.next(createAction(actionTypes.FINALIZE_ORDER_SUCCEEDED, response.body.data));
                     observer.complete();
                 })
                 .catch(response => {

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -4,31 +4,26 @@ import { RequestOptions } from '../common/http-request';
 
 import OrderRequestBody from './order-request-body';
 
-/**
- * @todo Convert this file into TypeScript properly
- */
+import { InternalOrderResponseBody } from './internal-order-responses';
+
 export default class OrderRequestSender {
-    /**
-     * @constructor
-     * @param {RequestSender} requestSender
-     */
     constructor(
         private _requestSender: RequestSender
     ) {}
 
-    loadOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response> {
+    loadOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
         const url = `/internalapi/v1/checkout/order/${orderId}`;
 
         return this._requestSender.get(url, { timeout });
     }
 
-    submitOrder(body: OrderRequestBody, { timeout }: RequestOptions = {}): Promise<Response> {
+    submitOrder(body: OrderRequestBody, { timeout }: RequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
         const url = '/internalapi/v1/checkout/order';
 
         return this._requestSender.post(url, { body, timeout });
     }
 
-    finalizeOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response> {
+    finalizeOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
         const url = `/internalapi/v1/checkout/order/${orderId}`;
 
         return this._requestSender.post(url, { timeout });

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -1,4 +1,5 @@
 export * from './payment-request-options';
+export * from './payment-method-responses';
 
 export { default as createPaymentClient } from './create-payment-client';
 export { default as createPaymentStrategyRegistry } from './create-payment-strategy-registry';

--- a/src/payment/payment-method-action-creator.ts
+++ b/src/payment/payment-method-action-creator.ts
@@ -20,8 +20,8 @@ export default class PaymentMethodActionCreator {
             observer.next(createAction(actionTypes.LOAD_PAYMENT_METHODS_REQUESTED));
 
             this._checkoutClient.loadPaymentMethods(options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(actionTypes.LOAD_PAYMENT_METHODS_SUCCEEDED, body.data));
+                .then(response => {
+                    observer.next(createAction(actionTypes.LOAD_PAYMENT_METHODS_SUCCEEDED, response.body.data));
                     observer.complete();
                 })
                 .catch(response => {
@@ -35,8 +35,8 @@ export default class PaymentMethodActionCreator {
             observer.next(createAction(actionTypes.LOAD_PAYMENT_METHOD_REQUESTED, undefined, { methodId }));
 
             this._checkoutClient.loadPaymentMethod(methodId, options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(actionTypes.LOAD_PAYMENT_METHOD_SUCCEEDED, body.data, { methodId }));
+                .then(response => {
+                    observer.next(createAction(actionTypes.LOAD_PAYMENT_METHOD_SUCCEEDED, response.body.data, { methodId }));
                     observer.complete();
                 })
                 .catch(response => {

--- a/src/payment/payment-method-request-sender.ts
+++ b/src/payment/payment-method-request-sender.ts
@@ -2,22 +2,20 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
 
-/**
- * @todo Convert this file into TypeScript properly
- * i.e.: Response<T>
- */
+import { PaymentMethodsResponseBody, PaymentMethodResponseBody } from './payment-method-responses';
+
 export default class PaymentMethodRequestSender {
     constructor(
         private _requestSender: RequestSender
     ) {}
 
-    loadPaymentMethods({ timeout }: RequestOptions = {}): Promise<Response> {
+    loadPaymentMethods({ timeout }: RequestOptions = {}): Promise<Response<PaymentMethodsResponseBody>> {
         const url = '/internalapi/v1/checkout/payments';
 
         return this._requestSender.get(url, { timeout });
     }
 
-    loadPaymentMethod(methodId: string, { timeout }: RequestOptions = {}): Promise<Response> {
+    loadPaymentMethod(methodId: string, { timeout }: RequestOptions = {}): Promise<Response<PaymentMethodResponseBody>> {
         const url = `/internalapi/v1/checkout/payments/${methodId}`;
 
         return this._requestSender.get(url, { timeout });

--- a/src/payment/payment-method-responses.ts
+++ b/src/payment/payment-method-responses.ts
@@ -1,0 +1,14 @@
+import { InternalResponseBody } from '../common/http-request';
+
+import PaymentMethod from './payment-method';
+
+export type PaymentMethodsResponseBody = InternalResponseBody<PaymentMethodsResponseData>;
+export type PaymentMethodResponseBody = InternalResponseBody<PaymentMethodResponseData>;
+
+export interface PaymentMethodsResponseData {
+    paymentMethods: PaymentMethod[];
+}
+
+export interface PaymentMethodResponseData {
+    paymentMethod: PaymentMethod;
+}

--- a/src/shipping/shipping-country-action-creator.ts
+++ b/src/shipping/shipping-country-action-creator.ts
@@ -21,8 +21,8 @@ export default class ShippingCountryActionCreator {
             observer.next(createAction(actionTypes.LOAD_SHIPPING_COUNTRIES_REQUESTED));
 
             this._checkoutClient.loadShippingCountries(options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(actionTypes.LOAD_SHIPPING_COUNTRIES_SUCCEEDED, body.data));
+                .then(response => {
+                    observer.next(createAction(actionTypes.LOAD_SHIPPING_COUNTRIES_SUCCEEDED, response.body.data));
                     observer.complete();
                 })
                 .catch(response => {

--- a/src/shipping/shipping-country-request-sender.ts
+++ b/src/shipping/shipping-country-request-sender.ts
@@ -1,17 +1,15 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
+import { CountryResponseBody } from '../geography';
 
-/**
- * @todo Convert this file into TypeScript properly
- */
 export default class ShippingCountryRequestSender {
     constructor(
         private _requestSender: RequestSender,
         private _config: { locale?: string }
     ) {}
 
-    loadCountries({ timeout }: RequestOptions = {}): Promise<Response> {
+    loadCountries({ timeout }: RequestOptions = {}): Promise<Response<CountryResponseBody>> {
         const url = '/internalapi/v1/shipping/countries';
         const headers = {
             'Accept-Language': this._config.locale,


### PR DESCRIPTION
## What?
* Define some types for various response objects

## Why?
* To help us transition to Storefront API

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
