### PR TITLE
CHECKOUT-3299: Fix object comparison performance

### DIFF
--- a/src/common/selector/selector-decorator.ts
+++ b/src/common/selector/selector-decorator.ts
@@ -1,6 +1,6 @@
-import { isEqual, memoize } from 'lodash';
+import { memoize } from 'lodash';
 
-import { bindDecorator, omitPrivate } from '../utility';
+import { bindDecorator, isEqual, isPrivate } from '../utility';
 
 import CacheKeyResolver from './cache-key-resolver';
 
@@ -51,7 +51,7 @@ function selectorMethodDecorator<T extends Method>(target: object, key: string, 
 
                 const newValue = method.call(this, ...args);
 
-                if (isEqual(omitPrivate(newValue), omitPrivate(cachedValue))) {
+                if (isEqual(newValue, cachedValue, { keyFilter: key => !isPrivate(key) })) {
                     return cachedValue;
                 }
 

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -2,6 +2,8 @@ export { default as bindDecorator } from './bind-decorator';
 export { default as createFreezeProxy, createFreezeProxies } from './create-freeze-proxy';
 export { default as CancellablePromise } from './cancellable-promise';
 export { default as getEnvironment } from './get-environment';
+export { default as isEqual } from './is-equal';
+export { default as isPrivate } from './is-private';
 export { default as mergeOrPush } from './merge-or-push';
 export { default as omitDeep } from './omit-deep';
 export { default as omitPrivate } from './omit-private';

--- a/src/common/utility/is-equal.spec.ts
+++ b/src/common/utility/is-equal.spec.ts
@@ -1,0 +1,67 @@
+import isEqual from './is-equal';
+import isPrivate from './is-private';
+
+describe('isEqual', () => {
+    it('returns true if objects are same', () => {
+        const object = { a: 'a', b: 'b' };
+
+        expect(isEqual(object, object))
+            .toEqual(true);
+    });
+
+    it('returns true if objects are equal in value', () => {
+        const objectA = { a: 'a', b: 'b' };
+        const objectB = { a: 'a', b: 'b' };
+
+        expect(isEqual(objectA, objectB))
+            .toEqual(true);
+    });
+
+    it('returns false if objects are different in value', () => {
+        const objectA = { a: 'a', b: 'b' };
+        const objectB = { a: 'A', b: 'B' };
+
+        expect(isEqual(objectA, objectB))
+            .toEqual(false);
+    });
+
+    it('returns true if objects are equal except ignored properties', () => {
+        const objectA = { a: 'a', b: 'b', _c: 'c' };
+        const objectB = { a: 'a', b: 'b' };
+
+        expect(isEqual(objectA, objectB, { keyFilter: key => !isPrivate(key) }))
+            .toEqual(true);
+    });
+
+    it('returns true if arrays are equal in value', () => {
+        const objectA = ['a', 'b'];
+        const objectB = ['a', 'b'];
+
+        expect(isEqual(objectA, objectB))
+            .toEqual(true);
+    });
+
+    it('returns false if arrays are different in value', () => {
+        const objectA = ['a', 'b'];
+        const objectB = ['A', 'B'];
+
+        expect(isEqual(objectA, objectB))
+            .toEqual(false);
+    });
+
+    it('returns true if nested objects are equal in value', () => {
+        const objectA = { a: 'a', b: 'b', c: [1, 2], d: { a: 'a', b: 'b' } };
+        const objectB = { a: 'a', b: 'b', c: [1, 2], d: { a: 'a', b: 'b' } };
+
+        expect(isEqual(objectA, objectB))
+            .toEqual(true);
+    });
+
+    it('returns false if nested objects are different in value', () => {
+        const objectA = { a: 'a', b: 'b', c: [1, 2], d: { a: 'a', b: 'b' } };
+        const objectB = { a: 'a', b: 'b', c: [1, 2], d: { a: 'A', b: 'B' } };
+
+        expect(isEqual(objectA, objectB))
+            .toEqual(false);
+    });
+});

--- a/src/common/utility/is-equal.ts
+++ b/src/common/utility/is-equal.ts
@@ -1,0 +1,88 @@
+export interface CompareOptions {
+    keyFilter?(key: string): boolean;
+}
+
+export default function isEqual(objectA: any, objectB: any, options?: CompareOptions): boolean {
+    if (objectA === objectB) {
+        return true;
+    }
+
+    if (objectA && objectB && typeof objectA === 'object' && typeof objectB === 'object') {
+        if (Array.isArray(objectA) && Array.isArray(objectB)) {
+            return isArrayEqual(objectA, objectB);
+        }
+
+        if (Array.isArray(objectA) || Array.isArray(objectB)) {
+            return false;
+        }
+
+        if ((objectA instanceof Date) && (objectB instanceof Date)) {
+            return isDateEqual(objectA, objectB);
+        }
+
+        if ((objectA instanceof Date) || (objectB instanceof Date)) {
+            return false;
+        }
+
+        if ((objectA instanceof RegExp) && (objectB instanceof RegExp)) {
+            return isRegExpEqual(objectA, objectB);
+        }
+
+        if ((objectA instanceof RegExp) || (objectB instanceof RegExp)) {
+            return false;
+        }
+
+        return isObjectEqual(objectA, objectB, options && options.keyFilter);
+    }
+
+    return objectA === objectB;
+}
+
+function isRegExpEqual(objectA: RegExp, objectB: RegExp): boolean {
+    return objectA.toString() === objectB.toString();
+}
+
+function isDateEqual(objectA: Date, objectB: Date): boolean {
+    return objectA.getTime() === objectB.getTime();
+}
+
+function isArrayEqual(objectA: any[], objectB: any[]): boolean {
+    if (objectA.length !== objectB.length) {
+        return false;
+    }
+
+    for (let index = 0, length = objectA.length; index < length; index++) {
+        if (!isEqual(objectA[index], objectB[index])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function isObjectEqual(
+    objectA: { [key: string]: any },
+    objectB: { [key: string]: any },
+    filter?: (key: string) => boolean
+): boolean {
+    const keysA = filter ? Object.keys(objectA).filter(filter) : Object.keys(objectA);
+    const keysB = filter ? Object.keys(objectB).filter(filter) : Object.keys(objectB);
+
+    if (keysA.length !== keysB.length) {
+        return false;
+    }
+
+    for (let index = 0, length = keysA.length; index < length; index++) {
+        const key = keysA[index];
+
+        if (!objectB.hasOwnProperty(key)) {
+            return false;
+        }
+
+        if (!isEqual(objectA[key], objectB[key])) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/common/utility/is-private.ts
+++ b/src/common/utility/is-private.ts
@@ -1,0 +1,3 @@
+export default function isPrivate(key: string): boolean {
+    return `${key}`.indexOf('$$') === 0 || `${key}`.indexOf('_') === 0;
+}

--- a/src/common/utility/omit-private.ts
+++ b/src/common/utility/omit-private.ts
@@ -1,7 +1,6 @@
+import isPrivate from './is-private';
 import omitDeep from './omit-deep';
 
 export default function omitPrivate(object: any): any {
-    return omitDeep(object, (value: any, key: string) =>
-        `${key}`.indexOf('$$') === 0 || `${key}`.indexOf('_') === 0
-    );
+    return omitDeep(object, (value: any, key: string) => isPrivate(key));
 }


### PR DESCRIPTION
## What?
* Fix object comparison performance

## Why?
* Previously, when we compare two objects, we recursively omit private properties for both objects and then do a deep object comparison. A more efficient way is to ignore private properties while comparing the two objects.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
