### PR TITLE
CHECKOUT-3211 Allow for consumers to set their own process.env.NODE_ENV

### DIFF
--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -3,6 +3,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { BillingAddressActionCreator } from '../billing';
 import { CartActionCreator } from '../cart';
 import { getDefaultLogger } from '../common/log';
+import { getEnvironment } from '../common/utility';
 import { ConfigActionCreator } from '../config';
 import { CouponActionCreator, GiftCertificateActionCreator } from '../coupon';
 import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '../customer';
@@ -46,6 +47,10 @@ import createCheckoutStore from './create-checkout-store';
 export default function createCheckoutService(options?: CheckoutServiceOptions): CheckoutService {
     if (document.location.protocol !== 'https:') {
         getDefaultLogger().warn('The BigCommerce Checkout SDK should not be used on a non-HTTPS page');
+    }
+
+    if (getEnvironment() !== 'production') {
+        getDefaultLogger().warn('Note that the development build is not optimized. To create a production build, set process.env.NODE_ENV to `production`.');
     }
 
     const { locale = '', shouldWarnMutation = true } = options || {};

--- a/src/common/log/index.ts
+++ b/src/common/log/index.ts
@@ -1,8 +1,10 @@
+import { getEnvironment } from '../utility';
+
 import ConsoleLogger from './console-logger';
 import Logger from './logger';
 import NoopLogger from './noop-logger';
 
-const logger = createLogger(process.env.NODE_ENV !== 'test');
+const logger = createLogger(getEnvironment() !== 'test');
 
 export function createLogger(isEnabled = true): Logger {
     if (!isEnabled) {

--- a/src/common/utility/get-environment.spec.ts
+++ b/src/common/utility/get-environment.spec.ts
@@ -1,0 +1,35 @@
+import { getEnvironment } from '.';
+
+describe('getEnvironment', () => {
+    let savedEnvironment;
+    let savedProcess;
+
+    beforeEach(() => {
+        savedEnvironment = process.env;
+        savedProcess = global.process;
+        process.env = {};
+    });
+
+    afterEach(() => {
+        process.env = savedEnvironment;
+        global.process = savedProcess;
+    });
+
+    it('returns the value set in process.env.NODE_ENV', () => {
+        global.process.env.NODE_ENV = 'test';
+
+        expect(getEnvironment()).toBe('test');
+    });
+
+    it('defaults to development if no value is set', () => {
+        global.process.env.NODE_ENV = undefined;
+
+        expect(getEnvironment()).toBe('development');
+    });
+
+    it('defaults to development if process is not defined', () => {
+        delete global.process;
+
+        expect(getEnvironment()).toBe('development');
+    });
+});

--- a/src/common/utility/get-environment.ts
+++ b/src/common/utility/get-environment.ts
@@ -1,0 +1,7 @@
+export default function getEnvironment() {
+    try {
+        return process.env.NODE_ENV || 'development';
+    } catch (e) {
+        return 'development';
+    }
+}

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -1,6 +1,7 @@
 export { default as bindDecorator } from './bind-decorator';
 export { default as createFreezeProxy, createFreezeProxies } from './create-freeze-proxy';
 export { default as CancellablePromise } from './cancellable-promise';
+export { default as getEnvironment } from './get-environment';
 export { default as mergeOrPush } from './merge-or-push';
 export { default as omitDeep } from './omit-deep';
 export { default as omitPrivate } from './omit-private';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,5 +53,8 @@ module.exports = [
         externals: [
             nodeExternals()
         ],
+        node: {
+            process: false,
+        },
     })
 ];


### PR DESCRIPTION
## What?
- As per title

## Why?
- To allow proper logging of warning messages depending on the environment.

## Testing / Proof
- Manual

@bigcommerce/checkout @bigcommerce/payments
