### PR TITLE
PAYMENTS-3064 Send Braintree SDK's DeviceData to Bigpay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bigcommerce/bigpay-client": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-3.2.0.tgz",
-      "integrity": "sha512-D+1ecjcoJl3KdE1G3yjw11itDVInhSrYqETRHmhRqxmYppi3nSpq+X2Zj1ed+wIlDKq+u+Cq8DRvXBsM6VLfcQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-3.2.1.tgz",
+      "integrity": "sha512-sLFgze+ZPBvS3jok2hjrPntRJQogqQaJMQAiumo2/oFogK/0EEnjB0h27T7gv5DpVCCKwpd2EOdANdOtw3dNSA==",
       "requires": {
         "@bigcommerce/form-poster": "^1.2.1",
         "deep-assign": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "validate-commits": "validate-commits"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^3.2.0",
+    "@bigcommerce/bigpay-client": "^3.2.1",
     "@bigcommerce/data-store": "^0.1.8",
     "@bigcommerce/form-poster": "^1.2.2",
     "@bigcommerce/request-sender": "^0.1.4",

--- a/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -11,7 +11,6 @@ import {
     getBraintreePaymentData,
     getBraintreeRequestData,
     getClientMock,
-    getDataCollectorMock,
     getThreeDSecureMock,
     getThreeDSecureOptionsMock,
     getTokenizeResponseBody,
@@ -164,7 +163,10 @@ describe('BraintreePaymentProcessor', () => {
         let processedPayment: TokenizedCreditCard;
 
         beforeEach(() => {
-            const dataCollector = getDataCollectorMock();
+            const dataCollector = {
+                deviceData: 'my_device_session_id',
+            };
+
             braintreeSDKCreator.getDataCollector = jest.fn().mockReturnValue(Promise.resolve(dataCollector));
             processedPayment = { nonce: 'my_nonce' };
         });

--- a/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
@@ -115,8 +115,8 @@ describe('Braintree SDK Creator', () => {
             jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(Promise.resolve(clientMock));
         });
 
-        it('uses the right parameters to instanciate a data collector', async () => {
-            const dataCollector = await braintreeSDKCreator.getDataCollector();
+        it('uses the right parameters to instantiate a data collector', async () => {
+            await braintreeSDKCreator.getDataCollector();
             expect(dataCollectorCreatorMock.create).toHaveBeenCalledWith({ client: clientMock, kount: true });
         });
 

--- a/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -70,6 +70,14 @@ export default class BraintreeSDKCreator {
                 this._braintreeScriptLoader.loadDataCollector(),
             ])
             .then(([client, dataCollector]) => dataCollector.create({ client, kount: true }))
+            .then(dataCollector => {
+                const { deviceData } = dataCollector;
+
+                return {
+                    ...dataCollector,
+                    deviceData: deviceData ? JSON.parse(deviceData).device_session_id : undefined,
+                };
+            })
             .catch(error => {
                 if (error && error.code === 'DATA_COLLECTOR_KOUNT_NOT_ENABLED') {
                     return { deviceData: undefined, teardown: () => Promise.resolve() };

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.spec.ts
@@ -9,7 +9,7 @@ import { BraintreeVisaCheckout } from './braintree';
 import BraintreeScriptLoader from './braintree-script-loader';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 import BraintreeVisaCheckoutPaymentProcessor from './braintree-visacheckout-payment-processor';
-import { getDataCollectorMock, getVisaCheckoutMock } from './braintree.mock';
+import { getVisaCheckoutMock } from './braintree.mock';
 import { VisaCheckoutPaymentSuccessPayload } from './visacheckout';
 import { getPaymentSuccessPayload, getTokenizedPayload, getVisaCheckoutRequestBody } from './visacheckout.mock';
 
@@ -81,7 +81,9 @@ describe('BraintreeVisaCheckoutPaymentProcessor', () => {
         beforeEach(() => {
             visaCheckoutMock = getVisaCheckoutMock();
             braintreeSDKCreator.getVisaCheckout = jest.fn(() => Promise.resolve(visaCheckoutMock));
-            braintreeSDKCreator.getDataCollector = jest.fn(() => Promise.resolve(getDataCollectorMock()));
+            braintreeSDKCreator.getDataCollector = jest.fn(() => Promise.resolve({
+                deviceData: 'my_device_session_id',
+            }));
             billing = getBillingAddress();
             shipping = getShippingAddress();
             paymentInformation = getPaymentSuccessPayload();

--- a/src/payment/strategies/braintree/braintree.mock.ts
+++ b/src/payment/strategies/braintree/braintree.mock.ts
@@ -23,7 +23,7 @@ export function getClientMock(): BraintreeClient {
 
 export function getDataCollectorMock(): BraintreeDataCollector {
     return {
-        deviceData: 'my_device_session_id',
+        deviceData: '{"device_session_id": "my_device_session_id", "fraud_merchant_id": "we_dont_use_this_field"}',
         teardown: jest.fn(() => Promise.resolve()),
     };
 }


### PR DESCRIPTION
Note: Hotfixing internal api version with this PR https://github.com/bigcommerce/checkout-sdk-js/pull/335

## What?
- Parse the JSON blob returned by the Braintree SDK instead of interpreting the entire blob as the deviceSessionInfo
- Bump bigpay-client to 3.2.1: https://github.com/bigcommerce/bigpay-client-js/pull/70

## Why?
- It was previously implemented as one string (the device_session_id) instead of a JSON blob (unless Braintree updated their SDK which might be likely). 
- This fixes a bug for Kount which requires this piece of data to make informed fraud decisions on the order

## Testing / Proof
Updated the unit test

Proof that the the payment request sent to BigPay now contains the `device_session_id`:

![screen shot 2018-07-09 at 4 46 52 pm](https://user-images.githubusercontent.com/7042476/42435481-472faefe-8346-11e8-80a1-557cd9b231b0.png)

Disclaimer: `device_session_id` is a one time use and is useless without the rest of the payment info so I think the token in the screenshot is ok :) 

@bigcommerce/checkout @bigcommerce/payments
