### PR TITLE
CHECKOUT-3072 Update address keys to match new API schema

### DIFF
--- a/src/checkout/checkout-store-selector.spec.js
+++ b/src/checkout/checkout-store-selector.spec.js
@@ -74,19 +74,19 @@ describe('CheckoutStoreSelector', () => {
 
     it('returns shipping address fields', () => {
         const results = selector.getShippingAddressFields('AU');
-        const predicate = ({ name }) => name === 'province' || name === 'provinceCode' || name === 'countryCode';
+        const predicate = ({ name }) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
 
         expect(reject(results, predicate)).toEqual(reject(getFormFields(), predicate));
-        expect(find(results, { name: 'provinceCode' }).options.items)
+        expect(find(results, { name: 'stateOrProvinceCode' }).options.items)
             .toEqual(getAustralia().subdivisions.map(({ code, name }) => ({ label: name, value: code })));
     });
 
     it('returns billing address fields', () => {
         const results = selector.getBillingAddressFields('US');
-        const predicate = ({ name }) => name === 'province' || name === 'provinceCode' || name === 'countryCode';
+        const predicate = ({ name }) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
 
         expect(reject(results, predicate)).toEqual(reject(getFormFields(), predicate));
-        expect(find(results, { name: 'provinceCode' }).options.items)
+        expect(find(results, { name: 'stateOrProvinceCode' }).options.items)
             .toEqual(getUnitedStates().subdivisions.map(({ code, name }) => ({ label: name, value: code })));
     });
 });

--- a/src/form/form-selector.spec.js
+++ b/src/form/form-selector.spec.js
@@ -50,7 +50,7 @@ describe('FormSelector', () => {
 
         it('includes the provinces for the selected country', () => {
             const forms = formSelector.getShippingAddressFields(countries, 'AU');
-            const province = find(forms, { name: 'provinceCode' });
+            const province = find(forms, { name: 'stateOrProvinceCode' });
 
             expect(province.required).toBe(true);
             expect(province.fieldType).toBe('dropdown');
@@ -61,7 +61,7 @@ describe('FormSelector', () => {
 
         it('does not make provinces required if we do not have them in the countries list', () => {
             const forms = formSelector.getShippingAddressFields(countries, 'JP');
-            const province = find(forms, { name: 'province' });
+            const province = find(forms, { name: 'stateOrProvince' });
 
             expect(province.required).toBe(false);
             expect(province.fieldType).not.toBe('dropdown');
@@ -69,14 +69,14 @@ describe('FormSelector', () => {
 
         it('makes postcode required for countries that require it', () => {
             const forms = formSelector.getShippingAddressFields(countries, 'AU');
-            const postCode = find(forms, { name: 'postCode' });
+            const postCode = find(forms, { name: 'postalCode' });
 
             expect(postCode.required).toBe(true);
         });
 
         it('makes postcode NOT required for countries that DO NOT require it', () => {
             const forms = formSelector.getShippingAddressFields(countries, 'JP');
-            const postCode = find(forms, { name: 'postCode' });
+            const postCode = find(forms, { name: 'postalCode' });
 
             expect(postCode.required).toBe(false);
         });
@@ -119,7 +119,7 @@ describe('FormSelector', () => {
 
         it('includes the provinces for the selected country', () => {
             const forms = formSelector.getBillingAddressFields(countries, 'AU');
-            const province = find(forms, { name: 'provinceCode' });
+            const province = find(forms, { name: 'stateOrProvinceCode' });
 
             expect(province.required).toBe(true);
             expect(province.fieldType).toBe('dropdown');
@@ -131,7 +131,7 @@ describe('FormSelector', () => {
 
         it('does not make provinces required if we do not have them in the countries list', () => {
             const forms = formSelector.getBillingAddressFields(countries, 'JP');
-            const province = find(forms, { name: 'province' });
+            const province = find(forms, { name: 'stateOrProvince' });
 
             expect(province.required).toBe(false);
             expect(province.fieldType).not.toBe('dropdown');
@@ -139,14 +139,14 @@ describe('FormSelector', () => {
 
         it('makes postcode required for countries that require it', () => {
             const forms = formSelector.getBillingAddressFields(countries, 'AU');
-            const postCode = find(forms, { name: 'postCode' });
+            const postCode = find(forms, { name: 'postalCode' });
 
             expect(postCode.required).toBe(true);
         });
 
         it('makes postcode NOT required for countries that DO NOT require it', () => {
             const forms = formSelector.getBillingAddressFields(countries, 'JP');
-            const postCode = find(forms, { name: 'postCode' });
+            const postCode = find(forms, { name: 'postalCode' });
 
             expect(postCode.required).toBe(false);
         });

--- a/src/form/form-selector.ts
+++ b/src/form/form-selector.ts
@@ -31,11 +31,11 @@ export default class FormSelector {
             return this._processCountry(field, countries, selectedCountry);
         }
 
-        if (field.name === 'province') {
+        if (field.name === 'stateOrProvince') {
             return this._processProvince(field, selectedCountry);
         }
 
-        if (field.name === 'postCode') {
+        if (field.name === 'postalCode') {
             return this._processsPostCode(field, selectedCountry);
         }
 
@@ -80,7 +80,7 @@ export default class FormSelector {
 
         return {
             ...field,
-            name: 'provinceCode',
+            name: 'stateOrProvinceCode',
             options: { items },
             required: true,
             type: 'array',

--- a/src/form/form.mocks.js
+++ b/src/form/form.mocks.js
@@ -32,14 +32,14 @@ export function getFormFields() {
         default: '',
     }, {
         id: 'field_8',
-        name: 'addressLine1',
+        name: 'address1',
         custom: false,
         label: 'Address Line 1',
         required: true,
         default: '',
     }, {
         id: 'field_9',
-        name: 'addressLine2',
+        name: 'address2',
         custom: false,
         label: 'Address Line 2',
         required: false,
@@ -60,14 +60,14 @@ export function getFormFields() {
         default: null,
     }, {
         id: 'field_12',
-        name: 'province',
+        name: 'stateOrProvince',
         custom: false,
         label: 'State/Province',
         required: true,
         default: null,
     }, {
         id: 'field_13',
-        name: 'postCode',
+        name: 'postalCode',
         custom: false,
         label: 'Zip/Postcode',
         required: true,


### PR DESCRIPTION
## What?
Update addresses key

## Why?
To properly handle form changes after API changes

## Testing / Proof
- [x] manual
- [x] functional https://ci.solanolabs.com/reports/4933109#report-tab=test-result

@bigcommerce/checkout @bigcommerce/payments
