### PR TITLE
feat(payment): PAYMENTS-2744 Updating Afterpay to support US and NZ customers

### DIFF
--- a/src/payment/strategies/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay-payment-strategy.spec.ts
@@ -46,7 +46,7 @@ describe('AfterpayPaymentStrategy', () => {
     let verifyCartAction: Observable<Action>;
 
     const afterpaySdk = {
-        init: () => {},
+        initialize: () => {},
         display: () => {},
     };
 
@@ -120,7 +120,7 @@ describe('AfterpayPaymentStrategy', () => {
         jest.spyOn(scriptLoader, 'load')
             .mockReturnValue(Promise.resolve(afterpaySdk));
 
-        jest.spyOn(afterpaySdk, 'init').mockImplementation(() => {});
+        jest.spyOn(afterpaySdk, 'initialize').mockImplementation(() => {});
         jest.spyOn(afterpaySdk, 'display').mockImplementation(() => {});
     });
 
@@ -128,7 +128,7 @@ describe('AfterpayPaymentStrategy', () => {
         it('loads script when initializing strategy', async () => {
             await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway });
 
-            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod);
+            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod, 'US');
         });
     });
 
@@ -144,7 +144,7 @@ describe('AfterpayPaymentStrategy', () => {
         });
 
         it('displays the afterpay modal', () => {
-            expect(afterpaySdk.init).toHaveBeenCalled();
+            expect(afterpaySdk.initialize).toHaveBeenCalledWith({ countryCode: 'US' });
             expect(afterpaySdk.display).toHaveBeenCalledWith({ token: paymentMethod.clientToken });
         });
 

--- a/src/payment/strategies/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay-payment-strategy.ts
@@ -33,12 +33,14 @@ export default class AfterpayPaymentStrategy extends PaymentStrategy {
 
         const state = this._store.getState();
         const paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId, options.gatewayId);
+        const config = state.config.getStoreConfig();
+        const storeCountryName = config ? config.storeProfile.storeCountry : '';
 
         if (!paymentMethod) {
             throw new MissingDataError(`Unable to initialize because "paymentMethod (${options.methodId})" data is missing.`);
         }
 
-        return this._afterpayScriptLoader.load(paymentMethod)
+        return this._afterpayScriptLoader.load(paymentMethod, this._mapCountryToISO2(storeCountryName))
             .then(afterpaySdk => {
                 this._afterpaySdk = afterpaySdk;
             })
@@ -66,6 +68,9 @@ export default class AfterpayPaymentStrategy extends PaymentStrategy {
 
         const useStoreCredit = !!payload.useStoreCredit;
         const customerMessage = payload.customerMessage ? payload.customerMessage : '';
+        const state = this._store.getState();
+        const config = state.config.getStoreConfig();
+        const storeCountryName = config ? config.storeProfile.storeCountry : '';
 
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.initializePayment(paymentId, { useStoreCredit, customerMessage })
@@ -76,7 +81,7 @@ export default class AfterpayPaymentStrategy extends PaymentStrategy {
             .then(() => this._store.dispatch(
                 this._paymentMethodActionCreator.loadPaymentMethod(paymentId, options)
             ))
-            .then(state => this._displayModal(state.paymentMethods.getPaymentMethod(paymentId)))
+            .then(state => this._displayModal(storeCountryName, state.paymentMethods.getPaymentMethod(paymentId)))
             // Afterpay will handle the rest of the flow so return a promise that doesn't really resolve
             .then(() => new Promise<never>(() => {}));
     }
@@ -106,12 +111,25 @@ export default class AfterpayPaymentStrategy extends PaymentStrategy {
             );
     }
 
-    private _displayModal(paymentMethod?: PaymentMethod): void {
+    private _displayModal(countryName: string, paymentMethod?: PaymentMethod): void {
         if (!this._afterpaySdk || !paymentMethod || !paymentMethod.clientToken) {
             throw new NotInitializedError('Unable to display payment modal because payment method has not been initialized.');
         }
 
-        this._afterpaySdk.init();
+        this._afterpaySdk.initialize({ countryCode: this._mapCountryToISO2(countryName)});
         this._afterpaySdk.display({ token: paymentMethod.clientToken });
+    }
+
+    private _mapCountryToISO2(countryName: string): string {
+        switch (countryName) {
+            case 'Australia':
+                return 'AU';
+            case 'New Zealand':
+                return 'NZ';
+            case 'United States':
+                return 'US';
+            default:
+                return 'AU';
+        }
     }
 }

--- a/src/remote-checkout/methods/afterpay/afterpay-script-loader.spec.ts
+++ b/src/remote-checkout/methods/afterpay/afterpay-script-loader.spec.ts
@@ -14,23 +14,55 @@ describe('AfterpayScriptLoader', () => {
             .mockReturnValue(Promise.resolve(new Event('load')));
     });
 
-    it('loads widget script', () => {
+    it('loads widget script for AU & NZ', () => {
         const method = getAfterpay();
 
-        afterpayScriptLoader.load(method);
+        afterpayScriptLoader.load(method, 'AU');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//www.secure-afterpay.com.au/afterpay-async.js'
+            '//portal.afterpay.com/afterpay-async.js'
+        );
+
+        afterpayScriptLoader.load(method, 'NZ');
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            '//portal.afterpay.com/afterpay-async.js'
         );
     });
 
-    it('loads sandbox widget script if in test mode', () => {
+    it('loads sandbox widget script if in test mode for AU & NZ', () => {
         const method = merge({}, getAfterpay(), { config: { testMode: true } });
 
-        afterpayScriptLoader.load(method);
+        afterpayScriptLoader.load(method, 'AU');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//www-sandbox.secure-afterpay.com.au/afterpay-async.js'
+            '//portal-sandbox.afterpay.com/afterpay-async.js'
+        );
+
+        afterpayScriptLoader.load(method, 'NZ');
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            '//portal-sandbox.afterpay.com/afterpay-async.js'
+        );
+    });
+
+    it('loads widget script for US', () => {
+        const method = getAfterpay();
+
+        afterpayScriptLoader.load(method, 'US');
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            '//portal.afterpay.com/afterpay-async.js'
+        );
+    });
+
+    it('loads sandbox widget script if in test mode for US', () => {
+        const method = merge({}, getAfterpay(), { config: { testMode: true } });
+
+        afterpayScriptLoader.load(method, 'US');
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            '//portal.us-sandbox.afterpay.com/afterpay-async.js'
         );
     });
 });

--- a/src/remote-checkout/methods/afterpay/afterpay-script-loader.ts
+++ b/src/remote-checkout/methods/afterpay/afterpay-script-loader.ts
@@ -5,8 +5,20 @@ import { PaymentMethod } from '../../../payment';
 import AfterpaySdk from './afterpay-sdk';
 import AfterpayWindow from './afterpay-window';
 
-const SCRIPT_PROD = '//www.secure-afterpay.com.au/afterpay-async.js';
-const SCRIPT_SANDBOX = '//www-sandbox.secure-afterpay.com.au/afterpay-async.js';
+interface AfterpayScripts {
+    PROD: string;
+    SANDBOX: string;
+}
+
+const SCRIPTS_DEFAULT: AfterpayScripts = {
+    PROD: '//portal.afterpay.com/afterpay-async.js',
+    SANDBOX: '//portal-sandbox.afterpay.com/afterpay-async.js',
+};
+
+const SCRIPTS_US: AfterpayScripts = {
+    PROD: '//portal.afterpay.com/afterpay-async.js',
+    SANDBOX: '//portal.us-sandbox.afterpay.com/afterpay-async.js',
+};
 
 /** Class responsible for loading the Afterpay SDK */
 export default class AfterpayScriptLoader {
@@ -18,11 +30,20 @@ export default class AfterpayScriptLoader {
      * Loads the appropriate Afterpay SDK depending on the payment method data.
      * @param method the payment method data
      */
-    load(method: PaymentMethod): Promise<AfterpaySdk> {
-        const testMode = method.config.testMode;
-        const scriptURI = testMode ? SCRIPT_SANDBOX : SCRIPT_PROD;
+    load(method: PaymentMethod, countryCode: string): Promise<AfterpaySdk> {
+        const testMode = method.config.testMode || false;
+        const scriptURI = this._getScriptURI(countryCode, testMode);
 
         return this._scriptLoader.loadScript(scriptURI)
             .then(() => (window as AfterpayWindow).AfterPay);
     }
+
+    private _getScriptURI(countryCode: string, testMode: boolean): string {
+        if (countryCode === 'US') {
+            return testMode ? SCRIPTS_US.SANDBOX : SCRIPTS_US.PROD;
+        }
+
+        return testMode ? SCRIPTS_DEFAULT.SANDBOX : SCRIPTS_DEFAULT.PROD;
+    }
+
 }

--- a/src/remote-checkout/methods/afterpay/afterpay-sdk.ts
+++ b/src/remote-checkout/methods/afterpay/afterpay-sdk.ts
@@ -1,8 +1,12 @@
 export default interface AfterpaySdk {
-    init(): void;
+    initialize(options: AfterpayInitializeOptions): void;
     display(options: AfterpayDisplayOptions): void;
 }
 
 export interface AfterpayDisplayOptions {
     token: string;
+}
+
+export interface AfterpayInitializeOptions {
+    countryCode: string;
 }


### PR DESCRIPTION
[PAYMENTS-2744](https://jira.bigcommerce.com/browse/PAYMENTS-2744)

## Sibling PRs
[bcapp](https://github.com/bigcommerce/bigcommerce/pull/24554)
[bigpay](https://github.com/bigcommerce/bigpay/pull/1145)
[checkout-sdk-js](https://github.com/bigcommerce/checkout-sdk-js/pull/229)

## What?
Updating the Afterpay Script Loader, SDK and Payment Strategy to support the launch of support for US and NZ markets.

## Why?
Afterpay altered their approach to require custom JS URLs per local and to require the country code to be passed into the `initialize()` method.

## Testing
In progress still. To Do:
- [x] Unit Tests
- [x] Provide Proof

@bigcommerce/checkout @bigcommerce/payments

## Proof
This shows Afterpay US working in sandbox mode on a US store. You can see the Afterpay script loaded is the US sandbox one.
<img width="961" alt="screen shot 2018-05-16 at 3 46 04 pm" src="https://user-images.githubusercontent.com/913070/40143166-5123814c-5920-11e8-8979-c425e6cafaf3.png">
