### PR TITLE
Billing Address enhancements

### DIFF
--- a/src/billing/billing-address-action-creator.spec.ts
+++ b/src/billing/billing-address-action-creator.spec.ts
@@ -10,7 +10,7 @@ import { getErrorResponse, getResponse } from '../common/http-request/responses.
 
 import { BillingAddressRequestBody } from './billing-address';
 import BillingAddressActionCreator from './billing-address-action-creator';
-import { BillingAddressActionType, UpdateBillingAddressAction } from './billing-address-actions';
+import { BillingAddressAction, BillingAddressActionType, UpdateBillingAddressAction } from './billing-address-actions';
 import { getBillingAddress } from './billing-addresses.mock';
 
 describe('BillingAddressActionCreator', () => {
@@ -21,7 +21,7 @@ describe('BillingAddressActionCreator', () => {
     let response: Response<Checkout>;
     let state: CheckoutStoreState;
     let store: CheckoutStore;
-    let actions: UpdateBillingAddressAction[] | UpdateBillingAddressAction | undefined;
+    let actions: BillingAddressAction[] | BillingAddressAction | undefined;
 
     beforeEach(() => {
         response = getResponse(getCheckout());
@@ -94,8 +94,8 @@ describe('BillingAddressActionCreator', () => {
                     .toPromise();
 
                 expect(actions).toEqual([
-                    { type: BillingAddressActionType.UpdateBillingAddressRequested },
-                    { type: BillingAddressActionType.UpdateBillingAddressSucceeded, payload: response.body },
+                    { type: BillingAddressActionType.ContinueAsGuestRequested },
+                    { type: BillingAddressActionType.ContinueAsGuestSucceeded, payload: response.body },
                 ]);
             });
 
@@ -115,8 +115,8 @@ describe('BillingAddressActionCreator', () => {
 
                 expect(errorHandler).toHaveBeenCalled();
                 expect(actions).toEqual([
-                    { type: BillingAddressActionType.UpdateBillingAddressRequested },
-                    { type: BillingAddressActionType.UpdateBillingAddressFailed, payload: errorResponse, error: true },
+                    { type: BillingAddressActionType.ContinueAsGuestRequested },
+                    { type: BillingAddressActionType.ContinueAsGuestFailed, payload: errorResponse, error: true },
                 ]);
             });
 
@@ -149,8 +149,8 @@ describe('BillingAddressActionCreator', () => {
                     .toPromise();
 
                 expect(actions).toEqual([
-                    { type: BillingAddressActionType.UpdateBillingAddressRequested },
-                    { type: BillingAddressActionType.UpdateBillingAddressSucceeded, payload: response.body },
+                    { type: BillingAddressActionType.ContinueAsGuestRequested },
+                    { type: BillingAddressActionType.ContinueAsGuestSucceeded, payload: response.body },
                 ]);
             });
 
@@ -161,7 +161,7 @@ describe('BillingAddressActionCreator', () => {
                 const errorHandler = jest.fn();
 
                 actions = await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
-                    .catch((action: UpdateBillingAddressAction) => {
+                    .catch((action: BillingAddressAction) => {
                         errorHandler();
                         return Observable.of(action);
                     })
@@ -170,8 +170,8 @@ describe('BillingAddressActionCreator', () => {
 
                 expect(errorHandler).toHaveBeenCalled();
                 expect(actions).toEqual([
-                    { type: BillingAddressActionType.UpdateBillingAddressRequested },
-                    { type: BillingAddressActionType.UpdateBillingAddressFailed, payload: errorResponse, error: true },
+                    { type: BillingAddressActionType.ContinueAsGuestRequested },
+                    { type: BillingAddressActionType.ContinueAsGuestFailed, payload: errorResponse, error: true },
                 ]);
             });
 

--- a/src/billing/billing-address-action-creator.ts
+++ b/src/billing/billing-address-action-creator.ts
@@ -9,7 +9,7 @@ import { RequestOptions } from '../common/http-request';
 import { GuestCredentials } from '../customer';
 
 import { BillingAddressUpdateRequestBody } from './billing-address';
-import { BillingAddressActionType, UpdateBillingAddressAction } from './billing-address-actions';
+import { BillingAddressActionType, ContinueAsGuestAction, UpdateBillingAddressAction } from './billing-address-actions';
 
 export default class BillingAddressActionCreator {
     constructor(
@@ -19,8 +19,8 @@ export default class BillingAddressActionCreator {
     continueAsGuest(
         credentials: GuestCredentials,
         options?: RequestOptions
-    ): ThunkAction<UpdateBillingAddressAction, InternalCheckoutSelectors> {
-        return store => Observable.create((observer: Observer<UpdateBillingAddressAction>) => {
+    ): ThunkAction<ContinueAsGuestAction, InternalCheckoutSelectors> {
+        return store => Observable.create((observer: Observer<ContinueAsGuestAction>) => {
             const state = store.getState();
             const checkout = state.checkout.getCheckout();
 
@@ -49,15 +49,15 @@ export default class BillingAddressActionCreator {
                 };
             }
 
-            observer.next(createAction(BillingAddressActionType.UpdateBillingAddressRequested));
+            observer.next(createAction(BillingAddressActionType.ContinueAsGuestRequested));
 
             this._createOrUpdateBillingAddress(checkout.id, billingAddressRequestBody, options)
                 .then(({ body }) => {
-                    observer.next(createAction(BillingAddressActionType.UpdateBillingAddressSucceeded, body));
+                    observer.next(createAction(BillingAddressActionType.ContinueAsGuestSucceeded, body));
                     observer.complete();
                 })
                 .catch(response => {
-                    observer.error(createErrorAction(BillingAddressActionType.UpdateBillingAddressFailed, response));
+                    observer.error(createErrorAction(BillingAddressActionType.ContinueAsGuestFailed, response));
                 });
         });
     }

--- a/src/billing/billing-address-action-creator.ts
+++ b/src/billing/billing-address-action-creator.ts
@@ -3,9 +3,10 @@ import { Response } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
-import { Checkout, CheckoutClient, InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
-import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { Checkout, CheckoutClient, InternalCheckoutSelectors } from '../checkout';
+import { MissingDataError, MissingDataErrorType, StandardError } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
+import { GuestCredentials } from '../customer';
 
 import { BillingAddressUpdateRequestBody } from './billing-address';
 import { BillingAddressActionType, UpdateBillingAddressAction } from './billing-address-actions';
@@ -15,14 +16,42 @@ export default class BillingAddressActionCreator {
         private _checkoutClient: CheckoutClient
     ) {}
 
-    updateAddress(
-        address: Partial<BillingAddressUpdateRequestBody>,
+    continueAsGuest(
+        credentials: GuestCredentials,
         options?: RequestOptions
     ): ThunkAction<UpdateBillingAddressAction, InternalCheckoutSelectors> {
         return store => Observable.create((observer: Observer<UpdateBillingAddressAction>) => {
+            const state = store.getState();
+            const checkout = state.checkout.getCheckout();
+
+            if (!checkout) {
+                throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+            }
+
+            const customer = state.customer.getCustomer();
+
+            if (customer && !customer.isGuest) {
+                throw new StandardError('Cannot continue as guest: customer is logged in.');
+            }
+
+            const billingAddress = state.billingAddress.getBillingAddress();
+
+            let billingAddressRequestBody;
+
+            if (!billingAddress) {
+                billingAddressRequestBody = credentials;
+            } else {
+                const { country, ...existingBillingAddressRequestBody } = billingAddress;
+
+                billingAddressRequestBody = {
+                    ...existingBillingAddressRequestBody,
+                    ...credentials,
+                };
+            }
+
             observer.next(createAction(BillingAddressActionType.UpdateBillingAddressRequested));
 
-            this._requestBillingAddressUpdate(store, address, options)
+            this._createOrUpdateBillingAddress(checkout.id, billingAddressRequestBody, options)
                 .then(({ body }) => {
                     observer.next(createAction(BillingAddressActionType.UpdateBillingAddressSucceeded, body));
                     observer.complete();
@@ -33,37 +62,56 @@ export default class BillingAddressActionCreator {
         });
     }
 
-    private _requestBillingAddressUpdate(
-        store: ReadableCheckoutStore,
+    updateAddress(
+        address: Partial<BillingAddressUpdateRequestBody>,
+        options?: RequestOptions
+    ): ThunkAction<UpdateBillingAddressAction, InternalCheckoutSelectors> {
+        return store => Observable.create((observer: Observer<UpdateBillingAddressAction>) => {
+            const state = store.getState();
+            const checkout = state.checkout.getCheckout();
+
+            if (!checkout) {
+                throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+            }
+
+            observer.next(createAction(BillingAddressActionType.UpdateBillingAddressRequested));
+
+            const billingAddress = state.billingAddress.getBillingAddress();
+
+            // If email is not present in the address provided by the client, then
+            // fall back to the stored email as it could have been set separately
+            // using a convenience method. We can't rely on billingAddress having
+            // an ID to consider that there's a preexisting email, as billingAddress
+            // object from Order doesn't have an ID.
+            const billingAddressRequestBody = {
+                ...address,
+                email: typeof address.email === 'undefined' && billingAddress ? billingAddress.email : address.email,
+            };
+
+            if (billingAddress && billingAddress.id) {
+                billingAddressRequestBody.id = billingAddress.id;
+            }
+
+            this._createOrUpdateBillingAddress(checkout.id, billingAddressRequestBody, options)
+                .then(({ body }) => {
+                    observer.next(createAction(BillingAddressActionType.UpdateBillingAddressSucceeded, body));
+                    observer.complete();
+                })
+                .catch(response => {
+                    observer.error(createErrorAction(BillingAddressActionType.UpdateBillingAddressFailed, response));
+                });
+        });
+    }
+
+    private _createOrUpdateBillingAddress(
+        checkoutId: string,
         address: Partial<BillingAddressUpdateRequestBody>,
         options?: RequestOptions
     ): Promise<Response<Checkout>> {
-        const state = store.getState();
-        const checkout = state.checkout.getCheckout();
-
-        if (!checkout) {
-            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+        if (!address.id) {
+            return this._checkoutClient.createBillingAddress(checkoutId, address, options);
         }
 
-        const billingAddress = state.billingAddress.getBillingAddress();
-
-        // If email is not present in the address provided by the client, then
-        // fall back to the stored email as it could have been set separately
-        // using a convenience method. We can't rely on billingAddress having
-        // an ID to consider that there's a preexisting email, as billingAddress
-        // object from Order doesn't have an ID.
-        const billingAddressRequestBody = {
-            ...address,
-            email: typeof address.email === 'undefined' && billingAddress ? billingAddress.email : address.email,
-        };
-
-        if (!billingAddress || !billingAddress.id) {
-            return this._checkoutClient.createBillingAddress(checkout.id, billingAddressRequestBody, options);
-        }
-
-        return this._checkoutClient.updateBillingAddress(checkout.id, {
-            ...billingAddressRequestBody,
-            id: billingAddress.id,
-        }, options);
+        return this._checkoutClient.updateBillingAddress(checkoutId, address, options);
     }
 }

--- a/src/billing/billing-address-actions.ts
+++ b/src/billing/billing-address-actions.ts
@@ -6,15 +6,25 @@ export enum BillingAddressActionType {
     UpdateBillingAddressRequested = 'UPDATE_BILLING_ADDRESS_REQUESTED',
     UpdateBillingAddressSucceeded = 'UPDATE_BILLING_ADDRESS_SUCCEEDED',
     UpdateBillingAddressFailed = 'UPDATE_BILLING_ADDRESS_FAILED',
+
+    ContinueAsGuestRequested = 'CONTINUE_AS_GUEST_REQUESTED',
+    ContinueAsGuestSucceeded = 'CONTINUE_AS_GUEST_SUCCEEDED',
+    ContinueAsGuestFailed = 'CONTINUE_AS_GUEST_FAILED',
 }
 
 export type BillingAddressAction =
+    ContinueAsGuestAction |
     UpdateBillingAddressAction;
 
 export type UpdateBillingAddressAction =
     UpdateBillingAddressRequested |
     UpdateBillingAddressSucceeded |
     UpdateBillingAddressFailed;
+
+export type ContinueAsGuestAction =
+    ContinueAsGuestRequested |
+    ContinueAsGuestSucceeded |
+    ContinueAsGuestFailed;
 
 export interface UpdateBillingAddressRequested extends Action {
     type: BillingAddressActionType.UpdateBillingAddressRequested;
@@ -26,4 +36,16 @@ export interface UpdateBillingAddressSucceeded extends Action<Checkout> {
 
 export interface UpdateBillingAddressFailed extends Action<Error> {
     type: BillingAddressActionType.UpdateBillingAddressFailed;
+}
+
+export interface ContinueAsGuestRequested extends Action {
+    type: BillingAddressActionType.ContinueAsGuestRequested;
+}
+
+export interface ContinueAsGuestSucceeded extends Action<Checkout> {
+    type: BillingAddressActionType.ContinueAsGuestSucceeded;
+}
+
+export interface ContinueAsGuestFailed extends Action<Error> {
+    type: BillingAddressActionType.ContinueAsGuestFailed;
 }

--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -31,6 +31,7 @@ function dataReducer(
 ): BillingAddress | undefined {
     switch (action.type) {
     case BillingAddressActionType.UpdateBillingAddressSucceeded:
+    case BillingAddressActionType.ContinueAsGuestSucceeded:
     case CheckoutActionType.LoadCheckoutSucceeded:
     case OrderActionType.LoadOrderSucceeded:
         return action.payload ? action.payload.billingAddress : data;
@@ -59,6 +60,13 @@ function errorsReducer(
     case BillingAddressActionType.UpdateBillingAddressFailed:
         return { ...errors, updateError: action.payload };
 
+    case BillingAddressActionType.ContinueAsGuestRequested:
+    case BillingAddressActionType.ContinueAsGuestSucceeded:
+        return { ...errors, continueAsGuestError: undefined };
+
+    case BillingAddressActionType.ContinueAsGuestFailed:
+        return { ...errors, continueAsGuestError: action.payload };
+
     default:
         return errors;
     }
@@ -82,6 +90,13 @@ function statusesReducer(
     case BillingAddressActionType.UpdateBillingAddressFailed:
     case BillingAddressActionType.UpdateBillingAddressSucceeded:
         return { ...statuses, isUpdating: false };
+
+    case BillingAddressActionType.ContinueAsGuestRequested:
+        return { ...statuses, isContinuingAsGuest: true };
+
+    case BillingAddressActionType.ContinueAsGuestFailed:
+    case BillingAddressActionType.ContinueAsGuestSucceeded:
+        return { ...statuses, isContinuingAsGuest: false };
 
     default:
         return statuses;

--- a/src/billing/billing-address-selector.spec.js
+++ b/src/billing/billing-address-selector.spec.js
@@ -45,6 +45,26 @@ describe('BillingAddressSelector', () => {
         });
     });
 
+    describe('#getContinueAsGuestError()', () => {
+        it('returns error if unable to update', () => {
+            const continueAsGuestError = getErrorResponse();
+
+
+            billingAddressSelector = new BillingAddressSelector({
+                ...state.billingAddress,
+                errors: { continueAsGuestError },
+            });
+
+            expect(billingAddressSelector.getContinueAsGuestError()).toEqual(continueAsGuestError);
+        });
+
+        it('does not returns error if able to update', () => {
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+
+            expect(billingAddressSelector.getContinueAsGuestError()).toBeUndefined();
+        });
+    });
+
     describe('#isUpdating()', () => {
         it('returns true if updating billing address', () => {
             billingAddressSelector = new BillingAddressSelector({
@@ -59,6 +79,23 @@ describe('BillingAddressSelector', () => {
             billingAddressSelector = new BillingAddressSelector(state.billingAddress);
 
             expect(billingAddressSelector.isUpdating()).toEqual(false);
+        });
+    });
+
+    describe('#isContinuingAsGuest()', () => {
+        it('returns true if updating billing address', () => {
+            billingAddressSelector = new BillingAddressSelector({
+                ...state.billingAddress,
+                statuses: { isContinuingAsGuest: true },
+            });
+
+            expect(billingAddressSelector.isContinuingAsGuest()).toEqual(true);
+        });
+
+        it('returns false if not updating billing address', () => {
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+
+            expect(billingAddressSelector.isContinuingAsGuest()).toEqual(false);
         });
     });
 });

--- a/src/billing/billing-address-selector.ts
+++ b/src/billing/billing-address-selector.ts
@@ -17,12 +17,20 @@ export default class BillingAddressSelector {
         return this._billingAddress.errors.updateError;
     }
 
+    getContinueAsGuestError(): Error | undefined {
+        return this._billingAddress.errors.continueAsGuestError;
+    }
+
     getLoadError(): Error | undefined {
         return this._billingAddress.errors.loadError;
     }
 
     isUpdating(): boolean {
         return !!this._billingAddress.statuses.isUpdating;
+    }
+
+    isContinuingAsGuest(): boolean {
+        return !!this._billingAddress.statuses.isContinuingAsGuest;
     }
 
     isLoading(): boolean {

--- a/src/billing/billing-address-state.ts
+++ b/src/billing/billing-address-state.ts
@@ -9,9 +9,11 @@ export default interface BillingAddressState {
 export interface BillingAddressErrorsState {
     loadError?: Error;
     updateError?: Error;
+    continueAsGuestError?: Error;
 }
 
 export interface BillingAddressStatusesState {
     isLoading?: boolean;
     isUpdating?: boolean;
+    isContinuingAsGuest?: boolean;
 }

--- a/src/billing/billing-address.ts
+++ b/src/billing/billing-address.ts
@@ -5,7 +5,10 @@ export default interface BillingAddress extends Address {
     email?: string;
 }
 
-export interface BillingAddressUpdateRequestBody extends AddressRequestBody {
-    id: string;
+export interface BillingAddressRequestBody extends AddressRequestBody {
     email?: string;
+}
+
+export interface BillingAddressUpdateRequestBody extends BillingAddressRequestBody {
+    id: string;
 }

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -1,6 +1,6 @@
 export * from './billing-address-actions';
 
-export { default as BillingAddress, BillingAddressUpdateRequestBody } from './billing-address';
+export { default as BillingAddress, BillingAddressRequestBody, BillingAddressUpdateRequestBody } from './billing-address';
 export { default as BillingAddressSelector } from './billing-address-selector';
 export { default as BillingAddressActionCreator } from './billing-address-action-creator';
 export { default as BillingAddressState } from './billing-address-state';

--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -603,14 +603,14 @@ describe('CheckoutService', () => {
         it('dispatches action to continue as guest', async () => {
             const action = Observable.of(createAction('SIGN_IN_GUEST'));
 
-            jest.spyOn(billingAddressActionCreator, 'updateAddress')
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
                 .mockReturnValue(action);
 
             jest.spyOn(store, 'dispatch');
 
             await checkoutService.continueAsGuest({ email: 'foo@bar.com' });
 
-            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith({ email: 'foo@bar.com' }, undefined);
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith({ email: 'foo@bar.com' }, undefined);
             expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
         });
     });

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -904,7 +904,7 @@ export default class CheckoutService {
      * @param options - Options for updating the billing address.
      * @returns A promise that resolves to the current state.
      */
-    updateBillingAddress(address: AddressRequestBody, options: RequestOptions = {}): Promise<CheckoutSelectors> {
+    updateBillingAddress(address: BillingAddressRequestBody, options: RequestOptions = {}): Promise<CheckoutSelectors> {
         const action = this._billingAddressActionCreator.updateAddress(address, options);
 
         return this._dispatch(action);

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -2,7 +2,7 @@ import { Action, ThunkAction } from '@bigcommerce/data-store';
 import { Observable } from 'rxjs/Observable';
 
 import { AddressRequestBody } from '../address';
-import { BillingAddressActionCreator } from '../billing';
+import { BillingAddressActionCreator, BillingAddressRequestBody } from '../billing';
 import { ErrorMessageTransformer } from '../common/error';
 import { RequestOptions } from '../common/http-request';
 import { ConfigActionCreator } from '../config';
@@ -550,7 +550,7 @@ export default class CheckoutService {
      * @returns A promise that resolves to the current state.
      */
     continueAsGuest(credentials: GuestCredentials, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._billingAddressActionCreator.updateAddress(credentials, options);
+        const action = this._billingAddressActionCreator.continueAsGuest(credentials, options);
 
         return this._dispatch(action);
     }

--- a/src/checkout/checkout-store-error-selector.spec.js
+++ b/src/checkout/checkout-store-error-selector.spec.js
@@ -289,17 +289,17 @@ describe('CheckoutStoreErrorSelector', () => {
 
     describe('#getContinueAsGuestError()', () => {
         it('returns error if there is an error', () => {
-            jest.spyOn(selectors.billingAddress, 'getUpdateError').mockReturnValue(errorResponse);
+            jest.spyOn(selectors.billingAddress, 'getContinueAsGuestError').mockReturnValue(errorResponse);
 
             expect(errors.getContinueAsGuestError()).toEqual(errorResponse);
-            expect(selectors.billingAddress.getUpdateError).toHaveBeenCalled();
+            expect(selectors.billingAddress.getContinueAsGuestError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO errors', () => {
-            jest.spyOn(selectors.billingAddress, 'getUpdateError').mockReturnValue();
+            jest.spyOn(selectors.billingAddress, 'getContinueAsGuestError').mockReturnValue();
 
             expect(errors.getContinueAsGuestError()).toEqual(undefined);
-            expect(selectors.billingAddress.getUpdateError).toHaveBeenCalled();
+            expect(selectors.billingAddress.getContinueAsGuestError).toHaveBeenCalled();
         });
     });
 

--- a/src/checkout/checkout-store-error-selector.spec.js
+++ b/src/checkout/checkout-store-error-selector.spec.js
@@ -287,6 +287,22 @@ describe('CheckoutStoreErrorSelector', () => {
         });
     });
 
+    describe('#getContinueAsGuestError()', () => {
+        it('returns error if there is an error', () => {
+            jest.spyOn(selectors.billingAddress, 'getUpdateError').mockReturnValue(errorResponse);
+
+            expect(errors.getContinueAsGuestError()).toEqual(errorResponse);
+            expect(selectors.billingAddress.getUpdateError).toHaveBeenCalled();
+        });
+
+        it('returns undefined if there is NO errors', () => {
+            jest.spyOn(selectors.billingAddress, 'getUpdateError').mockReturnValue();
+
+            expect(errors.getContinueAsGuestError()).toEqual(undefined);
+            expect(selectors.billingAddress.getUpdateError).toHaveBeenCalled();
+        });
+    });
+
     describe('#getUpdateConsignmentError()', () => {
         it('returns error if there is an error when updating consignments', () => {
             jest.spyOn(selectors.consignments, 'getUpdateError').mockReturnValue(errorResponse);

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -257,7 +257,7 @@ export default class CheckoutStoreErrorSelector {
      * @returns The error object if unable to continue, otherwise undefined.
      */
     getContinueAsGuestError(): Error | undefined {
-        return this._billingAddress.getUpdateError();
+        return this._billingAddress.getContinueAsGuestError();
     }
 
     /**

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -84,6 +84,7 @@ export default class CheckoutStoreErrorSelector {
             this.getInitializeCustomerError() ||
             this.getUpdateShippingAddressError() ||
             this.getUpdateBillingAddressError() ||
+            this.getContinueAsGuestError() ||
             this.getUpdateConsignmentError() ||
             this.getCreateConsignmentsError() ||
             this.getDeleteConsignmentError() ||
@@ -248,6 +249,15 @@ export default class CheckoutStoreErrorSelector {
     getSelectShippingOptionError(consignmentId?: string): Error | undefined {
         return this._shippingStrategies.getSelectOptionError() ||
             this._consignments.getUpdateShippingOptionError(consignmentId);
+    }
+
+    /**
+     * Returns an error if unable to continue as guest.
+     *
+     * @returns The error object if unable to continue, otherwise undefined.
+     */
+    getContinueAsGuestError(): Error | undefined {
+        return this._billingAddress.getUpdateError();
     }
 
     /**

--- a/src/checkout/checkout-store-status-selector.spec.js
+++ b/src/checkout/checkout-store-status-selector.spec.js
@@ -289,17 +289,17 @@ describe('CheckoutStoreStatusSelector', () => {
 
     describe('#isContinuingAsGuest()', () => {
         it('returns true if continuing as guest', () => {
-            jest.spyOn(selectors.billingAddress, 'isUpdating').mockReturnValue(true);
+            jest.spyOn(selectors.billingAddress, 'isContinuingAsGuest').mockReturnValue(true);
 
             expect(statuses.isContinuingAsGuest()).toEqual(true);
-            expect(selectors.billingAddress.isUpdating).toHaveBeenCalled();
+            expect(selectors.billingAddress.isContinuingAsGuest).toHaveBeenCalled();
         });
 
         it('returns false if not continuing as guest', () => {
-            jest.spyOn(selectors.billingAddress, 'isUpdating').mockReturnValue(false);
+            jest.spyOn(selectors.billingAddress, 'isContinuingAsGuest').mockReturnValue(false);
 
             expect(statuses.isContinuingAsGuest()).toEqual(false);
-            expect(selectors.billingAddress.isUpdating).toHaveBeenCalled();
+            expect(selectors.billingAddress.isContinuingAsGuest).toHaveBeenCalled();
         });
     });
 

--- a/src/checkout/checkout-store-status-selector.spec.js
+++ b/src/checkout/checkout-store-status-selector.spec.js
@@ -287,6 +287,22 @@ describe('CheckoutStoreStatusSelector', () => {
         });
     });
 
+    describe('#isContinuingAsGuest()', () => {
+        it('returns true if continuing as guest', () => {
+            jest.spyOn(selectors.billingAddress, 'isUpdating').mockReturnValue(true);
+
+            expect(statuses.isContinuingAsGuest()).toEqual(true);
+            expect(selectors.billingAddress.isUpdating).toHaveBeenCalled();
+        });
+
+        it('returns false if not continuing as guest', () => {
+            jest.spyOn(selectors.billingAddress, 'isUpdating').mockReturnValue(false);
+
+            expect(statuses.isContinuingAsGuest()).toEqual(false);
+            expect(selectors.billingAddress.isUpdating).toHaveBeenCalled();
+        });
+    });
+
     describe('#isUpdatingShippingAddress()', () => {
         it('returns true if updating shipping address', () => {
             jest.spyOn(selectors.shippingStrategies, 'isUpdatingAddress').mockReturnValue(true);

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -82,6 +82,7 @@ export default class CheckoutStoreStatusSelector {
             this.isSigningOut() ||
             this.isInitializingCustomer() ||
             this.isUpdatingBillingAddress() ||
+            this.isContinuingAsGuest() ||
             this.isUpdatingShippingAddress() ||
             this.isUpdatingConsignment() ||
             this.isCreatingConsignments() ||
@@ -272,7 +273,7 @@ export default class CheckoutStoreStatusSelector {
     }
 
     /**
-     * Checks whether the current customer is updating their billing address.
+     * Checks whether the billing address is being updated.
      *
      * @returns True if updating their billing address, otherwise false.
      */
@@ -281,7 +282,16 @@ export default class CheckoutStoreStatusSelector {
     }
 
     /**
-     * Checks whether the current customer is updating their shipping address.
+     * Checks whether the shopper is continuing out as a guest.
+     *
+     * @returns True if continuing as guest, otherwise false.
+     */
+    isContinuingAsGuest(): boolean {
+        return this._billingAddress.isUpdating();
+    }
+
+    /**
+     * Checks the shipping address is being updated.
      *
      * @returns True if updating their shipping address, otherwise false.
      */

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -287,7 +287,7 @@ export default class CheckoutStoreStatusSelector {
      * @returns True if continuing as guest, otherwise false.
      */
     isContinuingAsGuest(): boolean {
-        return this._billingAddress.isUpdating();
+        return this._billingAddress.isContinuingAsGuest();
     }
 
     /**


### PR DESCRIPTION
- Add status/error selectors for `CheckutService#continueAsGuest`
- Update `CheckutService#continueAsGuest` signature
- Do not overwrite billing info when using `CheckutService#continueAsGuest`

@bigcommerce/checkout @bigcommerce/payments
