### PR TITLE
CHECKOUT-3253 Return selected shipping option as available shipping options

### DIFF
--- a/src/shipping/map-to-internal-shipping-options.spec.ts
+++ b/src/shipping/map-to-internal-shipping-options.spec.ts
@@ -1,10 +1,17 @@
+import { omit } from 'lodash';
+
 import { getConsignment } from './consignments.mock';
-import { getShippingOptions as getInternalShippingOptions } from './internal-shipping-options.mock';
+import { getFlatRateOption, getShippingOptions as getInternalShippingOptions } from './internal-shipping-options.mock';
 import mapToInternalShippingOptions from './map-to-internal-shipping-options';
 
 describe('mapToInternalShippingOptions()', () => {
     it('maps to internal shipping options', () => {
-        expect(mapToInternalShippingOptions([getConsignment()], getInternalShippingOptions()))
+        expect(mapToInternalShippingOptions([getConsignment()]))
+            .toEqual(getInternalShippingOptions());
+    });
+
+    it('maps to selected shipping option if none available', () => {
+        expect(mapToInternalShippingOptions([omit(getConsignment(), 'availableShippingOptions')]))
             .toEqual(getInternalShippingOptions());
     });
 });

--- a/src/shipping/map-to-internal-shipping-options.ts
+++ b/src/shipping/map-to-internal-shipping-options.ts
@@ -3,15 +3,25 @@ import { InternalShippingOptionList } from './internal-shipping-option';
 import mapToInternalShippingOption from './map-to-internal-shipping-option';
 
 export default function mapToInternalShippingOptions(consignments: Consignment[]): InternalShippingOptionList {
-    return consignments.reduce((result, consignment) => ({
-        ...result,
-        [consignment.id]: (consignment.availableShippingOptions || []).map(option => {
-            const selectedOptionId = consignment.selectedShippingOption && consignment.selectedShippingOption.id;
+    return consignments.reduce((result, consignment) => {
+        let shippingOptions;
 
-            return mapToInternalShippingOption(
-                option,
-                option.id === selectedOptionId
-            );
-        }),
-    }), {});
+        if (consignment.availableShippingOptions && consignment.availableShippingOptions.length) {
+            shippingOptions = consignment.availableShippingOptions;
+        } else if (consignment.selectedShippingOption) {
+            shippingOptions = [consignment.selectedShippingOption];
+        }
+
+        return {
+            ...result,
+            [consignment.id]: (shippingOptions || []).map(option => {
+                const selectedOptionId = consignment.selectedShippingOption && consignment.selectedShippingOption.id;
+
+                return mapToInternalShippingOption(
+                    option,
+                    option.id === selectedOptionId
+                );
+            }),
+        };
+    }, {});
 }


### PR DESCRIPTION
## What?
Return selected shipping option as part of available shipping options

## Why?
Because when the page is refreshed and a shipping option has been selected, it shows as blank, because `availableShippingOptions` is empty.

## Testing / Proof
unit
manual

@bigcommerce/checkout 
