### PR TITLE
CHECKOUT-3044 Request all includes in other request senders

### DIFF
--- a/src/checkout/checkout-default-includes.ts
+++ b/src/checkout/checkout-default-includes.ts
@@ -1,0 +1,9 @@
+const DEFAULT_INCLUDES = [
+    'cart.lineItems.physicalItems.options',
+    'cart.lineItems.digitalItems.options',
+    'customer',
+    'payments',
+    'promotions.banners',
+];
+
+export default DEFAULT_INCLUDES;

--- a/src/checkout/checkout-request-sender.ts
+++ b/src/checkout/checkout-request-sender.ts
@@ -3,6 +3,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 import { ContentType, RequestOptions } from '../common/http-request';
 
 import Checkout from './checkout';
+import CheckoutDefaultIncludes from './checkout-default-includes';
 import CheckoutParams from './checkout-params';
 
 export default class CheckoutRequestSender {
@@ -13,17 +14,10 @@ export default class CheckoutRequestSender {
     loadCheckout(id: string, { params, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkout/${id}`;
         const headers = { Accept: ContentType.JsonV1 };
-        const defaultIncludes = [
-            'cart.lineItems.physicalItems.options',
-            'cart.lineItems.digitalItems.options',
-            'customer',
-            'payments',
-            'promotions.banners',
-        ];
 
         return this._requestSender.get(url, {
             params: {
-                include: defaultIncludes.concat(params && params.include || []).join(','),
+                include: CheckoutDefaultIncludes.concat(params && params.include || []).join(','),
             },
             headers,
             timeout,

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -1,6 +1,7 @@
 export * from './checkout-actions';
 
 export { default as Checkout, CheckoutPayment } from './checkout';
+export { default as CheckoutDefaultIncludes } from './checkout-default-includes';
 export { default as CheckoutActionCreator } from './checkout-action-creator';
 export { default as CheckoutClient } from './checkout-client';
 export { default as CheckoutParams } from './checkout-params';

--- a/src/coupon/coupon-request-sender.spec.js
+++ b/src/coupon/coupon-request-sender.spec.js
@@ -7,6 +7,13 @@ import CouponRequestSender from './coupon-request-sender';
 describe('Coupon Request Sender', () => {
     let couponRequestSender;
     let requestSender;
+    const defaultIncludes = [
+        'cart.lineItems.physicalItems.options',
+        'cart.lineItems.digitalItems.options',
+        'customer',
+        'payments',
+        'promotions.banners',
+    ].join(',');
 
     beforeEach(() => {
         requestSender = {
@@ -34,6 +41,9 @@ describe('Coupon Request Sender', () => {
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons', {
                 body: { couponCode },
+                params: {
+                    include: defaultIncludes,
+                },
                 headers: {
                     Accept: ContentType.JsonV1,
                 },
@@ -51,6 +61,9 @@ describe('Coupon Request Sender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons', {
                 ...options,
                 body: { couponCode },
+                params: {
+                    include: defaultIncludes,
+                },
                 headers: {
                     Accept: ContentType.JsonV1,
                 },
@@ -70,6 +83,9 @@ describe('Coupon Request Sender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                 },
+                params: {
+                    include: defaultIncludes,
+                },
             });
         });
 
@@ -85,6 +101,9 @@ describe('Coupon Request Sender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
+                },
+                params: {
+                    include: defaultIncludes,
                 },
             });
         });

--- a/src/coupon/coupon-request-sender.ts
+++ b/src/coupon/coupon-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { Checkout } from '../checkout';
+import { Checkout, CheckoutDefaultIncludes } from '../checkout';
 import { ContentType, RequestOptions } from '../common/http-request';
 
 export default class CouponRequestSender {
@@ -12,13 +12,26 @@ export default class CouponRequestSender {
         const url = `/api/storefront/checkouts/${checkoutId}/coupons`;
         const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.post(url, { headers, timeout, body: { couponCode } });
+        return this._requestSender.post(url, {
+            headers,
+            timeout,
+            params: {
+                include: CheckoutDefaultIncludes.join(','),
+            },
+            body: { couponCode },
+        });
     }
 
     removeCoupon(checkoutId: string, couponCode: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/coupons/${couponCode}`;
         const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.delete(url, { headers, timeout });
+        return this._requestSender.delete(url, {
+            headers,
+            timeout,
+            params: {
+                include: CheckoutDefaultIncludes.join(','),
+            },
+        });
     }
 }

--- a/src/coupon/gift-certificate-request-sender.spec.ts
+++ b/src/coupon/gift-certificate-request-sender.spec.ts
@@ -9,6 +9,13 @@ import { getGiftCertificateResponseBody } from './internal-gift-certificates.moc
 describe('Gift Certificate Request Sender', () => {
     let giftCertificateRequestSender: GiftCertificateRequestSender;
     let requestSender;
+    const defaultIncludes = [
+        'cart.lineItems.physicalItems.options',
+        'cart.lineItems.digitalItems.options',
+        'customer',
+        'payments',
+        'promotions.banners',
+    ].join(',');
 
     beforeEach(() => {
         requestSender = {
@@ -39,6 +46,9 @@ describe('Gift Certificate Request Sender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                 },
+                params: {
+                    include: defaultIncludes,
+                },
             });
         });
 
@@ -57,6 +67,9 @@ describe('Gift Certificate Request Sender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                 },
+                params: {
+                    include: defaultIncludes,
+                },
             });
         });
     });
@@ -73,6 +86,9 @@ describe('Gift Certificate Request Sender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                 },
+                params: {
+                    include: defaultIncludes,
+                },
             });
         });
 
@@ -88,6 +104,9 @@ describe('Gift Certificate Request Sender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
+                },
+                params: {
+                    include: defaultIncludes,
                 },
             });
         });

--- a/src/coupon/gift-certificate-request-sender.ts
+++ b/src/coupon/gift-certificate-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { Checkout } from '../checkout';
+import { Checkout, CheckoutDefaultIncludes } from '../checkout';
 import { ContentType, RequestOptions } from '../common/http-request';
 
 export default class GiftCertificateRequestSender {
@@ -12,13 +12,26 @@ export default class GiftCertificateRequestSender {
         const url = `/api/storefront/checkouts/${checkoutId}/gift-certificates`;
         const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.post(url, { headers, timeout, body: { giftCertificateCode } });
+        return this._requestSender.post(url, {
+            headers,
+            timeout,
+            params: {
+                include: CheckoutDefaultIncludes.join(','),
+            },
+            body: { giftCertificateCode },
+        });
     }
 
     removeGiftCertificate(checkoutId: string, giftCertificateCode: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/gift-certificates/${giftCertificateCode}`;
         const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.delete(url, { headers, timeout });
+        return this._requestSender.delete(url, {
+            headers,
+            timeout,
+            params: {
+                include: CheckoutDefaultIncludes.join(','),
+            },
+        });
     }
 }


### PR DESCRIPTION
## What?
Request all includes when adding/deleting a GC/Coupon

## Why?
Because otherwise cart comparator can fail if any of those actions are performed near the end of checkout.

Probably should readdress this later on.

## Testing / Proof
unit
manual

@bigcommerce/checkout @bigcommerce/payments
