### PR TITLE
CHECKOUT-3056 Store billing address state when order loads

### DIFF
--- a/src/billing/billing-address-reducer.spec.ts
+++ b/src/billing/billing-address-reducer.spec.ts
@@ -7,6 +7,8 @@ import { getErrorResponse } from '../common/http-request/responses.mock';
 
 import billingAddressReducer from './billing-address-reducer';
 import BillingAddressState from './billing-address-state';
+import { OrderActionType } from '../order';
+import { getOrder } from '../order/orders.mock';
 
 describe('billingAddressReducer', () => {
     let initialState: BillingAddressState;
@@ -23,6 +25,17 @@ describe('billingAddressReducer', () => {
             data: action.payload.billingAddress,
             errors: { loadError: undefined },
             statuses: { isLoading: false },
+        });
+    });
+
+    it('returns billing address when order loads', () => {
+        const action = createAction(OrderActionType.LoadOrderSucceeded, getOrder());
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            data: action.payload.billingAddress,
+            errors: {},
+            statuses: {},
         });
     });
 

--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -2,6 +2,7 @@ import { combineReducers } from '@bigcommerce/data-store';
 
 import { Address } from '../address';
 import { CheckoutAction, CheckoutActionType } from '../checkout';
+import { OrderAction, OrderActionType } from '../order';
 
 import { BillingAddressAction, BillingAddressActionType } from './billing-address-actions';
 import BillingAddressState, { BillingAddressErrorsState, BillingAddressStatusesState } from './billing-address-state';
@@ -13,9 +14,9 @@ const DEFAULT_STATE: BillingAddressState = {
 
 export default function billingAddressReducer(
     state: BillingAddressState = DEFAULT_STATE,
-    action: CheckoutAction
+    action: CheckoutAction | BillingAddressAction | OrderAction
 ): BillingAddressState {
-    const reducer = combineReducers<BillingAddressState, CheckoutAction | BillingAddressAction>({
+    const reducer = combineReducers<BillingAddressState, CheckoutAction | BillingAddressAction | OrderAction>({
         data: dataReducer,
         errors: errorsReducer,
         statuses: statusesReducer,
@@ -26,11 +27,12 @@ export default function billingAddressReducer(
 
 function dataReducer(
     data: Address | undefined,
-    action: CheckoutAction | BillingAddressAction
+    action: CheckoutAction | BillingAddressAction | OrderAction
 ): Address | undefined {
     switch (action.type) {
     case BillingAddressActionType.UpdateBillingAddressSucceeded:
     case CheckoutActionType.LoadCheckoutSucceeded:
+    case OrderActionType.LoadOrderSucceeded:
         return action.payload ? action.payload.billingAddress : data;
 
     default:
@@ -40,7 +42,7 @@ function dataReducer(
 
 function errorsReducer(
     errors: BillingAddressErrorsState = DEFAULT_STATE.errors,
-    action: CheckoutAction | BillingAddressAction
+    action: CheckoutAction | BillingAddressAction | OrderAction
 ): BillingAddressErrorsState {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
@@ -64,7 +66,7 @@ function errorsReducer(
 
 function statusesReducer(
     statuses: BillingAddressStatusesState = DEFAULT_STATE.statuses,
-    action: CheckoutAction | BillingAddressAction
+    action: CheckoutAction | BillingAddressAction | OrderAction
 ): BillingAddressStatusesState {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:


### PR DESCRIPTION
## What?
When load order succeeds, store billing address

## Why?
Because otherwise getOrder() selector returns undefined and order confirmation page is not rendered properly.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
