### PR TITLE
CHECKOUT-3057 Read billingAddress from billingAddress store and move mapper to the billingAddressSelector

### DIFF
--- a/src/billing/billing-address-action-creator.spec.js
+++ b/src/billing/billing-address-action-creator.spec.js
@@ -9,6 +9,7 @@ import BillingAddressActionCreator from './billing-address-action-creator';
 import { BillingAddressActionTypes } from './billing-address-actions';
 import { getBillingAddress } from './internal-billing-addresses.mock';
 import { getCustomerState } from '../customer/internal-customers.mock';
+import { getBillingAddressState } from './billing-addresses.mock';
 
 describe('BillingAddressActionCreator', () => {
     let address;
@@ -106,6 +107,7 @@ describe('BillingAddressActionCreator', () => {
             beforeEach(() => {
                 store = createCheckoutStore({
                     quote: getQuoteState(),
+                    billingAddress: getBillingAddressState(),
                     customer: getCustomerState(),
                     checkout: getCheckoutState(),
                 });

--- a/src/billing/billing-address-reducer.spec.ts
+++ b/src/billing/billing-address-reducer.spec.ts
@@ -2,16 +2,47 @@ import { createAction } from '@bigcommerce/data-store';
 
 import { CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
+import { RequestError } from '../common/error/errors';
+import { getErrorResponse } from '../common/http-request/responses.mock';
 
 import billingAddressReducer from './billing-address-reducer';
+import BillingAddressState from './billing-address-state';
 
 describe('billingAddressReducer', () => {
-    it('returns billing address', () => {
+    let initialState: BillingAddressState;
+
+    beforeEach(() => {
+        initialState = { errors: {}, statuses: {} };
+    });
+
+    it('returns billing address when checkout loads', () => {
         const action = createAction(CheckoutActionType.LoadCheckoutSucceeded, getCheckout());
-        const output = billingAddressReducer({}, action);
+        const output = billingAddressReducer(initialState, action);
 
         expect(output).toEqual({
             data: action.payload.billingAddress,
+            errors: { loadError: undefined },
+            statuses: { isLoading: false },
+        });
+    });
+
+    it('returns loading state when checkout is requested', () => {
+        const action = createAction(CheckoutActionType.LoadCheckoutRequested);
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { loadError: undefined },
+            statuses: { isLoading: true },
+        });
+    });
+
+    it('returns error state when checkout fails to load', () => {
+        const action = createAction(CheckoutActionType.LoadCheckoutFailed, new RequestError(getErrorResponse()));
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { loadError: action.payload },
+            statuses: { isLoading: false },
         });
     });
 });

--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -4,9 +4,12 @@ import { Address } from '../address';
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 
 import { BillingAddressAction, BillingAddressActionTypes } from './billing-address-actions';
-import BillingAddressState from './billing-address-state';
+import BillingAddressState, { BillingAddressErrorsState, BillingAddressStatusesState } from './billing-address-state';
 
-const DEFAULT_STATE: BillingAddressState = {};
+const DEFAULT_STATE: BillingAddressState = {
+    errors: {},
+    statuses: {},
+};
 
 export default function billingAddressReducer(
     state: BillingAddressState = DEFAULT_STATE,
@@ -14,6 +17,8 @@ export default function billingAddressReducer(
 ): BillingAddressState {
     const reducer = combineReducers<BillingAddressState, CheckoutAction | BillingAddressAction>({
         data: dataReducer,
+        errors: errorsReducer,
+        statuses: statusesReducer,
     });
 
     return reducer(state, action);
@@ -30,5 +35,53 @@ function dataReducer(
 
     default:
         return data;
+    }
+}
+
+function errorsReducer(
+    errors: BillingAddressErrorsState = DEFAULT_STATE.errors,
+    action: CheckoutAction | BillingAddressAction
+): BillingAddressErrorsState {
+    switch (action.type) {
+    case CheckoutActionType.LoadCheckoutRequested:
+    case CheckoutActionType.LoadCheckoutSucceeded:
+        return { ...errors, loadError: undefined };
+
+    case CheckoutActionType.LoadCheckoutFailed:
+        return { ...errors, loadError: action.payload };
+
+    case BillingAddressActionTypes.UpdateBillingAddressRequested:
+    case BillingAddressActionTypes.UpdateBillingAddressSucceeded:
+        return { ...errors, updateError: undefined };
+
+    case BillingAddressActionTypes.UpdateBillingAddressFailed:
+        return { ...errors, updateError: action.payload };
+
+    default:
+        return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: BillingAddressStatusesState = DEFAULT_STATE.statuses,
+    action: CheckoutAction | BillingAddressAction
+): BillingAddressStatusesState {
+    switch (action.type) {
+    case CheckoutActionType.LoadCheckoutRequested:
+        return { ...statuses, isLoading: true };
+
+    case CheckoutActionType.LoadCheckoutSucceeded:
+    case CheckoutActionType.LoadCheckoutFailed:
+        return { ...statuses, isLoading: false };
+
+    case BillingAddressActionTypes.UpdateBillingAddressRequested:
+        return { ...statuses, isUpdating: true };
+
+    case BillingAddressActionTypes.UpdateBillingAddressFailed:
+    case BillingAddressActionTypes.UpdateBillingAddressSucceeded:
+        return { ...statuses, isUpdating: false };
+
+    default:
+        return statuses;
     }
 }

--- a/src/billing/billing-address-selector.spec.js
+++ b/src/billing/billing-address-selector.spec.js
@@ -1,6 +1,7 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
-import { getQuoteState } from '../quote/internal-quotes.mock';
+import { getQuote } from '../quote/internal-quotes.mock';
 import BillingAddressSelector from './billing-address-selector';
+import { getBillingAddressState } from './billing-addresses.mock';
 
 describe('BillingAddressSelector', () => {
     let billingAddressSelector;
@@ -8,19 +9,19 @@ describe('BillingAddressSelector', () => {
 
     beforeEach(() => {
         state = {
-            quote: getQuoteState(),
+            billingAddress: getBillingAddressState(),
         };
     });
 
     describe('#getBillingAddress()', () => {
         it('returns the current billing address', () => {
-            billingAddressSelector = new BillingAddressSelector(state.quote);
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
 
-            expect(billingAddressSelector.getBillingAddress()).toEqual(state.quote.data.billingAddress);
+            expect(billingAddressSelector.getBillingAddress()).toEqual(getQuote().billingAddress);
         });
 
         it('returns undefined if quote is not available', () => {
-            billingAddressSelector = new BillingAddressSelector({ ...state.quote, data: undefined });
+            billingAddressSelector = new BillingAddressSelector({ ...state.billingAddress, data: undefined });
 
             expect(billingAddressSelector.getBillingAddress()).toEqual();
         });
@@ -28,18 +29,18 @@ describe('BillingAddressSelector', () => {
 
     describe('#getUpdateError()', () => {
         it('returns error if unable to update', () => {
-            const updateBillingAddressError = getErrorResponse();
+            const updateError = getErrorResponse();
 
             billingAddressSelector = new BillingAddressSelector({
-                ...state.quote,
-                errors: { updateBillingAddressError },
+                ...state.billingAddress,
+                errors: { updateError },
             });
 
-            expect(billingAddressSelector.getUpdateError()).toEqual(updateBillingAddressError);
+            expect(billingAddressSelector.getUpdateError()).toEqual(updateError);
         });
 
         it('does not returns error if able to update', () => {
-            billingAddressSelector = new BillingAddressSelector(state.quote);
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
 
             expect(billingAddressSelector.getUpdateError()).toBeUndefined();
         });
@@ -48,15 +49,15 @@ describe('BillingAddressSelector', () => {
     describe('#isUpdating()', () => {
         it('returns true if updating billing address', () => {
             billingAddressSelector = new BillingAddressSelector({
-                ...state.quote,
-                statuses: { isUpdatingBillingAddress: true },
+                ...state.billingAddress,
+                statuses: { isUpdating: true },
             });
 
             expect(billingAddressSelector.isUpdating()).toEqual(true);
         });
 
         it('returns false if not updating billing address', () => {
-            billingAddressSelector = new BillingAddressSelector(state.quote);
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
 
             expect(billingAddressSelector.isUpdating()).toEqual(false);
         });

--- a/src/billing/billing-address-selector.ts
+++ b/src/billing/billing-address-selector.ts
@@ -1,23 +1,31 @@
-import { InternalAddress } from '../address';
+import { mapToInternalAddress, InternalAddress } from '../address';
 import { selector } from '../common/selector';
 
-import { QuoteState } from '../quote';
+import BillingAddressState from './billing-address-state';
 
 @selector
 export default class BillingAddressSelector {
     constructor(
-        private _quote: QuoteState
+        private _billingAddress: BillingAddressState
     ) {}
 
     getBillingAddress(): InternalAddress | undefined {
-        return this._quote.data && this._quote.data.billingAddress;
+        return this._billingAddress.data && mapToInternalAddress(this._billingAddress.data);
     }
 
     getUpdateError(): Error | undefined {
-        return this._quote.errors.updateBillingAddressError;
+        return this._billingAddress.errors.updateError;
+    }
+
+    getLoadError(): Error | undefined {
+        return this._billingAddress.errors.loadError;
     }
 
     isUpdating(): boolean {
-        return !!this._quote.statuses.isUpdatingBillingAddress;
+        return !!this._billingAddress.statuses.isUpdating;
+    }
+
+    isLoading(): boolean {
+        return !!this._billingAddress.statuses.isLoading;
     }
 }

--- a/src/billing/billing-address-state.ts
+++ b/src/billing/billing-address-state.ts
@@ -2,4 +2,16 @@ import { Address } from '../address';
 
 export default interface BillingAddressState {
     data?: Address;
+    errors: BillingAddressErrorsState;
+    statuses: BillingAddressStatusesState;
+}
+
+export interface BillingAddressErrorsState {
+    loadError?: Error;
+    updateError?: Error;
+}
+
+export interface BillingAddressStatusesState {
+    isLoading?: boolean;
+    isUpdating?: boolean;
 }

--- a/src/billing/billing-addresses.mock.ts
+++ b/src/billing/billing-addresses.mock.ts
@@ -1,6 +1,8 @@
 
 import { Address } from '../address';
 
+import { BillingAddressState } from '.';
+
 export function getBillingAddress(): Address {
     return {
         id: '55c96cda6f04c',
@@ -17,5 +19,13 @@ export function getBillingAddress(): Address {
         postalCode: '95555',
         phone: '555-555-5555',
         customFields: [],
+    };
+}
+
+export function getBillingAddressState(): BillingAddressState {
+    return {
+        data: getBillingAddress(),
+        errors: {},
+        statuses: {},
     };
 }

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -1,4 +1,5 @@
 export { default as BillingAddressSelector } from './billing-address-selector';
 export { default as BillingAddressActionCreator } from './billing-address-action-creator';
+export { default as BillingAddressState } from './billing-address-state';
 export { default as BillingAddressRequestSender } from './billing-address-request-sender';
 export { default as billingAddressReducer } from './billing-address-reducer';

--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -4,7 +4,7 @@ import { map, merge } from 'lodash';
 import { Observable } from 'rxjs';
 
 import { BillingAddressActionCreator } from '../billing';
-import { getBillingAddress } from '../billing/internal-billing-addresses.mock';
+import { getBillingAddress, getBillingAddressState } from '../billing/billing-addresses.mock';
 import { getCartResponseBody, getCartState } from '../cart/internal-carts.mock';
 import { getResponse } from '../common/http-request/responses.mock';
 import { ConfigActionCreator } from '../config';
@@ -125,6 +125,7 @@ describe('CheckoutService', () => {
 
         store = createCheckoutStore({
             cart: getCartState(),
+            billingAddress: getBillingAddressState(),
             checkout: getCheckoutState(),
             config: getConfigState(),
             quote: getQuoteState(),

--- a/src/checkout/checkout-store-selector.spec.js
+++ b/src/checkout/checkout-store-selector.spec.js
@@ -10,6 +10,7 @@ import { getCheckoutStoreState } from './checkouts.mock';
 import CheckoutStoreSelector from './checkout-store-selector';
 import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
 import { getShippingOptions } from '../shipping/internal-shipping-options.mock';
+import { getBillingAddress } from '../billing/internal-billing-addresses.mock';
 
 describe('CheckoutStoreSelector', () => {
     let selector;
@@ -65,7 +66,7 @@ describe('CheckoutStoreSelector', () => {
     });
 
     it('returns billing address', () => {
-        expect(selector.getBillingAddress()).toEqual(state.quote.data.billingAddress);
+        expect(selector.getBillingAddress()).toEqual(getBillingAddress());
     });
 
     it('returns shipping address', () => {

--- a/src/checkout/checkout-store-state.ts
+++ b/src/checkout/checkout-store-state.ts
@@ -1,3 +1,4 @@
+import { BillingAddressState } from '../billing';
 import { CartState } from '../cart';
 import { ConfigState } from '../config';
 import { CouponState, GiftCertificateState } from '../coupon';
@@ -15,6 +16,7 @@ import CheckoutState from './checkout-state';
  * @todo Convert this file into TypeScript properly
  */
 export default interface CheckoutStoreState {
+    billingAddress: BillingAddressState;
     cart: CartState;
     checkout: CheckoutState;
     config: ConfigState;

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -1,5 +1,5 @@
 import { getBillingAddress } from '../billing/billing-addresses.mock';
-import { getBillingAddressState } from '../billing/internal-billing-addresses.mock';
+import { getBillingAddressState } from '../billing/billing-addresses.mock';
 import { getCart } from '../cart/carts.mock';
 import { getCartState } from '../cart/internal-carts.mock';
 import { getConfigState } from '../config/configs.mock';
@@ -96,6 +96,7 @@ export function getCheckoutState(): CheckoutState {
 
 export function getCheckoutStoreState() {
     return {
+        billingAddress: getBillingAddressState(),
         cart: getCartState(),
         checkout: getCheckoutState(),
         config: getConfigState(),

--- a/src/checkout/create-checkout-store-reducer.ts
+++ b/src/checkout/create-checkout-store-reducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers, Action, Reducer } from '@bigcommerce/data-store';
 
+import { billingAddressReducer } from '../billing';
 import { cartReducer } from '../cart';
 import { configReducer } from '../config';
 import { couponReducer, giftCertificateReducer } from '../coupon';
@@ -17,6 +18,7 @@ import CheckoutStoreState from './checkout-store-state';
 
 export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState, Action> {
     return combineReducers({
+        billingAddress: billingAddressReducer,
         cart: cartReducer,
         checkout: checkoutReducer,
         config: configReducer,

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -20,7 +20,7 @@ import CheckoutStoreState from './checkout-store-state';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 export default function createInternalCheckoutSelectors(state: CheckoutStoreState, options: CheckoutStoreOptions = {}): InternalCheckoutSelectors {
-    const billingAddress = new BillingAddressSelector(state.quote);
+    const billingAddress = new BillingAddressSelector(state.billingAddress);
     const cart = new CartSelector(state.cart);
     const checkout = new CheckoutSelector(state.checkout);
     const config = new ConfigSelector(state.config);
@@ -42,7 +42,7 @@ export default function createInternalCheckoutSelectors(state: CheckoutStoreStat
 
     // Compose selectors
     const payment = new PaymentSelector(checkout, order);
-    const quote = new QuoteSelector(state.quote, shippingAddress);
+    const quote = new QuoteSelector(state.quote, billingAddress, shippingAddress);
 
     const selectors = {
         billingAddress,

--- a/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
@@ -4,6 +4,7 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { Observable } from 'rxjs';
 
 import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '..';
+import { getBillingAddressState } from '../../billing/billing-addresses.mock';
 import { getBillingAddress } from '../../billing/internal-billing-addresses.mock';
 import { getCartState } from '../../cart/internal-carts.mock';
 import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
@@ -47,6 +48,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         paymentMethodMock = { ...getBraintreeVisaCheckout(), clientToken: 'clientToken' };
 
         store = createCheckoutStore({
+            billingAddress: getBillingAddressState(),
             checkout: getCheckoutState(),
             customer: getCustomerState(),
             config: getConfigState(),

--- a/src/payment/strategies/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.spec.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 import { BillingAddressActionCreator } from '../../billing';
 import { BillingAddressActionTypes } from '../../billing/billing-address-actions';
 import { getBillingAddress } from '../../billing/billing-addresses.mock';
+import { getBillingAddressState } from '../../billing/billing-addresses.mock';
 import { getCartResponseBody } from '../../cart/internal-carts.mock';
 import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { NotInitializedError, RequestError } from '../../common/error/errors';
@@ -343,6 +344,7 @@ describe('AmazonPayPaymentStrategy', () => {
             customer: {
                 data: getRemoteCustomer(),
             },
+            billingAddress: getBillingAddressState(),
             quote: getQuoteState(),
             paymentMethods: getPaymentMethodsState(),
             remoteCheckout: getRemoteCheckoutState(),
@@ -373,6 +375,7 @@ describe('AmazonPayPaymentStrategy', () => {
             customer: {
                 data: getRemoteCustomer(),
             },
+            billingAddress: getBillingAddressState(),
             quote: getQuoteState(),
             paymentMethods: getPaymentMethodsState(),
             remoteCheckout: merge({}, getRemoteCheckoutState(), {

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -179,7 +179,14 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
         });
 
         it('throws error if unable to submit payment due to missing data', async () => {
-            store = createCheckoutStore(merge({}, getCheckoutStoreState(), { quote: { data: null } }));
+            store = createCheckoutStore(
+                merge({},
+                    getCheckoutStoreState(),
+                    {
+                        quote: { data: null },
+                        billingAddress: { data: null },
+                    },
+                ));
 
             braintreeCreditCardPaymentStrategy = new BraintreeCreditCardPaymentStrategy(
                 store,

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -13,6 +13,7 @@ import {
     PaymentRequestSender,
     PaymentStrategyActionCreator,
 } from '../..';
+import { getBillingAddressState } from '../../../billing/billing-addresses.mock';
 import { getBillingAddress } from '../../../billing/internal-billing-addresses.mock';
 import { getCartState } from '../../../cart/internal-carts.mock';
 import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
@@ -59,6 +60,7 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
         paymentMethodMock = { ...getBraintreeVisaCheckout(), clientToken: 'clientToken' };
 
         store = createCheckoutStore({
+            billingAddress: getBillingAddressState(),
             checkout: getCheckoutState(),
             customer: getCustomerState(),
             config: getConfigState(),

--- a/src/quote/map-to-internal-quote.spec.ts
+++ b/src/quote/map-to-internal-quote.spec.ts
@@ -6,6 +6,9 @@ import mapToInternalQuote from './map-to-internal-quote';
 describe('mapToInternalQuote()', () => {
     it('maps to internal quote', () => {
         expect(mapToInternalQuote(getCheckout()))
-            .toEqual(getInternalQuote());
+            .toEqual({
+                ...getInternalQuote(),
+                billingAddress: {},
+            });
     });
 });

--- a/src/quote/map-to-internal-quote.ts
+++ b/src/quote/map-to-internal-quote.ts
@@ -7,7 +7,7 @@ export default function mapToInternalQuote(checkout: Checkout): InternalQuote {
     return {
         orderComment: checkout.customerMessage,
         shippingOption: checkout.consignments[0] ? checkout.consignments[0].selectedShippingOptionId : undefined,
-        billingAddress: checkout.billingAddress ? mapToInternalAddress(checkout.billingAddress) : {} as InternalAddress,
+        billingAddress: {} as InternalAddress,
         shippingAddress: checkout.consignments[0] ? mapToInternalAddress(checkout.consignments[0].shippingAddress, checkout.consignments[0].id) : undefined,
     };
 }

--- a/src/quote/quote-reducer.spec.js
+++ b/src/quote/quote-reducer.spec.js
@@ -1,8 +1,6 @@
-import { BillingAddressActionTypes } from '../billing/billing-address-actions';
 import { CheckoutActionType } from '../checkout';
 import { CustomerActionType } from '../customer';
 import { getCheckout } from '../checkout/checkouts.mock';
-import { getErrorResponse } from '../common/http-request/responses.mock';
 import { getCustomerResponseBody } from '../customer/internal-customers.mock';
 import { ConsignmentActionTypes } from '../shipping/consignment-actions';
 import { getQuote } from './internal-quotes.mock';
@@ -10,6 +8,12 @@ import quoteReducer from './quote-reducer';
 
 describe('quoteReducer()', () => {
     let initialState;
+    const quoteState = {
+        data: {
+            ...getQuote(),
+            billingAddress: {},
+        },
+    };
 
     beforeEach(() => {
         initialState = {};
@@ -22,7 +26,7 @@ describe('quoteReducer()', () => {
         };
 
         expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-            data: action.payload.quote,
+            data: getQuote(),
         }));
     });
 
@@ -33,7 +37,7 @@ describe('quoteReducer()', () => {
         };
 
         expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-            data: action.payload.quote,
+            data: getQuote(),
         }));
     });
 
@@ -43,9 +47,7 @@ describe('quoteReducer()', () => {
             payload: getCheckout(),
         };
 
-        expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-            data: getQuote(),
-        }));
+        expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining(quoteState));
     });
 
     it('returns new data when creating consignments', () => {
@@ -54,9 +56,7 @@ describe('quoteReducer()', () => {
             payload: getCheckout(),
         };
 
-        expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-            data: getQuote(),
-        }));
+        expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining(quoteState));
     });
 
     it('returns new data when updating a consignment', () => {
@@ -65,97 +65,6 @@ describe('quoteReducer()', () => {
             payload: getCheckout(),
         };
 
-        expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-            data: getQuote(),
-        }));
-    });
-
-    describe('when updating billing address', () => {
-        it('sets updating flag to true while updating', () => {
-            const action = {
-                type: BillingAddressActionTypes.UpdateBillingAddressRequested,
-            };
-
-            expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-                statuses: { isUpdatingBillingAddress: true },
-            }));
-        });
-
-        it('cleans errors while updating', () => {
-            const action = {
-                type: BillingAddressActionTypes.UpdateBillingAddressRequested,
-            };
-
-            initialState.errors = {
-                updateBillingAddressError: getErrorResponse(),
-            };
-
-            expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-                errors: {
-                    updateBillingAddressError: undefined,
-                },
-            }));
-        });
-
-        it('saves the payload when update succeeds', () => {
-            const action = {
-                type: BillingAddressActionTypes.UpdateBillingAddressSucceeded,
-                payload: getCheckout(),
-            };
-
-            expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-                data: getQuote(),
-            }));
-        });
-
-        it('sets updating flag to false if succeeded', () => {
-            const action = {
-                type: BillingAddressActionTypes.UpdateBillingAddressSucceeded,
-                payload: getCheckout(),
-            };
-
-            expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-                statuses: { isUpdatingBillingAddress: false },
-            }));
-        });
-
-        it('cleans errors when update succeeds', () => {
-            const action = {
-                type: BillingAddressActionTypes.UpdateBillingAddressSucceeded,
-                payload: getCheckout(),
-            };
-
-            initialState.errors = {
-                updateBillingAddressError: getErrorResponse(),
-            };
-
-            expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-                errors: {
-                    updateBillingAddressError: undefined,
-                },
-            }));
-        });
-
-        it('saves the error when update fails', () => {
-            const action = {
-                type: BillingAddressActionTypes.UpdateBillingAddressFailed,
-                payload: getErrorResponse(),
-            };
-
-            expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-                errors: { updateBillingAddressError: action.payload },
-            }));
-        });
-
-        it('sets the updating flag to false when update fails', () => {
-            const action = {
-                type: BillingAddressActionTypes.UpdateBillingAddressFailed,
-                payload: getErrorResponse(),
-            };
-
-            expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining({
-                errors: { updateBillingAddressError: action.payload },
-            }));
-        });
+        expect(quoteReducer(initialState, action)).toEqual(expect.objectContaining(quoteState));
     });
 });

--- a/src/quote/quote-reducer.ts
+++ b/src/quote/quote-reducer.ts
@@ -60,13 +60,6 @@ function errorsReducer(
     case CheckoutActionType.LoadCheckoutFailed:
         return { ...errors, loadError: action.payload };
 
-    case BillingAddressActionTypes.UpdateBillingAddressRequested:
-    case BillingAddressActionTypes.UpdateBillingAddressSucceeded:
-        return { ...errors, updateBillingAddressError: undefined };
-
-    case BillingAddressActionTypes.UpdateBillingAddressFailed:
-        return { ...errors, updateBillingAddressError: action.payload };
-
     default:
         return errors;
     }
@@ -83,13 +76,6 @@ function statusesReducer(
     case CheckoutActionType.LoadCheckoutSucceeded:
     case CheckoutActionType.LoadCheckoutFailed:
         return { ...statuses, isLoading: false };
-
-    case BillingAddressActionTypes.UpdateBillingAddressRequested:
-        return { ...statuses, isUpdatingBillingAddress: true };
-
-    case BillingAddressActionTypes.UpdateBillingAddressFailed:
-    case BillingAddressActionTypes.UpdateBillingAddressSucceeded:
-        return { ...statuses, isUpdatingBillingAddress: false };
 
     default:
         return statuses;

--- a/src/quote/quote-selector.spec.ts
+++ b/src/quote/quote-selector.spec.ts
@@ -1,22 +1,29 @@
-import { getQuoteState } from './internal-quotes.mock';
+import { BillingAddressSelector } from '../billing';
+import { getBillingAddressState } from '../billing/billing-addresses.mock';
+import { getCheckoutState } from '../checkout/checkouts.mock';
 import { getErrorResponse } from '../common/http-request/responses.mock';
-import QuoteSelector from './quote-selector';
-import { ShippingAddressSelector } from '../shipping';
 import { getConfig } from '../config/configs.mock';
+import { ShippingAddressSelector } from '../shipping';
+
+import { getQuoteState } from './internal-quotes.mock';
+import QuoteSelector from './quote-selector';
 
 describe('QuoteSelector', () => {
     let quoteSelector;
     let shippingAddressSelector;
+    let billingAddressSelector;
     let state;
 
     beforeEach(() => {
         state = {
             quote: getQuoteState(),
+            billingAddress: getBillingAddressState(),
             config: getConfig(),
         };
 
         shippingAddressSelector = new ShippingAddressSelector(state.quote, state.config);
-        quoteSelector = new QuoteSelector(state.quote, shippingAddressSelector);
+        billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+        quoteSelector = new QuoteSelector(state.quote, billingAddressSelector, shippingAddressSelector);
     });
 
     describe('#getQuote()', () => {
@@ -36,9 +43,9 @@ describe('QuoteSelector', () => {
             const loadError = getErrorResponse();
 
             quoteSelector = new QuoteSelector({
-                ...state.quote,
+                ...state.checkout,
                 errors: { loadError },
-            }, shippingAddressSelector);
+            }, billingAddressSelector, shippingAddressSelector);
 
             expect(quoteSelector.getLoadError()).toEqual(loadError);
         });
@@ -51,9 +58,9 @@ describe('QuoteSelector', () => {
     describe('#isLoading()', () => {
         it('returns true if loading quote', () => {
             quoteSelector = new QuoteSelector({
-                ...state.quote,
+                ...state.checkout,
                 statuses: { isLoading: true },
-            }, shippingAddressSelector);
+            }, billingAddressSelector, shippingAddressSelector);
 
             expect(quoteSelector.isLoading()).toEqual(true);
         });

--- a/src/quote/quote-selector.ts
+++ b/src/quote/quote-selector.ts
@@ -1,3 +1,5 @@
+import { InternalAddress } from '../address';
+import { BillingAddressSelector } from '../billing';
 import { selector } from '../common/selector';
 import { ShippingAddressSelector } from '../shipping';
 
@@ -8,6 +10,7 @@ import QuoteState from './quote-state';
 export default class QuoteSelector {
     constructor(
         private _quote: QuoteState,
+        private _billingAddressSelector: BillingAddressSelector,
         private _shippingAddressSelector: ShippingAddressSelector
     ) {}
 
@@ -19,6 +22,7 @@ export default class QuoteSelector {
         return {
             ...this._quote.data,
             shippingAddress: this._shippingAddressSelector.getShippingAddress(),
+            billingAddress: this._billingAddressSelector.getBillingAddress() || {}  as InternalAddress,
         };
     }
 

--- a/src/quote/quote-state.ts
+++ b/src/quote/quote-state.ts
@@ -17,12 +17,8 @@ export interface QuoteMetaState {
 
 export interface QuoteErrorsState {
     loadError?: Error;
-    updateBillingAddressError?: Error;
-    updateShippingAddressError?: Error;
 }
 
 export interface QuoteStatusesState {
     isLoading?: boolean;
-    isUpdatingBillingAddress?: boolean;
-    isUpdatingShippingAddress?: boolean;
 }


### PR DESCRIPTION
## What?
- Makes billingAddress store the source of truth for billing address data.
- Moves mapper to the billingAddress selector

## Why?
- So we can remove the mapper easily

## Testing / Proof
- Unit

@bigcommerce/checkout @bigcommerce/payments
