### PR TITLE
CHECKOUT-3057 Move quote mapper to external selector

### DIFF
--- a/src/checkout/checkout-store-error-selector.spec.js
+++ b/src/checkout/checkout-store-error-selector.spec.js
@@ -16,18 +16,18 @@ describe('CheckoutStoreErrorSelector', () => {
     });
 
     describe('#getLoadCheckoutError()', () => {
-        it('returns error if there is an error when loading quote', () => {
-            jest.spyOn(selectors.quote, 'getLoadError').mockReturnValue(errorResponse);
+        it('returns error if there is an error when loading checkout', () => {
+            jest.spyOn(selectors.checkout, 'getLoadError').mockReturnValue(errorResponse);
 
             expect(errors.getLoadCheckoutError()).toEqual(errorResponse);
-            expect(selectors.quote.getLoadError).toHaveBeenCalled();
+            expect(selectors.checkout.getLoadError).toHaveBeenCalled();
         });
 
-        it('returns undefined if there is no error when loading quote', () => {
-            jest.spyOn(selectors.quote, 'getLoadError').mockReturnValue();
+        it('returns undefined if there is no error when loading checkout', () => {
+            jest.spyOn(selectors.checkout, 'getLoadError').mockReturnValue();
 
             expect(errors.getLoadCheckoutError()).toEqual(undefined);
-            expect(selectors.quote.getLoadError).toHaveBeenCalled();
+            expect(selectors.checkout.getLoadError).toHaveBeenCalled();
         });
     });
 

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -8,7 +8,6 @@ import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
-import { QuoteSelector } from '../quote';
 import { ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 
 import CheckoutSelector from './checkout-selector';
@@ -36,7 +35,6 @@ export default class CheckoutStoreErrorSelector {
     private _order: OrderSelector;
     private _paymentMethods: PaymentMethodSelector;
     private _paymentStrategies: PaymentStrategySelector;
-    private _quote: QuoteSelector;
     private _shippingCountries: ShippingCountrySelector;
     private _shippingOptions: ShippingOptionSelector;
     private _shippingStrategies: ShippingStrategySelector;
@@ -57,7 +55,6 @@ export default class CheckoutStoreErrorSelector {
         this._order = selectors.order;
         this._paymentMethods = selectors.paymentMethods;
         this._paymentStrategies = selectors.paymentStrategies;
-        this._quote = selectors.quote;
         this._shippingCountries = selectors.shippingCountries;
         this._shippingOptions = selectors.shippingOptions;
         this._shippingStrategies = selectors.shippingStrategies;
@@ -103,7 +100,7 @@ export default class CheckoutStoreErrorSelector {
      * @returns The error object if unable to load, otherwise undefined.
      */
     getLoadCheckoutError(): Error | undefined {
-        return this._quote.getLoadError() || this._checkout.getLoadError();
+        return this._checkout.getLoadError();
     }
 
     /**

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -65,7 +65,7 @@ export default class CheckoutStoreSelector {
         this._order = selectors.order;
         this._payment = selectors.payment;
         this._paymentMethods = selectors.paymentMethods;
-        this._quote = selectors.quote;
+        this._quote = new QuoteSelector(selectors);
         this._shippingAddress = selectors.shippingAddress;
         this._shippingCountries = selectors.shippingCountries;
         this._shippingOptions = selectors.shippingOptions;

--- a/src/checkout/checkout-store-status-selector.spec.js
+++ b/src/checkout/checkout-store-status-selector.spec.js
@@ -12,18 +12,18 @@ describe('CheckoutStoreStatusSelector', () => {
     });
 
     describe('#isLoadingCheckout()', () => {
-        it('returns true if loading quote', () => {
-            jest.spyOn(selectors.quote, 'isLoading').mockReturnValue(true);
+        it('returns true if loading checkout', () => {
+            jest.spyOn(selectors.checkout, 'isLoading').mockReturnValue(true);
 
             expect(statuses.isLoadingCheckout()).toEqual(true);
-            expect(selectors.quote.isLoading).toHaveBeenCalled();
+            expect(selectors.checkout.isLoading).toHaveBeenCalled();
         });
 
-        it('returns false if loading quote', () => {
-            jest.spyOn(selectors.quote, 'isLoading').mockReturnValue(false);
+        it('returns false if loading checkout', () => {
+            jest.spyOn(selectors.checkout, 'isLoading').mockReturnValue(false);
 
             expect(statuses.isLoadingCheckout()).toEqual(false);
-            expect(selectors.quote.isLoading).toHaveBeenCalled();
+            expect(selectors.checkout.isLoading).toHaveBeenCalled();
         });
     });
 

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -8,7 +8,6 @@ import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
-import { QuoteSelector } from '../quote';
 import { ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 
 import CheckoutSelector from './checkout-selector';
@@ -36,7 +35,6 @@ export default class CheckoutStoreStatusSelector {
     private _order: OrderSelector;
     private _paymentMethods: PaymentMethodSelector;
     private _paymentStrategies: PaymentStrategySelector;
-    private _quote: QuoteSelector;
     private _shippingCountries: ShippingCountrySelector;
     private _shippingOptions: ShippingOptionSelector;
     private _shippingStrategies: ShippingStrategySelector;
@@ -57,7 +55,6 @@ export default class CheckoutStoreStatusSelector {
         this._order = selectors.order;
         this._paymentMethods = selectors.paymentMethods;
         this._paymentStrategies = selectors.paymentStrategies;
-        this._quote = selectors.quote;
         this._shippingCountries = selectors.shippingCountries;
         this._shippingOptions = selectors.shippingOptions;
         this._shippingStrategies = selectors.shippingStrategies;
@@ -104,7 +101,7 @@ export default class CheckoutStoreStatusSelector {
      * @returns True if the current checkout is loading, otherwise false.
      */
     isLoadingCheckout(): boolean {
-        return this._quote.isLoading() || this._checkout.isLoading();
+        return this._checkout.isLoading();
     }
 
     /**

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -10,7 +10,6 @@ import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
 import { PaymentSelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
-import { QuoteSelector } from '../quote';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import { ShippingAddressSelector, ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 
@@ -42,7 +41,6 @@ export default function createInternalCheckoutSelectors(state: CheckoutStoreStat
 
     // Compose selectors
     const payment = new PaymentSelector(checkout, order);
-    const quote = new QuoteSelector(state.checkout, billingAddress, shippingAddress, shippingOptions);
 
     const selectors = {
         billingAddress,
@@ -60,7 +58,6 @@ export default function createInternalCheckoutSelectors(state: CheckoutStoreStat
         payment,
         paymentMethods,
         paymentStrategies,
-        quote,
         remoteCheckout,
         shippingAddress,
         shippingCountries,

--- a/src/checkout/internal-checkout-selectors.ts
+++ b/src/checkout/internal-checkout-selectors.ts
@@ -8,7 +8,6 @@ import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
-import { QuoteSelector } from '../quote';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import { ShippingAddressSelector, ShippingCountrySelector, ShippingOptionSelector, ShippingStrategySelector } from '../shipping';
 
@@ -30,7 +29,6 @@ export default interface InternalCheckoutSelectors {
     payment: PaymentSelector;
     paymentMethods: PaymentMethodSelector;
     paymentStrategies: PaymentStrategySelector;
-    quote: QuoteSelector;
     remoteCheckout: RemoteCheckoutSelector;
     shippingAddress: ShippingAddressSelector;
     shippingCountries: ShippingCountrySelector;

--- a/src/quote/quote-selector.spec.ts
+++ b/src/quote/quote-selector.spec.ts
@@ -1,74 +1,32 @@
-import { BillingAddressSelector } from '../billing';
-import { getBillingAddressState } from '../billing/billing-addresses.mock';
-import { getCheckoutState } from '../checkout/checkouts.mock';
-import { getErrorResponse } from '../common/http-request/responses.mock';
-import { getConfig } from '../config/configs.mock';
-import { ShippingAddressSelector, ShippingOptionSelector } from '../shipping';
-import { getConsignmentsState } from '../shipping/consignments.mock';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import createInternalCheckoutSelectors from '../checkout/create-internal-checkout-selectors';
 
 import { getQuote } from './internal-quotes.mock';
 import QuoteSelector from './quote-selector';
 
 describe('QuoteSelector', () => {
     let quoteSelector;
-    let shippingAddressSelector;
-    let shippingOptionsSelector;
-    let billingAddressSelector;
     let state;
 
     beforeEach(() => {
-        state = {
-            checkout: getCheckoutState(),
-            consignments: getConsignmentsState(),
-            billingAddress: getBillingAddressState(),
-            config: getConfig(),
-        };
-
-        shippingOptionsSelector = new ShippingOptionSelector(state.consignments);
-        shippingAddressSelector = new ShippingAddressSelector(state.consignments, state.config);
-        billingAddressSelector = new BillingAddressSelector(state.billingAddress);
-        quoteSelector = new QuoteSelector(state.checkout, billingAddressSelector, shippingAddressSelector, shippingOptionsSelector);
+        state = getCheckoutStoreState();
+        quoteSelector = new QuoteSelector(createInternalCheckoutSelectors(state));
     });
 
     describe('#getQuote()', () => {
-        it('returns the current quote', () => {
+        it('returns the internal quote', () => {
             expect(quoteSelector.getQuote())
                 .toEqual(getQuote());
-        });
-
-        it('returns the same instance as the shipping selector', () => {
-            expect(quoteSelector.getQuote().shippingAddress)
-                .toBe(shippingAddressSelector.getShippingAddress());
         });
     });
 
     describe('#getLoadError()', () => {
-        it('returns error if unable to load', () => {
-            const loadError = getErrorResponse();
-
-            quoteSelector = new QuoteSelector({
-                ...state.checkout,
-                errors: { loadError },
-            }, billingAddressSelector, shippingAddressSelector, shippingOptionsSelector);
-
-            expect(quoteSelector.getLoadError()).toEqual(loadError);
-        });
-
         it('does not returns error if able to load', () => {
             expect(quoteSelector.getLoadError()).toBeUndefined();
         });
     });
 
     describe('#isLoading()', () => {
-        it('returns true if loading quote', () => {
-            quoteSelector = new QuoteSelector({
-                ...state.checkout,
-                statuses: { isLoading: true },
-            }, billingAddressSelector, shippingAddressSelector, shippingOptionsSelector);
-
-            expect(quoteSelector.isLoading()).toEqual(true);
-        });
-
         it('returns false if not loading quote', () => {
             expect(quoteSelector.isLoading()).toEqual(false);
         });

--- a/src/quote/quote-selector.ts
+++ b/src/quote/quote-selector.ts
@@ -1,39 +1,33 @@
-import { InternalAddress } from '../address';
-import { BillingAddressSelector } from '../billing';
-import { CheckoutState } from '../checkout';
+import { InternalCheckoutSelectors } from '../checkout';
 import { selector } from '../common/selector';
-import { ShippingAddressSelector, ShippingOptionSelector } from '../shipping';
 
 import InternalQuote from './internal-quote';
+import mapToInternalQuote from './map-to-internal-quote';
 
+/**
+ * @deprecated This method will be replaced in the future.
+ */
 @selector
 export default class QuoteSelector {
     constructor(
-        private _checkout: CheckoutState,
-        private _billingAddressSelector: BillingAddressSelector,
-        private _shippingAddressSelector: ShippingAddressSelector,
-        private _shippingOptionSelector: ShippingOptionSelector
+        private _selectors: InternalCheckoutSelectors
     ) {}
 
     getQuote(): InternalQuote | undefined {
-        if (!this._checkout.data) {
+        const checkout = this._selectors.checkout.getCheckout();
+
+        if (!checkout) {
             return;
         }
-        const shippingOption = this._shippingOptionSelector.getSelectedShippingOption();
 
-        return {
-            shippingOption: shippingOption && shippingOption.id,
-            orderComment: this._checkout.data.customerMessage,
-            shippingAddress: this._shippingAddressSelector.getShippingAddress() || {} as InternalAddress,
-            billingAddress: this._billingAddressSelector.getBillingAddress() || {}  as InternalAddress,
-        };
+        return mapToInternalQuote(checkout);
     }
 
     getLoadError(): Error | undefined {
-        return this._checkout.errors.loadError;
+        return this._selectors.checkout.getLoadError();
     }
 
     isLoading(): boolean {
-        return !! this._checkout.statuses.isLoading;
+        return !! this._selectors.checkout.isLoading();
     }
 }


### PR DESCRIPTION
## What?
Move quote mapper to external selector

## Why?
So SDK doesn't rely in deprecated `Quote` object

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
