### PR TITLE
CHECKOUT-3276 Create specific action for loading shipping option

### DIFF
--- a/src/shipping/consignment-action-creator.spec.js
+++ b/src/shipping/consignment-action-creator.spec.js
@@ -2,7 +2,7 @@ import { createTimeout } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 import { omit } from 'lodash';
 
-import { createCheckoutStore, CheckoutActionType } from '../checkout';
+import { createCheckoutStore } from '../checkout';
 import { getCheckout, getCheckoutState, getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { MissingDataError } from '../common/error/errors';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
@@ -72,8 +72,8 @@ describe('consignmentActionCreator', () => {
             });
 
             expect(actions).toEqual([
-                { type: CheckoutActionType.LoadCheckoutRequested },
-                { type: CheckoutActionType.LoadCheckoutSucceeded, payload: getCheckout() },
+                { type: ConsignmentActionType.LoadShippingOptionsRequested },
+                { type: ConsignmentActionType.LoadShippingOptionsSucceeded, payload: getCheckout() },
             ]);
         });
 
@@ -90,8 +90,8 @@ describe('consignmentActionCreator', () => {
 
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
-                { type: CheckoutActionType.LoadCheckoutRequested },
-                { type: CheckoutActionType.LoadCheckoutFailed, error: true, payload: getErrorResponse() },
+                { type: ConsignmentActionType.LoadShippingOptionsRequested },
+                { type: ConsignmentActionType.LoadShippingOptionsFailed, error: true, payload: getErrorResponse() },
             ]);
         });
     });

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -3,13 +3,18 @@ import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
 import { Address } from '../address';
-import { CheckoutAction, CheckoutActionType, CheckoutClient, InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
+import { CheckoutClient, InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
 import CheckoutRequestSender from '../checkout/checkout-request-sender';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
 import { ConsignmentRequestBody } from './consignment';
-import { ConsignmentActionType, CreateConsignmentsAction, UpdateConsignmentAction } from './consignment-actions';
+import {
+    ConsignmentActionType,
+    CreateConsignmentsAction,
+    LoadShippingOptionsAction,
+    UpdateConsignmentAction,
+} from './consignment-actions';
 
 export default class ConsignmentActionCreator {
     constructor(
@@ -49,15 +54,15 @@ export default class ConsignmentActionCreator {
         });
     }
 
-    loadShippingOptions(options?: RequestOptions): ThunkAction<CheckoutAction, InternalCheckoutSelectors> {
-        return store => Observable.create((observer: Observer<CheckoutAction>) => {
+    loadShippingOptions(options?: RequestOptions): ThunkAction<LoadShippingOptionsAction, InternalCheckoutSelectors> {
+        return store => Observable.create((observer: Observer<LoadShippingOptionsAction>) => {
             const checkout = store.getState().checkout.getCheckout();
 
             if (!checkout) {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckout);
             }
 
-            observer.next(createAction(CheckoutActionType.LoadCheckoutRequested));
+            observer.next(createAction(ConsignmentActionType.LoadShippingOptionsRequested));
 
             this._checkoutRequestSender.loadCheckout(checkout.id, {
                 ...options,
@@ -66,11 +71,11 @@ export default class ConsignmentActionCreator {
                 },
             })
             .then(({ body }) => {
-                observer.next(createAction(CheckoutActionType.LoadCheckoutSucceeded, body));
+                observer.next(createAction(ConsignmentActionType.LoadShippingOptionsSucceeded, body));
                 observer.complete();
             })
             .catch(response => {
-                observer.error(createErrorAction(CheckoutActionType.LoadCheckoutFailed, response));
+                observer.error(createErrorAction(ConsignmentActionType.LoadShippingOptionsFailed, response));
             });
         });
     }

--- a/src/shipping/consignment-actions.ts
+++ b/src/shipping/consignment-actions.ts
@@ -10,11 +10,16 @@ export enum ConsignmentActionType {
     UpdateConsignmentRequested = 'UPDATE_CONSIGNMENT_REQUESTED',
     UpdateConsignmentSucceeded = 'UPDATE_CONSIGNMENT_SUCCEEDED',
     UpdateConsignmentFailed = 'UPDATE_CONSIGNMENT_FAILED',
+
+    LoadShippingOptionsRequested = 'LOAD_SHIPPING_OPTIONS_REQUESTED',
+    LoadShippingOptionsSucceeded = 'LOAD_SHIPPING_OPTIONS_SUCCEEDED',
+    LoadShippingOptionsFailed = 'LOAD_SHIPPING_OPTIONS_FAILED',
 }
 
 export type ConsignmentAction =
     CreateConsignmentsAction |
-    UpdateConsignmentAction;
+    UpdateConsignmentAction |
+    LoadShippingOptionsAction;
 
 export type CreateConsignmentsAction =
     CreateConsignmentsRequestedAction |
@@ -25,6 +30,11 @@ export type UpdateConsignmentAction =
     UpdateConsignmentRequestedAction |
     UpdateConsignmentSucceededAction |
     UpdateConsignmentFailedAction;
+
+export type LoadShippingOptionsAction =
+    LoadShippingOptionsRequestedAction |
+    LoadShippingOptionsSucceededAction |
+    LoadShippingOptionsFailedAction;
 
 export interface CreateConsignmentsRequestedAction extends Action {
     type: ConsignmentActionType.CreateConsignmentsRequested;
@@ -48,4 +58,16 @@ export interface UpdateConsignmentSucceededAction extends Action<Checkout> {
 
 export interface UpdateConsignmentFailedAction extends Action<Error> {
     type: ConsignmentActionType.UpdateConsignmentFailed;
+}
+
+export interface LoadShippingOptionsRequestedAction extends Action {
+    type: ConsignmentActionType.LoadShippingOptionsRequested;
+}
+
+export interface LoadShippingOptionsSucceededAction extends Action<Checkout> {
+    type: ConsignmentActionType.LoadShippingOptionsSucceeded;
+}
+
+export interface LoadShippingOptionsFailedAction extends Action<Error> {
+    type: ConsignmentActionType.LoadShippingOptionsFailed;
 }

--- a/src/shipping/consignment-reducer.ts
+++ b/src/shipping/consignment-reducer.ts
@@ -31,6 +31,7 @@ function dataReducer(
 ): Consignment[] | undefined {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutSucceeded:
+    case ConsignmentActionType.LoadShippingOptionsSucceeded:
     case ConsignmentActionType.CreateConsignmentsSucceeded:
     case ConsignmentActionType.UpdateConsignmentSucceeded:
         return action.payload ? action.payload.consignments : data;
@@ -50,9 +51,12 @@ function errorsReducer(
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
     case CheckoutActionType.LoadCheckoutSucceeded:
+    case ConsignmentActionType.LoadShippingOptionsSucceeded:
+    case ConsignmentActionType.LoadShippingOptionsRequested:
         return { ...errors, loadError: undefined };
 
     case CheckoutActionType.LoadCheckoutFailed:
+    case ConsignmentActionType.LoadShippingOptionsFailed:
         return { ...errors, loadError: action.payload };
 
     case ConsignmentActionType.CreateConsignmentsRequested:
@@ -80,10 +84,13 @@ function statusesReducer(
 ): ConsignmentStatusesState {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
+    case ConsignmentActionType.LoadShippingOptionsRequested:
         return { ...statuses, isLoading: true };
 
     case CheckoutActionType.LoadCheckoutSucceeded:
     case CheckoutActionType.LoadCheckoutFailed:
+    case ConsignmentActionType.LoadShippingOptionsSucceeded:
+    case ConsignmentActionType.LoadShippingOptionsFailed:
         return { ...statuses, isLoading: false };
 
     case ConsignmentActionType.CreateConsignmentsRequested:


### PR DESCRIPTION
## What?
Creates specific action for loading shipping option

## Why?
Because triggering a load checkout action when requesting shipping option would cause extra overhead on other reducers/states.

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
