### PR TITLE
CHECKOUT-3449: Use correct order ID when reloading current order after order creation

### DIFF
--- a/src/order/order-action-creator.spec.js
+++ b/src/order/order-action-creator.spec.js
@@ -291,6 +291,13 @@ describe('OrderActionCreator', () => {
                 expect(action.payload).toEqual('foo');
             }
         });
+
+        it('loads current order after order submission', async () => {
+            await Observable.from(orderActionCreator.submitOrder(getOrderRequestBody())(store))
+                .toPromise();
+
+            expect(checkoutClient.loadOrder).toHaveBeenCalledWith(295, undefined);
+        });
     });
 
     describe('#finalizeOrder()', () => {

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -82,7 +82,7 @@ export default class OrderActionCreator {
                 ).pipe(
                     switchMap(response => concat(
                         // TODO: Remove once we can submit orders using storefront API
-                        this.loadCurrentOrder(options)(store),
+                        this.loadOrder(response.body.data.order.orderId, options),
                         of(createAction(OrderActionType.SubmitOrderSucceeded, response.body.data, { ...response.body.meta, token: response.headers.token }))
                     ))
                 );

--- a/src/order/order-reducer.spec.js
+++ b/src/order/order-reducer.spec.js
@@ -2,7 +2,7 @@ import { omit } from 'lodash';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
 import { getCompleteOrderResponseBody, getSubmitOrderResponseBody, getSubmitOrderResponseHeaders } from './internal-orders.mock';
-import { getOrder, getOrderState } from './orders.mock';
+import { getOrder } from './orders.mock';
 import { OrderActionType } from './order-actions';
 import orderReducer from './order-reducer';
 
@@ -83,19 +83,6 @@ describe('orderReducer()', () => {
             meta: {
                 payment: action.payload.order.payment,
             },
-        }));
-    });
-
-    it('cleans the order after a new order post', () => {
-        const response = getCompleteOrderResponseBody();
-        const action = {
-            type: OrderActionType.SubmitOrderSucceeded,
-            meta: response.meta,
-            payload: response.data,
-        };
-
-        expect(orderReducer(getOrderState(), action)).toEqual(expect.objectContaining({
-            data: undefined,
         }));
     });
 

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -29,8 +29,6 @@ function dataReducer(
     action: OrderAction
 ): OrderDataState | undefined {
     switch (action.type) {
-    case OrderActionType.SubmitOrderSucceeded:
-        return undefined;
     case OrderActionType.LoadOrderSucceeded:
     case OrderActionType.LoadOrderPaymentsSucceeded:
         return action.payload


### PR DESCRIPTION
## What?
* After order creation, use the order ID from the response to reload the current order using storefront API.
* Remove the reset after order submission because it's not needed anymore.

## Why?
* Previously, we call `loadCurrentOrder`, using the store cache to determine the current order ID in order to reload the object using storefront API. However, since #376, we don't cache the order object until after reloading the order object. Therefore, we need to get the order ID from the submission response instead.
* We only need to reset the order (#327) if order rehydration happens after order submission. Now it's no longer the case so we don't need to the reset anymore.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
