### PR TITLE
CHECKOUT-3401: Stop loading current order before executing payment strategy

### DIFF
--- a/src/order/order-action-creator.spec.js
+++ b/src/order/order-action-creator.spec.js
@@ -132,14 +132,14 @@ describe('OrderActionCreator', () => {
         });
     });
 
-    describe('#loadCurrentOrderPayments()', () => {
+    describe('#loadOrderPayments()', () => {
         beforeEach(() => {
             jest.spyOn(checkoutClient, 'loadOrder')
                 .mockReturnValue(Promise.resolve(getResponse(getOrder())));
         });
 
         it('emits actions if able to load order', async () => {
-            const actions = await Observable.from(orderActionCreator.loadCurrentOrderPayments()(store))
+            const actions = await orderActionCreator.loadOrderPayments(295)
                 .toArray()
                 .toPromise();
 
@@ -154,7 +154,7 @@ describe('OrderActionCreator', () => {
                 .mockReturnValue(Promise.reject(getErrorResponse()));
 
             const errorHandler = jest.fn((action) => Observable.of(action));
-            const actions = await Observable.from(orderActionCreator.loadCurrentOrderPayments()(store))
+            const actions = await orderActionCreator.loadOrderPayments(295)
                 .catch(errorHandler)
                 .toArray()
                 .toPromise();
@@ -167,7 +167,7 @@ describe('OrderActionCreator', () => {
         });
 
         it('loads order by using order id from order object', async () => {
-            await orderActionCreator.loadCurrentOrderPayments()(store)
+            await orderActionCreator.loadOrderPayments(295)
                 .toPromise();
 
             expect(checkoutClient.loadOrder).toHaveBeenCalledWith(295, undefined);
@@ -180,25 +180,14 @@ describe('OrderActionCreator', () => {
                 order: getOrderState(),
             });
 
-            await orderActionCreator.loadCurrentOrderPayments()(store)
+            await orderActionCreator.loadOrderPayments(295)
                 .toPromise();
 
             expect(checkoutClient.loadOrder).toHaveBeenCalledWith(295, undefined);
         });
 
-        it('throws error if there is no existing order id', async () => {
-            store = createCheckoutStore();
-
-            try {
-                await orderActionCreator.loadCurrentOrderPayments()(store)
-                    .toPromise();
-            } catch (error) {
-                expect(error).toBeInstanceOf(MissingDataError);
-            }
-        });
-
         it('loads order only when action is dispatched', async () => {
-            const action = orderActionCreator.loadCurrentOrderPayments()(store);
+            const action = orderActionCreator.loadOrderPayments(295);
 
             expect(checkoutClient.loadOrder).not.toHaveBeenCalled();
 

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -208,9 +208,6 @@ describe('PaymentStrategyActionCreator', () => {
 
             jest.spyOn(noPaymentDataStrategy, 'execute')
                 .mockReturnValue(Promise.resolve(store.getState()));
-
-            jest.spyOn(orderActionCreator, 'loadOrderPayments')
-                .mockReturnValue(Observable.of(createAction(OrderActionType.LoadOrderPaymentsRequested)));
         });
 
         it('finds payment strategy by method', async () => {
@@ -239,16 +236,6 @@ describe('PaymentStrategyActionCreator', () => {
             );
         });
 
-        it('loads payment data for the current order', async () => {
-            const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
-            const payload = getOrderRequestBody();
-
-            await Observable.from(actionCreator.execute(payload)(store))
-                .toPromise();
-
-            expect(orderActionCreator.loadOrderPayments).toHaveBeenCalled();
-        });
-
         it('emits action to load order and notify execution progress', async () => {
             const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
             const payload = getOrderRequestBody();
@@ -258,7 +245,6 @@ describe('PaymentStrategyActionCreator', () => {
                 .toPromise();
 
             expect(actions).toEqual([
-                { type: OrderActionType.LoadOrderPaymentsRequested },
                 { type: PaymentStrategyActionType.ExecuteRequested, meta: { methodId } },
                 { type: PaymentStrategyActionType.ExecuteSucceeded, meta: { methodId } },
             ]);
@@ -281,7 +267,6 @@ describe('PaymentStrategyActionCreator', () => {
 
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
-                { type: OrderActionType.LoadOrderPaymentsRequested },
                 { type: PaymentStrategyActionType.ExecuteRequested, meta: { methodId } },
                 { type: PaymentStrategyActionType.ExecuteFailed, error: true, payload: executeError, meta: { methodId } },
             ]);

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -209,8 +209,8 @@ describe('PaymentStrategyActionCreator', () => {
             jest.spyOn(noPaymentDataStrategy, 'execute')
                 .mockReturnValue(Promise.resolve(store.getState()));
 
-            jest.spyOn(orderActionCreator, 'loadCurrentOrderPayments')
-                .mockReturnValue(() => Observable.of(createAction(OrderActionType.LoadOrderPaymentsRequested)));
+            jest.spyOn(orderActionCreator, 'loadOrderPayments')
+                .mockReturnValue(Observable.of(createAction(OrderActionType.LoadOrderPaymentsRequested)));
         });
 
         it('finds payment strategy by method', async () => {
@@ -246,7 +246,7 @@ describe('PaymentStrategyActionCreator', () => {
             await Observable.from(actionCreator.execute(payload)(store))
                 .toPromise();
 
-            expect(orderActionCreator.loadCurrentOrderPayments).toHaveBeenCalled();
+            expect(orderActionCreator.loadOrderPayments).toHaveBeenCalled();
         });
 
         it('emits action to load order and notify execution progress', async () => {
@@ -343,8 +343,8 @@ describe('PaymentStrategyActionCreator', () => {
             jest.spyOn(strategy, 'finalize')
                 .mockReturnValue(Promise.resolve(store.getState()));
 
-            jest.spyOn(orderActionCreator, 'loadCurrentOrderPayments')
-                .mockReturnValue((() => Observable.of(createAction(OrderActionType.LoadOrderPaymentsRequested))));
+            jest.spyOn(orderActionCreator, 'loadOrderPayments')
+                .mockReturnValue(Observable.of(createAction(OrderActionType.LoadOrderPaymentsRequested)));
         });
 
         it('finds payment strategy by method', async () => {
@@ -372,7 +372,7 @@ describe('PaymentStrategyActionCreator', () => {
             await Observable.from(actionCreator.finalize()(store))
                 .toPromise();
 
-            expect(orderActionCreator.loadCurrentOrderPayments).toHaveBeenCalled();
+            expect(orderActionCreator.loadOrderPayments).toHaveBeenCalled();
         });
 
         it('emits action to load order and notify finalization progress', async () => {

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -29,45 +29,38 @@ export default class PaymentStrategyActionCreator {
         private _orderActionCreator: OrderActionCreator
     ) {}
 
-    execute(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<PaymentStrategyExecuteAction | LoadOrderPaymentsAction, InternalCheckoutSelectors> {
-        return store => {
-            const executeAction = new Observable((observer: Observer<PaymentStrategyExecuteAction>) => {
-                const state = store.getState();
-                const { payment = {} as Payment, useStoreCredit } = payload;
-                const meta = { methodId: payment.methodId };
+    execute(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<PaymentStrategyExecuteAction, InternalCheckoutSelectors> {
+        return store => new Observable((observer: Observer<PaymentStrategyExecuteAction>) => {
+            const state = store.getState();
+            const { payment = {} as Payment, useStoreCredit } = payload;
+            const meta = { methodId: payment.methodId };
 
-                let strategy: PaymentStrategy;
+            let strategy: PaymentStrategy;
 
-                if (state.payment.isPaymentDataRequired(useStoreCredit)) {
-                    const method = state.paymentMethods.getPaymentMethod(payment.methodId, payment.gatewayId);
+            if (state.payment.isPaymentDataRequired(useStoreCredit)) {
+                const method = state.paymentMethods.getPaymentMethod(payment.methodId, payment.gatewayId);
 
-                    if (!method) {
-                        throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-                    }
-
-                    strategy = this._strategyRegistry.getByMethod(method);
-                } else {
-                    strategy = this._strategyRegistry.get('nopaymentdatarequired');
+                if (!method) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                 }
 
-                observer.next(createAction(PaymentStrategyActionType.ExecuteRequested, undefined, meta));
+                strategy = this._strategyRegistry.getByMethod(method);
+            } else {
+                strategy = this._strategyRegistry.get('nopaymentdatarequired');
+            }
 
-                strategy
-                    .execute(payload, { ...options, methodId: payment.methodId, gatewayId: payment.gatewayId })
-                    .then(() => {
-                        observer.next(createAction(PaymentStrategyActionType.ExecuteSucceeded, undefined, meta));
-                        observer.complete();
-                    })
-                    .catch(error => {
-                        observer.error(createErrorAction(PaymentStrategyActionType.ExecuteFailed, error, meta));
-                    });
-            });
+            observer.next(createAction(PaymentStrategyActionType.ExecuteRequested, undefined, meta));
 
-            return concat(
-                this._loadOrderPaymentsIfNeeded(store, options),
-                executeAction
-            );
-        };
+            strategy
+                .execute(payload, { ...options, methodId: payment.methodId, gatewayId: payment.gatewayId })
+                .then(() => {
+                    observer.next(createAction(PaymentStrategyActionType.ExecuteSucceeded, undefined, meta));
+                    observer.complete();
+                })
+                .catch(error => {
+                    observer.error(createErrorAction(PaymentStrategyActionType.ExecuteFailed, error, meta));
+                });
+        });
     }
 
     finalize(options?: RequestOptions): ThunkAction<PaymentStrategyFinalizeAction | LoadOrderPaymentsAction, InternalCheckoutSelectors> {

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -1,7 +1,6 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat } from 'rxjs/observable/concat';
 import { empty } from 'rxjs/observable/empty';
-import { from } from 'rxjs/observable/from';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
@@ -174,10 +173,11 @@ export default class PaymentStrategyActionCreator {
     }
 
     private _loadOrderPaymentsIfNeeded(store: ReadableCheckoutStore, options?: RequestOptions): Observable<LoadOrderPaymentsAction> {
-        const checkout = store.getState().checkout.getCheckout();
+        const state = store.getState();
+        const checkout = state.checkout.getCheckout();
 
         if (checkout && checkout.orderId) {
-            return from(this._orderActionCreator.loadCurrentOrderPayments(options)(store));
+            return this._orderActionCreator.loadOrderPayments(checkout.orderId, options);
         }
 
         return empty();


### PR DESCRIPTION
## What?
1. Stop loading current order before executing payment strategy.
2. Directly pass `checkout.orderId` to load `order.payments` instead of trying to retrieve the value again.

## Why?
1. We don't have to load the current order to get payment statuses. If the current checkout hasn't been converted into an order, payment status information is available in the checkout object. We could potentially run into an issue if we try load the order because `checkout.orderId` might not be the latest one (it could be invalidated if you try to check out using a different window). Instead, we only need to load the current order for the finalisation step.
2. We should always use the `orderId` from the checkout object when we finalise the order.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
