### PR TITLE
CHECKOUT-3334 Prevent order data from overwriting checkout data when retrieving payment information

### DIFF
--- a/src/checkout/checkout.ts
+++ b/src/checkout/checkout.ts
@@ -17,7 +17,7 @@ export default interface Checkout {
     taxes: Tax[];
     discounts: Discount[];
     coupons: Coupon[];
-    orderId: number;
+    orderId?: number;
     shippingCostTotal: number;
     shippingCostBeforeDiscount: number;
     handlingCostTotal: number;

--- a/src/order/order-actions.ts
+++ b/src/order/order-actions.ts
@@ -8,6 +8,10 @@ export enum OrderActionType {
     LoadOrderSucceeded = 'LOAD_ORDER_SUCCEEDED',
     LoadOrderFailed = 'LOAD_ORDER_FAILED',
 
+    LoadOrderPaymentsRequested = 'LOAD_ORDER_PAYMENTS_REQUESTED',
+    LoadOrderPaymentsSucceeded = 'LOAD_ORDER_PAYMENTS_SUCCEEDED',
+    LoadOrderPaymentsFailed = 'LOAD_ORDER_PAYMENTS_FAILED',
+
     SubmitOrderRequested = 'SUBMIT_ORDER_REQUESTED',
     SubmitOrderSucceeded = 'SUBMIT_ORDER_SUCCEEDED',
     SubmitOrderFailed = 'SUBMIT_ORDER_FAILED',
@@ -18,8 +22,13 @@ export enum OrderActionType {
 }
 
 export type OrderAction = LoadOrderAction |
+    LoadOrderPaymentsAction |
     SubmitOrderAction |
     FinalizeOrderAction;
+
+export type LoadOrderPaymentsAction = LoadOrderPaymentsRequestedAction |
+    LoadOrderPaymentsSucceededAction |
+    LoadOrderPaymentsFailedAction;
 
 export type LoadOrderAction =
     LoadOrderRequestedAction |
@@ -46,6 +55,18 @@ export interface LoadOrderSucceededAction extends Action<Order> {
 
 export interface LoadOrderFailedAction extends Action<Error> {
     type: OrderActionType.LoadOrderFailed;
+}
+
+export interface LoadOrderPaymentsRequestedAction extends Action {
+    type: OrderActionType.LoadOrderPaymentsRequested;
+}
+
+export interface LoadOrderPaymentsSucceededAction extends Action<Order> {
+    type: OrderActionType.LoadOrderPaymentsSucceeded;
+}
+
+export interface LoadOrderPaymentsFailedAction extends Action<Error> {
+    type: OrderActionType.LoadOrderPaymentsFailed;
 }
 
 export interface SubmitOrderRequestedAction extends Action {

--- a/src/order/order-reducer.spec.js
+++ b/src/order/order-reducer.spec.js
@@ -13,7 +13,7 @@ describe('orderReducer()', () => {
         initialState = {};
     });
 
-    it('returns new data while fetching order', () => {
+    it('returns new status while fetching order', () => {
         const action = {
             type: OrderActionType.LoadOrderRequested,
         };
@@ -35,7 +35,7 @@ describe('orderReducer()', () => {
         }));
     });
 
-    it('returns new data if it is not fetched successfully', () => {
+    it('returns error if it is not fetched successfully', () => {
         const response = getErrorResponse();
         const action = {
             type: OrderActionType.LoadOrderFailed,
@@ -97,5 +97,42 @@ describe('orderReducer()', () => {
         expect(orderReducer(getOrderState(), action)).toEqual(expect.objectContaining({
             data: undefined,
         }));
+    });
+
+    describe('loadOrderPayments', () => {
+        it('returns new status while fetching order', () => {
+            const action = {
+                type: OrderActionType.LoadOrderPaymentsRequested,
+            };
+
+            expect(orderReducer(initialState, action)).toEqual(expect.objectContaining({
+                statuses: { isLoading: true },
+            }));
+        });
+
+        it('returns new data if it is fetched successfully', () => {
+            const action = {
+                type: OrderActionType.LoadOrderPaymentsSucceeded,
+                payload: getOrder(),
+            };
+
+            expect(orderReducer(initialState, action)).toEqual(expect.objectContaining({
+                data: omit(action.payload, ['billingAddress', 'coupons']),
+                statuses: { isLoading: false },
+            }));
+        });
+
+        it('returns error if it is not fetched successfully', () => {
+            const response = getErrorResponse();
+            const action = {
+                type: OrderActionType.LoadOrderPaymentsFailed,
+                payload: response.data,
+            };
+
+            expect(orderReducer(initialState, action)).toEqual(expect.objectContaining({
+                errors: { loadError: action.payload },
+                statuses: { isLoading: false },
+            }));
+        });
     });
 });

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -32,6 +32,7 @@ function dataReducer(
     case OrderActionType.SubmitOrderSucceeded:
         return undefined;
     case OrderActionType.LoadOrderSucceeded:
+    case OrderActionType.LoadOrderPaymentsSucceeded:
         return action.payload
             ? omit({ ...data, ...action.payload }, ['billingAddress', 'coupons'])
             : data;
@@ -68,9 +69,12 @@ function errorsReducer(
     switch (action.type) {
     case OrderActionType.LoadOrderRequested:
     case OrderActionType.LoadOrderSucceeded:
+    case OrderActionType.LoadOrderPaymentsSucceeded:
+    case OrderActionType.LoadOrderPaymentsRequested:
         return { ...errors, loadError: undefined };
 
     case OrderActionType.LoadOrderFailed:
+    case OrderActionType.LoadOrderPaymentsFailed:
         return { ...errors, loadError: action.payload };
 
     default:
@@ -84,11 +88,15 @@ function statusesReducer(
 ): OrderStatusesState {
     switch (action.type) {
     case OrderActionType.LoadOrderRequested:
+    case OrderActionType.LoadOrderPaymentsRequested:
         return { ...statuses, isLoading: true };
 
     case OrderActionType.LoadOrderSucceeded:
     case OrderActionType.LoadOrderFailed:
+    case OrderActionType.LoadOrderPaymentsSucceeded:
+    case OrderActionType.LoadOrderPaymentsFailed:
         return { ...statuses, isLoading: false };
+
     default:
         return statuses;
     }

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -209,8 +209,8 @@ describe('PaymentStrategyActionCreator', () => {
             jest.spyOn(noPaymentDataStrategy, 'execute')
                 .mockReturnValue(Promise.resolve(store.getState()));
 
-            jest.spyOn(orderActionCreator, 'loadOrder')
-                .mockReturnValue(Observable.of(createAction(OrderActionType.SubmitOrderRequested)));
+            jest.spyOn(orderActionCreator, 'loadCurrentOrderPayments')
+                .mockReturnValue(() => Observable.of(createAction(OrderActionType.LoadOrderPaymentsRequested)));
         });
 
         it('finds payment strategy by method', async () => {
@@ -239,17 +239,14 @@ describe('PaymentStrategyActionCreator', () => {
             );
         });
 
-        it('loads current order with payment data', async () => {
+        it('loads payment data for the current order', async () => {
             const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
             const payload = getOrderRequestBody();
-            const state = store.getState();
 
             await Observable.from(actionCreator.execute(payload)(store))
                 .toPromise();
 
-            const checkout = state.checkout.getCheckout();
-
-            expect(orderActionCreator.loadOrder).toHaveBeenCalledWith(checkout && checkout.orderId, undefined);
+            expect(orderActionCreator.loadCurrentOrderPayments).toHaveBeenCalled();
         });
 
         it('emits action to load order and notify execution progress', async () => {
@@ -261,7 +258,7 @@ describe('PaymentStrategyActionCreator', () => {
                 .toPromise();
 
             expect(actions).toEqual([
-                { type: OrderActionType.SubmitOrderRequested },
+                { type: OrderActionType.LoadOrderPaymentsRequested },
                 { type: PaymentStrategyActionType.ExecuteRequested, meta: { methodId } },
                 { type: PaymentStrategyActionType.ExecuteSucceeded, meta: { methodId } },
             ]);
@@ -284,7 +281,7 @@ describe('PaymentStrategyActionCreator', () => {
 
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
-                { type: OrderActionType.SubmitOrderRequested },
+                { type: OrderActionType.LoadOrderPaymentsRequested },
                 { type: PaymentStrategyActionType.ExecuteRequested, meta: { methodId } },
                 { type: PaymentStrategyActionType.ExecuteFailed, error: true, payload: executeError, meta: { methodId } },
             ]);
@@ -346,8 +343,8 @@ describe('PaymentStrategyActionCreator', () => {
             jest.spyOn(strategy, 'finalize')
                 .mockReturnValue(Promise.resolve(store.getState()));
 
-            jest.spyOn(orderActionCreator, 'loadOrder')
-                .mockReturnValue(Observable.of(createAction(OrderActionType.SubmitOrderRequested)));
+            jest.spyOn(orderActionCreator, 'loadCurrentOrderPayments')
+                .mockReturnValue((() => Observable.of(createAction(OrderActionType.LoadOrderPaymentsRequested))));
         });
 
         it('finds payment strategy by method', async () => {
@@ -369,16 +366,13 @@ describe('PaymentStrategyActionCreator', () => {
             expect(strategy.finalize).toHaveBeenCalled();
         });
 
-        it('loads current order with payment data', async () => {
+        it('loads payment data for current order', async () => {
             const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
-            const state = store.getState();
 
             await Observable.from(actionCreator.finalize()(store))
                 .toPromise();
 
-            const checkout = state.checkout.getCheckout();
-
-            expect(orderActionCreator.loadOrder).toHaveBeenCalledWith(checkout && checkout.orderId, undefined);
+            expect(orderActionCreator.loadCurrentOrderPayments).toHaveBeenCalled();
         });
 
         it('emits action to load order and notify finalization progress', async () => {
@@ -389,7 +383,7 @@ describe('PaymentStrategyActionCreator', () => {
                 .toPromise();
 
             expect(actions).toEqual([
-                { type: OrderActionType.SubmitOrderRequested },
+                { type: OrderActionType.LoadOrderPaymentsRequested },
                 { type: PaymentStrategyActionType.FinalizeRequested, meta: { methodId: method.id } },
                 { type: PaymentStrategyActionType.FinalizeSucceeded, meta: { methodId: method.id } },
             ]);
@@ -411,7 +405,7 @@ describe('PaymentStrategyActionCreator', () => {
 
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
-                { type: OrderActionType.SubmitOrderRequested },
+                { type: OrderActionType.LoadOrderPaymentsRequested },
                 { type: PaymentStrategyActionType.FinalizeRequested, meta: { methodId: method.id } },
                 { type: PaymentStrategyActionType.FinalizeFailed, error: true, payload: finalizeError, meta: { methodId: method.id } },
             ]);

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -8,7 +8,7 @@ import { Observer } from 'rxjs/Observer';
 import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
-import { LoadOrderAction, OrderActionCreator, OrderRequestBody } from '../order';
+import { LoadOrderPaymentsAction, OrderActionCreator, OrderRequestBody } from '../order';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 
 import Payment from './payment';
@@ -30,7 +30,7 @@ export default class PaymentStrategyActionCreator {
         private _orderActionCreator: OrderActionCreator
     ) {}
 
-    execute(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<PaymentStrategyExecuteAction | LoadOrderAction, InternalCheckoutSelectors> {
+    execute(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<PaymentStrategyExecuteAction | LoadOrderPaymentsAction, InternalCheckoutSelectors> {
         return store => {
             const executeAction = new Observable((observer: Observer<PaymentStrategyExecuteAction>) => {
                 const state = store.getState();
@@ -65,13 +65,13 @@ export default class PaymentStrategyActionCreator {
             });
 
             return concat(
-                this._loadOrderIfNeeded(store, options),
+                this._loadOrderPaymentsIfNeeded(store, options),
                 executeAction
             );
         };
     }
 
-    finalize(options?: RequestOptions): ThunkAction<PaymentStrategyFinalizeAction | LoadOrderAction, InternalCheckoutSelectors> {
+    finalize(options?: RequestOptions): ThunkAction<PaymentStrategyFinalizeAction | LoadOrderPaymentsAction, InternalCheckoutSelectors> {
         return store => {
             const finalizeAction = new Observable((observer: Observer<PaymentStrategyFinalizeAction>) => {
                 const state = store.getState();
@@ -107,7 +107,7 @@ export default class PaymentStrategyActionCreator {
             });
 
             return concat(
-                this._loadOrderIfNeeded(store, options),
+                this._loadOrderPaymentsIfNeeded(store, options),
                 finalizeAction
             );
         };
@@ -178,11 +178,11 @@ export default class PaymentStrategyActionCreator {
         });
     }
 
-    private _loadOrderIfNeeded(store: ReadableCheckoutStore, options?: RequestOptions): Observable<LoadOrderAction> {
+    private _loadOrderPaymentsIfNeeded(store: ReadableCheckoutStore, options?: RequestOptions): Observable<LoadOrderPaymentsAction> {
         const checkout = store.getState().checkout.getCheckout();
 
         if (checkout && checkout.orderId) {
-            return from(this._orderActionCreator.loadCurrentOrder(options)(store));
+            return from(this._orderActionCreator.loadCurrentOrderPayments(options)(store));
         }
 
         return empty();


### PR DESCRIPTION
## What?
- This commit adds a new action type `LoadOrderPayments` that allows for payment information to be loaded without causing all reducers to fire.

## Why?
- When we load an order to check if we have to finalize it, firing the reducers causes billing and coupons data to be overwritten by the order information.

Before|After
-|-
![before](https://user-images.githubusercontent.com/4542735/42450788-a788da46-83c8-11e8-9250-21b225730c5b.gif)|![after](https://user-images.githubusercontent.com/4542735/42450786-a73104a6-83c8-11e8-95c6-0a936dc0a517.gif)

## Testing / Proof
- Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
