### PR TITLE
CHECKOUT-3581 Translate Country and State in returned addresses

### DIFF
--- a/src/address/index.ts
+++ b/src/address/index.ts
@@ -1,4 +1,7 @@
-export { default as Address, AddressRequestBody } from './address';
+export {
+    default as Address,
+    AddressRequestBody,
+} from './address';
 export { default as InternalAddress } from './internal-address';
 export { default as LegacyAddress } from './legacy-address';
 

--- a/src/address/locale-address.ts
+++ b/src/address/locale-address.ts
@@ -1,0 +1,17 @@
+import { Country } from '../geography';
+
+import Address from './address';
+
+export default function localeAddress<T1 extends Address>(address: T1, countries?: Country[]): T1 {
+    const country =  (countries || []).find(({ code }) => code === address.countryCode);
+    const states = !country || !country.subdivisions.length ? [] : country.subdivisions;
+    const state = states.find(({ code }) => code === address.stateOrProvinceCode);
+
+    return Object.assign({},
+        address,
+        {
+            country: country ? country.name : address.country,
+            stateOrProvince: state ? state.name : address.stateOrProvince,
+        }
+    );
+}

--- a/src/billing/billing-address-selector.spec.js
+++ b/src/billing/billing-address-selector.spec.js
@@ -1,26 +1,32 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
+import { CountrySelector } from '../geography';
+import { getCountriesState } from '../geography/countries.mock';
+
 import BillingAddressSelector from './billing-address-selector';
 import { getBillingAddressState } from './billing-addresses.mock';
 
 describe('BillingAddressSelector', () => {
     let billingAddressSelector;
+    let countrySelector;
     let state;
 
     beforeEach(() => {
         state = {
             billingAddress: getBillingAddressState(),
         };
+
+        countrySelector = new CountrySelector(getCountriesState());
     });
 
     describe('#getBillingAddress()', () => {
         it('returns the current billing address', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress, countrySelector);
 
             expect(billingAddressSelector.getBillingAddress()).toEqual(state.billingAddress.data);
         });
 
         it('returns undefined if quote is not available', () => {
-            billingAddressSelector = new BillingAddressSelector({ ...state.billingAddress, data: undefined });
+            billingAddressSelector = new BillingAddressSelector({ ...state.billingAddress, data: undefined }, countrySelector);
 
             expect(billingAddressSelector.getBillingAddress()).toEqual();
         });
@@ -33,13 +39,13 @@ describe('BillingAddressSelector', () => {
             billingAddressSelector = new BillingAddressSelector({
                 ...state.billingAddress,
                 errors: { updateError },
-            });
+            }, countrySelector);
 
             expect(billingAddressSelector.getUpdateError()).toEqual(updateError);
         });
 
         it('does not returns error if able to update', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress, countrySelector);
 
             expect(billingAddressSelector.getUpdateError()).toBeUndefined();
         });
@@ -53,13 +59,13 @@ describe('BillingAddressSelector', () => {
             billingAddressSelector = new BillingAddressSelector({
                 ...state.billingAddress,
                 errors: { continueAsGuestError },
-            });
+            }, countrySelector);
 
             expect(billingAddressSelector.getContinueAsGuestError()).toEqual(continueAsGuestError);
         });
 
         it('does not returns error if able to update', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress, countrySelector);
 
             expect(billingAddressSelector.getContinueAsGuestError()).toBeUndefined();
         });
@@ -70,13 +76,13 @@ describe('BillingAddressSelector', () => {
             billingAddressSelector = new BillingAddressSelector({
                 ...state.billingAddress,
                 statuses: { isUpdating: true },
-            });
+            }, countrySelector);
 
             expect(billingAddressSelector.isUpdating()).toEqual(true);
         });
 
         it('returns false if not updating billing address', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress, countrySelector);
 
             expect(billingAddressSelector.isUpdating()).toEqual(false);
         });
@@ -87,13 +93,13 @@ describe('BillingAddressSelector', () => {
             billingAddressSelector = new BillingAddressSelector({
                 ...state.billingAddress,
                 statuses: { isContinuingAsGuest: true },
-            });
+            }, countrySelector);
 
             expect(billingAddressSelector.isContinuingAsGuest()).toEqual(true);
         });
 
         it('returns false if not updating billing address', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = new BillingAddressSelector(state.billingAddress, countrySelector);
 
             expect(billingAddressSelector.isContinuingAsGuest()).toEqual(false);
         });

--- a/src/billing/billing-address-selector.ts
+++ b/src/billing/billing-address-selector.ts
@@ -1,4 +1,6 @@
+import localeAddress from '../address/locale-address';
 import { selector } from '../common/selector';
+import { CountrySelector } from '../geography';
 
 import BillingAddress from './billing-address';
 import BillingAddressState from './billing-address-state';
@@ -6,11 +8,16 @@ import BillingAddressState from './billing-address-state';
 @selector
 export default class BillingAddressSelector {
     constructor(
-        private _billingAddress: BillingAddressState
+        private _billingAddress: BillingAddressState,
+        private _countries: CountrySelector
     ) {}
 
     getBillingAddress(): BillingAddress | undefined {
-        return this._billingAddress.data;
+        if (!this._billingAddress.data) {
+            return;
+        }
+
+        return localeAddress(this._billingAddress.data, this._countries.getCountries());
     }
 
     getUpdateError(): Error | undefined {

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -20,26 +20,26 @@ import CheckoutStoreState from './checkout-store-state';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 export default function createInternalCheckoutSelectors(state: CheckoutStoreState, options: CheckoutStoreOptions = {}): InternalCheckoutSelectors {
-    const billingAddress = new BillingAddressSelector(state.billingAddress);
+    const countries = new CountrySelector(state.countries);
     const cart = new CartSelector(state.cart);
     const checkoutButton = new CheckoutButtonSelector(state.checkoutButton);
     const config = new ConfigSelector(state.config);
-    const countries = new CountrySelector(state.countries);
     const coupons = new CouponSelector(state.coupons);
-    const customer = new CustomerSelector(state.customer);
     const customerStrategies = new CustomerStrategySelector(state.customerStrategies);
     const form = new FormSelector(state.config);
     const giftCertificates = new GiftCertificateSelector(state.giftCertificates);
     const instruments = new InstrumentSelector(state.instruments);
     const paymentMethods = new PaymentMethodSelector(state.paymentMethods);
     const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
-    const shippingAddress = new ShippingAddressSelector(state.consignments);
     const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);
     const shippingCountries = new ShippingCountrySelector(state.shippingCountries);
     const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);
 
     // Compose selectors
-    const consignments = new ConsignmentSelector(state.consignments, cart);
+    const billingAddress = new BillingAddressSelector(state.billingAddress, countries);
+    const customer = new CustomerSelector(state.customer, countries);
+    const consignments = new ConsignmentSelector(state.consignments, cart, countries);
+    const shippingAddress = new ShippingAddressSelector(consignments);
     const checkout = new CheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, customer, giftCertificates);
     const order = new OrderSelector(state.order, billingAddress, coupons);
     const payment = new PaymentSelector(checkout, order);

--- a/src/customer/customer-selector.spec.ts
+++ b/src/customer/customer-selector.spec.ts
@@ -1,5 +1,7 @@
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { CountrySelector } from '../geography';
+import { getCountriesState } from '../geography/countries.mock';
 
 import CustomerSelector from './customer-selector';
 import { getCustomer } from './customers.mock';
@@ -7,20 +9,22 @@ import { getCustomer } from './customers.mock';
 describe('CustomerSelector', () => {
     let selector: CustomerSelector;
     let state: CheckoutStoreState;
+    let countrySelector: CountrySelector;
 
     beforeEach(() => {
         state = getCheckoutStoreState();
+        countrySelector = new CountrySelector(getCountriesState());
     });
 
     describe('#getCustomer()', () => {
         it('returns current customer', () => {
-            selector = new CustomerSelector(state.customer);
+            selector = new CustomerSelector(state.customer, countrySelector);
 
             expect(selector.getCustomer()).toEqual(getCustomer());
         });
 
         it('returns undefined if customer is unavailable', () => {
-            selector = new CustomerSelector({});
+            selector = new CustomerSelector({}, countrySelector);
 
             expect(selector.getCustomer()).toEqual(undefined);
         });

--- a/src/customer/customer-selector.ts
+++ b/src/customer/customer-selector.ts
@@ -1,4 +1,6 @@
+import localeAddress from '../address/locale-address';
 import { selector } from '../common/selector';
+import { CountrySelector } from '../geography';
 
 import Customer from './customer';
 import CustomerState from './customer-state';
@@ -6,10 +8,20 @@ import CustomerState from './customer-state';
 @selector
 export default class CustomerSelector {
     constructor(
-        private _customer: CustomerState
+        private _customer: CustomerState,
+        private _countries: CountrySelector
     ) {}
 
     getCustomer(): Customer | undefined {
-        return this._customer.data;
+        if (!this._customer.data) {
+            return;
+        }
+
+        return {
+            ...this._customer.data,
+            addresses: this._customer.data.addresses.map(
+                address => localeAddress(address, this._countries.getCountries())
+            ),
+        };
     }
 }

--- a/src/shipping/consignment-selector.spec.ts
+++ b/src/shipping/consignment-selector.spec.ts
@@ -3,6 +3,8 @@ import { merge } from 'lodash';
 import { CartSelector } from '../cart';
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { CountrySelector } from '../geography';
+import { getCountriesState } from '../geography/countries.mock';
 
 import ConsignmentSelector from './consignment-selector';
 import ConsignmentState from './consignment-state';
@@ -29,15 +31,17 @@ describe('ConsignmentSelector', () => {
     let selector: ConsignmentSelector;
     let state: CheckoutStoreState;
     let cartSelector: CartSelector;
+    let countrySelector: CountrySelector;
 
     beforeEach(() => {
         state = getCheckoutStoreState();
         cartSelector = new CartSelector(state.cart);
+        countrySelector = new CountrySelector(getCountriesState());
     });
 
     describe('#getConsignmentByAddress()', () => {
         it('returns first matched consignment when address matches', () => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = new ConsignmentSelector(state.consignments, cartSelector, countrySelector);
 
             expect(selector.getConsignmentByAddress(existingAddress))
                 // tslint:disable-next-line:no-non-null-assertion
@@ -45,7 +49,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns undefined if no address matches a consignment', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.getConsignmentByAddress(nonexistentAddress))
                 .toEqual(undefined);
@@ -54,7 +58,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getConsignmentById()', () => {
         it('returns consignment that matches id', () => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = new ConsignmentSelector(state.consignments, cartSelector, countrySelector);
 
             expect(selector.getConsignmentById('55c96cda6f04c'))
                 // tslint:disable-next-line:no-non-null-assertion
@@ -62,7 +66,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns undefined if no id matches a consignment', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.getConsignmentById('none'))
                 .toEqual(undefined);
@@ -71,13 +75,13 @@ describe('ConsignmentSelector', () => {
 
     describe('#getConsignments()', () => {
         it('returns consignments', () => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = new ConsignmentSelector(state.consignments, cartSelector, countrySelector);
 
             expect(selector.getConsignments()).toEqual(getConsignmentsState().data);
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.getConsignments()).toEqual(undefined);
         });
@@ -85,13 +89,13 @@ describe('ConsignmentSelector', () => {
 
     describe('#getShippingOption()', () => {
         it('returns selected shipping option for default consignment', () => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = new ConsignmentSelector(state.consignments, cartSelector, countrySelector);
 
             expect(selector.getShippingOption()).toEqual(getConsignment().selectedShippingOption);
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.getConsignments()).toEqual(undefined);
         });
@@ -103,13 +107,13 @@ describe('ConsignmentSelector', () => {
 
             selector = new ConsignmentSelector(merge({}, emptyState, {
                 errors: { loadError },
-            }), cartSelector);
+            }), cartSelector, countrySelector);
 
             expect(selector.getLoadError()).toEqual(loadError);
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.getLoadError()).toEqual(undefined);
         });
@@ -121,13 +125,13 @@ describe('ConsignmentSelector', () => {
 
             selector = new ConsignmentSelector(merge({}, emptyState, {
                 errors: { createError },
-            }), cartSelector);
+            }), cartSelector, countrySelector);
 
             expect(selector.getCreateError()).toEqual(createError);
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.getCreateError()).toEqual(undefined);
         });
@@ -139,13 +143,13 @@ describe('ConsignmentSelector', () => {
 
             selector = new ConsignmentSelector(merge({}, emptyState, {
                 errors: { loadShippingOptionsError },
-            }), cartSelector);
+            }), cartSelector, countrySelector);
 
             expect(selector.getLoadShippingOptionsError()).toEqual(loadShippingOptionsError);
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.getLoadShippingOptionsError()).toEqual(undefined);
         });
@@ -153,7 +157,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getUpdateShippingOptionError()', () => {
         it('returns undefined if none errored', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector, countrySelector);
             expect(selector.getUpdateShippingOptionError()).toEqual(undefined);
         });
 
@@ -167,7 +171,7 @@ describe('ConsignmentSelector', () => {
                             foo: error,
                         },
                     },
-                }), cartSelector);
+                }), cartSelector, countrySelector);
             });
 
             it('returns first encountered error', () => {
@@ -186,7 +190,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getUpdateError()', () => {
         it('returns undefined if none errored', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector, countrySelector);
             expect(selector.getUpdateError()).toEqual(undefined);
         });
 
@@ -200,7 +204,7 @@ describe('ConsignmentSelector', () => {
                             foo: error,
                         },
                     },
-                }), cartSelector);
+                }), cartSelector, countrySelector);
             });
 
             it('returns first encountered error', () => {
@@ -219,7 +223,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getDeleteError()', () => {
         it('returns undefined if none errored', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector, countrySelector);
             expect(selector.getDeleteError()).toEqual(undefined);
         });
 
@@ -233,7 +237,7 @@ describe('ConsignmentSelector', () => {
                             foo: error,
                         },
                     },
-                }), cartSelector);
+                }), cartSelector, countrySelector);
             });
 
             it('returns first encountered error', () => {
@@ -262,7 +266,7 @@ describe('ConsignmentSelector', () => {
                     },
                     createError,
                 },
-            }), cartSelector);
+            }), cartSelector, countrySelector);
         });
 
         it('returns first encountered error for consignment with matching address', () => {
@@ -276,7 +280,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getUnassignedItems()', () => {
         beforeEach(() => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = new ConsignmentSelector(state.consignments, cartSelector, countrySelector);
         });
 
         it('returns unassigned items', () => {
@@ -318,13 +322,13 @@ describe('ConsignmentSelector', () => {
         it('returns true if loading', () => {
             selector = new ConsignmentSelector(merge({}, emptyState, {
                 statuses: { isLoading: true },
-            }), cartSelector);
+            }), cartSelector, countrySelector);
 
             expect(selector.isLoading()).toEqual(true);
         });
 
         it('returns false if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.isLoading()).toEqual(false);
         });
@@ -334,13 +338,13 @@ describe('ConsignmentSelector', () => {
         it('returns true if loading', () => {
             selector = new ConsignmentSelector(merge({}, emptyState, {
                 statuses: { isLoadingShippingOptions: true },
-            }), cartSelector);
+            }), cartSelector, countrySelector);
 
             expect(selector.isLoadingShippingOptions()).toEqual(true);
         });
 
         it('returns false if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.isLoadingShippingOptions()).toEqual(false);
         });
@@ -350,13 +354,13 @@ describe('ConsignmentSelector', () => {
         it('returns true if creating', () => {
             selector = new ConsignmentSelector(merge({}, emptyState, {
                 statuses: { isCreating: true },
-            }), cartSelector);
+            }), cartSelector, countrySelector);
 
             expect(selector.isCreating()).toEqual(true);
         });
 
         it('returns false if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = new ConsignmentSelector(emptyState, cartSelector, countrySelector);
 
             expect(selector.isCreating()).toEqual(false);
         });
@@ -364,7 +368,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#isUpdating()', () => {
         it('returns false if none is updating', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector, countrySelector);
             expect(selector.isUpdating()).toEqual(false);
         });
 
@@ -377,7 +381,7 @@ describe('ConsignmentSelector', () => {
                             bar: false,
                         },
                     },
-                }), cartSelector);
+                }), cartSelector, countrySelector);
             });
 
             it('returns true if updating any', () => {
@@ -396,7 +400,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#isDeleting()', () => {
         it('returns false if none is deleting', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector, countrySelector);
             expect(selector.isDeleting()).toEqual(false);
         });
 
@@ -409,7 +413,7 @@ describe('ConsignmentSelector', () => {
                             bar: false,
                         },
                     },
-                }), cartSelector);
+                }), cartSelector, countrySelector);
             });
 
             it('returns true if deleting any', () => {
@@ -435,7 +439,7 @@ describe('ConsignmentSelector', () => {
                     },
                     isCreating: false,
                 },
-            }), cartSelector);
+            }), cartSelector, countrySelector);
         });
 
         it('returns isUpdating state for consignment that matches given address', () => {
@@ -449,7 +453,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#isUpdatingShippingOption()', () => {
         it('returns false if none is updating', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector, countrySelector);
             expect(selector.isUpdatingShippingOption()).toEqual(false);
         });
 
@@ -462,7 +466,7 @@ describe('ConsignmentSelector', () => {
                             bar: false,
                         },
                     },
-                }), cartSelector);
+                }), cartSelector, countrySelector);
             });
 
             it('returns true if updating any', () => {

--- a/src/shipping/consignment-selector.ts
+++ b/src/shipping/consignment-selector.ts
@@ -1,8 +1,10 @@
 import { find } from 'lodash';
 
 import { isAddressEqual, AddressRequestBody } from '../address';
+import localeAddress from '../address/locale-address';
 import { CartSelector, PhysicalItem } from '../cart';
 import { selector } from '../common/selector';
+import { CountrySelector } from '../geography';
 
 import Consignment from './consignment';
 import ConsignmentState from './consignment-state';
@@ -12,15 +14,16 @@ import ShippingOption from './shipping-option';
 export default class ConsignmentSelector {
     constructor(
         private _consignments: ConsignmentState,
-        private _cart: CartSelector
+        private _cart: CartSelector,
+        private _countries: CountrySelector
     ) {}
 
     getConsignments(): Consignment[] | undefined {
-        return this._consignments.data;
+        return this._getConsignments();
     }
 
     getConsignmentById(id: string): Consignment | undefined {
-        const consignments = this._consignments.data;
+        const consignments = this._getConsignments();
 
         if (!consignments || !consignments.length) {
             return;
@@ -30,7 +33,7 @@ export default class ConsignmentSelector {
     }
 
     getConsignmentByAddress(address: AddressRequestBody): Consignment | undefined {
-        const consignments = this._consignments.data;
+        const consignments = this._getConsignments();
 
         if (!consignments || !consignments.length) {
             return;
@@ -42,7 +45,7 @@ export default class ConsignmentSelector {
     }
 
     getShippingOption(): ShippingOption | undefined {
-        const consignments = this._consignments.data;
+        const consignments = this._getConsignments();
 
         if (consignments && consignments.length) {
             return consignments[0].selectedShippingOption;
@@ -148,5 +151,16 @@ export default class ConsignmentSelector {
         }
 
         return find(this._consignments.statuses.isUpdatingShippingOption) === true;
+    }
+
+    _getConsignments(): Consignment[] | undefined {
+        if (!this._consignments.data || !this._consignments.data.length) {
+            return;
+        }
+
+        return this._consignments.data.map(consignment => ({
+            ...consignment,
+            shippingAddress: localeAddress(consignment.shippingAddress, this._countries.getCountries()),
+        }));
     }
 }

--- a/src/shipping/shipping-address-selector.spec.ts
+++ b/src/shipping/shipping-address-selector.spec.ts
@@ -1,3 +1,9 @@
+import { CartSelector } from '../cart';
+import { getCartState } from '../cart/carts.mock';
+import { CountrySelector } from '../geography';
+import { getCountriesState } from '../geography/countries.mock';
+
+import ConsignmentSelector from './consignment-selector';
 import ConsignmentState from './consignment-state';
 import { getConsignment, getConsignmentsState } from './consignments.mock';
 import ShippingAddressSelector from './shipping-address-selector';
@@ -5,14 +11,20 @@ import ShippingAddressSelector from './shipping-address-selector';
 describe('ShippingAddressSelector', () => {
     let shippingAddressSelector: ShippingAddressSelector;
     let consignmentState: ConsignmentState;
+    let countrySelector: CountrySelector;
+    let cartSelector: CartSelector;
 
     describe('#getShippingAddress()', () => {
         beforeEach(() => {
             consignmentState = getConsignmentsState();
+            countrySelector = new CountrySelector(getCountriesState());
+            cartSelector = new CartSelector(getCartState());
         });
 
         it('returns the current shipping address', () => {
-            shippingAddressSelector = new ShippingAddressSelector(consignmentState);
+            shippingAddressSelector = new ShippingAddressSelector(
+                new ConsignmentSelector(consignmentState, cartSelector, countrySelector)
+            );
 
             expect(shippingAddressSelector.getShippingAddress())
                 .toEqual(getConsignment().shippingAddress);
@@ -27,7 +39,9 @@ describe('ShippingAddressSelector', () => {
             });
 
             it('returns undefined', () => {
-                shippingAddressSelector = new ShippingAddressSelector(consignmentState);
+                shippingAddressSelector = new ShippingAddressSelector(
+                    new ConsignmentSelector(consignmentState, cartSelector, countrySelector)
+                );
 
                 expect(shippingAddressSelector.getShippingAddress()).toBeUndefined();
             });

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -2,16 +2,16 @@ import { selector } from '../common/selector';
 
 import { Address } from '../address';
 
-import ConsignmentState from './consignment-state';
+import ConsignmentSelector from './consignment-selector';
 
 @selector
 export default class ShippingAddressSelector {
     constructor(
-        private _consignments: ConsignmentState
+        private _consignments: ConsignmentSelector
     ) {}
 
     getShippingAddress(): Address | undefined {
-        const consignments = this._consignments.data;
+        const consignments = this._consignments.getConsignments();
 
         if (!consignments || !consignments[0]) {
             return;


### PR DESCRIPTION
## What?
Translate `country` and `stateOrProvince` when getting addresses from selectors

## Why?
To provide this functionality out of the box
