### PR TITLE
CHECKOUT-3340 Update @bigcommerce/request-sender to include SourceMaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       "integrity": "sha512-MXohUJDe7L9lb4t9M3tNDJgCvoFlXXepVPiB18UblVrbBCdKndYoj4KONcJX8/y2NE/GC9gZQra1JflECkYyrQ=="
     },
     "@bigcommerce/request-sender": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/request-sender/-/request-sender-0.1.7.tgz",
-      "integrity": "sha512-Lnhf0qYQ4tsKpCHCzfZPi0mMozd/XFocNHLlKOh0exJnuFNNXkPdSw4cU1RiI2osbY6wRLq2LykikO/XqktwdA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/request-sender/-/request-sender-0.1.8.tgz",
+      "integrity": "sha512-Fc+i9Pd8PNSf8gJCnoicmpAdMageZou3m0k0HnxlaJmn0SLByg85t61AxdcjnIzX0+nSqolaMv90K2wTnfcHgw==",
       "requires": {
         "@types/js-cookie": "^2.1.0",
         "@types/lodash": "^4.14.109",
@@ -44,9 +44,9 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.110",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.110.tgz",
-          "integrity": "sha512-iXYLa6olt4tnsCA+ZXeP6eEW3tk1SulWeYyP/yooWfAtXjozqXgtX4+XUtMuOCfYjKGz3F34++qUc3Q+TJuIIw=="
+          "version": "4.14.111",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.111.tgz",
+          "integrity": "sha512-t2FwnkdqdZNYPJHTEF+Zf//j5d2I7UbM2Ng+vqqmUCE2RuiVVINJi9RlVdpKvqPqVItsJa0X+ra/tvmwLzlcgg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@bigcommerce/bigpay-client": "^3.2.1",
     "@bigcommerce/data-store": "^0.1.8",
     "@bigcommerce/form-poster": "^1.2.3",
-    "@bigcommerce/request-sender": "^0.1.7",
+    "@bigcommerce/request-sender": "^0.1.8",
     "@bigcommerce/script-loader": "^0.1.5",
     "@types/lodash": "^4.14.92",
     "lodash": "^4.17.4",


### PR DESCRIPTION
## What?
- Update @bigcommerce/request-sender to include SourceMaps

## Why?
- The previous version didn't include the source files in the `npm` package, which meant source map generation wasn't accurate

## Testing / Proof
- Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
