### PR TITLE
Move shipping options mapper to external selector

### DIFF
--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -23,7 +23,7 @@ import { InstrumentActionCreator } from '../payment/instrument';
 import { deleteInstrumentResponseBody, getVaultAccessTokenResponseBody, getLoadInstrumentsResponseBody } from '../payment/instrument/instrument.mock';
 import { createShippingStrategyRegistry, ConsignmentActionCreator, ShippingCountryActionCreator, ShippingStrategyActionCreator } from '../shipping';
 import { getShippingAddress, getShippingAddressResponseBody } from '../shipping/internal-shipping-addresses.mock';
-import { getShippingOptionResponseBody } from '../shipping/internal-shipping-options.mock';
+import { getShippingOptionResponseBody, getShippingOptions } from '../shipping/internal-shipping-options.mock';
 
 import CheckoutActionCreator from './checkout-action-creator';
 import CheckoutService from './checkout-service';
@@ -639,7 +639,7 @@ describe('CheckoutService', () => {
             const state = await checkoutService.loadShippingOptions();
 
             expect(checkoutRequestSender.loadCheckout).toHaveBeenCalled();
-            expect(state.data.getShippingOptions()).toEqual(store.getState().shippingOptions.getShippingOptions());
+            expect(state.data.getShippingOptions()).toEqual(getShippingOptions());
         });
     });
 

--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -48,7 +48,7 @@ describe('CheckoutStoreSelector', () => {
     });
 
     it('returns shipping options', () => {
-        expect(selector.getShippingOptions()).toEqual(internalSelectors.shippingOptions.getShippingOptions());
+        expect(selector.getShippingOptions()).toEqual(getShippingOptions());
     });
 
     it('returns shipping countries', () => {

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -13,12 +13,15 @@ import { PaymentMethod, PaymentMethodSelector, PaymentSelector } from '../paymen
 import { Instrument, InstrumentSelector } from '../payment/instrument';
 import { InternalQuote, QuoteSelector } from '../quote';
 import {
+    mapToInternalShippingOption,
+    mapToInternalShippingOptions,
     InternalShippingOption,
     InternalShippingOptionList,
     ShippingAddressSelector,
     ShippingCountrySelector,
     ShippingOptionSelector,
 } from '../shipping';
+import ConsignmentSelector from '../shipping/consignment-selector';
 
 import Checkout from './checkout';
 import CheckoutSelector from './checkout-selector';
@@ -35,6 +38,7 @@ export default class CheckoutStoreSelector {
     private _billingAddress: BillingAddressSelector;
     private _checkout: CheckoutSelector;
     private _config: ConfigSelector;
+    private _consignments: ConsignmentSelector;
     private _countries: CountrySelector;
     private _coupons: CouponSelector;
     private _customer: CustomerSelector;
@@ -56,6 +60,7 @@ export default class CheckoutStoreSelector {
         this._billingAddress = selectors.billingAddress;
         this._checkout = selectors.checkout;
         this._config = selectors.config;
+        this._consignments = selectors.consignments;
         this._countries = selectors.countries;
         this._coupons = selectors.coupons;
         this._customer = selectors.customer;
@@ -135,7 +140,10 @@ export default class CheckoutStoreSelector {
      * undefined.
      */
     getShippingOptions(): InternalShippingOptionList | undefined {
-        return this._shippingOptions.getShippingOptions();
+        // @todo: once we remove the mappers, this should use the shippingOption selector
+        const consignments = this._consignments.getConsignments();
+
+        return consignments && mapToInternalShippingOptions(consignments);
     }
 
     /**
@@ -145,7 +153,9 @@ export default class CheckoutStoreSelector {
      * otherwise undefined.
      */
     getSelectedShippingOption(): InternalShippingOption | undefined {
-        return this._shippingOptions.getSelectedShippingOption();
+        const shippingOption = this._shippingOptions.getSelectedShippingOption();
+
+        return shippingOption  && mapToInternalShippingOption(shippingOption, true);
     }
 
     /**

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -10,6 +10,7 @@ import { InternalCheckoutSelectors } from '../checkout';
 import { MissingDataError } from '../common/error/errors';
 import { mapToInternalCustomer } from '../customer';
 import { mapToInternalOrder, OrderActionCreator } from '../order';
+import { mapToInternalShippingOption } from '../shipping';
 
 import isVaultedInstrument from './is-vaulted-instrument';
 import Payment from './payment';
@@ -91,7 +92,7 @@ export default class PaymentActionCreator {
             customer: internalCustomer,
             paymentMethod,
             shippingAddress: shippingAddress && mapToInternalAddress(shippingAddress),
-            shippingOption,
+            shippingOption: shippingOption && mapToInternalShippingOption(shippingOption, true),
             cart: checkout && mapToInternalCart(checkout),
             order: order && mapToInternalOrder(order),
             orderMeta: state.order.getOrderMeta(),

--- a/src/shipping/shipping-option-selector.spec.js
+++ b/src/shipping/shipping-option-selector.spec.js
@@ -1,5 +1,5 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
-import { getFlatRateOption, getShippingOptions } from './internal-shipping-options.mock';
+import { getShippingOption, getShippingOptions } from './shipping-options.mock';
 import ShippingOptionSelector from './shipping-option-selector';
 import { getConsignment, getConsignmentsState } from './consignments.mock';
 
@@ -23,7 +23,7 @@ describe('ShippingOptionSelector', () => {
 
     describe('#getSelectedShippingOption()', () => {
         it('returns selected shipping option', () => {
-            expect(shippingOptionSelector.getSelectedShippingOption()).toEqual(getFlatRateOption());
+            expect(shippingOptionSelector.getSelectedShippingOption()).toEqual(getShippingOption());
         });
 
         it('returns undefined if shipping option is not selected', () => {

--- a/src/shipping/shipping-option-selector.ts
+++ b/src/shipping/shipping-option-selector.ts
@@ -2,10 +2,9 @@ import { find } from 'lodash';
 
 import { selector } from '../common/selector';
 
+import Consignment from './consignment';
 import ConsignmentState from './consignment-state';
-import InternalShippingOption, { InternalShippingOptionList } from './internal-shipping-option';
-import mapToInternalShippingOption from './map-to-internal-shipping-option';
-import mapToInternalShippingOptions from './map-to-internal-shipping-options';
+import ShippingOption from './shipping-option';
 
 @selector
 export default class ShippingOptionSelector {
@@ -13,21 +12,23 @@ export default class ShippingOptionSelector {
         private _consignments: ConsignmentState
     ) {}
 
-    getShippingOptions(): InternalShippingOptionList | undefined {
-        return this._consignments.data && mapToInternalShippingOptions(this._consignments.data);
+    getShippingOptions(): ShippingOption[] | undefined {
+        const consignment = this._getConsignment();
+
+        return consignment && consignment.availableShippingOptions;
     }
 
-    getSelectedShippingOption(): InternalShippingOption | undefined {
-        if (!this._consignments.data) {
+    getSelectedShippingOption(): ShippingOption | undefined {
+        const consignment = this._getConsignment();
+
+        if (!consignment) {
             return;
         }
 
-        const { selectedShippingOptionId, availableShippingOptions } = this._consignments.data[0];
+        const { selectedShippingOptionId, availableShippingOptions } = consignment;
         const shippingOption = find(availableShippingOptions, { id: selectedShippingOptionId });
 
-        return shippingOption ?
-            mapToInternalShippingOption(shippingOption, true)
-            : undefined;
+        return shippingOption;
     }
 
     getLoadError(): Error | undefined {
@@ -52,5 +53,13 @@ export default class ShippingOptionSelector {
 
     isCreating(): boolean {
         return !!this._consignments.statuses.isCreating;
+    }
+
+    private _getConsignment(): Consignment | undefined {
+        if (!this._consignments.data) {
+            return;
+        }
+
+        return this._consignments.data[0];
     }
 }

--- a/src/shipping/shipping-options.mock.ts
+++ b/src/shipping/shipping-options.mock.ts
@@ -11,3 +11,7 @@ export function getShippingOption(): ShippingOption {
         type: 'shipping_flatrate',
     };
 }
+
+export function getShippingOptions(): ShippingOption[] {
+    return [getShippingOption()];
+}


### PR DESCRIPTION
## What?
Moves shipping options mapper to external selector

## Why?
So SDK internally uses storefront API schema

## Testing / Proof
unit

@bigcommerce/checkout
