### PR TITLE
CHECKOUT-3170: Remove engine requirement for consumers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+This document is still work in progress. We will add more information to the
+document in the near future.
+
+## Development
+
+### System requirement
+
+Please ensure you have the following software installed.
+
+* NodeJS `>=6`
+* NPM `>=6`

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "dist/",
     "docs/"
   ],
-  "engines": {
-    "node": "^6.10.0"
-  },
   "tsdoc": {
     "tsdocFlavor": "AEDoc"
   },
@@ -26,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/checkout-sdk-js",
   "scripts": {
-    "prepare": "npx check-node-version --node 6 --npm 6",
+    "prepare": "check-node-version --node '>=6' --npm '>=6'",
     "prebuild": "npm run lint && npm test",
     "build": "npm run bundle && npm run bundle-dts",
     "prebundle": "rm -rf dist",


### PR DESCRIPTION
## What?
* Remove engine requirement when consuming the package.
* Remove `npx` from `prepare` script as it is redundant.

## Why?
* This is because the `engine` field also affects consumers who are using the package - not just for developers maintaining the package.
* `prepare` script also gets run if the consumer installs the package via Github. Therefore, if the consumer doesn't have `npx` available, the installation will fail.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
