### PR TITLE
fix(payment): INT-751 Show Masterpass button in payments section into square form

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -161,7 +161,6 @@ export default function createPaymentStrategyRegistry(
         new SquarePaymentStrategy(
             store,
             new CheckoutActionCreator(checkoutRequestSender, configActionCreator),
-            createFormPoster(),
             orderActionCreator,
             paymentActionCreator,
             paymentMethodActionCreator,

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -160,11 +160,14 @@ export default function createPaymentStrategyRegistry(
     registry.register('squarev2', () =>
         new SquarePaymentStrategy(
             store,
+            new CheckoutActionCreator(checkoutRequestSender, configActionCreator),
+            createFormPoster(),
             orderActionCreator,
             paymentActionCreator,
-            new SquareScriptLoader(scriptLoader),
+            paymentMethodActionCreator,
+            new PaymentStrategyActionCreator(registry, orderActionCreator),
             requestSender,
-            createFormPoster()
+            new SquareScriptLoader(scriptLoader)
         )
     );
 

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -162,7 +162,9 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
-            new SquareScriptLoader(scriptLoader)
+            new SquareScriptLoader(scriptLoader),
+            requestSender,
+            createFormPoster()
         )
     );
 

--- a/src/payment/strategies/square/square-form.ts
+++ b/src/payment/strategies/square/square-form.ts
@@ -19,6 +19,39 @@ export interface SquareFormOptions {
     cvv: SquareFormElement;
     expirationDate: SquareFormElement;
     postalCode: SquareFormElement;
+    masterpass: SquareFormElement;
+}
+
+export interface Error {
+    type: string;
+    message: string;
+    field: string;
+}
+
+export interface CardData {
+    cardBrand: CardBrand;
+    last4: number;
+    expMonth: number;
+    expYear: number;
+    billingPostalCode: string;
+    digitalWalletType: DigitalWalletType;
+}
+
+export enum CardBrand {
+    americanExpress,
+    discover,
+    discoverDiners,
+    JCB,
+    masterCard,
+    unionPay,
+    unknown,
+    visa
+}
+
+export enum DigitalWalletType {
+    applePay,
+    masterpass,
+    none,
 }
 
 /**

--- a/src/payment/strategies/square/square-form.ts
+++ b/src/payment/strategies/square/square-form.ts
@@ -37,6 +37,18 @@ export interface CardData {
     digital_wallet_type: string;
 }
 
+export interface Contact {
+    familyName: string;
+    givenName: string;
+    email: string;
+    country: string;
+    countryName: string;
+    region: string;
+    city: string;
+    addressLines: string[];
+    postalCode: string;
+}
+
 export enum CardBrand {
     americanExpress,
     discover,

--- a/src/payment/strategies/square/square-form.ts
+++ b/src/payment/strategies/square/square-form.ts
@@ -29,12 +29,12 @@ export interface Error {
 }
 
 export interface CardData {
-    cardBrand: CardBrand;
-    last4: number;
-    expMonth: number;
-    expYear: number;
-    billingPostalCode: string;
-    digitalWalletType: DigitalWalletType;
+    card_brand: CardBrand;
+    last_4: number;
+    exp_month: number;
+    exp_year: number;
+    billing_postal_code: string;
+    digital_wallet_type: string;
 }
 
 export enum CardBrand {
@@ -46,12 +46,6 @@ export enum CardBrand {
     unionPay,
     unknown,
     visa,
-}
-
-export enum DigitalWalletType {
-    applePay,
-    masterpass,
-    none,
 }
 
 /**

--- a/src/payment/strategies/square/square-form.ts
+++ b/src/payment/strategies/square/square-form.ts
@@ -45,7 +45,7 @@ export enum CardBrand {
     masterCard,
     unionPay,
     unknown,
-    visa
+    visa,
 }
 
 export enum DigitalWalletType {

--- a/src/payment/strategies/square/square-form.ts
+++ b/src/payment/strategies/square/square-form.ts
@@ -22,10 +22,18 @@ export interface SquareFormOptions {
     masterpass: SquareFormElement;
 }
 
-export interface Error {
+export interface NonceGenerationError {
     type: string;
     message: string;
     field: string;
+}
+
+export interface SquareValidationErrors {
+    country: string[];
+    region: string[];
+    city: string[];
+    addressLines: string[];
+    postalCode: string[];
 }
 
 export interface CardData {
@@ -78,8 +86,8 @@ export interface SquareFormElement {
 export interface SquareFormCallbacks {
     paymentFormLoaded?(form: SquarePaymentForm): void;
     unsupportedBrowserDetected?(): void;
-    cardNonceResponseReceived?(errors: Error[], nonce: string, cardData: CardData,
-                               billingContact: Contact | undefined | undefined, shippingContact: Contact): void;
+    cardNonceResponseReceived?(errors: NonceGenerationError[] | null, nonce: string, cardData: CardData, billingContact: Contact | undefined,
+                               shippingContact: Contact | undefined): void;
 }
 
 export type SquareFormFactory = (options: SquareFormOptions) => SquarePaymentForm;

--- a/src/payment/strategies/square/square-form.ts
+++ b/src/payment/strategies/square/square-form.ts
@@ -78,7 +78,8 @@ export interface SquareFormElement {
 export interface SquareFormCallbacks {
     paymentFormLoaded?(form: SquarePaymentForm): void;
     unsupportedBrowserDetected?(): void;
-    cardNonceResponseReceived?(errors: any, nonce: string): void;
+    cardNonceResponseReceived?(errors: Error[], nonce: string, cardData: CardData,
+                               billingContact: Contact | undefined | undefined, shippingContact: Contact): void;
 }
 
 export type SquareFormFactory = (options: SquareFormOptions) => SquarePaymentForm;

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -1,6 +1,5 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
-import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { Observable } from 'rxjs';
@@ -83,11 +82,7 @@ describe('SquarePaymentStrategy', () => {
         paymentMethod = getSquare();
         orderActionCreator = new OrderActionCreator(
             createCheckoutClient(),
-            new CheckoutValidator(
-                new CheckoutRequestSender(
-                    requestSender
-            )
-        )
+            checkoutValidator
         );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
@@ -99,7 +94,6 @@ describe('SquarePaymentStrategy', () => {
         strategy = new SquarePaymentStrategy(
             store,
             checkoutActionCreator,
-            createFormPoster(),
             orderActionCreator,
             paymentActionCreator,
             paymentMethodActionCreator,

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -19,7 +19,7 @@ import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import SquarePaymentForm, { CardData, DigitalWalletType, Error, SquareFormElement, SquareFormOptions } from './square-form';
+import SquarePaymentForm, { CardData, Error, SquareFormElement, SquareFormOptions } from './square-form';
 import SquareScriptLoader from './square-script-loader';
 
 export default class SquarePaymentStrategy extends PaymentStrategy {
@@ -117,7 +117,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                     if (!cardData) {
                         return;
                     }
-                    if (cardData.digitalWalletType !== DigitalWalletType.none) {
+                    if (cardData.digital_wallet_type !== 'NONE') {
                         this._setExternalCheckoutData(cardData, nonce)
                         .then(() => {
                             if (squareOptions.onPaymentSelect) {

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -19,7 +19,7 @@ import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import SquarePaymentForm, { CardData, Error, SquareFormElement, SquareFormOptions } from './square-form';
+import SquarePaymentForm, { CardData, Contact, Error, SquareFormElement, SquareFormOptions } from './square-form';
 import SquareScriptLoader from './square-script-loader';
 
 export default class SquarePaymentStrategy extends PaymentStrategy {
@@ -113,7 +113,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                 unsupportedBrowserDetected: () => {
                     deferred.reject(new UnsupportedBrowserError());
                 },
-                cardNonceResponseReceived: (errors: Error[], nonce: string, cardData: CardData) => {
+                cardNonceResponseReceived: (errors: Error[], nonce: string, cardData: CardData, billingContact: Contact, shippingContact: Contact) => {
                     if (!cardData) {
                         return;
                     }
@@ -148,11 +148,14 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                     }
 
                     return {
+                        requestShippingAddress: true,
+                        requestBillingInfo: true,
                         currencyCode: storeConfig.currency.code,
                         countryCode: 'US',
                         total: {
                             label: storeConfig.storeProfile.storeName,
                             amount: checkout.subtotal.toString(),
+                            pending: false,
                         },
                     };
                 },

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -1,19 +1,25 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
     InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
     NotInitializedError,
     NotInitializedErrorType,
     StandardError,
     TimeoutError,
     UnsupportedBrowserError,
 } from '../../../common/error/errors';
+import { toFormUrlEncoded } from '../../../common/http-request';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { NonceInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import SquarePaymentForm, { SquareFormElement, SquareFormOptions } from './square-form';
+import SquarePaymentForm, { SquareFormElement, SquareFormOptions, Error, CardData, DigitalWalletType } from './square-form';
 import SquareScriptLoader from './square-script-loader';
 
 export default class SquarePaymentStrategy extends PaymentStrategy {
@@ -24,12 +30,15 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
         store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
-        private _scriptLoader: SquareScriptLoader
+        private _scriptLoader: SquareScriptLoader,
+        private _requestSender: RequestSender,
+        private _formPoster: FormPoster
     ) {
         super(store);
     }
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        console.log(options);
         return this._scriptLoader.load()
             .then(createSquareForm =>
                 new Promise((resolve, reject) => {
@@ -91,7 +100,6 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
             callbacks: {
                 paymentFormLoaded: () => {
                     deferred.resolve();
-
                     const state = this._store.getState();
                     const billingAddress = state.billingAddress.getBillingAddress();
 
@@ -106,14 +114,54 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                 unsupportedBrowserDetected: () => {
                     deferred.reject(new UnsupportedBrowserError());
                 },
-                cardNonceResponseReceived: (errors, nonce) => {
-                    this._cardNonceResponseReceived(errors, nonce);
+                cardNonceResponseReceived: (errors: Error[], nonce: string, cardData: CardData) => {
+                    if (!cardData) {
+                        return;
+                    }
+                    if (cardData.digitalWalletType !== DigitalWalletType.none) {
+                        this._setExternalCheckoutData(cardData, nonce)
+                        .then(() => {
+                            if (squareOptions.onPaymentSelect) {
+                                squareOptions.onPaymentSelect();
+                            }
+                        });
+                    } else {
+                        this._cardNonceResponseReceived(errors, nonce);
+                    }
+                },
+                methodsSupported: () => {},
+
+                /*
+                 * callback function: createPaymentRequest
+                 * Triggered when: a digital wallet payment button is clicked.
+                */
+                createPaymentRequest: () => {
+                    const state = this._store.getState(); 
+                    const checkout = state.checkout.getCheckout();
+                    const storeConfig = state.config.getStoreConfig();
+    
+                    if (!checkout) {
+                        throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+                    }
+    
+                    if (!storeConfig) {
+                        throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+                    }
+
+                    return {
+                        currencyCode: storeConfig.currency.code,
+                        countryCode: 'US',
+                        total: {
+                            label: storeConfig.storeProfile.storeName,
+                            amount: checkout.subtotal.toString(),
+                        },
+                    };
                 },
             },
         };
     }
 
-    private _cardNonceResponseReceived(errors: any, nonce: string): void {
+    private _cardNonceResponseReceived(errors: Error[], nonce: string): void {
         if (!this._deferredRequestNonce) {
             throw new StandardError();
         }
@@ -124,6 +172,22 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
             this._deferredRequestNonce.resolve({ nonce });
         }
     }
+
+    private _setExternalCheckoutData(cardData: CardData, nonce: string): Promise<Response> {
+        const url = `checkout.php?provider=squarev2&action=set_external_checkout`;
+        const options = {
+          headers: {
+            Accept: 'text/html',
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+          },
+          body: toFormUrlEncoded({
+              nonce: nonce,
+              cardData: JSON.stringify(cardData),
+          }),
+        };
+
+        return this._requestSender.post(url, options);
+      }
 }
 
 export interface DeferredPromise {
@@ -168,4 +232,12 @@ export interface SquarePaymentInitializeOptions {
      * The set of CSS styles to apply to all form fields.
      */
     inputStyles?: Array<{ [key: string]: string }>;
+
+    // Initialize Masterpass placeholder ID
+    masterpass?: SquareFormElement;
+
+    /**
+     * A callback that gets called when the customer selects a payment option.
+     */
+    onPaymentSelect?(): void;
 }

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -19,7 +19,7 @@ import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import SquarePaymentForm, { SquareFormElement, SquareFormOptions, Error, CardData, DigitalWalletType } from './square-form';
+import SquarePaymentForm, { CardData, DigitalWalletType, Error, SquareFormElement, SquareFormOptions } from './square-form';
 import SquareScriptLoader from './square-script-loader';
 
 export default class SquarePaymentStrategy extends PaymentStrategy {
@@ -38,7 +38,6 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
     }
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
-        console.log(options);
         return this._scriptLoader.load()
             .then(createSquareForm =>
                 new Promise((resolve, reject) => {
@@ -136,14 +135,14 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                  * Triggered when: a digital wallet payment button is clicked.
                 */
                 createPaymentRequest: () => {
-                    const state = this._store.getState(); 
+                    const state = this._store.getState();
                     const checkout = state.checkout.getCheckout();
                     const storeConfig = state.config.getStoreConfig();
-    
+
                     if (!checkout) {
                         throw new MissingDataError(MissingDataErrorType.MissingCheckout);
                     }
-    
+
                     if (!storeConfig) {
                         throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
                     }
@@ -181,7 +180,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
             'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
           },
           body: toFormUrlEncoded({
-              nonce: nonce,
+              nonce: { nonce },
               cardData: JSON.stringify(cardData),
           }),
         };

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -58,7 +58,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
         const { payment, ...order } = payload;
 
         if (!payment || !payment.methodId) {
-            throw new InvalidArgumentError('Unable to submit payment because "payload.payment.methodId" argument is not provided.');
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         const paymentName = payment.methodId;

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -1,4 +1,3 @@
-import { FormPoster } from '@bigcommerce/form-poster';
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
@@ -14,7 +13,7 @@ import {
 } from '../../../common/error/errors';
 import { toFormUrlEncoded } from '../../../common/http-request';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
-import { PaymentMethod, PaymentMethodActionCreator, PaymentStrategyActionCreator } from '../../index';
+import { PaymentMethodActionCreator, PaymentStrategyActionCreator } from '../../index';
 import { NonceInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
@@ -30,7 +29,6 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
     constructor(
         store: CheckoutStore,
         private _checkoutActionCreator: CheckoutActionCreator,
-        private _formPoster: FormPoster,
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
@@ -169,7 +167,6 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
     }
 
     private _paymentInstrumentSelected(nonce: string, cardData: CardData) {
-        const state = this._store.getState();
         return this._store.dispatch(this._paymentStrategyActionCreator.widgetInteraction(() => {
                 return Promise.all([
                     this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -116,7 +116,7 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
                     deferred.reject(new UnsupportedBrowserError());
                 },
                 cardNonceResponseReceived: (errors: Error[], nonce: string, cardData: CardData,
-                                            billingContact: Contact, shippingContact: Contact) => {
+                                            billingContact: Contact | undefined, shippingContact: Contact | undefined) => {
                     if (cardData.digital_wallet_type !== 'NONE') {
                         this._setExternalCheckoutData(cardData, nonce)
                         .then(() => {


### PR DESCRIPTION
[INT-751](https://jira.bigcommerce.com/browse/INT-751)

## What?

- MasterPass button is displayed in the Square Form in the UCO page
- When the shopper clicks on the MasterPass button the MasterPass box is opened and the shopper can select a credit card

## Why?

As a Shopper when Masterpass is enabled on Square I want to be able to use the MasterPass button to open the Master Pass box to select a credit card from my wallet

Dependency with PR for [INT-752](https://github.com/bigcommerce/bigcommerce/pull/25547 ) BCApp changes:

## Testing / Proof
[Cart](https://drive.google.com/open?id=1LLGrJdP38OcKqzwZ8hUQ__peIcMoablv)
[QuickCart](https://drive.google.com/open?id=1GRlI8uhewpN9YSTnh-D8lMJRWyIytdp6)
[UCO](https://drive.google.com/open?id=1SU5cOw9ZZKlF-dTdha1iRoc6BteRMggm)

@bigcommerce-labs/checkout @bigcommerce/integrations @bigcommerce/payments 