### PR TITLE
feat(checkout): INT-775 Implement Masterpass button in customer section

### DIFF
--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -9,6 +9,7 @@ import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payme
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createBraintreeVisaCheckoutPaymentProcessor, VisaCheckoutScriptLoader } from '../payment/strategies/braintree';
 import { ChasePayScriptLoader } from '../payment/strategies/chasepay';
+import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 
 import CustomerActionCreator from './customer-action-creator';
@@ -20,6 +21,7 @@ import {
     ChasePayCustomerStrategy,
     CustomerStrategy,
     DefaultCustomerStrategy,
+    MasterpassCustomerStrategy,
 } from './strategies';
 import SquareCustomerStrategy from './strategies/square-customer-strategy';
 
@@ -35,6 +37,7 @@ export default function createCustomerStrategyRegistry(
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(requestSender);
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender);
+    const scriptLoader = getScriptLoader();
 
     registry.register('amazon', () =>
         new AmazonPayCustomerStrategy(
@@ -42,7 +45,7 @@ export default function createCustomerStrategyRegistry(
             paymentMethodActionCreator,
             remoteCheckoutActionCreator,
             remoteCheckoutRequestSender,
-            new AmazonPayScriptLoader(getScriptLoader())
+            new AmazonPayScriptLoader(scriptLoader)
         )
     );
 
@@ -53,8 +56,8 @@ export default function createCustomerStrategyRegistry(
             paymentMethodActionCreator,
             new CustomerStrategyActionCreator(registry),
             remoteCheckoutActionCreator,
-            createBraintreeVisaCheckoutPaymentProcessor(getScriptLoader(), requestSender),
-            new VisaCheckoutScriptLoader(getScriptLoader())
+            createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender),
+            new VisaCheckoutScriptLoader(scriptLoader)
         )
     );
 
@@ -63,7 +66,7 @@ export default function createCustomerStrategyRegistry(
             store,
             paymentMethodActionCreator,
             remoteCheckoutActionCreator,
-            new ChasePayScriptLoader(getScriptLoader()),
+            new ChasePayScriptLoader(scriptLoader),
             requestSender,
             createFormPoster()
         )
@@ -73,8 +76,17 @@ export default function createCustomerStrategyRegistry(
         new SquareCustomerStrategy(
             store,
             new RemoteCheckoutActionCreator(remoteCheckoutRequestSender)
-    )
-);
+        )
+    );
+
+    registry.register('masterpass', () =>
+        new MasterpassCustomerStrategy(
+            store,
+            paymentMethodActionCreator,
+            remoteCheckoutActionCreator,
+            new MasterpassScriptLoader(scriptLoader)
+        )
+    );
 
     registry.register('default', () =>
         new DefaultCustomerStrategy(

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -1,6 +1,11 @@
 import { RequestOptions } from '../common/http-request';
 
-import { AmazonPayCustomerInitializeOptions, BraintreeVisaCheckoutCustomerInitializeOptions, ChasePayCustomerInitializeOptions } from './strategies';
+import {
+    AmazonPayCustomerInitializeOptions,
+    BraintreeVisaCheckoutCustomerInitializeOptions,
+    ChasePayCustomerInitializeOptions,
+    MasterpassCustomerInitializeOptions
+} from './strategies';
 
 /**
  * A set of options for configuring any requests related to the customer step of
@@ -41,4 +46,5 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      * They can be omitted unless you need to support Chasepay.
      */
     chasepay?: ChasePayCustomerInitializeOptions;
+    masterpass?: MasterpassCustomerInitializeOptions;
 }

--- a/src/customer/strategies/chasepay-customer-strategy.spec.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.spec.ts
@@ -146,6 +146,34 @@ describe('ChasePayCustomerStrategy', () => {
             expect(JPMC.ChasePay.configure).toHaveBeenCalled();
         });
 
+        it('fails to initialize the strategy if no methodid is supplied', async () => {
+            chasePayOptions = { methodId: undefined, chasepay: { container: 'login' } };
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('fails to initialize the strategy if no cart is supplied', async () => {
+            jest.spyOn(store.getState().cart, 'getCart')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('fails to initialize the strategy if no digitalSessionID is supplied', async () => {
+            paymentMethodMock.initializationData.digitalSessionId = undefined;
+            try {
+                await strategy.initialize(chasePayOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(NotInitializedError);
+            }
+        });
+
         it('registers the start and complete callbacks', async () => {
             JPMC.ChasePay.on = jest.fn((type, callback) => callback);
 

--- a/src/customer/strategies/index.ts
+++ b/src/customer/strategies/index.ts
@@ -4,3 +4,5 @@ export { default as DefaultCustomerStrategy } from './default-customer-strategy'
 export { default as BraintreeVisaCheckoutCustomerStrategy, BraintreeVisaCheckoutCustomerInitializeOptions } from './braintree-visacheckout-customer-strategy';
 export { default as ChasePayCustomerStrategy, ChasePayCustomerInitializeOptions } from './chasepay-customer-strategy';
 export { default as SquareCustomerStrategy } from './square-customer-strategy';
+export { default as MasterpassCustomerInitializeOptions} from './masterpass-customer-initialize-options';
+export { default as MasterpassCustomerStrategy } from './masterpass-customer-strategy';

--- a/src/customer/strategies/masterpass-customer-initialize-options.ts
+++ b/src/customer/strategies/masterpass-customer-initialize-options.ts
@@ -1,0 +1,6 @@
+export default interface MasterpassCustomerInitializeOptions {
+    /**
+     * The ID of a container which the checkout button should be inserted into.
+     */
+    container: string;
+}

--- a/src/customer/strategies/masterpass-customer-strategy.spec.ts
+++ b/src/customer/strategies/masterpass-customer-strategy.spec.ts
@@ -1,0 +1,215 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { getCartState } from '../../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../../checkout';
+import { getCheckoutState } from '../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../common/error/errors';
+import { getConfigState } from '../../config/configs.mock';
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../payment';
+import { getMasterpass, getPaymentMethodsState } from '../../payment/payment-methods.mock';
+import { Masterpass, MasterpassScriptLoader } from '../../payment/strategies/masterpass';
+import { getMasterpassScriptMock } from '../../payment/strategies/masterpass/masterpass.mock';
+import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../remote-checkout';
+import { CustomerInitializeOptions } from '../customer-request-options';
+import { getCustomerState } from '../customers.mock';
+
+import { CustomerStrategy, MasterpassCustomerStrategy } from './';
+
+describe('MasterpassCustomerStrategy', () => {
+    let container: HTMLDivElement;
+    let masterpass: Masterpass;
+    let masterpassScriptLoader: MasterpassScriptLoader;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: CustomerStrategy;
+
+    beforeEach(() => {
+        paymentMethodMock = {
+            ...getMasterpass(),
+            initializationData: {
+                checkoutId: 'checkoutId',
+                allowedCardTypes: ['visa', 'amex', 'mastercard'],
+            },
+        };
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethodMock);
+
+        requestSender = createRequestSender();
+
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+            new RemoteCheckoutRequestSender(requestSender)
+        );
+
+        masterpass = getMasterpassScriptMock();
+
+        masterpassScriptLoader = new MasterpassScriptLoader(createScriptLoader());
+
+        jest.spyOn(masterpassScriptLoader, 'load')
+            .mockReturnValue(Promise.resolve(masterpass));
+
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(requestSender)
+        );
+        strategy = new MasterpassCustomerStrategy(
+            store,
+            paymentMethodActionCreator,
+            remoteCheckoutActionCreator,
+            masterpassScriptLoader
+        );
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'login');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('creates an instance of MasterpassCustomerStrategy', () => {
+        expect(strategy).toBeInstanceOf(MasterpassCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+        let masterpassOptions: CustomerInitializeOptions;
+
+        beforeEach(() => {
+            masterpassOptions = { methodId: 'masterpass', masterpass: { container: 'login' } };
+        });
+
+        it('loads masterpass script in test mode if enabled', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(masterpassOptions);
+
+            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(true);
+        });
+
+        it('loads masterpass without test mode if disabled', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(masterpassOptions);
+
+            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(false);
+        });
+
+        it('fails to initialize the strategy if no methodid is supplied', async () => {
+            masterpassOptions = { methodId: undefined, masterpass: { container: 'login' } };
+            try {
+                await strategy.initialize(masterpassOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('fails to initialize the strategy if no cart is supplied', async () => {
+            jest.spyOn(store.getState().cart, 'getCart')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(masterpassOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('fails to initialize the strategy if no checkoutId is supplied', async () => {
+            paymentMethodMock.initializationData.checkoutId = undefined;
+            try {
+                await strategy.initialize(masterpassOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('proceeds to checkout if masterpass button is clicked', async () => {
+            jest.spyOn(masterpass, 'checkout');
+            await strategy.initialize(masterpassOptions);
+            if (masterpassOptions.masterpass) {
+                const masterpassButton = document.getElementById(masterpassOptions.masterpass.container);
+                if (masterpassButton) {
+                    const btn = masterpassButton.firstChild as HTMLElement;
+                    if (btn) {
+                        btn.click();
+                        expect(masterpass.checkout).toHaveBeenCalled();
+                    }
+                }
+            }
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        let masterpassOptions: CustomerInitializeOptions;
+
+        beforeEach(() => {
+            masterpassOptions = { methodId: 'masterpass', masterpass: { container: 'login' } };
+        });
+
+        it('succesfully deinitializes the strategy', async () => {
+            jest.spyOn(masterpass, 'checkout');
+            await strategy.initialize(masterpassOptions);
+            strategy.deinitialize();
+            if (masterpassOptions.masterpass) {
+                const masterpassButton = document.getElementById(masterpassOptions.masterpass.container);
+                if (masterpassButton) {
+                    expect(masterpassButton.firstChild).toBe(null);
+                }
+            }
+            // Prevent "After Each" failure
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+    });
+
+    describe('#signIn()', () => {
+        beforeEach(async () => {
+            await strategy.initialize({ methodId: 'masterpass', masterpass: { container: 'login' } });
+        });
+
+        it('throws error if trying to sign in programmatically', async () => {
+            expect(() => strategy.signIn({ email: 'foo@bar.com', password: 'foobar' })).toThrowError();
+        });
+    });
+
+    describe('#signOut()', () => {
+        beforeEach(async () => {
+            const paymentId = {
+                providerId: 'masterpass',
+            };
+
+            jest.spyOn(store.getState().payment, 'getPaymentId')
+                .mockReturnValue(paymentId);
+
+            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+                .mockReturnValue('data');
+
+            await strategy.initialize({ methodId: 'masterpass', masterpass: { container: 'login' } });
+        });
+
+        it('throws error if trying to sign out programmatically', async () => {
+            const options = {
+                methodId: 'masterpass',
+            };
+
+            await strategy.signOut(options);
+
+            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('masterpass', options);
+            expect(store.dispatch).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/customer/strategies/masterpass-customer-strategy.ts
+++ b/src/customer/strategies/masterpass-customer-strategy.ts
@@ -1,0 +1,119 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    NotImplementedError
+} from '../../common/error/errors';
+import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
+import { MasterpassScriptLoader } from '../../payment/strategies/masterpass';
+import { RemoteCheckoutActionCreator } from '../../remote-checkout';
+import CustomerCredentials from '../customer-credentials';
+import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-request-options';
+
+import CustomerStrategy from './customer-strategy';
+
+export default class MasterpassCustomerStrategy extends CustomerStrategy {
+    private _signInButton?: HTMLElement;
+    private _paymentMethod?: PaymentMethod;
+
+    constructor(
+        store: CheckoutStore,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
+        private _masterpassScriptLoader: MasterpassScriptLoader
+    ) {
+        super(store);
+    }
+
+    initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { masterpass: masterpassOptions, methodId } = options;
+
+        if (!masterpassOptions || !methodId) {
+            throw new InvalidArgumentError('Unable to proceed because "options.masterpass" argument is not provided.');
+        }
+
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
+            .then(state => {
+
+                this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+                if (!this._paymentMethod || !this._paymentMethod.initializationData.checkoutId) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                const cart = state.cart.getCart();
+                if (!cart) {
+                    throw new MissingDataError(MissingDataErrorType.MissingCart);
+                }
+
+                const { container } = masterpassOptions;
+
+                const payload = {
+                    checkoutId: this._paymentMethod.initializationData.checkoutId,
+                    allowedCardTypes: this._paymentMethod.initializationData.allowedCardTypes,
+                    amount: cart.cartAmount.toString(),
+                    currency: cart.currency.code,
+                    cartId: cart.id,
+                };
+
+                return this._masterpassScriptLoader.load(this._paymentMethod.config.testMode)
+                    .then(Masterpass => {
+                        this._signInButton = this._createSignInButton(container);
+
+                        this._signInButton.addEventListener('click', () => {
+                            Masterpass.checkout(payload);
+                        });
+                    });
+            })
+            .then(() => super.initialize(options));
+    }
+
+    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (!this._isInitialized) {
+            return super.deinitialize(options);
+        }
+
+        this._paymentMethod = undefined;
+        if (this._signInButton && this._signInButton.parentNode) {
+            this._signInButton.parentNode.removeChild(this._signInButton);
+            this._signInButton = undefined;
+        }
+
+        return super.deinitialize(options);
+    }
+
+    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        throw new NotImplementedError(
+            'In order to sign in via Masterpass, the shopper must click on "Masterpass" button.'
+        );
+    }
+
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const payment = state.payment.getPaymentId();
+
+        if (!payment) {
+            return Promise.resolve(this._store.getState());
+        }
+
+        return this._store.dispatch(
+            this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    private _createSignInButton(containerId: string): HTMLElement {
+        const container = document.querySelector(`#${containerId}`);
+
+        if (!container) {
+            throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
+        }
+
+        const button = document.createElement('input');
+
+        button.type = 'image';
+        button.src = 'https://static.masterpass.com/dyn/img/btn/global/mp_chk_btn_160x037px.svg';
+        container.appendChild(button);
+
+        return button;
+    }
+}

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -244,6 +244,28 @@ export function getChasePay(): PaymentMethod {
     };
 }
 
+export function getMasterpass(): PaymentMethod {
+    return {
+        id: 'masterpass',
+        logoUrl: '',
+        method: 'masterpass',
+        supportedCards: [
+            'VISA',
+            'MC',
+            'AMEX',
+        ],
+        config: {
+            displayName: 'Masterpass',
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        initializationData: {
+            checkoutId: 'checkoutId',
+            allowedCardTypes: ['visa', 'amex', 'mastercard'],
+        },
+    };
+}
+
 export function getWepay(): PaymentMethod {
     return {
         id: 'wepay',

--- a/src/payment/strategies/masterpass/index.ts
+++ b/src/payment/strategies/masterpass/index.ts
@@ -1,0 +1,3 @@
+export { Masterpass, MasterpassHostWindow, MasterpassCheckoutOptions } from './masterpass';
+
+export { default as MasterpassScriptLoader } from './masterpass-script-loader';

--- a/src/payment/strategies/masterpass/masterpass-script-loader.ts
+++ b/src/payment/strategies/masterpass/masterpass-script-loader.ts
@@ -1,0 +1,23 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { StandardError } from '../../../common/error/errors';
+import { Masterpass, MasterpassHostWindow } from '../masterpass/masterpass';
+
+export default class MasterpassScriptLoader {
+    constructor(
+        private _scriptLoader: ScriptLoader,
+        public _window: MasterpassHostWindow = window
+    ) {}
+
+    load(testMode?: boolean): Promise<Masterpass> {
+        return this._scriptLoader
+            .loadScript(`//${testMode ? 'sandbox.' : ''}masterpass.com/integration/merchant.js`)
+            .then(() => {
+                if (!this._window.masterpass) {
+                    throw new StandardError();
+                }
+
+                return this._window.masterpass;
+            });
+    }
+}

--- a/src/payment/strategies/masterpass/masterpass.mock.ts
+++ b/src/payment/strategies/masterpass/masterpass.mock.ts
@@ -1,0 +1,7 @@
+import { Masterpass } from './masterpass';
+
+export function getMasterpassScriptMock(): Masterpass {
+    return {
+        checkout: jest.fn(),
+    };
+}

--- a/src/payment/strategies/masterpass/masterpass.ts
+++ b/src/payment/strategies/masterpass/masterpass.ts
@@ -1,0 +1,49 @@
+/**
+ * The name of the masterpass script that is hosted by the browser window
+ */
+export interface MasterpassHostWindow extends Window {
+    /**
+     *  Use this to refer to the loaded masterpass client script instance
+     */
+    masterpass?: Masterpass;
+}
+
+/**
+ * Methods loaded by the masterpass script
+ */
+export interface Masterpass {
+    /**
+     * Proceed to checkout with the given parameters
+     */
+    checkout(options: MasterpassCheckoutOptions): void;
+}
+
+/**
+ * Payload that must be passed to masterpass script to start a checkout
+ */
+export interface MasterpassCheckoutOptions {
+    /**
+     * Merchant checkout identifier received when merchant onboarded for masterpass
+     */
+    checkoutId: string;
+    /**
+     * Card types accepted by merchant
+     */
+    allowedCardTypes: string[];
+    /**
+     * Shopping cart subtotal
+     */
+    amount: string;
+    /**
+     * Currency code for cart
+     */
+    currency: string;
+    /**
+     * Merchant Cart identifier
+     */
+    cartId: string;
+    /**
+     * This optional parameter can be used to override the callbackUrl specified in the Merchant Portal.
+     */
+    callbackUrl?: string;
+}


### PR DESCRIPTION
[INT-775](https://jira.bigcommerce.com/browse/INT-775)
### Depends on:
https://github.com/bigcommerce-labs/ng-checkout/pull/927
## What?
Add Masterpass button to the customer section on checkout

## Why?
When Masterpass is enabled on Stripe, Masterpass button can be used from Customer section of checkout page.

## Testing / Proof

![screen shot 2018-09-04 at 2 59 09 pm](https://user-images.githubusercontent.com/35502707/45055670-1f15d280-b056-11e8-8357-344df484f285.png)


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/integrations 
