### PR TITLE
CHECKOUT-3112: Stop requesting additional data when signing in customer

### DIFF
--- a/src/customer/customer-request-sender.spec.js
+++ b/src/customer/customer-request-sender.spec.js
@@ -33,9 +33,6 @@ describe('CustomerRequestSender', () => {
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', {
                 body: credentials,
-                params: {
-                    includes: 'quote,shippingOptions',
-                },
             });
         });
 
@@ -47,9 +44,6 @@ describe('CustomerRequestSender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', {
                 ...options,
                 body: credentials,
-                params: {
-                    includes: 'quote,shippingOptions',
-                },
             });
         });
     });
@@ -67,11 +61,7 @@ describe('CustomerRequestSender', () => {
             const output = await customerRequestSender.signOutCustomer();
 
             expect(output).toEqual(response);
-            expect(requestSender.delete).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', {
-                params: {
-                    includes: 'quote,shippingOptions',
-                },
-            });
+            expect(requestSender.delete).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', { timeout: undefined });
         });
 
         it('signs out customer with timeout', async () => {
@@ -79,12 +69,7 @@ describe('CustomerRequestSender', () => {
             const output = await customerRequestSender.signOutCustomer(options);
 
             expect(output).toEqual(response);
-            expect(requestSender.delete).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', {
-                ...options,
-                params: {
-                    includes: 'quote,shippingOptions',
-                },
-            });
+            expect(requestSender.delete).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', options);
         });
     });
 });

--- a/src/customer/customer-request-sender.ts
+++ b/src/customer/customer-request-sender.ts
@@ -12,19 +12,13 @@ export default class CustomerRequestSender {
 
     signInCustomer(credentials: CustomerCredentials, { timeout }: RequestOptions = {}): Promise<Response<InternalCustomerResponseBody>> {
         const url = '/internalapi/v1/checkout/customer';
-        const params = {
-            includes: ['quote', 'shippingOptions'].join(','),
-        };
 
-        return this._requestSender.post(url, { params, timeout, body: credentials });
+        return this._requestSender.post(url, { timeout, body: credentials });
     }
 
     signOutCustomer({ timeout }: RequestOptions = {}): Promise<Response<InternalCustomerResponseBody>> {
         const url = '/internalapi/v1/checkout/customer';
-        const params = {
-            includes: ['quote', 'shippingOptions'].join(','),
-        };
 
-        return this._requestSender.delete(url, { params, timeout });
+        return this._requestSender.delete(url, { timeout });
     }
 }

--- a/src/customer/internal-customer-responses.ts
+++ b/src/customer/internal-customer-responses.ts
@@ -1,6 +1,4 @@
 import { InternalResponseBody } from '../common/http-request';
-import { InternalQuote } from '../quote';
-import { InternalShippingOptionList } from '../shipping';
 
 import InternalCustomer from './internal-customer';
 
@@ -8,6 +6,4 @@ export type InternalCustomerResponseBody = InternalResponseBody<InternalCustomer
 
 export interface InternalCustomerResponseData {
     customer: InternalCustomer;
-    quote: InternalQuote;
-    shippingOptions: InternalShippingOptionList;
 }

--- a/src/customer/internal-customers.mock.ts
+++ b/src/customer/internal-customers.mock.ts
@@ -1,6 +1,4 @@
-import { getQuote } from '../quote/internal-quotes.mock';
 import { getShippingAddress } from '../shipping/internal-shipping-addresses.mock';
-import { getShippingOptions } from '../shipping/internal-shipping-options.mock';
 
 import CustomerStrategyState from './customer-strategy-state';
 import InternalCustomer from './internal-customer';
@@ -51,9 +49,7 @@ export function getRemoteCustomer(): InternalCustomer {
 export function getCustomerResponseBody(): InternalCustomerResponseBody {
     return {
         data: {
-            quote: getQuote(),
             customer: getGuestCustomer(),
-            shippingOptions: getShippingOptions(),
         },
         meta: {},
     };


### PR DESCRIPTION
## What?
* Remove `include` when signing in / out customers.

## Why?
* We no longer need the additional data.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
