### PR TITLE
fix(payment) PAYMENTS-3288 Checking out with PayPal does not send device data

### DIFF
--- a/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
@@ -6,7 +6,9 @@ import BraintreeSDKCreator from './braintree-sdk-creator';
 import {
     getClientMock,
     getDataCollectorMock,
+    getDeviceDataMock,
     getModuleCreatorMock,
+    getModuleCreatorNewMock,
     getThreeDSecureMock,
     getVisaCheckoutMock,
 } from './braintree.mock';
@@ -112,7 +114,7 @@ describe('Braintree SDK Creator', () => {
 
         beforeEach(() => {
             dataCollectorMock = getDataCollectorMock();
-            dataCollectorCreatorMock = getModuleCreatorMock(dataCollectorMock);
+            dataCollectorCreatorMock = getModuleCreatorNewMock(dataCollectorMock);
             braintreeScriptLoader.loadDataCollector = jest.fn().mockReturnValue(Promise.resolve(dataCollectorCreatorMock));
             braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
             jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(Promise.resolve(clientMock));
@@ -126,7 +128,7 @@ describe('Braintree SDK Creator', () => {
             expect(dataCollectorCreatorMock.create).toHaveBeenCalledWith({ client: clientMock, kount: true, paypal: true });
         });
 
-        it('always returns the same instance of the 3ds client', async () => {
+        it('always returns the same instance of the data collector', async () => {
             const dataCollector1 = await braintreeSDKCreator.getDataCollector();
             const dataCollector2 = await braintreeSDKCreator.getDataCollector();
             expect(dataCollector1).toBe(dataCollector2);
@@ -145,7 +147,8 @@ describe('Braintree SDK Creator', () => {
 
         it('returns the data collector information', async () => {
             const dataCollector = await braintreeSDKCreator.getDataCollector();
-            expect(dataCollector).toEqual(expect.objectContaining({ deviceData: 'my_device_session_id' }));
+
+            expect(dataCollector).toEqual(expect.objectContaining({ deviceData: getDeviceDataMock() }));
         });
 
         it('catches the KOUNT_IS_NOT_ENABLED error ', async () => {

--- a/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -90,14 +90,6 @@ export default class BraintreeSDKCreator {
                 this._braintreeScriptLoader.loadDataCollector(),
             ])
             .then(([client, dataCollector]) => dataCollector.create({ client, kount: true, ...options }))
-            .then(dataCollector => {
-                const { deviceData } = dataCollector;
-
-                return {
-                    ...dataCollector,
-                    deviceData: deviceData ? JSON.parse(deviceData).device_session_id : undefined,
-                };
-            })
             .catch(error => {
                 if (error && error.code === 'DATA_COLLECTOR_KOUNT_NOT_ENABLED') {
                     return { deviceData: undefined, teardown: () => Promise.resolve() };

--- a/src/payment/strategies/braintree/braintree.mock.ts
+++ b/src/payment/strategies/braintree/braintree.mock.ts
@@ -25,9 +25,13 @@ export function getClientMock(): BraintreeClient {
 
 export function getDataCollectorMock(): BraintreeDataCollector {
     return {
-        deviceData: '{"device_session_id": "my_device_session_id", "fraud_merchant_id": "we_dont_use_this_field"}',
+        deviceData: getDeviceDataMock(),
         teardown: jest.fn(() => Promise.resolve()),
     };
+}
+
+export function getDeviceDataMock(): string {
+    return '{"device_session_id": "my_device_session_id", "fraud_merchant_id": "we_dont_use_this_field"}';
 }
 
 export function getThreeDSecureMock(): BraintreeThreeDSecure {
@@ -57,6 +61,12 @@ export function getPaypalCheckoutMock(): BraintreePaypalCheckout {
 export function getModuleCreatorMock<T>(module: BraintreeModule | BraintreeClient): BraintreeModuleCreator<T> {
     return {
         create: jest.fn(() => Promise.resolve(module)),
+    };
+}
+
+export function getModuleCreatorNewMock<T>(module: BraintreeDataCollector): BraintreeModuleCreator<T> {
+    return {
+        create: jest.fn(() => Promise.resolve({ ...module })),
     };
 }
 


### PR DESCRIPTION
## What?

Device data is not being sent as expected when checkout with PayPal, I have removed the transformation applied to the data collector in the getDataCollector method.

## Why?

The `device_info` part of the deviceData should be sent as it is.

## Testing / Proof

Before:
<img width="770" alt="screen shot 2018-09-12 at 4 19 33 pm" src="https://user-images.githubusercontent.com/2579218/45467609-d64fcf00-b763-11e8-8406-0cde43b3170b.png">

After:
<img width="770" alt="screen shot 2018-09-12 at 4 22 43 pm" src="https://user-images.githubusercontent.com/2579218/45467615-e36cbe00-b763-11e8-98bb-8a4388eb1e62.png">

@bigcommerce/checkout @bigcommerce/payments
