### PR TITLE
feat(payment): INT-751 Show Masterpass button in payments section into square form

### DIFF
--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -21,6 +21,7 @@ import {
     CustomerStrategy,
     DefaultCustomerStrategy,
 } from './strategies';
+import SquareCustomerStrategy from './strategies/square-customer-strategy';
 
 export default function createCustomerStrategyRegistry(
     store: CheckoutStore,
@@ -67,6 +68,13 @@ export default function createCustomerStrategyRegistry(
             createFormPoster()
         )
     );
+
+    registry.register('squarev2', () =>
+        new SquareCustomerStrategy(
+            store,
+            new RemoteCheckoutActionCreator(remoteCheckoutRequestSender)
+    )
+);
 
     registry.register('default', () =>
         new DefaultCustomerStrategy(

--- a/src/customer/strategies/index.ts
+++ b/src/customer/strategies/index.ts
@@ -3,3 +3,4 @@ export { default as CustomerStrategy } from './customer-strategy';
 export { default as DefaultCustomerStrategy } from './default-customer-strategy';
 export { default as BraintreeVisaCheckoutCustomerStrategy, BraintreeVisaCheckoutCustomerInitializeOptions } from './braintree-visacheckout-customer-strategy';
 export { default as ChasePayCustomerStrategy, ChasePayCustomerInitializeOptions } from './chasepay-customer-strategy';
+export { default as SquareCustomerStrategy } from './square-customer-strategy';

--- a/src/customer/strategies/square-customer-strategy.spec.ts
+++ b/src/customer/strategies/square-customer-strategy.spec.ts
@@ -1,0 +1,90 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import { getCartState } from '../../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../../checkout';
+import { getCheckoutState } from '../../checkout/checkouts.mock';
+import { getConfigState } from '../../config/configs.mock';
+import { PaymentMethod } from '../../payment';
+import { getPaymentMethodsState, getSquare } from '../../payment/payment-methods.mock';
+import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../remote-checkout';
+import { getCustomerState } from '../customers.mock';
+
+import CustomerStrategy from './customer-strategy';
+import SquareCustomerStrategy from './square-customer-strategy';
+
+describe('SquareCustomerStrategy', () => {
+    let container: HTMLDivElement;
+    let paymentMethodMock: PaymentMethod;
+    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let store: CheckoutStore;
+    let strategy: CustomerStrategy;
+
+    beforeEach(() => {
+        paymentMethodMock = { ...getSquare() };
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethodMock);
+
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+            new RemoteCheckoutRequestSender(createRequestSender())
+        );
+
+        strategy = new SquareCustomerStrategy(
+            store,
+            remoteCheckoutActionCreator
+        );
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'login');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('creates an instance of SquareCustomerStrategy', () => {
+        expect(strategy).toBeInstanceOf(SquareCustomerStrategy);
+    });
+
+    describe('#signIn()', () => {
+        it('throws error if trying to sign in programmatically', async () => {
+            expect(() => strategy.signIn({ email: 'foo@bar.com', password: 'foobar' })).toThrowError();
+        });
+    });
+
+    describe('#signOut()', () => {
+        beforeEach(async () => {
+            const paymentId = {
+                providerId: 'squarev2',
+            };
+
+            jest.spyOn(store.getState().payment, 'getPaymentId').mockReturnValue(paymentId);
+
+            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+                .mockReturnValue('data');
+        });
+
+        it('throws error if trying to sign out programmatically', async () => {
+            const options = {
+                methodId: 'squarev2',
+            };
+
+            await strategy.signOut(options);
+
+            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('squarev2', options);
+            expect(store.dispatch).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/customer/strategies/square-customer-strategy.ts
+++ b/src/customer/strategies/square-customer-strategy.ts
@@ -1,0 +1,36 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
+import { NotImplementedError} from '../../common/error/errors';
+import { RemoteCheckoutActionCreator } from '../../remote-checkout';
+import CustomerCredentials from '../customer-credentials';
+import { CustomerRequestOptions } from '../customer-request-options';
+
+import CustomerStrategy from './customer-strategy';
+
+export default class SquareCustomerStrategy extends CustomerStrategy {
+
+    constructor(
+        store: CheckoutStore,
+        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator
+    ) {
+        super(store);
+    }
+
+    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        throw new NotImplementedError(
+            'In order to sign in via Masterpass, the shopper must click on "Masterpass" button.'
+        );
+    }
+
+    signOut(options?: any): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const payment = state.payment.getPaymentId();
+
+        if (!payment) {
+            return Promise.resolve(this._store.getState());
+        }
+
+        return this._store.dispatch(
+            this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+}

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -59,10 +59,15 @@ export default function createPaymentStrategyRegistry(
         new PaymentRequestSender(paymentClient),
         orderActionCreator
     );
+
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
         new RemoteCheckoutRequestSender(requestSender)
     );
+    const configRequestSender = new ConfigRequestSender(requestSender);
+    const configActionCreator = new ConfigActionCreator(configRequestSender);
+    const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
+    const paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
 
     registry.register('afterpay', () =>
         new AfterpayPaymentStrategy(
@@ -164,8 +169,12 @@ export default function createPaymentStrategyRegistry(
     registry.register('squarev2', () =>
         new SquarePaymentStrategy(
             store,
+            checkoutActionCreator,
             orderActionCreator,
             paymentActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            requestSender,
             new SquareScriptLoader(scriptLoader)
         )
     );
@@ -211,12 +220,9 @@ export default function createPaymentStrategyRegistry(
     registry.register('braintreevisacheckout', () =>
         new BraintreeVisaCheckoutPaymentStrategy(
             store,
-            new CheckoutActionCreator(
-                checkoutRequestSender,
-                new ConfigActionCreator(new ConfigRequestSender(requestSender))
-            ),
+            checkoutActionCreator,
             paymentMethodActionCreator,
-            new PaymentStrategyActionCreator(registry, orderActionCreator),
+            paymentStrategyActionCreator,
             paymentActionCreator,
             orderActionCreator,
             createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender),

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -5,8 +5,9 @@ export * from './payment-status-types';
 
 export { default as createPaymentClient } from './create-payment-client';
 export { default as createPaymentStrategyRegistry } from './create-payment-strategy-registry';
+export { default as isNonceLike } from './is-nonce-like';
 export { default as PaymentActionCreator } from './payment-action-creator';
-export { default as Payment, CreditCardInstrument, VaultedInstrument, PaymentInstrument } from './payment';
+export { default as Payment, CreditCardInstrument, VaultedInstrument, PaymentInstrument, NonceInstrument } from './payment';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -220,9 +220,13 @@ export function getSquare(): PaymentMethod {
             applicationId: 'test',
             env: 'bar',
             locationId: 'foo',
+            paymentData: {
+                nonce: undefined,
+            },
         },
     };
 }
+
 export function getChasePay(): PaymentMethod {
     return {
         id: 'chasepay',

--- a/src/payment/strategies/square/index.ts
+++ b/src/payment/strategies/square/index.ts
@@ -1,2 +1,4 @@
-export { default as SquarePaymentStrategy, SquarePaymentInitializeOptions } from './square-payment-strategy';
+export { default as SquarePaymentStrategy } from './square-payment-strategy';
 export { default as SquareScriptLoader } from './square-script-loader';
+export { default as SquarePaymentForm } from './square-form';
+export { default as SquarePaymentInitializeOptions } from './square-payment-initialize-options';

--- a/src/payment/strategies/square/square-form.ts
+++ b/src/payment/strategies/square/square-form.ts
@@ -19,6 +19,68 @@ export interface SquareFormOptions {
     cvv: SquareFormElement;
     expirationDate: SquareFormElement;
     postalCode: SquareFormElement;
+    masterpass: SquareFormElement;
+}
+export interface LineItem {
+    label: string;
+    amount: string;
+    pending: boolean;
+}
+
+export interface SquarePaymentRequest {
+    requestShippingAddress: boolean;
+    requestBillingInfo: boolean;
+    shippingContact?: Contact;
+    countryCode: string;
+    currencyCode: string;
+    lineItems?: LineItem[];
+    total: LineItem;
+}
+
+export interface NonceGenerationError {
+    type: string;
+    message: string;
+    field: string;
+}
+
+export interface CardData {
+    card_brand: CardBrand;
+    last_4: number;
+    exp_month: number;
+    exp_year: number;
+    billing_postal_code: string;
+    digital_wallet_type: DigitalWalletType;
+}
+
+export interface Contact {
+    familyName: string;
+    givenName: string;
+    email: string;
+    country: string;
+    countryName: string;
+    region: string;
+    city: string;
+    addressLines: string[];
+    postalCode: string;
+    phone: string;
+}
+
+export enum CardBrand {
+    americanExpress = 'AMERICAN_EXPRESS',
+    discover = 'DISCOVER',
+    discoverDiners = 'DISCOVER_DINERS',
+    JCB = 'JCB',
+    masterCard = 'MASTERCARD',
+    unionPay = 'CHINA_UNIONPAY',
+    unknown = 'OTHER_BRAND',
+    visa = 'VISA',
+    squareGift = 'SQUARE_GIFT_CARD',
+}
+
+export enum DigitalWalletType {
+    applePay = 'APPLEPAY',
+    masterpass = 'MASTERPASS',
+    none = 'NONE',
 }
 
 /**
@@ -39,7 +101,14 @@ export interface SquareFormElement {
 export interface SquareFormCallbacks {
     paymentFormLoaded?(form: SquarePaymentForm): void;
     unsupportedBrowserDetected?(): void;
-    cardNonceResponseReceived?(errors: any, nonce: string): void;
+    cardNonceResponseReceived?(
+        errors?: NonceGenerationError[],
+        nonce?: string,
+        cardData?: CardData,
+        billingContact?: Contact,
+        shippingContact?: Contact): void;
+    methodsSupported?(methods: { [key: string]: boolean }): void;
+    createPaymentRequest?(): void;
 }
 
 export type SquareFormFactory = (options: SquareFormOptions) => SquarePaymentForm;

--- a/src/payment/strategies/square/square-payment-initialize-options.ts
+++ b/src/payment/strategies/square/square-payment-initialize-options.ts
@@ -1,0 +1,55 @@
+import { NonceGenerationError, SquareFormElement } from './square-form';
+
+/**
+ * A set of options that are required to initialize the Square payment method.
+ *
+ * Once Square payment is initialized, credit card form fields, provided by the
+ * payment provider as iframes, will be inserted into the current page. These
+ * options provide a location and styling for each of the form fields.
+ */
+export default interface SquarePaymentInitializeOptions {
+    /**
+     * The location to insert the credit card number form field.
+     */
+    cardNumber: SquareFormElement;
+
+    /**
+     * The location to insert the CVV form field.
+     */
+    cvv: SquareFormElement;
+
+    /**
+     * The location to insert the expiration date form field.
+     */
+    expirationDate: SquareFormElement;
+
+    /**
+     * The location to insert the postal code form field.
+     */
+    postalCode: SquareFormElement;
+
+    /**
+     * The CSS class to apply to all form fields.
+     */
+    inputClass?: string;
+
+    /**
+     * The set of CSS styles to apply to all form fields.
+     */
+    inputStyles?: Array<{ [key: string]: string }>;
+
+    /**
+     * Initialize Masterpass placeholder ID
+     */
+    masterpass?: SquareFormElement;
+
+    /**
+     * A callback that gets called when the customer selects a payment option.
+     */
+    onPaymentSelect?(): void;
+
+    /**
+     * A callback that gets called when an error occurs in the card nonce generation
+     */
+    onError?(errors?: NonceGenerationError[]): void;
+}

--- a/src/payment/strategies/square/square-payment-strategy-mock.ts
+++ b/src/payment/strategies/square/square-payment-strategy-mock.ts
@@ -1,0 +1,81 @@
+import { PaymentInitializeOptions } from '../..';
+import { OrderRequestBody } from '../../../order';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+
+import { CardBrand, CardData, DigitalWalletType, NonceGenerationError } from './square-form';
+
+const methodId = 'square';
+
+export function getNonceGenerationErrors(): NonceGenerationError[] {
+    return [
+        {
+            type: 'some-type',
+            message: 'some-message',
+            field: 'some-field',
+        },
+    ];
+
+}
+export function getCardData(): CardData {
+    return {
+        card_brand: CardBrand.masterCard,
+        last_4: 1234,
+        exp_month: 1,
+        exp_year: 2020,
+        billing_postal_code: '12345',
+        digital_wallet_type: DigitalWalletType.masterpass,
+    };
+}
+
+export function getPayloadCreditCard(): OrderRequestBody {
+    return {
+        payment: {
+            ...getOrderRequestBody().payment,
+            methodId,
+        },
+    };
+}
+
+export function getPayloadVaulted(): OrderRequestBody {
+    return {
+        useStoreCredit: true,
+        payment:  {
+            paymentData: {
+                instrumentId: 'string',
+            },
+            methodId,
+        },
+    };
+}
+
+export function getPayloadNonce(): OrderRequestBody {
+    return {
+        payment: {
+            methodId,
+        },
+    };
+}
+
+export function getSquarePaymentInitializeOptions(): PaymentInitializeOptions {
+    return {
+        methodId,
+        square: {
+            cardNumber: {
+                elementId: 'cardNumber',
+            },
+            cvv: {
+                elementId: 'cvv',
+            },
+            expirationDate: {
+                elementId: 'expirationDate',
+            },
+            postalCode: {
+                elementId: 'postalCode',
+            },
+            onPaymentSelect: () => { },
+            masterpass: {
+                elementId: 'sq-masterpass',
+            },
+        },
+    };
+}

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -4,27 +4,63 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { Observable } from 'rxjs';
 
-import { PaymentActionCreator, PaymentRequestSender } from '../..';
-import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
-import { InvalidArgumentError, TimeoutError } from '../../../common/error/errors';
+import {
+    createPaymentStrategyRegistry,
+    PaymentActionCreator,
+    PaymentInitializeOptions,
+    PaymentMethodActionCreator,
+    PaymentMethodRequestSender,
+    PaymentRequestSender,
+    PaymentStrategyActionCreator
+} from '../..';
+import {
+    createCheckoutStore,
+    CheckoutActionCreator,
+    CheckoutRequestSender,
+    CheckoutStore,
+    CheckoutValidator,
+    InternalCheckoutSelectors
+} from '../../../checkout';
+import { getCheckoutState, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    NotInitializedError,
+    StandardError,
+    TimeoutError,
+    UnsupportedBrowserError
+} from '../../../common/error/errors';
+import ConfigActionCreator from '../../../config/config-action-creator';
+import ConfigRequestSender from '../../../config/config-request-sender';
+import { getConfigState } from '../../../config/configs.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { getPaymentMethodsState, getSquare } from '../../../payment/payment-methods.mock';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
 
-import SquarePaymentForm, { SquareFormCallbacks, SquareFormOptions } from './square-form';
-import SquarePaymentStrategy from './square-payment-strategy';
-import SquareScriptLoader from './square-script-loader';
+import { SquarePaymentForm, SquarePaymentStrategy, SquareScriptLoader } from './';
+
+import { DigitalWalletType, SquareFormCallbacks, SquareFormOptions } from './square-form';
+import {
+    getCardData,
+    getNonceGenerationErrors,
+    getPayloadVaulted,
+    getSquarePaymentInitializeOptions
+} from './square-payment-strategy-mock';
 
 describe('SquarePaymentStrategy', () => {
+    let callbacks: SquareFormCallbacks;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let initOptions: PaymentInitializeOptions;
+    let orderActionCreator: OrderActionCreator;
+    let orderRequestSender: OrderRequestSender;
+    let paymentActionCreator: PaymentActionCreator;
+    let paymentMethod: PaymentMethod;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentStrategyActionCreator: PaymentStrategyActionCreator;
     let scriptLoader: SquareScriptLoader;
     let store: CheckoutStore;
     let strategy: SquarePaymentStrategy;
-    let orderActionCreator: OrderActionCreator;
-    let paymentActionCreator: PaymentActionCreator;
-    let paymentMethod: PaymentMethod;
-    let callbacks: SquareFormCallbacks;
-    let orderRequestSender: OrderRequestSender;
     let submitOrderAction: Observable<Action>;
     let submitPaymentAction: Observable<Action>;
 
@@ -55,9 +91,20 @@ describe('SquarePaymentStrategy', () => {
     beforeEach(() => {
         store = createCheckoutStore({
             paymentMethods: getPaymentMethodsState(),
+            checkout: getCheckoutState(),
+            config: getConfigState(),
+            billingAddress: getCheckoutStoreState().billingAddress,
         });
         orderRequestSender = new OrderRequestSender(createRequestSender());
         paymentMethod = getSquare();
+
+        const requestSender = createRequestSender();
+        const paymentClient = createPaymentClient(store);
+        const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender);
+        const checkoutRequestSender = new CheckoutRequestSender(requestSender);
+        const configRequestSender = new ConfigRequestSender(requestSender);
+        const configActionCreator = new ConfigActionCreator(configRequestSender);
+
         orderActionCreator = new OrderActionCreator(
             orderRequestSender,
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
@@ -66,8 +113,22 @@ describe('SquarePaymentStrategy', () => {
             new PaymentRequestSender(createPaymentClient()),
             orderActionCreator
         );
+        initOptions = getSquarePaymentInitializeOptions();
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(requestSender));
+        paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
         scriptLoader = new SquareScriptLoader(createScriptLoader());
-        strategy = new SquarePaymentStrategy(store, orderActionCreator, paymentActionCreator, scriptLoader);
+        checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
+        strategy = new SquarePaymentStrategy(
+            store,
+            checkoutActionCreator,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            requestSender,
+            scriptLoader
+        );
         submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
         submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
 
@@ -90,13 +151,13 @@ describe('SquarePaymentStrategy', () => {
     });
 
     describe('#initialize()', () => {
+        initOptions = {
+            methodId: 'square',
+            square: squareOptions,
+        };
+
         describe('when form loads successfully', () => {
             it('loads script when initializing strategy with required params', async () => {
-                const initOptions = {
-                    methodId: paymentMethod.id,
-                    square: squareOptions,
-                };
-
                 await strategy.initialize(initOptions);
 
                 expect(scriptLoader.load).toHaveBeenCalledTimes(1);
@@ -106,8 +167,53 @@ describe('SquarePaymentStrategy', () => {
                 try {
                     await strategy.initialize({ methodId: paymentMethod.id });
                 } catch (error) {
-                    expect(error.type).toEqual('invalid_argument');
+                    expect(error).toBeInstanceOf(InvalidArgumentError);
                 }
+            });
+
+            it('Shows the masterpass button', async () => {
+                await strategy.initialize(initOptions);
+
+                let container: HTMLDivElement;
+                container = document.createElement('div');
+                container.id = 'sq-masterpass';
+                document.body.appendChild(container);
+
+                if (callbacks.methodsSupported) {
+                    callbacks.methodsSupported({ masterpass: true });
+                }
+
+                expect(scriptLoader.load).toHaveBeenCalledTimes(1);
+            });
+
+            describe('Payment Request callback fired', () => {
+
+                beforeEach(async () => {
+                    await strategy.initialize(initOptions);
+                });
+
+                it('Creates Payload', async () => {
+                    jest.spyOn(store.getState().checkout, 'getCheckout')
+                    .mockReturnValue(getSquarePaymentInitializeOptions());
+
+                    if (callbacks.createPaymentRequest) {
+                        callbacks.createPaymentRequest();
+                    }
+
+                    expect(scriptLoader.load).toHaveBeenCalledTimes(1);
+                });
+
+                it('Fails because no checkout information is present' , async () => {
+                    store = createCheckoutStore({});
+
+                    if (callbacks.createPaymentRequest) {
+                        try {
+                            callbacks.createPaymentRequest();
+                        } catch (error) {
+                            expect(error).toBeInstanceOf(MissingDataError);
+                        }
+                    }
+                });
             });
         });
 
@@ -129,7 +235,7 @@ describe('SquarePaymentStrategy', () => {
                 };
 
                 strategy.initialize(initOptions)
-                    .catch(e => expect(e.type).toEqual('unsupported_browser'));
+                    .catch(e => expect(e).toBeInstanceOf(UnsupportedBrowserError));
 
                 expect(scriptLoader.load).toHaveBeenCalledTimes(1);
                 expect(squareForm.build).toHaveBeenCalledTimes(0);
@@ -140,14 +246,15 @@ describe('SquarePaymentStrategy', () => {
     describe('#execute()', () => {
         const payload = {
             payment: {
-                methodId: 'foo',
+                methodId: 'square',
             },
         };
+        const cardData = getCardData();
 
         describe('when form has not been initialized', () => {
             it('rejects the promise', () => {
                 strategy.execute(payload)
-                    .catch(e => expect(e.type).toEqual('not_initialized'));
+                    .catch(e => expect(e).toBeInstanceOf(NotInitializedError));
 
                 expect(squareForm.requestCardNonce).toHaveBeenCalledTimes(0);
             });
@@ -182,7 +289,7 @@ describe('SquarePaymentStrategy', () => {
 
                 setTimeout(() => {
                     if (callbacks.cardNonceResponseReceived) {
-                        callbacks.cardNonceResponseReceived(null, 'nonce');
+                        callbacks.cardNonceResponseReceived(undefined, 'nonce');
                     }
                 }, 0);
 
@@ -196,7 +303,7 @@ describe('SquarePaymentStrategy', () => {
                     promise = strategy.execute({ payment: { methodId: 'square' }, useStoreCredit: true });
 
                     if (callbacks.cardNonceResponseReceived) {
-                        callbacks.cardNonceResponseReceived(null, 'nonce');
+                        callbacks.cardNonceResponseReceived(undefined, 'nonce');
                     }
                 });
 
@@ -222,13 +329,10 @@ describe('SquarePaymentStrategy', () => {
             });
 
             describe('when a failure happens receiving the nonce', () => {
-                let promise: Promise<InternalCheckoutSelectors>;
 
                 beforeEach(() => {
-                    promise = strategy.execute(payload);
-
                     if (callbacks.cardNonceResponseReceived) {
-                        callbacks.cardNonceResponseReceived({}, 'nonce');
+                        callbacks.cardNonceResponseReceived(undefined, 'nonce', cardData, undefined, undefined);
                     }
                 });
 
@@ -240,9 +344,50 @@ describe('SquarePaymentStrategy', () => {
                 it('does not submit payment', () => {
                     expect(paymentActionCreator.submitPayment).toHaveBeenCalledTimes(0);
                 });
+            });
 
-                it('rejects the promise', async () => {
-                    await promise.catch(error => expect(error).toBeTruthy());
+            describe('when cardNonceResponseReceived returns errors', async () => {
+
+                beforeEach(async () => {
+                    await strategy.initialize(initOptions);
+                });
+
+                it('no deferred promise', () => {
+                    try {
+                        if (callbacks.cardNonceResponseReceived) {
+                            callbacks.cardNonceResponseReceived(getNonceGenerationErrors(), undefined, undefined, undefined, undefined);
+                        }
+                    } catch (e) {
+                        expect(e).toBeTruthy();
+                        expect(e).toBeInstanceOf(StandardError);
+                    }
+                });
+            });
+
+            describe('when the nonce is received', async () => {
+                const payloadVaulted = getPayloadVaulted();
+
+                beforeEach(async () => {
+                    await strategy.initialize(initOptions);
+                    if (callbacks.cardNonceResponseReceived) {
+                        callbacks.cardNonceResponseReceived(undefined, 'nonce', cardData, undefined, undefined);
+                    }
+                });
+
+                it('calls submit order with the order request information for masterpass', async () => {
+                    cardData.digital_wallet_type = DigitalWalletType.none;
+
+                    const promise: Promise<InternalCheckoutSelectors> = strategy.execute(payloadVaulted, initOptions);
+                    if (callbacks.cardNonceResponseReceived) {
+                        callbacks.cardNonceResponseReceived(undefined, 'nonce', cardData, undefined, undefined);
+                    }
+                    jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getSquarePaymentInitializeOptions());
+                    await promise.then(() => {
+                        expect(store.dispatch).toHaveBeenCalledTimes(3);
+                        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith({ useStoreCredit: true }, initOptions);
+                        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+                        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({ methodId: 'square', paymentData: { nonce: 'nonce' }});
+                    });
                 });
             });
         });

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -1,55 +1,123 @@
-import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+import { omit } from 'lodash';
+
+import { PaymentStrategy } from '../';
+import {
+    NonceInstrument,
+    PaymentActionCreator,
+    PaymentInitializeOptions,
+    PaymentMethodActionCreator,
+    PaymentRequestOptions,
+    PaymentStrategyActionCreator
+} from '../../';
+import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
     InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
     NotInitializedError,
     NotInitializedErrorType,
     StandardError,
     TimeoutError,
     UnsupportedBrowserError,
 } from '../../../common/error/errors';
+import { toFormUrlEncoded } from '../../../common/http-request';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
-import { NonceInstrument } from '../../payment';
-import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
-import PaymentStrategy from '../payment-strategy';
+import PaymentMethod from '../../payment-method';
 
-import SquarePaymentForm, { SquareFormElement, SquareFormOptions } from './square-form';
-import SquareScriptLoader from './square-script-loader';
+import { SquarePaymentForm, SquareScriptLoader } from '.';
+import {
+    CardData,
+    Contact,
+    DigitalWalletType,
+    NonceGenerationError,
+    SquareFormElement,
+    SquareFormOptions,
+    SquarePaymentRequest
+} from './square-form';
+import SquarePaymentInitializeOptions from './square-payment-initialize-options';
 
 export default class SquarePaymentStrategy extends PaymentStrategy {
-    private _paymentForm?: SquarePaymentForm;
     private _deferredRequestNonce?: DeferredPromise;
+    private _paymentForm?: SquarePaymentForm;
+    private _paymentMethod?: PaymentMethod;
+    private _squareOptions?: SquarePaymentInitializeOptions;
 
     constructor(
         store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _paymentStrategyActionCreator: PaymentStrategyActionCreator,
+        private _requestSender: RequestSender,
         private _scriptLoader: SquareScriptLoader
     ) {
         super(store);
     }
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options;
+        this._syncPaymentMethod(methodId);
+
         return this._scriptLoader.load()
             .then(createSquareForm =>
                 new Promise((resolve, reject) => {
                     this._paymentForm = createSquareForm(
                         this._getFormOptions(options, { resolve, reject })
                     );
-
                     this._paymentForm.build();
                 }))
             .then(() => super.initialize(options));
     }
 
-    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        const { payment, ...order } = payload;
+    execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment } = orderRequest;
 
         if (!payment || !payment.methodId) {
             throw new InvalidArgumentError('Unable to submit payment because "payload.payment.methodId" argument is not provided.');
         }
 
-        const paymentName = payment.methodId;
+        this._syncPaymentMethod(payment.methodId);
+
+        return this._getNonceInstrument(payment.methodId)
+            .then(paymentData =>
+                this._store.dispatch(this._orderActionCreator.submitOrder(omit(orderRequest, 'payment'), options))
+                .then(() =>
+                    this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }))
+                ));
+    }
+
+    private _syncPaymentMethod(methodId: string): void {
+        const state = this._store.getState();
+        this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+        if (!this._paymentMethod || !this._paymentMethod.initializationData) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+    }
+
+    private _getCountryCode(countryName: string) {
+        switch (countryName.toUpperCase()) {
+            case 'NEW ZELAND':
+                return 'NZ';
+            case 'AUSTRALIA':
+                return 'AU';
+            default:
+                return 'US';
+        }
+    }
+
+    private _getNonceInstrument(methodId: string): Promise<NonceInstrument> {
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+        if (paymentMethod) {
+            const { initializationData } = paymentMethod;
+            if (initializationData && initializationData.paymentData.nonce) {
+                return Promise.resolve({ nonce: paymentMethod.initializationData.paymentData.nonce });
+            }
+        }
 
         return new Promise<NonceInstrument>((resolve, reject) => {
             if (!this._paymentForm) {
@@ -62,66 +130,147 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
 
             this._deferredRequestNonce = { resolve, reject };
             this._paymentForm.requestCardNonce();
-        })
-        .then(paymentData => {
-            const paymentPayload = {
-                methodId: paymentName,
-                paymentData,
-            };
-
-            return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
-                .then(() =>
-                    this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload))
-                );
         });
     }
 
     private _getFormOptions(options: PaymentInitializeOptions, deferred: DeferredPromise): SquareFormOptions {
-        const { square: squareOptions, methodId } = options;
-        const state = this._store.getState();
-        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+        const { square: squareOptions } = options;
 
-        if (!squareOptions || !paymentMethod) {
+        if (!squareOptions || !this._paymentMethod) {
             throw new InvalidArgumentError('Unable to proceed because "options.square" argument is not provided.');
         }
 
+        this._squareOptions = squareOptions;
+
         return {
-            ...squareOptions,
-            ...paymentMethod.initializationData,
+            ...this._squareOptions,
+            ...this._paymentMethod.initializationData,
             callbacks: {
+                cardNonceResponseReceived: (errors, nonce, cardData, billingContact, shippingContact) => {
+                    if (cardData && cardData.digital_wallet_type !== DigitalWalletType.none) {
+                        this._handleWalletNonceResponse(errors, nonce, cardData, billingContact, shippingContact);
+                    } else {
+                        this._handleCardNonceResponse(errors, nonce);
+                    }
+                },
+                createPaymentRequest: () => this._paymentRequestPayload(),
+                methodsSupported: methods => {
+                    const { masterpass } = squareOptions;
+
+                    if (masterpass) {
+                        this._showPaymentMethods(methods, masterpass);
+                    }
+                },
                 paymentFormLoaded: () => {
                     deferred.resolve();
-
-                    const state = this._store.getState();
-                    const billingAddress = state.billingAddress.getBillingAddress();
-
-                    if (!this._paymentForm) {
-                        throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-                    }
-
-                    if (billingAddress && billingAddress.postalCode) {
-                        this._paymentForm.setPostalCode(billingAddress.postalCode);
-                    }
+                    this._setPostalCode();
                 },
-                unsupportedBrowserDetected: () => {
-                    deferred.reject(new UnsupportedBrowserError());
-                },
-                cardNonceResponseReceived: (errors, nonce) => {
-                    this._cardNonceResponseReceived(errors, nonce);
-                },
+                unsupportedBrowserDetected: () => deferred.reject(new UnsupportedBrowserError()),
             },
         };
     }
 
-    private _cardNonceResponseReceived(errors: any, nonce: string): void {
+    private _handleWalletNonceResponse(errors?: NonceGenerationError[], nonce?: string, cardData?: CardData, billingContact?: Contact, shippingContact?: Contact): void {
+        if (errors && this._squareOptions && this._squareOptions.onError) {
+            this._squareOptions.onError(errors);
+        } else if (nonce && this._paymentMethod) {
+            this._paymentInstrumentSelected(this._paymentMethod.id, nonce, cardData, billingContact, shippingContact)
+                .then(() => this._squareOptions && this._squareOptions.onPaymentSelect && this._squareOptions.onPaymentSelect())
+                .catch(error => this._squareOptions && this._squareOptions.onError && this._squareOptions.onError(error));
+        }
+    }
+
+    private _handleCardNonceResponse(errors?: NonceGenerationError[], nonce?: string): void {
         if (!this._deferredRequestNonce) {
             throw new StandardError();
         }
 
-        if (errors) {
+        if (errors && this._squareOptions && this._squareOptions.onError) {
+            this._squareOptions.onError(errors);
             this._deferredRequestNonce.reject(errors);
-        } else {
+        } else if (nonce) {
             this._deferredRequestNonce.resolve({ nonce });
+        }
+    }
+
+    private _paymentInstrumentSelected(
+        methodId: string,
+        nonce?: string,
+        cardData?: CardData,
+        billingContact?: Contact,
+        shippingContact?: Contact): Promise<InternalCheckoutSelectors> {
+
+        return this._store.dispatch(this._paymentStrategyActionCreator.widgetInteraction(() => {
+            return this._setExternalCheckoutData(nonce, cardData, billingContact, shippingContact)
+            .then(() =>
+                Promise.all([
+                this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
+                this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId)),
+            ]));
+        }, { methodId }), { queueId: 'widgetInteraction' });
+    }
+
+    private _paymentRequestPayload(): SquarePaymentRequest {
+        const state = this._store.getState();
+        const checkout = state.checkout.getCheckout();
+        const storeConfig = state.config.getStoreConfig();
+
+        if (!checkout) {
+            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+        }
+
+        if (!storeConfig) {
+            throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+        }
+
+        return {
+            requestShippingAddress: true,
+            requestBillingInfo: true,
+            currencyCode: storeConfig.currency.code,
+            countryCode: this._getCountryCode(storeConfig.storeProfile.storeCountry),
+            total: {
+                label: storeConfig.storeProfile.storeName,
+                amount: String(checkout.subtotal),
+                pending: false,
+            },
+        };
+    }
+
+    private _setExternalCheckoutData(nonce?: string, cardData?: CardData, billingContact?: Contact, shippingContact?: Contact): Promise<Response<any>> {
+        return this._requestSender.post('/checkout.php', {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: toFormUrlEncoded({
+                nonce,
+                provider: 'squarev2',
+                action: 'set_external_checkout',
+                cardData: JSON.stringify(cardData),
+                billingContact: JSON.stringify(billingContact),
+                shippingContact: JSON.stringify(shippingContact),
+            }),
+        });
+    }
+
+    private _setPostalCode(): void {
+        const state = this._store.getState();
+        const billingAddress = state.billingAddress.getBillingAddress();
+
+        if (!this._paymentForm) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (billingAddress && billingAddress.postalCode) {
+            this._paymentForm.setPostalCode(billingAddress.postalCode);
+        }
+    }
+
+    private _showPaymentMethods(methods: { [key: string]: boolean }, element: SquareFormElement): void {
+        const masterpassBtn = document.getElementById(element.elementId);
+
+        if (masterpassBtn && methods.masterpass) {
+            masterpassBtn.style.display = 'inline-block';
         }
     }
 }
@@ -129,43 +278,4 @@ export default class SquarePaymentStrategy extends PaymentStrategy {
 export interface DeferredPromise {
     resolve(resolution?: NonceInstrument): void;
     reject(reason?: any): void;
-}
-
-/**
- * A set of options that are required to initialize the Square payment method.
- *
- * Once Square payment is initialized, credit card form fields, provided by the
- * payment provider as iframes, will be inserted into the current page. These
- * options provide a location and styling for each of the form fields.
- */
-export interface SquarePaymentInitializeOptions {
-    /**
-     * The location to insert the credit card number form field.
-     */
-    cardNumber: SquareFormElement;
-
-    /**
-     * The location to insert the CVV form field.
-     */
-    cvv: SquareFormElement;
-
-    /**
-     * The location to insert the expiration date form field.
-     */
-    expirationDate: SquareFormElement;
-
-    /**
-     * The location to insert the postal code form field.
-     */
-    postalCode: SquareFormElement;
-
-    /**
-     * The CSS class to apply to all form fields.
-     */
-    inputClass?: string;
-
-    /**
-     * The set of CSS styles to apply to all form fields.
-     */
-    inputStyles?: Array<{ [key: string]: string }>;
 }


### PR DESCRIPTION
[INT-751](https://jira.bigcommerce.com/browse/INT-751)

## What?

- MasterPass button is displayed in the Square Form in the UCO page
- When the shopper clicks on the MasterPass button the MasterPass box is opened and the shopper can select a credit card

## Why?
As a Shopper when Masterpass is enabled on Square I want to be able to use the MasterPass button to open the Master Pass box to select a credit card from my wallet

Dependency with PR for [INT-752](https://github.com/bigcommerce/bigcommerce/pull/25547) BCApp changes: 

## Testing / Proof

[Cart](https://drive.google.com/drive/u/0/folders/1_CYuz2HMWpQlbq1N2saG3IemueRusaHd)

![image](https://user-images.githubusercontent.com/8570490/44301298-2446f380-a2da-11e8-9917-443a0e0b0d29.png)

![image](https://user-images.githubusercontent.com/8570490/44301304-3b85e100-a2da-11e8-90f4-9ab7b3275cfe.png)

## Sibling PRs
[`ng-checkout`](https://github.com/bigcommerce-labs/ng-checkout/pull/893)

@bigcommerce/checkout 