### PR TITLE
CHECKOUT-3457: Use `PaymentMethodRequestSender` directly to send requests

### DIFF
--- a/src/checkout/checkout-client.spec.js
+++ b/src/checkout/checkout-client.spec.js
@@ -5,7 +5,6 @@ import { getCompleteOrder } from '../order/internal-orders.mock';
 import { getCheckout } from './checkouts.mock';
 import { getCountries } from '../geography/countries.mock';
 import { getCustomerResponseBody } from '../customer/internal-customers.mock';
-import { getPaymentMethod, getPaymentMethods } from '../payment/payment-methods.mock';
 import CheckoutClient from './checkout-client';
 
 describe('CheckoutClient', () => {
@@ -14,7 +13,6 @@ describe('CheckoutClient', () => {
     let countryRequestSender;
     let customerRequestSender;
     let orderRequestSender;
-    let paymentMethodRequestSender;
     let shippingCountryRequestSender;
 
     beforeEach(() => {
@@ -44,11 +42,6 @@ describe('CheckoutClient', () => {
             submitOrder: jest.fn(() => Promise.resolve(getResponse(getCompleteOrder()))),
         };
 
-        paymentMethodRequestSender = {
-            loadPaymentMethods: jest.fn(() => Promise.resolve(getResponse(getPaymentMethods()))),
-            loadPaymentMethod: jest.fn(() => Promise.resolve(getResponse(getPaymentMethod()))),
-        };
-
         shippingCountryRequestSender = {
             loadCountries: jest.fn(() => Promise.resolve(getResponse(getCountries()))),
         };
@@ -58,7 +51,6 @@ describe('CheckoutClient', () => {
             countryRequestSender,
             customerRequestSender,
             orderRequestSender,
-            paymentMethodRequestSender,
             shippingCountryRequestSender
         );
     });
@@ -113,40 +105,6 @@ describe('CheckoutClient', () => {
 
             expect(output).toEqual(getResponse(getCompleteOrder()));
             expect(orderRequestSender.finalizeOrder).toHaveBeenCalledWith(295, options);
-        });
-    });
-
-    describe('#loadPaymentMethods()', () => {
-        it('loads payment methods', async () => {
-            const output = await client.loadPaymentMethods();
-
-            expect(output).toEqual(getResponse(getPaymentMethods()));
-            expect(paymentMethodRequestSender.loadPaymentMethods).toHaveBeenCalledWith(undefined);
-        });
-
-        it('loads payment methods with timeout', async () => {
-            const options = { timeout: createTimeout() };
-            const output = await client.loadPaymentMethods(options);
-
-            expect(output).toEqual(getResponse(getPaymentMethods()));
-            expect(paymentMethodRequestSender.loadPaymentMethods).toHaveBeenCalledWith(options);
-        });
-    });
-
-    describe('#loadPaymentMethod()', () => {
-        it('loads payment method', async () => {
-            const output = await client.loadPaymentMethod('braintree');
-
-            expect(output).toEqual(getResponse(getPaymentMethod()));
-            expect(paymentMethodRequestSender.loadPaymentMethod).toHaveBeenCalledWith('braintree', undefined);
-        });
-
-        it('loads payment method with timeout', async () => {
-            const options = { timeout: createTimeout() };
-            const output = await client.loadPaymentMethod('braintree', options);
-
-            expect(output).toEqual(getResponse(getPaymentMethod()));
-            expect(paymentMethodRequestSender.loadPaymentMethod).toHaveBeenCalledWith('braintree', options);
         });
     });
 

--- a/src/checkout/checkout-client.ts
+++ b/src/checkout/checkout-client.ts
@@ -5,7 +5,6 @@ import { RequestOptions } from '../common/http-request';
 import { CustomerCredentials, CustomerRequestSender } from '../customer';
 import { CountryRequestSender, CountryResponseBody } from '../geography';
 import { InternalOrderRequestBody, InternalOrderResponseBody, Order, OrderRequestSender } from '../order';
-import { PaymentMethodsResponseBody, PaymentMethodRequestSender, PaymentMethodResponseBody } from '../payment';
 import { ShippingCountryRequestSender } from '../shipping';
 
 import Checkout from './checkout';
@@ -22,7 +21,6 @@ export default class CheckoutClient {
         private _countryRequestSender: CountryRequestSender,
         private _customerRequestSender: CustomerRequestSender,
         private _orderRequestSender: OrderRequestSender,
-        private _paymentMethodRequestSender: PaymentMethodRequestSender,
         private _shippingCountryRequestSender: ShippingCountryRequestSender
     ) {}
 
@@ -36,14 +34,6 @@ export default class CheckoutClient {
 
     finalizeOrder(orderId: number, options?: RequestOptions): Promise<Response<InternalOrderResponseBody>> {
         return this._orderRequestSender.finalizeOrder(orderId, options);
-    }
-
-    loadPaymentMethods(options?: RequestOptions): Promise<Response<PaymentMethodsResponseBody>> {
-        return this._paymentMethodRequestSender.loadPaymentMethods(options);
-    }
-
-    loadPaymentMethod(methodId: string, options?: RequestOptions): Promise<Response<PaymentMethodResponseBody>> {
-        return this._paymentMethodRequestSender.loadPaymentMethod(methodId, options);
     }
 
     loadCountries(options?: RequestOptions): Promise<Response<CountryResponseBody>> {

--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -50,6 +50,8 @@ describe('CheckoutService', () => {
     let giftCertificateRequestSender;
     let instrumentActionCreator;
     let orderActionCreator;
+    let paymentMethodRequestSender;
+    let paymentMethodActionCreator;
     let paymentStrategy;
     let paymentStrategyRegistry;
     let shippingStrategyActionCreator;
@@ -75,14 +77,6 @@ describe('CheckoutService', () => {
 
             finalizeOrder: jest.fn(() =>
                 Promise.resolve(getResponse(getCompleteOrderResponseBody()))
-            ),
-
-            loadPaymentMethod: jest.fn(() =>
-                Promise.resolve(getResponse(getPaymentMethodResponseBody()))
-            ),
-
-            loadPaymentMethods: jest.fn(() =>
-                Promise.resolve(getResponse(getPaymentMethodsResponseBody()))
             ),
 
             loadShippingCountries: jest.fn(() =>
@@ -172,6 +166,16 @@ describe('CheckoutService', () => {
             ),
         };
 
+        paymentMethodRequestSender = {
+            loadPaymentMethod: jest.fn(() =>
+                Promise.resolve(getResponse(getPaymentMethodResponseBody()))
+            ),
+
+            loadPaymentMethods: jest.fn(() =>
+                Promise.resolve(getResponse(getPaymentMethodsResponseBody()))
+            ),
+        };
+
         checkoutValidator = {
             validate: jest.fn(() => Promise.resolve()),
         };
@@ -188,15 +192,17 @@ describe('CheckoutService', () => {
         consignmentActionCreator = new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender);
 
         customerStrategyActionCreator = new CustomerStrategyActionCreator(
-            createCustomerStrategyRegistry(store, checkoutClient)
+            createCustomerStrategyRegistry(store)
         );
 
         instrumentActionCreator = new InstrumentActionCreator(checkoutClient);
 
         orderActionCreator = new OrderActionCreator(checkoutClient, checkoutValidator);
 
+        paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
+
         shippingStrategyActionCreator = new ShippingStrategyActionCreator(
-            createShippingStrategyRegistry(store, checkoutClient)
+            createShippingStrategyRegistry(store)
         );
 
         checkoutService = new CheckoutService(
@@ -211,7 +217,7 @@ describe('CheckoutService', () => {
             new GiftCertificateActionCreator(giftCertificateRequestSender),
             instrumentActionCreator,
             orderActionCreator,
-            new PaymentMethodActionCreator(checkoutClient),
+            paymentMethodActionCreator,
             new PaymentStrategyActionCreator(
                 paymentStrategyRegistry,
                 new OrderActionCreator(checkoutClient, checkoutValidator)
@@ -466,7 +472,7 @@ describe('CheckoutService', () => {
         it('loads payment methods', async () => {
             await checkoutService.loadPaymentMethods();
 
-            expect(checkoutClient.loadPaymentMethods).toHaveBeenCalledWith(undefined);
+            expect(paymentMethodRequestSender.loadPaymentMethods).toHaveBeenCalledWith(undefined);
         });
 
         it('loads payment methods with timeout', async () => {
@@ -474,7 +480,7 @@ describe('CheckoutService', () => {
 
             await checkoutService.loadPaymentMethods(options);
 
-            expect(checkoutClient.loadPaymentMethods).toHaveBeenCalledWith(options);
+            expect(paymentMethodRequestSender.loadPaymentMethods).toHaveBeenCalledWith(options);
         });
 
         it('returns payment methods', async () => {

--- a/src/checkout/create-checkout-client.ts
+++ b/src/checkout/create-checkout-client.ts
@@ -4,7 +4,6 @@ import { BillingAddressRequestSender } from '../billing';
 import { CustomerRequestSender } from '../customer';
 import { CountryRequestSender } from '../geography';
 import { OrderRequestSender } from '../order';
-import { PaymentMethodRequestSender } from '../payment';
 import { ShippingCountryRequestSender } from '../shipping';
 
 import CheckoutClient from './checkout-client';
@@ -16,7 +15,6 @@ export default function createCheckoutClient(config: { locale?: string } = {}): 
     const countryRequestSender = new CountryRequestSender(requestSender, config);
     const customerRequestSender = new CustomerRequestSender(requestSender);
     const orderRequestSender = new OrderRequestSender(requestSender);
-    const paymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
     const shippingCountryRequestSender = new ShippingCountryRequestSender(requestSender, config);
 
     return new CheckoutClient(
@@ -24,7 +22,6 @@ export default function createCheckoutClient(config: { locale?: string } = {}): 
         countryRequestSender,
         customerRequestSender,
         orderRequestSender,
-        paymentMethodRequestSender,
         shippingCountryRequestSender
     );
 }

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -17,6 +17,7 @@ import {
     createPaymentClient,
     createPaymentStrategyRegistry,
     PaymentMethodActionCreator,
+    PaymentMethodRequestSender,
     PaymentStrategyActionCreator,
 } from '../payment';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
@@ -66,9 +67,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     const paymentClient = createPaymentClient(store);
     const requestSender = createRequestSender();
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
-    const configRequestSender = new ConfigRequestSender(requestSender);
-    const configActionCreator = new ConfigActionCreator(configRequestSender);
-    const consignmentRequestSender = new ConsignmentRequestSender(requestSender);
+    const configActionCreator = new ConfigActionCreator(new ConfigRequestSender(requestSender));
     const orderActionCreator = new OrderActionCreator(client, new CheckoutValidator(checkoutRequestSender));
 
     return new CheckoutService(
@@ -76,20 +75,20 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new BillingAddressActionCreator(client),
         new CheckoutActionCreator(checkoutRequestSender, configActionCreator),
         configActionCreator,
-        new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender),
+        new ConsignmentActionCreator(new ConsignmentRequestSender(requestSender), checkoutRequestSender),
         new CountryActionCreator(client),
         new CouponActionCreator(new CouponRequestSender(requestSender)),
-        new CustomerStrategyActionCreator(createCustomerStrategyRegistry(store, client)),
+        new CustomerStrategyActionCreator(createCustomerStrategyRegistry(store)),
         new GiftCertificateActionCreator(new GiftCertificateRequestSender(requestSender)),
         new InstrumentActionCreator(new InstrumentRequestSender(paymentClient, requestSender)),
         orderActionCreator,
-        new PaymentMethodActionCreator(client),
+        new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
         new PaymentStrategyActionCreator(
             createPaymentStrategyRegistry(store, client, paymentClient),
             orderActionCreator
         ),
         new ShippingCountryActionCreator(client),
-        new ShippingStrategyActionCreator(createShippingStrategyRegistry(store, client))
+        new ShippingStrategyActionCreator(createShippingStrategyRegistry(store))
     );
 }
 

--- a/src/customer/customer-strategy-action-creator.spec.ts
+++ b/src/customer/customer-strategy-action-creator.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
-import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutClient, CheckoutRequestSender, CheckoutStore } from '../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 
@@ -13,7 +13,6 @@ import { CustomerStrategyActionType } from './customer-strategy-actions';
 import { CustomerStrategy, DefaultCustomerStrategy } from './strategies';
 
 describe('CustomerStrategyActionCreator', () => {
-    let client: CheckoutClient;
     let registry: Registry<CustomerStrategy>;
     let store: CheckoutStore;
     let strategy: DefaultCustomerStrategy;
@@ -28,8 +27,7 @@ describe('CustomerStrategyActionCreator', () => {
         );
 
         store = createCheckoutStore();
-        client = createCheckoutClient();
-        registry = createCustomerStrategyRegistry(store, client);
+        registry = createCustomerStrategyRegistry(store);
         strategy = new DefaultCustomerStrategy(
             store,
             new CustomerActionCreator(

--- a/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
@@ -3,11 +3,11 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { Observable } from 'rxjs';
 
-import { createCheckoutClient, createCheckoutStore, CheckoutState, CheckoutStore, CheckoutStoreState } from '../../checkout';
+import { createCheckoutStore, CheckoutState, CheckoutStore, CheckoutStoreState } from '../../checkout';
 import { getCheckoutStoreState, getCheckoutWithPayments } from '../../checkout/checkouts.mock';
 import { MissingDataError } from '../../common/error/errors';
 import { getErrorResponse, getResponse } from '../../common/http-request/responses.mock';
-import { HOSTED, INITIALIZE, PaymentMethod, PaymentMethodActionCreator, PaymentMethodActionType } from '../../payment';
+import { HOSTED, INITIALIZE, PaymentMethod, PaymentMethodActionCreator, PaymentMethodActionType, PaymentMethodRequestSender } from '../../payment';
 import { getAmazonPay } from '../../payment/payment-methods.mock';
 import {
     AmazonPayLogin,
@@ -70,7 +70,7 @@ describe('AmazonPayCustomerStrategy', () => {
         container = document.createElement('div');
         hostWindow = window;
         paymentMethod = getAmazonPay();
-        paymentMethodActionCreator = new PaymentMethodActionCreator(createCheckoutClient());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(createRequestSender());
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender);
         state = getCheckoutStoreState();

--- a/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
@@ -6,10 +6,10 @@ import { Observable } from 'rxjs';
 
 import { createCustomerStrategyRegistry, CustomerInitializeOptions, CustomerStrategyActionCreator } from '..';
 import { getBillingAddress } from '../../billing/billing-addresses.mock';
-import { createCheckoutClient, createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../checkout';
 import { getCheckoutStoreState } from '../../checkout/checkouts.mock';
 import { ConfigActionCreator, ConfigRequestSender } from '../../config';
-import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../payment';
 import { getBraintreeVisaCheckout } from '../../payment/payment-methods.mock';
 import { VisaCheckoutScriptLoader, VisaCheckoutSDK } from '../../payment/strategies/braintree';
 import { createBraintreeVisaCheckoutPaymentProcessor, BraintreeVisaCheckoutPaymentProcessor } from '../../payment/strategies/braintree';
@@ -56,14 +56,13 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         visaCheckoutScriptLoader = new VisaCheckoutScriptLoader(scriptLoader);
         visaCheckoutScriptLoader.load = jest.fn(() => Promise.resolve(visaCheckoutSDK));
 
-        const client = createCheckoutClient();
-        const registry = createCustomerStrategyRegistry(store, client);
+        const registry = createCustomerStrategyRegistry(store);
         const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
         const configRequestSender = new ConfigRequestSender(createRequestSender());
         const configActionCreator = new ConfigActionCreator(configRequestSender);
 
         checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
-        paymentMethodActionCreator = new PaymentMethodActionCreator(createCheckoutClient());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         customerStrategyActionCreator = new CustomerStrategyActionCreator(registry);
 
         strategy = new BraintreeVisaCheckoutCustomerStrategy(

--- a/src/customer/strategies/chasepay-customer-strategy.spec.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.spec.ts
@@ -3,10 +3,10 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { getCartState } from '../../cart/carts.mock';
-import { createCheckoutClient, createCheckoutStore, CheckoutStore } from '../../checkout';
+import { createCheckoutStore, CheckoutStore } from '../../checkout';
 import { getCheckoutState } from '../../checkout/checkouts.mock';
 import { getConfigState } from '../../config/configs.mock';
-import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../payment';
 import { getChasePay, getPaymentMethodsState } from '../../payment/payment-methods.mock';
 import { ChasePayScriptLoader, JPMC } from '../../payment/strategies/chasepay';
 import { getChasePayScriptMock } from '../../payment/strategies/chasepay/chasepay.mock';
@@ -57,7 +57,7 @@ describe('ChasePayCustomerStrategy', () => {
         jest.spyOn(chasePayScriptLoader, 'load')
             .mockReturnValue(Promise.resolve(JPMC));
 
-        paymentMethodActionCreator = new PaymentMethodActionCreator(createCheckoutClient());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         requestSender = createRequestSender();
         formPoster = createFormPoster();
         strategy = new ChasePayCustomerStrategy(

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -10,6 +10,7 @@ import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../rem
 
 import PaymentActionCreator from './payment-action-creator';
 import PaymentMethodActionCreator from './payment-method-action-creator';
+import PaymentMethodRequestSender from './payment-method-request-sender';
 import PaymentRequestSender from './payment-request-sender';
 import PaymentStrategyActionCreator from './payment-strategy-action-creator';
 import PaymentStrategyRegistry from './payment-strategy-registry';
@@ -55,12 +56,10 @@ export default function createPaymentStrategyRegistry(
         new PaymentRequestSender(paymentClient),
         orderActionCreator
     );
-    const paymentMethodActionCreator = new PaymentMethodActionCreator(client);
+    const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
         new RemoteCheckoutRequestSender(createRequestSender())
     );
-    const configRequestSender = new ConfigRequestSender(requestSender);
-    const configActionCreator = new ConfigActionCreator(configRequestSender);
 
     registry.register('afterpay', () =>
         new AfterpayPaymentStrategy(
@@ -207,7 +206,10 @@ export default function createPaymentStrategyRegistry(
     registry.register('braintreevisacheckout', () =>
         new BraintreeVisaCheckoutPaymentStrategy(
             store,
-            new CheckoutActionCreator(checkoutRequestSender, configActionCreator),
+            new CheckoutActionCreator(
+                checkoutRequestSender,
+                new ConfigActionCreator(new ConfigRequestSender(requestSender))
+            ),
             paymentMethodActionCreator,
             new PaymentStrategyActionCreator(registry, orderActionCreator),
             paymentActionCreator,

--- a/src/payment/payment-method-action-creator.ts
+++ b/src/payment/payment-method-action-creator.ts
@@ -2,21 +2,21 @@ import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
-import { CheckoutClient } from '../checkout';
 import { RequestOptions } from '../common/http-request';
 
 import { LoadPaymentMethodsAction, LoadPaymentMethodAction, PaymentMethodActionType } from './payment-method-actions';
+import PaymentMethodRequestSender from './payment-method-request-sender';
 
 export default class PaymentMethodActionCreator {
     constructor(
-        private _checkoutClient: CheckoutClient
+        private _requestSender: PaymentMethodRequestSender
     ) {}
 
     loadPaymentMethods(options?: RequestOptions): Observable<LoadPaymentMethodsAction> {
         return Observable.create((observer: Observer<LoadPaymentMethodsAction>) => {
             observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodsRequested));
 
-            this._checkoutClient.loadPaymentMethods(options)
+            this._requestSender.loadPaymentMethods(options)
                 .then(response => {
                     observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, response.body.data, response.body.meta));
                     observer.complete();
@@ -31,7 +31,7 @@ export default class PaymentMethodActionCreator {
         return Observable.create((observer: Observer<LoadPaymentMethodAction>) => {
             observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodRequested, undefined, { methodId }));
 
-            this._checkoutClient.loadPaymentMethod(methodId, options)
+            this._requestSender.loadPaymentMethod(methodId, options)
                 .then(response => {
                     observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, response.body.data, { methodId }));
                     observer.complete();

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -17,6 +17,7 @@ import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentMethodActionType } from '../../payment-method-actions';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getAfterpay } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
 
@@ -50,7 +51,7 @@ describe('AfterpayPaymentStrategy', () => {
     beforeEach(() => {
         client = createCheckoutClient();
         store = createCheckoutStore(getCheckoutStoreState());
-        paymentMethodActionCreator = new PaymentMethodActionCreator(client);
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
         checkoutValidator = new CheckoutValidator(checkoutRequestSender);
         orderActionCreator = new OrderActionCreator(client, checkoutValidator);

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -15,6 +15,7 @@ import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentMethodActionType } from '../../payment-method-actions';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getBraintree } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
@@ -54,7 +55,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
             new PaymentRequestSender(createPaymentClient()),
             orderActionCreator
         );
-        paymentMethodActionCreator = new PaymentMethodActionCreator(createCheckoutClient());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
 
         submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
         submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -22,6 +22,7 @@ import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import { PaymentActionType } from '../../payment-actions';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getBraintreeVisaCheckout } from '../../payment-methods.mock';
 import { PaymentStrategyActionType } from '../../payment-strategy-actions';
 
@@ -77,7 +78,7 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
 
         checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
         orderActionCreator = new OrderActionCreator(client, checkoutValidator);
-        paymentMethodActionCreator = new PaymentMethodActionCreator(client);
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient(store)),

--- a/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
@@ -21,6 +21,7 @@ import { PaymentMethodCancelledError, PaymentMethodInvalidError } from '../../er
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentMethodActionType } from '../../payment-method-actions';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
 
 import KlarnaCredit from './klarna-credit';
 import KlarnaPaymentStrategy from './klarna-payment-strategy';
@@ -50,7 +51,7 @@ describe('KlarnaPaymentStrategy', () => {
             client,
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
-        paymentMethodActionCreator = new PaymentMethodActionCreator(client);
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
             new RemoteCheckoutRequestSender(createRequestSender())
         );

--- a/src/shipping/create-shipping-strategy-registry.ts
+++ b/src/shipping/create-shipping-strategy-registry.ts
@@ -1,10 +1,9 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
-import { CheckoutClient, CheckoutStore } from '../checkout';
-import CheckoutRequestSender from '../checkout/checkout-request-sender';
+import { CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
-import { PaymentMethodActionCreator } from '../payment';
+import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 
@@ -12,10 +11,7 @@ import { ConsignmentRequestSender } from '.';
 import ConsignmentActionCreator from './consignment-action-creator';
 import { AmazonPayShippingStrategy, DefaultShippingStrategy, ShippingStrategy } from './strategies';
 
-export default function createShippingStrategyRegistry(
-    store: CheckoutStore,
-    client: CheckoutClient
-): Registry<ShippingStrategy> {
+export default function createShippingStrategyRegistry(store: CheckoutStore): Registry<ShippingStrategy> {
     const requestSender = createRequestSender();
     const registry = new Registry<ShippingStrategy>();
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
@@ -25,7 +21,7 @@ export default function createShippingStrategyRegistry(
         new AmazonPayShippingStrategy(
             store,
             new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender),
-            new PaymentMethodActionCreator(client),
+            new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
             new RemoteCheckoutActionCreator(new RemoteCheckoutRequestSender(requestSender)),
             new AmazonPayScriptLoader(getScriptLoader())
         )

--- a/src/shipping/shipping-strategy-action-creator.spec.ts
+++ b/src/shipping/shipping-strategy-action-creator.spec.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore, CheckoutStoreState } from '../checkout';
+import { createCheckoutStore, CheckoutStore, CheckoutStoreState } from '../checkout';
 import { getCheckoutState, getCheckoutStoreState, getCheckoutWithPayments } from '../checkout/checkouts.mock';
 import { Registry } from '../common/registry';
 import { getPaymentMethod } from '../payment/payment-methods.mock';
@@ -12,7 +12,6 @@ import { ShippingStrategyActionType } from './shipping-strategy-actions';
 import { ShippingStrategy } from './strategies';
 
 describe('ShippingStrategyActionCreator', () => {
-    let client: CheckoutClient;
     let registry: Registry<ShippingStrategy>;
     let state: CheckoutStoreState;
     let store: CheckoutStore;
@@ -20,8 +19,7 @@ describe('ShippingStrategyActionCreator', () => {
     beforeEach(() => {
         state = getCheckoutStoreState();
         store = createCheckoutStore(state);
-        client = createCheckoutClient();
-        registry = createShippingStrategyRegistry(store, client);
+        registry = createShippingStrategyRegistry(store);
     });
 
     describe('#initialize()', () => {

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
@@ -4,10 +4,10 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { Observable } from 'rxjs';
 
 import { ConsignmentRequestSender } from '..';
-import { createCheckoutClient, createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState } from '../../checkout';
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState } from '../../checkout';
 import { getCheckoutStoreState } from '../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../common/error/errors';
-import { PaymentMethodActionCreator, PaymentMethodActionType } from '../../payment';
+import { PaymentMethodActionCreator, PaymentMethodActionType, PaymentMethodRequestSender } from '../../payment';
 import { getAmazonPay } from '../../payment/payment-methods.mock';
 import {
     AmazonPayAddressBook,
@@ -79,7 +79,7 @@ describe('AmazonPayShippingStrategy', () => {
         state = getCheckoutStoreState();
         store = createCheckoutStore(state);
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(new RemoteCheckoutRequestSender(createRequestSender()));
-        paymentMethodActionCreator = new PaymentMethodActionCreator(createCheckoutClient());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         scriptLoader = new AmazonPayScriptLoader(createScriptLoader());
 
         orderReference = {


### PR DESCRIPTION
## What?
* Use `PaymentMethodRequestSender` directly to send requests related to payment methods.

## Why?
* `CheckoutClient` is deprecated.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
