### PR TITLE
CP-4020 Added Product Category to cart & checkout payload

### DIFF
--- a/src/cart/internal-carts.mock.ts
+++ b/src/cart/internal-carts.mock.ts
@@ -27,6 +27,7 @@ export function getCart(): InternalCart {
                 variantId: 71,
                 addedByPromotion: false,
                 productId: 103,
+                categoryNames: ['Cat 1'],
             },
             {
                 id: '667',
@@ -51,6 +52,7 @@ export function getCart(): InternalCart {
                 variantId: 71,
                 addedByPromotion: false,
                 productId: 103,
+                categoryNames: ['Cat 1'],
             },
             {
                 id: 'bd391ead-8c58-4105-b00e-d75d233b429a',

--- a/src/cart/internal-line-item.ts
+++ b/src/cart/internal-line-item.ts
@@ -12,6 +12,7 @@ export default interface InternalLineItem {
     name?: string;
     quantity: number;
     brand?: string;
+    categoryNames?: string[];
     type: string;
     variantId: number | null;
     productId?: number;

--- a/src/cart/line-item.ts
+++ b/src/cart/line-item.ts
@@ -48,6 +48,7 @@ export interface LineItem {
     url: string;
     quantity: number;
     brand: string;
+    categoryNames?: string[];
     isTaxable: boolean;
     imageUrl: string;
     discounts: Array<{ name: string, discountedAmount: number }>;

--- a/src/cart/line-items.mock.ts
+++ b/src/cart/line-items.mock.ts
@@ -29,6 +29,7 @@ export function getPhysicalItem(): PhysicalItem {
                 valueId: 3,
             },
         ],
+        categoryNames: ['Cat 1'],
     };
 }
 
@@ -63,6 +64,7 @@ export function getDigitalItem(): DigitalItem {
                 valueId: 3,
             },
         ],
+        categoryNames: ['Cat 1'],
     };
 }
 

--- a/src/cart/map-to-internal-line-item.ts
+++ b/src/cart/map-to-internal-line-item.ts
@@ -24,6 +24,7 @@ export default function mapToInternalLineItem(
         name: item.name,
         quantity: item.quantity,
         brand: item.brand,
+        categoryNames: item.categoryNames,
         variantId: item.variantId,
         productId: item.productId,
         attributes: (item.options || []).map(option => ({

--- a/src/checkout/checkout-params.ts
+++ b/src/checkout/checkout-params.ts
@@ -1,3 +1,9 @@
+export enum CheckoutIncludes {
+    AvailableShippingOptions = 'consignments.availableShippingOptions',
+    PhysicalItemsCategoryNames = 'cart.lineItems.physicalItems.categoryNames',
+    DigitalItemsCategoryNames = 'cart.lineItems.digitalItems.categoryNames',
+}
+
 export default interface CheckoutParams {
-    include?: Array<'consignments.availableShippingOptions'>;
+    include?: CheckoutIncludes[];
 }

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -17,6 +17,7 @@ import { ConsignmentAssignmentRequestBody, ConsignmentUpdateRequestBody } from '
 
 import { CheckoutRequestBody } from './checkout';
 import CheckoutActionCreator from './checkout-action-creator';
+import CheckoutParams from './checkout-params';
 import CheckoutSelectors from './checkout-selectors';
 import CheckoutStore from './checkout-store';
 import createCheckoutSelectors from './create-checkout-selectors';
@@ -151,7 +152,7 @@ export default class CheckoutService {
      * @param options - Options for loading the current checkout.
      * @returns A promise that resolves to the current state.
      */
-    loadCheckout(id?: string, options?: RequestOptions): Promise<CheckoutSelectors> {
+    loadCheckout(id?: string, options?: RequestOptions<CheckoutParams>): Promise<CheckoutSelectors> {
         return this._dispatch(id ?
             this._checkoutActionCreator.loadCheckout(id, options) :
             this._checkoutActionCreator.loadDefaultCheckout(options)

--- a/src/order/internal-orders.mock.ts
+++ b/src/order/internal-orders.mock.ts
@@ -89,6 +89,7 @@ export function getCompleteOrder(): InternalOrder {
                     },
                 ],
                 productId: 103,
+                categoryNames: ['Cat 1'],
             },
             {
                 id: 'bd391ead-8c58-4105-b00e-d75d233b429a',

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -5,6 +5,7 @@ import { Observer } from 'rxjs/Observer';
 import { AddressRequestBody } from '../address';
 import { Cart } from '../cart';
 import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
+import { CheckoutIncludes } from '../checkout/checkout-params';
 import CheckoutRequestSender from '../checkout/checkout-request-sender';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
@@ -151,7 +152,7 @@ export default class ConsignmentActionCreator {
             this._checkoutRequestSender.loadCheckout(checkout.id, {
                 ...options,
                 params: {
-                    include: ['consignments.availableShippingOptions'],
+                    include: [CheckoutIncludes.AvailableShippingOptions],
                 },
             })
             .then(({ body }) => {


### PR DESCRIPTION
## What?
Add Product Category information to Checkout payload.

## Why?
Product category information is currently missing the in the checkout payload of all the line items. By this implementation, we will have the Prodcut category list of the given product in the checkout process. 

## Testing / Proof

![image](https://user-images.githubusercontent.com/39140274/46523379-66040d00-c83a-11e8-81d8-705f889e733f.png)


@bigcommerce/checkout @davidchin @lord2800 
