### PR TITLE
CHECKOUT-3060: Update method names to be consistent

### DIFF
--- a/src/checkout/checkout-store-error-selector.spec.js
+++ b/src/checkout/checkout-store-error-selector.spec.js
@@ -175,18 +175,18 @@ describe('CheckoutStoreErrorSelector', () => {
         });
     });
 
-    describe('#getInitializePaymentMethodError()', () => {
+    describe('#getInitializePaymentError()', () => {
         it('returns error if unable to initialize payment', () => {
             jest.spyOn(selectors.paymentStrategies, 'getInitializeError').mockReturnValue(errorResponse);
 
-            expect(errors.getInitializePaymentMethodError('braintree')).toEqual(errorResponse);
+            expect(errors.getInitializePaymentError('braintree')).toEqual(errorResponse);
             expect(selectors.paymentStrategies.getInitializeError).toHaveBeenCalledWith('braintree');
         });
 
         it('returns undefined if able to initialize payment', () => {
             jest.spyOn(selectors.paymentStrategies, 'getInitializeError').mockReturnValue();
 
-            expect(errors.getInitializePaymentMethodError('braintree')).toEqual(undefined);
+            expect(errors.getInitializePaymentError('braintree')).toEqual(undefined);
             expect(selectors.paymentStrategies.getInitializeError).toHaveBeenCalledWith('braintree');
         });
     });
@@ -303,7 +303,7 @@ describe('CheckoutStoreErrorSelector', () => {
         });
     });
 
-    describe('#getInitializePaymentMethodError()', () => {
+    describe('#getInitializePaymentError()', () => {
         it('returns error if unable to initialize shipping', () => {
             jest.spyOn(selectors.shippingStrategies, 'getInitializeError').mockReturnValue(errorResponse);
 

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -63,7 +63,7 @@ export default class CheckoutStoreErrorSelector {
             this.getLoadShippingCountriesError() ||
             this.getLoadPaymentMethodsError() ||
             this.getLoadPaymentMethodError() ||
-            this.getInitializePaymentMethodError() ||
+            this.getInitializePaymentError() ||
             this.getLoadShippingOptionsError() ||
             this.getSelectShippingOptionError() ||
             this.getSignInError() ||
@@ -122,7 +122,7 @@ export default class CheckoutStoreErrorSelector {
         return this._paymentMethods.getLoadMethodError(methodId);
     }
 
-    getInitializePaymentMethodError(methodId?: string): Error | undefined {
+    getInitializePaymentError(methodId?: string): Error | undefined {
         return this._paymentStrategies.getInitializeError(methodId);
     }
 

--- a/src/checkout/checkout-store-status-selector.spec.js
+++ b/src/checkout/checkout-store-status-selector.spec.js
@@ -171,7 +171,7 @@ describe('CheckoutStoreStatusSelector', () => {
         });
     });
 
-    describe('#isInitializingPaymentMethod()', () => {
+    describe('#isInitializingPayment()', () => {
         beforeEach(() => {
             jest.spyOn(selectors.paymentStrategies, 'isInitializing').mockReturnValue(false);
         });
@@ -179,12 +179,12 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if initializing payment', () => {
             jest.spyOn(selectors.paymentStrategies, 'isInitializing').mockReturnValue(true);
 
-            expect(statuses.isInitializingPaymentMethod('foobar')).toEqual(true);
+            expect(statuses.isInitializingPayment('foobar')).toEqual(true);
             expect(selectors.paymentStrategies.isInitializing).toHaveBeenCalledWith('foobar');
         });
 
         it('returns false if not initializing payment', () => {
-            expect(statuses.isInitializingPaymentMethod('foobar')).toEqual(false);
+            expect(statuses.isInitializingPayment('foobar')).toEqual(false);
             expect(selectors.paymentStrategies.isInitializing).toHaveBeenCalledWith('foobar');
         });
     });

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -63,7 +63,7 @@ export default class CheckoutStoreStatusSelector {
             this.isLoadingShippingCountries() ||
             this.isLoadingPaymentMethods() ||
             this.isLoadingPaymentMethod() ||
-            this.isInitializingPaymentMethod() ||
+            this.isInitializingPayment() ||
             this.isLoadingShippingOptions() ||
             this.isSelectingShippingOption() ||
             this.isSigningIn() ||
@@ -122,7 +122,7 @@ export default class CheckoutStoreStatusSelector {
         return this._paymentMethods.isLoadingMethod(methodId);
     }
 
-    isInitializingPaymentMethod(methodId?: string): boolean {
+    isInitializingPayment(methodId?: string): boolean {
         return this._paymentStrategies.isInitializing(methodId);
     }
 


### PR DESCRIPTION
## What?
* **BREAKING CHANGE:** `getInitializePaymentMethod` and `isInitializingPaymentMethod` have now been renamed to `getInitializePayment` and `isInitializingPayment` respectively.

## Why?
* So they are consistent with `initializePayment` method.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
