### PR TITLE
CHECKOUT-3044 Fix subtotal mapping

### DIFF
--- a/src/cart/map-to-internal-cart.ts
+++ b/src/cart/map-to-internal-cart.ts
@@ -41,8 +41,8 @@ export default function mapToInternalCart(checkout: Checkout): InternalCart {
             required: some(checkout.cart.lineItems.physicalItems, lineItem => lineItem.isShippingRequired),
         },
         subtotal: {
-            amount: checkout.cart.cartAmount,
-            integerAmount: amountTransformer.toInteger(checkout.cart.cartAmount),
+            amount: checkout.subtotal,
+            integerAmount: amountTransformer.toInteger(checkout.subtotal),
         },
         storeCredit: {
             amount: checkout.storeCredit,

--- a/src/checkout/checkout.ts
+++ b/src/checkout/checkout.ts
@@ -22,6 +22,7 @@ export default interface Checkout {
     shippingCostBeforeDiscount: number;
     handlingCostTotal: number;
     taxTotal: number;
+    subtotal: number;
     grandTotal: number;
     storeCredit: number;
     giftCertificates: GiftCertificate[];

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -43,6 +43,7 @@ export function getCheckout(): Checkout {
         shippingCostBeforeDiscount: 20,
         handlingCostTotal: 8,
         taxTotal: 0,
+        subtotal: 190,
         grandTotal: 190,
         storeCredit: 0,
         giftCertificates: [


### PR DESCRIPTION
## What?
Fix subtotal mapping

## Why?
Because storefront API now returns a new subtotal field that is the appropriate one.

@bigcommerce/checkout 
