### PR TITLE
PAYMENTS-3251 Throw proper errors when Klarna authorization fails

### DIFF
--- a/src/remote-checkout/methods/klarna/klarna-credit.ts
+++ b/src/remote-checkout/methods/klarna/klarna-credit.ts
@@ -23,4 +23,7 @@ export interface KlarnaAuthorizationResponse {
     authorization_token: string;
     approved: boolean;
     show_form: boolean;
+    error?: {
+        invalid_fields: string[];
+    };
 }


### PR DESCRIPTION
## What?
Throw SDK errors when Klarna fails, instead of raw Klarna response

## Why?
For unified error handling

@bigcommerce/checkout @bigcommerce/payments
