### PR TITLE
CHECKOUT-3253 Change consigment schema to store selected shipping option object

### DIFF
--- a/src/quote/map-to-internal-quote.ts
+++ b/src/quote/map-to-internal-quote.ts
@@ -4,10 +4,12 @@ import { Checkout } from '../checkout';
 import InternalQuote from './internal-quote';
 
 export default function mapToInternalQuote(checkout: Checkout): InternalQuote {
+    const consignment = checkout.consignments && checkout.consignments[0];
+
     return {
         orderComment: checkout.customerMessage,
-        shippingOption: checkout.consignments[0] ? checkout.consignments[0].selectedShippingOptionId : undefined,
+        shippingOption: consignment && consignment.selectedShippingOption ? consignment.selectedShippingOption.id : undefined,
         billingAddress: checkout.billingAddress ? mapToInternalAddress(checkout.billingAddress) : {} as InternalAddress,
-        shippingAddress: checkout.consignments[0] ? mapToInternalAddress(checkout.consignments[0].shippingAddress, checkout.consignments[0].id) : undefined,
+        shippingAddress: consignment ? mapToInternalAddress(checkout.consignments[0].shippingAddress, checkout.consignments[0].id) : undefined,
     };
 }

--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -8,7 +8,7 @@ export default interface Consignment {
     handlingCost: number;
     shippingCost: number;
     availableShippingOptions?: ShippingOption[];
-    selectedShippingOptionId?: string;
+    selectedShippingOption?: ShippingOption;
     lineItemIds?: string[];
 }
 

--- a/src/shipping/consignments.mock.ts
+++ b/src/shipping/consignments.mock.ts
@@ -10,7 +10,7 @@ import ConsignmentState from './consignment-state';
 export function getConsignment(): Consignment {
     return {
         id: '55c96cda6f04c',
-        selectedShippingOptionId: '0:61d4bb52f746477e1d4fb411221318c3',
+        selectedShippingOption: getShippingOption(),
         shippingCost: 0,
         handlingCost: 0,
         lineItemIds: [

--- a/src/shipping/map-to-internal-shipping-options.ts
+++ b/src/shipping/map-to-internal-shipping-options.ts
@@ -5,11 +5,13 @@ import mapToInternalShippingOption from './map-to-internal-shipping-option';
 export default function mapToInternalShippingOptions(consignments: Consignment[]): InternalShippingOptionList {
     return consignments.reduce((result, consignment) => ({
         ...result,
-        [consignment.id]: (consignment.availableShippingOptions || []).map(option =>
-            mapToInternalShippingOption(
+        [consignment.id]: (consignment.availableShippingOptions || []).map(option => {
+            const selectedOptionId = consignment.selectedShippingOption && consignment.selectedShippingOption.id;
+
+            return mapToInternalShippingOption(
                 option,
-                option.id === consignment.selectedShippingOptionId
-            )
-        ),
+                option.id === selectedOptionId
+            );
+        }),
     }), {});
 }

--- a/src/shipping/shipping-option-selector.spec.js
+++ b/src/shipping/shipping-option-selector.spec.js
@@ -30,7 +30,7 @@ describe('ShippingOptionSelector', () => {
             const consignmentState = {
                 data: [{
                     ...getConsignment(),
-                    selectedShippingOptionId: undefined,
+                    selectedShippingOption: undefined,
                 }],
             };
 

--- a/src/shipping/shipping-option-selector.ts
+++ b/src/shipping/shipping-option-selector.ts
@@ -1,5 +1,3 @@
-import { find } from 'lodash';
-
 import { selector } from '../common/selector';
 
 import Consignment from './consignment';
@@ -21,14 +19,7 @@ export default class ShippingOptionSelector {
     getSelectedShippingOption(): ShippingOption | undefined {
         const consignment = this._getConsignment();
 
-        if (!consignment) {
-            return;
-        }
-
-        const { selectedShippingOptionId, availableShippingOptions } = consignment;
-        const shippingOption = find(availableShippingOptions, { id: selectedShippingOptionId });
-
-        return shippingOption;
+        return consignment && consignment.selectedShippingOption;
     }
 
     getLoadError(): Error | undefined {


### PR DESCRIPTION
## What?
Change `consignment` schema to store `selectedShippingOption` object instead of just the id.

## Why?
Because API will return an object instead of an ID.

## Testing / Proof
unit

@bigcommerce/checkout 