### PR TITLE
CHECKOUT-2957 Prevent the use of the SDK in non https pages

### DIFF
--- a/src/checkout/create-checkout-service.spec.js
+++ b/src/checkout/create-checkout-service.spec.js
@@ -1,7 +1,20 @@
 import CheckoutService from './checkout-service';
 import createCheckoutService from './create-checkout-service';
+import { getDefaultLogger } from '../common/log';
 
 describe('createCheckoutService()', () => {
+    const nodeEnviroment = process.env.NODE_ENV;
+    let logger;
+
+    beforeEach(() => {
+        logger = getDefaultLogger();
+        jest.spyOn(logger, 'warn');
+    });
+
+    afterEach(() => {
+        process.env.NODE_ENV = nodeEnviroment;
+    });
+
     it('creates an instance of CheckoutService', () => {
         const checkoutClient = jest.fn();
         const checkoutService = createCheckoutService({ client: checkoutClient });
@@ -13,5 +26,13 @@ describe('createCheckoutService()', () => {
         const checkoutService = createCheckoutService();
 
         expect(checkoutService).toEqual(expect.any(CheckoutService));
+    });
+
+    it('throws if production and protocol is not https', () => {
+        process.env.NODE_ENV = 'production';
+
+        createCheckoutService();
+
+        expect(logger.warn).toHaveBeenCalled();
     });
 });

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -2,6 +2,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { BillingAddressActionCreator } from '../billing';
 import { CartActionCreator } from '../cart';
+import { getDefaultLogger } from '../common/log';
 import { ConfigActionCreator } from '../config';
 import { CouponActionCreator, GiftCertificateActionCreator } from '../coupon';
 import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '../customer';
@@ -27,6 +28,10 @@ import createCheckoutClient from './create-checkout-client';
 import createCheckoutStore from './create-checkout-store';
 
 export default function createCheckoutService(options: CheckoutServiceOptions = {}): CheckoutService {
+    if (document.location.protocol !== 'https:') {
+        getDefaultLogger().warn('The BigCommerce Checkout SDK should not be used on a non-HTTPS page');
+    }
+
     const client = createCheckoutClient({ locale: options.locale });
     const store = createCheckoutStore({}, { shouldWarnMutation: options.shouldWarnMutation });
     const paymentClient = createPaymentClient(store);

--- a/src/common/log/index.ts
+++ b/src/common/log/index.ts
@@ -2,10 +2,16 @@ import ConsoleLogger from './console-logger';
 import Logger from './logger';
 import NoopLogger from './noop-logger';
 
+const logger = createLogger(process.env.NODE_ENV !== 'test');
+
 export function createLogger(isEnabled = true): Logger {
     if (!isEnabled) {
         return new NoopLogger();
     }
 
     return new ConsoleLogger(console);
+}
+
+export function getDefaultLogger(): Logger {
+    return logger;
 }

--- a/src/locale/create-language-service.ts
+++ b/src/locale/create-language-service.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '../common/log';
+import { getDefaultLogger } from '../common/log';
 
 import LanguageConfig from './language-config';
 import LanguageService from './language-service';
@@ -6,6 +6,6 @@ import LanguageService from './language-service';
 export default function createLanguageService(config: Partial<LanguageConfig> = {}): LanguageService {
     return new LanguageService(
         config,
-        createLogger(process.env.NODE_ENV !== 'test')
+        getDefaultLogger()
     );
 }


### PR DESCRIPTION
## What?
- Warn if the SDK is used on a non-HTTPS page

## Why?
- We collect sensitive information. It shouldn't be run through http. 

## Testing / Proof
- Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
