### PR TITLE
fix(order): CHECKOUT-3314 Map fields for digital items

### DIFF
--- a/src/cart/carts.mock.ts
+++ b/src/cart/carts.mock.ts
@@ -3,7 +3,7 @@ import { getCoupon, getShippingCoupon } from '../coupon/coupons.mock';
 import { getCurrency } from '../currency/currencies.mock';
 import { getDiscount } from '../discount/discounts.mock';
 
-import { getGiftCertificateItem } from './line-items.mock';
+import { getDigitalItem, getGiftCertificateItem } from './line-items.mock';
 import { getPhysicalItem } from './line-items.mock';
 
 export function getCart(): Cart {
@@ -26,7 +26,9 @@ export function getCart(): Cart {
             physicalItems: [
                 getPhysicalItem(),
             ],
-            digitalItems: [],
+            digitalItems: [
+                getDigitalItem(),
+            ],
             giftCertificates: [
                 getGiftCertificateItem(),
             ],

--- a/src/cart/internal-carts.mock.ts
+++ b/src/cart/internal-carts.mock.ts
@@ -25,6 +25,27 @@ export function getCart(): InternalCart {
                 variantId: 71,
             },
             {
+                id: '667',
+                type: 'ItemDigitalEntity',
+                name: 'Canvas Laundry Cart',
+                downloadsPageUrl: 'url.php',
+                imageUrl: '/images/canvas-laundry-cart.jpg',
+                quantity: 1,
+                amount: 200,
+                discount: 0,
+                amountAfterDiscount: 200,
+                attributes: [
+                    {
+                        name: 'n',
+                        value: 'v',
+                    },
+                ],
+                integerAmount: 20000,
+                integerDiscount: 0,
+                integerAmountAfterDiscount: 20000,
+                variantId: 71,
+            },
+            {
                 id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
                 name: '$100 Gift Certificate',
                 type: 'ItemGiftCertificateEntity',

--- a/src/cart/internal-line-item.ts
+++ b/src/cart/internal-line-item.ts
@@ -4,6 +4,7 @@ export default interface InternalLineItem {
     attributes: Array<{ name: string, value: string }>;
     discount: number;
     integerAmount: number;
+    downloadsPageUrl?: string;
     integerAmountAfterDiscount: number;
     integerDiscount: number;
     id: string | number;

--- a/src/cart/line-item.ts
+++ b/src/cart/line-item.ts
@@ -8,9 +8,7 @@ export interface PhysicalItem extends LineItem {
 }
 
 export interface DigitalItem extends LineItem {
-    downloadFileUrls: [
-        string
-    ];
+    downloadFileUrls: string[];
     downloadPageUrl: string;
     downloadSize: string;
 }

--- a/src/cart/line-items.mock.ts
+++ b/src/cart/line-items.mock.ts
@@ -1,4 +1,4 @@
-import { GiftCertificateItem, PhysicalItem } from '../cart';
+import { DigitalItem, GiftCertificateItem, PhysicalItem } from '../cart';
 
 export function getPhysicalItem(): PhysicalItem {
     return {
@@ -19,6 +19,38 @@ export function getPhysicalItem(): PhysicalItem {
         extendedListPrice: 200,
         extendedSalePrice: 200,
         isShippingRequired: true,
+        options: [
+            {
+                name: 'n',
+                nameId: 1,
+                value: 'v',
+                valueId: 3,
+            },
+        ],
+    };
+}
+
+export function getDigitalItem(): DigitalItem {
+    return {
+        id: '667',
+        variantId: 71,
+        productId: 103,
+        sku: 'CLC',
+        name: 'Canvas Laundry Cart',
+        url: '/canvas-laundry-cart/',
+        quantity: 1,
+        isTaxable: true,
+        imageUrl: '/images/canvas-laundry-cart.jpg',
+        discounts: [],
+        discountAmount: 0,
+        couponAmount: 0,
+        listPrice: 200,
+        salePrice: 200,
+        downloadPageUrl: 'url.php',
+        downloadFileUrls: [],
+        downloadSize: '',
+        extendedListPrice: 200,
+        extendedSalePrice: 200,
         options: [
             {
                 name: 'n',

--- a/src/cart/map-to-internal-line-item.ts
+++ b/src/cart/map-to-internal-line-item.ts
@@ -1,5 +1,5 @@
 import InternalLineItem from './internal-line-item';
-import { LineItem } from './line-item';
+import { DigitalItem, LineItem } from './line-item';
 
 import { AmountTransformer } from '.';
 
@@ -20,6 +20,7 @@ export default function mapToInternalLineItem(
         integerAmount: amountTransformer.toInteger(item.extendedListPrice),
         integerAmountAfterDiscount: amountTransformer.toInteger(item.extendedSalePrice),
         integerDiscount: amountTransformer.toInteger(item.discountAmount),
+        downloadsPageUrl: (item as DigitalItem).downloadPageUrl,
         name: item.name,
         quantity: item.quantity,
         variantId: item.variantId,


### PR DESCRIPTION
## What?
Add extra mapping for digital items

## Why?
Because they were missing

## Testing / Proof
- [x] unit

@bigcommerce/checkout @bigcommerce/payments
