### PR TITLE
feat(payments): INT-685 Correctly set up CCAvenue MARS return URL

### DIFF
--- a/src/payment/strategies/offsite-payment-strategy.spec.ts
+++ b/src/payment/strategies/offsite-payment-strategy.spec.ts
@@ -76,6 +76,18 @@ describe('OffsitePaymentStrategy', () => {
         expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
     });
 
+    it('submits order with payment data if payment method is "ccavenuemars"', async () => {
+        const payload = merge({}, getOrderRequestBody(), {
+            payment: { methodId: 'ccavenuemars' },
+        });
+        const options = { methodId: 'ccavenuemars', gatewayId: '' };
+
+        await strategy.execute(payload, options);
+
+        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(payload, options);
+        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    });
+
     it('initializes offsite payment flow', async () => {
         const payload = getOrderRequestBody();
         const options = { methodId: 'amex', gatewayId: 'adyen' };


### PR DESCRIPTION
## What?
Add a check to pull correct data for CCAvenue MARS offsite payments.

## Why?
Without this BigPay does not receive a value for `returnUrl` when processing the offsite initialization request.

## Testing / Proof
Manual testing to verify successful payment initialization.

@bigcommerce/checkout @bigcommerce/payments
