### PR TITLE
CHECKOUT-3199 Add prefix to payment step when mapping to internal order

### DIFF
--- a/src/order/map-to-internal-order.ts
+++ b/src/order/map-to-internal-order.ts
@@ -93,7 +93,7 @@ function mapToInteralOrderPayment(payments?: OrderPayments): InternalOrderPaymen
 
     return {
         id: item.providerId,
-        status: item.detail.step,
+        status: `PAYMENT_STATUS_${item.detail.step}`,
         helpText: item.detail.instructions,
     };
 }

--- a/src/order/orders.mock.ts
+++ b/src/order/orders.mock.ts
@@ -52,7 +52,7 @@ export function getOrder(): Order {
                 description: 'credit-card',
                 amount: 190,
                 detail: {
-                    step: 'PAYMENT_STATUS_FINALIZE',
+                    step: 'FINALIZE',
                     instructions: '%%OrderID%% text %%OrderID%%',
                 },
             },


### PR DESCRIPTION
## What?
When mapping to internal order, add prefix to payment step.

## Why?
Because the prefix was dropped in Storefront API, but not internal API.