### PR TITLE
feat(checkout-button): PAYMENTS-3071 Support more features of paypal checkout buttons

### DIFF
--- a/src/checkout-buttons/strategies/braintree-paypal-button-options.ts
+++ b/src/checkout-buttons/strategies/braintree-paypal-button-options.ts
@@ -17,7 +17,7 @@ export interface BraintreePaypalButtonInitializeOptions {
     /**
      * A set of styling options for the checkout button.
      */
-    style?: Pick<PaypalButtonStyleOptions, 'color' | 'shape' | 'size'>;
+    style?: Pick<PaypalButtonStyleOptions, 'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons'>;
 
     /**
      * A callback that gets called if unable to authorize and tokenize payment.

--- a/src/checkout-buttons/strategies/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree-paypal-button-strategy.spec.ts
@@ -159,6 +159,10 @@ describe('BraintreePaypalButtonStrategy', () => {
                     color: 'blue',
                     shape: 'pill',
                     size: 'responsive',
+                    layout: 'horizontal',
+                    label: 'paypal',
+                    tagline: true,
+                    fundingicons: false,
                 },
             },
         };
@@ -170,6 +174,10 @@ describe('BraintreePaypalButtonStrategy', () => {
                 color: 'blue',
                 shape: 'pill',
                 size: 'responsive',
+                layout: 'horizontal',
+                label: 'paypal',
+                tagline: true,
+                fundingicons: false,
             },
         }), 'checkout-button');
     });

--- a/src/checkout-buttons/strategies/braintree-paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/braintree-paypal-button-strategy.ts
@@ -58,7 +58,7 @@ export default class BraintreePaypalButtonStrategy extends CheckoutButtonStrateg
                     style: {
                         shape: 'rect',
                         label: this._offerCredit ? 'credit' : undefined,
-                        ...pick(paypalOptions.style, 'color', 'shape', 'size'),
+                        ...pick(paypalOptions.style, 'layout', 'size', 'color', 'label', 'shape', 'tagline', 'fundingicons'),
                     },
                     payment: () => this._setupPayment(paypalOptions.onPaymentError),
                     onAuthorize: data => this._tokenizePayment(data, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -16,10 +16,13 @@ export interface PaypalButtonOptions {
 }
 
 export interface PaypalButtonStyleOptions {
+    layout?: 'horizontal' | 'vertical';
     size?: 'small' | 'medium' | 'large' | 'responsive';
     color?: 'gold' | 'blue' | 'silver' | 'black';
-    label?: 'credit' | 'checkout';
+    label?: 'checkout' | 'pay' | 'buynow' | 'paypal' | 'credit';
     shape?: 'pill' | 'rect';
+    tagline?: boolean;
+    fundingicons?: boolean;
 }
 
 export interface PaypalAuthorizeData {


### PR DESCRIPTION
## What?
Add support for styling options and some funding sources to the Braintree/Paypal checkout button strategy.

## Why?
First part of enabling merchants to be able to customize those properties.

## Testing / Proof
Unit tested.

@bigcommerce/checkout @bigcommerce/payments
