### PR TITLE
refactor(payment): INT-491 Re-map WePay risk token into deviceSessionId field

### DIFF
--- a/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
@@ -102,9 +102,7 @@ describe('WepayPaymentStrategy', () => {
                 ...payload.payment,
                 paymentData: {
                     ...(payload.payment && payload.payment.paymentData),
-                    extraData: {
-                        riskToken: testRiskToken,
-                    },
+                    deviceSessionId: testRiskToken,
                 },
             };
 

--- a/src/payment/strategies/wepay/wepay-payment-strategy.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.ts
@@ -29,9 +29,7 @@ export default class WepayPaymentStrategy extends CreditCardPaymentStrategy {
         const payloadWithToken = merge({}, payload, {
             payment: {
                 paymentData: {
-                    extraData: {
-                        riskToken: token,
-                    },
+                    deviceSessionId: token,
                 },
             },
         });


### PR DESCRIPTION
[INT-491](https://jira.bigcommerce.com/browse/INT-491)

## Sibling PR's
[bigpay](https://github.com/bigcommerce/bigpay/pull/1260#pullrequestreview-139125977)
[bigpay-client-js](https://github.com/bigcommerce/bigpay-client-js/pull/71)
[checkout-skd-js](https://github.com/bigcommerce/checkout-sdk-js/pull/343)

## What?
Map wepay risk token to use deviceSessionId instead of extraData field

## Why?
Clean up handling of wepay risk token to reuse preexisting deviceSessionId (maps to device_info) field for uniformity

## Testing / Proof
Placing orders with extra_data risk_token and device_info is successful
![image](https://user-images.githubusercontent.com/19637426/42845985-2f63bda4-89dd-11e8-86d0-12acbf9ad413.png)
![image](https://user-images.githubusercontent.com/19637426/42846002-374911b8-89dd-11e8-9e67-7b44b491a695.png)

ping @bigcommerce/checkout ping @bigcommerce/payments ping @bigcommerce/integrations 
