### PR TITLE
CHECKOUT-3449: Return correct status flags for actions that trigger other sub-actions

### DIFF
--- a/src/checkout/checkout-action-creator.spec.ts
+++ b/src/checkout/checkout-action-creator.spec.ts
@@ -206,7 +206,7 @@ describe('CheckoutActionCreator', () => {
             store = createCheckoutStore();
 
             try {
-                await from(actionCreator.loadCurrentCheckout()(store))
+                await Observable.from(actionCreator.loadCurrentCheckout()(store))
                     .toPromise();
             } catch (error) {
                 expect(error).toBeInstanceOf(MissingDataError);
@@ -237,10 +237,10 @@ describe('CheckoutActionCreator', () => {
             store = createCheckoutStore();
 
             try {
-                await from(actionCreator.loadDefaultCheckout()(store))
+                await Observable.from(actionCreator.loadDefaultCheckout()(store))
                     .toPromise();
-            } catch (error) {
-                expect(error).toBeInstanceOf(StandardError);
+            } catch ({ payload }) {
+                expect(payload).toBeInstanceOf(StandardError);
             }
         });
 

--- a/src/checkout/checkout-action-creator.ts
+++ b/src/checkout/checkout-action-creator.ts
@@ -2,13 +2,15 @@ import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-
 import { concat } from 'rxjs/observable/concat';
 import { defer } from 'rxjs/observable/defer';
 import { merge } from 'rxjs/observable/merge';
+import { of } from 'rxjs/observable/of';
+import { catchError } from 'rxjs/operators';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
+import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType, StandardError } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 import { ConfigActionCreator } from '../config';
-import { LoadConfigAction } from '../config/config-actions';
 
 import { CheckoutRequestBody } from './checkout';
 import { CheckoutActionType, LoadCheckoutAction, UpdateCheckoutAction } from './checkout-actions';
@@ -24,15 +26,22 @@ export default class CheckoutActionCreator {
     loadCheckout(
         id: string,
         options?: RequestOptions
-    ): ThunkAction<LoadCheckoutAction | LoadConfigAction, InternalCheckoutSelectors> {
-        return store => merge(
-            this._configActionCreator.loadConfig()(store),
-            this._loadCheckout(id)
+    ): ThunkAction<LoadCheckoutAction, InternalCheckoutSelectors> {
+        return store => concat(
+            of(createAction(CheckoutActionType.LoadCheckoutRequested)),
+            merge(
+                this._configActionCreator.loadConfig()(store),
+                defer(() => this._checkoutRequestSender.loadCheckout(id, options)
+                    .then(({ body }) => createAction(CheckoutActionType.LoadCheckoutSucceeded, body)))
+            )
+        ).pipe(
+            catchError(error => throwErrorAction(CheckoutActionType.LoadCheckoutFailed, error))
         );
     }
 
     loadDefaultCheckout(options?: RequestOptions): ThunkAction<LoadCheckoutAction, InternalCheckoutSelectors> {
         return store => concat(
+            of(createAction(CheckoutActionType.LoadCheckoutRequested)),
             this._configActionCreator.loadConfig()(store),
             defer(() => {
                 const state = store.getState();
@@ -42,8 +51,11 @@ export default class CheckoutActionCreator {
                     throw new StandardError('Unable to load checkout: no cart is available');
                 }
 
-                return this._loadCheckout(context.checkoutId, options);
+                return this._checkoutRequestSender.loadCheckout(context.checkoutId, options)
+                    .then(({ body }) => createAction(CheckoutActionType.LoadCheckoutSucceeded, body));
             })
+        ).pipe(
+            catchError(error => throwErrorAction(CheckoutActionType.LoadCheckoutFailed, error))
         );
     }
 
@@ -73,7 +85,7 @@ export default class CheckoutActionCreator {
     }
 
     loadCurrentCheckout(options?: RequestOptions): ThunkAction<LoadCheckoutAction, InternalCheckoutSelectors> {
-        return store => defer(() => {
+        return store => {
             const state = store.getState();
             const checkout = state.checkout.getCheckout();
 
@@ -81,22 +93,7 @@ export default class CheckoutActionCreator {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckout);
             }
 
-            return this._loadCheckout(checkout.id, options);
-        });
-    }
-
-    private _loadCheckout(id: string, options?: RequestOptions): Observable<LoadCheckoutAction> {
-        return Observable.create((observer: Observer<LoadCheckoutAction>) => {
-            observer.next(createAction(CheckoutActionType.LoadCheckoutRequested));
-
-            this._checkoutRequestSender.loadCheckout(id, options)
-                .then(({ body }) => {
-                    observer.next(createAction(CheckoutActionType.LoadCheckoutSucceeded, body));
-                    observer.complete();
-                })
-                .catch(response => {
-                    observer.error(createErrorAction(CheckoutActionType.LoadCheckoutFailed, response));
-                });
-        });
+            return this.loadCheckout(checkout.id, options)(store);
+        };
     }
 }

--- a/src/common/error/index.ts
+++ b/src/common/error/index.ts
@@ -1,3 +1,4 @@
 export { default as createRequestErrorFactory } from './create-request-error-factory';
+export { default as throwErrorAction } from './throw-error-action';
 export { default as ErrorMessageTransformer } from './error-message-transformer';
 export { default as RequestErrorFactory } from './request-error-factory';

--- a/src/common/error/throw-error-action.ts
+++ b/src/common/error/throw-error-action.ts
@@ -1,0 +1,21 @@
+import { createErrorAction, Action } from '@bigcommerce/data-store';
+import { concat } from 'rxjs/observable/concat';
+import { of } from 'rxjs/observable/of';
+import { _throw } from 'rxjs/observable/throw';
+import { Observable } from 'rxjs/Observable';
+
+export default function throwErrorAction<TPayload, TMeta, TType extends string>(
+    type: TType,
+    error?: TPayload,
+    meta?: TMeta
+): Observable<Action<TPayload, TMeta, TType>> {
+    if (isErrorAction(error)) {
+        return concat(of(error), _throw(createErrorAction(type, error.payload, meta)));
+    }
+
+    return _throw(createErrorAction(type, error, meta));
+}
+
+function isErrorAction(action: any): action is Action {
+    return action && action.type && action.error;
+}

--- a/src/customer/customer-action-creator.spec.js
+++ b/src/customer/customer-action-creator.spec.js
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutActionType } from '../checkout';
+import { getCheckout } from '../checkout/checkouts.mock';
 
 import { getCustomerResponseBody } from './internal-customers.mock';
 import CustomerActionCreator from './customer-action-creator';
@@ -32,7 +33,10 @@ describe('CustomerActionCreator', () => {
         );
 
         jest.spyOn(checkoutActionCreator, 'loadCurrentCheckout')
-            .mockReturnValue(() => Observable.of(createAction(CheckoutActionType.LoadCheckoutRequested)));
+            .mockReturnValue(() => Observable.from([
+                createAction(CheckoutActionType.LoadCheckoutRequested),
+                createAction(CheckoutActionType.LoadCheckoutSucceeded, getCheckout()),
+            ]));
 
         customerActionCreator = new CustomerActionCreator(
             customerRequestSender,
@@ -49,8 +53,9 @@ describe('CustomerActionCreator', () => {
 
             expect(actions).toEqual([
                 { type: CustomerActionType.SignInCustomerRequested },
-                { type: CustomerActionType.SignInCustomerSucceeded, payload: response.body.data },
                 { type: CheckoutActionType.LoadCheckoutRequested },
+                { type: CheckoutActionType.LoadCheckoutSucceeded, payload: getCheckout() },
+                { type: CustomerActionType.SignInCustomerSucceeded, payload: response.body.data },
             ]);
         });
 
@@ -90,8 +95,9 @@ describe('CustomerActionCreator', () => {
 
             expect(actions).toEqual([
                 { type: CustomerActionType.SignOutCustomerRequested },
-                { type: CustomerActionType.SignOutCustomerSucceeded, payload: response.body.data },
                 { type: CheckoutActionType.LoadCheckoutRequested },
+                { type: CheckoutActionType.LoadCheckoutSucceeded, payload: getCheckout() },
+                { type: CustomerActionType.SignOutCustomerSucceeded, payload: response.body.data },
             ]);
         });
 

--- a/src/customer/customer-actions.ts
+++ b/src/customer/customer-actions.ts
@@ -1,5 +1,7 @@
 import { Action } from '@bigcommerce/data-store';
 
+import { LoadCheckoutAction } from '../checkout';
+
 import { InternalCustomerResponseData } from './internal-customer-responses';
 
 export enum CustomerActionType {
@@ -19,12 +21,14 @@ export type CustomerAction =
 export type SignInCustomerAction =
     SignInCustomerRequestedAction |
     SignInCustomerSucceededAction |
-    SignInCustomerFailedAction;
+    SignInCustomerFailedAction |
+    LoadCheckoutAction;
 
 export type SignOutCustomerAction =
     SignOutCustomerRequestedAction |
     SignOutCustomerSucceededAction |
-    SignOutCustomerFailedAction;
+    SignOutCustomerFailedAction |
+    LoadCheckoutAction;
 
 export interface SignInCustomerRequestedAction extends Action {
     type: CustomerActionType.SignInCustomerRequested;

--- a/src/order/order-action-creator.spec.js
+++ b/src/order/order-action-creator.spec.js
@@ -224,6 +224,8 @@ describe('OrderActionCreator', () => {
 
             expect(actions).toEqual([
                 { type: OrderActionType.SubmitOrderRequested },
+                { type: OrderActionType.LoadOrderRequested },
+                { type: OrderActionType.LoadOrderSucceeded, payload: getOrder() },
                 {
                     type: OrderActionType.SubmitOrderSucceeded,
                     payload: submitResponse.body.data,
@@ -232,8 +234,6 @@ describe('OrderActionCreator', () => {
                         token: submitResponse.headers.token,
                     },
                 },
-                { type: OrderActionType.LoadOrderRequested },
-                { type: OrderActionType.LoadOrderSucceeded, payload: getOrder() },
             ]);
         });
 
@@ -315,9 +315,9 @@ describe('OrderActionCreator', () => {
 
             expect(actions).toEqual([
                 { type: OrderActionType.FinalizeOrderRequested },
-                { type: OrderActionType.FinalizeOrderSucceeded, payload: response.body.data },
                 { type: OrderActionType.LoadOrderRequested },
                 { type: OrderActionType.LoadOrderSucceeded, payload: getOrder() },
+                { type: OrderActionType.FinalizeOrderSucceeded, payload: response.body.data },
             ]);
         });
 

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -1,10 +1,14 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat } from 'rxjs/observable/concat';
 import { defer } from 'rxjs/observable/defer';
+import { from } from 'rxjs/observable/from';
+import { of } from 'rxjs/observable/of';
+import { catchError, switchMap } from 'rxjs/operators';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
 import { CheckoutClient, CheckoutValidator, InternalCheckoutSelectors } from '../checkout';
+import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
@@ -61,11 +65,10 @@ export default class OrderActionCreator {
         });
     }
 
-    submitOrder(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<SubmitOrderAction | LoadOrderAction, InternalCheckoutSelectors> {
+    submitOrder(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<SubmitOrderAction, InternalCheckoutSelectors> {
         return store => concat(
-            new Observable((observer: Observer<SubmitOrderAction>) => {
-                observer.next(createAction(OrderActionType.SubmitOrderRequested));
-
+            of(createAction(OrderActionType.SubmitOrderRequested)),
+            defer(() => {
                 const state = store.getState();
                 const checkout = state.checkout.getCheckout();
 
@@ -73,37 +76,34 @@ export default class OrderActionCreator {
                     throw new MissingDataError(MissingDataErrorType.MissingCheckout);
                 }
 
-                this._checkoutValidator.validate(checkout, options)
-                    .then(() => this._checkoutClient.submitOrder(this._mapToOrderRequestBody(payload, checkout.customerMessage), options))
-                    .then(response => {
-                        observer.next(createAction(OrderActionType.SubmitOrderSucceeded, response.body.data, { ...response.body.meta, token: response.headers.token }));
-                        observer.complete();
-                    })
-                    .catch(response => {
-                        observer.error(createErrorAction(OrderActionType.SubmitOrderFailed, response));
-                    });
-            }),
-            // TODO: Remove once we can submit orders using storefront API
-            this.loadCurrentOrder(options)(store)
+                return from(
+                    this._checkoutValidator.validate(checkout, options)
+                        .then(() => this._checkoutClient.submitOrder(this._mapToOrderRequestBody(payload, checkout.customerMessage), options))
+                ).pipe(
+                    switchMap(response => concat(
+                        // TODO: Remove once we can submit orders using storefront API
+                        this.loadCurrentOrder(options)(store),
+                        of(createAction(OrderActionType.SubmitOrderSucceeded, response.body.data, { ...response.body.meta, token: response.headers.token }))
+                    ))
+                );
+            }).pipe(
+                catchError(error => throwErrorAction(OrderActionType.SubmitOrderFailed, error))
+            )
         );
     }
 
     finalizeOrder(orderId: number, options?: RequestOptions): Observable<FinalizeOrderAction | LoadOrderAction> {
         return concat(
-            new Observable((observer: Observer<FinalizeOrderAction>) => {
-                observer.next(createAction(OrderActionType.FinalizeOrderRequested));
-
-                this._checkoutClient.finalizeOrder(orderId, options)
-                    .then(response => {
-                        observer.next(createAction(OrderActionType.FinalizeOrderSucceeded, response.body.data));
-                        observer.complete();
-                    })
-                    .catch(response => {
-                        observer.error(createErrorAction(OrderActionType.FinalizeOrderFailed, response));
-                    });
-            }),
-            // TODO: Remove once we can submit orders using storefront API
-            this.loadOrder(orderId, options)
+            of(createAction(OrderActionType.FinalizeOrderRequested)),
+            from(this._checkoutClient.finalizeOrder(orderId, options))
+                .pipe(
+                    switchMap(response => concat(
+                        this.loadOrder(orderId, options),
+                        of(createAction(OrderActionType.FinalizeOrderSucceeded, response.body.data))
+                    ))
+                )
+        ).pipe(
+            catchError(error => throwErrorAction(OrderActionType.FinalizeOrderFailed, error))
         );
     }
 

--- a/src/order/order-actions.ts
+++ b/src/order/order-actions.ts
@@ -38,12 +38,14 @@ export type LoadOrderAction =
 export type SubmitOrderAction =
     SubmitOrderRequestedAction |
     SubmitOrderSucceededAction |
-    SubmitOrderFailedAction;
+    SubmitOrderFailedAction |
+    LoadOrderAction;
 
 export type FinalizeOrderAction =
     FinalizeOrderRequestedAction |
     FinalizeOrderSucceededAction |
-    FinalizeOrderFailedAction;
+    FinalizeOrderFailedAction |
+    LoadOrderAction;
 
 export interface LoadOrderRequestedAction extends Action {
     type: OrderActionType.LoadOrderRequested;

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -48,15 +48,15 @@ describe('PaymentActionCreator', () => {
                     type: PaymentActionType.SubmitPaymentRequested,
                 },
                 {
-                    type: PaymentActionType.SubmitPaymentSucceeded,
-                    payload: getPaymentResponseBody(),
-                },
-                {
                     type: OrderActionType.LoadOrderRequested,
                 },
                 {
                     type: OrderActionType.LoadOrderSucceeded,
                     payload: getOrder(),
+                },
+                {
+                    type: PaymentActionType.SubmitPaymentSucceeded,
+                    payload: getPaymentResponseBody(),
                 },
             ]);
         });

--- a/src/payment/payment-actions.ts
+++ b/src/payment/payment-actions.ts
@@ -1,5 +1,7 @@
 import { Action } from '@bigcommerce/data-store';
 
+import { LoadOrderAction } from '../order';
+
 import PaymentResponseBody from './payment-response-body';
 
 export enum PaymentActionType {
@@ -18,7 +20,8 @@ export type PaymentAction = SubmitPaymentAction |
 export type SubmitPaymentAction =
     SubmitPaymentRequestedAction |
     SubmitPaymentSucceededAction |
-    SubmitPaymentFailedAction;
+    SubmitPaymentFailedAction |
+    LoadOrderAction;
 
 export type InitializeOffsitePaymentAction =
     InitializeOffsitePaymentRequestedAction |

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -368,8 +368,8 @@ describe('PaymentStrategyActionCreator', () => {
                 .toPromise();
 
             expect(actions).toEqual([
+                { type: PaymentStrategyActionType.FinalizeRequested },
                 { type: OrderActionType.LoadOrderPaymentsRequested },
-                { type: PaymentStrategyActionType.FinalizeRequested, meta: { methodId: method.id } },
                 { type: PaymentStrategyActionType.FinalizeSucceeded, meta: { methodId: method.id } },
             ]);
         });
@@ -390,8 +390,8 @@ describe('PaymentStrategyActionCreator', () => {
 
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
+                { type: PaymentStrategyActionType.FinalizeRequested },
                 { type: OrderActionType.LoadOrderPaymentsRequested },
-                { type: PaymentStrategyActionType.FinalizeRequested, meta: { methodId: method.id } },
                 { type: PaymentStrategyActionType.FinalizeFailed, error: true, payload: finalizeError, meta: { methodId: method.id } },
             ]);
         });

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -1,10 +1,14 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat } from 'rxjs/observable/concat';
+import { defer } from 'rxjs/observable/defer';
 import { empty } from 'rxjs/observable/empty';
+import { of } from 'rxjs/observable/of';
+import { catchError } from 'rxjs/operators';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
 import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
+import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 import { LoadOrderPaymentsAction, OrderActionCreator, OrderRequestBody } from '../order';
@@ -63,9 +67,11 @@ export default class PaymentStrategyActionCreator {
         });
     }
 
-    finalize(options?: RequestOptions): ThunkAction<PaymentStrategyFinalizeAction | LoadOrderPaymentsAction, InternalCheckoutSelectors> {
-        return store => {
-            const finalizeAction = new Observable((observer: Observer<PaymentStrategyFinalizeAction>) => {
+    finalize(options?: RequestOptions): ThunkAction<PaymentStrategyFinalizeAction, InternalCheckoutSelectors> {
+        return store => concat(
+            of(createAction(PaymentStrategyActionType.FinalizeRequested)),
+            this._loadOrderPaymentsIfNeeded(store, options),
+            defer(() => {
                 const state = store.getState();
                 const payment = state.payment.getPaymentId();
 
@@ -74,30 +80,23 @@ export default class PaymentStrategyActionCreator {
                 }
 
                 const method = state.paymentMethods.getPaymentMethod(payment.providerId, payment.gatewayId);
-                const meta = { methodId: payment.providerId };
 
                 if (!method) {
                     throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                 }
 
-                observer.next(createAction(PaymentStrategyActionType.FinalizeRequested, undefined, meta));
-
-                this._strategyRegistry.getByMethod(method)
+                return this._strategyRegistry.getByMethod(method)
                     .finalize({ ...options, methodId: method.id, gatewayId: method.gateway })
-                    .then(() => {
-                        observer.next(createAction(PaymentStrategyActionType.FinalizeSucceeded, undefined, meta));
-                        observer.complete();
-                    })
-                    .catch(error => {
-                        observer.error(createErrorAction(PaymentStrategyActionType.FinalizeFailed, error, meta));
-                    });
-            });
+                    .then(() => createAction(PaymentStrategyActionType.FinalizeSucceeded, undefined, { methodId: payment.providerId }));
+            })
+        ).pipe(
+            catchError(error => {
+                const state = store.getState();
+                const payment = state.payment.getPaymentId();
 
-            return concat(
-                this._loadOrderPaymentsIfNeeded(store, options),
-                finalizeAction
-            );
-        };
+                return throwErrorAction(PaymentStrategyActionType.FinalizeFailed, error, { methodId: payment && payment.providerId });
+            })
+        );
     }
 
     initialize(options: PaymentInitializeOptions): ThunkAction<PaymentStrategyInitializeAction, InternalCheckoutSelectors> {

--- a/src/payment/payment-strategy-actions.ts
+++ b/src/payment/payment-strategy-actions.ts
@@ -1,5 +1,7 @@
 import { Action } from '@bigcommerce/data-store';
 
+import { LoadOrderPaymentsAction } from '../order';
+
 export enum PaymentStrategyActionType {
     ExecuteFailed = 'PAYMENT_STRATEGY_EXECUTE_FAILED',
     ExecuteRequested = 'PAYMENT_STRATEGY_EXECUTE_REQUESTED',
@@ -28,12 +30,14 @@ export type PaymentStrategyAction =
 export type PaymentStrategyExecuteAction =
     ExecuteRequestedAction |
     ExecuteSucceededAction |
-    ExecuteFailedAction;
+    ExecuteFailedAction |
+    LoadOrderPaymentsAction;
 
 export type PaymentStrategyFinalizeAction =
     FinalizeRequestedAction |
     FinalizeSucceededAction |
-    FinalizeFailedAction;
+    FinalizeFailedAction |
+    LoadOrderPaymentsAction;
 
 export type PaymentStrategyInitializeAction =
     InitializeRequestedAction |

--- a/src/shipping/strategies/default-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/default-shipping-strategy.spec.ts
@@ -1,8 +1,8 @@
 import { createAction } from '@bigcommerce/data-store';
+import { createRequestSender } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
 import { ConsignmentRequestSender } from '..';
-import { createRequestSender } from '../../../node_modules/@bigcommerce/request-sender';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore } from '../../checkout';
 import ConsignmentActionCreator from '../consignment-action-creator';
 import { ConsignmentActionType } from '../consignment-actions';


### PR DESCRIPTION
## What?
Emit the start of an asynchronous action as soon as it begins; and emit the end of it as soon as it ends.

## Why?
Some asynchronous actions trigger other actions in order to complete. For example, previously, we emit the sub-actions in this order:
```
SIGN_IN_CUSTOMER_REQUESTED
SIGN_IN_CUSTOMER_SUCCEEDED
LOAD_CHECKOUT_REQUESTED
LOAD_CHECKOUT_SUCCEEDED
```
This means that the sign-in action could be marked as complete even though it could still be waiting for the checkout object to load. Instead, what we want is the following order:
```
SIGN_IN_CUSTOMER_REQUESTED
LOAD_CHECKOUT_REQUESTED
LOAD_CHECKOUT_SUCCEEDED
SIGN_IN_CUSTOMER_SUCCEEDED
```
This order ensures that `CheckoutStoreStatusSelector#isSigningIn` method returns the correct statuses while signing in.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
