### PR TITLE
feat(checkout): CHECKOUT-3312 Provide updateCheckout method

### DIFF
--- a/src/checkout/checkout-actions.ts
+++ b/src/checkout/checkout-actions.ts
@@ -6,14 +6,23 @@ export enum CheckoutActionType {
     LoadCheckoutRequested = 'LOAD_CHECKOUT_REQUESTED',
     LoadCheckoutSucceeded = 'LOAD_CHECKOUT_SUCCEEDED',
     LoadCheckoutFailed = 'LOAD_CHECKOUT_FAILED',
+
+    UpdateCheckoutRequested = 'UPDATE_CHECKOUT_REQUESTED',
+    UpdateCheckoutSucceeded = 'UPDATE_CHECKOUT_SUCCEEDED',
+    UpdateCheckoutFailed = 'UPDATE_CHECKOUT_FAILED',
 }
 
-export type CheckoutAction = LoadCheckoutAction;
+export type CheckoutAction = LoadCheckoutAction | UpdateCheckoutAction;
 
 export type LoadCheckoutAction =
     LoadCheckoutRequestedAction |
     LoadCheckoutSucceededAction |
     LoadCheckoutFailedAction;
+
+export type UpdateCheckoutAction =
+    UpdateCheckoutRequestedAction |
+    UpdateCheckoutSucceededAction |
+    UpdateCheckoutFailedAction;
 
 export interface LoadCheckoutRequestedAction extends Action {
     type: CheckoutActionType.LoadCheckoutRequested;
@@ -25,4 +34,16 @@ export interface LoadCheckoutSucceededAction extends Action<Checkout> {
 
 export interface LoadCheckoutFailedAction extends Action<Error> {
     type: CheckoutActionType.LoadCheckoutFailed;
+}
+
+export interface UpdateCheckoutRequestedAction extends Action {
+    type: CheckoutActionType.UpdateCheckoutRequested;
+}
+
+export interface UpdateCheckoutSucceededAction extends Action<Checkout> {
+    type: CheckoutActionType.UpdateCheckoutSucceeded;
+}
+
+export interface UpdateCheckoutFailedAction extends Action<Error> {
+    type: CheckoutActionType.UpdateCheckoutFailed;
 }

--- a/src/checkout/checkout-reducer.spec.ts
+++ b/src/checkout/checkout-reducer.spec.ts
@@ -46,4 +46,35 @@ describe('checkoutReducer', () => {
             statuses: { isLoading: false },
         });
     });
+
+    it('returns updated state', () => {
+        const action = createAction(CheckoutActionType.UpdateCheckoutSucceeded, getCheckout());
+        const output = checkoutReducer(initialState, action);
+
+        expect(output).toEqual({
+            data: omit(action.payload, ['billingAddress', 'cart', 'customer', 'consignments', 'coupons', 'giftCertifcates']),
+            errors: { updateError: undefined },
+            statuses: { isUpdating: false },
+        });
+    });
+
+    it('returns loading state', () => {
+        const action = createAction(CheckoutActionType.UpdateCheckoutRequested);
+        const output = checkoutReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { updateError: undefined },
+            statuses: { isUpdating: true },
+        });
+    });
+
+    it('returns error state', () => {
+        const action = createAction(CheckoutActionType.UpdateCheckoutFailed, new RequestError(getErrorResponse()));
+        const output = checkoutReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { updateError: action.payload },
+            statuses: { isUpdating: false },
+        });
+    });
 });

--- a/src/checkout/checkout-reducer.ts
+++ b/src/checkout/checkout-reducer.ts
@@ -33,6 +33,7 @@ function dataReducer(
 ): CheckoutDataState | undefined {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutSucceeded:
+    case CheckoutActionType.UpdateCheckoutSucceeded:
     case BillingAddressActionType.UpdateBillingAddressSucceeded:
     case CouponActionType.ApplyCouponSucceeded:
     case CouponActionType.RemoveCouponSucceeded:
@@ -72,6 +73,19 @@ function errorsReducer(
             loadError: action.payload,
         };
 
+    case CheckoutActionType.UpdateCheckoutRequested:
+    case CheckoutActionType.UpdateCheckoutSucceeded:
+        return {
+            ...errors,
+            updateError: undefined,
+        };
+
+    case CheckoutActionType.UpdateCheckoutFailed:
+        return {
+            ...errors,
+            updateError: action.payload,
+        };
+
     default:
         return errors;
     }
@@ -93,6 +107,19 @@ function statusesReducer(
         return {
             ...statuses,
             isLoading: false,
+        };
+
+    case CheckoutActionType.UpdateCheckoutRequested:
+        return {
+            ...statuses,
+            isUpdating: true,
+        };
+
+    case CheckoutActionType.UpdateCheckoutFailed:
+    case CheckoutActionType.UpdateCheckoutSucceeded:
+        return {
+            ...statuses,
+            isUpdating: false,
         };
 
     default:

--- a/src/checkout/checkout-request-sender.spec.js
+++ b/src/checkout/checkout-request-sender.spec.js
@@ -7,6 +7,7 @@ import CheckoutRequestSender from './checkout-request-sender';
 describe('CheckoutRequestSender', () => {
     let requestSender;
     let response;
+    let checkoutRequestSender;
 
     const defaultIncludes = [
         'cart.lineItems.physicalItems.options',
@@ -21,47 +22,77 @@ describe('CheckoutRequestSender', () => {
         response = getResponse(getCheckout());
 
         jest.spyOn(requestSender, 'get').mockReturnValue(response);
+        jest.spyOn(requestSender, 'put').mockReturnValue(response);
+        checkoutRequestSender = new CheckoutRequestSender(requestSender);
     });
 
-    it('sends request to load checkout', async () => {
-        const checkoutRequestSender = new CheckoutRequestSender(requestSender);
-
-        expect(await checkoutRequestSender.loadCheckout('6cb62bfc-c92d-45f5-869b-d3d9681a58d4')).toEqual(response);
-    });
-
-    it('sends expected params to load checkout', async () => {
-        const checkoutRequestSender = new CheckoutRequestSender(requestSender);
-
-        await checkoutRequestSender.loadCheckout('6cb62bfc-c92d-45f5-869b-d3d9681a58d4');
-
-        expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
-            headers: {
-                Accept: ContentType.JsonV1,
-            },
-            params: {
-                include: defaultIncludes,
-            },
-            timeout: undefined,
-        });
-    });
-
-    it('appends passed params when loading checkout', async () => {
-        const checkoutRequestSender = new CheckoutRequestSender(requestSender);
-
-        await checkoutRequestSender.loadCheckout('6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
-            params: {
-                include: ['foo'],
-            },
+    describe('loadCheckout', () => {
+        it('returns the response of the requestSender', async () => {
+            expect(await checkoutRequestSender.loadCheckout('6cb62bfc-c92d-45f5-869b-d3d9681a58d4')).toEqual(response);
         });
 
-        expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
-            headers: {
-                Accept: ContentType.JsonV1,
-            },
-            params: {
-                include: defaultIncludes.concat(',foo'),
+        it('sends expected params to requestSender', async () => {
+            await checkoutRequestSender.loadCheckout('6cb62bfc-c92d-45f5-869b-d3d9681a58d4');
+
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+                params: {
+                    include: defaultIncludes,
+                },
                 timeout: undefined,
-            },
+            });
+        });
+
+        it('appends passed params when loading checkout', async () => {
+            await checkoutRequestSender.loadCheckout('6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
+                params: {
+                    include: ['foo'],
+                },
+            });
+
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+                params: {
+                    include: defaultIncludes.concat(',foo'),
+                    timeout: undefined,
+                },
+            });
+        });
+    });
+
+    describe('updateCheckout', () => {
+        it('returns the response of the requestSender', async () => {
+            expect(await checkoutRequestSender.updateCheckout('6cb62bfc-c92d-45f5-869b-d3d9681a58d4', { customerMessage: 'foo' }))
+                .toEqual(response);
+        });
+
+        it('sends expected params to requestSender', async () => {
+            await checkoutRequestSender.updateCheckout(
+                '6cb62bfc-c92d-45f5-869b-d3d9681a58d4',
+                { customerMessage: 'foo' },
+                {
+                    params: {
+                        include: ['foo'],
+                    },
+                }
+            );
+
+            expect(requestSender.put).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+                body: {
+                    customerMessage: 'foo',
+                },
+                params: {
+                    include: defaultIncludes.concat(',foo'),
+                },
+                timeout: undefined,
+            });
         });
     });
 });

--- a/src/checkout/checkout-request-sender.ts
+++ b/src/checkout/checkout-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { ContentType, RequestOptions } from '../common/http-request';
 
-import Checkout from './checkout';
+import Checkout, { CheckoutRequestBody } from './checkout';
 import CheckoutDefaultIncludes from './checkout-default-includes';
 import CheckoutParams from './checkout-params';
 
@@ -19,6 +19,20 @@ export default class CheckoutRequestSender {
             params: {
                 include: CheckoutDefaultIncludes.concat(params && params.include || []).join(','),
             },
+            headers,
+            timeout,
+        });
+    }
+
+    updateCheckout(id: string, body: CheckoutRequestBody, { params, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
+        const url = `/api/storefront/checkout/${id}`;
+        const headers = { Accept: ContentType.JsonV1 };
+
+        return this._requestSender.put(url, {
+            params: {
+                include: CheckoutDefaultIncludes.concat(params && params.include || []).join(','),
+            },
+            body,
             headers,
             timeout,
         });

--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -137,6 +137,10 @@ describe('CheckoutService', () => {
             loadCheckout: jest.fn(() =>
                 Promise.resolve(getResponse(getCheckout())),
             ),
+
+            updateCheckout: jest.fn(() =>
+                Promise.resolve(getResponse(getCheckout())),
+            ),
         };
 
         couponRequestSender = {
@@ -262,6 +266,20 @@ describe('CheckoutService', () => {
 
             expect(checkoutRequestSender.loadCheckout).toHaveBeenCalled();
             expect(state.data.getCheckout()).toEqual(store.getState().checkout.getCheckout());
+        });
+    });
+
+    describe('#updateCheckout()', () => {
+        const { id } = getCheckout();
+
+        it('updates checkout data', async () => {
+            const state = await checkoutService.updateCheckout({ customerMessage: 'foo' });
+
+            expect(checkoutRequestSender.updateCheckout)
+                .toHaveBeenCalledWith(id, { customerMessage: 'foo' }, undefined);
+
+            expect(state.data.getCheckout())
+                .toEqual(store.getState().checkout.getCheckout());
         });
     });
 

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -20,6 +20,7 @@ import {
     ShippingStrategyActionCreator,
 } from '../shipping';
 
+import { CheckoutRequestBody } from './checkout';
 import CheckoutActionCreator from './checkout-action-creator';
 import CheckoutSelectors from './checkout-selectors';
 import CheckoutStore from './checkout-store';
@@ -181,6 +182,25 @@ export default class CheckoutService {
         const action = this._configActionCreator.loadConfig(options);
 
         return this._dispatch(action, { queueId: 'config' });
+    }
+
+    /**
+     * Updates specific properties of the current checkout.
+     *
+     * ```js
+     * const state = await service.updateCheckout(checkout);
+     *
+     * console.log(state.checkout.getCheckout());
+     * ```
+     *
+     * @param payload - The checkout properties to be updated.
+     * @param options - Options for loading the current checkout.
+     * @returns A promise that resolves to the current state.
+     */
+    updateCheckout(payload: CheckoutRequestBody, options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._checkoutActionCreator.updateCheckout(payload, options);
+
+        return this._dispatch(action);
     }
 
     /**

--- a/src/checkout/checkout-state.ts
+++ b/src/checkout/checkout-state.ts
@@ -12,8 +12,10 @@ export type CheckoutDataState = Omit<Checkout, 'billingAddress' | 'cart' | 'cons
 
 export interface CheckoutErrorsState {
     loadError?: Error;
+    updateError?: Error;
 }
 
 export interface CheckoutStatusesState {
     isLoading?: boolean;
+    isUpdating?: boolean;
 }

--- a/src/checkout/checkout.ts
+++ b/src/checkout/checkout.ts
@@ -32,6 +32,10 @@ export default interface Checkout {
     payments?: CheckoutPayment[];
 }
 
+export interface CheckoutRequestBody {
+    customerMessage: string;
+}
+
 export interface CheckoutPayment {
     detail: {
         step: string;

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -27,7 +27,7 @@ export function getCheckout(): Checkout {
         id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
         cart: getCart(),
         customer: getCustomer(),
-        customerMessage: '',
+        customerMessage: 'comment',
         billingAddress: getBillingAddress(),
         consignments: [
             getConsignment(),

--- a/src/order/internal-orders.mock.ts
+++ b/src/order/internal-orders.mock.ts
@@ -18,7 +18,7 @@ export function getInternalOrderRequestBody(): InternalOrderRequestBody {
     const payment = getPayment();
 
     return {
-        customerMessage: '',
+        customerMessage: 'comment',
         useStoreCredit: false,
         payment: {
             name: payment.methodId,

--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -18,11 +18,6 @@ export default interface OrderRequestBody {
      * works if the customer has previously signed in.
      */
     useStoreCredit?: boolean;
-
-    /**
-     * If provided, the string will be added to the order as a comment.
-     */
-    customerMessage?: string;
 }
 
 /**

--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -12,6 +12,7 @@ export default interface Order {
     currency: Currency;
     customerCanBeCreated: boolean;
     customerId: number;
+    customerMessage: string;
     discountAmount: number;
     hasDigitalItems: boolean;
     isComplete: boolean;

--- a/src/order/orders.mock.ts
+++ b/src/order/orders.mock.ts
@@ -19,6 +19,7 @@ export function getOrder(): Order {
             getShippingCoupon(),
         ],
         currency: getCurrency(),
+        customerMessage: '',
         customerCanBeCreated: true,
         customerId: 0,
         discountAmount: 10,

--- a/src/payment/strategies/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay-payment-strategy.spec.ts
@@ -89,7 +89,7 @@ describe('AfterpayPaymentStrategy', () => {
         ));
         loadRemoteSettingsAction = Observable.of(createAction(
             LOAD_REMOTE_SETTINGS_SUCCEEDED,
-            { useStoreCredit: false, customerMessage: 'foo' },
+            { useStoreCredit: false },
             { methodId: paymentMethod.gateway }
         ));
         submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
@@ -154,7 +154,7 @@ describe('AfterpayPaymentStrategy', () => {
         });
 
         it('notifies store credit usage to remote checkout service', () => {
-            expect(remoteCheckoutActionCreator.initializePayment).toHaveBeenCalledWith( paymentMethod.gateway, { useStoreCredit: false, customerMessage: '' });
+            expect(remoteCheckoutActionCreator.initializePayment).toHaveBeenCalledWith( paymentMethod.gateway, { useStoreCredit: false });
             expect(store.dispatch).toHaveBeenCalledWith(initializePaymentAction);
         });
 
@@ -237,7 +237,7 @@ describe('AfterpayPaymentStrategy', () => {
             expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
 
             expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(
-                { useStoreCredit: false, customerMessage: 'foo' },
+                { useStoreCredit: false },
                 { methodId: paymentMethod.id, gatewayId: paymentMethod.gateway }
             );
 

--- a/src/payment/strategies/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay-payment-strategy.ts
@@ -67,13 +67,12 @@ export default class AfterpayPaymentStrategy extends PaymentStrategy {
         }
 
         const useStoreCredit = !!payload.useStoreCredit;
-        const customerMessage = payload.customerMessage ? payload.customerMessage : '';
         const state = this._store.getState();
         const config = state.config.getStoreConfig();
         const storeCountryName = config ? config.storeProfile.storeCountry : '';
 
         return this._store.dispatch(
-            this._remoteCheckoutActionCreator.initializePayment(paymentId, { useStoreCredit, customerMessage })
+            this._remoteCheckoutActionCreator.initializePayment(paymentId, { useStoreCredit })
         )
             .then(state => this._checkoutValidator.validate(state.checkout.getCheckout(), options))
             .then(() => this._store.dispatch(
@@ -105,7 +104,6 @@ export default class AfterpayPaymentStrategy extends PaymentStrategy {
 
                 const orderPayload = {
                     useStoreCredit: afterpay.settings.useStoreCredit,
-                    customerMessage: afterpay.settings.customerMessage,
                 };
 
                 const paymentPayload = {

--- a/src/quote/internal-quotes.mock.ts
+++ b/src/quote/internal-quotes.mock.ts
@@ -2,7 +2,7 @@ import InternalQuote from './internal-quote';
 
 export function getQuote(): InternalQuote {
     return {
-        orderComment: '',
+        orderComment: 'comment',
         shippingOption: '0:61d4bb52f746477e1d4fb411221318c3',
         shippingAddress: {
             id: '55c96cda6f04c',


### PR DESCRIPTION
## What?
Provide `CheckoutService#updateCheckout` method.

## Why?
So order comments can be persisted in API

## Testing / Proof
- [x] unit test

@bigcommerce/checkout @bigcommerce/payments
