### PR TITLE
chore(common): INT-769 Bumping bigpay-client-js to version 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@bigcommerce/bigpay-client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-3.2.1.tgz",
-      "integrity": "sha512-sLFgze+ZPBvS3jok2hjrPntRJQogqQaJMQAiumo2/oFogK/0EEnjB0h27T7gv5DpVCCKwpd2EOdANdOtw3dNSA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-3.2.2.tgz",
+      "integrity": "sha512-U6KH7TofujQCwgdaL3/B+qUgHRkQFQ4x+s1Pdj9XgtVi4Zngy6tFypHQL1PptYcMnVBMumsROsOojeOCuEoSPg==",
       "requires": {
         "@bigcommerce/form-poster": "^1.2.1",
         "deep-assign": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "validate-commits": "validate-commits"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^3.2.1",
+    "@bigcommerce/bigpay-client": "^3.2.2",
     "@bigcommerce/data-store": "^0.1.8",
     "@bigcommerce/form-poster": "^1.2.3",
     "@bigcommerce/request-sender": "^0.1.8",


### PR DESCRIPTION
## What?
Bumping the bigpay-client since we updated WePay to use the proper pass through for Risk Tokens.

New release => https://github.com/bigcommerce/bigpay-client-js/releases/tag/3.2.2

## Why?
To expose [https://github.com/bigcommerce/bigpay-client-js/pull/71](https://github.com/bigcommerce/bigpay-client-js/pull/71)

## Testing / Proof
n/a

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/integrations 
