### PR TITLE
CHECKOUT-3275 Remove Address mapper

### DIFF
--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -23,7 +23,7 @@ import { InstrumentActionCreator } from '../payment/instrument';
 import { deleteInstrumentResponseBody, getVaultAccessTokenResponseBody, getLoadInstrumentsResponseBody } from '../payment/instrument/instrument.mock';
 import { createShippingStrategyRegistry, ConsignmentActionCreator, ShippingCountryActionCreator, ShippingStrategyActionCreator } from '../shipping';
 import { getShippingAddress, getShippingAddressResponseBody } from '../shipping/internal-shipping-addresses.mock';
-import { getShippingOptionResponseBody, getShippingOptions } from '../shipping/internal-shipping-options.mock';
+import { getShippingOptions } from '../shipping/shipping-options.mock';
 
 import CheckoutActionCreator from './checkout-action-creator';
 import CheckoutService from './checkout-service';
@@ -89,7 +89,7 @@ describe('CheckoutService', () => {
             ),
 
             loadShippingOptions: jest.fn(() =>
-                Promise.resolve(getResponse(getShippingOptionResponseBody())),
+                Promise.resolve(getResponse(getCheckout())),
             ),
 
             updateBillingAddress: jest.fn(() =>
@@ -108,7 +108,7 @@ describe('CheckoutService', () => {
             ),
 
             selectShippingOption: jest.fn(() =>
-                Promise.resolve(getResponse(getShippingOptionResponseBody())),
+                Promise.resolve(getResponse(getCheckout())),
             ),
 
             getVaultAccessToken: jest.fn(() =>

--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -1,16 +1,13 @@
 import { find, reject } from 'lodash';
 
-import { mapToInternalAddress } from '../address';
 import { getBillingAddress } from '../billing/internal-billing-addresses.mock';
-import { mapToInternalCart } from '../cart';
 import { getCustomer } from '../customer/internal-customers.mock';
 import { getFormFields } from '../form/form.mocks';
 import { getUnitedStates } from '../geography/countries.mock';
 import { getBraintree } from '../payment/payment-methods.mock';
 import { QuoteSelector } from '../quote';
 import { getQuote } from '../quote/internal-quotes.mock';
-import { getShippingAddress } from '../shipping/internal-shipping-addresses.mock';
-import { getShippingOptions } from '../shipping/internal-shipping-options.mock';
+import { getShippingOptions } from '../shipping/shipping-options.mock';
 import { getAustralia } from '../shipping/shipping-countries.mock';
 
 import CheckoutStoreSelector from './checkout-store-selector';
@@ -75,11 +72,11 @@ describe('CheckoutStoreSelector', () => {
     });
 
     it('returns billing address', () => {
-        expect(selector.getBillingAddress()).toEqual(mapToInternalAddress(internalSelectors.billingAddress.getBillingAddress()));
+        expect(selector.getBillingAddress()).toEqual(internalSelectors.billingAddress.getBillingAddress());
     });
 
     it('returns shipping address', () => {
-        expect(selector.getShippingAddress()).toEqual(mapToInternalAddress(internalSelectors.shippingAddress.getShippingAddress()));
+        expect(selector.getShippingAddress()).toEqual(internalSelectors.shippingAddress.getShippingAddress());
     });
 
     it('returns instruments', () => {

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -1,4 +1,4 @@
-import { mapToInternalAddress, InternalAddress } from '../address';
+import { Address } from '../address';
 import { BillingAddressSelector } from '../billing';
 import { Cart, CartSelector } from '../cart';
 import { selector } from '../common/selector';
@@ -13,12 +13,9 @@ import { PaymentMethod, PaymentMethodSelector, PaymentSelector } from '../paymen
 import { Instrument, InstrumentSelector } from '../payment/instrument';
 import { InternalQuote, QuoteSelector } from '../quote';
 import {
-    mapToInternalShippingOption,
-    mapToInternalShippingOptions,
-    InternalShippingOption,
-    InternalShippingOptionList,
     ShippingAddressSelector,
     ShippingCountrySelector,
+    ShippingOption,
     ShippingOptionSelector,
 } from '../shipping';
 import ConsignmentSelector from '../shipping/consignment-selector';
@@ -124,10 +121,8 @@ export default class CheckoutStoreSelector {
      * @returns The shipping address object if it is loaded, otherwise
      * undefined.
      */
-    getShippingAddress(): InternalAddress | undefined {
-        const shippingAddress = this._shippingAddress.getShippingAddress();
-
-        return shippingAddress && mapToInternalAddress(shippingAddress);
+    getShippingAddress(): Address | undefined {
+        return this._shippingAddress.getShippingAddress();
     }
 
     /**
@@ -139,11 +134,14 @@ export default class CheckoutStoreSelector {
      * @returns The list of shipping options per address if loaded, otherwise
      * undefined.
      */
-    getShippingOptions(): InternalShippingOptionList | undefined {
-        // @todo: once we remove the mappers, this should use the shippingOption selector
+    getShippingOptions(): ShippingOption[] | undefined {
         const consignments = this._consignments.getConsignments();
 
-        return consignments && mapToInternalShippingOptions(consignments);
+        if (consignments && consignments.length) {
+            return consignments[0].availableShippingOptions;
+        }
+
+        return;
     }
 
     /**
@@ -152,10 +150,8 @@ export default class CheckoutStoreSelector {
      * @returns The shipping option object if there is a selected option,
      * otherwise undefined.
      */
-    getSelectedShippingOption(): InternalShippingOption | undefined {
-        const shippingOption = this._shippingOptions.getSelectedShippingOption();
-
-        return shippingOption  && mapToInternalShippingOption(shippingOption, true);
+    getSelectedShippingOption(): ShippingOption | undefined {
+        return this._shippingOptions.getSelectedShippingOption();
     }
 
     /**
@@ -172,10 +168,8 @@ export default class CheckoutStoreSelector {
      *
      * @returns The billing address object if it is loaded, otherwise undefined.
      */
-    getBillingAddress(): InternalAddress | undefined {
-        const billingAddress = this._billingAddress.getBillingAddress();
-
-        return billingAddress && mapToInternalAddress(billingAddress);
+    getBillingAddress(): Address | undefined {
+        return this._billingAddress.getBillingAddress();
     }
 
     /**


### PR DESCRIPTION
## What?
Remove address mapper

## Why?
So SDK returns storefront API objects

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
