### PR TITLE
feat(payment): INT-616 Add Chase Pay wallet support

### DIFF
--- a/src/common/error/errors/missing-data-error.ts
+++ b/src/common/error/errors/missing-data-error.ts
@@ -8,6 +8,7 @@ export enum MissingDataErrorType {
     MissingOrder,
     MissingOrderConfig,
     MissingOrderId,
+    MissingPayment,
     MissingPaymentMethod,
 }
 
@@ -41,6 +42,9 @@ function getErrorMessage(type: MissingDataErrorType): string {
 
     case MissingDataErrorType.MissingOrderId:
         return 'Unable to proceed because order ID is unavailable or not generated yet.';
+
+    case MissingDataErrorType.MissingPayment:
+        return 'Unable to proceed because payment data is unavailable.';
 
     case MissingDataErrorType.MissingPaymentMethod:
         return 'Unable to proceed because payment method data is unavailable or not properly configured.';

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -35,5 +35,10 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      * when using Visa Checkout provided by Braintree.
      */
     braintreevisacheckout?: BraintreeVisaCheckoutCustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the Chasepay payment method.
+     * They can be omitted unless you need to support Chasepay.
+     */
     chasepay?: ChasePayCustomerInitializeOptions;
 }

--- a/src/customer/strategies/chasepay-customer-strategy.spec.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.spec.ts
@@ -5,10 +5,11 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { getCartState } from '../../cart/carts.mock';
 import { createCheckoutStore, CheckoutStore } from '../../checkout';
 import { getCheckoutState } from '../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../common/error/errors';
 import { getConfigState } from '../../config/configs.mock';
 import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../payment';
 import { getChasePay, getPaymentMethodsState } from '../../payment/payment-methods.mock';
-import { ChasePayScriptLoader, JPMC } from '../../payment/strategies/chasepay';
+import { ChasePayEventType, ChasePayScriptLoader, JPMC } from '../../payment/strategies/chasepay';
 import { getChasePayScriptMock } from '../../payment/strategies/chasepay/chasepay.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../remote-checkout';
 import { CustomerInitializeOptions } from '../customer-request-options';
@@ -105,13 +106,81 @@ describe('ChasePayCustomerStrategy', () => {
             expect(chasePayScriptLoader.load).toHaveBeenLastCalledWith(false);
         });
 
+        it('does not load chasepay if initialization options are not provided', async () => {
+            chasePayOptions = { methodId: 'chasepay' };
+            expect(() => strategy.initialize(chasePayOptions)).toThrowError(InvalidArgumentError);
+            expect(chasePayScriptLoader.load).not.toHaveBeenCalled();
+        });
+
+        it('does not load chase  pay if initialization data is not provided', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (error) {
+                expect(chasePayScriptLoader.load).not.toHaveBeenCalled();
+            }
+        });
+
+        it('does not load chase  pay if store config is not provided', async () => {
+            jest.spyOn(store.getState().config, 'getStoreConfig')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(chasePayScriptLoader.load).not.toHaveBeenCalled();
+
+            }
+        });
+
+        it('sets the configuration for chasepay lightbox', async () => {
+            await strategy.initialize(chasePayOptions);
+
+            expect(JPMC.ChasePay.insertButtons).toHaveBeenCalled();
+        });
+
+        it('sets the configuration for chasepay lightbox', async () => {
+            await strategy.initialize(chasePayOptions);
+
+            expect(JPMC.ChasePay.configure).toHaveBeenCalled();
+        });
+
         it('registers the start and complete callbacks', async () => {
             JPMC.ChasePay.on = jest.fn((type, callback) => callback);
 
             await strategy.initialize(chasePayOptions);
 
-            expect(JPMC.ChasePay.on).toHaveBeenCalledWith('START_CHECKOUT', expect.any(Function));
-            expect(JPMC.ChasePay.on).toHaveBeenCalledWith('COMPLETE_CHECKOUT', expect.any(Function));
+            expect(JPMC.ChasePay.on).toHaveBeenCalledWith(ChasePayEventType.StartCheckout, expect.any(Function));
+            expect(JPMC.ChasePay.on).toHaveBeenCalledWith(ChasePayEventType.CompleteCheckout, expect.any(Function));
+        });
+
+        it('fails to initialize the strategy if no methodid is supplied', async () => {
+            chasePayOptions = { methodId: undefined, chasepay: { container: 'login' } };
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('fails to initialize the strategy if no cart is supplied', async () => {
+            jest.spyOn(store.getState().cart, 'getCart')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('fails to initialize the strategy if no digitalSessionID is supplied', async () => {
+            paymentMethodMock.initializationData.digitalSessionId = undefined;
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(NotInitializedError);
+            }
         });
     });
 

--- a/src/customer/strategies/chasepay-customer-strategy.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.ts
@@ -59,6 +59,10 @@ export default class ChasePayCustomerStrategy extends CustomerStrategy {
                     .then(JPMC => {
                         const ChasePay = JPMC.ChasePay;
 
+                        ChasePay.configure({
+                            language: storeConfig.storeProfile.storeLanguage,
+                        });
+
                         if (ChasePay.isChasePayUp) {
                             ChasePay.insertButtons({
                                 containers: [container],

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -35,6 +35,7 @@ import {
 import { AfterpayScriptLoader } from './strategies/afterpay';
 import { AmazonPayScriptLoader } from './strategies/amazon-pay';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, VisaCheckoutScriptLoader } from './strategies/braintree';
+import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
 import { KlarnaScriptLoader } from './strategies/klarna';
 import { PaypalScriptLoader } from './strategies/paypal';
 import { SquareScriptLoader } from './strategies/square';
@@ -48,7 +49,6 @@ export default function createPaymentStrategyRegistry(
     const registry = new PaymentStrategyRegistry(store, { defaultToken: 'creditcard' });
     const scriptLoader = getScriptLoader();
     const braintreePaymentProcessor = createBraintreePaymentProcessor(scriptLoader);
-
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
     const orderActionCreator = new OrderActionCreator(
@@ -227,6 +227,20 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender),
             new VisaCheckoutScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register('chasepay', () =>
+        new ChasePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            requestSender,
+            new ChasePayScriptLoader(getScriptLoader()),
+            new WepayRiskClient(scriptLoader)
         )
     );
 

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -123,8 +123,18 @@ export default class PaymentActionCreator {
     private _getPaymentMethod(payment: Payment, paymentMethodSelector: PaymentMethodSelector): PaymentMethod | undefined {
         const paymentMethod = paymentMethodSelector.getPaymentMethod(payment.methodId, payment.gatewayId);
 
-        return (paymentMethod && paymentMethod.method === 'multi-option' && !paymentMethod.gateway) ?
-            { ...paymentMethod, gateway: paymentMethod.id } :
-            paymentMethod;
+        if (!paymentMethod) {
+            return;
+        }
+
+        if (paymentMethod.method === 'multi-option' && !paymentMethod.gateway) {
+            return { ...paymentMethod, gateway: paymentMethod.id };
+        }
+
+        if (paymentMethod.initializationData && paymentMethod.initializationData.gateway) {
+            return { ...paymentMethod, id: paymentMethod.initializationData.gateway };
+        }
+
+        return paymentMethod;
     }
 }

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -4,6 +4,7 @@ import {
     AmazonPayPaymentInitializeOptions,
     BraintreePaymentInitializeOptions,
     BraintreeVisaCheckoutPaymentInitializeOptions,
+    ChasePayInitializeOptions,
     KlarnaPaymentInitializeOptions,
     SquarePaymentInitializeOptions,
 } from './strategies';
@@ -61,4 +62,10 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support Square.
      */
     square?: SquarePaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the Chasepay payment method.
+     * They can be omitted unless you need to support Chasepay.
+     */
+    chasepay?: ChasePayInitializeOptions;
 }

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -43,4 +43,5 @@ export interface CryptogramInstrument {
     };
     ccNumber: string;
     accountMask: string;
+    extraData?: any;
 }

--- a/src/payment/strategies/chasepay/chasepay-initialize-options.ts
+++ b/src/payment/strategies/chasepay/chasepay-initialize-options.ts
@@ -1,0 +1,24 @@
+export default interface ChasePayInitializeOptions {
+    /**
+     * This container is used to host the chasepay branding logo.
+     * It should be an HTML element.
+     */
+    logoContainer?: string;
+
+    /**
+     * This walletButton is used to set an event listener, provide an element ID if you want
+     * users to be able to launch the ChasePay wallet modal by clicking on a button.
+     * It should be an HTML element.
+     */
+    walletButton?: string;
+
+    /**
+     * A callback that gets called when the customer selects a payment option.
+     */
+    onPaymentSelect?(): void;
+
+    /**
+     * A callback that gets called when the customer cancels their payment selection.
+     */
+    onCancel?(): void;
+}

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
@@ -1,0 +1,458 @@
+import { createAction, Action } from '@bigcommerce/data-store';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
+import { Observable } from 'rxjs';
+
+import { getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import InvalidArgumentError from '../../../common/error/errors/invalid-argument-error';
+import MissingDataError from '../../../common/error/errors/missing-data-error';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createPaymentClient, createPaymentStrategyRegistry, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
+import { getChasePay, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { ChasePayEventType, ChasePayScriptLoader, JPMC } from '../../../payment/strategies/chasepay';
+import { getChasePayScriptMock } from '../../../payment/strategies/chasepay/chasepay.mock';
+import { PaymentActionType } from '../../payment-actions';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
+import PaymentStrategy from '../payment-strategy';
+import WepayRiskClient from '../wepay/wepay-risk-client';
+
+import ChasePayPaymentStrategy from './chasepay-payment-strategy';
+
+describe('ChasePayPaymentStrategy', () => {
+    const testRiskToken = 'test-risk-token';
+    let container: HTMLDivElement;
+    let walletButton: HTMLAnchorElement;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentStrategyActionCreator: PaymentStrategyActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let orderActionCreator: OrderActionCreator;
+    let store: CheckoutStore;
+    let strategy: PaymentStrategy;
+    let chasePayScriptLoader: ChasePayScriptLoader;
+    let JPMC: JPMC;
+    let requestSender: RequestSender;
+    let wepayRiskClient: WepayRiskClient;
+    let scriptLoader: ScriptLoader;
+
+    beforeEach(() => {
+        paymentMethodMock = { ...getChasePay(), initializationData: { digitalSessionId: 'digitalSessionId', merchantRequestId: '1234567890' } };
+        scriptLoader = createScriptLoader();
+        wepayRiskClient = new WepayRiskClient(scriptLoader);
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethodMock);
+
+        jest.spyOn(store, 'getState');
+
+        jest.spyOn(wepayRiskClient, 'initialize')
+            .mockReturnValue(Promise.resolve(wepayRiskClient));
+
+        jest.spyOn(wepayRiskClient, 'getRiskToken')
+            .mockReturnValue(testRiskToken);
+
+        JPMC = getChasePayScriptMock();
+
+        chasePayScriptLoader = new ChasePayScriptLoader(createScriptLoader());
+
+        jest.spyOn(chasePayScriptLoader, 'load')
+            .mockReturnValue(Promise.resolve(JPMC));
+        jest.spyOn(JPMC.ChasePay, 'isChasePayUp')
+            .mockReturnValue(true);
+        jest.spyOn(JPMC.ChasePay, 'insertBrandings');
+        jest.spyOn(JPMC.ChasePay, 'showLoadingAnimation');
+        jest.spyOn(JPMC.ChasePay, 'startCheckout');
+
+        requestSender = createRequestSender();
+
+        const paymentClient = createPaymentClient(store);
+        const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
+        const configRequestSender = new ConfigRequestSender(createRequestSender());
+        const configActionCreator = new ConfigActionCreator(configRequestSender);
+        const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender);
+        const _requestSender: PaymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
+
+        paymentMethodActionCreator = new PaymentMethodActionCreator(_requestSender);
+        orderActionCreator = new OrderActionCreator(paymentClient, new CheckoutValidator(new CheckoutRequestSender(createRequestSender())));
+        paymentActionCreator = new PaymentActionCreator(new PaymentRequestSender(paymentClient), orderActionCreator);
+        checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
+        paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
+
+        jest.spyOn(paymentStrategyActionCreator, 'widgetInteraction');
+        jest.spyOn(requestSender, 'post');
+        JPMC.ChasePay.showLoadingAnimation = jest.fn(() => jest.fn(() => {}))
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        strategy = new ChasePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            requestSender,
+            chasePayScriptLoader,
+            wepayRiskClient
+        );
+
+        container = document.createElement('div');
+        walletButton = document.createElement('a');
+        container.setAttribute('id', 'login');
+        walletButton.setAttribute('id', 'mockButton');
+        document.body.appendChild(container);
+        document.body.appendChild(walletButton);
+
+        jest.spyOn(walletButton, 'addEventListener');
+        jest.spyOn(walletButton, 'removeEventListener');
+        jest.spyOn(requestSender, 'post')
+            .mockReturnValue(checkoutActionCreator);
+        jest.spyOn(checkoutActionCreator, 'loadCurrentCheckout');
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod');
+        jest.spyOn(document, 'getElementById');
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        document.body.removeChild(walletButton);
+    });
+
+    it('creates an instance of ChasePayPaymentStrategy', () => {
+        expect(strategy).toBeInstanceOf(ChasePayPaymentStrategy);
+    });
+
+    describe('#initialize()', () => {
+        let chasePayOptions: PaymentInitializeOptions;
+
+        beforeEach(() => {
+            chasePayOptions = { methodId: 'chasepay', chasepay: { logoContainer: 'login', walletButton: 'mockButton' } };
+        });
+
+        it('loads chasepay in test mode if enabled', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(chasePayOptions);
+
+            expect(chasePayScriptLoader.load).toHaveBeenLastCalledWith(true);
+        });
+
+        it('loads chasepay in test mode if enabled', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(chasePayOptions);
+
+            expect(chasePayScriptLoader.load).toHaveBeenLastCalledWith(true);
+        });
+
+        it('loads chasepay without test mode if disabled', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(chasePayOptions);
+
+            expect(chasePayScriptLoader.load).toHaveBeenLastCalledWith(false);
+        });
+
+        it('registers the start and complete callbacks', async () => {
+            JPMC.ChasePay.on = jest.fn((type, callback) => callback);
+
+            await strategy.initialize(chasePayOptions);
+
+            expect(JPMC.ChasePay.on).toHaveBeenCalledWith(ChasePayEventType.CompleteCheckout, expect.any(Function));
+        });
+
+        it('expect the chasepay complete checkout to call request sender', async () => {
+            const payload = {
+                sessionToken: '1111111111',
+            };
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
+
+            JPMC.ChasePay.on = jest.fn((type, callback) => callback(payload));
+
+            await strategy.initialize(chasePayOptions);
+
+            expect(JPMC.ChasePay.on).toHaveBeenCalledWith(ChasePayEventType.CompleteCheckout, expect.any(Function));
+            expect(requestSender.post).toBeCalled();
+        });
+
+        it('registers the start and cancel callbacks', async () => {
+            JPMC.ChasePay.on = jest.fn((type, callback) => callback);
+
+            await strategy.initialize(chasePayOptions);
+
+            expect(JPMC.ChasePay.on).toHaveBeenCalledWith(ChasePayEventType.CancelCheckout, expect.any(Function));
+        });
+
+        it('does not load chasepay if initialization options are not provided', async () => {
+            chasePayOptions = { methodId: 'chasepay'};
+            expect(() => strategy.initialize(chasePayOptions)).toThrowError(InvalidArgumentError);
+            expect(chasePayScriptLoader.load).not.toHaveBeenCalled();
+        });
+
+        it('does not load chase  pay if initialization data is not provided', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(chasePayScriptLoader.load).not.toHaveBeenCalled();
+
+            }
+        });
+
+        it('does not load chase  pay if store config is not provided', async () => {
+            jest.spyOn(store.getState().config, 'getStoreConfig')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(chasePayScriptLoader.load).not.toHaveBeenCalled();
+
+            }
+        });
+
+        it('adds the event listener to the wallet button', async () => {
+            await strategy.initialize(chasePayOptions);
+
+            expect(walletButton.addEventListener).toHaveBeenCalled();
+        });
+
+        it('insert the brandings if initialized', async () => {
+            if (chasePayOptions.chasepay) {
+                await strategy.initialize(chasePayOptions);
+
+                expect(JPMC.ChasePay.insertBrandings).toHaveBeenCalledWith({
+                    color: 'white',
+                    containers: [chasePayOptions.chasepay.logoContainer],
+                });
+            }
+        });
+
+        it('does not insert the branding if logo container does not exist', async () => {
+            chasePayOptions = { methodId: 'chasepay', chasepay: { logoContainer: '' } };
+            await strategy.initialize(chasePayOptions);
+
+            expect(JPMC.ChasePay.insertBrandings).not.toHaveBeenCalled();
+        });
+
+        it('configure chasepay lightbox', async () => {
+            await strategy.initialize(chasePayOptions);
+
+            expect(JPMC.ChasePay.configure).toHaveBeenCalled();
+        });
+
+        it('configure chasepay lightbox', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (error) {
+
+                expect(error).toBeInstanceOf(Error);
+            }
+
+        });
+
+        it('check if element exist in the DOM', async () => {
+            if (chasePayOptions.chasepay) {
+                await strategy.initialize(chasePayOptions);
+
+                expect(document.getElementById).toHaveBeenCalledWith(chasePayOptions.chasepay.logoContainer);
+            }
+
+        });
+
+        it('dispatch widget interaction when wallet button is clicked', async () => {
+            if (chasePayOptions.chasepay) {
+                await strategy.initialize(chasePayOptions);
+
+                const chasepayButton = document.getElementById(chasePayOptions.chasepay.walletButton || '');
+
+                if (chasepayButton) {
+                    await chasepayButton.click();
+                }
+
+                expect(store.dispatch).toBeCalledWith(expect.any(Function), { queueId: 'widgetInteraction' });
+            }
+        });
+
+        it('triggers widget interaction when wallet button is clicked', async () => {
+            if (chasePayOptions.chasepay) {
+                await strategy.initialize(chasePayOptions);
+
+                const chasepayButton = document.getElementById(chasePayOptions.chasepay.walletButton || '');
+
+                if (chasepayButton) {
+                    await chasepayButton.click();
+                }
+
+                expect(paymentStrategyActionCreator.widgetInteraction).toHaveBeenCalled();
+            }
+        });
+    });
+
+    describe('#execute()', () => {
+        let chasePayOptions: PaymentInitializeOptions;
+        let orderRequestBody: OrderRequestBody;
+        let submitOrderAction: Observable<Action>;
+        let submitPaymentAction: Observable<Action>;
+
+        beforeEach(async () => {
+            orderRequestBody = getOrderRequestBody();
+            submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+            submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+            chasePayOptions = { methodId: 'chasepay', chasepay: { logoContainer: 'login', walletButton: 'mockButton' } };
+            paymentMethodMock.initializationData = {
+                paymentCryptogram: '11111111111111',
+                eci: '11111111111',
+                reqTokenId: '111111111',
+                expDate: '11/11',
+                accountNum: '1111',
+                accountMask: '1111',
+                transactionId: 'MTExMTExMTEx',
+            };
+
+            paymentActionCreator.submitPayment = jest.fn(() => submitPaymentAction);
+            orderActionCreator.submitOrder = jest.fn(() => submitOrderAction);
+            await strategy.initialize(chasePayOptions);
+        });
+
+        it('calls submit order with the order request information', async () => {
+            await strategy.execute(orderRequestBody, chasePayOptions);
+            const { payment, ...order } = orderRequestBody;
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(order, expect.any(Object));
+            expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+        });
+
+        it('calls submit payment with the payment information', async () => {
+            await strategy.execute(orderRequestBody, chasePayOptions);
+
+            expect(store.dispatch).toHaveBeenCalled();
+        });
+
+        it('calls payment method actioncreator and loads the payment method', async () => {
+            await strategy.execute(orderRequestBody, chasePayOptions);
+
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(chasePayOptions.methodId);
+        });
+
+        it('returns the payment information', async () => {
+            await strategy.execute(orderRequestBody, chasePayOptions);
+
+            expect(store.getState).toHaveBeenCalled();
+        });
+
+        it('does not execute the payment if initialization data is not provided', async () => {
+            paymentMethodMock.initializationData = {};
+            try {
+                await strategy.execute(orderRequestBody, chasePayOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+            }
+        });
+
+        it('pass the options to submitOrder', async () => {
+            await strategy.execute(orderRequestBody, chasePayOptions);
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(expect.any(Object), chasePayOptions);
+        });
+
+        it('expect the wepayRiskClient not to be called', async () => {
+            await strategy.execute(orderRequestBody, chasePayOptions);
+
+            expect(wepayRiskClient.initialize).not.toHaveBeenCalled();
+        });
+
+        it('expect the not to obtain the risk token', async () => {
+            await strategy.execute(orderRequestBody, chasePayOptions);
+
+            expect(wepayRiskClient.getRiskToken).not.toHaveBeenCalled();
+        });
+
+        it('expect to get the payment method', async () => {
+            await strategy.execute(orderRequestBody, chasePayOptions);
+
+            expect(store.getState().paymentMethods.getPaymentMethod).toHaveBeenCalledWith(chasePayOptions.methodId);
+        });
+
+        it('initialize wepayRiskClient', async () => {
+            if (chasePayOptions.chasepay) {
+                chasePayOptions = { methodId: 'wepay', chasepay: { logoContainer: 'login' } };
+                await strategy.initialize(chasePayOptions);
+
+                await strategy.execute(orderRequestBody, chasePayOptions);
+
+                expect(wepayRiskClient.initialize).toHaveBeenCalled();
+            }
+        });
+
+        it('calls get risk token function', async () => {
+            if (chasePayOptions.chasepay) {
+                chasePayOptions = { methodId: 'wepay', chasepay: { logoContainer: 'login' } };
+                await strategy.initialize(chasePayOptions);
+
+                await strategy.execute(orderRequestBody, chasePayOptions);
+
+                expect(wepayRiskClient.getRiskToken).toHaveBeenCalled();
+            }
+        });
+
+    });
+
+    describe('#deinitialize()', () => {
+        let chasePayOptions: PaymentInitializeOptions;
+        let submitOrderAction: Observable<Action>;
+
+        beforeEach(async () => {
+            chasePayOptions = { methodId: 'chasepay', chasepay: { logoContainer: 'login', walletButton: 'mockButton' } };
+            submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+            orderActionCreator.submitOrder = jest.fn(() => submitOrderAction);
+
+            await strategy.initialize(chasePayOptions);
+        });
+
+        it('deinitializes wallet button', async () => {
+            if (chasePayOptions.chasepay) {
+                await strategy.deinitialize();
+
+                expect(walletButton.removeEventListener).toHaveBeenCalled();
+            }
+        });
+
+        it('expect to not call the orderActionCreator', async () => {
+            await strategy.deinitialize(chasePayOptions);
+
+            expect(orderActionCreator.submitOrder).not.toHaveBeenCalled();
+        });
+
+        it('deinitializes strategy', async () => {
+            await strategy.deinitialize();
+            expect(await strategy.deinitialize()).toEqual(store.getState());
+        });
+
+    });
+
+});

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
@@ -1,0 +1,248 @@
+import { RequestSender } from '@bigcommerce/request-sender';
+import { Subject } from 'rxjs';
+
+import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { toFormUrlEncoded } from '../../../common/http-request';
+import { bindDecorator as bind } from '../../../common/utility';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { PaymentMethodCancelledError } from '../../errors';
+import Payment from '../../payment';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
+import PaymentStrategy from '../payment-strategy';
+import { WepayRiskClient } from '../wepay';
+
+import { ChasePay, ChasePayEventType, ChasePaySuccessPayload } from './chasepay';
+import ChasePayInitializeOptions from './chasepay-initialize-options';
+import ChasePayScriptLoader from './chasepay-script-loader';
+
+export default class ChasePayPaymentStrategy extends PaymentStrategy {
+    private _chasePayClient?: ChasePay;
+    private _methodId!: string;
+    private _walletButton?: HTMLElement;
+    private _walletEvent$: Subject<{ type: ChasePayEventType }>;
+
+    constructor(
+        store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _paymentStrategyActionCreator: PaymentStrategyActionCreator,
+        private _requestSender: RequestSender,
+        private _chasePayScriptLoader: ChasePayScriptLoader,
+        private _wepayRiskClient: WepayRiskClient
+    ) {
+        super(store);
+
+        this._walletEvent$ = new Subject();
+    }
+
+    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        this._methodId = options.methodId;
+
+        if (!options.chasepay) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.chasepay" argument is not provided.');
+        }
+
+        const walletButton = options.chasepay.walletButton && document.getElementById(options.chasepay.walletButton);
+
+        if (walletButton) {
+            this._walletButton = walletButton;
+            this._walletButton.addEventListener('click', this._handleWalletButtonClick);
+        }
+
+        return this._configureWallet(options.chasepay)
+            .then(() => super.initialize(options));
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (this._walletButton) {
+            this._walletButton.removeEventListener('click', this._handleWalletButtonClick);
+        }
+
+        this._walletButton = undefined;
+        this._chasePayClient = undefined;
+
+        return super.deinitialize(options);
+    }
+
+    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._getPayment()
+            .catch(error => {
+                if (error.subtype === MissingDataErrorType.MissingPayment) {
+                    return this._displayWallet()
+                        .then(() => this._getPayment());
+                }
+
+                throw error;
+            })
+            .then(payment =>
+                this._createOrder(payment, payload.useStoreCredit, options)
+            );
+    }
+
+    private _configureWallet(options: ChasePayInitializeOptions): Promise<void> {
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethod(this._methodId);
+        const storeConfig = state.config.getStoreConfig();
+
+        if (!paymentMethod) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        if (!storeConfig) {
+            throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+        }
+
+        return this._chasePayScriptLoader.load(paymentMethod.config.testMode)
+            .then(({ ChasePay }) => {
+                this._chasePayClient = ChasePay;
+
+                if (options.logoContainer && document.getElementById(options.logoContainer)) {
+                    this._chasePayClient.insertBrandings({
+                        color: 'white',
+                        containers: [options.logoContainer],
+                    });
+                }
+
+                this._chasePayClient.configure({
+                    language: storeConfig.storeProfile.storeLanguage,
+                });
+
+                this._chasePayClient.on(ChasePayEventType.CancelCheckout, () => {
+                    this._walletEvent$.next({ type: ChasePayEventType.CancelCheckout });
+
+                    if (options.onCancel) {
+                        options.onCancel();
+                    }
+                });
+
+                this._chasePayClient.on(ChasePayEventType.CompleteCheckout, (payload: ChasePaySuccessPayload) => {
+                    this._setSessionToken(payload.sessionToken)
+                        .then(() => {
+                            this._walletEvent$.next({ type: ChasePayEventType.CompleteCheckout });
+
+                            if (options.onPaymentSelect) {
+                                options.onPaymentSelect();
+                            }
+                        });
+                });
+            });
+    }
+
+    private _displayWallet(): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(this._paymentStrategyActionCreator.widgetInteraction(() => {
+            this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(this._methodId))
+                .then(state => {
+                    const paymentMethod = state.paymentMethods.getPaymentMethod(this._methodId);
+
+                    if (!this._chasePayClient) {
+                        throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+                    }
+
+                    if (!paymentMethod) {
+                        throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                    }
+
+                    this._chasePayClient.showLoadingAnimation();
+                    this._chasePayClient.startCheckout(paymentMethod.initializationData.digitalSessionId);
+                });
+
+            // Wait for payment selection
+            return new Promise((resolve, reject) => {
+                this._walletEvent$.take(1)
+                    .subscribe((event: { type: ChasePayEventType }) => {
+                        if (event.type === ChasePayEventType.CancelCheckout) {
+                            reject(new PaymentMethodCancelledError());
+                        } else if (event.type === ChasePayEventType.CompleteCheckout) {
+                            resolve();
+                        }
+                    });
+            });
+        }, { methodId: this._methodId }), { queueId: 'widgetInteraction' });
+    }
+
+    private _setSessionToken(sessionToken: string): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethod(this._methodId);
+        const merchantRequestId = paymentMethod && paymentMethod.initializationData.merchantRequestId;
+
+        return this._requestSender.post('checkout.php', {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            },
+            body: toFormUrlEncoded({
+                action: 'set_external_checkout',
+                provider: this._methodId,
+                sessionToken,
+                merchantRequestId,
+            }),
+        })
+            // Re-hydrate checkout data
+            .then(() => Promise.all([
+                this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
+                this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(this._methodId)),
+            ]))
+            .then(() => this._store.getState());
+    }
+
+    private _getPayment(): Promise<Payment> {
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(this._methodId))
+            .then(() => {
+                if (this._methodId === 'wepay') {
+                    return this._wepayRiskClient.initialize()
+                        .then(client => client.getRiskToken());
+                }
+
+                return '';
+            })
+            .then(riskToken => {
+                const state = this._store.getState();
+                const paymentMethod = state.paymentMethods.getPaymentMethod(this._methodId);
+
+                if (!paymentMethod) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                if (!paymentMethod.initializationData.paymentCryptogram) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPayment);
+                }
+
+                const paymentData = {
+                    method: this._methodId,
+                    cryptogramId: paymentMethod.initializationData.paymentCryptogram,
+                    eci: paymentMethod.initializationData.eci,
+                    transactionId: btoa(paymentMethod.initializationData.reqTokenId),
+                    ccExpiry: {
+                        month: paymentMethod.initializationData.expDate.toString().substr(0, 2),
+                        year: paymentMethod.initializationData.expDate.toString().substr(2, 2),
+                    },
+                    ccNumber: paymentMethod.initializationData.accountNum,
+                    accountMask: paymentMethod.initializationData.accountMask,
+                    extraData: riskToken ? { riskToken } : undefined,
+                };
+
+                return {
+                    methodId: this._methodId,
+                    paymentData,
+                };
+            });
+    }
+
+    private _createOrder(payment: Payment, useStoreCredit?: boolean, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(this._orderActionCreator.submitOrder({ useStoreCredit }, options))
+            .then(() => this._store.dispatch(this._paymentActionCreator.submitPayment(payment)));
+    }
+
+    @bind
+    private _handleWalletButtonClick(event: Event): void {
+        event.preventDefault();
+
+        this._displayWallet();
+    }
+}

--- a/src/payment/strategies/chasepay/chasepay.mock.ts
+++ b/src/payment/strategies/chasepay/chasepay.mock.ts
@@ -1,16 +1,19 @@
-import { JPMC } from './chasepay';
+import { ChasePayEventType, JPMC } from './chasepay';
 
 export function getChasePayScriptMock(): JPMC {
     return {
         ChasePay: {
             insertButtons: jest.fn(),
+            insertBrandings: jest.fn(),
             isChasePayUp: jest.fn(),
             startCheckout: jest.fn(),
+            configure: jest.fn(),
+            showLoadingAnimation: jest.fn(),
             on: jest.fn(),
             EventType: {
-                START_CHECKOUT: 'START_CHECKOUT',
-                COMPLETE_CHECKOUT: 'COMPLETE_CHECKOUT',
-                CANCEL_CHECKOUT: 'CANCEL_CHECKOUT',
+                START_CHECKOUT: ChasePayEventType.StartCheckout,
+                COMPLETE_CHECKOUT: ChasePayEventType.CompleteCheckout,
+                CANCEL_CHECKOUT: ChasePayEventType.CancelCheckout,
             },
         },
     };

--- a/src/payment/strategies/chasepay/chasepay.ts
+++ b/src/payment/strategies/chasepay/chasepay.ts
@@ -1,7 +1,13 @@
+export enum ChasePayEventType {
+    StartCheckout = 'startCheckout',
+    CompleteCheckout = 'completeCheckout',
+    CancelCheckout = 'cancelCheckout',
+}
+
 export interface ChasePayEventMap {
-    'START_CHECKOUT'(digitalSessionId: string): void;
-    'COMPLETE_CHECKOUT'(payload: ChasePaySuccessPayload): void;
-    'CANCEL_CHECKOUT'(): void;
+    [ChasePayEventType.StartCheckout](digitalSessionId: string): void;
+    [ChasePayEventType.CompleteCheckout](payload: ChasePaySuccessPayload): void;
+    [ChasePayEventType.CancelCheckout](): void;
 }
 
 export interface ChasePayHostWindow extends Window {
@@ -16,14 +22,51 @@ export interface ChasePaySuccessPayload {
     sessionToken: string;
 }
 
+export interface ChasePayInsertOptions {
+    color?: string;
+    containers?: string[];
+    height?: number;
+    width?: number;
+}
+
+export interface ChasePayConfigureOptions {
+    language?: string;
+    zindex?: number;
+    sessionWarningTime?: number;
+    sessionTimeoutTime?: number;
+}
+
 export interface ChasePay {
     EventType: {
-        START_CHECKOUT: 'START_CHECKOUT';
-        COMPLETE_CHECKOUT: 'COMPLETE_CHECKOUT';
-        CANCEL_CHECKOUT: 'CANCEL_CHECKOUT';
+        START_CHECKOUT: ChasePayEventType.StartCheckout;
+        COMPLETE_CHECKOUT: ChasePayEventType.CompleteCheckout;
+        CANCEL_CHECKOUT: ChasePayEventType.CancelCheckout;
     };
     isChasePayUp(): boolean;
-    insertButtons(options: any): void;
+    insertButtons(options: ChasePayInsertOptions): void;
+    insertBrandings(options: ChasePayInsertOptions): void;
     startCheckout(digitalSessionId?: string): void;
+    showLoadingAnimation(): void;
+    configure(options: ChasePayConfigureOptions): void;
     on<ChasePayEventType extends keyof ChasePayEventMap>(eventType: ChasePayEventType, callback: ChasePayEventMap[ChasePayEventType]): {};
+}
+
+export interface ChasePayInitializeOptions {
+    /**
+     * This container is used to host the chasepay branding logo.
+     * It should be an HTML element.
+     */
+    logoContainer: string;
+
+    /**
+     * This walletButton is used to set an event listener, provide an element ID if you want
+     * users to be able to launch the ChasePay wallet modal by clicking on a button.
+     * It should be an HTML element.
+     */
+    walletButton?: string;
+
+    /**
+     * A callback that gets called when the customer selects a payment option.
+     */
+    onPaymentSelect?(): void;
 }

--- a/src/payment/strategies/chasepay/index.ts
+++ b/src/payment/strategies/chasepay/index.ts
@@ -1,3 +1,6 @@
 export * from './chasepay';
 
 export { default as ChasePayScriptLoader } from './chasepay-script-loader';
+export { default as ChasePayPaymentStrategy } from './chasepay-payment-strategy';
+export { default as ChasePayInitializeOptions } from './chasepay-initialize-options';
+export { default as ChasepayPaymentStrategy } from './chasepay-payment-strategy';

--- a/src/payment/strategies/index.ts
+++ b/src/payment/strategies/index.ts
@@ -11,5 +11,6 @@ export { AmazonPayPaymentStrategy, AmazonPayPaymentInitializeOptions } from './a
 export { BraintreeCreditCardPaymentStrategy, BraintreePaymentInitializeOptions, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy, BraintreeVisaCheckoutPaymentInitializeOptions } from './braintree';
 export { KlarnaPaymentStrategy, KlarnaPaymentInitializeOptions } from './klarna';
 export { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy } from './paypal';
+export { ChasePayPaymentStrategy, ChasePayInitializeOptions } from './chasepay';
 export { SquarePaymentStrategy, SquarePaymentInitializeOptions } from './square';
 export { WepayPaymentStrategy } from './wepay';


### PR DESCRIPTION
## What? [INT-616](https://jira.bigcommerce.com/browse/INT-616)
Extend full Chase Pay support to Checkout SDK

## Why?
So that partners building custom checkout implementations can utilize  Chase Pay.

## Testing / Proof
![image](https://user-images.githubusercontent.com/1013633/43862290-e427f5aa-9b1e-11e8-9de7-571b0eb4a89b.png)

## Sibling PRs
For bicommerce: [PR#26067](https://github.com/bigcommerce/bigcommerce/pull/26067)
For `ng-checkout`: [PR#914](https://github.com/bigcommerce-labs/ng-checkout/pull/914)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/integrations 