### PR TITLE
CHECKOUT-3188 Rename coupon description to displayName

### DIFF
--- a/src/coupon/coupon.ts
+++ b/src/coupon/coupon.ts
@@ -1,6 +1,6 @@
 export default interface Coupon {
     id: string;
-    description: string;
+    displayName: string;
     code: string;
     couponType: string;
     discountedAmount: number;

--- a/src/coupon/coupons.mock.ts
+++ b/src/coupon/coupons.mock.ts
@@ -3,7 +3,7 @@ import Coupon from './coupon';
 export function getCoupon(): Coupon {
     return {
         code: 'savebig2015',
-        description: '20% off each item',
+        displayName: '20% off each item',
         couponType: 'percentage_discount',
         discountedAmount: 5,
         id: '1',
@@ -13,7 +13,7 @@ export function getCoupon(): Coupon {
 export function getShippingCoupon(): Coupon {
     return {
         code: '279F507D817E3E7',
-        description: '$5.00 off the shipping total',
+        displayName: '$5.00 off the shipping total',
         couponType: 'shipping_discount',
         discountedAmount: 5,
         id: '4',

--- a/src/coupon/map-to-internal-coupon.ts
+++ b/src/coupon/map-to-internal-coupon.ts
@@ -12,7 +12,7 @@ const couponTypes = [
 export default function mapToInternalCoupon(coupon: Coupon): InternalCoupon {
     return {
         code: coupon.code,
-        discount: coupon.description,
+        discount: coupon.displayName,
         discountType: couponTypes.indexOf(coupon.couponType),
     };
 }


### PR DESCRIPTION
## What?
Renames `description` to `displayName`

## Why?
So it matches new API schema.