### PR TITLE
CHECKOUT-3009 Speed up bundle:watch by using dev mode and give feedback with progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prebundle": "rm -rf dist",
     "bundle": "webpack --config webpack.config.js",
     "bundle:analyze": "npm run --silent bundle -- --config-name umd --profile --json > webpack-stats.json && webpack-bundle-analyzer webpack-stats.json dist --default-sizes gzip",
-    "bundle:watch": "npm run bundle -- --config-name cjs --watch",
+    "bundle:watch": "npm run bundle -- --config-name cjs --watch -d --progress",
     "bundle-dts": "tsc --outDir temp --declaration && api-extractor run && rm -rf temp",
     "docs": "typedoc --theme markdown --plugin @bigcommerce/typedoc-plugin-markdown --mode file --module commonjs --readme none --out docs --includeDeclarations --excludeExternals --excludePrivate --excludeProtected --mdEngine github --mdHideSources dist/checkout-sdk.d.ts",
     "lint": "npm run lint:js && npm run lint:ts",


### PR DESCRIPTION
## What?
- By using `-d` mode `bundle:watch` comes down to 2.3s from 7.0s
- By using `--progress` we get quick feedback on when the compilation starts

## Why?
- 8s for every save is pretty slow
- Having no visual feedback for 8s is a bit confusing

## Testing / Proof
- Manual

State | Image
--|--
Before|![old](https://user-images.githubusercontent.com/4542735/43244193-34232a2a-90ed-11e8-8e7a-c36d55f92f7a.gif)
After|![new](https://user-images.githubusercontent.com/4542735/43244188-28efdf22-90ed-11e8-9342-4f2aea609d49.gif)

@bigcommerce/checkout @bigcommerce/payments
