### PR TITLE
CHECKOUT-3056: Export internal mappers to be used for UCO

### DIFF
--- a/src/cart/map-to-internal-line-items.ts
+++ b/src/cart/map-to-internal-line-items.ts
@@ -4,7 +4,7 @@ import LineItemMap from './line-item-map';
 import mapGiftCertificateToInternalLineItem from './map-gift-certificate-to-internal-line-item';
 import mapToInternalLineItem from './map-to-internal-line-item';
 
-export default function notificationsmapToInternalLineItems(
+export default function mapToInternalLineItems(
     itemMap: LineItemMap,
     decimalPlaces: number,
     idKey: keyof LineItem = 'id'

--- a/src/internal-mappers.ts
+++ b/src/internal-mappers.ts
@@ -1,0 +1,12 @@
+/**
+ * Please note that these mappers are for internal use only. DO NOT USE. They
+ * can be removed or changed at any time.
+ */
+export { mapToInternalAddress } from './address';
+export { mapToInternalCart } from './cart';
+export { mapToInternalCoupon, mapToInternalGiftCertificate } from './coupon';
+export { mapToInternalCustomer } from './customer';
+export { mapToInternalLineItem, mapToInternalLineItems } from './cart';
+export { mapToInternalOrder } from './order';
+export { mapToInternalQuote } from './quote';
+export { mapToInternalShippingOption, mapToInternalShippingOptions } from './shipping';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const assetConfig = {
 
     entry: {
         'checkout-sdk': './src/index.ts',
+        'internal-mappers': './src/internal-mappers.ts',
     },
 
     output: {


### PR DESCRIPTION
## What?
* Export mappers for mapping storefront API objects into internal API objects.
* These mappers are for internal use only. They are undocumented and can be removed at any time.

## Why?
* To be used in UCO.
* This is because mappers are also used for sending requests to BigPay service. Therefore, we can't just extract them yet. However, we don't want to duplicate the mappers. So, we have decided to export them but leave them undocumented.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
