### PR TITLE
CP-3982 adding product-id to the cart item property for checkout process

### DIFF
--- a/src/cart/internal-carts.mock.ts
+++ b/src/cart/internal-carts.mock.ts
@@ -25,6 +25,7 @@ export function getCart(): InternalCart {
                 integerAmountAfterDiscount: 20000,
                 variantId: 71,
                 addedByPromotion: false,
+                productId: 103,
             },
             {
                 id: '667',
@@ -47,6 +48,7 @@ export function getCart(): InternalCart {
                 integerAmountAfterDiscount: 20000,
                 variantId: 71,
                 addedByPromotion: false,
+                productId: 103,
             },
             {
                 id: 'bd391ead-8c58-4105-b00e-d75d233b429a',

--- a/src/cart/internal-line-item.ts
+++ b/src/cart/internal-line-item.ts
@@ -13,6 +13,7 @@ export default interface InternalLineItem {
     quantity: number;
     type: string;
     variantId: number | null;
+    productId?: number;
     addedByPromotion?: boolean;
     sender?: {
         name: string;

--- a/src/cart/map-to-internal-line-item.ts
+++ b/src/cart/map-to-internal-line-item.ts
@@ -24,6 +24,7 @@ export default function mapToInternalLineItem(
         name: item.name,
         quantity: item.quantity,
         variantId: item.variantId,
+        productId: item.productId,
         attributes: (item.options || []).map(option => ({
             name: option.name,
             value: option.value,

--- a/src/order/internal-orders.mock.ts
+++ b/src/order/internal-orders.mock.ts
@@ -86,6 +86,7 @@ export function getCompleteOrder(): InternalOrder {
                         value: 'v',
                     },
                 ],
+                productId: 103,
             },
             {
                 id: 'bd391ead-8c58-4105-b00e-d75d233b429a',


### PR DESCRIPTION
## What?
Added the ProductId as one of the properties to the `internal line item` to have the ProductId as part of the checkout payload while sending the checkout started event to GA.

## Why?
Checkout started event does not have the product id as part of payload. So, we need to add this to the original cart items. 

## Testing / Proof


@bigcommerce/checkout @bigcommerce/cp-dt 
