### PR TITLE
CHECKOUT-3390: Fix customer message getting overridden when submitting order

### DIFF
--- a/src/order/order-action-creator.spec.js
+++ b/src/order/order-action-creator.spec.js
@@ -1,5 +1,5 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { merge } from 'lodash';
+import { omit, merge } from 'lodash';
 import { Observable } from 'rxjs';
 
 import { getCart, getCartState } from '../cart/internal-carts.mock';
@@ -271,11 +271,18 @@ describe('OrderActionCreator', () => {
             expect(checkoutValidator.validate).toHaveBeenCalled();
         });
 
-        it('submits order payload', async () => {
+        it('submits order payload with payment data', async () => {
             await Observable.from(orderActionCreator.submitOrder(getOrderRequestBody())(store))
                 .toPromise();
 
             expect(checkoutClient.submitOrder).toHaveBeenCalledWith(getInternalOrderRequestBody(), undefined);
+        });
+
+        it('submits order payload without payment data', async () => {
+            await Observable.from(orderActionCreator.submitOrder(omit(getOrderRequestBody(), 'payment'))(store))
+                .toPromise();
+
+            expect(checkoutClient.submitOrder).toHaveBeenCalledWith(omit(getInternalOrderRequestBody(), 'payment'), undefined);
         });
 
         it('does not submit order if cart verification fails', async () => {

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -130,11 +130,14 @@ export default class OrderActionCreator {
         const { payment, ...order } = payload;
 
         if (!payment) {
-            return order;
+            return {
+                ...order,
+                customerMessage,
+            };
         }
 
         return {
-            ...payload,
+            ...order,
             customerMessage,
             payment: {
                 paymentData: payment.paymentData,


### PR DESCRIPTION
## What?
* Pass `customerMessage` to `POST /internalapi/order` endpoint when submitting order without payment data.

## Why?
* Otherwise, `customerMessage` gets overridden and set to `null`.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
