### PR TITLE
chore(common): INT-646 Bump bigpay-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bigcommerce/bigpay-client": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-3.1.0.tgz",
-      "integrity": "sha512-duUwpdrjOzylMifbcg3eJie2rSs/A/xXlP5nkd51twBJ4ZyX1X7imQ6+p3XdUVhIgxOcheq4oY52rK0k52PQKw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-3.2.0.tgz",
+      "integrity": "sha512-D+1ecjcoJl3KdE1G3yjw11itDVInhSrYqETRHmhRqxmYppi3nSpq+X2Zj1ed+wIlDKq+u+Cq8DRvXBsM6VLfcQ==",
       "requires": {
         "@bigcommerce/form-poster": "^1.2.1",
         "deep-assign": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "validate-commits": "validate-commits"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^3.1.0",
+    "@bigcommerce/bigpay-client": "^3.2.0",
     "@bigcommerce/data-store": "^0.1.8",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/request-sender": "^0.1.4",


### PR DESCRIPTION
## What?
Bumping the bigpay-client since we added the account mask to the cryptogram payment method for Chase Pay + WePay

New release => https://github.com/bigcommerce/bigpay-client-js/releases/tag/3.2.0

## Why?
To expose [https://github.com/bigcommerce/bigpay-client-js/pull/69](https://github.com/bigcommerce/bigpay-client-js/pull/69)

## Testing / Proof
n/a

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/integrations 
