### PR TITLE
CHECKOUT-3183 Default to geoCountry when quote has no shipping address

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -33,9 +33,9 @@ export default function createInternalCheckoutSelectors(state: CheckoutStoreStat
     const order = new OrderSelector(state.order, state.customer, state.cart);
     const paymentMethods = new PaymentMethodSelector(state.paymentMethods, state.order);
     const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
-    const quote = new QuoteSelector(state.quote);
+    const shippingAddress = new ShippingAddressSelector(state.quote, state.config);
+    const quote = new QuoteSelector(state.quote, shippingAddress);
     const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);
-    const shippingAddress = new ShippingAddressSelector(state.quote);
     const shippingCountries = new ShippingCountrySelector(state.shippingCountries);
     const shippingOptions = new ShippingOptionSelector(state.shippingOptions, state.quote);
     const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -99,6 +99,7 @@ export interface CustomizationConfig {
 }
 
 export interface ContextConfig {
+    geoCountryCode: string;
     flashMessages: any[];
     payment: {
         token?: string;

--- a/src/config/configs.mock.js
+++ b/src/config/configs.mock.js
@@ -4,6 +4,7 @@ export function getConfig() {
     return {
         context: {
             flashMessages: [],
+            geoCountryCode: 'AU',
             payment: {
                 token: null,
             },

--- a/src/quote/internal-quote.ts
+++ b/src/quote/internal-quote.ts
@@ -4,5 +4,5 @@ export default interface InternalQuote {
     orderComment: string;
     shippingOption?: string;
     billingAddress: InternalAddress;
-    shippingAddress: InternalAddress;
+    shippingAddress?: InternalAddress;
 }

--- a/src/quote/map-to-internal-quote.ts
+++ b/src/quote/map-to-internal-quote.ts
@@ -8,6 +8,6 @@ export default function mapToInternalQuote(checkout: Checkout): InternalQuote {
         orderComment: checkout.customerMessage,
         shippingOption: checkout.consignments[0] ? checkout.consignments[0].selectedShippingOptionId : undefined,
         billingAddress: checkout.billingAddress ? mapToInternalAddress(checkout.billingAddress) : {} as InternalAddress,
-        shippingAddress: checkout.consignments[0] ? mapToInternalAddress(checkout.consignments[0].shippingAddress, checkout.consignments[0].id) : {} as InternalAddress,
+        shippingAddress: checkout.consignments[0] ? mapToInternalAddress(checkout.consignments[0].shippingAddress, checkout.consignments[0].id) : undefined,
     };
 }

--- a/src/quote/quote-selector.spec.js
+++ b/src/quote/quote-selector.spec.js
@@ -1,22 +1,33 @@
 import { getQuoteState } from './internal-quotes.mock';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 import QuoteSelector from './quote-selector';
+import { ShippingAddressSelector } from '../shipping';
+import { getConfig } from '../config/configs.mock';
 
 describe('QuoteSelector', () => {
     let quoteSelector;
+    let shippingAddressSelector;
     let state;
 
     beforeEach(() => {
         state = {
             quote: getQuoteState(),
+            config: getConfig(),
         };
+
+        shippingAddressSelector = new ShippingAddressSelector(state.quote, state.config);
+        quoteSelector = new QuoteSelector(state.quote, shippingAddressSelector);
     });
 
     describe('#getQuote()', () => {
         it('returns the current quote', () => {
-            quoteSelector = new QuoteSelector(state.quote);
+            expect(quoteSelector.getQuote())
+                .toEqual(state.quote.data);
+        });
 
-            expect(quoteSelector.getQuote()).toEqual(state.quote.data);
+        it('returns the same instance as the shipping selector', () => {
+            expect(quoteSelector.getQuote().shippingAddress)
+                .toBe(shippingAddressSelector.getShippingAddress());
         });
     });
 
@@ -27,14 +38,12 @@ describe('QuoteSelector', () => {
             quoteSelector = new QuoteSelector({
                 ...state.quote,
                 errors: { loadError },
-            });
+            }, shippingAddressSelector);
 
             expect(quoteSelector.getLoadError()).toEqual(loadError);
         });
 
         it('does not returns error if able to load', () => {
-            quoteSelector = new QuoteSelector(state.quote);
-
             expect(quoteSelector.getLoadError()).toBeUndefined();
         });
     });
@@ -44,14 +53,12 @@ describe('QuoteSelector', () => {
             quoteSelector = new QuoteSelector({
                 ...state.quote,
                 statuses: { isLoading: true },
-            });
+            }, shippingAddressSelector);
 
             expect(quoteSelector.isLoading()).toEqual(true);
         });
 
         it('returns false if not loading quote', () => {
-            quoteSelector = new QuoteSelector(state.quote);
-
             expect(quoteSelector.isLoading()).toEqual(false);
         });
     });

--- a/src/quote/quote-selector.ts
+++ b/src/quote/quote-selector.ts
@@ -1,4 +1,5 @@
 import { selector } from '../common/selector';
+import { ShippingAddressSelector } from '../shipping';
 
 import InternalQuote from './internal-quote';
 import QuoteState from './quote-state';
@@ -6,11 +7,19 @@ import QuoteState from './quote-state';
 @selector
 export default class QuoteSelector {
     constructor(
-        private _quote: QuoteState
+        private _quote: QuoteState,
+        private _shippingAddressSelector: ShippingAddressSelector
     ) {}
 
     getQuote(): InternalQuote | undefined {
-        return this._quote.data;
+        if (!this._quote.data) {
+            return;
+        }
+
+        return {
+            ...this._quote.data,
+            shippingAddress: this._shippingAddressSelector.getShippingAddress(),
+        };
     }
 
     getLoadError(): Error | undefined {

--- a/src/shipping/shipping-address-selector.spec.js
+++ b/src/shipping/shipping-address-selector.spec.js
@@ -1,5 +1,6 @@
 import { getQuoteState } from '../quote/internal-quotes.mock';
 import ShippingAddressSelector from './shipping-address-selector';
+import { getConfigState } from '../config/configs.mock';
 
 describe('ShippingAddressSelector', () => {
     let shippingAddressSelector;
@@ -7,21 +8,52 @@ describe('ShippingAddressSelector', () => {
 
     beforeEach(() => {
         state = {
+            config: getConfigState(),
             quote: getQuoteState(),
         };
     });
 
     describe('#getShippingAddress()', () => {
         it('returns the current shipping address', () => {
-            shippingAddressSelector = new ShippingAddressSelector(state.quote);
+            shippingAddressSelector = new ShippingAddressSelector(state.quote, state.config);
 
             expect(shippingAddressSelector.getShippingAddress()).toEqual(state.quote.data.shippingAddress);
         });
 
         it('returns undefined if quote is not available', () => {
-            shippingAddressSelector = new ShippingAddressSelector({ ...state.quote, data: undefined });
+            shippingAddressSelector = new ShippingAddressSelector({ ...state.quote, data: undefined }, state.config);
 
             expect(shippingAddressSelector.getShippingAddress()).toEqual();
+        });
+
+        describe('when there is no shipping information', () => {
+            beforeEach(() => {
+                state = {
+                    quote: { data: {} },
+                    config: getConfigState(),
+                };
+            });
+
+            it('returns the current shipping address', () => {
+                shippingAddressSelector = new ShippingAddressSelector(state.quote, state.config);
+
+                expect(shippingAddressSelector.getShippingAddress().countryCode).toEqual('AU');
+            });
+        });
+
+        describe('when there is no shipping neither config information', () => {
+            beforeEach(() => {
+                state = {
+                    quote: { data: {} },
+                    config: { data: {} },
+                };
+            });
+
+            it('returns undefined', () => {
+                shippingAddressSelector = new ShippingAddressSelector(state.quote, state.config);
+
+                expect(shippingAddressSelector.getShippingAddress()).toBeUndefined();
+            });
         });
     });
 });

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -3,13 +3,41 @@ import { selector } from '../common/selector';
 import { InternalAddress } from '../address';
 import { QuoteState } from '../quote';
 
+import ConfigState from '../config/config-state';
+
 @selector
 export default class ShippingAddressSelector {
     constructor(
-        private _quote: QuoteState
+        private _quote: QuoteState,
+        private _config: ConfigState
     ) {}
 
     getShippingAddress(): InternalAddress | undefined {
-        return this._quote.data && this._quote.data.shippingAddress;
+        const quote = this._quote.data;
+        const context = this._config.data && this._config.data.context;
+
+        if (quote
+            && !quote.shippingAddress
+            && context
+            && context.geoCountryCode
+        ) {
+            return {
+                firstName: '',
+                lastName: '',
+                company: '',
+                addressLine1: '',
+                addressLine2: '',
+                city: '',
+                province: '',
+                provinceCode: '',
+                postCode: '',
+                country: '',
+                phone: '',
+                customFields: [],
+                countryCode: context.geoCountryCode,
+            };
+        }
+
+        return quote && quote.shippingAddress;
     }
 }


### PR DESCRIPTION
## What?
Default to geoCountry when quote has no shipping address

## Why?
To support automatic selecting country based on shopper's IP

## Testing / Proof
manual
unit
