### PR TITLE
CHECKOUT-3052 Pass consignment id to address mapper

### DIFF
--- a/src/shipping/consignments.mock.ts
+++ b/src/shipping/consignments.mock.ts
@@ -1,3 +1,6 @@
+import { omit } from 'lodash';
+
+import { Address } from '../address';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 import { getShippingOption } from '../shipping/shipping-options.mock';
 
@@ -13,7 +16,7 @@ export function getConsignment(): Consignment {
         lineItemIds: [
             '12e11c8f-7dce-4da3-9413-b649533f8bad',
         ],
-        shippingAddress: getShippingAddress(),
+        shippingAddress: omit(getShippingAddress(), 'id') as Address,
         availableShippingOptions: [
             getShippingOption(),
         ],

--- a/src/shipping/shipping-address-selector.spec.js
+++ b/src/shipping/shipping-address-selector.spec.js
@@ -17,7 +17,10 @@ describe('ShippingAddressSelector', () => {
         it('returns the current shipping address', () => {
             shippingAddressSelector = new ShippingAddressSelector(state.consignments, state.config);
 
-            expect(shippingAddressSelector.getShippingAddress()).toEqual(state.consignments.data[0].shippingAddress);
+            expect(shippingAddressSelector.getShippingAddress()).toEqual({
+                ...state.consignments.data[0].shippingAddress,
+                id: state.consignments.data[0].id,
+            });
         });
 
         describe('when there is no shipping information', () => {

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -38,6 +38,9 @@ export default class ShippingAddressSelector {
             };
         }
 
-        return consignments[0].shippingAddress;
+        return {
+            ...consignments[0].shippingAddress,
+            id: consignments[0].id,
+        };
     }
 }


### PR DESCRIPTION
## What?
Pass consignment ID to address mapper

## Why?
Because shipping address no longer has an ID

## Testing / Proof
unit
manual

@bigcommerce/checkout 
