### PR TITLE
CHECKOUT-3282: Remove `loadConfig` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The SDK has a convenient application interface for starting and completing a che
     - [CORS](#cors)
 - [Usage](#usage)
     - [Initialize instance](#initialize-instance)
-        - [Load configuration](#load-configuration)
         - [Load checkout](#load-checkout)
     - [Sign in customer](#sign-in-customer)
     - [Set shipping details](#set-shipping-details)
@@ -96,19 +95,9 @@ import { createCheckoutService } from '@bigcommerce/checkout-sdk';
 const service = createCheckoutService();
 ```
 
-#### Load configuration
-
-Once you have the instance, you need to load the store's checkout configuration. The configuration object contains information about various settings related to checkout, such as the default currency of the store etc...
-
-```js
-const state = await service.loadConfig();
-
-console.log(state.data.getConfig());
-```
-
 #### Load checkout
 
-Afterwards, you should load the current checkout and present the information to the customer.
+Once you have the instance, you should load the current checkout and present the information to the customer.
 
 ```js
 const checkoutId = '0cfd6c06-57c3-4e29-8d7a-de55cc8a9052';
@@ -123,6 +112,12 @@ The checkout object contains various information about the checkout process, suc
 console.log(state.data.getCart());
 console.log(state.data.getBillingAddress());
 console.log(state.data.getShippingAddress());
+```
+
+In addition, you can also access the store's checkout configuration. The configuration object contains information about various settings related to checkout, such as the default currency of the store etc...
+
+```js
+console.log(state.data.getConfig());
 ```
 
 ### Sign in customer

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -156,31 +156,14 @@ export default class CheckoutService {
      * @returns A promise that resolves to the current state.
      */
     loadCheckout(id: string, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._checkoutActionCreator.loadCheckout(id, options);
+        const loadCheckoutAction = this._checkoutActionCreator.loadCheckout(id, options);
+        const loadConfigAction = this._configActionCreator.loadConfig(options);
 
-        return this._dispatch(action);
-    }
-
-    /**
-     * Loads the checkout configuration of a store.
-     *
-     * This method should be called before performing any other actions using
-     * this service. If it is successfully executed, the data can be retrieved
-     * by calling `CheckoutStoreSelector#getConfig`.
-     *
-     * ```js
-     * const state = await service.loadConfig();
-     *
-     * console.log(state.checkout.getConfig());
-     * ```
-     *
-     * @param options - Options for loading the checkout configuration.
-     * @returns A promise that resolves to the current state.
-     */
-    loadConfig(options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._configActionCreator.loadConfig(options);
-
-        return this._dispatch(action, { queueId: 'config' });
+        return Promise.all([
+            this._dispatch(loadCheckoutAction),
+            this._dispatch(loadConfigAction, { queueId: 'config' }),
+        ])
+            .then(() => this.getState());
     }
 
     /**
@@ -201,9 +184,14 @@ export default class CheckoutService {
      * @returns A promise that resolves to the current state.
      */
     loadOrder(orderId: number, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._orderActionCreator.loadOrder(orderId, options);
+        const loadCheckoutAction = this._orderActionCreator.loadOrder(orderId, options);
+        const loadConfigAction = this._configActionCreator.loadConfig(options);
 
-        return this._dispatch(action);
+        return Promise.all([
+            this._dispatch(loadCheckoutAction),
+            this._dispatch(loadConfigAction, { queueId: 'config' }),
+        ])
+            .then(() => this.getState());
     }
 
     /**

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -13,12 +13,12 @@ import { PaymentMethod, PaymentMethodSelector, PaymentSelector } from '../paymen
 import { Instrument, InstrumentSelector } from '../payment/instrument';
 import {
     Consignment,
+    ConsignmentSelector,
     ShippingAddressSelector,
     ShippingCountrySelector,
     ShippingOption,
     ShippingOptionSelector,
 } from '../shipping';
-import ConsignmentSelector from '../shipping/consignment-selector';
 
 import Checkout from './checkout';
 import CheckoutSelector from './checkout-selector';

--- a/src/config/config-action-creator.spec.js
+++ b/src/config/config-action-creator.spec.js
@@ -1,18 +1,23 @@
 import { Observable } from 'rxjs';
-import { getConfig } from './configs.mock';
+
+import { createCheckoutStore } from '../checkout';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+
 import ConfigActionCreator from './config-action-creator';
 import { ConfigActionType } from './config-actions';
+import { getConfig, getConfigState } from './configs.mock';
 
 describe('ConfigActionCreator', () => {
     let checkoutClient;
     let configActionCreator;
     let errorResponse;
     let response;
+    let store;
 
     beforeEach(() => {
         response = getResponse(getConfig());
         errorResponse = getErrorResponse();
+        store = createCheckoutStore();
 
         checkoutClient = {
             loadConfig: jest.fn(() => Promise.resolve(response)),
@@ -22,31 +27,41 @@ describe('ConfigActionCreator', () => {
     });
 
     describe('#loadConfig()', () => {
-        it('emits actions if able to load config', () => {
-            configActionCreator.loadConfig()
+        it('emits actions if able to load config', async () => {
+            const actions = await Observable.from(configActionCreator.loadConfig()(store))
                 .toArray()
-                .subscribe((actions) => {
-                    expect(actions).toEqual([
-                        { type: ConfigActionType.LoadConfigRequested },
-                        { type: ConfigActionType.LoadConfigSucceeded, payload: response.body },
-                    ]);
-                });
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: ConfigActionType.LoadConfigRequested },
+                { type: ConfigActionType.LoadConfigSucceeded, payload: response.body },
+            ]);
         });
 
-        it('emits error actions if unable to load config', () => {
+        it('emits error actions if unable to load config', async () => {
             checkoutClient.loadConfig.mockReturnValue(Promise.reject(errorResponse));
-            const errorHandler = jest.fn((action) => Observable.of(action));
 
-            configActionCreator.loadConfig()
+            const errorHandler = jest.fn((action) => Observable.of(action));
+            const actions = await Observable.from(configActionCreator.loadConfig()(store))
                 .catch(errorHandler)
                 .toArray()
-                .subscribe((actions) => {
-                    expect(errorHandler).toHaveBeenCalled();
-                    expect(actions).toEqual([
-                        { type: ConfigActionType.LoadConfigRequested },
-                        { type: ConfigActionType.LoadConfigFailed, payload: errorResponse, error: true },
-                    ]);
-                });
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: ConfigActionType.LoadConfigRequested },
+                { type: ConfigActionType.LoadConfigFailed, payload: errorResponse, error: true },
+            ]);
+        });
+
+        it('does not emit actions if config is already loaded', async () => {
+            store = createCheckoutStore({ config: getConfigState() });
+
+            const actions = await Observable.from(configActionCreator.loadConfig()(store))
+                .toArray()
+                .toPromise();
+
+            expect(actions).toEqual([]);
         });
     });
 });

--- a/src/config/config-action-creator.ts
+++ b/src/config/config-action-creator.ts
@@ -1,4 +1,4 @@
-import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
@@ -12,8 +12,15 @@ export default class ConfigActionCreator {
         private _checkoutClient: CheckoutClient
     ) {}
 
-    loadConfig(options?: RequestOptions): Observable<LoadConfigAction> {
-        return Observable.create((observer: Observer<LoadConfigAction>) => {
+    loadConfig(options?: RequestOptions): ThunkAction<LoadConfigAction> {
+        return store => Observable.create((observer: Observer<LoadConfigAction>) => {
+            const state = store.getState();
+            const config = state.config.getConfig();
+
+            if (config) {
+                return observer.complete();
+            }
+
             observer.next(createAction(ConfigActionType.LoadConfigRequested));
 
             this._checkoutClient.loadConfig(options)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,4 @@
-export { default as Config } from './config';
+export { default as Config, StoreConfig } from './config';
 export { default as ConfigActionCreator } from './config-action-creator';
 export { default as ConfigSelector } from './config-selector';
 export { default as configReducer } from './config-reducer';


### PR DESCRIPTION
## What?
* Remove `CheckoutService#loadConfig` method.
* **BREAKING CHANGE**: `loadConfig` method has been removed. Configuration data is now automatically loaded when you call `loadCheckout` or `loadOrder`.

## Why?
* As discussed, `loadConfig` should be done in the background and only once.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
