### PR TITLE
CHECKOUT-3053: Add `initialize` convenience method for hydrating initial state

### DIFF
--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -274,6 +274,59 @@ describe('CheckoutService', () => {
         });
     });
 
+    describe('#initialize()', () => {
+        const checkoutId = 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7';
+        const options = { timeout: createTimeout() };
+
+        it('loads checkout configuration', async () => {
+            jest.spyOn(checkoutService, 'loadConfig');
+
+            await checkoutService.initialize(checkoutId, options);
+
+            expect(checkoutService.loadConfig).toHaveBeenCalledWith(options);
+        });
+
+        it('loads checkout', async () => {
+            jest.spyOn(checkoutService, 'loadCheckout');
+
+            await checkoutService.initialize(checkoutId, options);
+
+            expect(checkoutService.loadCheckout).toHaveBeenCalledWith(checkoutId, options);
+        });
+
+        it('loads address fields', async () => {
+            jest.spyOn(checkoutService, 'loadBillingAddressFields');
+            jest.spyOn(checkoutService, 'loadShippingAddressFields');
+
+            await checkoutService.initialize(checkoutId, options);
+
+            expect(checkoutService.loadBillingAddressFields).toHaveBeenCalledWith(options);
+            expect(checkoutService.loadShippingAddressFields).toHaveBeenCalledWith(options);
+        });
+
+        it('loads shipping options', async () => {
+            jest.spyOn(checkoutService, 'loadShippingOptions');
+
+            await checkoutService.initialize(checkoutId, options);
+
+            expect(checkoutService.loadShippingOptions).toHaveBeenCalledWith(options);
+        });
+
+        it('loads payment methods', async () => {
+            jest.spyOn(checkoutService, 'loadPaymentMethods');
+
+            await checkoutService.initialize(checkoutId, options);
+
+            expect(checkoutService.loadPaymentMethods).toHaveBeenCalledWith(options);
+        });
+
+        it('returns promise that resolves to current state', async () => {
+            const state = await checkoutService.initialize(checkoutId, options);
+
+            expect(state).toEqual(checkoutService.getState());
+        });
+    });
+
     describe('#loadCheckout()', () => {
         const { id } = getCheckout();
 

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -131,6 +131,35 @@ export default class CheckoutService {
     }
 
     /**
+     * Initialize the instance by loading the initial checkout state.
+     *
+     * The method is a convenience method for populating the following data:
+     * checkout, configuration, billing address fields, shipping address fields,
+     * shipping options and payment methods.
+     *
+     * ```js
+     * const state = await service.initialize('0cfd6c06-57c3-4e29-8d7a-de55cc8a9052');
+     *
+     * console.log(state.checkout.getCheckout());
+     * ```
+     *
+     * @param checkoutId - The identifier of the checkout to load.
+     * @param options - Options for the initialization.
+     * @returns A promise that resolves to the current state.
+     */
+    initialize(checkoutId: string, options?: RequestOptions): Promise<CheckoutSelectors> {
+        return Promise.all([
+            this.loadCheckout(checkoutId, options),
+            this.loadConfig(options),
+            this.loadBillingAddressFields(options),
+            this.loadShippingAddressFields(options),
+            this.loadShippingOptions(options),
+            this.loadPaymentMethods(options),
+        ])
+            .then(() => this.getState());
+    }
+
+    /**
      * Loads the current checkout.
      *
      * This method can only be called if there is an active checkout. Also, it


### PR DESCRIPTION
## What?
* Add `initialize` convenience method for hydrating the initial state.

## Why?
* A convenient way to load the essential data that is required to function.

```js
import { createCheckoutService } from '@bigcommerce/checkout-sdk';

const service = createCheckoutService();

service.initialize();

service.subscribe(state => {
    // Update view with `state`
});
```

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
