### PR TITLE
CHECKOUT-3072 Use prepare instead of preinstall in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-sdk-js",
   "scripts": {
-    "preinstall": "npx check-node-version --node 6 --npm 6",
+    "prepare": "npx check-node-version --node 6 --npm 6",
     "prebuild": "npm run lint && npm test",
     "build": "npm run bundle && npm run bundle-dts",
     "prebundle": "rm -rf dist",


### PR DESCRIPTION
## What?
Use `prepare` instead of `preinstall`

## Why?
Because that was the initial intention. We want to check node 6 when installing dependencies, not when SDK is being installed as a dependency.

## Testing / Proof
manual

@bigcommerce/checkout @bigcommerce/payments
