### PR TITLE
CHECKOUT-3142: Remove `finalizeOrder` method

### DIFF
--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -107,16 +107,6 @@ export default class CheckoutService {
             .then(() => this.getState());
     }
 
-    /**
-     * @deprecated
-     */
-    finalizeOrder(orderId: number, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._orderActionCreator.finalizeOrder(orderId, options);
-
-        return this._store.dispatch(action)
-            .then(() => this.getState());
-    }
-
     finalizeOrderIfNeeded(options?: RequestOptions): Promise<CheckoutSelectors> {
         const action = this._paymentStrategyActionCreator.finalize(options);
 


### PR DESCRIPTION
## What?
* Remove `CheckoutService#finalizeOrder` method.
* **BREAKING CHANGE**: `CheckoutService#finalizeOrder` method has been removed.

## Why?
* The method has been depreciated for some time. UCO no longer calls it. So it's safe to remove.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
