### PR TITLE
feat(checkout): INT-951 Implement Masterpass button in cart and quick

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -1,6 +1,6 @@
 import { RequestOptions } from '../common/http-request';
 
-import { BraintreePaypalButtonInitializeOptions } from './strategies';
+import { BraintreePaypalButtonInitializeOptions, MasterpassButtonInitializeOptions } from './strategies';
 
 /**
  * The set of options for configuring the checkout button.
@@ -24,4 +24,5 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * omitted unless you need to support Braintree Credit.
      */
     braintreepaypalcredit?: BraintreePaypalButtonInitializeOptions;
+    masterpass?: MasterpassButtonInitializeOptions;
 }

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -6,9 +6,10 @@ import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
+import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 
-import { BraintreePaypalButtonStrategy, CheckoutButtonStrategy } from './strategies';
+import { BraintreePaypalButtonStrategy, CheckoutButtonStrategy, MasterpassButtonStrategy } from './strategies';
 
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
@@ -39,6 +40,14 @@ export default function createCheckoutButtonRegistry(
             new PaypalScriptLoader(scriptLoader),
             createFormPoster(),
             true
+        )
+    );
+
+    registry.register('masterpass', () =>
+        new MasterpassButtonStrategy(
+            store,
+            checkoutActionCreator,
+            new MasterpassScriptLoader(scriptLoader)
         )
     );
 

--- a/src/checkout-buttons/index.ts
+++ b/src/checkout-buttons/index.ts
@@ -1,5 +1,6 @@
 export { default as createCheckoutButtonInitializer } from './create-checkout-button-initializer';
-
 export { default as checkoutButtonReducer } from './checkout-button-reducer';
 export { default as CheckoutButtonSelector } from './checkout-button-selector';
 export { default as CheckoutButtonState } from './checkout-button-state';
+
+export { CheckoutButtonOptions, CheckoutButtonInitializeOptions } from './checkout-button-options';

--- a/src/checkout-buttons/strategies/index.ts
+++ b/src/checkout-buttons/strategies/index.ts
@@ -1,4 +1,6 @@
 export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
 export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
+export { default as MasterpassButtonStrategy } from './masterpass-button-strategy';
 
 export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+export { MasterpassButtonInitializeOptions } from './masterpass-button-options';

--- a/src/checkout-buttons/strategies/masterpass-button-options.ts
+++ b/src/checkout-buttons/strategies/masterpass-button-options.ts
@@ -1,0 +1,6 @@
+export interface MasterpassButtonInitializeOptions {
+    /**
+     * The ID of a container which the checkout button should be inserted.
+     */
+    container: string;
+}

--- a/src/checkout-buttons/strategies/masterpass-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/masterpass-button-strategy.spec.ts
@@ -1,0 +1,202 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { CheckoutButtonInitializeOptions } from '../';
+import { getCartState } from '../../cart/carts.mock';
+import {
+    createCheckoutStore,
+    Checkout,
+    CheckoutActionCreator,
+    CheckoutRequestSender,
+    CheckoutStore
+} from '../../checkout';
+import { getCheckout, getCheckoutState } from '../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../config';
+import { PaymentMethod } from '../../payment';
+import { getMasterpass, getPaymentMethodsState } from '../../payment/payment-methods.mock';
+import { Masterpass, MasterpassScriptLoader } from '../../payment/strategies/masterpass';
+import { getMasterpassScriptMock } from '../../payment/strategies/masterpass/masterpass.mock';
+
+import { CheckoutButtonStrategy, MasterpassButtonStrategy } from './';
+
+describe('MasterpassCustomerStrategy', () => {
+    let container: HTMLDivElement;
+    let masterpass: Masterpass;
+    let masterpassScriptLoader: MasterpassScriptLoader;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let checkoutMock: Checkout;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: CheckoutButtonStrategy;
+
+    beforeEach(() => {
+        paymentMethodMock = {
+            ...getMasterpass(),
+            initializationData: {
+                checkoutId: 'checkoutId',
+                allowedCardTypes: ['visa', 'amex', 'mastercard'],
+            },
+        };
+
+        checkoutMock = getCheckout();
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethodMock);
+
+        jest.spyOn(store.getState().checkout, 'getCheckout')
+            .mockReturnValue(checkoutMock);
+
+        requestSender = createRequestSender();
+
+        masterpass = getMasterpassScriptMock();
+
+        masterpassScriptLoader = new MasterpassScriptLoader(createScriptLoader());
+
+        jest.spyOn(masterpassScriptLoader, 'load')
+            .mockReturnValue(Promise.resolve(masterpass));
+
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+        );
+
+        strategy = new MasterpassButtonStrategy(
+            store,
+            checkoutActionCreator,
+            masterpassScriptLoader
+        );
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'login');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('creates an instance of MasterpassCustomerStrategy', () => {
+        expect(strategy).toBeInstanceOf(CheckoutButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        let masterpassOptions: CheckoutButtonInitializeOptions;
+        beforeEach(() => {
+            masterpassOptions = { methodId: 'masterpass', masterpass: { container: 'login' } };
+        });
+
+        it('loads masterpass script in test mode if enabled', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(masterpassOptions);
+
+            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(true);
+        });
+
+        it('loads masterpass without test mode if disabled', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(masterpassOptions);
+
+            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(false);
+        });
+
+        it('fails to initialize the strategy if no methodid is supplied', async () => {
+            masterpassOptions = { methodId: '', masterpass: { container: 'login' } };
+            try {
+                await strategy.initialize(masterpassOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('fails to initialize the strategy if no cart is supplied', async () => {
+            jest.spyOn(store.getState().checkout, 'getCheckout')
+                .mockReturnValue(undefined);
+            try {
+                await strategy.initialize(masterpassOptions);
+                expect(strategy).toBeInstanceOf(CheckoutButtonStrategy);
+            } catch (e) {
+                expect(e).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('fails to initialize the strategy if no checkoutId is supplied', async () => {
+            paymentMethodMock.initializationData.checkoutId = undefined;
+            try {
+                await strategy.initialize(masterpassOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('fails to initialize the strategy if no container is supplied', async () => {
+            document.body.removeChild(container);
+            try {
+                await strategy.initialize(masterpassOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(Error);
+                document.body.appendChild(container);
+            }
+        });
+
+        it('fails to initialize the strategy if no payment method is supplied', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+                .mockReturnValueOnce(null);
+            try {
+                await strategy.initialize(masterpassOptions);
+            } catch (e) {
+                expect(e).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('proceeds to checkout if masterpass button is clicked', async () => {
+            jest.spyOn(masterpass, 'checkout');
+            await strategy.initialize(masterpassOptions);
+            if (masterpassOptions.masterpass) {
+                const masterpassButton = document.getElementById(masterpassOptions.masterpass.container);
+                if (masterpassButton) {
+                    const btn = masterpassButton.firstChild as HTMLElement;
+                    if (btn) {
+                        btn.click();
+                        expect(masterpass.checkout).toHaveBeenCalled();
+                    }
+                }
+            }
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        let masterpassOptions: CheckoutButtonInitializeOptions;
+
+        beforeEach(() => {
+            masterpassOptions = { methodId: 'masterpass', masterpass: { container: 'login' } };
+        });
+
+        it('succesfully deinitializes the strategy', async () => {
+            jest.spyOn(masterpass, 'checkout');
+            await strategy.initialize(masterpassOptions);
+            strategy.deinitialize({ methodId: 'masterpass' });
+            if (masterpassOptions.masterpass) {
+                const masterpassButton = document.getElementById(masterpassOptions.masterpass.container);
+                if (masterpassButton) {
+                    expect(masterpassButton.firstChild).toBe(null);
+                }
+            }
+            // Prevent "After Each" failure
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+    });
+});

--- a/src/checkout-buttons/strategies/masterpass-button-strategy.ts
+++ b/src/checkout-buttons/strategies/masterpass-button-strategy.ts
@@ -1,0 +1,122 @@
+import { CheckoutButtonInitializeOptions, CheckoutButtonOptions } from '../';
+import { CheckoutActionCreator, CheckoutStore } from '../../checkout';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedError,
+    NotInitializedErrorType
+} from '../../common/error/errors';
+import { bindDecorator as bind } from '../../common/utility';
+import { Masterpass, MasterpassCheckoutOptions, MasterpassScriptLoader } from '../../payment/strategies/masterpass';
+
+import { CheckoutButtonStrategy } from './';
+
+export default class MasterpassButtonStrategy extends CheckoutButtonStrategy {
+    private _masterpassClient?: Masterpass;
+    private _methodId?: string;
+    private _signInButton?: HTMLElement;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _masterpassScriptLoader: MasterpassScriptLoader
+    ) {
+        super();
+    }
+
+    initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { masterpass: masterpassOptions, methodId } = options;
+
+        if (!masterpassOptions || !methodId) {
+            throw new InvalidArgumentError('Unable to proceed because "options.masterpass" argument is not provided.');
+        }
+
+        if (this._isInitialized) {
+            return super.initialize(options);
+        }
+
+        this._methodId = methodId;
+
+        return this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout())
+            .then(state => {
+                const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+                if (!paymentMethod || !paymentMethod.initializationData.checkoutId) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                return this._masterpassScriptLoader.load(paymentMethod.config.testMode);
+            })
+            .then(masterpass => {
+                this._masterpassClient = masterpass;
+                this._signInButton = this._createSignInButton(masterpassOptions.container);
+
+                return super.initialize(options);
+            });
+    }
+
+    deinitialize(options: CheckoutButtonOptions): Promise<void> {
+        if (!this._isInitialized) {
+            return super.deinitialize(options);
+        }
+
+        if (this._signInButton && this._signInButton.parentNode) {
+            this._signInButton.removeEventListener('click', this._handleWalletButtonClick);
+            this._signInButton.parentNode.removeChild(this._signInButton);
+            this._signInButton = undefined;
+        }
+
+        return super.deinitialize(options);
+    }
+
+    private _createSignInButton(containerId: string): HTMLElement {
+        const buttonContainer = document.querySelector(`#${containerId}`);
+
+        if (!buttonContainer) {
+            throw new Error('Need a container to place the button');
+        }
+
+        const button = document.createElement('input');
+
+        button.type = 'image';
+        button.src = 'https://static.masterpass.com/dyn/img/btn/global/mp_chk_btn_160x037px.svg';
+        buttonContainer.appendChild(button);
+
+        button.addEventListener('click', this._handleWalletButtonClick);
+
+        return button;
+    }
+
+    private _createMasterpassPayload(): MasterpassCheckoutOptions {
+        const state = this._store.getState();
+        const checkout = state.checkout.getCheckout();
+        const paymentMethod = this._methodId ? state.paymentMethods.getPaymentMethod(this._methodId) : null;
+
+        if (!checkout) {
+            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+        }
+
+        if (!paymentMethod) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return {
+            checkoutId: paymentMethod.initializationData.checkoutId,
+            allowedCardTypes: paymentMethod.initializationData.allowedCardTypes,
+            amount: checkout.cart.cartAmount.toString(),
+            currency: checkout.cart.currency.code,
+            cartId: checkout.cart.id,
+            suppressShippingAddress: true,
+        };
+    }
+
+    @bind
+    private _handleWalletButtonClick(): void {
+        if (!this._masterpassClient) {
+            throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);
+        }
+
+        this._masterpassClient.checkout(this._createMasterpassPayload());
+    }
+}

--- a/src/customer/strategies/masterpass-customer-strategy.ts
+++ b/src/customer/strategies/masterpass-customer-strategy.ts
@@ -54,6 +54,7 @@ export default class MasterpassCustomerStrategy extends CustomerStrategy {
                     amount: cart.cartAmount.toString(),
                     currency: cart.currency.code,
                     cartId: cart.id,
+                    suppressShippingAddress: true,
                 };
 
                 return this._masterpassScriptLoader.load(this._paymentMethod.config.testMode)

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.ts
@@ -6,11 +6,7 @@ import {
     PaymentRequestOptions
 } from '../../';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import {
-    InvalidArgumentError,
-    MissingDataError,
-    MissingDataErrorType
-} from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { bindDecorator as bind } from '../../../common/utility';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import PaymentMethod from '../../payment-method';


### PR DESCRIPTION
## What? [INT-951](https://jira.bigcommerce.com/browse/INT-951)
Create checkout-buttons masterpass strategy
&
Hide the shipping address in the customer section as requested in [INT-984](https://jira.bigcommerce.com/browse/INT-984)
## Why?
We need this strategy to implement the cart and quick cart buttons for Masterpass

Due the delivery dates i made only one PR in order to simplify the process

## Testing / Proof
![image](https://user-images.githubusercontent.com/6343437/46386657-5c3aa800-c688-11e8-92da-b9a6ee2a6098.png)
![image](https://user-images.githubusercontent.com/6343437/47200409-ae8ff000-d33b-11e8-852d-32571931c87c.png)
![image](https://user-images.githubusercontent.com/6343437/47200515-1b0aef00-d33c-11e8-8293-7afb2f33f370.png)
![image](https://user-images.githubusercontent.com/6343437/47200520-22ca9380-d33c-11e8-8a65-aae997e2d638.png)



