### PR TITLE
CHECKOUT-3052 Move address mappers to external selectors

### DIFF
--- a/src/billing/billing-address-selector.spec.js
+++ b/src/billing/billing-address-selector.spec.js
@@ -1,5 +1,4 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
-import { getQuote } from '../quote/internal-quotes.mock';
 import BillingAddressSelector from './billing-address-selector';
 import { getBillingAddressState } from './billing-addresses.mock';
 
@@ -17,7 +16,7 @@ describe('BillingAddressSelector', () => {
         it('returns the current billing address', () => {
             billingAddressSelector = new BillingAddressSelector(state.billingAddress);
 
-            expect(billingAddressSelector.getBillingAddress()).toEqual(getQuote().billingAddress);
+            expect(billingAddressSelector.getBillingAddress()).toEqual(state.billingAddress.data);
         });
 
         it('returns undefined if quote is not available', () => {

--- a/src/billing/billing-address-selector.ts
+++ b/src/billing/billing-address-selector.ts
@@ -1,4 +1,4 @@
-import { mapToInternalAddress, InternalAddress } from '../address';
+import { Address } from '../address';
 import { selector } from '../common/selector';
 
 import BillingAddressState from './billing-address-state';
@@ -9,8 +9,8 @@ export default class BillingAddressSelector {
         private _billingAddress: BillingAddressState
     ) {}
 
-    getBillingAddress(): InternalAddress | undefined {
-        return this._billingAddress.data && mapToInternalAddress(this._billingAddress.data);
+    getBillingAddress(): Address | undefined {
+        return this._billingAddress.data;
     }
 
     getUpdateError(): Error | undefined {

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -1,4 +1,4 @@
-import { InternalAddress } from '../address';
+import { mapToInternalAddress, InternalAddress } from '../address';
 import { BillingAddressSelector } from '../billing';
 import { mapToInternalCart, InternalCart } from '../cart';
 import { selector } from '../common/selector';
@@ -120,7 +120,9 @@ export default class CheckoutStoreSelector {
      * undefined.
      */
     getShippingAddress(): InternalAddress | undefined {
-        return this._shippingAddress.getShippingAddress();
+        const shippingAddress = this._shippingAddress.getShippingAddress();
+
+        return shippingAddress && mapToInternalAddress(shippingAddress);
     }
 
     /**
@@ -161,7 +163,9 @@ export default class CheckoutStoreSelector {
      * @returns The billing address object if it is loaded, otherwise undefined.
      */
     getBillingAddress(): InternalAddress | undefined {
-        return this._billingAddress.getBillingAddress();
+        const billingAddress = this._billingAddress.getBillingAddress();
+
+        return billingAddress && mapToInternalAddress(billingAddress);
     }
 
     /**

--- a/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 
 import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '..';
 import { getBillingAddressState } from '../../billing/billing-addresses.mock';
-import { getBillingAddress } from '../../billing/internal-billing-addresses.mock';
+import { getBillingAddress } from '../../billing/billing-addresses.mock';
 import { getCartState } from '../../cart/internal-carts.mock';
 import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { getCheckoutState } from '../../checkout/checkouts.mock';
@@ -20,7 +20,7 @@ import { VisaCheckoutSDK } from '../../payment/strategies/braintree/visacheckout
 import VisaCheckoutScriptLoader from '../../payment/strategies/braintree/visacheckout-script-loader';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../remote-checkout';
 import { getConsignmentsState } from '../../shipping/consignments.mock';
-import { getShippingAddress } from '../../shipping/internal-shipping-addresses.mock';
+import { getShippingAddress } from '../../shipping/shipping-addresses.mock';
 import { CustomerStrategyActionType } from '../customer-strategy-actions';
 import { getCustomerState, getRemoteCustomer } from '../internal-customers.mock';
 

--- a/src/payment/instrument/instrument-action-creator.spec.js
+++ b/src/payment/instrument/instrument-action-creator.spec.js
@@ -12,7 +12,7 @@ import {
     deleteInstrumentResponseBody,
 } from './instrument.mock';
 import { getConsignmentsState } from '../../shipping/consignments.mock';
-import { getShippingAddress } from '../../shipping/internal-shipping-addresses.mock';
+import { getShippingAddress } from '../../shipping/shipping-addresses.mock';
 
 describe('InstrumentActionCreator', () => {
     let instrumentActionCreator;

--- a/src/payment/instrument/instrument-action-creator.ts
+++ b/src/payment/instrument/instrument-action-creator.ts
@@ -2,7 +2,7 @@ import { createAction, createErrorAction, Action, ThunkAction } from '@bigcommer
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
-import { InternalAddress } from '../../address';
+import { Address } from '../../address';
 import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../../checkout';
 import { addMinutes, isFuture } from '../../common/date-time';
 import { MissingDataError } from '../../common/error/errors';
@@ -102,7 +102,7 @@ export default class InstrumentActionCreator {
                 }));
     }
 
-    private _getShippingAddress(store: ReadableCheckoutStore): InternalAddress | undefined {
+    private _getShippingAddress(store: ReadableCheckoutStore): Address | undefined {
         const state = store.getState();
 
         return state.shippingAddress.getShippingAddress();

--- a/src/payment/instrument/instrument-request-sender.spec.js
+++ b/src/payment/instrument/instrument-request-sender.spec.js
@@ -1,6 +1,7 @@
 import { createTimeout } from '@bigcommerce/request-sender';
 import { getResponse } from '../../common/http-request/responses.mock';
-import { getShippingAddress } from '../../shipping/internal-shipping-addresses.mock';
+import { getShippingAddress } from '../../shipping/shipping-addresses.mock';
+import { getShippingAddress as getInternalShippingAddress } from '../../shipping/internal-shipping-addresses.mock';
 import {
     deleteInstrumentResponseBody,
     getErrorInstrumentResponseBody,
@@ -123,7 +124,7 @@ describe('InstrumentMethodRequestSender', () => {
             expect(client.loadInstrumentsWithAddress).toHaveBeenCalledWith(
                 {
                     ...requestContext,
-                    shippingAddress,
+                    shippingAddress: getInternalShippingAddress(),
                 },
                 expect.any(Function)
             );

--- a/src/payment/instrument/instrument-request-sender.ts
+++ b/src/payment/instrument/instrument-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { InternalAddress } from '../../address';
+import { mapToInternalAddress, Address } from '../../address';
 import { RequestOptions } from '../../common/http-request';
 
 import { InstrumentRequestContext } from './instrument';
@@ -18,7 +18,7 @@ export default class InstrumentRequestSender {
         return this._requestSender.get(url, { timeout });
     }
 
-    loadInstruments(requestContext: InstrumentRequestContext, shippingAddress?: InternalAddress): Promise<Response<InstrumentsResponseBody>> {
+    loadInstruments(requestContext: InstrumentRequestContext, shippingAddress?: Address): Promise<Response<InstrumentsResponseBody>> {
         return (shippingAddress) ?
             this._loadInstrumentsWithAddress(requestContext, shippingAddress) :
             this._loadInstruments(requestContext);
@@ -53,10 +53,10 @@ export default class InstrumentRequestSender {
         });
     }
 
-    private _loadInstrumentsWithAddress(requestContext: InstrumentRequestContext, shippingAddress: InternalAddress): Promise<Response<InstrumentsResponseBody>> {
+    private _loadInstrumentsWithAddress(requestContext: InstrumentRequestContext, shippingAddress: Address): Promise<Response<InstrumentsResponseBody>> {
         const payload = {
             ...requestContext,
-            shippingAddress,
+            shippingAddress: mapToInternalAddress(shippingAddress),
         };
 
         return new Promise((resolve, reject) => {

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -4,6 +4,7 @@ import { concat } from 'rxjs/observable/concat';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
+import { mapToInternalAddress } from '../address';
 import { mapToInternalCart } from '../cart';
 import { InternalCheckoutSelectors } from '../checkout';
 import { MissingDataError } from '../common/error/errors';
@@ -83,13 +84,13 @@ export default class PaymentActionCreator {
 
         return {
             authToken,
-            billingAddress,
+            billingAddress: billingAddress && mapToInternalAddress(billingAddress),
             customer,
             paymentMethod,
-            shippingAddress,
+            shippingAddress: shippingAddress && mapToInternalAddress(shippingAddress),
             shippingOption,
-            cart: checkout ? mapToInternalCart(checkout) : undefined,
-            order: order ? mapToInternalOrder(order) : undefined,
+            cart: checkout && mapToInternalCart(checkout),
+            order: order && mapToInternalOrder(order),
             orderMeta: state.order.getOrderMeta(),
             payment: payment.paymentData,
             quoteMeta: {

--- a/src/payment/strategies/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay-payment-strategy.ts
@@ -1,6 +1,6 @@
 import { noop } from 'lodash';
 
-import { isAddressEqual, mapFromInternalAddress } from '../../address';
+import { isAddressEqual, mapFromInternalAddress, mapToInternalAddress } from '../../address';
 import { BillingAddressActionCreator } from '../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
 import { InvalidArgumentError, MissingDataError, NotInitializedError, RequestError, StandardError } from '../../common/error/errors';
@@ -190,13 +190,14 @@ export default class AmazonPayPaymentStrategy extends PaymentStrategy {
             .then(state => {
                 const amazon = state.remoteCheckout.getCheckout('amazon');
                 const remoteAddress = amazon && amazon.billing && amazon.billing.address;
-                const address = state.billingAddress.getBillingAddress();
+                const billingAddress = state.billingAddress.getBillingAddress();
+                const internalBillingAddress = billingAddress && mapToInternalAddress(billingAddress);
 
                 if (remoteAddress === false) {
                     throw new RemoteCheckoutSynchronizationError();
                 }
 
-                if (!remoteAddress || isAddressEqual(remoteAddress, address || {})) {
+                if (!remoteAddress || isAddressEqual(remoteAddress, internalBillingAddress || {})) {
                     return this._store.getState();
                 }
 

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -3,7 +3,7 @@ import { createAction, Action } from '@bigcommerce/data-store';
 import { merge, omit } from 'lodash';
 import { Observable } from 'rxjs';
 
-import { getBillingAddress } from '../../../billing/internal-billing-addresses.mock';
+import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { getCart } from '../../../cart/internal-carts.mock';
 import { createCheckoutClient, createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';

--- a/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -1,6 +1,6 @@
 import { omit } from 'lodash';
 
-import { getBillingAddress } from '../../../billing/internal-billing-addresses.mock';
+import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { getBraintree } from '../../../payment/payment-methods.mock';
 import { PaymentMethodCancelledError } from '../../errors';
 import { TokenizedCreditCard } from '../../payment';

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -1,4 +1,4 @@
-import { InternalAddress } from '../../../address';
+import { Address } from '../../../address';
 import { NotInitializedError } from '../../../common/error/errors';
 import { CancellablePromise } from '../../../common/utility';
 import { OrderPaymentRequestBody } from '../../../order';
@@ -25,7 +25,7 @@ export default class BraintreePaymentProcessor {
         return this._braintreeSDKCreator.getPaypal();
     }
 
-    tokenizeCard(payment: OrderPaymentRequestBody, billingAddress: InternalAddress): Promise<NonceInstrument> {
+    tokenizeCard(payment: OrderPaymentRequestBody, billingAddress: Address): Promise<NonceInstrument> {
         const { paymentData } = payment;
         const requestData = this._mapToCreditCard(paymentData as CreditCardInstrument, billingAddress);
 
@@ -49,7 +49,7 @@ export default class BraintreePaymentProcessor {
             }));
     }
 
-    verifyCard(payment: OrderPaymentRequestBody, billingAddress: InternalAddress, amount: number): Promise<NonceInstrument> {
+    verifyCard(payment: OrderPaymentRequestBody, billingAddress: Address, amount: number): Promise<NonceInstrument> {
         if (!this._threeDSecureOptions) {
             throw new NotInitializedError('Unable to verify card because the choosen payment method has not been initialized.');
         }
@@ -93,11 +93,11 @@ export default class BraintreePaymentProcessor {
         return this._braintreeSDKCreator.teardown();
     }
 
-    private _mapToCreditCard(creditCard: CreditCardInstrument, billingAddress: InternalAddress): BraintreeRequestData {
-        let streetAddress = billingAddress.addressLine1;
+    private _mapToCreditCard(creditCard: CreditCardInstrument, billingAddress: Address): BraintreeRequestData {
+        let streetAddress = billingAddress.address1;
 
-        if (billingAddress.addressLine2) {
-            streetAddress = ` ${billingAddress.addressLine2}`;
+        if (billingAddress.address2) {
+            streetAddress = ` ${billingAddress.address2}`;
         }
 
         return {
@@ -112,7 +112,7 @@ export default class BraintreePaymentProcessor {
                     },
                     billingAddress: {
                         countryName: billingAddress.country,
-                        postalCode: billingAddress.postCode,
+                        postalCode: billingAddress.postalCode,
                         streetAddress,
                     },
                 },

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
@@ -1,6 +1,6 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
-import { InternalAddress } from '../../../address';
+import { Address } from '../../../address';
 import { NotInitializedError } from '../../../common/error/errors';
 
 import { BraintreeDataCollector } from './braintree';
@@ -44,7 +44,7 @@ export default class BraintreeVisaCheckoutPaymentProcessor {
         return this._braintreeSDKCreator.teardown();
     }
 
-    handleSuccess(payment: VisaCheckoutPaymentSuccessPayload, shipping?: InternalAddress, billing?: InternalAddress): Promise<any> {
+    handleSuccess(payment: VisaCheckoutPaymentSuccessPayload, shipping?: Address, billing?: Address): Promise<any> {
         return this._braintreeSDKCreator.getVisaCheckout()
             .then(braintreeVisaCheckout => Promise.all([
                 braintreeVisaCheckout.tokenize(payment),
@@ -107,7 +107,7 @@ export default class BraintreeVisaCheckoutPaymentProcessor {
             .join('&');
     }
 
-    private _toVisaCheckoutAddress(address?: InternalAddress): VisaCheckoutAddress {
+    private _toVisaCheckoutAddress(address?: Address): VisaCheckoutAddress {
         if (!address) {
             return {};
         }
@@ -116,12 +116,12 @@ export default class BraintreeVisaCheckoutPaymentProcessor {
             firstName: address.firstName,
             lastName: address.lastName,
             phoneNumber: address.phone,
-            streetAddress: address.addressLine1,
-            extendedAddress: address.addressLine2,
+            streetAddress: address.address1,
+            extendedAddress: address.address2,
             locality: address.city,
-            region: address.provinceCode,
+            region: address.stateOrProvinceCode,
             countryCode: address.countryCode,
-            postalCode: address.postCode,
+            postalCode: address.postalCode,
         };
     }
 

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -14,7 +14,7 @@ import {
     PaymentStrategyActionCreator,
 } from '../..';
 import { getBillingAddressState } from '../../../billing/billing-addresses.mock';
-import { getBillingAddress } from '../../../billing/internal-billing-addresses.mock';
+import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { getCartState } from '../../../cart/internal-carts.mock';
 import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
@@ -24,7 +24,7 @@ import { getCustomerState } from '../../../customer/internal-customers.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getConsignmentsState } from '../../../shipping/consignments.mock';
-import { getShippingAddress } from '../../../shipping/internal-shipping-addresses.mock';
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import { SUBMIT_PAYMENT_REQUESTED } from '../../payment-action-types';
 import { getBraintreeVisaCheckout, getPaymentMethodsState } from '../../payment-methods.mock';
 import { PaymentStrategyActionType } from '../../payment-strategy-actions';

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -99,8 +99,8 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                         throw new NotInitializedError();
                     }
 
-                    if (billingAddress && billingAddress.postCode) {
-                        this._paymentForm.setPostalCode(billingAddress.postCode);
+                    if (billingAddress && billingAddress.postalCode) {
+                        this._paymentForm.setPostalCode(billingAddress.postalCode);
                     }
                 },
                 unsupportedBrowserDetected: () => {

--- a/src/shipping/shipping-address-selector.spec.js
+++ b/src/shipping/shipping-address-selector.spec.js
@@ -1,7 +1,6 @@
 import ShippingAddressSelector from './shipping-address-selector';
 import { getConfigState } from '../config/configs.mock';
 import { getConsignmentsState } from './consignments.mock';
-import { getShippingAddress } from './internal-shipping-addresses.mock';
 
 describe('ShippingAddressSelector', () => {
     let shippingAddressSelector;
@@ -18,7 +17,7 @@ describe('ShippingAddressSelector', () => {
         it('returns the current shipping address', () => {
             shippingAddressSelector = new ShippingAddressSelector(state.consignments, state.config);
 
-            expect(shippingAddressSelector.getShippingAddress()).toEqual(getShippingAddress());
+            expect(shippingAddressSelector.getShippingAddress()).toEqual(state.consignments.data[0].shippingAddress);
         });
 
         describe('when there is no shipping information', () => {

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -1,6 +1,6 @@
 import { selector } from '../common/selector';
 
-import { mapToInternalAddress, InternalAddress } from '../address';
+import { Address } from '../address';
 import ConfigState from '../config/config-state';
 
 import ConsignmentState from './consignment-state';
@@ -12,7 +12,7 @@ export default class ShippingAddressSelector {
         private _config: ConfigState
     ) {}
 
-    getShippingAddress(): InternalAddress | undefined {
+    getShippingAddress(): Address | undefined {
         const consignments = this._consignments.data;
         const context = this._config.data && this._config.data.context;
 
@@ -25,12 +25,12 @@ export default class ShippingAddressSelector {
                 firstName: '',
                 lastName: '',
                 company: '',
-                addressLine1: '',
-                addressLine2: '',
+                address1: '',
+                address2: '',
                 city: '',
-                province: '',
-                provinceCode: '',
-                postCode: '',
+                stateOrProvince: '',
+                stateOrProvinceCode: '',
+                postalCode: '',
                 country: '',
                 phone: '',
                 customFields: [],
@@ -38,6 +38,6 @@ export default class ShippingAddressSelector {
             };
         }
 
-        return mapToInternalAddress(consignments[0].shippingAddress);
+        return consignments[0].shippingAddress;
     }
 }


### PR DESCRIPTION
## What?
Move address mappers to external selectors

## Why?
So SDK relies on storefront address schemas instead of legacy schemas

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
