### PR TITLE
CHECKOUT-3299: Filter keys recursively when comparing objects

### DIFF
--- a/src/common/utility/is-equal.spec.ts
+++ b/src/common/utility/is-equal.spec.ts
@@ -26,8 +26,8 @@ describe('isEqual', () => {
     });
 
     it('returns true if objects are equal except ignored properties', () => {
-        const objectA = { a: 'a', b: 'b', _c: 'c' };
-        const objectB = { a: 'a', b: 'b' };
+        const objectA = { a: 'a', b: 'b', _c: 'c', d: [{ $$a: 'a' }] };
+        const objectB = { a: 'a', b: 'b', d: [{}] };
 
         expect(isEqual(objectA, objectB, { keyFilter: key => !isPrivate(key) }))
             .toEqual(true);

--- a/src/common/utility/is-equal.ts
+++ b/src/common/utility/is-equal.ts
@@ -9,7 +9,7 @@ export default function isEqual(objectA: any, objectB: any, options?: CompareOpt
 
     if (objectA && objectB && typeof objectA === 'object' && typeof objectB === 'object') {
         if (Array.isArray(objectA) && Array.isArray(objectB)) {
-            return isArrayEqual(objectA, objectB);
+            return isArrayEqual(objectA, objectB, options);
         }
 
         if (Array.isArray(objectA) || Array.isArray(objectB)) {
@@ -32,7 +32,7 @@ export default function isEqual(objectA: any, objectB: any, options?: CompareOpt
             return false;
         }
 
-        return isObjectEqual(objectA, objectB, options && options.keyFilter);
+        return isObjectEqual(objectA, objectB, options);
     }
 
     return objectA === objectB;
@@ -46,13 +46,13 @@ function isDateEqual(objectA: Date, objectB: Date): boolean {
     return objectA.getTime() === objectB.getTime();
 }
 
-function isArrayEqual(objectA: any[], objectB: any[]): boolean {
+function isArrayEqual(objectA: any[], objectB: any[], options?: CompareOptions): boolean {
     if (objectA.length !== objectB.length) {
         return false;
     }
 
     for (let index = 0, length = objectA.length; index < length; index++) {
-        if (!isEqual(objectA[index], objectB[index])) {
+        if (!isEqual(objectA[index], objectB[index], options)) {
             return false;
         }
     }
@@ -63,8 +63,9 @@ function isArrayEqual(objectA: any[], objectB: any[]): boolean {
 function isObjectEqual(
     objectA: { [key: string]: any },
     objectB: { [key: string]: any },
-    filter?: (key: string) => boolean
+    options?: CompareOptions
 ): boolean {
+    const filter = options && options.keyFilter;
     const keysA = filter ? Object.keys(objectA).filter(filter) : Object.keys(objectA);
     const keysB = filter ? Object.keys(objectB).filter(filter) : Object.keys(objectB);
 
@@ -79,7 +80,7 @@ function isObjectEqual(
             return false;
         }
 
-        if (!isEqual(objectA[key], objectB[key])) {
+        if (!isEqual(objectA[key], objectB[key], options)) {
             return false;
         }
     }


### PR DESCRIPTION
## What?
* Filter keys recursively when comparing objects

## Why?
* Otherwise, the function only filters keys at the top level.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
