### PR TITLE
feat(checkout): INT-475 Chase Pay button to display on Customer section UCO page

### DIFF
--- a/src/common/http-request/index.ts
+++ b/src/common/http-request/index.ts
@@ -1,3 +1,4 @@
 export { default as InternalResponseBody } from './internal-response-body';
 export { default as ContentType } from './content-type';
 export { default as RequestOptions } from './request-options';
+export { default as toFormUrlEncoded } from './to-form-url-encoded';

--- a/src/common/http-request/to-form-url-encoded.spec.ts
+++ b/src/common/http-request/to-form-url-encoded.spec.ts
@@ -1,0 +1,12 @@
+import { toFormUrlEncoded } from './';
+
+describe('toFormUrlEncoded()', () => {
+    it('encodes the given object to formUrlEncoded', () => {
+        const object = {
+            A: 'A',
+            B: 'B',
+        };
+        const expected = 'A=A&B=B';
+        expect(toFormUrlEncoded(object)).toEqual(expected);
+    });
+});

--- a/src/common/http-request/to-form-url-encoded.ts
+++ b/src/common/http-request/to-form-url-encoded.ts
@@ -1,0 +1,14 @@
+export default function toFormUrlEncoded(data: { [key: string]: object | string | undefined }): string {
+    return Object.keys(data)
+        .filter(key => data[key] !== undefined)
+        .map(key => {
+            const value = data[key];
+
+            if (typeof value === 'string') {
+                return `${key}=${encodeURIComponent(value)}`;
+            }
+
+            return `${key}=${encodeURIComponent(JSON.stringify(value) || '')}`;
+        })
+        .join('&');
+}

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -1,3 +1,4 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
@@ -5,6 +6,7 @@ import { CheckoutActionCreator, CheckoutClient, CheckoutRequestSender, CheckoutS
 import { Registry } from '../common/registry';
 import { PaymentMethodActionCreator } from '../payment';
 import { createBraintreeVisaCheckoutPaymentProcessor, VisaCheckoutScriptLoader } from '../payment/strategies/braintree';
+import { ChasePayScriptLoader } from '../payment/strategies/chasepay';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 import { AmazonPayScriptLoader } from '../remote-checkout/methods/amazon-pay';
 
@@ -13,6 +15,7 @@ import CustomerActionCreator from './customer-action-creator';
 import {
     AmazonPayCustomerStrategy,
     BraintreeVisaCheckoutCustomerStrategy,
+    ChasePayCustomerStrategy,
     CustomerStrategy,
     DefaultCustomerStrategy,
 } from './strategies';
@@ -45,6 +48,17 @@ export default function createCustomerStrategyRegistry(
             new RemoteCheckoutActionCreator(remoteCheckoutRequestSender),
             createBraintreeVisaCheckoutPaymentProcessor(getScriptLoader()),
             new VisaCheckoutScriptLoader(getScriptLoader())
+        )
+    );
+
+    registry.register('chasepay', () =>
+        new ChasePayCustomerStrategy(
+            store,
+            new PaymentMethodActionCreator(client),
+            new RemoteCheckoutActionCreator(remoteCheckoutRequestSender),
+            new ChasePayScriptLoader(getScriptLoader()),
+            requestSender,
+            createFormPoster()
         )
     );
 

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -1,6 +1,6 @@
 import { RequestOptions } from '../common/http-request';
 
-import { AmazonPayCustomerInitializeOptions, BraintreeVisaCheckoutCustomerInitializeOptions } from './strategies';
+import { AmazonPayCustomerInitializeOptions, BraintreeVisaCheckoutCustomerInitializeOptions, ChasePayCustomerInitializeOptions } from './strategies';
 
 /**
  * A set of options for configuring any requests related to the customer step of
@@ -35,4 +35,5 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      * when using Visa Checkout provided by Braintree.
      */
     braintreevisacheckout?: BraintreeVisaCheckoutCustomerInitializeOptions;
+    chasepay?: ChasePayCustomerInitializeOptions;
 }

--- a/src/customer/strategies/chasepay-customer-strategy.spec.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.spec.ts
@@ -1,0 +1,170 @@
+import { createAction } from '@bigcommerce/data-store';
+import { createFormPoster } from '@bigcommerce/form-poster';
+import {createRequestSender, RequestSender} from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { Observable } from 'rxjs';
+
+import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '..';
+import { getBillingAddress } from '../../billing/internal-billing-addresses.mock';
+import { getCartState } from '../../cart/internal-carts.mock';
+import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
+import { getCheckoutState } from '../../checkout/checkouts.mock';
+import { getConfigState } from '../../config/configs.mock';
+import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
+import { getChasePay, getPaymentMethodsState } from '../../payment/payment-methods.mock';
+
+import { ChasePayScriptLoader } from '../../payment/strategies/chasepay';
+import { getQuoteState } from '../../quote/internal-quotes.mock';
+import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../remote-checkout';
+import { getShippingAddress } from '../../shipping/internal-shipping-addresses.mock';
+import { CustomerStrategyActionType } from '../customer-strategy-actions';
+import { getCustomerState, getRemoteCustomer } from '../internal-customers.mock';
+
+import { ChasePayCustomerStrategy, CustomerStrategy } from './';
+import {ChasePayEventMap, ChasePayScript, JPMC} from '../../payment/strategies/chasepay/chasepay';
+
+describe('ChasePayCustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
+    let container: HTMLDivElement;
+    let customerStrategyActionCreator: CustomerStrategyActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let store: CheckoutStore;
+    let strategy: CustomerStrategy;
+    let chasePayScriptLoader: ChasePayScriptLoader;
+    let ChasePayScript: ChasePayScript;
+    let JPMC: JPMC;
+    let requestSender: RequestSender;
+    let formPoster;
+    let EventType: ChasePayEventMap;
+
+    beforeEach(() => {
+        const scriptLoader = createScriptLoader();
+        paymentMethodMock = { ...getChasePay(), initializationData: {digitalSessionId: 'digitalSessionId'}, };
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethodMock);
+
+        const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(createRequestSender());
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender);
+
+        JPMC = {} as JPMC;
+        JPMC.insertButtons = jest.fn();
+        JPMC.isChasePayUp = jest.fn();
+        EventType = {} as ChasePayEventMap;
+        EventType.START_CHECKOUT = 'startCheckout';
+        EventType.COMPLETE_CHECKOUT = 'completeCheckout';
+
+        ChasePayScript = {} as ChasePayScript;
+        ChasePayScript.ChasePay = JPMC;
+        ChasePayScript.ChasePay.EventType = EventType;
+        ChasePayScript.ChasePay.on = jest.fn();
+
+        chasePayScriptLoader = new ChasePayScriptLoader(scriptLoader);
+        chasePayScriptLoader.load = jest.fn(() => Promise.resolve(ChasePayScript));
+
+        const client = createCheckoutClient();
+        const registry = createCustomerStrategyRegistry(store, client);
+        const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
+        const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
+
+        checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender);
+        paymentMethodActionCreator = new PaymentMethodActionCreator(createCheckoutClient());
+        customerStrategyActionCreator = new CustomerStrategyActionCreator(registry);
+        requestSender = createRequestSender();
+        formPoster = createFormPoster();
+        strategy = new ChasePayCustomerStrategy(
+            store,
+            paymentMethodActionCreator,
+            remoteCheckoutActionCreator,
+            chasePayScriptLoader,
+            requestSender,
+            formPoster,
+        );
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'login');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('creates an instance of ChasePayCustomerStrategy', () => {
+        expect(strategy).toBeInstanceOf(ChasePayCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+        let chasePayOptions;
+
+        beforeEach(() => {
+            chasePayOptions = { methodId: 'chasepay', chasepay: { container: 'login' } };
+        });
+
+        it('loads chasepay in test mode if enabled', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(chasePayOptions);
+
+            expect(chasePayScriptLoader.load).toHaveBeenLastCalledWith(true);
+        });
+
+        it('loads chasepay without test mode if disabled', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(chasePayOptions);
+
+            expect(chasePayScriptLoader.load).toHaveBeenLastCalledWith(false);
+        });
+
+        it('registers the start and complete callbacks', async () => {
+            ChasePayScript.ChasePay.on = jest.fn((type, callback) => callback);
+            await strategy.initialize(chasePayOptions);
+
+            expect(ChasePayScript.ChasePay.on).toHaveBeenCalledWith('startCheckout', expect.any(Function));
+            expect(ChasePayScript.ChasePay.on).toHaveBeenCalledWith('completeCheckout', expect.any(Function));
+        });
+    });
+
+    describe('#signIn()', () => {
+        beforeEach(async () => {
+            await strategy.initialize({ methodId: 'chasepay', chasepay: { container: 'login' } });
+        });
+
+        it('throws error if trying to sign in programmatically', async () => {
+            expect(() => strategy.signIn({ email: 'foo@bar.com', password: 'foobar' })).toThrowError();
+        });
+    });
+
+    describe('#signOut()', () => {
+        beforeEach(async () => {
+            let paymentId = {};
+            paymentId.providerId = 'chasepay';
+            jest.spyOn(store.getState().payment, 'getPaymentId').mockReturnValue(paymentId);
+
+            store.getState().payment.getPaymentId().providerId = 'chasepay';
+            remoteCheckoutActionCreator.signOut = jest.fn(() => 'data');
+            await strategy.initialize({ methodId: 'chasepay', chasepay: { container: 'login' } });
+        });
+
+        it('throws error if trying to sign out programmatically', async () => {
+            const options = {
+                methodId: 'chasepay',
+            };
+
+            await strategy.signOut(options);
+            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('chasepay', options);
+            expect(store.dispatch).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/customer/strategies/chasepay-customer-strategy.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.ts
@@ -1,0 +1,136 @@
+import FormPoster from '@bigcommerce/form-poster/lib/form-poster';
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
+import { InvalidArgumentError, MissingDataError, NotImplementedError } from '../../common/error/errors';
+import { toFormUrlEncoded } from '../../common/http-request';
+import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
+import { ChasePayScriptLoader } from '../../payment/strategies/chasepay';
+import {ChasePaySuccessPayload} from '../../payment/strategies/chasepay/chasepay';
+import { RemoteCheckoutActionCreator } from '../../remote-checkout';
+import CustomerCredentials from '../customer-credentials';
+import {CustomerInitializeOptions, CustomerRequestOptions} from '../customer-request-options';
+
+import CustomerStrategy from './customer-strategy';
+
+export default class ChasePayCustomerStrategy extends CustomerStrategy {
+    private _paymentMethod?: PaymentMethod;
+
+    constructor(
+        store: CheckoutStore,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
+        private _chasePayScriptLoader: ChasePayScriptLoader,
+        private _requestSender: RequestSender,
+        private _formPoster: FormPoster
+    ) {
+        super(store);
+    }
+
+    initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { chasepay: chasePayOptions, methodId } = options;
+
+        if (!chasePayOptions || !methodId) {
+            throw new InvalidArgumentError('Unable to proceed because "options.chasepay" argument is not provided.');
+        }
+
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
+            .then(state => {
+                this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+                const cart = state.cart.getCart();
+                const storeConfig = state.config.getStoreConfig();
+
+                if (!cart || !storeConfig || !this._paymentMethod || !this._paymentMethod.initializationData.digitalSessionId) {
+                    throw new MissingDataError('Unable to prepare payment data because "cart", "config" or "paymentMethod (Chase Pay)" data is missing.');
+                }
+
+                const {
+                    container,
+                } = chasePayOptions;
+
+                return this._chasePayScriptLoader.load(this._paymentMethod.config.testMode)
+                    .then(JPMC => {
+                        const ChasePay = JPMC.ChasePay;
+                        if (ChasePay.isChasePayUp) {
+                            ChasePay.insertButtons({
+                                containers: [container],
+                            });
+                        }
+                        ChasePay.on(ChasePay.EventType.START_CHECKOUT, () => {
+                            this._refreshDigitalSessionId(methodId)
+                                .then(digitalSessionId => ChasePay.startCheckout(digitalSessionId));
+                        });
+                        ChasePay.on(ChasePay.EventType.COMPLETE_CHECKOUT, (payload: ChasePaySuccessPayload) => {
+                            this._setExternalCheckoutData(payload)
+                                .then(() => {
+                                    this._reloadPage();
+                                });
+                        });
+                    });
+            })
+            .then(() => super.initialize(options));
+    }
+
+    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        throw new NotImplementedError(
+            'In order to sign in via Chase Pay, the shopper must click on "Visa Checkout" button.'
+        );
+    }
+
+    signOut(options?: any): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const payment = state.payment.getPaymentId();
+
+        if (!payment) {
+            return Promise.resolve(this._store.getState());
+        }
+
+        return this._store.dispatch(
+            this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    private _refreshDigitalSessionId(methodId: string): Promise<string | undefined> {
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
+            .then(state => {
+                this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+                if (!this._paymentMethod) {
+                    return (null);
+                }
+                return this._paymentMethod.initializationData.digitalSessionId;
+            });
+    }
+
+    private _setExternalCheckoutData(payload: ChasePaySuccessPayload): Promise<Response> {
+        const url = `checkout.php?provider=chasepay&action=set_external_checkout`;
+        const options = {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            },
+            body: toFormUrlEncoded({
+                sessionToken: payload.sessionToken,
+            }),
+            method: 'post',
+        };
+
+        return this._requestSender.sendRequest(url, options);
+    }
+
+    private _reloadPage() {
+        this._formPoster.postForm('/checkout.php', {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            params: {
+                fromChasePay: true,
+            },
+        });
+    }
+}
+
+export interface ChasePayCustomerInitializeOptions {
+    container: string;
+}

--- a/src/customer/strategies/index.ts
+++ b/src/customer/strategies/index.ts
@@ -2,3 +2,4 @@ export { default as AmazonPayCustomerStrategy, AmazonPayCustomerInitializeOption
 export { default as CustomerStrategy } from './customer-strategy';
 export { default as DefaultCustomerStrategy } from './default-customer-strategy';
 export { default as BraintreeVisaCheckoutCustomerStrategy, BraintreeVisaCheckoutCustomerInitializeOptions } from './braintree-visacheckout-customer-strategy';
+export { default as ChasePayCustomerStrategy, ChasePayCustomerInitializeOptions } from './chasepay-customer-strategy';

--- a/src/payment/payment-methods.mock.js
+++ b/src/payment/payment-methods.mock.js
@@ -321,6 +321,29 @@ export function getSquare() {
         returnUrl: null,
     };
 }
+export function getChasePay() {
+    return {
+        id: 'chasepay',
+        gateway: null,
+        logoUrl: '',
+        method: 'chasepay',
+        supportedCards: [],
+        config: {
+            displayName: 'Chase Pay',
+            cardCode: null,
+            helpText: null,
+            merchantId: null,
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        nonce: null,
+        initializationData: {
+            digitalSessionId: 'digitalSessionId',
+        },
+        clientToken: null,
+        returnUrl: null,
+    };
+}
 
 export function getWepay() {
     return {

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
@@ -2,6 +2,7 @@ import { RequestSender } from '@bigcommerce/request-sender';
 
 import { Address } from '../../../address';
 import { NotInitializedError } from '../../../common/error/errors';
+import { toFormUrlEncoded } from '../../../common/http-request';
 
 import { BraintreeDataCollector } from './braintree';
 import BraintreeSDKCreator from './braintree-sdk-creator';
@@ -79,7 +80,7 @@ export default class BraintreeVisaCheckoutPaymentProcessor {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
-            body: this._toFormUrlEncoded({
+            body: toFormUrlEncoded({
                 payment_type: paymentData.type,
                 nonce: paymentData.nonce,
                 provider: 'braintreevisacheckout',
@@ -90,21 +91,6 @@ export default class BraintreeVisaCheckoutPaymentProcessor {
                 shipping_address: this._getAddress(userEmail, shippingAddress),
             }),
         });
-    }
-
-    private _toFormUrlEncoded(data: { [key: string]: object | string | undefined }): string {
-        return Object.keys(data)
-            .filter(key => data[key] !== undefined)
-            .map(key => {
-                const value = data[key];
-
-                if (typeof value === 'string') {
-                    return `${key}=${encodeURIComponent(value)}`;
-                }
-
-                return `${key}=${encodeURIComponent(JSON.stringify(value) || '')}`;
-            })
-            .join('&');
     }
 
     private _toVisaCheckoutAddress(address?: Address): VisaCheckoutAddress {

--- a/src/payment/strategies/chasepay/chasepay-script-loader.spec.ts
+++ b/src/payment/strategies/chasepay/chasepay-script-loader.spec.ts
@@ -1,0 +1,51 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { ChasePayHostWindow, JPMC } from './chasepay';
+import ChasePayScriptLoader from './chasepay-script-loader';
+import { getChasePayScriptMock } from './chasepay.mock';
+
+describe('ChasePayScriptLoader', () => {
+    let chasePayScriptLoader: ChasePayScriptLoader;
+    let scriptLoader: ScriptLoader;
+    let mockWindow: ChasePayHostWindow;
+
+    beforeEach(() => {
+        mockWindow = { } as ChasePayHostWindow;
+        scriptLoader = {} as ScriptLoader;
+        chasePayScriptLoader = new ChasePayScriptLoader(scriptLoader, mockWindow);
+    });
+
+    describe('#load()', () => {
+        let chasePayScript: JPMC;
+
+        beforeEach(() => {
+            chasePayScript = getChasePayScriptMock();
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.JPMC = chasePayScript;
+                return Promise.resolve();
+            });
+        });
+
+        it('loads the Script', async () => {
+            await chasePayScriptLoader.load(false);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//pwc.chase.com/pwc/checkout/js/v20170521/list.action?type=raw&applId=PWC&channelId=CWC&version=1');
+        });
+
+        it('returns the Script from the window', async () => {
+            const JPMC = await chasePayScriptLoader.load();
+            expect(JPMC).toBe(chasePayScript);
+        });
+
+        describe('when testMode is on', () => {
+            it('loads the Script in sandbox mode', async () => {
+                await chasePayScriptLoader.load(true);
+                expect(scriptLoader.loadScript).toHaveBeenCalledWith('//pwcpsb.chase.com/pwc/checkout/js/v20170521/list.action?type=raw&applId=PWC&channelId=CWC&version=1');
+            });
+
+            it('returns the Script from the window', async () => {
+                const JPMC = await chasePayScriptLoader.load(true);
+                expect(JPMC).toBe(chasePayScript);
+            });
+        });
+    });
+});

--- a/src/payment/strategies/chasepay/chasepay-script-loader.ts
+++ b/src/payment/strategies/chasepay/chasepay-script-loader.ts
@@ -1,0 +1,24 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { StandardError } from '../../../common/error/errors';
+
+import { ChasePayHostWindow } from '../chasepay/chasepay';
+
+export default class ChasePayScriptLoader {
+    constructor(
+        private _scriptLoader: ScriptLoader,
+        public _window: ChasePayHostWindow = window
+    ) {}
+
+    load(testMode?: boolean): Promise<any> {
+        return this._scriptLoader
+            .loadScript(`//pwc${testMode ? 'psb' : ''}.chase.com/pwc/checkout/js/v20170521/list.action?type=raw&applId=PWC&channelId=CWC&version=1`)
+            .then(() => {
+                if (!this._window.JPMC) {
+                    throw new StandardError();
+                }
+
+                return this._window.JPMC;
+            });
+    }
+}

--- a/src/payment/strategies/chasepay/chasepay.mock.ts
+++ b/src/payment/strategies/chasepay/chasepay.mock.ts
@@ -1,0 +1,14 @@
+import {
+    ChasePayEventMap,
+    ChasePayPaymentSuccessPayload,
+    JPMC,
+} from './chasepay';
+
+export function getChasePayScriptMock(): JPMC {
+    return {
+        EventType: {} as ChasePayEventMap,
+        isChasePayUp: jest.fn(),
+        insertButtons: jest.fn(),
+        on: jest.fn(),
+    };
+}

--- a/src/payment/strategies/chasepay/chasepay.ts
+++ b/src/payment/strategies/chasepay/chasepay.ts
@@ -1,0 +1,24 @@
+export interface ChasePayEventMap {
+    'START_CHECKOUT'(digitalSessionId: string): void;
+    'COMPLETE_CHECKOUT'(): ChasePaySuccessPayload;
+    'CANCEL_CHECKOUT'(): void;
+}
+
+export interface ChasePayScript {
+    ChasePay: JPMC;
+}
+
+export interface ChasePayHostWindow extends Window {
+    JPMC?: ChasePayScript;
+}
+
+export interface ChasePaySuccessPayload {
+    sessionToken: string;
+}
+
+export interface JPMC {
+    EventType: ChasePayEventMap;
+    isChasePayUp(): boolean;
+    insertButtons(options: any): void;
+    on<ChasePayEventType extends keyof ChasePayEventMap>(eventType: ChasePayEventType, callback: ChasePayEventMap[ChasePayEventType]): {};
+}

--- a/src/payment/strategies/chasepay/index.ts
+++ b/src/payment/strategies/chasepay/index.ts
@@ -1,0 +1,1 @@
+export { default as ChasePayScriptLoader } from './chasepay-script-loader';


### PR DESCRIPTION
## What?
Display Chase Pay button on Customer section UCO page

## Why?
Shoppers should be able to use the Chase Pay button from UCO Page, so checkout can be done faster and easier.
## Testing / Proof
![screen shot 2018-06-13 at 11 51 31 am](https://user-images.githubusercontent.com/35502707/41368655-34140b5a-6f08-11e8-8a32-d2412651de73.png)

depends on: https://github.com/bigcommerce-labs/ng-checkout/pull/839

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/integrations 
