### PR TITLE
feat(payment): INT-690 Remove all VCO references from Chase Pay code

### DIFF
--- a/src/customer/strategies/chasepay-customer-strategy.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.ts
@@ -97,7 +97,7 @@ export default class ChasePayCustomerStrategy extends CustomerStrategy {
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
         throw new NotImplementedError(
-            'In order to sign in via Chase Pay, the shopper must click on "Visa Checkout" button.'
+            'In order to sign in via Chase Pay®, the shopper must click on "Chase Pay®" button.'
         );
     }
 


### PR DESCRIPTION
## What? [INT-690](https://jira.bigcommerce.com/browse/INT-690)
I change Visa Checkout to Chase Pay error message

## Why?
In order to remove all VCO references from Chase Pay code

## Testing / Proof
 --Domain
    - tools1531239626-testly-the-third.my-integration.zone
    - store-vj72yx7gp3.my-integration.zone
--Credentials
    - tools+1531239626@bigcommerce.com
    - 7c8356b0bacef08f52cd

<img width="664" alt="screen shot 2018-07-10 at 3 31 08 pm" src="https://user-images.githubusercontent.com/32551743/42536509-e6095aae-8457-11e8-82e9-1a5f08cd70b2.png">
<img width="612" alt="screen shot 2018-07-10 at 3 34 23 pm" src="https://user-images.githubusercontent.com/32551743/42536516-eb52ce28-8457-11e8-8a10-1f7efb0a650e.png">
<img width="769" alt="screen shot 2018-07-10 at 3 34 54 pm" src="https://user-images.githubusercontent.com/32551743/42536524-f15b2a36-8457-11e8-8248-b12d339734d0.png">
<img width="487" alt="screen shot 2018-07-10 at 3 48 07 pm" src="https://user-images.githubusercontent.com/32551743/42536825-c0d24060-8458-11e8-8a58-8dff48ace51b.png">


@bigcommerce/checkout 
@bigcommerce/payments
