### PR TITLE
CHECKOUT-3371 Provide status/error checks for CheckoutService#updateCheckout

### DIFF
--- a/src/checkout/checkout-selector.spec.ts
+++ b/src/checkout/checkout-selector.spec.ts
@@ -43,4 +43,23 @@ describe('CheckoutSelector', () => {
 
         expect(selector.isLoading()).toEqual(true);
     });
+
+    it('returns update error', () => {
+        const updateError = new Error();
+        const selector = new CheckoutSelector({
+            ...getCheckoutState(),
+            errors: { updateError },
+        }, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.customer, selectors.giftCertificates);
+
+        expect(selector.getUpdateError()).toEqual(updateError);
+    });
+
+    it('returns updating status', () => {
+        const selector = new CheckoutSelector({
+            ...getCheckoutState(),
+            statuses: { isUpdating: true },
+        }, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.customer, selectors.giftCertificates);
+
+        expect(selector.isUpdating()).toEqual(true);
+    });
 });

--- a/src/checkout/checkout-selector.ts
+++ b/src/checkout/checkout-selector.ts
@@ -51,4 +51,12 @@ export default class CheckoutSelector {
     isLoading(): boolean {
         return this._checkout.statuses.isLoading === true;
     }
+
+    getUpdateError(): Error | undefined {
+        return this._checkout.errors.updateError;
+    }
+
+    isUpdating(): boolean {
+        return this._checkout.statuses.isUpdating === true;
+    }
 }

--- a/src/checkout/checkout-store-error-selector.spec.js
+++ b/src/checkout/checkout-store-error-selector.spec.js
@@ -31,6 +31,22 @@ describe('CheckoutStoreErrorSelector', () => {
         });
     });
 
+    describe('#getUpdateCheckoutError()', () => {
+        it('returns error if there is an error when loading checkout', () => {
+            jest.spyOn(selectors.checkout, 'getUpdateError').mockReturnValue(errorResponse);
+
+            expect(errors.getUpdateCheckoutError()).toEqual(errorResponse);
+            expect(selectors.checkout.getUpdateError).toHaveBeenCalled();
+        });
+
+        it('returns undefined if there is no error when loading checkout', () => {
+            jest.spyOn(selectors.checkout, 'getUpdateError').mockReturnValue();
+
+            expect(errors.getUpdateCheckoutError()).toEqual(undefined);
+            expect(selectors.checkout.getUpdateError).toHaveBeenCalled();
+        });
+    });
+
     describe('#getSubmitOrderError()', () => {
         it('returns error if there is an error when submitting order', () => {
             jest.spyOn(selectors.paymentStrategies, 'getExecuteError').mockReturnValue(errorResponse);

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -106,6 +106,15 @@ export default class CheckoutStoreErrorSelector {
     }
 
     /**
+     * Returns an error if unable to update the current checkout.
+     *
+     * @returns The error object if unable to update, otherwise undefined.
+     */
+    getUpdateCheckoutError(): Error | undefined {
+        return this._checkout.getUpdateError();
+    }
+
+    /**
      * Returns an error if unable to submit the current order.
      *
      * @returns The error object if unable to submit, otherwise undefined.

--- a/src/checkout/checkout-store-status-selector.spec.js
+++ b/src/checkout/checkout-store-status-selector.spec.js
@@ -27,6 +27,22 @@ describe('CheckoutStoreStatusSelector', () => {
         });
     });
 
+    describe('#isUpdatingCheckout()', () => {
+        it('returns true if loading checkout', () => {
+            jest.spyOn(selectors.checkout, 'isUpdating').mockReturnValue(true);
+
+            expect(statuses.isUpdatingCheckout()).toEqual(true);
+            expect(selectors.checkout.isUpdating).toHaveBeenCalled();
+        });
+
+        it('returns false if loading checkout', () => {
+            jest.spyOn(selectors.checkout, 'isUpdating').mockReturnValue(false);
+
+            expect(statuses.isUpdatingCheckout()).toEqual(false);
+            expect(selectors.checkout.isUpdating).toHaveBeenCalled();
+        });
+    });
+
     describe('#isSubmittingOrder()', () => {
         it('returns true if submitting order', () => {
             jest.spyOn(selectors.paymentStrategies, 'isExecuting').mockReturnValue(true);

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -107,6 +107,15 @@ export default class CheckoutStoreStatusSelector {
     }
 
     /**
+     * Checks whether the current checkout is being updated.
+     *
+     * @returns True if the current checkout is being updated, otherwise false.
+     */
+    isUpdatingCheckout(): boolean {
+        return this._checkout.isUpdating();
+    }
+
+    /**
      * Checks whether the current order is submitting.
      *
      * @returns True if the current order is submitting, otherwise false.


### PR DESCRIPTION
## What?
Provide `getUpdateError` and `isUpdating` selectors for checkout state

## Why?
Because otherwise clients can't tell what happened.

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
