### PR TITLE
CHECKOUT-3044 Map subtotal value properly

### DIFF
--- a/src/cart/internal-carts.mock.js
+++ b/src/cart/internal-carts.mock.js
@@ -48,8 +48,8 @@ export function getCart() {
         ],
         currency: 'USD',
         subtotal: {
-            amount: 200,
-            integerAmount: 20000,
+            amount: 190,
+            integerAmount: 19000,
         },
         coupon: {
             discountedAmount: 10,

--- a/src/cart/map-to-internal-cart.ts
+++ b/src/cart/map-to-internal-cart.ts
@@ -41,8 +41,8 @@ export default function mapToInternalCart(checkout: Checkout): InternalCart {
             required: some(checkout.cart.lineItems.physicalItems, lineItem => lineItem.isShippingRequired),
         },
         subtotal: {
-            amount: checkout.cart.baseAmount,
-            integerAmount: amountTransformer.toInteger(checkout.cart.baseAmount),
+            amount: checkout.cart.cartAmount,
+            integerAmount: amountTransformer.toInteger(checkout.cart.cartAmount),
         },
         storeCredit: {
             amount: checkout.storeCredit,


### PR DESCRIPTION
## What?
Changes the mapping of `subTotal`

## Why?
Because it was using the incorrect one. 

## Testing / Proof
Unit
Manual

@bigcommerce/checkout @bigcommerce/payments
