### PR TITLE
feat(checkout): INT-660 Update checkout SDK to support merchantRequestid

### DIFF
--- a/src/customer/strategies/chasepay-customer-strategy.spec.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.spec.ts
@@ -36,11 +36,11 @@ describe('ChasePayCustomerStrategy', () => {
     let JPMC: JPMC;
     let requestSender: RequestSender;
     let formPoster;
-    let EventType:  ChasePayEventMap;
+    let EventType: ChasePayEventMap;
 
     beforeEach(() => {
         const scriptLoader = createScriptLoader();
-        paymentMethodMock = { ...getChasePay(), initializationData: {digitalSessionId: 'digitalSessionId'} };
+        paymentMethodMock = { ...getChasePay(), initializationData: {digitalSessionId: 'digitalSessionId', merchantRequestId: '1234567890'} };
 
         store = createCheckoutStore({
             checkout: getCheckoutState(),


### PR DESCRIPTION
Depends on:
https://github.com/bigcommerce/bigcommerce/pull/25104
https://github.com/bigcommerce-labs/ng-checkout/pull/852

## What?
Update the Checkout SDK to support merchantRequestid field from Bc-app

## Why?
bc-app now requires an additional field called merchantRequestid to set the external checkout data

## Testing / Proof
<img width="559" alt="screen shot 2018-06-22 at 12 51 22 pm" src="https://user-images.githubusercontent.com/35502707/41791953-f4295952-761c-11e8-96b0-d26a9a0f9e23.png">
<img width="757" alt="screen shot 2018-06-22 at 1 04 53 pm" src="https://user-images.githubusercontent.com/35502707/41791967-fe1baeba-761c-11e8-8d1a-d1e50585a2b5.png">

@cbandam 
@bigcommerce/checkout @bigcommerce/payments @bigcommerce/integrations 
