### PR TITLE
CHECKOUT-3183 Compose shipping address in quote using shipping selector

### DIFF
--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -40,7 +40,7 @@ describe('CheckoutStoreSelector', () => {
     });
 
     it('returns quote', () => {
-        expect(selector.getQuote()).toEqual(mapToInternalQuote(selector.getCheckout()));
+        expect(selector.getQuote()).toEqual(getQuote());
     });
 
     it('returns config', () => {

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -91,8 +91,9 @@ export default class CheckoutStoreSelector {
      */
     getQuote(): InternalQuote | undefined {
         const checkout = this._checkout.getCheckout();
+        const shippingAddress = this._shippingAddress.getShippingAddress();
 
-        return checkout && mapToInternalQuote(checkout);
+        return checkout && mapToInternalQuote(checkout, shippingAddress);
     }
 
     /**

--- a/src/quote/map-to-internal-quote.spec.ts
+++ b/src/quote/map-to-internal-quote.spec.ts
@@ -1,11 +1,12 @@
 import { getCheckout } from '../checkout/checkouts.mock';
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 
 import { getQuote as getInternalQuote } from './internal-quotes.mock';
 import mapToInternalQuote from './map-to-internal-quote';
 
 describe('mapToInternalQuote()', () => {
     it('maps to internal quote', () => {
-        expect(mapToInternalQuote(getCheckout()))
+        expect(mapToInternalQuote(getCheckout(), getShippingAddress()))
             .toEqual(getInternalQuote());
     });
 });

--- a/src/quote/map-to-internal-quote.ts
+++ b/src/quote/map-to-internal-quote.ts
@@ -1,15 +1,15 @@
-import { mapToInternalAddress, InternalAddress } from '../address';
+import { mapToInternalAddress, Address, InternalAddress } from '../address';
 import { Checkout } from '../checkout';
 
 import InternalQuote from './internal-quote';
 
-export default function mapToInternalQuote(checkout: Checkout): InternalQuote {
+export default function mapToInternalQuote(checkout: Checkout, shippingAddress?: Address): InternalQuote {
     const consignment = checkout.consignments && checkout.consignments[0];
 
     return {
         orderComment: checkout.customerMessage,
         shippingOption: consignment && consignment.selectedShippingOption ? consignment.selectedShippingOption.id : undefined,
         billingAddress: checkout.billingAddress ? mapToInternalAddress(checkout.billingAddress) : {} as InternalAddress,
-        shippingAddress: consignment ? mapToInternalAddress(checkout.consignments[0].shippingAddress, checkout.consignments[0].id) : undefined,
+        shippingAddress: shippingAddress && mapToInternalAddress(shippingAddress),
     };
 }


### PR DESCRIPTION
## What?
Compose shipping address in quote using shipping selector

## Why?
Because shipping selector has special logic that prefills country when no shipping address is present.

## Testing / Proof
unit
manual

@bigcommerce/checkout 
