### PR TITLE
CHECKOUT-3320: Clean order store after new order is created

### DIFF
--- a/src/order/order-reducer.spec.js
+++ b/src/order/order-reducer.spec.js
@@ -2,7 +2,7 @@ import { omit } from 'lodash';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
 import { getCompleteOrderResponseBody, getSubmitOrderResponseBody, getSubmitOrderResponseHeaders } from './internal-orders.mock';
-import { getOrder } from './orders.mock';
+import { getOrder, getOrderState } from './orders.mock';
 import { OrderActionType } from './order-actions';
 import orderReducer from './order-reducer';
 
@@ -83,6 +83,19 @@ describe('orderReducer()', () => {
             meta: {
                 payment: action.payload.order.payment,
             },
+        }));
+    });
+
+    it('cleans the order after a new order post', () => {
+        const response = getCompleteOrderResponseBody();
+        const action = {
+            type: OrderActionType.SubmitOrderSucceeded,
+            meta: response.meta,
+            payload: response.data,
+        };
+
+        expect(orderReducer(getOrderState(), action)).toEqual(expect.objectContaining({
+            data: undefined,
         }));
     });
 });

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -29,6 +29,8 @@ function dataReducer(
     action: OrderAction
 ): OrderDataState | undefined {
     switch (action.type) {
+    case OrderActionType.SubmitOrderSucceeded:
+        return undefined;
     case OrderActionType.LoadOrderSucceeded:
         return action.payload
             ? omit({ ...data, ...action.payload }, ['billingAddress', 'coupons'])


### PR DESCRIPTION
## What?
- As per title

## Why?
- When we create a new order, the previous data is stale. We have to clean it so the store is not in an inconsistent state.

## Testing / Proof
- Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
