### PR TITLE
CHECKOUT-3278 Read from customer selector in checkout selector

### DIFF
--- a/src/checkout/checkout-reducer.spec.ts
+++ b/src/checkout/checkout-reducer.spec.ts
@@ -21,7 +21,7 @@ describe('checkoutReducer', () => {
         const output = checkoutReducer(initialState, action);
 
         expect(output).toEqual({
-            data: omit(action.payload, ['billingAddress', 'cart', 'consignments', 'coupons', 'giftCertifcates']),
+            data: omit(action.payload, ['billingAddress', 'cart', 'customer', 'consignments', 'coupons', 'giftCertifcates']),
             errors: { loadError: undefined },
             statuses: { isLoading: false },
         });

--- a/src/checkout/checkout-reducer.ts
+++ b/src/checkout/checkout-reducer.ts
@@ -41,7 +41,7 @@ function dataReducer(
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
         return action.payload
-            ? omit({ ...data, ...action.payload }, ['billingAddress', 'cart', 'consignments', 'coupons', 'giftCertifcates'])
+            ? omit({ ...data, ...action.payload }, ['billingAddress', 'cart', 'consignments', 'customer', 'coupons', 'giftCertifcates'])
             : data;
 
     case OrderActionType.SubmitOrderSucceeded:

--- a/src/checkout/checkout-selector.spec.ts
+++ b/src/checkout/checkout-selector.spec.ts
@@ -14,7 +14,7 @@ describe('CheckoutSelector', () => {
     });
 
     it('returns checkout', () => {
-        const selector = new CheckoutSelector(state.checkout, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.giftCertificates);
+        const selector = new CheckoutSelector(state.checkout, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.customer, selectors.giftCertificates);
 
         expect(selector.getCheckout()).toEqual({
             ...getCheckout(),
@@ -30,7 +30,7 @@ describe('CheckoutSelector', () => {
         const selector = new CheckoutSelector({
             ...getCheckoutState(),
             errors: { loadError },
-        }, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.giftCertificates);
+        }, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.customer, selectors.giftCertificates);
 
         expect(selector.getLoadError()).toEqual(loadError);
     });
@@ -39,7 +39,7 @@ describe('CheckoutSelector', () => {
         const selector = new CheckoutSelector({
             ...getCheckoutState(),
             statuses: { isLoading: true },
-        }, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.giftCertificates);
+        }, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.customer, selectors.giftCertificates);
 
         expect(selector.isLoading()).toEqual(true);
     });

--- a/src/checkout/checkout-selector.ts
+++ b/src/checkout/checkout-selector.ts
@@ -2,6 +2,7 @@ import { BillingAddressSelector } from '../billing';
 import { CartSelector } from '../cart';
 import { selector } from '../common/selector';
 import { CouponSelector, GiftCertificateSelector } from '../coupon';
+import { CustomerSelector } from '../customer';
 import { ConsignmentSelector } from '../shipping';
 
 import Checkout from './checkout';
@@ -15,6 +16,7 @@ export default class CheckoutSelector {
         private _cart: CartSelector,
         private _consignments: ConsignmentSelector,
         private _coupons: CouponSelector,
+        private _customer: CustomerSelector,
         private _giftCertificates: GiftCertificateSelector
     ) {}
 
@@ -22,11 +24,12 @@ export default class CheckoutSelector {
         const { data } = this._checkout;
         const billingAddress = this._billingAddress.getBillingAddress();
         const cart = this._cart.getCart();
+        const customer = this._customer.getCustomer();
         const consignments = this._consignments.getConsignments() || [];
         const coupons = this._coupons.getCoupons() || [];
         const giftCertificates = this._giftCertificates.getGiftCertificates() || [];
 
-        if (!data || !cart) {
+        if (!data || !cart || !customer) {
             return;
         }
 
@@ -34,6 +37,7 @@ export default class CheckoutSelector {
             ...data,
             billingAddress,
             cart,
+            customer,
             consignments,
             coupons,
             giftCertificates,

--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -33,6 +33,7 @@ import CheckoutStoreSelector from './checkout-store-selector';
 import CheckoutStoreErrorSelector from './checkout-store-error-selector';
 import CheckoutStoreStatusSelector from './checkout-store-status-selector';
 import { getConsignmentsState } from '../shipping/consignments.mock';
+import { getCustomerState } from '../customer/customers.mock';
 
 describe('CheckoutService', () => {
     let billingAddressActionCreator;
@@ -125,6 +126,7 @@ describe('CheckoutService', () => {
 
         store = createCheckoutStore({
             cart: getCartState(),
+            customer: getCustomerState(),
             billingAddress: getBillingAddressState(),
             checkout: getCheckoutState(),
             config: getConfigState(),

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -39,7 +39,7 @@ export default function createInternalCheckoutSelectors(state: CheckoutStoreStat
     const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);
 
     // Compose selectors
-    const checkout = new CheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, giftCertificates);
+    const checkout = new CheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, customer, giftCertificates);
     const order = new OrderSelector(state.order, billingAddress, coupons);
     const payment = new PaymentSelector(checkout, order);
 

--- a/src/payment/payment-selector.spec.ts
+++ b/src/payment/payment-selector.spec.ts
@@ -155,11 +155,9 @@ describe('PaymentSelector', () => {
 
         it('returns false if store credit exceeds grand total', () => {
             selectors = createInternalCheckoutSelectors(merge({}, state, {
-                checkout: {
+                customer: {
                     data: {
-                        customer: {
-                            storeCredit: 100000000000,
-                        },
+                        storeCredit: 100000000000,
                     },
                 },
             }));
@@ -170,11 +168,9 @@ describe('PaymentSelector', () => {
 
         it('returns true if store credit exceeds grand total but not using store credit', () => {
             selectors = createInternalCheckoutSelectors(merge({}, state, {
-                checkout: {
+                customer: {
                     data: {
-                        customer: {
-                            storeCredit: 100000000000,
-                        },
+                        storeCredit: 100000000000,
                     },
                 },
             }));

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -302,11 +302,9 @@ describe('PaymentStrategyActionCreator', () => {
         it('finds `nopaymentrequired` strategy if payment data is not required', async () => {
             store = createCheckoutStore({
                 ...state,
-                checkout: merge({}, getCheckoutState(), {
+                customer: merge({}, getCustomerState(), {
                     data: {
-                        customer: {
-                            storeCredit: 9999,
-                        },
+                        storeCredit: 9999,
                     },
                 }),
             });


### PR DESCRIPTION
## What?
- Read `customer` from `customerSelector` in `checkoutSelector`
- Do not store customer data in checkout state

## Why?
- To avoid data redudancy

## Testing / Proof
unit