### PR TITLE
CHECKOUT-3477: Show loading indicator while waiting for iframe to load

### DIFF
--- a/src/embedded-checkout/__snapshots__/loading-indicator.spec.ts.snap
+++ b/src/embedded-checkout/__snapshots__/loading-indicator.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoadingIndicator inserts loading indicator element into container 1`] = `
+<div
+  style="display: block; bottom: 0px; left: 0px; height: 100%; width: 100%; position: absolute; right: 0px; top: 0px; opacity: 1; visibility: visible;"
+>
+  <div
+    style="display: block; width: 70px; height: 70px; border-radius: 70px; border: 1px solid; border-color: #ffffff #ffffff #d9d9d9 #d9d9d9; margin: 0px auto; position: absolute; left: 0px; right: 0px; top: 50%; transform: translateY(-50%) rotate(0deg);"
+  />
+</div>
+`;

--- a/src/embedded-checkout/embed-checkout.spec.ts
+++ b/src/embedded-checkout/embed-checkout.spec.ts
@@ -2,6 +2,7 @@ import embedCheckout from './embed-checkout';
 import EmbeddedCheckout from './embedded-checkout';
 import EmbeddedCheckoutOptions from './embedded-checkout-options';
 import IframeEventListener from './iframe-event-listener';
+import IframeEventPoster from './iframe-event-poster';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
 jest.mock('./embedded-checkout', () => {
@@ -38,6 +39,7 @@ describe('embedCheckout()', () => {
         expect(EmbeddedCheckout).toHaveBeenCalledWith(
             expect.any(ResizableIframeCreator),
             expect.any(IframeEventListener),
+            expect.any(IframeEventPoster),
             options
         );
     });

--- a/src/embedded-checkout/embed-checkout.spec.ts
+++ b/src/embedded-checkout/embed-checkout.spec.ts
@@ -3,6 +3,7 @@ import EmbeddedCheckout from './embedded-checkout';
 import EmbeddedCheckoutOptions from './embedded-checkout-options';
 import IframeEventListener from './iframe-event-listener';
 import IframeEventPoster from './iframe-event-poster';
+import LoadingIndicator from './loading-indicator';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
 jest.mock('./embedded-checkout', () => {
@@ -40,6 +41,7 @@ describe('embedCheckout()', () => {
             expect.any(ResizableIframeCreator),
             expect.any(IframeEventListener),
             expect.any(IframeEventPoster),
+            expect.any(LoadingIndicator),
             options
         );
     });

--- a/src/embedded-checkout/embed-checkout.ts
+++ b/src/embedded-checkout/embed-checkout.ts
@@ -4,6 +4,7 @@ import EmbeddedCheckoutOptions from './embedded-checkout-options';
 import { EmbeddedContentEvent } from './iframe-content/embedded-content-events';
 import IframeEventListener from './iframe-event-listener';
 import IframeEventPoster from './iframe-event-poster';
+import LoadingIndicator from './loading-indicator';
 import parseOrigin from './parse-origin';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
@@ -34,6 +35,7 @@ export default function embedCheckout(options: EmbeddedCheckoutOptions): Promise
         new ResizableIframeCreator(),
         new IframeEventListener<EmbeddedCheckoutEventMap>(origin),
         new IframeEventPoster<EmbeddedContentEvent>(origin),
+        new LoadingIndicator({ styles: options.styles && options.styles.loadingIndicator }),
         options
     );
 

--- a/src/embedded-checkout/embed-checkout.ts
+++ b/src/embedded-checkout/embed-checkout.ts
@@ -1,7 +1,9 @@
 import EmbeddedCheckout from './embedded-checkout';
 import { EmbeddedCheckoutEventMap } from './embedded-checkout-events';
 import EmbeddedCheckoutOptions from './embedded-checkout-options';
+import { EmbeddedContentEvent } from './iframe-content/embedded-content-events';
 import IframeEventListener from './iframe-event-listener';
+import IframeEventPoster from './iframe-event-poster';
 import parseOrigin from './parse-origin';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
@@ -27,9 +29,11 @@ import ResizableIframeCreator from './resizable-iframe-creator';
  * @returns A promise that resolves to an instance of `EmbeddedCheckout`.
  */
 export default function embedCheckout(options: EmbeddedCheckoutOptions): Promise<EmbeddedCheckout> {
+    const origin = parseOrigin(options.url);
     const embeddedCheckout = new EmbeddedCheckout(
         new ResizableIframeCreator(),
-        new IframeEventListener<EmbeddedCheckoutEventMap>(parseOrigin(options.url)),
+        new IframeEventListener<EmbeddedCheckoutEventMap>(origin),
+        new IframeEventPoster<EmbeddedContentEvent>(origin),
         options
     );
 

--- a/src/embedded-checkout/embedded-checkout-styles.ts
+++ b/src/embedded-checkout/embedded-checkout-styles.ts
@@ -20,6 +20,7 @@ export default interface EmbeddedCheckoutStyles {
     checklist?: ChecklistStyles;
     discountBanner?: BlockElementStyles;
     loadingBanner?: BlockElementStyles;
+    loadingIndicator?: LoadingIndicatorStyles;
     orderSummary?: BlockElementStyles;
     step?: StepStyles;
 }
@@ -84,4 +85,10 @@ export interface ChecklistStyles extends BlockElementStyles {
 
 export interface StepStyles extends BlockElementStyles {
     icon?: BlockElementStyles;
+}
+
+export interface LoadingIndicatorStyles {
+    size?: number;
+    color?: string;
+    backgroundColor?: string;
 }

--- a/src/embedded-checkout/embedded-checkout-styles.ts
+++ b/src/embedded-checkout/embedded-checkout-styles.ts
@@ -33,7 +33,7 @@ export interface InlineElementStyles {
     lineHeight?: string;
 }
 
-export interface BlockElementStyles {
+export interface BlockElementStyles extends InlineElementStyles {
     backgroundColor?: string;
     boxShadow?: string;
     borderColor?: string;

--- a/src/embedded-checkout/embedded-checkout-styles.ts
+++ b/src/embedded-checkout/embedded-checkout-styles.ts
@@ -20,6 +20,7 @@ export default interface EmbeddedCheckoutStyles {
     checklist?: ChecklistStyles;
     discountBanner?: BlockElementStyles;
     loadingBanner?: BlockElementStyles;
+    orderSummary?: BlockElementStyles;
     step?: StepStyles;
 }
 

--- a/src/embedded-checkout/embedded-checkout.spec.ts
+++ b/src/embedded-checkout/embedded-checkout.spec.ts
@@ -8,12 +8,14 @@ import { NotEmbeddableError } from './errors';
 import { EmbeddedContentEvent, EmbeddedContentEventType } from './iframe-content/embedded-content-events';
 import IframeEventListener from './iframe-event-listener';
 import IframeEventPoster from './iframe-event-poster';
+import LoadingIndicator from './loading-indicator';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
 describe('EmbeddedCheckout', () => {
     let embeddedCheckout: EmbeddedCheckout;
     let iframe: IFrameComponent;
     let iframeCreator: ResizableIframeCreator;
+    let loadingIndicator: LoadingIndicator;
     let messageListener: IframeEventListener<EmbeddedCheckoutEventMap>;
     let messagePoster: IframeEventPoster<EmbeddedContentEvent>;
     let options: EmbeddedCheckoutOptions;
@@ -35,14 +37,22 @@ describe('EmbeddedCheckout', () => {
         iframeCreator = new ResizableIframeCreator();
         messageListener = new IframeEventListener('https://mybigcommerce.com');
         messagePoster = new IframeEventPoster('https://mybigcommerce.com');
+        loadingIndicator = new LoadingIndicator();
 
         jest.spyOn(iframeCreator, 'createFrame')
             .mockReturnValue(Promise.resolve(iframe));
+
+        jest.spyOn(loadingIndicator, 'show')
+            .mockImplementation(() => {});
+
+        jest.spyOn(loadingIndicator, 'hide')
+            .mockImplementation(() => {});
 
         embeddedCheckout = new EmbeddedCheckout(
             iframeCreator,
             messageListener,
             messagePoster,
+            loadingIndicator,
             options
         );
     });
@@ -145,6 +155,7 @@ describe('EmbeddedCheckout', () => {
             iframeCreator,
             messageListener,
             messagePoster,
+            loadingIndicator,
             options
         );
 
@@ -167,6 +178,7 @@ describe('EmbeddedCheckout', () => {
             iframeCreator,
             messageListener,
             messagePoster,
+            loadingIndicator,
             options
         );
 
@@ -186,6 +198,7 @@ describe('EmbeddedCheckout', () => {
             iframeCreator,
             messageListener,
             messagePoster,
+            loadingIndicator,
             options
         );
 
@@ -200,5 +213,16 @@ describe('EmbeddedCheckout', () => {
             type: EmbeddedContentEventType.StyleConfigured,
             payload: styles,
         });
+    });
+
+    it('toggles loading indicator', done => {
+        embeddedCheckout.attach()
+            .then(() => {
+                expect(loadingIndicator.hide).toHaveBeenCalled();
+                done();
+            });
+
+        expect(loadingIndicator.show).toHaveBeenCalled();
+        expect(loadingIndicator.hide).not.toHaveBeenCalled();
     });
 });

--- a/src/embedded-checkout/embedded-checkout.ts
+++ b/src/embedded-checkout/embedded-checkout.ts
@@ -5,6 +5,7 @@ import EmbeddedCheckoutOptions from './embedded-checkout-options';
 import { EmbeddedContentEvent, EmbeddedContentEventType } from './iframe-content/embedded-content-events';
 import IframeEventListener from './iframe-event-listener';
 import IframeEventPoster from './iframe-event-poster';
+import LoadingIndicator from './loading-indicator';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
 export default class EmbeddedCheckout {
@@ -18,6 +19,7 @@ export default class EmbeddedCheckout {
         private _iframeCreator: ResizableIframeCreator,
         private _messageListener: IframeEventListener<EmbeddedCheckoutEventMap>,
         private _messagePoster: IframeEventPoster<EmbeddedContentEvent>,
+        private _loadingIndicator: LoadingIndicator,
         private _options: EmbeddedCheckoutOptions
     ) {
         this._isAttached = false;
@@ -48,12 +50,14 @@ export default class EmbeddedCheckout {
 
         this._isAttached = true;
         this._messageListener.listen();
+        this._loadingIndicator.show(this._options.containerId);
 
         return this._iframeCreator.createFrame(this._options.url, this._options.containerId)
             .then(iframe => {
                 this._iframe = iframe;
 
                 this._configureStyles();
+                this._loadingIndicator.hide();
 
                 return this;
             })
@@ -64,6 +68,8 @@ export default class EmbeddedCheckout {
                     type: EmbeddedCheckoutEventType.FrameError,
                     payload: error,
                 });
+
+                this._loadingIndicator.hide();
 
                 throw error;
             });

--- a/src/embedded-checkout/iframe-event-poster.ts
+++ b/src/embedded-checkout/iframe-event-poster.ts
@@ -1,7 +1,7 @@
 export default class IframeEventPoster<TEvent> {
     constructor(
         private _targetOrigin: string,
-        private _targetWindow: Window
+        private _targetWindow?: Window
     ) {}
 
     post(event: TEvent): void {
@@ -9,6 +9,14 @@ export default class IframeEventPoster<TEvent> {
             return;
         }
 
+        if (!this._targetWindow) {
+            throw new Error('Unable to post message becauset target window is not set.');
+        }
+
         this._targetWindow.postMessage(event, this._targetOrigin);
+    }
+
+    setTarget(window: Window) {
+        this._targetWindow = window;
     }
 }

--- a/src/embedded-checkout/loading-indicator.spec.ts
+++ b/src/embedded-checkout/loading-indicator.spec.ts
@@ -1,0 +1,65 @@
+import LoadingIndicator from './loading-indicator';
+
+describe('LoadingIndicator', () => {
+    let indicator: LoadingIndicator;
+    let parentId: string;
+    let parent: HTMLElement;
+
+    beforeEach(() => {
+        parentId = 'container';
+        indicator = new LoadingIndicator();
+
+        parent = document.createElement('div');
+        parent.id = parentId;
+
+        document.body.appendChild(parent);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(parent);
+    });
+
+    it('inserts loading indicator element into container', () => {
+        indicator.show(parentId);
+
+        expect(parent.firstChild).toMatchSnapshot();
+    });
+
+    it('shows loading indicator', () => {
+        indicator.show(parentId);
+
+        const child = parent.firstChild as HTMLElement;
+
+        expect(child.style.visibility).toEqual('visible');
+        expect(child.style.opacity).toEqual('1');
+    });
+
+    it('throws error is parent element does not exist', () => {
+        expect(() => indicator.show('invalid_container')).toThrow();
+    });
+
+    it('hides loading indicator', () => {
+        indicator.show(parentId);
+        indicator.hide();
+
+        const child = parent.firstChild as HTMLElement;
+
+        expect(child.style.opacity).toEqual('0');
+    });
+
+    it('completely hides loading indicator once transition is complete', () => {
+        indicator.show(parentId);
+        indicator.hide();
+
+        const child = parent.firstChild as HTMLElement;
+        const event = new Event('transitionend');
+
+        child.dispatchEvent(event);
+
+        expect(child.style.visibility).toEqual('hidden');
+    });
+
+    it('does not throw error if it is already hidden', () => {
+        expect(() => indicator.hide()).not.toThrow();
+    });
+});

--- a/src/embedded-checkout/loading-indicator.ts
+++ b/src/embedded-checkout/loading-indicator.ts
@@ -1,0 +1,116 @@
+import { LoadingIndicatorStyles } from './embedded-checkout-styles';
+
+const DEFAULT_STYLES: LoadingIndicatorStyles = {
+    size: 70,
+    color: '#d9d9d9',
+    backgroundColor: '#ffffff',
+};
+
+const ROTATION_ANIMATION = 'embedded-checkout-loading-indicator-rotation';
+
+export default class LoadingIndicator {
+    private _container: HTMLElement;
+    private _indicator: HTMLElement;
+    private _styles: LoadingIndicatorStyles;
+
+    constructor(
+        options?: { styles?: LoadingIndicatorStyles }
+    ) {
+        this._styles = { ...DEFAULT_STYLES, ...options && options.styles };
+
+        this._defineAnimation();
+
+        this._container = this._buildContainer();
+        this._indicator = this._buildIndicator();
+
+        this._container.appendChild(this._indicator);
+    }
+
+    show(parentId?: string): void {
+        if (parentId) {
+            const parent = document.getElementById(parentId);
+
+            if (!parent) {
+                throw new Error('Unable to attach the loading indicator because the parent ID is not valid.');
+            }
+
+            parent.appendChild(this._container);
+        }
+
+        this._container.style.visibility = 'visible';
+        this._container.style.opacity = '1';
+    }
+
+    hide(): void {
+        const handleTransitionEnd = () => {
+            this._container.style.visibility = 'hidden';
+
+            this._container.removeEventListener('transitionend', handleTransitionEnd);
+        };
+
+        this._container.addEventListener('transitionend', handleTransitionEnd);
+
+        this._container.style.opacity = '0';
+    }
+
+    private _buildContainer(): HTMLElement {
+        const container = document.createElement('div');
+
+        container.style.display = 'block';
+        container.style.bottom = '0';
+        container.style.left = '0';
+        container.style.height = '100%';
+        container.style.width = '100%';
+        container.style.position = 'absolute';
+        container.style.right = '0';
+        container.style.top = '0';
+        container.style.transition = 'all 250ms ease-out';
+        container.style.opacity = '0';
+
+        return container;
+    }
+
+    private _buildIndicator(): HTMLElement {
+        const indicator = document.createElement('div');
+
+        indicator.style.display = 'block';
+        indicator.style.width = `${this._styles.size}px`;
+        indicator.style.height = `${this._styles.size}px`;
+        indicator.style.borderRadius = `${this._styles.size}px`;
+        indicator.style.border = 'solid 1px';
+        indicator.style.borderColor = `${this._styles.backgroundColor} ${this._styles.backgroundColor} ${this._styles.color} ${this._styles.color}`;
+        indicator.style.margin = '0 auto';
+        indicator.style.position = 'absolute';
+        indicator.style.left = '0';
+        indicator.style.right = '0';
+        indicator.style.top = '50%';
+        indicator.style.transform = 'translateY(-50%) rotate(0deg)';
+        indicator.style.transformStyle = 'preserve-3d';
+        indicator.style.animation = `${ROTATION_ANIMATION} 500ms infinite cubic-bezier(0.69, 0.31, 0.56, 0.83)`;
+
+        return indicator;
+    }
+
+    private _defineAnimation(): void {
+        // In order to define CSS animation, we need to insert a stylesheet into the host frame.
+        // We only have to do it once.
+        if (document.getElementById(ROTATION_ANIMATION)) {
+            return;
+        }
+
+        const style = document.createElement('style');
+
+        style.id = ROTATION_ANIMATION;
+
+        document.head.appendChild(style);
+
+        if (style.sheet instanceof CSSStyleSheet) {
+            style.sheet.insertRule(`
+                @keyframes ${ROTATION_ANIMATION} {
+                    0% { transform: translateY(-50%) rotate(0deg); }
+                    100% { transform: translateY(-50%) rotate(360deg); }
+                }
+            `);
+        }
+    }
+}


### PR DESCRIPTION
## What?
1. Show a loading indicator while waiting for the iframe to load.
1. Reconfigure the iframe with styling information if it's reloaded again.

## Why?
1. To tell the shopper that something is happening in the background.
2. Otherwise, we'd lose the styling configuration.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
