### PR TITLE
CHECKOUT-3011: Make sure the host config is passed to the dependencies of `CheckoutService` and `CheckoutButtonInitializer`

### DIFF
--- a/src/billing/billing-address-action-creator.spec.ts
+++ b/src/billing/billing-address-action-creator.spec.ts
@@ -1,4 +1,4 @@
-import { Response } from '@bigcommerce/request-sender';
+import { createRequestSender, Response } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
 import { Observable } from 'rxjs';
 
@@ -26,7 +26,7 @@ describe('BillingAddressActionCreator', () => {
         response = getResponse(getCheckout());
         errorResponse = getErrorResponse();
         state = getCheckoutStoreState();
-        checkoutClient = createCheckoutClient();
+        checkoutClient = createCheckoutClient(createRequestSender());
 
         jest.spyOn(checkoutClient, 'updateBillingAddress').mockImplementation(() => Promise.resolve(response));
         jest.spyOn(checkoutClient, 'createBillingAddress').mockImplementation(() => Promise.resolve(response));

--- a/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -20,7 +20,7 @@ describe('CheckoutButtonInitializer', () => {
     beforeEach(() => {
         store = createCheckoutStore();
         buttonActionCreator = new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store),
+            createCheckoutButtonRegistry(store, createRequestSender()),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()))
         );
 

--- a/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -39,7 +39,7 @@ export default function createCheckoutButtonInitializer(
     return new CheckoutButtonInitializer(
         store,
         new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store),
+            createCheckoutButtonRegistry(store, requestSender),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender))
         )
     );

--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -1,3 +1,5 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+
 import { createCheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
 
@@ -8,7 +10,7 @@ describe('createCheckoutButtonRegistry', () => {
     let registry: Registry<CheckoutButtonStrategy>;
 
     beforeEach(() => {
-        registry = createCheckoutButtonRegistry(createCheckoutStore());
+        registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender());
     });
 
     it('returns registry with Braintree PayPal registered', () => {

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -1,5 +1,5 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
@@ -10,10 +10,12 @@ import { PaypalScriptLoader } from '../payment/strategies/paypal';
 
 import { BraintreePaypalButtonStrategy, CheckoutButtonStrategy } from './strategies';
 
-export default function createCheckoutButtonRegistry(store: CheckoutStore): Registry<CheckoutButtonStrategy> {
+export default function createCheckoutButtonRegistry(
+    store: CheckoutStore,
+    requestSender: RequestSender
+): Registry<CheckoutButtonStrategy> {
     const registry = new Registry<CheckoutButtonStrategy>();
     const scriptLoader = getScriptLoader();
-    const requestSender = createRequestSender();
     const checkoutActionCreator = new CheckoutActionCreator(
         new CheckoutRequestSender(requestSender),
         new ConfigActionCreator(new ConfigRequestSender(requestSender))

--- a/src/checkout/create-checkout-client.spec.ts
+++ b/src/checkout/create-checkout-client.spec.ts
@@ -1,9 +1,11 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+
 import CheckoutClient from './checkout-client';
 import createCheckoutClient from './create-checkout-client';
 
 describe('createCheckoutClient()', () => {
     it('creates an instance of CheckoutClient', () => {
-        const checkoutClient = createCheckoutClient();
+        const checkoutClient = createCheckoutClient(createRequestSender());
 
         expect(checkoutClient).toEqual(expect.any(CheckoutClient));
     });

--- a/src/checkout/create-checkout-client.ts
+++ b/src/checkout/create-checkout-client.ts
@@ -1,4 +1,4 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { RequestSender } from '@bigcommerce/request-sender';
 
 import { BillingAddressRequestSender } from '../billing';
 import { CustomerRequestSender } from '../customer';
@@ -8,9 +8,10 @@ import { ShippingCountryRequestSender } from '../shipping';
 
 import CheckoutClient from './checkout-client';
 
-export default function createCheckoutClient(config: { locale?: string } = {}): CheckoutClient {
-    const requestSender = createRequestSender();
-
+export default function createCheckoutClient(
+    requestSender: RequestSender,
+    config: { locale?: string } = {}
+): CheckoutClient {
     const billingAddressRequestSender = new BillingAddressRequestSender(requestSender);
     const countryRequestSender = new CountryRequestSender(requestSender, config);
     const customerRequestSender = new CustomerRequestSender(requestSender);

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -45,10 +45,10 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     }
 
     const { locale = '', shouldWarnMutation = true } = options || {};
-    const client = createCheckoutClient({ locale });
+    const requestSender = createRequestSender({ host: options && options.host });
+    const client = createCheckoutClient(requestSender, { locale });
     const store = createCheckoutStore({}, { shouldWarnMutation });
     const paymentClient = createPaymentClient(store);
-    const requestSender = createRequestSender({ host: options && options.host });
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const configActionCreator = new ConfigActionCreator(new ConfigRequestSender(requestSender));
     const orderActionCreator = new OrderActionCreator(client, new CheckoutValidator(checkoutRequestSender));
@@ -61,17 +61,17 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new ConsignmentActionCreator(new ConsignmentRequestSender(requestSender), checkoutRequestSender),
         new CountryActionCreator(client),
         new CouponActionCreator(new CouponRequestSender(requestSender)),
-        new CustomerStrategyActionCreator(createCustomerStrategyRegistry(store)),
+        new CustomerStrategyActionCreator(createCustomerStrategyRegistry(store, requestSender)),
         new GiftCertificateActionCreator(new GiftCertificateRequestSender(requestSender)),
         new InstrumentActionCreator(new InstrumentRequestSender(paymentClient, requestSender)),
         orderActionCreator,
         new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
         new PaymentStrategyActionCreator(
-            createPaymentStrategyRegistry(store, client, paymentClient),
+            createPaymentStrategyRegistry(store, client, paymentClient, requestSender),
             orderActionCreator
         ),
         new ShippingCountryActionCreator(client),
-        new ShippingStrategyActionCreator(createShippingStrategyRegistry(store))
+        new ShippingStrategyActionCreator(createShippingStrategyRegistry(store, requestSender))
     );
 }
 

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -1,5 +1,5 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
@@ -22,9 +22,11 @@ import {
     DefaultCustomerStrategy,
 } from './strategies';
 
-export default function createCustomerStrategyRegistry(store: CheckoutStore): Registry<CustomerStrategy> {
+export default function createCustomerStrategyRegistry(
+    store: CheckoutStore,
+    requestSender: RequestSender
+): Registry<CustomerStrategy> {
     const registry = new Registry<CustomerStrategy>();
-    const requestSender = createRequestSender();
     const checkoutActionCreator = new CheckoutActionCreator(
         new CheckoutRequestSender(requestSender),
         new ConfigActionCreator(new ConfigRequestSender(requestSender))
@@ -50,7 +52,7 @@ export default function createCustomerStrategyRegistry(store: CheckoutStore): Re
             paymentMethodActionCreator,
             new CustomerStrategyActionCreator(registry),
             remoteCheckoutActionCreator,
-            createBraintreeVisaCheckoutPaymentProcessor(getScriptLoader()),
+            createBraintreeVisaCheckoutPaymentProcessor(getScriptLoader(), requestSender),
             new VisaCheckoutScriptLoader(getScriptLoader())
         )
     );

--- a/src/customer/customer-strategy-action-creator.spec.ts
+++ b/src/customer/customer-strategy-action-creator.spec.ts
@@ -27,7 +27,7 @@ describe('CustomerStrategyActionCreator', () => {
         );
 
         store = createCheckoutStore();
-        registry = createCustomerStrategyRegistry(store);
+        registry = createCustomerStrategyRegistry(store, createRequestSender());
         strategy = new DefaultCustomerStrategy(
             store,
             new CustomerActionCreator(

--- a/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
@@ -35,7 +35,8 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
 
     beforeEach(() => {
         const scriptLoader = createScriptLoader();
-        braintreeVisaCheckoutPaymentProcessor = createBraintreeVisaCheckoutPaymentProcessor(scriptLoader);
+        const requestSender = createRequestSender();
+        braintreeVisaCheckoutPaymentProcessor = createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender);
         braintreeVisaCheckoutPaymentProcessor.initialize = jest.fn(() => Promise.resolve());
         braintreeVisaCheckoutPaymentProcessor.handleSuccess = jest.fn(() => Promise.resolve());
 
@@ -56,7 +57,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         visaCheckoutScriptLoader = new VisaCheckoutScriptLoader(scriptLoader);
         visaCheckoutScriptLoader.load = jest.fn(() => Promise.resolve(visaCheckoutSDK));
 
-        const registry = createCustomerStrategyRegistry(store);
+        const registry = createCustomerStrategyRegistry(store, createRequestSender());
         const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
         const configRequestSender = new ConfigRequestSender(createRequestSender());
         const configActionCreator = new ConfigActionCreator(configRequestSender);

--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -1,4 +1,5 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { createCheckoutClient, createCheckoutStore } from '../checkout';
 
@@ -24,9 +25,10 @@ describe('CreatePaymentStrategyRegistry', () => {
 
     beforeEach(() => {
         const store = createCheckoutStore();
-        const client = createCheckoutClient();
+        const requestSender = createRequestSender();
+        const client = createCheckoutClient(requestSender);
         const paymentClient = createPaymentClient();
-        registry = createPaymentStrategyRegistry(store, client, paymentClient);
+        registry = createPaymentStrategyRegistry(store, client, paymentClient, requestSender);
     });
 
     it('can create a payment strategy registry', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -1,5 +1,5 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import { BillingAddressActionCreator } from '../billing';
@@ -43,12 +43,12 @@ import { WepayRiskClient } from './strategies/wepay';
 export default function createPaymentStrategyRegistry(
     store: CheckoutStore,
     client: CheckoutClient,
-    paymentClient: any
+    paymentClient: any,
+    requestSender: RequestSender
 ) {
     const registry = new PaymentStrategyRegistry(store, { defaultToken: 'creditcard' });
     const scriptLoader = getScriptLoader();
     const braintreePaymentProcessor = createBraintreePaymentProcessor(scriptLoader);
-    const requestSender = createRequestSender();
 
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
@@ -59,7 +59,7 @@ export default function createPaymentStrategyRegistry(
     );
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-        new RemoteCheckoutRequestSender(createRequestSender())
+        new RemoteCheckoutRequestSender(requestSender)
     );
 
     registry.register('afterpay', () =>
@@ -215,7 +215,7 @@ export default function createPaymentStrategyRegistry(
             new PaymentStrategyActionCreator(registry, orderActionCreator),
             paymentActionCreator,
             orderActionCreator,
-            createBraintreeVisaCheckoutPaymentProcessor(scriptLoader),
+            createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender),
             new VisaCheckoutScriptLoader(scriptLoader)
         )
     );

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -1,3 +1,4 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
 import { createCheckoutClient, createCheckoutStore, CheckoutClient, CheckoutStore, CheckoutValidator } from '../checkout';
@@ -21,7 +22,7 @@ describe('PaymentActionCreator', () => {
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreStateWithOrder());
-        client = createCheckoutClient();
+        client = createCheckoutClient(createRequestSender());
         paymentRequestSender = new PaymentRequestSender(createPaymentClient(store));
 
         jest.spyOn(client, 'loadOrder')

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -1,6 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction } from '@bigcommerce/data-store';
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { merge } from 'lodash';
 import { Observable } from 'rxjs';
 
@@ -26,6 +26,7 @@ describe('PaymentStrategyActionCreator', () => {
     let client: CheckoutClient;
     let orderActionCreator: OrderActionCreator;
     let paymentClient: any;
+    let requestSender: RequestSender;
     let registry: PaymentStrategyRegistry;
     let state: CheckoutStoreState;
     let store: CheckoutStore;
@@ -35,9 +36,10 @@ describe('PaymentStrategyActionCreator', () => {
     beforeEach(() => {
         state = getCheckoutStoreState();
         store = createCheckoutStore(state);
-        client = createCheckoutClient();
+        requestSender = createRequestSender();
+        client = createCheckoutClient(requestSender);
         paymentClient = createPaymentClient();
-        registry = createPaymentStrategyRegistry(store, client, paymentClient);
+        registry = createPaymentStrategyRegistry(store, client, paymentClient, requestSender);
         orderActionCreator = new OrderActionCreator(
             client,
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
@@ -277,7 +279,7 @@ describe('PaymentStrategyActionCreator', () => {
                 ...state,
                 paymentMethods: { ...state.paymentMethods, data: [] },
             });
-            registry = createPaymentStrategyRegistry(store, client, paymentClient);
+            registry = createPaymentStrategyRegistry(store, client, paymentClient, requestSender);
 
             const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
 
@@ -298,7 +300,7 @@ describe('PaymentStrategyActionCreator', () => {
                 }),
             });
 
-            registry = createPaymentStrategyRegistry(store, client, paymentClient);
+            registry = createPaymentStrategyRegistry(store, client, paymentClient, requestSender);
 
             jest.spyOn(registry, 'get')
                 .mockReturnValue(noPaymentDataStrategy);
@@ -401,7 +403,7 @@ describe('PaymentStrategyActionCreator', () => {
                 ...state,
                 order: getOrderState(),
             });
-            registry = createPaymentStrategyRegistry(store, client, paymentClient);
+            registry = createPaymentStrategyRegistry(store, client, paymentClient, requestSender);
 
             const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
 

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -49,7 +49,7 @@ describe('AfterpayPaymentStrategy', () => {
     };
 
     beforeEach(() => {
-        client = createCheckoutClient();
+        client = createCheckoutClient(createRequestSender());
         store = createCheckoutStore(getCheckoutStoreState());
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         checkoutRequestSender = new CheckoutRequestSender(createRequestSender());

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -84,7 +84,7 @@ describe('AmazonPayPaymentStrategy', () => {
 
     beforeEach(() => {
         container = document.createElement('div');
-        client = createCheckoutClient();
+        client = createCheckoutClient(createRequestSender());
         state = getCheckoutStoreState();
         store = createCheckoutStore({
             ...state,

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -48,7 +48,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
         store = createCheckoutStore(getCheckoutStoreState());
 
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
         paymentActionCreator = new PaymentActionCreator(

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -50,7 +50,8 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
 
     beforeEach(() => {
         const scriptLoader = createScriptLoader();
-        braintreeVisaCheckoutPaymentProcessor = createBraintreeVisaCheckoutPaymentProcessor(scriptLoader);
+        const requestSender = createRequestSender();
+        braintreeVisaCheckoutPaymentProcessor = createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender);
         braintreeVisaCheckoutPaymentProcessor.initialize = jest.fn(() => Promise.resolve());
         braintreeVisaCheckoutPaymentProcessor.handleSuccess = jest.fn(() => Promise.resolve());
 
@@ -68,9 +69,9 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
         visaCheckoutScriptLoader = new VisaCheckoutScriptLoader(scriptLoader);
         jest.spyOn(visaCheckoutScriptLoader, 'load').mockImplementation(() => Promise.resolve(visaCheckoutSDK));
 
-        const client = createCheckoutClient();
+        const client = createCheckoutClient(requestSender);
         const paymentClient = createPaymentClient(store);
-        const registry = createPaymentStrategyRegistry(store, client, paymentClient);
+        const registry = createPaymentStrategyRegistry(store, client, paymentClient, requestSender);
         const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
         const configRequestSender = new ConfigRequestSender(createRequestSender());
         const configActionCreator = new ConfigActionCreator(configRequestSender);

--- a/src/payment/strategies/braintree/create-braintree-visacheckout-payment-processor.ts
+++ b/src/payment/strategies/braintree/create-braintree-visacheckout-payment-processor.ts
@@ -1,14 +1,16 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { RequestSender } from '@bigcommerce/request-sender';
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import BraintreeScriptLoader from './braintree-script-loader';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 import BraintreeVisaCheckoutPaymentProcessor from './braintree-visacheckout-payment-processor';
 
-export default function createBraintreeVisaCheckoutPaymentProcessor(scriptLoader: ScriptLoader) {
+export default function createBraintreeVisaCheckoutPaymentProcessor(
+    scriptLoader: ScriptLoader,
+    requestSender: RequestSender
+) {
     const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader);
     const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
-    const requestSender = createRequestSender();
 
     return new BraintreeVisaCheckoutPaymentProcessor(braintreeSDKCreator, requestSender);
 }

--- a/src/payment/strategies/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card-payment-strategy.spec.ts
@@ -33,7 +33,7 @@ describe('CreditCardPaymentStrategy', () => {
         submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
 

--- a/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
@@ -43,7 +43,7 @@ describe('KlarnaPaymentStrategy', () => {
     let strategy: KlarnaPaymentStrategy;
 
     beforeEach(() => {
-        client = createCheckoutClient();
+        client = createCheckoutClient(createRequestSender());
         store = createCheckoutStore({
             paymentMethods: getPaymentMethodsState(),
         });

--- a/src/payment/strategies/legacy-payment-strategy.spec.ts
+++ b/src/payment/strategies/legacy-payment-strategy.spec.ts
@@ -17,7 +17,7 @@ describe('LegacyPaymentStrategy', () => {
     beforeEach(() => {
         store = createCheckoutStore();
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
         submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));

--- a/src/payment/strategies/no-payment-data-required-strategy.spec.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.spec.ts
@@ -18,7 +18,7 @@ describe('NoPaymentDataRequiredPaymentStrategy', () => {
     beforeEach(() => {
         store = createCheckoutStore();
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
         submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));

--- a/src/payment/strategies/offline-payment-strategy.spec.ts
+++ b/src/payment/strategies/offline-payment-strategy.spec.ts
@@ -17,7 +17,7 @@ describe('OfflinePaymentStrategy', () => {
     beforeEach(() => {
         store = createCheckoutStore();
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
         submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));

--- a/src/payment/strategies/offsite-payment-strategy.spec.ts
+++ b/src/payment/strategies/offsite-payment-strategy.spec.ts
@@ -29,7 +29,7 @@ describe('OffsitePaymentStrategy', () => {
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
         paymentActionCreator = new PaymentActionCreator(

--- a/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
@@ -32,7 +32,7 @@ describe('PaypalExpressPaymentStrategy', () => {
 
     beforeEach(() => {
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
 

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
@@ -29,7 +29,7 @@ describe('PaypalProPaymentStrategy', () => {
         submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
 

--- a/src/payment/strategies/sage-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/sage-pay-payment-strategy.spec.ts
@@ -33,7 +33,7 @@ describe('SagePayPaymentStrategy', () => {
 
     beforeEach(() => {
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
 

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -57,7 +57,7 @@ describe('SquarePaymentStrategy', () => {
         });
         paymentMethod = getSquare();
         orderActionCreator = new OrderActionCreator(
-            createCheckoutClient(),
+            createCheckoutClient(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
         paymentActionCreator = new PaymentActionCreator(

--- a/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { createScriptLoader } from '@bigcommerce/script-loader';
+import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
 import { Observable } from 'rxjs';
 
@@ -19,7 +19,8 @@ import WepayRiskClient from './wepay-risk-client';
 
 describe('WepayPaymentStrategy', () => {
     const testRiskToken = 'test-risk-token';
-    let scriptLoader;
+
+    let scriptLoader: ScriptLoader;
     let wepayRiskClient: WepayRiskClient;
     let client: CheckoutClient;
     let orderActionCreator: OrderActionCreator;
@@ -32,7 +33,7 @@ describe('WepayPaymentStrategy', () => {
     let submitPaymentAction: Observable<Action>;
 
     beforeEach(() => {
-        client = createCheckoutClient();
+        client = createCheckoutClient(createRequestSender());
         store = createCheckoutStore();
         scriptLoader = createScriptLoader();
         wepayRiskClient = new WepayRiskClient(scriptLoader);

--- a/src/shipping/create-shipping-strategy-registry.ts
+++ b/src/shipping/create-shipping-strategy-registry.ts
@@ -1,4 +1,4 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import { CheckoutRequestSender, CheckoutStore } from '../checkout';
@@ -7,12 +7,14 @@ import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payme
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 
-import { ConsignmentRequestSender } from '.';
 import ConsignmentActionCreator from './consignment-action-creator';
+import ConsignmentRequestSender from './consignment-request-sender';
 import { AmazonPayShippingStrategy, DefaultShippingStrategy, ShippingStrategy } from './strategies';
 
-export default function createShippingStrategyRegistry(store: CheckoutStore): Registry<ShippingStrategy> {
-    const requestSender = createRequestSender();
+export default function createShippingStrategyRegistry(
+    store: CheckoutStore,
+    requestSender: RequestSender
+): Registry<ShippingStrategy> {
     const registry = new Registry<ShippingStrategy>();
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const consignmentRequestSender = new ConsignmentRequestSender(requestSender);

--- a/src/shipping/shipping-strategy-action-creator.spec.ts
+++ b/src/shipping/shipping-strategy-action-creator.spec.ts
@@ -1,3 +1,4 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutStore, CheckoutStoreState } from '../checkout';
@@ -13,13 +14,15 @@ import { ShippingStrategy } from './strategies';
 
 describe('ShippingStrategyActionCreator', () => {
     let registry: Registry<ShippingStrategy>;
+    let requestSender: RequestSender;
     let state: CheckoutStoreState;
     let store: CheckoutStore;
 
     beforeEach(() => {
         state = getCheckoutStoreState();
         store = createCheckoutStore(state);
-        registry = createShippingStrategyRegistry(store);
+        requestSender = createRequestSender();
+        registry = createShippingStrategyRegistry(store, requestSender);
     });
 
     describe('#initialize()', () => {


### PR DESCRIPTION
## What?
* Make sure the host config is passed to the dependencies of `CheckoutService` and `CheckoutButtonInitializer`. This is done by creating one instance of `RequestSender`with the `host` config and passing it to other dependencies at the root level.

## Why?
* Otherwise, we could be making XHR requests without hitting the host domain.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
