### PR TITLE
feat(payment): INT-594 Send ChasePay CheckoutData needed for WePay

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -42,4 +42,5 @@ export interface CryptogramInstrument {
         year: string,
     };
     ccNumber: string;
+    accountMask: string;
 }


### PR DESCRIPTION
## What? [INT-594](https://jira.bigcommerce.com/browse/INT-594)
 Add accountMask field to CryptogramInstrument interface.

## Why?
To be able to send accountMask to bigPay.

## Testing / Proof

![image](https://user-images.githubusercontent.com/32551743/41440375-e158e902-6ff3-11e8-84d5-47d4c9053990.png)

@bigcommerce/checkout 
@bigcommerce/payments 
@bigcommerce/integrations 
