### PR TITLE
fix(payment): PAYMENTS-3251 Load Klarna widget only once

### DIFF
--- a/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
@@ -96,8 +96,7 @@ describe('KlarnaPaymentStrategy', () => {
         jest.spyOn(scriptLoader, 'load')
             .mockImplementation(() => Promise.resolve(klarnaCredit));
 
-        jest.spyOn(store, 'subscribe')
-            .mockImplementation(() => Promise.resolve());
+        jest.spyOn(store, 'subscribe');
     });
 
     describe('#initialize()', () => {
@@ -116,6 +115,10 @@ describe('KlarnaPaymentStrategy', () => {
             expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
         });
 
+        it('loads store subscribe once', () => {
+            expect(store.subscribe).toHaveBeenCalledTimes(1);
+        });
+
         it('loads widget', () => {
             expect(klarnaCredit.init).toHaveBeenCalledWith({ client_token: 'foo' });
             expect(klarnaCredit.load).toHaveBeenCalledTimes(1);
@@ -123,6 +126,20 @@ describe('KlarnaPaymentStrategy', () => {
 
         it('triggers callback with response', () => {
             expect(onLoad).toHaveBeenCalledWith({ show_form: true });
+        });
+
+        describe('on subsequent calls', () => {
+            beforeEach(async () => {
+                await strategy.initialize({ methodId: paymentMethod.id, klarna: { container: '#container', onLoad } });
+                await strategy.initialize({ methodId: paymentMethod.id, klarna: { container: '#container', onLoad } });
+            });
+
+            it('does not call anything again', async () => {
+                expect(store.subscribe).toHaveBeenCalledTimes(1);
+                expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledTimes(1);
+                expect(klarnaCredit.init).toHaveBeenCalledTimes(1);
+                expect(klarnaCredit.load).toHaveBeenCalledTimes(1);
+            });
         });
     });
 

--- a/src/payment/strategies/klarna/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.ts
@@ -32,11 +32,15 @@ export default class KlarnaPaymentStrategy extends PaymentStrategy {
     }
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        if (this._isInitialized) {
+            return super.initialize(options);
+        }
+
         return this._klarnaScriptLoader.load()
             .then(klarnaCredit => { this._klarnaCredit = klarnaCredit; })
             .then(() => {
                 this._unsubscribe = this._store.subscribe(
-                    () => this._loadWidget(options),
+                    () => this._isInitialized && this._loadWidget(options),
                     state => {
                         const checkout = state.checkout.getCheckout();
 


### PR DESCRIPTION
## What?
Let subscribe do it works and don't manually call `loadWidget`

## Why?
Because it causes the widget to load twice, potentially creating issues.

@bigcommerce/checkout @bigcommerce/payments
