### PR TITLE
feat(checkout-buttons): PAYMENTS-3073 Support credit buttons by implementing funding sources

### DIFF
--- a/src/checkout-buttons/strategies/braintree-paypal-button-options.ts
+++ b/src/checkout-buttons/strategies/braintree-paypal-button-options.ts
@@ -15,6 +15,11 @@ export interface BraintreePaypalButtonInitializeOptions {
     style?: Pick<PaypalButtonStyleOptions, 'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons'>;
 
     /**
+     * Whether or not to show a credit button.
+     */
+    allowCredit?: boolean;
+
+    /**
      * A callback that gets called if unable to authorize and tokenize payment.
      *
      * @param error - The error object describing the failure.

--- a/src/checkout-buttons/strategies/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree-paypal-button-strategy.spec.ts
@@ -148,6 +148,10 @@ describe('BraintreePaypalButtonStrategy', () => {
                 label: undefined,
                 shape: 'rect',
             },
+            funding: {
+                allowed: [],
+                disallowed: [paypal.FUNDING.CREDIT],
+            },
         }, 'checkout-button');
     });
 
@@ -417,6 +421,9 @@ describe('BraintreePaypalButtonStrategy', () => {
             options = {
                 methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT,
                 containerId: 'checkout-button',
+                braintreepaypalcredit: {
+                    allowCredit: true,
+                },
             };
 
             strategy = new BraintreePaypalButtonStrategy(
@@ -440,6 +447,10 @@ describe('BraintreePaypalButtonStrategy', () => {
                 style: {
                     label: 'credit',
                     shape: 'rect',
+                },
+                funding: {
+                    allowed: [paypal.FUNDING.CREDIT],
+                    disallowed: [],
                 },
             }, 'checkout-button');
         });

--- a/src/checkout-buttons/strategies/braintree-paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/braintree-paypal-button-strategy.ts
@@ -48,9 +48,22 @@ export default class BraintreePaypalButtonStrategy extends CheckoutButtonStrateg
             .then(([paypalCheckout, paypal]) => {
                 this._paypalCheckout = paypalCheckout;
 
+                const allowedSources = [];
+                const disallowedSources = [];
+
+                if (paypalOptions.allowCredit) {
+                    allowedSources.push(paypal.FUNDING.CREDIT);
+                } else {
+                    disallowedSources.push(paypal.FUNDING.CREDIT);
+                }
+
                 return paypal.Button.render({
                     env: paymentMethod.config.testMode ? 'sandbox' : 'production',
                     commit: paypalOptions.shouldProcessPayment ? true : false,
+                    funding: {
+                        allowed: allowedSources,
+                        disallowed: disallowedSources,
+                    },
                     style: {
                         shape: 'rect',
                         label: this._offerCredit ? 'credit' : undefined,

--- a/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
@@ -46,6 +46,10 @@ describe('PaypalExpressPaymentStrategy', () => {
             Button: {
                 render: jest.fn(),
             },
+            FUNDING: {
+                CARD: 'card',
+                CREDIT: 'credit',
+            },
         };
 
         scriptLoader = new PaypalScriptLoader(createScriptLoader());

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -1,6 +1,12 @@
 export interface PaypalSDK {
     Button: PaypalButton;
     checkout: PaypalExpressCheckout;
+    FUNDING: PaypalFundingTypeList;
+}
+
+export interface PaypalFundingTypeList {
+    CARD: string;
+    CREDIT: string;
 }
 
 export interface PaypalButton {
@@ -11,8 +17,14 @@ export interface PaypalButtonOptions {
     env?: string;
     commit?: boolean;
     style?: PaypalButtonStyleOptions;
+    funding?: PaypalFundingType;
     payment(): Promise<any>;
     onAuthorize(data: PaypalAuthorizeData): Promise<any>;
+}
+
+export interface PaypalFundingType {
+    allowed?: string[];
+    disallowed?: string[];
 }
 
 export interface PaypalButtonStyleOptions {

--- a/src/payment/strategies/paypal/paypal.mock.ts
+++ b/src/payment/strategies/paypal/paypal.mock.ts
@@ -2,6 +2,10 @@ import { PaypalSDK } from './paypal-sdk';
 
 export function getPaypalMock(): PaypalSDK {
     return {
+        FUNDING: {
+            CARD: 'card',
+            CREDIT: 'credit',
+        },
         Button: {
             render: jest.fn(),
         },


### PR DESCRIPTION
## What?
Support credit buttons by implementing funding sources.

## Why?
Removes the need to have two separate strategies (to be removed later) to support credit buttons--it's just an option to the Braintree and Paypal button SDKs.

## Testing / Proof
Add a product to your cart, open the cart page, see that with credit enabled you get two side-by-side (by default, changeable with Smart Buttons) buttons. With credit disabled, you get the standard braintree/paypal button.

@bigcommerce/checkout @bigcommerce/payments
