### PR TITLE
CHECKOUT-3243: Fix checkout data not getting retained after updating shipping option

### DIFF
--- a/src/cart/cart-reducer.spec.js
+++ b/src/cart/cart-reducer.spec.js
@@ -61,6 +61,17 @@ describe('cartReducer()', () => {
         }));
     });
 
+    it('returns new data when a shipping option is updated', () => {
+        const action = {
+            type: ConsignmentActionType.UpdateShippingOptionSucceeded,
+            payload: getCheckout(),
+        };
+
+        expect(cartReducer(initialState, action)).toEqual(expect.objectContaining({
+            data: getCart(),
+        }));
+    });
+
     it('returns new data when coupon gets applied', () => {
         const action = {
             type: CouponActionType.ApplyCouponSucceeded,

--- a/src/cart/cart-reducer.ts
+++ b/src/cart/cart-reducer.ts
@@ -36,6 +36,7 @@ function dataReducer(
     case CheckoutActionType.LoadCheckoutSucceeded:
     case ConsignmentActionType.CreateConsignmentsSucceeded:
     case ConsignmentActionType.UpdateConsignmentSucceeded:
+    case ConsignmentActionType.UpdateShippingOptionSucceeded:
     case CouponActionType.ApplyCouponSucceeded:
     case CouponActionType.RemoveCouponSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:

--- a/src/checkout/checkout-reducer.spec.ts
+++ b/src/checkout/checkout-reducer.spec.ts
@@ -5,6 +5,7 @@ import { CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
+import { ConsignmentActionType } from '../shipping';
 
 import checkoutReducer from './checkout-reducer';
 import CheckoutState from './checkout-state';
@@ -56,6 +57,15 @@ describe('checkoutReducer', () => {
             errors: { updateError: undefined },
             statuses: { isUpdating: false },
         });
+    });
+
+    it('returns new state when shipping option gets updated', () => {
+        const action = createAction(ConsignmentActionType.UpdateShippingOptionSucceeded, getCheckout(), { id: '123' });
+        const output = checkoutReducer(initialState, action);
+
+        expect(output).toEqual(expect.objectContaining({
+            data: omit(action.payload, ['billingAddress', 'cart', 'customer', 'consignments', 'coupons', 'giftCertifcates']),
+        }));
     });
 
     it('returns loading state', () => {

--- a/src/checkout/checkout-reducer.ts
+++ b/src/checkout/checkout-reducer.ts
@@ -39,6 +39,7 @@ function dataReducer(
     case CouponActionType.RemoveCouponSucceeded:
     case ConsignmentActionType.CreateConsignmentsSucceeded:
     case ConsignmentActionType.UpdateConsignmentSucceeded:
+    case ConsignmentActionType.UpdateShippingOptionSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
         return action.payload

--- a/src/coupon/gift-certificate-reducer.spec.ts
+++ b/src/coupon/gift-certificate-reducer.spec.ts
@@ -4,6 +4,7 @@ import { CheckoutActionType } from '../checkout';
 import { getCheckout, getCheckoutWithGiftCertificates } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
+import { ConsignmentActionType } from '../shipping';
 
 import { GiftCertificateActionType } from './gift-certificate-actions';
 import giftCertificateReducer from './gift-certificate-reducer';
@@ -25,6 +26,14 @@ describe('giftCertificateReducer()', () => {
 
         expect(giftCertificateReducer(initialState, action)).toEqual(expect.objectContaining({
             data: [],
+        }));
+    });
+
+    it('returns new state when shipping option gets updated', () => {
+        const action = createAction(ConsignmentActionType.UpdateShippingOptionSucceeded, getCheckoutWithGiftCertificates(), { id: '123' });
+
+        expect(giftCertificateReducer(initialState, action)).toEqual(expect.objectContaining({
+            data: action.payload && action.payload.giftCertificates,
         }));
     });
 

--- a/src/coupon/gift-certificate-reducer.ts
+++ b/src/coupon/gift-certificate-reducer.ts
@@ -15,7 +15,7 @@ const DEFAULT_STATE: GiftCertificateState = {
 
 export default function giftCertificateReducer(
     state: GiftCertificateState = DEFAULT_STATE,
-    action: CheckoutAction | GiftCertificateAction
+    action: CheckoutAction | GiftCertificateAction | ConsignmentAction | CouponAction
 ): GiftCertificateState {
     const reducer = combineReducers<GiftCertificateState>({
         data: dataReducer,
@@ -32,8 +32,9 @@ function dataReducer(
 ): GiftCertificate[] | undefined {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutSucceeded:
-    case ConsignmentActionType.UpdateConsignmentSucceeded:
     case ConsignmentActionType.CreateConsignmentsSucceeded:
+    case ConsignmentActionType.UpdateConsignmentSucceeded:
+    case ConsignmentActionType.UpdateShippingOptionSucceeded:
     case CouponActionType.ApplyCouponSucceeded:
     case CouponActionType.RemoveCouponSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:


### PR DESCRIPTION
## What?
* Update checkout-related data when `ConsignmentActionType.UpdateShippingOptionSucceeded` action is dispatched.

## Why?
* Previously we listen for `ConsignmentActionType.UpdateConsignmentSucceeded`. But now we have a new action type for updating the shipping option for a single consignment. So we need to listen for that as well.

## Testing / Proof
* Unit

@bigcommerce/checkout
