### PR TITLE
CHECKOUT-3516: Trigger `onReady` callback after order reference is passed to BC

### DIFF
--- a/src/payment/strategies/amazon-pay/amazon-pay-address-book.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-address-book.ts
@@ -18,5 +18,4 @@ export interface AmazonPayAddressBookOptions {
     onAddressSelect(orderReference: AmazonPayOrderReference): void;
     onError(error: AmazonPayWidgetError): void;
     onReady(orderReference: AmazonPayOrderReference): void;
-    onOrderReferenceCreate(orderReference: AmazonPayOrderReference): void;
 }

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -68,9 +68,9 @@ describe('AmazonPayPaymentStrategy', () => {
                 this.options.onPaymentSelect(orderReference);
             });
 
-            element.addEventListener('orderReferenceCreate', () => {
-                if (this.options.onOrderReferenceCreate) {
-                    this.options.onOrderReferenceCreate(orderReference);
+            element.addEventListener('ready', () => {
+                if (this.options.onReady) {
+                    this.options.onReady(orderReference);
                 }
             });
 
@@ -192,9 +192,8 @@ describe('AmazonPayPaymentStrategy', () => {
             scope: 'payments:billing_address payments:shipping_address payments:widget profile',
             sellerId: merchantId,
             onError: expect.any(Function),
-            onOrderReferenceCreate: expect.any(Function),
-            onPaymentSelect: expect.any(Function),
             onReady: expect.any(Function),
+            onPaymentSelect: expect.any(Function),
         });
     });
 
@@ -214,7 +213,7 @@ describe('AmazonPayPaymentStrategy', () => {
         const element = document.getElementById('wallet');
 
         if (element) {
-            element.dispatchEvent(new CustomEvent('orderReferenceCreate'));
+            element.dispatchEvent(new CustomEvent('ready'));
         }
 
         expect(remoteCheckoutActionCreator.updateCheckout)

--- a/src/payment/strategies/amazon-pay/amazon-pay-wallet.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-wallet.ts
@@ -19,5 +19,4 @@ export interface AmazonPayWalletOptions {
     onError(error: WidgetError): void;
     onReady(orderReference: OrderReference): void;
     onPaymentSelect(orderReference: OrderReference): void;
-    onOrderReferenceCreate?(orderReference: OrderReference): void;
 }

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
@@ -62,8 +62,8 @@ describe('AmazonPayShippingStrategy', () => {
                 }));
             });
 
-            element.addEventListener('orderReferenceCreate', () => {
-                this.options.onOrderReferenceCreate(orderReference);
+            element.addEventListener('ready', () => {
+                this.options.onReady(orderReference);
             });
         }
     }
@@ -228,7 +228,7 @@ describe('AmazonPayShippingStrategy', () => {
         const element = document.getElementById('addressBook');
 
         if (element) {
-            element.dispatchEvent(new CustomEvent('orderReferenceCreate'));
+            element.dispatchEvent(new CustomEvent('ready'));
         }
 
         expect(remoteCheckoutActionCreator.updateCheckout)


### PR DESCRIPTION
## What?
* Trigger `onReady` callback after order reference is passed to BC.
* Stop passing `onOrderReferenceCreate` because `onReady` has access to the same data.

## Why?
* Otherwise, `onReady` callback and `initialize` method will not be resolved at the right moment.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
