### PR TITLE
CHECKOUT-3011: Load checkout object only when required

### DIFF
--- a/src/checkout-buttons/checkout-button-actions.ts
+++ b/src/checkout-buttons/checkout-button-actions.ts
@@ -1,8 +1,5 @@
 import { Action } from '@bigcommerce/data-store';
 
-import { CheckoutAction } from '../checkout';
-import { PaymentMethodResponseData } from '../payment';
-
 export enum CheckoutButtonActionType {
     InitializeButtonFailed = 'INITIALIZE_BUTTON_FAILED',
     InitializeButtonRequested = 'INITIALIZE_BUTTON_REQUESTED',
@@ -18,9 +15,7 @@ export type CheckoutButtonAction = InitializeButtonAction | DeinitializeButtonAc
 export type InitializeButtonAction =
     InitializeButtonRequestedAction |
     InitializeButtonSucceededAction |
-    InitializeButtonFailedAction |
-    CheckoutAction |
-    Action<PaymentMethodResponseData>;
+    InitializeButtonFailedAction;
 
 export type DeinitializeButtonAction =
     DeinitializeButtonRequestedAction |

--- a/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -1,9 +1,7 @@
 import { createAction } from '@bigcommerce/data-store';
-import { createRequestSender } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
-import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
-import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { createCheckoutClient, createCheckoutStore, CheckoutStore } from '../checkout';
 import { PaymentMethodActionCreator } from '../payment';
 
 import { CheckoutButtonActionType } from './checkout-button-actions';
@@ -22,10 +20,6 @@ describe('CheckoutButtonInitializer', () => {
         store = createCheckoutStore();
         buttonActionCreator = new CheckoutButtonStrategyActionCreator(
             createCheckoutButtonRegistry(store),
-            new CheckoutActionCreator(
-                new CheckoutRequestSender(createRequestSender()),
-                new ConfigActionCreator(new ConfigRequestSender(createRequestSender()))
-            ),
             new PaymentMethodActionCreator(createCheckoutClient())
         );
 

--- a/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -1,16 +1,12 @@
 import { createAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat } from 'rxjs/observable/concat';
 import { defer } from 'rxjs/observable/defer';
-import { empty } from 'rxjs/observable/empty';
-import { merge } from 'rxjs/observable/merge';
 import { of } from 'rxjs/observable/of';
-import { catchError, switchMapTo, takeWhile } from 'rxjs/operators';
-import { Observable, SubscribableOrPromise } from 'rxjs/Observable';
+import { catchError } from 'rxjs/operators';
+import { Observable } from 'rxjs/Observable';
 
-import { CheckoutActionCreator, InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
-import { LoadCheckoutAction } from '../checkout/checkout-actions';
+import { ReadableCheckoutStore } from '../checkout';
 import { throwErrorAction } from '../common/error';
-import { RequestOptions } from '../common/http-request';
 import { Registry } from '../common/registry';
 import { PaymentMethodActionCreator } from '../payment';
 
@@ -21,7 +17,6 @@ import { CheckoutButtonStrategy } from './strategies';
 export default class CheckoutButtonStrategyActionCreator {
     constructor(
         private _registry: Registry<CheckoutButtonStrategy>,
-        private _checkoutActionCreator: CheckoutActionCreator,
         private _paymentMethodActionCreator: PaymentMethodActionCreator
     ) {}
 
@@ -30,10 +25,7 @@ export default class CheckoutButtonStrategyActionCreator {
             const meta = { methodId: options.methodId };
             const action$: Observable<InitializeButtonAction> = concat(
                 of(createAction(CheckoutButtonActionType.InitializeButtonRequested, undefined, meta)),
-                merge(
-                    this._loadCheckout(store, options),
-                    this._paymentMethodActionCreator.loadPaymentMethod(options.methodId, options)
-                ),
+                this._paymentMethodActionCreator.loadPaymentMethod(options.methodId, options),
                 defer(() => this._registry.get(options.methodId).initialize(options)
                     .then(() => createAction(CheckoutButtonActionType.InitializeButtonSucceeded, undefined, meta)))
             );
@@ -55,17 +47,5 @@ export default class CheckoutButtonStrategyActionCreator {
         return action$.pipe(
             catchError(error => throwErrorAction(CheckoutButtonActionType.DeinitializeButtonFailed, error, meta))
         );
-    }
-
-    private _loadCheckout(store: ReadableCheckoutStore, options?: RequestOptions): SubscribableOrPromise<LoadCheckoutAction> {
-        if (store.getState().checkout.isLoading()) {
-            return new Observable<InternalCheckoutSelectors>(observer => store.subscribe(state => observer.next(state)))
-                .pipe(
-                    takeWhile(state => !state.checkout.getCheckout()),
-                    switchMapTo(empty())
-                );
-        }
-
-        return this._checkoutActionCreator.loadDefaultCheckout(options)(store);
     }
 }

--- a/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -1,7 +1,4 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
-
-import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender } from '../checkout';
-import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { createCheckoutClient, createCheckoutStore } from '../checkout';
 import { PaymentMethodActionCreator } from '../payment';
 
 import CheckoutButtonInitializer from './checkout-button-initializer';
@@ -10,16 +7,11 @@ import createCheckoutButtonRegistry from './create-checkout-button-registry';
 
 export default function createCheckoutButtonInitializer(): CheckoutButtonInitializer {
     const store = createCheckoutStore();
-    const requestSender = createRequestSender();
 
     return new CheckoutButtonInitializer(
         store,
         new CheckoutButtonStrategyActionCreator(
             createCheckoutButtonRegistry(store),
-            new CheckoutActionCreator(
-                new CheckoutRequestSender(requestSender),
-                new ConfigActionCreator(new ConfigRequestSender(requestSender))
-            ),
             new PaymentMethodActionCreator(createCheckoutClient())
         )
     );

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -1,8 +1,10 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
-import { CheckoutStore } from '../checkout';
+import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
+import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 
@@ -10,10 +12,16 @@ import { BraintreePaypalButtonStrategy, CheckoutButtonStrategy } from './strateg
 
 export default function createCheckoutButtonRegistry(store: CheckoutStore): Registry<CheckoutButtonStrategy> {
     const registry = new Registry<CheckoutButtonStrategy>();
+    const requestSender = createRequestSender();
+    const checkoutActionCreator = new CheckoutActionCreator(
+        new CheckoutRequestSender(requestSender),
+        new ConfigActionCreator(new ConfigRequestSender(requestSender))
+    );
 
     registry.register('braintreepaypal', () =>
         new BraintreePaypalButtonStrategy(
             store,
+            checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(getScriptLoader())),
             new PaypalScriptLoader(getScriptLoader()),
             createFormPoster()
@@ -23,6 +31,7 @@ export default function createCheckoutButtonRegistry(store: CheckoutStore): Regi
     registry.register('braintreepaypalcredit', () =>
         new BraintreePaypalButtonStrategy(
             store,
+            checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(getScriptLoader())),
             new PaypalScriptLoader(getScriptLoader()),
             createFormPoster(),


### PR DESCRIPTION
## What?
* For the Braintree PayPal button, load the default checkout object only when it is required.

## Why?
* Previously, we load the checkout object before we render the button. However, we actually don't need the information until the shopper clicks on button and tries to check out.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
