### PR TITLE
CHECKOUT-3370: Fix Afterpay not able to finalize order after redirection

### DIFF
--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -411,19 +411,6 @@ describe('PaymentStrategyActionCreator', () => {
             ]);
         });
 
-        it('throws error if payment data is not available', async () => {
-            store = createCheckoutStore();
-            registry = createPaymentStrategyRegistry(store, client, paymentClient);
-
-            const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
-
-            try {
-                await Observable.from(actionCreator.finalize()(store)).toPromise();
-            } catch (error) {
-                expect(error).toBeInstanceOf(MissingDataError);
-            }
-        });
-
         it('returns rejected promise if order does not require finalization', async () => {
             store = createCheckoutStore({
                 ...state,

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -75,12 +75,7 @@ export default class PaymentStrategyActionCreator {
         return store => {
             const finalizeAction = new Observable((observer: Observer<PaymentStrategyFinalizeAction>) => {
                 const state = store.getState();
-                const order = state.order.getOrder();
                 const payment = state.payment.getPaymentId();
-
-                if (!order) {
-                    throw new MissingDataError(MissingDataErrorType.MissingOrder);
-                }
 
                 if (!payment) {
                     throw new OrderFinalizationNotRequiredError();


### PR DESCRIPTION
## What?
* Don't check if the order object exists before finalising the order when checking out with Afterpay.

## Why?
* The order object doesn't exist at the point. For Afterpay, we submit the order at the finalisation step. So we shouldn't check if the order object exists.
* Plus, we don't use the order object anymore. We now get the selected payment ID via `PaymentSelector#getPaymentId` instead of reading directly from order & checkout object. So the check is actually redundant.

## Testing / Proof
![afterpay-fix](https://user-images.githubusercontent.com/667603/43111185-4cdcebe8-8f33-11e8-9a5f-9aeafc388a0f.gif)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/integrations 