### PR TITLE
CHECKOUT-3475: Emit `FRAME_ERROR` event if unable to embed checkout in iframe

### DIFF
--- a/src/embedded-checkout/embedded-checkout-events.ts
+++ b/src/embedded-checkout/embedded-checkout-events.ts
@@ -2,6 +2,7 @@ export enum EmbeddedCheckoutEventType {
     CheckoutComplete = 'CHECKOUT_COMPLETE',
     CheckoutError = 'CHECKOUT_ERROR',
     CheckoutLoaded = 'CHECKOUT_LOADED',
+    FrameError = 'FRAME_ERROR',
     FrameLoaded = 'FRAME_LOADED',
 }
 
@@ -9,12 +10,14 @@ export interface EmbeddedCheckoutEventMap {
     [EmbeddedCheckoutEventType.CheckoutComplete]: EmbeddedCheckoutCompleteEvent;
     [EmbeddedCheckoutEventType.CheckoutError]: EmbeddedCheckoutErrorEvent;
     [EmbeddedCheckoutEventType.CheckoutLoaded]: EmbeddedCheckoutLoadedEvent;
+    [EmbeddedCheckoutEventType.FrameError]: EmbeddedCheckoutFrameErrorEvent;
     [EmbeddedCheckoutEventType.FrameLoaded]: EmbeddedCheckoutFrameLoadedEvent;
 }
 
 export type EmbeddedCheckoutEvent = (
     EmbeddedCheckoutCompleteEvent |
     EmbeddedCheckoutErrorEvent |
+    EmbeddedCheckoutFrameErrorEvent |
     EmbeddedCheckoutFrameLoadedEvent |
     EmbeddedCheckoutLoadedEvent
 );
@@ -25,17 +28,24 @@ export interface EmbeddedCheckoutCompleteEvent {
 
 export interface EmbeddedCheckoutErrorEvent {
     type: EmbeddedCheckoutEventType.CheckoutError;
-    payload: {
-        message: string;
-        type?: string;
-        subtype?: string;
-    };
+    payload: EmbeddedCheckoutError;
 }
 
 export interface EmbeddedCheckoutLoadedEvent {
     type: EmbeddedCheckoutEventType.CheckoutLoaded;
 }
 
+export interface EmbeddedCheckoutFrameErrorEvent {
+    type: EmbeddedCheckoutEventType.FrameError;
+    payload: EmbeddedCheckoutError;
+}
+
 export interface EmbeddedCheckoutFrameLoadedEvent {
     type: EmbeddedCheckoutEventType.FrameLoaded;
+}
+
+export interface EmbeddedCheckoutError {
+    message: string;
+    type?: string;
+    subtype?: string;
 }

--- a/src/embedded-checkout/embedded-checkout-options.ts
+++ b/src/embedded-checkout/embedded-checkout-options.ts
@@ -1,10 +1,17 @@
-import { EmbeddedCheckoutCompleteEvent, EmbeddedCheckoutErrorEvent, EmbeddedCheckoutFrameLoadedEvent, EmbeddedCheckoutLoadedEvent } from './embedded-checkout-events';
+import {
+    EmbeddedCheckoutCompleteEvent,
+    EmbeddedCheckoutErrorEvent,
+    EmbeddedCheckoutFrameErrorEvent,
+    EmbeddedCheckoutFrameLoadedEvent,
+    EmbeddedCheckoutLoadedEvent,
+} from './embedded-checkout-events';
 
 export default interface EmbeddedCheckoutOptions {
     containerId: string;
     url: string;
     onComplete?(event: EmbeddedCheckoutCompleteEvent): void;
     onError?(event: EmbeddedCheckoutErrorEvent): void;
+    onFrameError?(event: EmbeddedCheckoutFrameErrorEvent): void;
     onFrameLoad?(event: EmbeddedCheckoutFrameLoadedEvent): void;
     onLoad?(event: EmbeddedCheckoutLoadedEvent): void;
 }

--- a/src/embedded-checkout/embedded-checkout.spec.ts
+++ b/src/embedded-checkout/embedded-checkout.spec.ts
@@ -66,7 +66,7 @@ describe('EmbeddedCheckout', () => {
         } catch (thrown) {
             expect(messageListener.trigger)
                 .toHaveBeenCalledWith({
-                    type: EmbeddedCheckoutEventType.CheckoutError,
+                    type: EmbeddedCheckoutEventType.FrameError,
                     payload: error,
                 });
 

--- a/src/embedded-checkout/embedded-checkout.ts
+++ b/src/embedded-checkout/embedded-checkout.ts
@@ -54,7 +54,7 @@ export default class EmbeddedCheckout {
                 this._isAttached = false;
 
                 this._messageListener.trigger({
-                    type: EmbeddedCheckoutEventType.CheckoutError,
+                    type: EmbeddedCheckoutEventType.FrameError,
                     payload: error,
                 });
 

--- a/src/embedded-checkout/iframe-content/embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/embedded-checkout-messenger.spec.ts
@@ -1,4 +1,5 @@
 import { CartChangedError } from '../../cart/errors';
+import { StandardError } from '../../common/error/errors';
 import { EmbeddedCheckoutEventType } from '../embedded-checkout-events';
 
 import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
@@ -53,6 +54,20 @@ describe('EmbeddedCheckoutMessenger', () => {
 
         expect(parentWindow.postMessage).toHaveBeenCalledWith({
             type: EmbeddedCheckoutEventType.FrameLoaded,
+        }, parentOrigin);
+    });
+
+    it('posts `frame_error` event to parent window', () => {
+        const error = new StandardError();
+
+        messenger.postFrameError(error);
+
+        expect(parentWindow.postMessage).toHaveBeenCalledWith({
+            type: EmbeddedCheckoutEventType.FrameError,
+            payload: {
+                message: error.message,
+                type: error.type,
+            },
         }, parentOrigin);
     });
 });

--- a/src/embedded-checkout/iframe-content/embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/embedded-checkout-messenger.ts
@@ -1,9 +1,11 @@
 import { isCustomError, CustomError } from '../../common/error/errors';
 import {
     EmbeddedCheckoutCompleteEvent,
+    EmbeddedCheckoutError,
     EmbeddedCheckoutErrorEvent,
     EmbeddedCheckoutEvent,
     EmbeddedCheckoutEventType,
+    EmbeddedCheckoutFrameErrorEvent,
     EmbeddedCheckoutFrameLoadedEvent,
     EmbeddedCheckoutLoadedEvent,
 } from '../embedded-checkout-events';
@@ -35,11 +37,16 @@ export default class EmbeddedCheckoutMessenger {
     postError(payload: Error | CustomError): void {
         const message: EmbeddedCheckoutErrorEvent = {
             type: EmbeddedCheckoutEventType.CheckoutError,
-            payload: {
-                message: payload.message,
-                type: isCustomError(payload) ? payload.type : undefined,
-                subtype: isCustomError(payload) ? payload.subtype : undefined,
-            },
+            payload: this._transformError(payload),
+        };
+
+        this._notifyParent(message);
+    }
+
+    postFrameError(payload: Error | CustomError): void {
+        const message: EmbeddedCheckoutFrameErrorEvent = {
+            type: EmbeddedCheckoutEventType.FrameError,
+            payload: this._transformError(payload),
         };
 
         this._notifyParent(message);
@@ -59,6 +66,14 @@ export default class EmbeddedCheckoutMessenger {
         };
 
         this._notifyParent(message);
+    }
+
+    private _transformError(error: Error | CustomError): EmbeddedCheckoutError {
+        return {
+            message: error.message,
+            type: isCustomError(error) ? error.type : undefined,
+            subtype: isCustomError(error) ? error.subtype : undefined,
+        };
     }
 
     private _notifyParent(message: EmbeddedCheckoutEvent): void {

--- a/src/embedded-checkout/is-embedded-checkout-event.ts
+++ b/src/embedded-checkout/is-embedded-checkout-event.ts
@@ -1,7 +1,14 @@
-import { EmbeddedCheckoutEvent, EmbeddedCheckoutEventType } from './embedded-checkout-events';
+import { EmbeddedCheckoutEvent, EmbeddedCheckoutEventMap, EmbeddedCheckoutEventType } from './embedded-checkout-events';
 
 export default function isEmbeddedCheckoutEvent(object: any): object is EmbeddedCheckoutEvent {
     return Object.keys(EmbeddedCheckoutEventType)
         .map((key: any) => EmbeddedCheckoutEventType[key])
         .indexOf(object && object.type) >= 0;
+}
+
+export function isEmbeddedCheckoutEventType<TType extends keyof EmbeddedCheckoutEventMap>(
+    event: EmbeddedCheckoutEvent,
+    type: TType
+): event is EmbeddedCheckoutEventMap[TType] {
+    return event.type === type;
 }


### PR DESCRIPTION
## What?
* Emit an error event if unable to embed the checkout form as an iframe.

## Why?
* So you can catch and handle the error in case you can't embed the iframe for whatever reason. i.e.:
```ts
embedCheckout(config)
    .catch(error => {
        window.alert(error.message);
        window.location.assign('/cart');
    });
```
* Because most likely the iframe will be embedded across domains, so you can't listen for error events from the parent frame. Instead, you need to rely on the child frame to tell the parent frame when the checkout form cannot be loaded.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
