### PR TITLE
CHECKOUT-3214: Fix PayPal Express cart and checkout flow.

### DIFF
--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -7,7 +7,7 @@ import { StoreConfig } from '../config/config';
 import { CustomerSelector, InternalCustomer } from '../customer';
 import { FormField, FormSelector } from '../form';
 import { Country, CountrySelector } from '../geography';
-import { InternalOrder, OrderSelector } from '../order';
+import { InternalIncompleteOrder, InternalOrder, OrderSelector } from '../order';
 import { PaymentMethod, PaymentMethodSelector } from '../payment';
 import { Instrument, InstrumentSelector } from '../payment/instrument';
 import { InternalQuote, QuoteSelector } from '../quote';
@@ -90,7 +90,7 @@ export default class CheckoutStoreSelector {
      *
      * @returns The current order if it is loaded, otherwise undefined.
      */
-    getOrder(): InternalOrder | undefined {
+    getOrder(): InternalOrder | InternalIncompleteOrder | undefined {
         return this._order.getOrder();
     }
 

--- a/src/checkout/checkout.ts
+++ b/src/checkout/checkout.ts
@@ -33,6 +33,9 @@ export default interface Checkout {
 }
 
 export interface CheckoutPayment {
+    detail: {
+        step: string;
+    };
     providerId: string;
     providerType: string;
     gatewayId?: string;

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -72,6 +72,9 @@ export function getCheckoutWithPayments(): Checkout {
                 providerId: getPaymentMethod().id,
                 gatewayId: getPaymentMethod().gateway,
                 providerType: HOSTED,
+                detail: {
+                    step: 'ACKNOWLEDGE',
+                },
             },
         ],
     };

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -2,7 +2,7 @@ export * from './internal-order-responses';
 export * from './order-actions';
 
 export { default as Order } from './order';
-export { default as InternalOrder } from './internal-order';
+export { default as InternalOrder, InternalIncompleteOrder } from './internal-order';
 export { default as InternalOrderRequestBody } from './internal-order-request-body';
 
 export { default as OrderActionCreator } from './order-action-creator';

--- a/src/order/internal-order.ts
+++ b/src/order/internal-order.ts
@@ -50,6 +50,12 @@ export default interface InternalOrder {
     callbackUrl?: string;
 }
 
+export interface InternalIncompleteOrder {
+    isComplete: false;
+    orderId: null;
+    payment: InternalOrderPayment;
+}
+
 export interface InternalGiftCertificateList {
     totalDiscountedAmount: number;
     appliedGiftCertificates: { [code: string]: InternalGiftCertificate };
@@ -62,10 +68,6 @@ export interface InternalOrderPayment {
     returnUrl?: string;
     status?: string;
     helpText?: string;
-    detail?: {
-        step: string;
-        instructions: string;
-    };
 }
 
 export interface InternalOrderMeta {

--- a/src/order/map-to-internal-order.spec.ts
+++ b/src/order/map-to-internal-order.spec.ts
@@ -1,10 +1,27 @@
+import { getCheckoutWithPayments } from '../checkout/checkouts.mock';
+
 import { getCompleteOrder as getInternalOrder } from './internal-orders.mock';
-import mapToInternalOrder from './map-to-internal-order';
+import mapToInternalOrder, { mapToInternalIncompleteOrder } from './map-to-internal-order';
 import { getOrder } from './orders.mock';
 
 describe('mapToInternalOrder()', () => {
     it('maps to internal line items', () => {
-        expect(mapToInternalOrder(getOrder(), getInternalOrder()))
+        expect(mapToInternalOrder(getOrder()))
             .toEqual(getInternalOrder());
+    });
+});
+
+describe('mapToInternalIncompleteOrder()', () => {
+    it('maps to internal incomplete order', () => {
+        expect(mapToInternalIncompleteOrder(getCheckoutWithPayments()))
+            .toEqual({
+                isComplete: false,
+                orderId: null,
+                payment: {
+                    gateway: null,
+                    id: 'authorizenet',
+                    status: 'PAYMENT_STATUS_ACKNOWLEDGE',
+                },
+            });
     });
 });

--- a/src/order/order-reducer.spec.js
+++ b/src/order/order-reducer.spec.js
@@ -1,6 +1,10 @@
-import { getCompleteOrderResponseBody, getSubmitOrderResponseBody, getSubmitOrderResponseHeaders } from './internal-orders.mock';
-import { getOrder } from './orders.mock';
+import { CheckoutActionType } from '../checkout';
+import { getCheckoutWithPayments } from '../checkout/checkouts.mock';
 import { getErrorResponse } from '../common/http-request/responses.mock';
+
+import { getCompleteOrderResponseBody, getSubmitOrderResponseBody, getSubmitOrderResponseHeaders } from './internal-orders.mock';
+import { mapToInternalIncompleteOrder } from './map-to-internal-order';
+import { getOrder } from './orders.mock';
 import { OrderActionType } from './order-actions';
 import orderReducer from './order-reducer';
 
@@ -47,6 +51,17 @@ describe('orderReducer()', () => {
         expect(orderReducer(initialState, action)).toEqual(expect.objectContaining({
             errors: { loadError: action.payload },
             statuses: { isLoading: false },
+        }));
+    });
+
+    it('returns new data if checkout is fetched successfully', () => {
+        const action = {
+            type: CheckoutActionType.LoadCheckoutSucceeded,
+            payload: getCheckoutWithPayments(),
+        };
+
+        expect(orderReducer(initialState, action)).toEqual(expect.objectContaining({
+            data: mapToInternalIncompleteOrder(action.payload),
         }));
     });
 

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -1,7 +1,9 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
-import InternalOrder from './internal-order';
-import mapToInternalOrder from './map-to-internal-order';
+import { CheckoutAction, CheckoutActionType } from '../checkout';
+
+import InternalOrder, { InternalIncompleteOrder } from './internal-order';
+import mapToInternalOrder, { mapToInternalIncompleteOrder } from './map-to-internal-order';
 import { OrderAction, OrderActionType } from './order-actions';
 import OrderState, { OrderErrorsState, OrderMetaState, OrderStatusesState } from './order-state';
 
@@ -13,7 +15,7 @@ const DEFAULT_STATE: OrderState = {
 
 export default function orderReducer(
     state: OrderState = DEFAULT_STATE,
-    action: OrderAction
+    action: OrderAction | CheckoutAction
 ): OrderState {
     const reducer = combineReducers<OrderState>({
         data: dataReducer,
@@ -26,12 +28,15 @@ export default function orderReducer(
 }
 
 function dataReducer(
-    data: InternalOrder | undefined,
-    action: OrderAction
-): InternalOrder | undefined {
+    data: InternalOrder | InternalIncompleteOrder | undefined,
+    action: OrderAction | CheckoutAction
+): InternalOrder | InternalIncompleteOrder | undefined {
     switch (action.type) {
     case OrderActionType.LoadOrderSucceeded:
-        return action.payload ? mapToInternalOrder(action.payload) : data;
+        return action.payload ? { ...data, ...mapToInternalOrder(action.payload) } : data;
+
+    case CheckoutActionType.LoadCheckoutSucceeded:
+        return action.payload ? { ...data, ...mapToInternalIncompleteOrder(action.payload) } : data;
 
     case OrderActionType.FinalizeOrderSucceeded:
     case OrderActionType.SubmitOrderSucceeded:

--- a/src/order/order-selector.ts
+++ b/src/order/order-selector.ts
@@ -4,7 +4,7 @@ import { CustomerState } from '../customer';
 import { PaymentMethod } from '../payment';
 import * as paymentStatusTypes from '../payment/payment-status-types';
 
-import InternalOrder, { InternalOrderMeta, InternalOrderPayment } from './internal-order';
+import InternalOrder, { InternalIncompleteOrder, InternalOrderMeta, InternalOrderPayment } from './internal-order';
 import OrderState from './order-state';
 
 @selector
@@ -15,7 +15,7 @@ export default class OrderSelector {
         private _cart: CartState
     ) {}
 
-    getOrder(): InternalOrder | undefined {
+    getOrder(): InternalOrder | InternalIncompleteOrder | undefined {
         return this._order.data;
     }
 

--- a/src/order/order-state.ts
+++ b/src/order/order-state.ts
@@ -1,7 +1,7 @@
-import InternalOrder, { InternalOrderMeta, InternalOrderPayment } from './internal-order';
+import InternalOrder, { InternalIncompleteOrder, InternalOrderMeta, InternalOrderPayment } from './internal-order';
 
 export default interface OrderState {
-    data?: InternalOrder;
+    data?: InternalOrder | InternalIncompleteOrder;
     meta?: OrderMetaState;
     errors: OrderErrorsState;
     statuses: OrderStatusesState;

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -1,5 +1,6 @@
 export * from './payment-request-options';
 export * from './payment-method-responses';
+export * from './payment-method-types';
 
 export { default as createPaymentClient } from './create-payment-client';
 export { default as createPaymentStrategyRegistry } from './create-payment-strategy-registry';

--- a/src/payment/strategies/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite-payment-strategy.ts
@@ -42,9 +42,7 @@ export default class OffsitePaymentStrategy extends PaymentStrategy {
 
         const { orderId, payment = {} } = order;
 
-        if (orderId &&
-            payment.status === paymentStatusTypes.ACKNOWLEDGE ||
-            payment.status === paymentStatusTypes.FINALIZE) {
+        if (orderId && (payment.status === paymentStatusTypes.ACKNOWLEDGE || payment.status === paymentStatusTypes.FINALIZE)) {
             return this._store.dispatch(this._orderActionCreator.finalizeOrder(orderId, options));
         }
 

--- a/src/payment/strategies/paypal-express-payment-strategy.ts
+++ b/src/payment/strategies/paypal-express-payment-strategy.ts
@@ -110,9 +110,9 @@ export default class PaypalExpressPaymentStrategy extends PaymentStrategy {
             throw new MissingDataError('Unable to finalize order because "order" data is missing.');
         }
 
-        if (order.orderId &&
-            this._getPaymentStatus() === paymentStatusTypes.ACKNOWLEDGE ||
-            this._getPaymentStatus() === paymentStatusTypes.FINALIZE) {
+        const status = this._getPaymentStatus();
+
+        if (order.orderId && (status === paymentStatusTypes.ACKNOWLEDGE || status === paymentStatusTypes.FINALIZE)) {
             return this._store.dispatch(this._orderActionCreator.finalizeOrder(order.orderId, options));
         }
 


### PR DESCRIPTION
## What?
* Restore mapping for `InternalIncompleteOrder`.
* This is a temporary solution. I'll introduce a proper fix when we remove all the mappers. Since we move to storefront API, the payment status flag has come from three different places - storefront checkout, storefront order and internal order endpoints. Therefore it'd be good to centralise everything regarding payment so there is a single source of truth.

## Why?
* PayPal Express wasn't working because the payment status flag was not available. Previously with internal API, the payment status was a part of the quote response, under `order` object. However, the storefront checkout API no longer provides the order object. Therefore, we need to find a way to map it back to the original schema.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
