### PR TITLE
CHECKOUT-3011: Move Paypal related strategies to Paypal folder

### DIFF
--- a/src/payment/strategies/index.ts
+++ b/src/payment/strategies/index.ts
@@ -4,13 +4,12 @@ export { default as NoPaymentDataRequiredPaymentStrategy } from './no-payment-da
 export { default as OfflinePaymentStrategy } from './offline-payment-strategy';
 export { default as OffsitePaymentStrategy } from './offsite-payment-strategy';
 export { default as PaymentStrategy } from './payment-strategy';
-export { default as PaypalExpressPaymentStrategy } from './paypal-express-payment-strategy';
-export { default as PaypalProPaymentStrategy } from './paypal-pro-payment-strategy';
 export { default as SagePayPaymentStrategy } from './sage-pay-payment-strategy';
 
 export { AfterpayPaymentStrategy } from './afterpay';
 export { AmazonPayPaymentStrategy, AmazonPayPaymentInitializeOptions } from './amazon-pay';
 export { BraintreeCreditCardPaymentStrategy, BraintreePaymentInitializeOptions, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy, BraintreeVisaCheckoutPaymentInitializeOptions } from './braintree';
 export { KlarnaPaymentStrategy, KlarnaPaymentInitializeOptions } from './klarna';
+export { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy } from './paypal';
 export { SquarePaymentStrategy, SquarePaymentInitializeOptions } from './square';
 export { WepayPaymentStrategy } from './wepay';

--- a/src/payment/strategies/paypal/index.ts
+++ b/src/payment/strategies/paypal/index.ts
@@ -1,3 +1,5 @@
 export * from './paypal-sdk';
 
 export { default as PaypalScriptLoader } from './paypal-script-loader';
+export { default as PaypalExpressPaymentStrategy } from './paypal-express-payment-strategy';
+export { default as PaypalProPaymentStrategy } from './paypal-pro-payment-strategy';

--- a/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
@@ -4,18 +4,19 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
 import { Observable } from 'rxjs';
 
-import { createCheckoutClient, createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../checkout';
-import { getCheckoutPayment, getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../../checkout/checkouts.mock';
-import { getCustomer } from '../../customer/internal-customers.mock';
-import { FinalizeOrderAction, InternalOrder, OrderActionCreator, OrderActionType, OrderRequestBody, SubmitOrderAction } from '../../order';
-import { OrderFinalizationNotRequiredError } from '../../order/errors';
-import { getOrderRequestBody, getSubmittedOrder } from '../../order/internal-orders.mock';
-import PaymentMethod from '../payment-method';
-import { getPaypalExpress } from '../payment-methods.mock';
-import * as paymentStatusTypes from '../payment-status-types';
+import { createCheckoutClient, createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../../checkout';
+import { getCheckoutPayment, getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
+import { getCustomer } from '../../../customer/internal-customers.mock';
+import { FinalizeOrderAction, InternalOrder, OrderActionCreator, OrderActionType, OrderRequestBody, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody, getSubmittedOrder } from '../../../order/internal-orders.mock';
+import PaymentMethod from '../../payment-method';
+import { getPaypalExpress } from '../../payment-methods.mock';
+import * as paymentStatusTypes from '../../payment-status-types';
 
-import { PaypalScriptLoader, PaypalSDK } from './paypal';
 import PaypalExpressPaymentStrategy from './paypal-express-payment-strategy';
+import PaypalScriptLoader from './paypal-script-loader';
+import { PaypalSDK } from './paypal-sdk';
 
 describe('PaypalExpressPaymentStrategy', () => {
     let finalizeOrderAction: Observable<FinalizeOrderAction>;

--- a/src/payment/strategies/paypal/paypal-express-payment-strategy.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-strategy.ts
@@ -1,12 +1,13 @@
-import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
-import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../common/error/errors';
-import { OrderActionCreator, OrderRequestBody } from '../../order';
-import PaymentMethod from '../payment-method';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../payment-request-options';
-import * as paymentStatusTypes from '../payment-status-types';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import PaymentMethod from '../../payment-method';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import * as paymentStatusTypes from '../../payment-status-types';
+import PaymentStrategy from '../payment-strategy';
 
-import PaymentStrategy from './payment-strategy';
-import { PaypalScriptLoader, PaypalSDK } from './paypal';
+import PaypalScriptLoader from './paypal-script-loader';
+import { PaypalSDK } from './paypal-sdk';
 
 export default class PaypalExpressPaymentStrategy extends PaymentStrategy {
     private _paypalSdk?: PaypalSDK;

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
@@ -1,16 +1,17 @@
+
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
 import { Observable } from 'rxjs';
 
-import { createCheckoutClient, createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../checkout';
-import { getCheckoutStoreState, getCheckoutWithPayments } from '../../checkout/checkouts.mock';
-import { OrderActionCreator, OrderActionType, SubmitOrderAction } from '../../order';
-import { getOrderRequestBody } from '../../order/internal-orders.mock';
-import PaymentActionCreator from '../payment-action-creator';
-import { PaymentActionType, SubmitPaymentAction } from '../payment-actions';
-import PaymentRequestSender from '../payment-request-sender';
+import { createCheckoutClient, createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../../checkout';
+import { getCheckoutStoreState, getCheckoutWithPayments } from '../../../checkout/checkouts.mock';
+import { OrderActionCreator, OrderActionType, SubmitOrderAction } from '../../../order';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import PaymentRequestSender from '../../payment-request-sender';
 
 import PaypalProPaymentStrategy from './paypal-pro-payment-strategy';
 

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.ts
@@ -1,11 +1,11 @@
-import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
-import { OrderActionCreator, OrderRequestBody } from '../../order';
-import { PaymentArgumentInvalidError } from '../errors';
-import PaymentActionCreator from '../payment-action-creator';
-import { PaymentRequestOptions } from '../payment-request-options';
-import * as paymentStatusTypes from '../payment-status-types';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentRequestOptions } from '../../payment-request-options';
+import * as paymentStatusTypes from '../../payment-status-types';
 
-import PaymentStrategy from './payment-strategy';
+import PaymentStrategy from '../payment-strategy';
 
 export default class PaypalProPaymentStrategy extends PaymentStrategy {
     constructor(


### PR DESCRIPTION
## What?
* Move Paypal related strategies to Paypal folder

## Why?
* Better organisation

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
