### PR TITLE
chore(common): CHECKOUT-3009 Remove -d option from bundle:watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prebundle": "rm -rf dist",
     "bundle": "webpack --config webpack.config.js",
     "bundle:analyze": "npm run --silent bundle -- --config-name umd --profile --json > webpack-stats.json && webpack-bundle-analyzer webpack-stats.json dist --default-sizes gzip",
-    "bundle:watch": "npm run bundle -- --config-name cjs --watch -d --progress",
+    "bundle:watch": "npm run bundle -- --config-name cjs --watch --progress",
     "bundle-dts": "tsc --outDir temp --declaration && api-extractor run && rm -rf temp",
     "docs": "typedoc --theme markdown --plugin @bigcommerce/typedoc-plugin-markdown --mode file --module commonjs --readme none --out docs --includeDeclarations --excludeExternals --excludePrivate --excludeProtected --mdEngine github --mdHideSources dist/checkout-sdk.d.ts",
     "lint": "npm run lint:js && npm run lint:ts",


### PR DESCRIPTION
## What?
Do not use `-d` when using `bundle:watch`

## Why?
We added `-d` to make the watch build quicker, but it will generate 
a huge distribution file, it causes consumers of this library to 
struggle parsing it when in watch mode.

## Testing / Proof
Manual

@bigcommerce/checkout @bigcommerce/payments
