### PR TITLE
CHECKOUT-3011: Allow PayPal checkout button to process payment

### DIFF
--- a/src/checkout-button.ts
+++ b/src/checkout-button.ts
@@ -1,1 +1,6 @@
+/**
+ * @alpha
+ * `CheckoutButtonInitializer` is currently in an early stage of development.
+ * Therefore the API is unstable and not ready for public consumption.
+ */
 export { createCheckoutButtonInitializer } from './checkout-buttons';

--- a/src/checkout-buttons/strategies/braintree-paypal-button-options.ts
+++ b/src/checkout-buttons/strategies/braintree-paypal-button-options.ts
@@ -3,6 +3,12 @@ import { BraintreeError } from '../../payment/strategies/braintree';
 import { PaypalButtonStyleOptions } from '../../payment/strategies/paypal';
 
 export interface BraintreePaypalButtonInitializeOptions {
+    /**
+     * @internal
+     * This is an internal property and therefore subject to change. DO NOT USE.
+     */
+    shouldProcessPayment?: boolean;
+
     container: string;
     style?: Pick<PaypalButtonStyleOptions, 'color' | 'shape' | 'size'>;
     onAuthorizeError?(error: BraintreeError | StandardError): void;


### PR DESCRIPTION
## What?
* Process payment if `shouldProcessPayment` flag is passed. This is marked as `internal` because it is never intended to be used by external parties. It is only needed to support legacy checkout flow.
* Mark `CheckoutButtonInitializer` as `alpha` so that it is clear it is not ready for public consumption yet.

## Why?
* Please see "what".

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
