### PR TITLE
CHECKOUT-3274 Remove quote mapper

### DIFF
--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -5,8 +5,6 @@ import { getCustomer } from '../customer/internal-customers.mock';
 import { getFormFields } from '../form/form.mocks';
 import { getUnitedStates } from '../geography/countries.mock';
 import { getBraintree } from '../payment/payment-methods.mock';
-import { mapToInternalQuote } from '../quote';
-import { getQuote } from '../quote/internal-quotes.mock';
 import { getShippingOptions } from '../shipping/shipping-options.mock';
 import { getAustralia } from '../shipping/shipping-countries.mock';
 
@@ -33,10 +31,6 @@ describe('CheckoutStoreSelector', () => {
 
     it('returns order', () => {
         expect(selector.getOrder()).toEqual(internalSelectors.order.getOrder());
-    });
-
-    it('returns quote', () => {
-        expect(selector.getQuote()).toEqual(getQuote());
     });
 
     it('returns config', () => {

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -11,7 +11,6 @@ import { Country, CountrySelector } from '../geography';
 import { Order, OrderSelector } from '../order';
 import { PaymentMethod, PaymentMethodSelector, PaymentSelector } from '../payment';
 import { Instrument, InstrumentSelector } from '../payment/instrument';
-import { mapToInternalQuote, InternalQuote } from '../quote';
 import {
     ShippingAddressSelector,
     ShippingCountrySelector,
@@ -80,19 +79,6 @@ export default class CheckoutStoreSelector {
      */
     getCheckout(): Checkout | undefined {
         return this._checkout.getCheckout();
-    }
-
-    /**
-     * Gets the current quote.
-     *
-     * @deprecated This method will be replaced in the future.
-     * @returns The current quote if it is loaded, otherwise undefined.
-     */
-    getQuote(): InternalQuote | undefined {
-        const checkout = this._checkout.getCheckout();
-        const shippingAddress = this._shippingAddress.getShippingAddress();
-
-        return checkout && mapToInternalQuote(checkout, shippingAddress);
     }
 
     /**


### PR DESCRIPTION
## What?
Remove `getQuote` from checkout selectors

## Why?
Because it's a legacy object

## Testing / Proof
unit

@bigcommerce/checkout