### PR TITLE
CHECKOUT-3142: Remove `CheckoutClient` from public exports

### DIFF
--- a/src/checkout/checkout-client.ts
+++ b/src/checkout/checkout-client.ts
@@ -13,8 +13,9 @@ import { PaymentMethodRequestSender } from '../payment';
 import { QuoteRequestSender } from '../quote';
 import { ShippingAddressRequestSender, ShippingCountryRequestSender, ShippingOptionRequestSender } from '../shipping';
 
-// Convert this file into TypeScript properly
-// i.e.: Response<T>
+/**
+ * @deprecated Use request senders directly
+ */
 export default class CheckoutClient {
     /**
      * @internal

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -22,13 +22,12 @@ import {
     ShippingStrategyActionCreator,
 } from '../shipping';
 
-import CheckoutClient from './checkout-client';
 import CheckoutService from './checkout-service';
 import createCheckoutClient from './create-checkout-client';
 import createCheckoutStore from './create-checkout-store';
 
 export default function createCheckoutService(options: CheckoutServiceOptions = {}): CheckoutService {
-    const client = options.client || createCheckoutClient({ locale: options.locale });
+    const client = createCheckoutClient({ locale: options.locale });
     const store = createCheckoutStore({}, { shouldWarnMutation: options.shouldWarnMutation });
     const paymentClient = createPaymentClient(store);
 
@@ -55,7 +54,6 @@ export default function createCheckoutService(options: CheckoutServiceOptions = 
 }
 
 export interface CheckoutServiceOptions {
-    client?: CheckoutClient;
     locale?: string;
     shouldWarnMutation?: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,4 @@
 export { createTimeout } from '@bigcommerce/request-sender';
 
-export {
-    createCheckoutClient,
-    createCheckoutService,
-    CheckoutClient,
-    CheckoutSelectors,
-    CheckoutService,
-} from './checkout';
-
+export { createCheckoutService, CheckoutSelectors, CheckoutService } from './checkout';
 export { createLanguageService, LanguageService } from './locale';


### PR DESCRIPTION
## What?
* Remove `CheckoutClient` from public exports 
* **BREAKING CHANGE**: `CheckoutClient` is no longer exported for public use.

## Why?
* Initially we want to export a thin JS client for various checkout API endpoints. But now we realise a lot of these methods either don't belong specifically to checkout or are considered to be internal. So there is not much value in exposing it. If we don't expose it, internally we could just consume request senders directly instead of maintaining this facade.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
