### PR TITLE
INT-835 Implement Google Pay + Braintree in Payments Section

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -19,6 +19,7 @@ import {
     SagePayPaymentStrategy,
     SquarePaymentStrategy,
 } from './strategies';
+import { GooglePayPaymentStrategy } from './strategies/googlepay';
 
 describe('CreatePaymentStrategyRegistry', () => {
     let registry: PaymentStrategyRegistry;
@@ -97,5 +98,10 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate nopaymentdatarequired', () => {
         const paymentStrategy = registry.get('nopaymentdatarequired');
         expect(paymentStrategy).toBeInstanceOf(NoPaymentDataRequiredPaymentStrategy);
+    });
+
+    it('can instantiate googlepaybraintree', () => {
+        const paymentStrategy = registry.get('googlepaybraintree');
+        expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
     });
 });

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -21,6 +21,7 @@ import {
     BraintreePaypalPaymentStrategy,
     BraintreeVisaCheckoutPaymentStrategy,
     CreditCardPaymentStrategy,
+    GooglePayPaymentStrategy,
     KlarnaPaymentStrategy,
     LegacyPaymentStrategy,
     NoPaymentDataRequiredPaymentStrategy,
@@ -34,8 +35,15 @@ import {
 } from './strategies';
 import { AfterpayScriptLoader } from './strategies/afterpay';
 import { AmazonPayScriptLoader } from './strategies/amazon-pay';
-import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, VisaCheckoutScriptLoader } from './strategies/braintree';
+import {
+    createBraintreePaymentProcessor,
+    createBraintreeVisaCheckoutPaymentProcessor,
+    BraintreeScriptLoader,
+    BraintreeSDKCreator,
+    VisaCheckoutScriptLoader
+} from './strategies/braintree';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
+import { GooglePayBraintreeInitializer, GooglePayPaymentProcessor, GooglePayScriptLoader } from './strategies/googlepay';
 import { KlarnaScriptLoader } from './strategies/klarna';
 import { PaypalScriptLoader } from './strategies/paypal';
 import { SquareScriptLoader } from './strategies/square';
@@ -49,6 +57,9 @@ export default function createPaymentStrategyRegistry(
     const registry = new PaymentStrategyRegistry(store, { defaultToken: 'creditcard' });
     const scriptLoader = getScriptLoader();
     const braintreePaymentProcessor = createBraintreePaymentProcessor(scriptLoader);
+    const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader);
+    const braintreeSdkCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
     const orderActionCreator = new OrderActionCreator(
@@ -241,6 +252,25 @@ export default function createPaymentStrategyRegistry(
             requestSender,
             new ChasePayScriptLoader(getScriptLoader()),
             new WepayRiskClient(scriptLoader)
+        )
+    );
+
+    registry.register('googlepaybraintree', () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            new GooglePayPaymentProcessor(
+                store,
+                paymentMethodActionCreator,
+                new GooglePayScriptLoader(scriptLoader),
+                new GooglePayBraintreeInitializer(braintreeSdkCreator),
+                requestSender,
+                new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender))
+            )
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -290,6 +290,33 @@ export function getWepay(): PaymentMethod {
     };
 }
 
+export function getGooglePay(): PaymentMethod {
+    return {
+        id: 'googlepay',
+        logoUrl: '',
+        method: 'googlepay',
+        supportedCards: [
+            'VISA',
+            'MC',
+            'AMEX',
+        ],
+        config: {
+            displayName: 'Google Pay',
+            merchantId: '',
+            testMode: true,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'clientToken',
+        initializationData: {
+            nonce: 'nonce',
+            card_information: {
+                type: 'MasterCard',
+                number: '4111',
+            },
+        },
+    };
+}
+
 export function getPaymentMethod(): PaymentMethod {
     return getAuthorizenet();
 }
@@ -307,6 +334,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getAmazonPay(),
         getKlarna(),
         getSquare(),
+        getGooglePay(),
     ];
 }
 

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -5,6 +5,7 @@ import {
     BraintreePaymentInitializeOptions,
     BraintreeVisaCheckoutPaymentInitializeOptions,
     ChasePayInitializeOptions,
+    GooglePayPaymentInitializeOptions,
     KlarnaPaymentInitializeOptions,
     SquarePaymentInitializeOptions,
 } from './strategies';
@@ -68,4 +69,10 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support Chasepay.
      */
     chasepay?: ChasePayInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
+    googlepay?: GooglePayPaymentInitializeOptions;
 }

--- a/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -2,6 +2,8 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { StandardError } from '../../../common/error/errors';
 
+import { GooglePayCreator } from '../googlepay';
+
 import {
     BraintreeClientCreator,
     BraintreeDataCollectorCreator,
@@ -20,7 +22,7 @@ export default class BraintreeScriptLoader {
 
     loadClient(): Promise<BraintreeClientCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.15.0/js/client.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.37.0/js/client.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.client) {
                     throw new StandardError();
@@ -32,7 +34,7 @@ export default class BraintreeScriptLoader {
 
     load3DS(): Promise<BraintreeThreeDSecureCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.15.0/js/three-d-secure.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.37.0/js/three-d-secure.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.threeDSecure) {
                     throw new StandardError();
@@ -44,7 +46,7 @@ export default class BraintreeScriptLoader {
 
     loadDataCollector(): Promise<BraintreeDataCollectorCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.15.0/js/data-collector.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.37.0/js/data-collector.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.dataCollector) {
                     throw new StandardError();
@@ -56,7 +58,7 @@ export default class BraintreeScriptLoader {
 
     loadPaypal(): Promise<BraintreePaypalCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.15.0/js/paypal.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.37.0/js/paypal.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.paypal) {
                     throw new StandardError();
@@ -68,7 +70,7 @@ export default class BraintreeScriptLoader {
 
     loadPaypalCheckout(): Promise<BraintreePaypalCheckoutCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.15.0/js/paypal-checkout.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.37.0/js/paypal-checkout.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.paypalCheckout) {
                     throw new StandardError();
@@ -80,13 +82,25 @@ export default class BraintreeScriptLoader {
 
     loadVisaCheckout(): Promise<BraintreeVisaCheckoutCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.15.0/js/visa-checkout.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.37.0/js/visa-checkout.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.visaCheckout) {
                     throw new StandardError();
                 }
 
                 return this._window.braintree.visaCheckout;
+            });
+    }
+
+    loadGooglePayment(): Promise<GooglePayCreator> {
+        return this._scriptLoader
+            .loadScript('//js.braintreegateway.com/web/3.37.0/js/google-payment.min.js')
+            .then(() => {
+                if (!this._window.braintree || !this._window.braintree.googlePayment) {
+                    throw new StandardError();
+                }
+
+                return this._window.braintree.googlePayment;
             });
     }
 }

--- a/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
@@ -1,6 +1,14 @@
 import { NotInitializedError } from '../../../common/error/errors';
+import { getGooglePayBraintreeMock } from '../googlepay/googlepay.mock';
 
-import { BraintreeClient, BraintreeDataCollector, BraintreeModuleCreator, BraintreeThreeDSecure, BraintreeVisaCheckout } from './braintree';
+import {
+    BraintreeClient,
+    BraintreeDataCollector,
+    BraintreeModuleCreator,
+    BraintreeThreeDSecure,
+    BraintreeVisaCheckout,
+    GooglePayBraintreeSDK,
+} from './braintree';
 import BraintreeScriptLoader from './braintree-script-loader';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 import {
@@ -202,6 +210,45 @@ describe('Braintree SDK Creator', () => {
                 .mockImplementation(() => { throw new Error(errorMessage); });
 
             expect(() => braintreeSDKCreator.getVisaCheckout()).toThrow(errorMessage);
+        });
+    });
+
+    describe('#getGooglePaymentComponent()', () => {
+        let googlePayMock: GooglePayBraintreeSDK;
+        let googlePayCreatorMock: BraintreeModuleCreator<GooglePayBraintreeSDK>;
+        let braintreeSDKCreator: BraintreeSDKCreator;
+
+        beforeEach(() => {
+            googlePayMock = getGooglePayBraintreeMock();
+            googlePayCreatorMock = getModuleCreatorMock(googlePayMock);
+            braintreeScriptLoader.loadGooglePayment = jest.fn().mockReturnValue(Promise.resolve(googlePayCreatorMock));
+            braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+            jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(Promise.resolve(clientMock));
+        });
+
+        it('returns a promise that resolves to the Google Pay client', async () => {
+            const googlePay = await braintreeSDKCreator.getGooglePaymentComponent();
+
+            expect(googlePayCreatorMock.create).toHaveBeenCalledWith({ client: clientMock });
+            expect(googlePay).toBe(googlePayMock);
+        });
+
+        it('always returns the same instance of the Google Pay client', async () => {
+            const googlePay1 = await braintreeSDKCreator.getGooglePaymentComponent();
+            const googlePay2 = await braintreeSDKCreator.getGooglePaymentComponent();
+
+            expect(googlePay1).toBe(googlePay2);
+            expect(braintreeScriptLoader.loadGooglePayment).toHaveBeenCalledTimes(1);
+            expect(googlePayCreatorMock.create).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws if getting the client throws', async () => {
+            const errorMessage = 'some_error';
+
+            jest.spyOn(braintreeSDKCreator, 'getClient')
+                .mockImplementation(() => { throw new Error(errorMessage); });
+
+            expect(() => braintreeSDKCreator.getGooglePaymentComponent()).toThrow(errorMessage);
         });
     });
 

--- a/src/payment/strategies/braintree/braintree.mock.ts
+++ b/src/payment/strategies/braintree/braintree.mock.ts
@@ -13,6 +13,7 @@ import {
     BraintreeTokenizeResponse,
     BraintreeVerifyPayload,
     BraintreeVisaCheckout,
+    GooglePayBraintreeSDK,
 } from './braintree';
 import { BraintreeThreeDSecureOptions } from './braintree-payment-options';
 
@@ -75,6 +76,14 @@ export function getTokenizeResponseBody(): BraintreeTokenizeResponse {
         creditCards: [
             { nonce: 'demo_nonce' },
         ],
+    };
+}
+
+export function getGooglePayMock(): GooglePayBraintreeSDK {
+    return {
+        createPaymentDataRequest: jest.fn((() => Promise.resolve())),
+        parseResponse: jest.fn((() => Promise.resolve())),
+        teardown: jest.fn(),
     };
 }
 

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -1,7 +1,17 @@
-
+import {
+    GooglePaymentData,
+    GooglePayCreator,
+    GooglePayDataRequestV1,
+    GooglePayPaymentDataRequestV1,
+    TokenizePayload,
+} from '../googlepay';
 import { PaypalAuthorizeData, PaypalSDK } from '../paypal';
 
-import { VisaCheckoutInitOptions, VisaCheckoutPaymentSuccessPayload, VisaCheckoutTokenizedPayload } from './visacheckout';
+import {
+    VisaCheckoutInitOptions,
+    VisaCheckoutPaymentSuccessPayload,
+    VisaCheckoutTokenizedPayload
+} from './visacheckout';
 
 export interface BraintreeSDK {
     client?: BraintreeClientCreator;
@@ -10,6 +20,7 @@ export interface BraintreeSDK {
     paypalCheckout?: BraintreePaypalCheckoutCreator;
     threeDSecure?: BraintreeThreeDSecureCreator;
     visaCheckout?: BraintreeVisaCheckoutCreator;
+    googlePayment?: GooglePayCreator;
 }
 
 export interface BraintreeModuleCreator<T> {
@@ -71,6 +82,11 @@ export interface BraintreePaypalCheckout {
 export interface BraintreeVisaCheckout extends BraintreeModule {
     tokenize(payment: VisaCheckoutPaymentSuccessPayload): Promise<VisaCheckoutTokenizedPayload>;
     createInitOptions(options: Partial<VisaCheckoutInitOptions>): VisaCheckoutInitOptions;
+}
+
+export interface GooglePayBraintreeSDK extends BraintreeModule {
+    createPaymentDataRequest(request?: GooglePayDataRequestV1): GooglePayPaymentDataRequestV1;
+    parseResponse(paymentData: GooglePaymentData): Promise<TokenizePayload>;
 }
 
 export interface BraintreeTokenizeReturn {

--- a/src/payment/strategies/googlepay/googlepay-braintree-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree-initializer.spec.ts
@@ -1,0 +1,127 @@
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentMethod } from '../..';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { BraintreeScriptLoader, BraintreeSDKCreator, GooglePayBraintreeSDK } from '../braintree';
+
+import GooglePayBraintreeInitializer from './googlepay-braintree-initializer';
+import {
+    getCheckoutMock,
+    getGooglePaymentDataMock,
+    getGooglePaymentDataPayload,
+    getGooglePayBraintreeMock,
+    getPaymentMethodMock
+} from './googlepay.mock';
+
+describe('GooglePayBraintreeInitializer', () => {
+    let braintreeSDKCreator: BraintreeSDKCreator;
+
+    beforeEach(() => {
+        const braintreeScriptLoader = new BraintreeScriptLoader(createScriptLoader());
+        braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        braintreeSDKCreator.initialize = jest.fn();
+    });
+
+    it('creates an instance of GooglePayBraintreeInitializer', () => {
+        const googlePayBraintreeInitializer = new GooglePayBraintreeInitializer(braintreeSDKCreator);
+
+        expect(googlePayBraintreeInitializer).toBeInstanceOf(GooglePayBraintreeInitializer);
+    });
+
+    describe('#initialize', async () => {
+        let googlePayMock: GooglePayBraintreeSDK;
+        let googlePayBraintreeInitializer: GooglePayBraintreeInitializer;
+
+        beforeEach(() => {
+            googlePayMock = getGooglePayBraintreeMock();
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getGooglePaymentComponent = jest.fn(() => Promise.resolve(googlePayMock));
+            googlePayBraintreeInitializer = new GooglePayBraintreeInitializer(braintreeSDKCreator);
+        });
+
+        it('initializes the google pay configuration for braintree', async () => {
+            await googlePayBraintreeInitializer.initialize(getCheckoutMock(), getPaymentMethodMock(), false)
+                .then(() => {
+                    expect(googlePayMock.createPaymentDataRequest).toHaveBeenCalled();
+                    expect(googlePayMock.createPaymentDataRequest).toHaveBeenCalledTimes(1);
+                    expect(googlePayMock.createPaymentDataRequest).toHaveBeenCalledWith(getGooglePaymentDataPayload());
+                });
+        });
+
+        it('initializes the google pay configuration for braintree and fail to create google pay payload', async () => {
+            spyOn(googlePayMock, 'createPaymentDataRequest').and.returnValue(Promise.reject({message: 'error'}));
+
+            await googlePayBraintreeInitializer.initialize(getCheckoutMock(), getPaymentMethodMock(), false)
+                .catch(error => {
+                    expect(error.message).toEqual('error');
+                });
+        });
+
+        it('initializes the google pay configuration for braintree and platformToken is missing', async () => {
+            const paymentMethod: PaymentMethod = getPaymentMethodMock();
+            paymentMethod.initializationData = {};
+
+            await googlePayBraintreeInitializer.initialize(getCheckoutMock(), paymentMethod, false)
+                .catch(error => {
+                    expect(error).toBeInstanceOf(Error);
+                    expect(new MissingDataError(MissingDataErrorType.MissingPaymentMethod).message).toEqual(error.message);
+                });
+        });
+
+        it('initializes the google pay configuration for braintree and clientToken is missing', () => {
+            const paymentMethod: PaymentMethod = getPaymentMethodMock();
+            paymentMethod.clientToken = undefined;
+
+            try {
+                googlePayBraintreeInitializer.initialize(getCheckoutMock(), paymentMethod, false);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(error).toBeTruthy();
+                expect(new MissingDataError(MissingDataErrorType.MissingPaymentMethod).message).toEqual(error.message);
+            }
+        });
+    });
+
+    describe('#teardown', () => {
+        let googlePayMock: GooglePayBraintreeSDK;
+        let googlePayBraintreeInitializer: GooglePayBraintreeInitializer;
+
+        beforeEach(() => {
+            googlePayMock = getGooglePayBraintreeMock();
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getGooglePaymentComponent = jest.fn(() => Promise.resolve(googlePayMock));
+            googlePayBraintreeInitializer = new GooglePayBraintreeInitializer(braintreeSDKCreator);
+        });
+
+        it('teardowns the initializer', async () => {
+            spyOn(braintreeSDKCreator, 'teardown');
+
+            await googlePayBraintreeInitializer.teardown();
+
+            expect(braintreeSDKCreator.teardown).toHaveBeenCalled();
+            expect(braintreeSDKCreator.teardown).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('#parseResponse', () => {
+        let googlePayMock: GooglePayBraintreeSDK;
+        let googlePayBraintreeInitializer: GooglePayBraintreeInitializer;
+
+        beforeEach(() => {
+            googlePayMock = getGooglePayBraintreeMock();
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getGooglePaymentComponent = jest.fn(() => Promise.resolve(googlePayMock));
+            googlePayBraintreeInitializer = new GooglePayBraintreeInitializer(braintreeSDKCreator);
+        });
+
+        it('parses a response from google pay payload received', async () => {
+            spyOn(googlePayMock, 'parseResponse');
+
+            await googlePayBraintreeInitializer.initialize(getCheckoutMock(), getPaymentMethodMock(), false);
+            await googlePayBraintreeInitializer.parseResponse(getGooglePaymentDataMock());
+
+            expect(googlePayMock.parseResponse).toHaveBeenCalled();
+            expect(googlePayMock.parseResponse).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -1,0 +1,84 @@
+import { Checkout } from '../../../checkout';
+import {
+    MissingDataError,
+    MissingDataErrorType
+} from '../../../common/error/errors';
+import PaymentMethod from '../../payment-method';
+import { BraintreeSDKCreator, GooglePayBraintreeSDK } from '../braintree';
+
+import {
+    GooglePaymentData,
+    GooglePayDataRequestV1,
+    GooglePayInitializer,
+    GooglePayPaymentDataRequestV1,
+    TokenizePayload
+} from './googlepay';
+
+export default class GooglePayBraintreeInitializer implements GooglePayInitializer {
+    private _googlePaymentInstance!: GooglePayBraintreeSDK;
+
+    constructor(
+        private _braintreeSDKCreator: BraintreeSDKCreator
+    ) {}
+
+    initialize(
+        checkout: Checkout,
+        paymentMethod: PaymentMethod,
+        hasShippingAddress: boolean
+    ): Promise<GooglePayPaymentDataRequestV1> {
+        if (!paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+
+        return this._braintreeSDKCreator.getGooglePaymentComponent()
+            .then(googleBraintreePaymentInstance => {
+                this._googlePaymentInstance = googleBraintreePaymentInstance;
+
+                return this._createGooglePayPayload(
+                    checkout,
+                    paymentMethod.initializationData.platformToken,
+                    hasShippingAddress
+                );
+            });
+    }
+
+    teardown(): Promise<void> {
+        return this._braintreeSDKCreator.teardown();
+    }
+
+    parseResponse(paymentData: GooglePaymentData): Promise<TokenizePayload> {
+        return this._googlePaymentInstance.parseResponse(paymentData);
+    }
+
+    private _createGooglePayPayload(
+        checkout: Checkout,
+        platformToken: string,
+        hasShippingAddress: boolean
+    ): GooglePayPaymentDataRequestV1 {
+        if (!platformToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const googlePaymentDataRequest: GooglePayDataRequestV1 = {
+            merchantInfo: {
+                authJwt: platformToken,
+            },
+            transactionInfo: {
+                currencyCode: checkout.cart.currency.code,
+                totalPriceStatus: 'FINAL',
+                totalPrice: checkout.grandTotal.toString(),
+            },
+            cardRequirements: {
+                billingAddressRequired: true,
+                billingAddressFormat: 'FULL',
+            },
+            shippingAddressRequired: !hasShippingAddress,
+            emailRequired: true,
+            phoneNumberRequired: true,
+        };
+
+        return this._googlePaymentInstance.createPaymentDataRequest(googlePaymentDataRequest);
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay-initialize-options.ts
+++ b/src/payment/strategies/googlepay/googlepay-initialize-options.ts
@@ -1,0 +1,28 @@
+/**
+ * A set of options that are required to initialize the GooglePay payment method
+ *
+ * If the customer chooses to pay with GooglePay, they will be asked to
+ * enter their payment details via a modal. You can hook into events emitted by
+ * the modal by providing the callbacks listed below.
+ */
+export default interface GooglePayPaymentInitializeOptions {
+    /**
+     * This walletButton is used to set an event listener, provide an element ID if you want
+     * users to be able to launch the GooglePay wallet modal by clicking on a button.
+     * It should be an HTML element.
+     */
+    walletButton?: string;
+
+    /**
+     * A callback that gets called when GooglePay fails to initialize or
+     * selects a payment option.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: Error): void;
+
+    /**
+     * A callback that gets called when the customer selects a payment option.
+     */
+    onPaymentSelect?(): void;
+}

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
@@ -1,0 +1,370 @@
+import {createRequestSender, RequestSender} from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
+import { getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import {
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedError,
+    NotInitializedErrorType,
+    StandardError
+} from '../../../common/error/errors';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { PaymentMethodActionCreator} from '../../index';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
+import { getGooglePay, getPaymentMethodsState } from '../../payment-methods.mock';
+import { BraintreeScriptLoader, BraintreeSDKCreator } from '../braintree';
+
+import {
+    GooglePaymentsError,
+    GooglePayClient,
+    GooglePayInitializer,
+    GooglePayIsReadyToPayResponse,
+    TokenizePayload
+} from './googlepay';
+import GooglePayBraintreeInitializer from './googlepay-braintree-initializer';
+import GooglePayPaymentProcessor from './googlepay-payment-processor';
+import GooglePayScriptLoader from './googlepay-script-loader';
+import {
+    getGooglePaymentDataMock,
+    getGooglePayAddressMock,
+    getGooglePayPaymentDataRequestMock,
+    getGooglePaySDKMock
+} from './googlepay.mock';
+
+describe('GooglePayPaymentProcessor', () => {
+    let processor: GooglePayPaymentProcessor;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let googlePayScriptLoader: GooglePayScriptLoader;
+    let store: CheckoutStore;
+    let googlePayInitializer: GooglePayInitializer;
+    let billingAddressActionCreator: BillingAddressActionCreator;
+    let clientMock: GooglePayClient;
+    let requestSender: RequestSender;
+
+    beforeEach(() => {
+        const _requestSender: PaymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
+        const scriptLoader = createScriptLoader();
+        const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader);
+        const braintreeSdkCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        billingAddressActionCreator = new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender));
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+        paymentMethodActionCreator = new PaymentMethodActionCreator(_requestSender);
+        googlePayScriptLoader = new GooglePayScriptLoader(createScriptLoader());
+        googlePayInitializer = new GooglePayBraintreeInitializer(braintreeSdkCreator);
+        requestSender = createRequestSender();
+
+        processor = new GooglePayPaymentProcessor(
+            store,
+            paymentMethodActionCreator,
+            googlePayScriptLoader,
+            googlePayInitializer,
+            requestSender,
+            billingAddressActionCreator
+        );
+    });
+
+    it('creates an instance of GooglePayPaymentProcessor', () => {
+        expect(processor).toBeInstanceOf(GooglePayPaymentProcessor);
+    });
+
+    describe('#initialize', () => {
+        beforeEach(() => {
+            const googlePayIsReadyToPayResponse = {
+                result: true,
+            };
+            const googlePaymentDataMock = getGooglePaymentDataMock();
+            const googlePaySDK = getGooglePaySDKMock();
+            clientMock = {
+                isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
+                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                createButton: jest.fn(() => Promise.resolve(new HTMLElement())),
+            };
+            googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
+
+            jest.spyOn(googlePayScriptLoader, 'load').mockReturnValue(Promise.resolve(googlePaySDK));
+            jest.spyOn(googlePayInitializer, 'initialize').mockReturnValue(Promise.resolve());
+        });
+
+        it('initializes processor successfully', async () => {
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getGooglePay());
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+
+            await processor.initialize('googlepay');
+
+            expect(googlePayScriptLoader.load).toHaveBeenCalled();
+        });
+
+        it('initializes processor without paymentMethod', async () => {
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(undefined);
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+
+            try {
+                await processor.initialize('googlepay');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(error).toEqual(new MissingDataError(MissingDataErrorType.MissingPaymentMethod));
+            }
+        });
+
+        it('initializes processor without checkout', async () => {
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getGooglePay());
+            jest.spyOn(store.getState().checkout, 'getCheckout').mockReturnValue(undefined);
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+
+            try {
+                await processor.initialize('googlepay');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(error).toEqual(new MissingDataError(MissingDataErrorType.MissingCheckout));
+            }
+        });
+
+        it('initializes processor without testMode', async () => {
+            const googlePayMethod: PaymentMethod = getGooglePay();
+            googlePayMethod.config.testMode = undefined;
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(googlePayMethod);
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+
+            try {
+                await processor.initialize('googlepay');
+            } catch (error) {
+                expect(error).toBeInstanceOf(Error);
+                expect(error).toEqual(new StandardError(new MissingDataError(MissingDataErrorType.MissingPaymentMethod).message));
+            }
+        });
+    });
+
+    describe('#deinitialize', () => {
+        it('deinitializes processor', async () => {
+            jest.spyOn(googlePayInitializer, 'teardown');
+
+            await processor.deinitialize();
+
+            expect(googlePayInitializer.teardown).toHaveBeenCalled();
+        });
+    });
+
+    describe('#createButton', () => {
+        beforeEach(() => {
+            const googlePayIsReadyToPayResponse = {
+                result: true,
+            };
+            const googlePaymentDataMock = getGooglePaymentDataMock();
+            const googlePaySDK = getGooglePaySDKMock();
+            clientMock = {
+                isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
+                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                createButton: jest.fn(() => Promise.resolve()),
+            };
+            googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
+
+            jest.spyOn(googlePayScriptLoader, 'load').mockReturnValue(Promise.resolve(googlePaySDK));
+            jest.spyOn(googlePayInitializer, 'initialize').mockReturnValue(Promise.resolve());
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getGooglePay());
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+        });
+
+        it('creates the html button element', async () => {
+            await processor.initialize('googlepay');
+            await processor.createButton(jest.fn(() => {}));
+
+            expect(clientMock.createButton).toHaveBeenCalled();
+        });
+
+        it('throws an error when googlePaymentsClient is not initialized', async () => {
+            try {
+                await processor.createButton(jest.fn(() => {}));
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+                expect(error).toEqual(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+            }
+        });
+    });
+
+    describe('#handleSuccess', () => {
+        let tokenizePayload: TokenizePayload;
+
+        beforeEach(() => {
+            tokenizePayload = {
+                details: {
+                    cardType: 'MasterCard',
+                    lastFour: '4111',
+                    lastTwo: '11',
+                },
+                type: 'AndroidPayCard',
+                nonce: 'nonce',
+                description: '',
+                binData: {},
+            } as TokenizePayload;
+
+            const googlePayIsReadyToPayResponse = {
+                result: true,
+            };
+            const googlePaymentDataMock = getGooglePaymentDataMock();
+            const googlePaySDK = getGooglePaySDKMock();
+            clientMock = {
+                isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
+                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                createButton: jest.fn(() => Promise.resolve(new HTMLElement())),
+            };
+            googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
+
+            jest.spyOn(googlePayScriptLoader, 'load').mockReturnValue(Promise.resolve(googlePaySDK));
+            jest.spyOn(googlePayInitializer, 'initialize').mockReturnValue(Promise.resolve());
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getGooglePay());
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+        });
+
+        it('handles success response', async () => {
+            jest.spyOn(googlePayInitializer, 'parseResponse').mockReturnValue(Promise.resolve(tokenizePayload));
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
+            jest.spyOn(store.getState().billingAddress, 'getBillingAddress').mockReturnValue(getGooglePayAddressMock());
+            jest.spyOn(billingAddressActionCreator, 'updateAddress');
+            const googlePaymentDataMock = getGooglePaymentDataMock();
+            googlePaymentDataMock.cardInfo.billingAddress = getGooglePayAddressMock();
+
+            await processor.initialize('googlepay');
+            await processor.handleSuccess(googlePaymentDataMock);
+
+            expect(googlePayInitializer.parseResponse).toHaveBeenCalled();
+        });
+
+        it('throws when methodId from state is missed', async () => {
+            jest.spyOn(googlePayInitializer, 'parseResponse').mockReturnValue(Promise.resolve(tokenizePayload));
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
+            jest.spyOn(store.getState().billingAddress, 'getBillingAddress').mockReturnValue(getGooglePayAddressMock());
+
+            try {
+                await processor.handleSuccess(getGooglePaymentDataMock());
+
+                expect(googlePayInitializer.parseResponse).toHaveBeenCalled();
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+                expect(error).toEqual(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+            }
+        });
+
+        it('throws when billingAddress from state is missed', async () => {
+            jest.spyOn(googlePayInitializer, 'parseResponse').mockReturnValue(Promise.resolve(tokenizePayload));
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
+            const googlePaymentDataMock = getGooglePaymentDataMock();
+            googlePaymentDataMock.cardInfo.billingAddress = getGooglePayAddressMock();
+
+            await processor.initialize('googlepay');
+
+            try {
+                await processor.handleSuccess(getGooglePaymentDataMock());
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(error).toEqual(new MissingDataError(MissingDataErrorType.MissingPaymentMethod));
+            }
+        });
+    });
+
+    describe('#displayWallet', () => {
+        let googlePayIsReadyToPayResponse: GooglePayIsReadyToPayResponse;
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+        const googlePaySDK = getGooglePaySDKMock();
+
+        beforeEach(() => {
+            googlePayIsReadyToPayResponse = {
+                result: true,
+            };
+
+            jest.spyOn(googlePayScriptLoader, 'load').mockReturnValue(Promise.resolve(googlePaySDK));
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getGooglePay());
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+        });
+
+        it('displays wallet properly', async () => {
+            clientMock = {
+                isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
+                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                createButton: jest.fn(() => Promise.resolve()),
+            };
+            googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
+
+            jest.spyOn(googlePayInitializer, 'initialize').mockReturnValue(Promise.resolve(getGooglePayPaymentDataRequestMock()));
+
+            await processor.initialize('googlepay');
+            await processor.displayWallet();
+
+            expect(clientMock.isReadyToPay).toHaveBeenCalled();
+            expect(clientMock.loadPaymentData).toHaveBeenCalled();
+        });
+
+        it('throws when googlePaymentDataRequest is missed', async () => {
+            try {
+                await processor.displayWallet();
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+                expect(error).toEqual(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+            }
+        });
+
+        it('throws when Google Pay is not ready to pay', async () => {
+            googlePayIsReadyToPayResponse = {
+                result: false,
+            };
+            clientMock = {
+                isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
+                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                createButton: jest.fn(() => Promise.resolve()),
+            };
+            googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
+
+            jest.spyOn(googlePayInitializer, 'initialize').mockReturnValue(Promise.resolve(getGooglePayPaymentDataRequestMock()));
+
+            await processor.initialize('googlepay');
+
+            try {
+                await processor.displayWallet();
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+                expect(error).toEqual(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+            }
+        });
+
+        it('throws when Google Pay does not load payment data', async () => {
+            const googlePayError: GooglePaymentsError = {
+                statusCode: 'Error loading payment data',
+            };
+            clientMock = {
+                isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
+                loadPaymentData: jest.fn((a: any) => Promise.reject(googlePayError)),
+                createButton: jest.fn(() => Promise.resolve()),
+            };
+            googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
+
+            jest.spyOn(googlePayInitializer, 'initialize').mockReturnValue(Promise.resolve(getGooglePayPaymentDataRequestMock()));
+
+            await processor.initialize('googlepay');
+
+            try {
+                await processor.displayWallet();
+            } catch (error) {
+                expect(error).toEqual({ statusCode: googlePayError.statusCode });
+            }
+        });
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -1,0 +1,200 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { PaymentMethodActionCreator } from '../..';
+import { BillingAddressActionCreator, BillingAddressUpdateRequestBody } from '../../../billing';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import {
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedError,
+    NotInitializedErrorType,
+} from '../../../common/error/errors';
+import { toFormUrlEncoded } from '../../../common/http-request/';
+
+import {
+    ButtonColor,
+    ButtonType,
+    EnvironmentType,
+    GooglePaymentData,
+    GooglePayAddress,
+    GooglePayClient,
+    GooglePayInitializer,
+    GooglePayPaymentDataRequestV1,
+    GooglePaySDK,
+    TokenizePayload
+} from './googlepay';
+import GooglePayScriptLoader from './googlepay-script-loader';
+
+export default class GooglePayPaymentProcessor {
+    private _googlePaymentsClient?: GooglePayClient;
+    private _methodId?: string;
+    private _googlePaymentDataRequest?: GooglePayPaymentDataRequestV1;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _googlePayScriptLoader: GooglePayScriptLoader,
+        private _googlePayInitializer: GooglePayInitializer,
+        private _requestSender: RequestSender,
+        private _billingAddressActionCreator: BillingAddressActionCreator
+    ) { }
+
+    initialize(methodId: string): Promise<void> {
+        this._methodId = methodId;
+
+        return this._configureWallet();
+    }
+
+    deinitialize(): Promise<void> {
+        return this._googlePayInitializer.teardown();
+    }
+
+    createButton(
+        onClick: () => {},
+        buttonType: ButtonType = ButtonType.Short,
+        buttonColor: ButtonColor = ButtonColor.Default
+    ): HTMLElement {
+        if (!this._googlePaymentsClient) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._googlePaymentsClient.createButton({
+            buttonColor: ButtonColor.Default,
+            buttonType: ButtonType.Short,
+            onClick,
+        });
+    }
+
+    displayWallet(): Promise<GooglePaymentData> {
+        if (!this._googlePaymentsClient || !this._googlePaymentDataRequest || !this._googlePaymentDataRequest) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const googlePaymentsClient = this._googlePaymentsClient;
+        const googlePaymentDataRequest = this._googlePaymentDataRequest;
+
+        return this._googlePaymentsClient.isReadyToPay({
+            allowedPaymentMethods: this._googlePaymentDataRequest.allowedPaymentMethods,
+        }).then(response => {
+            if (response.result) {
+                return googlePaymentsClient.loadPaymentData(googlePaymentDataRequest);
+            } else {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+        });
+    }
+
+    handleSuccess(paymentData: GooglePaymentData): Promise<InternalCheckoutSelectors> {
+        return this._googlePayInitializer.parseResponse(paymentData)
+            .then(tokenizedPayload => this._postForm(tokenizedPayload))
+            .then(() => this.updateBillingAddress(paymentData.cardInfo.billingAddress));
+    }
+
+    private updateBillingAddress(billingAddress: GooglePayAddress): Promise<InternalCheckoutSelectors> {
+        if (!this._methodId) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const remoteBillingAddress = this._store.getState().billingAddress.getBillingAddress();
+
+        if (!remoteBillingAddress) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const googlePayAddressMapped = this._mapGooglePayAddressToBillingAddress(billingAddress, remoteBillingAddress.id);
+
+        return this._store.dispatch(
+            this._billingAddressActionCreator.updateAddress(googlePayAddressMapped)
+        );
+    }
+
+    private _getCardInformation(cardInformation: { cardType: string, lastFour: string }) {
+        return {
+            type: cardInformation.cardType,
+            number: cardInformation.lastFour,
+        };
+    }
+
+    private _postForm(postPaymentData: TokenizePayload): Promise<Response<any>> {
+        const cardInformation = postPaymentData.details;
+
+        return this._requestSender.post('/checkout.php', {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: toFormUrlEncoded({
+                payment_type: postPaymentData.type,
+                nonce: postPaymentData.nonce,
+                provider: this._methodId,
+                action: 'set_external_checkout',
+                card_information: this._getCardInformation(cardInformation),
+            }),
+        });
+    }
+
+    private _configureWallet(): Promise<void> {
+        if (!this._methodId) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const methodId = this._methodId;
+
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
+            .then(state => {
+                const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+                const checkout = state.checkout.getCheckout();
+                const hasShippingAddress = !!state.shippingAddress.getShippingAddress();
+
+                if (!paymentMethod) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                if (!checkout) {
+                    throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+                }
+
+                const testMode = paymentMethod.config.testMode;
+
+                return Promise.all([
+                    this._googlePayScriptLoader.load(),
+                    this._googlePayInitializer.initialize(checkout, paymentMethod, hasShippingAddress),
+                ])
+                    .then(([googlePay, googlePayPaymentDataRequest]) => {
+                        this._googlePaymentsClient = this._getGooglePayClient(googlePay, testMode);
+                        this._googlePaymentDataRequest = googlePayPaymentDataRequest;
+                    })
+                    .catch((error: Error) => {
+                        throw error;
+                    });
+            });
+    }
+
+    private _getGooglePayClient(google: GooglePaySDK, testMode?: boolean): GooglePayClient {
+        if (testMode === undefined) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const environment: EnvironmentType = testMode ? 'TEST' : 'PRODUCTION';
+
+        return new google.payments.api.PaymentsClient({ environment });
+    }
+
+    private _mapGooglePayAddressToBillingAddress(address: GooglePayAddress, id: string): BillingAddressUpdateRequestBody {
+        return {
+            id,
+            firstName: address.name.split(' ').slice(0, -1).join(' '),
+            lastName: address.name.split(' ').slice(-1).join(' '),
+            company: address.companyName,
+            address1: address.address1,
+            address2: address.address2 + address.address3 + address.address4 + address.address5,
+            city: address.locality,
+            stateOrProvince: address.administrativeArea,
+            stateOrProvinceCode: address.administrativeArea,
+            postalCode: address.postalCode,
+            countryCode: address.countryCode,
+            phone: address.phoneNumber,
+            customFields: [],
+        };
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -1,0 +1,431 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentInitializeOptions, PaymentMethod, PaymentMethodRequestSender, PaymentRequestSender } from '../..';
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
+import { getCartState } from '../../../cart/carts.mock';
+import {
+    createCheckoutStore,
+    CheckoutActionCreator,
+    CheckoutRequestSender,
+    CheckoutStore,
+    CheckoutValidator
+} from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import {
+    InvalidArgumentError, MissingDataError, MissingDataErrorType,
+    NotInitializedError, NotInitializedErrorType
+} from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { OrderActionCreator } from '../../../order';
+import {
+    createPaymentClient,
+    createPaymentStrategyRegistry,
+    PaymentActionCreator,
+    PaymentMethodActionCreator,
+    PaymentStrategyActionCreator
+} from '../../../payment';
+import { getGooglePay, getPaymentMethodsState } from '../../payment-methods.mock';
+import { BraintreeScriptLoader, BraintreeSDKCreator } from '../braintree';
+
+import {
+    GooglePayBraintreeInitializer,
+    GooglePayPaymentProcessor,
+    GooglePayPaymentStrategy,
+    GooglePayScriptLoader
+} from './';
+import { GooglePaymentData, GooglePayInitializer } from './googlepay';
+import { getGoogleOrderRequestBody, getGooglePaymentDataPayload } from './googlepay.mock';
+
+describe('GooglePayPaymentStrategy', () => {
+    let store: CheckoutStore;
+    let googlePayScriptLoader: GooglePayScriptLoader;
+    let strategy: GooglePayPaymentStrategy;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentStrategyActionCreator: PaymentStrategyActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let orderActionCreator: OrderActionCreator;
+    let googlePayInitializer: GooglePayInitializer;
+    let requestSender: RequestSender;
+    let googlePayPaymentProcessor: GooglePayPaymentProcessor;
+    let container: HTMLDivElement;
+    let walletButton: HTMLAnchorElement;
+    let paymentMethodMock: PaymentMethod;
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
+        const configRequestSender = new ConfigRequestSender(createRequestSender());
+        const configActionCreator = new ConfigActionCreator(configRequestSender);
+        const paymentMethodRequestSender: PaymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
+        const paymentClient = createPaymentClient(store);
+        const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender);
+        const scriptLoader = createScriptLoader();
+        const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader);
+        const braintreeSdkCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        const billingAddressActionCreator = new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender));
+
+        googlePayScriptLoader = new GooglePayScriptLoader(createScriptLoader());
+        requestSender = createRequestSender();
+        checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
+        paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
+        paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
+        paymentActionCreator = new PaymentActionCreator(new PaymentRequestSender(paymentClient), orderActionCreator);
+        orderActionCreator = new OrderActionCreator(
+            paymentClient,
+            new CheckoutValidator(
+                new CheckoutRequestSender(createRequestSender())
+            )
+        );
+        googlePayInitializer = new GooglePayBraintreeInitializer(braintreeSdkCreator);
+        googlePayPaymentProcessor = new GooglePayPaymentProcessor(
+            store,
+            paymentMethodActionCreator,
+            googlePayScriptLoader,
+            googlePayInitializer,
+            requestSender,
+            billingAddressActionCreator
+        );
+
+        strategy = new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            googlePayPaymentProcessor
+        );
+
+        container = document.createElement('div');
+        walletButton = document.createElement('a');
+        container.setAttribute('id', 'login');
+        walletButton.setAttribute('id', 'mockButton');
+        document.body.appendChild(container);
+        document.body.appendChild(walletButton);
+
+        jest.spyOn(walletButton, 'removeEventListener');
+        jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
+        jest.spyOn(googlePayInitializer, 'initialize').mockReturnValue(getGooglePaymentDataPayload());
+        jest.spyOn(checkoutActionCreator, 'loadCurrentCheckout').mockReturnValue(Promise.resolve());
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(googlePayPaymentProcessor, 'initialize').mockReturnValue(Promise.resolve());
+
+        paymentMethodMock = { ...getGooglePay() };
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        document.body.removeChild(walletButton);
+    });
+
+    it('creates an instance of GooglePayPaymentStrategy', () => {
+        expect(strategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+
+    describe('#initialize()', () => {
+        let googlePayOptions: PaymentInitializeOptions;
+
+        beforeEach(() => {
+            jest.spyOn(walletButton, 'addEventListener');
+            googlePayOptions = { methodId: 'googlepay', googlepay: { walletButton: 'mockButton' } };
+        });
+
+        it('loads googlepay script', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(googlePayOptions);
+
+            expect(googlePayPaymentProcessor.initialize).toHaveBeenCalled();
+        });
+
+        it('does not load googlepay if initialization options are not provided', async () => {
+            googlePayOptions = { methodId: 'googlepay'};
+
+            try {
+                await strategy.initialize(googlePayOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('adds the event listener to the wallet button', async () => {
+            await strategy.initialize(googlePayOptions);
+
+            expect(walletButton.addEventListener).toHaveBeenCalled();
+        });
+
+        it('does not add the event listener to the wallet button', async () => {
+            googlePayOptions = { methodId: 'googlepay', googlepay: { } };
+
+            await strategy.initialize(googlePayOptions);
+
+            expect(walletButton.addEventListener).toHaveBeenCalledTimes(0);
+        });
+
+        it('checks if element exist in the DOM', async () => {
+            if (googlePayOptions.googlepay && googlePayOptions.googlepay.walletButton) {
+                jest.spyOn(document, 'getElementById').mockReturnValue(document.getElementById(googlePayOptions.googlepay.walletButton));
+
+                await strategy.initialize(googlePayOptions);
+
+                expect(document.getElementById).toHaveBeenCalledWith(googlePayOptions.googlepay.walletButton);
+            }
+        });
+    });
+
+    describe('#deinitialize', () => {
+        let googlePayOptions: PaymentInitializeOptions;
+
+        beforeEach(() => {
+            jest.spyOn(walletButton, 'addEventListener');
+            googlePayOptions = { methodId: 'googlepay', googlepay: { walletButton: 'mockButton' } };
+        });
+
+        it('deinitializes googlePayInitializer and GooglePayment Processor', async () => {
+            jest.spyOn(googlePayPaymentProcessor, 'deinitialize').mockReturnValue(Promise.resolve());
+
+            await strategy.deinitialize();
+
+            expect(googlePayPaymentProcessor.deinitialize).toHaveBeenCalled();
+        });
+
+        it('removes the eventListener', async () => {
+            jest.spyOn(googlePayPaymentProcessor, 'deinitialize').mockReturnValue(Promise.resolve());
+
+            await strategy.initialize(googlePayOptions);
+            await strategy.deinitialize();
+
+            expect(googlePayPaymentProcessor.deinitialize).toHaveBeenCalled();
+        });
+    });
+
+    describe('#execute', () => {
+        let googlePayOptions: PaymentInitializeOptions;
+
+        beforeEach(() => {
+            jest.spyOn(walletButton, 'addEventListener');
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve());
+            googlePayOptions = {
+                methodId: 'googlepay',
+                googlepay: {
+                    walletButton: 'mockButton',
+                    onError: () => {},
+                    onPaymentSelect: () => {},
+                },
+            };
+        });
+
+        it('creates the order and submit payment', async () => {
+            const googlePaymentMethodData = {
+                initializationData: {
+                    nonce: 'nonce',
+                    card_information: 'card_info',
+                },
+            };
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(googlePaymentMethodData);
+
+            await strategy.initialize(googlePayOptions);
+            await strategy.execute(getGoogleOrderRequestBody());
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+        });
+
+        it('throws and error when GooglePaymentOptions are not available', async () => {
+            try {
+                await strategy.execute(getGoogleOrderRequestBody());
+            } catch (exception) {
+                expect(exception).toBeInstanceOf(InvalidArgumentError);
+                expect(exception).toEqual(
+                    new InvalidArgumentError('Unable to initialize payment because "options.googlepay" argument is not provided.')
+                );
+            }
+        });
+
+        it('gets again the payment information and submit payment', async () => {
+            const googlePaymentMethodData = {
+                initializationData: {
+                    nonce: 'nonce',
+                    card_information: undefined,
+                },
+            };
+
+            const paymentData = {
+                cardInfo: {
+                    billingAddress: {},
+                },
+                paymentMethodToken: {},
+                shippingAddress: {},
+                email: 'email',
+            } as GooglePaymentData;
+
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(paymentData));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(googlePaymentMethodData);
+
+            await strategy.initialize(googlePayOptions);
+            await strategy.execute(getGoogleOrderRequestBody());
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+        });
+
+        it('gets again the payment information and gets an error', async () => {
+            const googlePaymentMethodData = {
+                initializationData: {
+                    nonce: 'nonce',
+                    card_information: undefined,
+                },
+            };
+
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(
+                Promise.reject({statusCode: 'ERROR'})
+            );
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(googlePaymentMethodData);
+
+            await strategy.initialize(googlePayOptions);
+            await strategy.execute(getGoogleOrderRequestBody());
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+        });
+
+        it('gets again the payment information and user closes widget', async () => {
+            const googlePaymentMethodData = {
+                initializationData: {
+                    nonce: 'nonce',
+                    card_information: undefined,
+                },
+            };
+
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(
+                Promise.reject({statusCode: 'CANCELED'})
+            );
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(googlePaymentMethodData);
+
+            await strategy.initialize(googlePayOptions);
+            await strategy.execute(getGoogleOrderRequestBody());
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+        });
+
+        it('gets again the payment information and methodId is not defined', async () => {
+            const googlePaymentMethodData = {
+                initializationData: {
+                    nonce: 'nonce',
+                    card_information: undefined,
+                },
+            };
+
+            const googlePayOptionsWithOutMethodId: any = {
+                googlepay: {
+                    walletButton: 'mockButton',
+                    onError: () => {},
+                    onPaymentSelect: () => {},
+                },
+            };
+
+            const paymentData = {
+                cardInfo: {
+                    billingAddress: {},
+                },
+                paymentMethodToken: {},
+                shippingAddress: {},
+                email: 'email',
+            } as GooglePaymentData;
+
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(paymentData));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(googlePaymentMethodData);
+
+            await strategy.initialize(googlePayOptionsWithOutMethodId);
+            try {
+                await strategy.execute(getGoogleOrderRequestBody());
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+                expect(error).toEqual(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+            }
+        });
+
+        it('gets again the payment information and in getPayment, paymentMethod is missed', async () => {
+            const paymentData = {
+                cardInfo: {
+                    billingAddress: {},
+                },
+                paymentMethodToken: {},
+                shippingAddress: {},
+                email: 'email',
+            } as GooglePaymentData;
+
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(paymentData));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(undefined);
+
+            await strategy.initialize(googlePayOptions);
+            try {
+                await strategy.execute(getGoogleOrderRequestBody());
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(error).toEqual(new MissingDataError(MissingDataErrorType.MissingPaymentMethod));
+            }
+        });
+
+        it('gets again the payment information and in getPayment, nonce is missed', async () => {
+            const paymentData = {
+                cardInfo: {
+                    billingAddress: {},
+                },
+                paymentMethodToken: {},
+                shippingAddress: {},
+                email: 'email',
+            } as GooglePaymentData;
+
+            const googlePaymentMethodData = {
+                initializationData: {
+                    nonce: undefined,
+                    card_information: undefined,
+                },
+            };
+
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(paymentData));
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(googlePaymentMethodData);
+
+            await strategy.initialize(googlePayOptions);
+            try {
+                await strategy.execute(getGoogleOrderRequestBody());
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+                expect(error).toEqual(new MissingDataError(MissingDataErrorType.MissingPayment));
+            }
+        });
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -1,0 +1,180 @@
+import { PaymentStrategy } from '../';
+import {
+    PaymentActionCreator,
+    PaymentInitializeOptions,
+    PaymentMethodActionCreator,
+    PaymentRequestOptions,
+    PaymentStrategyActionCreator
+} from '../..';
+import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { NotInitializedError } from '../../../common/error/errors';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedErrorType,
+} from '../../../common/error/errors';
+import { bindDecorator as bind } from '../../../common/utility';
+import {
+    OrderActionCreator, OrderRequestBody } from '../../../order';
+
+import { GooglePayPaymentInitializeOptions, GooglePayPaymentProcessor } from './';
+import {
+    GooglePaymentData,
+    PaymentMethodData,
+} from './googlepay';
+
+export default class GooglePayPaymentStrategy extends PaymentStrategy {
+    private _googlePayOptions?: GooglePayPaymentInitializeOptions;
+    private _methodId?: string;
+    private _walletButton?: HTMLElement;
+
+    constructor(
+        store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _paymentStrategyActionCreator: PaymentStrategyActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _orderActionCreator: OrderActionCreator,
+        private _googlePayPaymentProcessor: GooglePayPaymentProcessor
+    ) {
+        super(store);
+    }
+
+    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        this._methodId = options.methodId;
+
+        this._googlePayOptions = options.googlepay;
+
+        return this._googlePayPaymentProcessor.initialize(this._methodId)
+            .then(() => {
+                if (!options.googlepay) {
+                    throw new InvalidArgumentError('Unable to initialize payment because "options.googlepay" argument is not provided.');
+                }
+
+                const walletButton = options.googlepay.walletButton && document.getElementById(options.googlepay.walletButton);
+
+                if (walletButton) {
+                    this._walletButton = walletButton;
+                    this._walletButton.addEventListener('click', this._handleWalletButtonClick);
+                }
+
+                return super.initialize(options);
+            });
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (this._walletButton) {
+            this._walletButton.removeEventListener('click', this._handleWalletButtonClick);
+        }
+
+        this._walletButton = undefined;
+
+        return Promise.all([
+            this._googlePayPaymentProcessor.deinitialize(),
+        ]).then(() => super.deinitialize(options));
+    }
+
+    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (!this._googlePayOptions) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.googlepay" argument is not provided.');
+        }
+
+        const {
+            onError = () => {},
+            onPaymentSelect = () => {},
+        } = this._googlePayOptions;
+
+        return Promise.resolve(this._getPayment())
+            .then(payment => {
+                if (!payment.paymentData.nonce || !payment.paymentData.cardInformation) {
+                    // TODO: Find a way to share the code with _handleWalletButtonClick method
+                    return this._googlePayPaymentProcessor.displayWallet()
+                        .then(paymentData => this._paymentInstrumentSelected(paymentData))
+                        .then(() => onPaymentSelect())
+                        .then(() => this._getPayment())
+                        .catch(error => {
+                            if (error.statusCode !== 'CANCELED') {
+                                onError(error);
+                            }
+                        });
+                }
+
+                return payment;
+            })
+            .then(payment =>
+                this._store.dispatch(this._orderActionCreator.submitOrder({ useStoreCredit: payload.useStoreCredit }, options))
+                    .then(() => this._store.dispatch(this._paymentActionCreator.submitPayment(this._getPayment())))
+            );
+    }
+
+    private _paymentInstrumentSelected(paymentData: GooglePaymentData) {
+        if (!this._methodId) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const methodId = this._methodId;
+
+        // TODO: Revisit how we deal with GooglePaymentData after receiving it from Google
+        return this._googlePayPaymentProcessor.handleSuccess(paymentData)
+            .then(() => Promise.all([
+                this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
+                this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId)),
+            ]));
+    }
+
+    private _getPayment(): PaymentMethodData {
+        if (!this._methodId) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethod(this._methodId);
+
+        if (!paymentMethod) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        if (!paymentMethod.initializationData.nonce) {
+            throw new MissingDataError(MissingDataErrorType.MissingPayment);
+        }
+
+        const paymentData = {
+            method: this._methodId,
+            nonce: paymentMethod.initializationData.nonce,
+            cardInformation: paymentMethod.initializationData.card_information,
+        };
+
+        return {
+            methodId: this._methodId,
+            paymentData,
+        };
+    }
+
+    @bind
+    private _handleWalletButtonClick(event: Event): Promise<InternalCheckoutSelectors> {
+        event.preventDefault();
+
+        if (!this._methodId || !this._googlePayOptions) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const methodId = this._methodId;
+
+        const {
+            onError = () => {},
+            onPaymentSelect = () => {},
+        } = this._googlePayOptions;
+
+        return this._store.dispatch(this._paymentStrategyActionCreator.widgetInteraction(() => {
+            return this._googlePayPaymentProcessor.displayWallet()
+                .then(paymentData => this._paymentInstrumentSelected(paymentData))
+                .then(() => onPaymentSelect())
+                .catch(error => {
+                    if (error.statusCode !== 'CANCELED') {
+                        onError(error);
+                    }
+                });
+        }, { methodId }), { queueId: 'widgetInteraction' });
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay-script-loader.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-script-loader.spec.ts
@@ -1,0 +1,54 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { StandardError } from '../../../common/error/errors';
+
+import { GooglePayScriptLoader } from './';
+import { GooglePayHostWindow, GooglePaySDK } from './googlepay';
+import { getGooglePaySDKMock } from './googlepay.mock';
+
+describe('GooglePayScriptLoader', () => {
+    let googlePayScriptLoader: GooglePayScriptLoader;
+    let scriptLoader: ScriptLoader;
+    let mockWindow: GooglePayHostWindow;
+
+    beforeEach(() => {
+        mockWindow = { } as GooglePayHostWindow;
+        scriptLoader = {} as ScriptLoader;
+        googlePayScriptLoader = new GooglePayScriptLoader(scriptLoader, mockWindow);
+    });
+
+    describe('#load()', () => {
+        let googlePaySDKMock: GooglePaySDK;
+
+        beforeEach(() => {
+            googlePaySDKMock = getGooglePaySDKMock();
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.google = googlePaySDKMock;
+                return Promise.resolve();
+            });
+        });
+
+        it('loads the SDK', async () => {
+            await googlePayScriptLoader.load();
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('https://pay.google.com/gp/p/js/pay.js');
+        });
+
+        it('returns the SDK from the window', async () => {
+            const sdk = await googlePayScriptLoader.load();
+            expect(sdk).toBe(googlePaySDKMock);
+        });
+
+        it('throws an error when window is not set', async () => {
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.google = undefined;
+                return Promise.resolve();
+            });
+
+            try {
+                await googlePayScriptLoader.load();
+            } catch (error) {
+                expect(error).toBeInstanceOf(StandardError);
+            }
+        });
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-script-loader.ts
+++ b/src/payment/strategies/googlepay/googlepay-script-loader.ts
@@ -1,0 +1,24 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { StandardError } from '../../../common/error/errors';
+
+import { GooglePayHostWindow, GooglePaySDK } from './googlepay';
+
+export default class GooglePayScriptLoader {
+    constructor(
+        private _scriptLoader: ScriptLoader,
+        private _window: GooglePayHostWindow = window
+    ) {}
+
+    load(): Promise<GooglePaySDK> {
+        return this._scriptLoader
+            .loadScript('https://pay.google.com/gp/p/js/pay.js')
+            .then(() => {
+                if (!this._window.google) {
+                    throw new StandardError();
+                }
+
+                return this._window.google;
+            });
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -1,0 +1,181 @@
+import { Cart } from '../../../cart';
+import { Checkout } from '../../../checkout';
+import { Coupon } from '../../../coupon';
+import { GiftCertificate } from '../../../coupon';
+import { Customer } from '../../../customer';
+import { Discount } from '../../../discount';
+import { OrderRequestBody } from '../../../order';
+import { Consignment } from '../../../shipping';
+import { Tax } from '../../../tax';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodConfig from '../../payment-method-config';
+import { GooglePayBraintreeSDK } from '../braintree';
+
+import {
+    GooglePaymentData,
+    GooglePayAddress,
+    GooglePayPaymentDataRequestV1,
+    GooglePaySDK
+} from './googlepay';
+
+export function getGooglePaySDKMock(): GooglePaySDK {
+    return {
+        payments: {
+            api: {
+                PaymentsClient: jest.fn(),
+            },
+        },
+    };
+}
+
+export function getGooglePayBraintreeMock(): GooglePayBraintreeSDK {
+    return {
+        createPaymentDataRequest: jest.fn(dataRequest => Promise.resolve(dataRequest as GooglePayPaymentDataRequestV1)),
+        parseResponse: jest.fn(),
+        teardown: jest.fn(() => Promise.resolve()),
+    };
+}
+
+export function getCheckoutMock(): Checkout {
+    return {
+        id: '1',
+        cart: {
+            currency: {
+                code: 'USD',
+            },
+        } as Cart,
+        customer: {} as Customer,
+        customerMessage: '',
+        consignments: [{}] as Consignment[],
+        taxes: [{}] as Tax[],
+        discounts: [{}] as Discount[],
+        coupons: [{}] as Coupon[],
+        shippingCostTotal: 0,
+        shippingCostBeforeDiscount: 0,
+        handlingCostTotal: 0,
+        taxTotal: 0,
+        subtotal: 0,
+        grandTotal: 1,
+        giftCertificates: [{}] as GiftCertificate[],
+        balanceDue: 0,
+        createdTime: '',
+        updatedTime: '',
+    };
+}
+
+export function getPaymentMethodMock(): PaymentMethod {
+    return {
+        id: 'id',
+        config: {} as PaymentMethodConfig,
+        method: 'method',
+        supportedCards: [] as string[],
+        type: '',
+        clientToken: 'token',
+        nonce: 'nonce',
+        initializationData: {
+            platformToken: 'platformToken',
+        },
+    };
+}
+
+export function getGooglePaymentDataPayload() {
+    return {
+        cardRequirements: {
+            billingAddressFormat: 'FULL',
+            billingAddressRequired: true,
+        },
+        emailRequired: true,
+        merchantInfo: {
+            authJwt: 'platformToken',
+        },
+        phoneNumberRequired: true,
+        shippingAddressRequired: true,
+        transactionInfo: {
+            currencyCode: 'USD',
+            totalPrice: '1',
+            totalPriceStatus: 'FINAL',
+        },
+    };
+}
+
+export function getGooglePaymentDataMock(): GooglePaymentData {
+    return {
+        cardInfo: {
+            cardClass: 'cardClass',
+            cardDescription: 'cardDescription',
+            cardDetails: 'cardDetails',
+            cardImageUri: 'cardImageUri',
+            cardNetwork: 'cardNetwork',
+            billingAddress: {} as GooglePayAddress,
+        },
+        paymentMethodToken: {
+            token: 'token',
+            tokenizationType: 'tokenizationType',
+        },
+        shippingAddress: {} as GooglePayAddress,
+        email: 'email',
+    };
+}
+
+export function getGoogleOrderRequestBody(): OrderRequestBody {
+    return {
+        useStoreCredit: true,
+    };
+}
+
+export function getGooglePayAddressMock(): GooglePayAddress {
+    return {
+        address1: 'mock',
+        address2: 'mock',
+        address3: 'mock',
+        address4: 'mock',
+        address5: 'mock',
+        administrativeArea: 'mock',
+        companyName: 'mock',
+        countryCode: 'mock',
+        locality: 'mock',
+        name: 'mock',
+        postalCode: 'mock',
+        sortingCode: 'mock',
+        phoneNumber: 'mock',
+    };
+}
+
+export function getGooglePayPaymentDataRequestMock(): GooglePayPaymentDataRequestV1 {
+    return {
+        allowedPaymentMethods: [
+            'CreditCard',
+        ],
+        apiVersion: 1,
+        cardRequirements: {
+            allowedCardNetworks: [''],
+            billingAddressRequired: true,
+            billingAddressFormat: '',
+        },
+        enviroment: '',
+        i: {
+            googleTransactionId: '',
+            startTimeMs: 1,
+        },
+        merchantInfo: {
+            merchantId: '',
+        },
+        paymentMethodTokenizationParameters: {
+            parameters: {
+                'braintree:apiVersion': '',
+                'braintree:authorizationFingerprint': '',
+                'braintree:merchantId': '',
+                'braintree:metadata': '',
+                'braintree:sdkVersion': '',
+                gateway: '',
+            },
+            tokenizationType: '',
+        },
+        shippingAddressRequired: true,
+        transactionInfo: {
+            currencyCode: '',
+            totalPrice: '',
+            totalPriceStatus: '',
+        },
+    };
+}

--- a/src/payment/strategies/googlepay/googlepay.ts
+++ b/src/payment/strategies/googlepay/googlepay.ts
@@ -1,0 +1,180 @@
+import { PaymentMethod } from '../..';
+import { Checkout } from '../../../checkout';
+import { BraintreeModuleCreator, GooglePayBraintreeSDK } from '../braintree';
+
+export type EnvironmentType = 'PRODUCTION' | 'TEST';
+type AddressFormat = 'FULL' | 'MIN';
+type TotalPriceStatus = 'ESTIMATED' | 'FINAL' | 'NOT_CURRENTLY_KNOWN';
+type TokenizeType = 'AndroidPayCard' | 'CreditCard';
+
+export interface GooglePayInitializer {
+    initialize(checkout: Checkout, paymentMethod: PaymentMethod, hasShippingAddress: boolean, publishableKey?: string): Promise<GooglePayPaymentDataRequestV1>;
+    teardown(): Promise<void>;
+    parseResponse(paymentData: GooglePaymentData): Promise<TokenizePayload>;
+}
+
+export interface GooglePayCreator extends BraintreeModuleCreator<GooglePayBraintreeSDK> {}
+
+export interface GooglePayPaymentOptions {
+    environment: EnvironmentType;
+}
+
+export interface GooglePayDataRequestV1 {
+    merchantInfo: {
+        authJwt?: string,
+    };
+    transactionInfo: {
+        currencyCode: string,
+        totalPriceStatus: TotalPriceStatus,
+        totalPrice: string,
+    };
+    cardRequirements: {
+        billingAddressRequired: boolean,
+        billingAddressFormat: AddressFormat,
+    };
+    emailRequired: boolean;
+    phoneNumberRequired: boolean;
+    shippingAddressRequired: boolean;
+}
+
+export interface GooglePayPaymentDataRequestV1 {
+    allowedPaymentMethods: string[];
+    apiVersion: number;
+    cardRequirements: {
+        allowedCardNetworks: string[];
+        billingAddressFormat: string;
+        billingAddressRequired: boolean;
+    };
+    enviroment: string;
+    i: {
+        googleTransactionId: string;
+        startTimeMs: number;
+    };
+    merchantInfo: {
+        merchantId: string;
+    };
+    paymentMethodTokenizationParameters: {
+        parameters: {
+            'braintree:apiVersion': string;
+            'braintree:authorizationFingerprint': string;
+            'braintree:merchantId': string;
+            'braintree:metadata': string;
+            'braintree:sdkVersion': string;
+            gateway: string;
+        };
+        tokenizationType: string;
+    };
+    shippingAddressRequired: boolean;
+    transactionInfo: {
+        currencyCode: string;
+        totalPrice: string;
+        totalPriceStatus: string;
+    };
+}
+
+export interface GooglePayIsReadyToPayResponse {
+    result: boolean;
+    paymentMethodPresend?: boolean;
+}
+
+export interface GooglePaySDK {
+    payments: {
+        api: {
+            PaymentsClient: {
+                new(options: GooglePayPaymentOptions): GooglePayClient;
+            },
+        },
+    };
+}
+
+export interface GooglePayClient {
+    isReadyToPay(options: object): Promise<GooglePayIsReadyToPayResponse>;
+    loadPaymentData(paymentDataRequest: GooglePayPaymentDataRequestV1): Promise<GooglePaymentData>;
+    createButton(options: { [key: string]: string | object }): HTMLElement;
+}
+
+export interface GooglePayHostWindow extends Window {
+    google?: GooglePaySDK;
+}
+
+export interface TokenizePayload {
+    nonce: string;
+    details: {
+        cardType: string;
+        lastFour: string;
+        lastTwo: string;
+    };
+    description: string;
+    type: TokenizeType;
+    binData: {
+        commercial: string;
+        countryOfIssuance: string;
+        debit: string;
+        durbinRegulated: string;
+        healthcare: string;
+        issuingBank: string;
+        payroll: string;
+        prepaid: string;
+        productId: string;
+    };
+}
+
+export interface GooglePaymentData {
+    cardInfo: {
+        cardClass: string;
+        cardDescription: string;
+        cardDetails: string;
+        cardImageUri: string;
+        cardNetwork: string;
+        billingAddress: GooglePayAddress;
+    };
+    paymentMethodToken: {
+        token: string;
+        tokenizationType: string;
+    };
+    shippingAddress: GooglePayAddress;
+    email: string;
+}
+
+export interface GooglePayAddress {
+    address1: string;
+    address2: string;
+    address3: string;
+    address4: string;
+    address5: string;
+    administrativeArea: string;
+    companyName: string;
+    countryCode: string;
+    locality: string;
+    name: string;
+    postalCode: string;
+    sortingCode: string;
+    phoneNumber: string;
+}
+
+export interface GooglePaymentsError {
+    statusCode: string;
+    statusMessage?: string;
+}
+
+export interface PaymentMethodData {
+    methodId: string;
+    paymentData: {
+        method: string,
+        nonce: string,
+        cardInformation: {
+            type: string,
+            number: string,
+        },
+    };
+}
+
+export enum ButtonType {
+    Long = 'long',
+    Short = 'short',
+}
+export enum ButtonColor {
+    Default = 'default',
+    Black = 'black',
+    White = 'white',
+}

--- a/src/payment/strategies/googlepay/index.ts
+++ b/src/payment/strategies/googlepay/index.ts
@@ -1,0 +1,7 @@
+export * from './googlepay';
+
+export { default as GooglePayScriptLoader } from './googlepay-script-loader';
+export { default as GooglePayPaymentStrategy } from './googlepay-payment-strategy';
+export { default as GooglePayBraintreeInitializer } from './googlepay-braintree-initializer';
+export { default as GooglePayPaymentInitializeOptions } from './googlepay-initialize-options';
+export { default as GooglePayPaymentProcessor } from './googlepay-payment-processor';

--- a/src/payment/strategies/index.ts
+++ b/src/payment/strategies/index.ts
@@ -8,7 +8,18 @@ export { default as SagePayPaymentStrategy } from './sage-pay-payment-strategy';
 
 export { AfterpayPaymentStrategy } from './afterpay';
 export { AmazonPayPaymentStrategy, AmazonPayPaymentInitializeOptions } from './amazon-pay';
-export { BraintreeCreditCardPaymentStrategy, BraintreePaymentInitializeOptions, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy, BraintreeVisaCheckoutPaymentInitializeOptions } from './braintree';
+export {
+    BraintreeCreditCardPaymentStrategy,
+    BraintreePaymentInitializeOptions,
+    BraintreePaypalPaymentStrategy,
+    BraintreeVisaCheckoutPaymentStrategy,
+    BraintreeVisaCheckoutPaymentInitializeOptions
+} from './braintree';
+export {
+    GooglePayPaymentStrategy,
+    GooglePayPaymentInitializeOptions,
+    GooglePayPaymentProcessor
+} from './googlepay';
 export { KlarnaPaymentStrategy, KlarnaPaymentInitializeOptions } from './klarna';
 export { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy } from './paypal';
 export { ChasePayPaymentStrategy, ChasePayInitializeOptions } from './chasepay';


### PR DESCRIPTION
## What?
Support Google Pay as a Wallet implementing a strategy. Google Pay needs to work with Braintree configuration and load the proper files.

## Why?
I want to be able to open the Google Pay Wallet, select a car and get a nonce from Google Pay using Braintree configuration and after that checkout using Google Pay as a Wallet and Braintree as a Provider.

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/47050693-eeea4500-d166-11e8-8a72-726901ff5b0e.png)

Video: https://drive.google.com/open?id=12WrpSCazOym9DnrjA3tfVXPLW3F4YdE9



## Jira Ticket
https://jira.bigcommerce.com/browse/INT-835