### PR TITLE
CHECKOUT-3053: Remove cart mapper from reducer

### DIFF
--- a/src/cart/cart-comparator.spec.js
+++ b/src/cart/cart-comparator.spec.js
@@ -1,4 +1,4 @@
-import { getCart } from './internal-carts.mock';
+import { getCart } from './carts.mock';
 import CartComparator from './cart-comparator';
 
 describe('CartComparator', () => {
@@ -27,18 +27,14 @@ describe('CartComparator', () => {
             const cartA = getCart();
             const cartB = {
                 ...cartA,
-                items: [
-                    {
-                        ...cartA.items[0],
-                        id: '22e11c8f-7dce-4da3-9413-b649533f8bad',
-                        imageUrl: '/images/canvas-laundry-cart-2.jpg',
-                    },
-                    {
-                        ...cartA.items[1],
-                        id: '22e11c8f-7dce-4da3-9413-b649533f8bad',
-                        imageUrl: '/images/canvas-laundry-cart-2.jpg',
-                    },
-                ],
+                lineItems: {
+                    ...cartA.lineItems,
+                    physicalItems: cartA.lineItems.physicalItems.map(item => ({
+                        ...item,
+                        id: `${item.id}123`,
+                        imageUrl: `${item.imageUrl}123`,
+                    })),
+                },
             };
 
             expect(comparator.isEqual(cartA, cartB)).toEqual(true);

--- a/src/cart/cart-reducer.spec.js
+++ b/src/cart/cart-reducer.spec.js
@@ -2,12 +2,11 @@ import { BillingAddressActionTypes } from '../billing/billing-address-actions';
 import { CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { CouponActionType } from '../coupon/coupon-actions';
-import { getCustomerResponseBody } from '../customer/internal-customers.mock';
-import { ConsignmentActionTypes } from '../shipping/consignment-actions';
-import cartReducer from './cart-reducer';
-import { getCart } from './internal-carts.mock';
 import { GiftCertificateActionType } from '../coupon/gift-certificate-actions';
-import { CustomerActionType } from '../customer';
+import { ConsignmentActionTypes } from '../shipping';
+
+import cartReducer from './cart-reducer';
+import { getCart } from './carts.mock';
 
 describe('cartReducer()', () => {
     let initialState;
@@ -16,28 +15,6 @@ describe('cartReducer()', () => {
         initialState = {
             data: getCart(),
         };
-    });
-
-    it('returns new data if customer has signed in successfully', () => {
-        const action = {
-            type: CustomerActionType.SignInCustomerRequested,
-            payload: getCustomerResponseBody().data,
-        };
-
-        expect(cartReducer(initialState, action)).toEqual(expect.objectContaining({
-            data: action.payload.cart,
-        }));
-    });
-
-    it('returns new data if customer has signed out successfully', () => {
-        const action = {
-            type: CustomerActionType.SignOutCustomerSucceeded,
-            payload: getCustomerResponseBody().data,
-        };
-
-        expect(cartReducer(initialState, action)).toEqual(expect.objectContaining({
-            data: action.payload.cart,
-        }));
     });
 
     it('returns new data when checkout is loaded', () => {

--- a/src/cart/cart-reducer.ts
+++ b/src/cart/cart-reducer.ts
@@ -4,13 +4,10 @@ import { BillingAddressAction, BillingAddressActionTypes } from '../billing/bill
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { CouponAction, CouponActionType } from '../coupon/coupon-actions';
 import { GiftCertificateAction, GiftCertificateActionType } from '../coupon/gift-certificate-actions';
-import { CustomerAction, CustomerActionType } from '../customer';
 import { ConsignmentAction, ConsignmentActionTypes } from '../shipping/consignment-actions';
 
 import Cart from './cart';
 import CartState, { CartErrorsState, CartStatusesState } from './cart-state';
-import InternalCart from './internal-cart';
-import mapToInternalCart from './map-to-internal-cart';
 
 const DEFAULT_STATE: CartState = {
     errors: {},
@@ -23,7 +20,6 @@ export default function cartReducer(
 ): CartState {
     const reducer = combineReducers<CartState>({
         data: dataReducer,
-        externalData: externalDataReducer,
         errors: errorsReducer,
         statuses: statusesReducer,
     });
@@ -32,9 +28,9 @@ export default function cartReducer(
 }
 
 function dataReducer(
-    data: InternalCart | undefined,
-    action: BillingAddressAction | CheckoutAction | ConsignmentAction | CouponAction | GiftCertificateAction | CustomerAction
-): InternalCart | undefined {
+    data: Cart | undefined,
+    action: BillingAddressAction | CheckoutAction | ConsignmentAction | CouponAction | GiftCertificateAction
+): Cart | undefined {
     switch (action.type) {
     case BillingAddressActionTypes.UpdateBillingAddressSucceeded:
     case CheckoutActionType.LoadCheckoutSucceeded:
@@ -44,21 +40,7 @@ function dataReducer(
     case CouponActionType.RemoveCouponSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
-        return action.payload ? { ...data, ...mapToInternalCart(action.payload) } : data;
-
-    case CustomerActionType.SignInCustomerSucceeded:
-    case CustomerActionType.SignOutCustomerSucceeded:
         return action.payload ? { ...data, ...action.payload.cart } : data;
-
-    default:
-        return data;
-    }
-}
-
-function externalDataReducer(data: Cart | undefined, action: Action): Cart | undefined {
-    switch (action.type) {
-    case CheckoutActionType.LoadCheckoutSucceeded:
-        return { ...data, ...action.payload.cart };
 
     default:
         return data;

--- a/src/cart/cart-selector.ts
+++ b/src/cart/cart-selector.ts
@@ -1,7 +1,7 @@
 import { selector } from '../common/selector';
 
+import Cart from './cart';
 import CartState from './cart-state';
-import InternalCart from './internal-cart';
 
 @selector
 export default class CartSelector {
@@ -9,7 +9,7 @@ export default class CartSelector {
         private _cart: CartState
     ) {}
 
-    getCart(): InternalCart | undefined {
+    getCart(): Cart | undefined {
         return this._cart.data;
     }
 

--- a/src/cart/cart-state.ts
+++ b/src/cart/cart-state.ts
@@ -1,9 +1,7 @@
 import Cart from './cart';
-import InternalCart from './internal-cart';
 
 export default interface CartState {
-    data?: InternalCart;
-    externalData?: Cart;
+    data?: Cart;
     errors: CartErrorsState;
     statuses: CartStatusesState;
 }

--- a/src/cart/carts.mock.ts
+++ b/src/cart/carts.mock.ts
@@ -1,4 +1,4 @@
-import { Cart } from '../cart';
+import { Cart, CartState } from '../cart';
 import { getCoupon, getShippingCoupon } from '../coupon/coupons.mock';
 import { getCurrency } from '../currency/currencies.mock';
 import { getDiscount } from '../discount/discounts.mock';
@@ -33,5 +33,13 @@ export function getCart(): Cart {
         },
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
+    };
+}
+
+export function getCartState(): CartState {
+    return {
+        data: getCart(),
+        errors: {},
+        statuses: {},
     };
 }

--- a/src/checkout/checkout-actions.ts
+++ b/src/checkout/checkout-actions.ts
@@ -8,7 +8,9 @@ export enum CheckoutActionType {
     LoadCheckoutFailed = 'LOAD_CHECKOUT_FAILED',
 }
 
-export type CheckoutAction =
+export type CheckoutAction = LoadCheckoutAction;
+
+export type LoadCheckoutAction =
     LoadCheckoutRequestedAction |
     LoadCheckoutSucceededAction |
     LoadCheckoutFailedAction;

--- a/src/checkout/checkout-client.spec.js
+++ b/src/checkout/checkout-client.spec.js
@@ -2,7 +2,6 @@ import { createTimeout } from '@bigcommerce/request-sender';
 import { getConfig } from '../config/configs.mock';
 import { getResponse } from '../common/http-request/responses.mock';
 import { getBillingAddress } from '../billing/internal-billing-addresses.mock';
-import { getCart } from '../cart/internal-carts.mock';
 import { getCompleteOrder } from '../order/internal-orders.mock';
 import { getCheckout } from './checkouts.mock';
 import { getCountries } from '../geography/countries.mock';
@@ -15,7 +14,6 @@ import { getConsignmentRequestBody } from '../shipping/consignments.mock';
 describe('CheckoutClient', () => {
     let client;
     let billingAddressRequestSender;
-    let cartRequestSender;
     let configRequestSender;
     let countryRequestSender;
     let customerRequestSender;
@@ -29,10 +27,6 @@ describe('CheckoutClient', () => {
         billingAddressRequestSender = {
             updateAddress: jest.fn(() => Promise.resolve(getResponse(getCheckout()))),
             createAddress: jest.fn(() => Promise.resolve(getResponse(getCheckout()))),
-        };
-
-        cartRequestSender = {
-            loadCart: jest.fn(() => Promise.resolve(getResponse(getCart()))),
         };
 
         configRequestSender = {
@@ -79,7 +73,6 @@ describe('CheckoutClient', () => {
 
         client = new CheckoutClient(
             billingAddressRequestSender,
-            cartRequestSender,
             configRequestSender,
             consignmentRequestSender,
             countryRequestSender,
@@ -192,23 +185,6 @@ describe('CheckoutClient', () => {
 
             expect(output).toEqual(getResponse(getPaymentMethod()));
             expect(paymentMethodRequestSender.loadPaymentMethod).toHaveBeenCalledWith('braintree', options);
-        });
-    });
-
-    describe('#loadCart()', () => {
-        it('loads cart', async () => {
-            const output = await client.loadCart();
-
-            expect(output).toEqual(getResponse(getCart()));
-            expect(cartRequestSender.loadCart).toHaveBeenCalled();
-        });
-
-        it('loads cart with timeout', async () => {
-            const options = { timeout: createTimeout() };
-            const output = await client.loadCart(options);
-
-            expect(output).toEqual(getResponse(getCart()));
-            expect(cartRequestSender.loadCart).toHaveBeenCalledWith(options);
         });
     });
 

--- a/src/checkout/checkout-client.ts
+++ b/src/checkout/checkout-client.ts
@@ -2,7 +2,6 @@ import { Response } from '@bigcommerce/request-sender';
 
 import { AddressRequestBody } from '../address';
 import { BillingAddressRequestSender } from '../billing';
-import { CartRequestSender } from '../cart';
 import { RequestOptions } from '../common/http-request';
 import { Config, ConfigRequestSender } from '../config';
 import { CustomerCredentials, CustomerRequestSender } from '../customer';
@@ -23,7 +22,6 @@ export default class CheckoutClient {
      */
     constructor(
         private _billingAddressRequestSender: BillingAddressRequestSender,
-        private _cartRequestSender: CartRequestSender,
         private _configRequestSender: ConfigRequestSender,
         private _consignmentRequestSender: ConsignmentRequestSender,
         private _countryRequestSender: CountryRequestSender,
@@ -36,10 +34,6 @@ export default class CheckoutClient {
 
     loadQuote(options?: RequestOptions): Promise<Response> {
         return this._quoteRequestSender.loadQuote(options);
-    }
-
-    loadCart(options?: RequestOptions): Promise<Response> {
-        return this._cartRequestSender.loadCart(options);
     }
 
     loadOrder(orderId: number, options?: RequestOptions): Promise<Response<Order>> {

--- a/src/checkout/checkout-selector.ts
+++ b/src/checkout/checkout-selector.ts
@@ -17,6 +17,13 @@ export default class CheckoutSelector {
         return this._checkout.errors.loadError;
     }
 
+    isPaymentDataRequired(useStoreCredit: boolean = false): boolean {
+        const grandTotal = this._checkout.data && this._checkout.data.grandTotal || 0;
+        const storeCredit = this._checkout.data && this._checkout.data.customer.storeCredit || 0;
+
+        return (useStoreCredit ? grandTotal - storeCredit : grandTotal) > 0;
+    }
+
     isLoading(): boolean {
         return this._checkout.statuses.isLoading === true;
     }

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -524,6 +524,19 @@ export default class CheckoutService {
     }
 
     /**
+     * @deprecated This method has been renamed to `continueAsGuest`.
+     * @param credentials - The guest credentials to use.
+     * @param options - Options for continuing as a guest.
+     * @returns A promise that resolves to the current state.
+     */
+    signInGuest(credentials: GuestCredentials, options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._billingAddressActionCreator.updateAddress(credentials, options);
+
+        return this._store.dispatch(action)
+            .then(() => this.getState());
+    }
+
+    /**
      * Continues to check out as a guest.
      *
      * The customer is required to provide their email address in order to
@@ -534,7 +547,7 @@ export default class CheckoutService {
      * @param options - Options for continuing as a guest.
      * @returns A promise that resolves to the current state.
      */
-    signInGuest(credentials: GuestCredentials, options?: RequestOptions): Promise<CheckoutSelectors> {
+    continueAsGuest(credentials: GuestCredentials, options?: RequestOptions): Promise<CheckoutSelectors> {
         const action = this._billingAddressActionCreator.updateAddress(credentials, options);
 
         return this._store.dispatch(action)

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -1,6 +1,6 @@
 import { InternalAddress } from '../address';
 import { BillingAddressSelector } from '../billing';
-import { CartSelector, InternalCart } from '../cart';
+import { mapToInternalCart, InternalCart } from '../cart';
 import { selector } from '../common/selector';
 import { ConfigSelector } from '../config';
 import { StoreConfig } from '../config/config';
@@ -32,7 +32,6 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
 @selector
 export default class CheckoutStoreSelector {
     private _billingAddress: BillingAddressSelector;
-    private _cart: CartSelector;
     private _checkout: CheckoutSelector;
     private _config: ConfigSelector;
     private _countries: CountrySelector;
@@ -52,7 +51,6 @@ export default class CheckoutStoreSelector {
      */
     constructor(selectors: InternalCheckoutSelectors) {
         this._billingAddress = selectors.billingAddress;
-        this._cart = selectors.cart;
         this._checkout = selectors.checkout;
         this._config = selectors.config;
         this._countries = selectors.countries;
@@ -214,7 +212,9 @@ export default class CheckoutStoreSelector {
      * @returns The current cart object if it is loaded, otherwise undefined.
      */
     getCart(): InternalCart | undefined {
-        return this._cart.getCart();
+        const checkout = this._checkout.getCheckout();
+
+        return checkout ? mapToInternalCart(checkout) : undefined;
     }
 
     /**

--- a/src/checkout/create-checkout-client.ts
+++ b/src/checkout/create-checkout-client.ts
@@ -1,7 +1,6 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { BillingAddressRequestSender } from '../billing';
-import { CartRequestSender } from '../cart';
 import { ConfigRequestSender } from '../config';
 import { CustomerRequestSender } from '../customer';
 import { CountryRequestSender } from '../geography';
@@ -16,7 +15,6 @@ export default function createCheckoutClient(config: { locale?: string } = {}): 
     const requestSender = createRequestSender();
 
     const billingAddressRequestSender = new BillingAddressRequestSender(requestSender);
-    const cartRequestSender = new CartRequestSender(requestSender);
     const configRequestSender = new ConfigRequestSender(requestSender);
     const consignmentRequestSender = new ConsignmentRequestSender(requestSender);
     const countryRequestSender = new CountryRequestSender(requestSender, config);
@@ -28,7 +26,6 @@ export default function createCheckoutClient(config: { locale?: string } = {}): 
 
     return new CheckoutClient(
         billingAddressRequestSender,
-        cartRequestSender,
         configRequestSender,
         consignmentRequestSender,
         countryRequestSender,

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -8,7 +8,7 @@ import { createBraintreeVisaCheckoutPaymentProcessor, VisaCheckoutScriptLoader }
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
 
-import { CustomerStrategyActionCreator } from '.';
+import { CustomerRequestSender, CustomerStrategyActionCreator } from '.';
 import CustomerActionCreator from './customer-action-creator';
 import {
     AmazonPayCustomerStrategy,
@@ -24,6 +24,7 @@ export default function createCustomerStrategyRegistry(
     const registry = new Registry<CustomerStrategy>();
     const requestSender = createRequestSender();
     const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(requestSender);
+    const checkoutActionCreator = new CheckoutActionCreator(new CheckoutRequestSender(requestSender));
 
     registry.register('amazon', () =>
         new AmazonPayCustomerStrategy(
@@ -38,7 +39,7 @@ export default function createCustomerStrategyRegistry(
     registry.register('braintreevisacheckout', () =>
         new BraintreeVisaCheckoutCustomerStrategy(
             store,
-            new CheckoutActionCreator(new CheckoutRequestSender(requestSender)),
+            checkoutActionCreator,
             new PaymentMethodActionCreator(client),
             new CustomerStrategyActionCreator(registry),
             new RemoteCheckoutActionCreator(remoteCheckoutRequestSender),
@@ -50,7 +51,10 @@ export default function createCustomerStrategyRegistry(
     registry.register('default', () =>
         new DefaultCustomerStrategy(
             store,
-            new CustomerActionCreator(client)
+            new CustomerActionCreator(
+                new CustomerRequestSender(requestSender),
+                checkoutActionCreator
+            )
         )
     );
 

--- a/src/customer/customer-action-creator.ts
+++ b/src/customer/customer-action-creator.ts
@@ -1,45 +1,65 @@
-import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { RequestOptions } from '@bigcommerce/request-sender';
+import { concat } from 'rxjs/observable/concat';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
-import { CheckoutClient } from '../checkout';
+import { CheckoutActionCreator, InternalCheckoutSelectors, LoadCheckoutAction } from '../checkout';
 
 import { CustomerActionType, SignInCustomerAction, SignOutCustomerAction } from './customer-actions';
 import CustomerCredentials from './customer-credentials';
+import CustomerRequestSender from './customer-request-sender';
 
 export default class CustomerActionCreator {
     constructor(
-        private _checkoutClient: CheckoutClient
+        private _customerRequestSender: CustomerRequestSender,
+        private _checkoutActionCreator: CheckoutActionCreator
     ) {}
 
-    signInCustomer(credentials: CustomerCredentials, options?: RequestOptions): Observable<SignInCustomerAction> {
-        return Observable.create((observer: Observer<Action>) => {
-            observer.next(createAction(CustomerActionType.SignInCustomerRequested));
+    signInCustomer(
+        credentials: CustomerCredentials,
+        options?: RequestOptions
+    ): ThunkAction<SignInCustomerAction | LoadCheckoutAction, InternalCheckoutSelectors> {
+        return store => {
+            const signInAction = new Observable((observer: Observer<SignInCustomerAction>) => {
+                observer.next(createAction(CustomerActionType.SignInCustomerRequested));
 
-            this._checkoutClient.signInCustomer(credentials, options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(CustomerActionType.SignInCustomerSucceeded, body.data));
-                    observer.complete();
-                })
-                .catch(response => {
-                    observer.error(createErrorAction(CustomerActionType.SignInCustomerFailed, response));
-                });
-        });
+                this._customerRequestSender.signInCustomer(credentials, options)
+                    .then(({ body }) => {
+                        observer.next(createAction(CustomerActionType.SignInCustomerSucceeded, body.data));
+                        observer.complete();
+                    })
+                    .catch(response => {
+                        observer.error(createErrorAction(CustomerActionType.SignInCustomerFailed, response));
+                    });
+            });
+
+            const loadCheckoutAction = this._checkoutActionCreator.loadCurrentCheckout(options)(store);
+
+            return concat(signInAction, loadCheckoutAction);
+        };
     }
 
-    signOutCustomer(options?: RequestOptions): Observable<SignOutCustomerAction> {
-        return Observable.create((observer: Observer<SignOutCustomerAction>) => {
-            observer.next(createAction(CustomerActionType.SignOutCustomerRequested));
+    signOutCustomer(
+        options?: RequestOptions
+    ): ThunkAction<SignOutCustomerAction | LoadCheckoutAction, InternalCheckoutSelectors> {
+        return store => {
+            const signOutAction = new Observable((observer: Observer<SignOutCustomerAction>) => {
+                observer.next(createAction(CustomerActionType.SignOutCustomerRequested));
 
-            this._checkoutClient.signOutCustomer(options)
-                .then(({ body = {} }) => {
-                    observer.next(createAction(CustomerActionType.SignOutCustomerSucceeded, body.data));
-                    observer.complete();
-                })
-                .catch(response => {
-                    observer.error(createErrorAction(CustomerActionType.SignOutCustomerFailed, response));
-                });
-        });
+                this._customerRequestSender.signOutCustomer(options)
+                    .then(({ body }) => {
+                        observer.next(createAction(CustomerActionType.SignOutCustomerSucceeded, body.data));
+                        observer.complete();
+                    })
+                    .catch(response => {
+                        observer.error(createErrorAction(CustomerActionType.SignOutCustomerFailed, response));
+                    });
+            });
+
+            const loadCheckoutAction = this._checkoutActionCreator.loadCurrentCheckout(options)(store);
+
+            return concat(signOutAction, loadCheckoutAction);
+        };
     }
 }

--- a/src/customer/customer-reducer.ts
+++ b/src/customer/customer-reducer.ts
@@ -15,7 +15,7 @@ export default function customerReducer(
     state: CustomerState = DEFAULT_STATE,
     action: CheckoutAction | BillingAddressAction | CustomerAction | OrderAction
 ): CustomerState {
-    const reducer = combineReducers<any>({
+    const reducer = combineReducers<CustomerState, CheckoutAction | BillingAddressAction | CustomerAction | OrderAction>({
         data: dataReducer,
     });
 

--- a/src/customer/customer-request-sender.spec.js
+++ b/src/customer/customer-request-sender.spec.js
@@ -34,7 +34,7 @@ describe('CustomerRequestSender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', {
                 body: credentials,
                 params: {
-                    includes: 'cart,quote,shippingOptions',
+                    includes: 'quote,shippingOptions',
                 },
             });
         });
@@ -48,7 +48,7 @@ describe('CustomerRequestSender', () => {
                 ...options,
                 body: credentials,
                 params: {
-                    includes: 'cart,quote,shippingOptions',
+                    includes: 'quote,shippingOptions',
                 },
             });
         });
@@ -69,7 +69,7 @@ describe('CustomerRequestSender', () => {
             expect(output).toEqual(response);
             expect(requestSender.delete).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', {
                 params: {
-                    includes: 'cart,quote,shippingOptions',
+                    includes: 'quote,shippingOptions',
                 },
             });
         });
@@ -82,7 +82,7 @@ describe('CustomerRequestSender', () => {
             expect(requestSender.delete).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', {
                 ...options,
                 params: {
-                    includes: 'cart,quote,shippingOptions',
+                    includes: 'quote,shippingOptions',
                 },
             });
         });

--- a/src/customer/customer-request-sender.ts
+++ b/src/customer/customer-request-sender.ts
@@ -13,7 +13,7 @@ export default class CustomerRequestSender {
     signInCustomer(credentials: CustomerCredentials, { timeout }: RequestOptions = {}): Promise<Response<InternalCustomerResponseBody>> {
         const url = '/internalapi/v1/checkout/customer';
         const params = {
-            includes: ['cart', 'quote', 'shippingOptions'].join(','),
+            includes: ['quote', 'shippingOptions'].join(','),
         };
 
         return this._requestSender.post(url, { params, timeout, body: credentials });
@@ -22,7 +22,7 @@ export default class CustomerRequestSender {
     signOutCustomer({ timeout }: RequestOptions = {}): Promise<Response<InternalCustomerResponseBody>> {
         const url = '/internalapi/v1/checkout/customer';
         const params = {
-            includes: ['cart', 'quote', 'shippingOptions'].join(','),
+            includes: ['quote', 'shippingOptions'].join(','),
         };
 
         return this._requestSender.delete(url, { params, timeout });

--- a/src/customer/customer-strategy-action-creator.spec.ts
+++ b/src/customer/customer-strategy-action-creator.spec.ts
@@ -1,10 +1,12 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
-import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutClient, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
 
 import createCustomerStrategyRegistry from './create-customer-strategy-registry';
 import CustomerActionCreator from './customer-action-creator';
+import CustomerRequestSender from './customer-request-sender';
 import CustomerStrategyActionCreator from './customer-strategy-action-creator';
 import { CustomerStrategyActionType } from './customer-strategy-actions';
 import { CustomerStrategy, DefaultCustomerStrategy } from './strategies';
@@ -21,7 +23,12 @@ describe('CustomerStrategyActionCreator', () => {
         registry = createCustomerStrategyRegistry(store, client);
         strategy = new DefaultCustomerStrategy(
             store,
-            new CustomerActionCreator(client)
+            new CustomerActionCreator(
+                new CustomerRequestSender(createRequestSender()),
+                new CheckoutActionCreator(
+                    new CheckoutRequestSender(createRequestSender())
+                )
+            )
         );
 
         jest.spyOn(registry, 'get')

--- a/src/customer/internal-customer-responses.ts
+++ b/src/customer/internal-customer-responses.ts
@@ -1,4 +1,3 @@
-import { InternalCart } from '../cart';
 import { InternalResponseBody } from '../common/http-request';
 import { InternalQuote } from '../quote';
 import { InternalShippingOptionList } from '../shipping';
@@ -8,7 +7,6 @@ import InternalCustomer from './internal-customer';
 export type InternalCustomerResponseBody = InternalResponseBody<InternalCustomerResponseData>;
 
 export interface InternalCustomerResponseData {
-    cart: InternalCart;
     customer: InternalCustomer;
     quote: InternalQuote;
     shippingOptions: InternalShippingOptionList;

--- a/src/customer/strategies/braintree-visacheckout-customer-strategy.ts
+++ b/src/customer/strategies/braintree-visacheckout-customer-strategy.ts
@@ -38,11 +38,11 @@ export default class BraintreeVisaCheckoutCustomerStrategy extends CustomerStrat
             .then(state => {
                 this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
 
-                const cart = state.cart.getCart();
+                const checkout = state.checkout.getCheckout();
                 const storeConfig = state.config.getStoreConfig();
 
-                if (!cart || !storeConfig || !this._paymentMethod || !this._paymentMethod.clientToken) {
-                    throw new MissingDataError('Unable to prepare payment data because "cart", "config" or "paymentMethod (Visa Checkout)" data is missing.');
+                if (!checkout || !storeConfig || !this._paymentMethod || !this._paymentMethod.clientToken) {
+                    throw new MissingDataError('Unable to prepare payment data because "checkout", "config" or "paymentMethod (Visa Checkout)" data is missing.');
                 }
 
                 const {
@@ -53,7 +53,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy extends CustomerStrat
                 const initOptions = {
                     locale: storeConfig.storeProfile.storeLanguage,
                     collectShipping: true,
-                    subtotal: cart.subtotal.amount,
+                    subtotal: checkout.subtotal,
                     currencyCode: storeConfig.currency.code,
                 };
 

--- a/src/customer/strategies/default-customer-strategy.spec.ts
+++ b/src/customer/strategies/default-customer-strategy.spec.ts
@@ -1,22 +1,27 @@
 import { createAction } from '@bigcommerce/data-store';
+import { createRequestSender } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
-import { CustomerActionType } from '..';
-import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutClient, CheckoutRequestSender, CheckoutStore } from '../../checkout';
 import { getQuote } from '../../quote/internal-quotes.mock';
 import CustomerActionCreator from '../customer-action-creator';
+import { CustomerActionType } from '../customer-actions';
+import CustomerRequestSender from '../customer-request-sender';
 
 import DefaultCustomerStrategy from './default-customer-strategy';
 
 describe('DefaultCustomerStrategy', () => {
     let customerActionCreator: CustomerActionCreator;
-    let client: CheckoutClient;
     let store: CheckoutStore;
 
     beforeEach(() => {
         store = createCheckoutStore();
-        client = createCheckoutClient();
-        customerActionCreator = new CustomerActionCreator(client);
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender())
+            )
+        );
     });
 
     it('dispatches action to sign in customer', async () => {

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -54,9 +54,9 @@ export default class OrderActionCreator {
                 observer.next(createAction(OrderActionType.SubmitOrderRequested));
 
                 const state = store.getState();
-                const cart = state.cart.getCart();
+                const checkout = state.checkout.getCheckout();
 
-                this._checkoutValidator.validate(cart, options)
+                this._checkoutValidator.validate(checkout, options)
                     .then(() => this._checkoutClient.submitOrder(this._mapToOrderRequestBody(payload), options))
                     .then(response => {
                         observer.next(createAction(OrderActionType.SubmitOrderSucceeded, response.body.data, { ...response.body.meta, token: response.headers.token }));

--- a/src/order/order-selector.spec.js
+++ b/src/order/order-selector.spec.js
@@ -22,7 +22,7 @@ describe('OrderSelector', () => {
 
     describe('#getOrder()', () => {
         it('returns the current order', () => {
-            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order);
 
             expect(orderSelector.getOrder()).toEqual(order);
         });
@@ -30,7 +30,7 @@ describe('OrderSelector', () => {
 
     describe('#getOrderMeta()', () => {
         it('returns order meta', () => {
-            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order);
 
             expect(orderSelector.getOrderMeta()).toEqual(getSubmittedOrderState().meta);
         });
@@ -43,13 +43,13 @@ describe('OrderSelector', () => {
             orderSelector = new OrderSelector({
                 ...state.order,
                 errors: { loadError },
-            }, state.payment, state.customer, state.cart);
+            });
 
             expect(orderSelector.getLoadError()).toEqual(loadError);
         });
 
         it('does not returns error if able to load', () => {
-            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order);
 
             expect(orderSelector.getLoadError()).toBeUndefined();
         });
@@ -60,13 +60,13 @@ describe('OrderSelector', () => {
             orderSelector = new OrderSelector({
                 ...state.order,
                 statuses: { isLoading: true },
-            }, state.payment, state.customer, state.cart);
+            });
 
             expect(orderSelector.isLoading()).toEqual(true);
         });
 
         it('returns false if not loading order', () => {
-            orderSelector = new OrderSelector(state.order, state.customer, state.cart);
+            orderSelector = new OrderSelector(state.order);
 
             expect(orderSelector.isLoading()).toEqual(false);
         });

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -4,6 +4,7 @@ import { concat } from 'rxjs/observable/concat';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
+import { mapToInternalCart } from '../cart';
 import { InternalCheckoutSelectors } from '../checkout';
 import { MissingDataError } from '../common/error/errors';
 import { mapToInternalOrder, OrderActionCreator } from '../order';
@@ -62,7 +63,7 @@ export default class PaymentActionCreator {
 
     private _getPaymentRequestBody(payment: Payment, state: InternalCheckoutSelectors): PaymentRequestBody {
         const billingAddress = state.billingAddress.getBillingAddress();
-        const cart = state.cart.getCart();
+        const checkout = state.checkout.getCheckout();
         const customer = state.customer.getCustomer();
         const order = state.order.getOrder();
         const paymentMethod = this._getPaymentMethod(payment, state.paymentMethods);
@@ -83,15 +84,13 @@ export default class PaymentActionCreator {
         return {
             authToken,
             billingAddress,
-            cart,
             customer,
             paymentMethod,
             shippingAddress,
             shippingOption,
+            cart: checkout ? mapToInternalCart(checkout) : undefined,
             order: order ? mapToInternalOrder(order) : undefined,
-            orderMeta: pick(state.order.getOrderMeta(), [
-                'deviceFingerprint',
-            ]),
+            orderMeta: state.order.getOrderMeta(),
             payment: payment.paymentData,
             quoteMeta: {
                 request: paymentMeta && paymentMeta.request,

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -291,8 +291,6 @@ describe('PaymentStrategyActionCreator', () => {
 
             try {
                 await Observable.from(actionCreator.execute(getOrderRequestBody())(store)).toPromise();
-
-                expect(true).toBe(true);
             } catch (error) {
                 expect(error).toBeInstanceOf(MissingDataError);
             }

--- a/src/payment/strategies/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay-payment-strategy.ts
@@ -75,7 +75,7 @@ export default class AfterpayPaymentStrategy extends PaymentStrategy {
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.initializePayment(paymentId, { useStoreCredit, customerMessage })
         )
-            .then(state => this._checkoutValidator.validate(state.cart.getCart(), options))
+            .then(state => this._checkoutValidator.validate(state.checkout.getCheckout(), options))
             .then(() => this._store.dispatch(
                 this._paymentMethodActionCreator.loadPaymentMethod(paymentId, options)
             ))

--- a/src/payment/strategies/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.spec.ts
@@ -8,7 +8,7 @@ import { BillingAddressActionCreator } from '../../billing';
 import { BillingAddressActionTypes } from '../../billing/billing-address-actions';
 import { getBillingAddress } from '../../billing/billing-addresses.mock';
 import { getCartResponseBody } from '../../cart/internal-carts.mock';
-import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore } from '../../checkout';
+import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { NotInitializedError, RequestError } from '../../common/error/errors';
 import { getErrorResponse, getResponse } from '../../common/http-request/responses.mock';
 import { getRemoteCustomer } from '../../customer/internal-customers.mock';
@@ -89,7 +89,10 @@ describe('AmazonPayPaymentStrategy', () => {
             remoteCheckout: getRemoteCheckoutState(),
         });
         billingAddressActionCreator = new BillingAddressActionCreator(client);
-        orderActionCreator = new OrderActionCreator(client);
+        orderActionCreator = new OrderActionCreator(
+            client,
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+        );
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
             new RemoteCheckoutRequestSender(createRequestSender())
         );
@@ -125,9 +128,6 @@ describe('AmazonPayPaymentStrategy', () => {
 
             return Promise.resolve();
         });
-
-        jest.spyOn(client, 'loadCart')
-            .mockReturnValue(Promise.resolve(getResponse(getCartResponseBody())));
 
         jest.spyOn(orderActionCreator, 'submitOrder')
             .mockReturnValue(submitOrderAction);

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -92,15 +92,15 @@ export default class BraintreeCreditCardPaymentStrategy extends PaymentStrategy 
             return Promise.resolve(payment as Payment);
         }
 
-        const cart = state.cart.getCart();
+        const checkout = state.checkout.getCheckout();
         const billingAddress = state.billingAddress.getBillingAddress();
 
-        if (!cart || !billingAddress) {
-            throw new MissingDataError('Unable to prepare payment data because "cart" and "billingAddress" data is missing.');
+        if (!checkout || !billingAddress) {
+            throw new MissingDataError('Unable to prepare payment data because "checkout" and "billingAddress" data is missing.');
         }
 
         const tokenizedCard = this._is3dsEnabled ?
-            this._braintreePaymentProcessor.verifyCard(payment, billingAddress, cart.grandTotal.amount) :
+            this._braintreePaymentProcessor.verifyCard(payment, billingAddress, checkout.grandTotal) :
             this._braintreePaymentProcessor.tokenizeCard(payment, billingAddress);
 
         return this._braintreePaymentProcessor.appendSessionId(tokenizedCard)

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -82,14 +82,13 @@ export default class BraintreePaypalPaymentStrategy extends PaymentStrategy {
 
     private _preparePaymentData(payment: OrderPaymentRequestBody): Promise<Payment> {
         const state = this._store.getState();
-        const cart = state.cart.getCart();
+        const checkout = state.checkout.getCheckout();
         const config = state.config.getStoreConfig();
 
-        if (!cart || !config || !this._paymentMethod) {
-            throw new MissingDataError(`Unable to prepare payment data because "cart", "config" or "paymentMethod (${payment.methodId})" data is missing.`);
+        if (!checkout || !config || !this._paymentMethod) {
+            throw new MissingDataError(`Unable to prepare payment data because "checkout", "config" or "paymentMethod (${payment.methodId})" data is missing.`);
         }
 
-        const { amount } = cart.grandTotal;
         const { currency, storeProfile: { storeLanguage } } = config;
         const { method, nonce } = this._paymentMethod;
 
@@ -98,7 +97,7 @@ export default class BraintreePaypalPaymentStrategy extends PaymentStrategy {
         }
 
         const tokenizedCard = this._braintreePaymentProcessor
-            .paypal(amount, storeLanguage, currency.code, this._credit);
+            .paypal(checkout.grandTotal, storeLanguage, currency.code, this._credit);
 
         return this._braintreePaymentProcessor.appendSessionId(tokenizedCard)
             .then(paymentData => ({ ...payment, paymentData: { ...paymentData, method } }));

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
@@ -41,10 +41,10 @@ export default class BraintreeVisaCheckoutPaymentStrategy extends PaymentStrateg
             .then(state => {
                 this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
 
-                const cart = state.cart.getCart();
+                const checkout = state.checkout.getCheckout();
                 const storeConfig = state.config.getStoreConfig();
 
-                if (!cart || !storeConfig || !this._paymentMethod || !this._paymentMethod.clientToken) {
+                if (!checkout || !storeConfig || !this._paymentMethod || !this._paymentMethod.clientToken) {
                     throw new MissingDataError(`Unable to prepare payment data because "cart", "config" or "paymentMethod (Visa Checkout)" data is missing.`);
                 }
 
@@ -56,7 +56,7 @@ export default class BraintreeVisaCheckoutPaymentStrategy extends PaymentStrateg
                 const initOptions = {
                     locale: storeConfig.storeProfile.storeLanguage,
                     collectShipping: false,
-                    subtotal: cart.subtotal.amount,
+                    subtotal: checkout.subtotal,
                     currencyCode: storeConfig.currency.code,
                 };
 

--- a/src/payment/strategies/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna-payment-strategy.ts
@@ -29,9 +29,9 @@ export default class KlarnaPaymentStrategy extends PaymentStrategy {
                 this._unsubscribe = this._store.subscribe(
                     () => this._loadWidget(options),
                     state => {
-                        const cart = state.cart.getCart();
+                        const checkout = state.checkout.getCheckout();
 
-                        return cart && cart.grandTotal;
+                        return checkout && checkout.grandTotal;
                     }
                 );
 

--- a/src/shipping/consignment-action-creator.spec.js
+++ b/src/shipping/consignment-action-creator.spec.js
@@ -1,13 +1,13 @@
 import { createTimeout } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
-import { getCartState } from '../cart/internal-carts.mock';
-import { createCheckoutStore } from '../checkout';
-import { CheckoutActionType } from '../checkout/checkout-actions';
+import { getCartState } from '../cart/carts.mock';
+import { createCheckoutStore, CheckoutActionType } from '../checkout';
 import { getCheckout, getCheckoutState } from '../checkout/checkouts.mock';
 import { MissingDataError } from '../common/error/errors';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import { getQuoteState } from '../quote/internal-quotes.mock';
+
 import ConsignmentActionCreator from './consignment-action-creator';
 import { ConsignmentActionTypes } from './consignment-actions';
 import { getShippingAddress } from './internal-shipping-addresses.mock';

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -77,7 +77,7 @@ export default class ConsignmentActionCreator {
             const checkout = store.getState().checkout.getCheckout();
 
             if (!consignments || !checkout || !checkout.id) {
-                throw new MissingDataError('Unable to update shipping address: "checkout.id" or "cart.lineItems" are missing.');
+                throw new MissingDataError('Unable to update shipping address: "checkout.id" is missing.');
             }
 
             observer.next(createAction(ConsignmentActionTypes.CreateConsignmentsRequested));
@@ -100,14 +100,13 @@ export default class ConsignmentActionCreator {
         const state = store.getState();
         const cart = state.cart.getCart();
 
-        if (!cart || !cart.items) {
+        if (!cart) {
             return;
         }
 
         return [{
             shippingAddress,
-            lineItems: cart.items
-                .filter(item => item.type === 'ItemPhysicalEntity')
+            lineItems: (cart.lineItems && cart.lineItems.physicalItems || [])
                 .map(item => ({
                     itemId: item.id,
                     quantity: item.quantity,

--- a/src/shipping/consignment-actions.ts
+++ b/src/shipping/consignment-actions.ts
@@ -1,5 +1,7 @@
 import { Action } from '@bigcommerce/data-store';
 
+import { Checkout } from '../checkout';
+
 export enum ConsignmentActionTypes {
     CreateConsignmentsRequested = 'CREATE_CONSIGNMENTS_REQUESTED',
     CreateConsignmentsSucceeded = 'CREATE_CONSIGNMENTS_SUCCEEDED',
@@ -28,7 +30,7 @@ export interface CreateConsignmentsRequestedAction extends Action {
     type: ConsignmentActionTypes.CreateConsignmentsRequested;
 }
 
-export interface CreateConsignmentsSucceededAction extends Action {
+export interface CreateConsignmentsSucceededAction extends Action<Checkout> {
     type: ConsignmentActionTypes.CreateConsignmentsSucceeded;
 }
 
@@ -40,7 +42,7 @@ export interface UpdateConsignmentRequestedAction extends Action {
     type: ConsignmentActionTypes.UpdateConsignmentRequested;
 }
 
-export interface UpdateConsignmentSucceededAction extends Action {
+export interface UpdateConsignmentSucceededAction extends Action<Checkout> {
     type: ConsignmentActionTypes.UpdateConsignmentSucceeded;
 }
 

--- a/src/shipping/index.ts
+++ b/src/shipping/index.ts
@@ -1,3 +1,4 @@
+export * from './consignment-actions';
 export * from './shipping-request-options';
 
 export { default as createShippingStrategyRegistry } from './create-shipping-strategy-registry';


### PR DESCRIPTION
## What?
1. Move `mapToInternalCart` mapper from `cartReducer` to the external selector.
1. Update `CustomerActionCreator` so that it stops getting `cart` data from internal API. Instead, get the data from storefront checkout API.

## Why?
1. The mapper is pushed to the boundary so we can use storefront API objects internally.
1. We should only use the internal API for signing in and ignore all other information.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
