### PR TITLE
feat(payment): INT-836 Add Google Pay button to Customer Section of Checkout

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -1,6 +1,6 @@
 import { RequestOptions } from '../common/http-request';
 
-import { BraintreePaypalButtonInitializeOptions, CheckoutButtonMethodType } from './strategies';
+import { BraintreePaypalButtonInitializeOptions, CheckoutButtonMethodType, GooglePayBraintreeButtonInitializeOptions } from './strategies';
 
 /**
  * The set of options for configuring the checkout button.
@@ -29,4 +29,10 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * The ID of a container which the checkout button should be inserted.
      */
     containerId: string;
+
+    /**
+     * The options that are required to facilitate Braintree GooglePay. They can be
+     * omitted unles you need to support Braintree GooglePay.
+     */
+    googlepaybraintree?: GooglePayBraintreeButtonInitializeOptions;
 }

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -6,10 +6,18 @@ import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
+
+import { createGooglePayPaymentProcessor } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 
-import { BraintreePaypalButtonStrategy, CheckoutButtonMethodType, CheckoutButtonStrategy, MasterpassButtonStrategy } from './strategies';
+import {
+    BraintreePaypalButtonStrategy,
+    CheckoutButtonMethodType,
+    CheckoutButtonStrategy,
+    GooglePayBraintreeButtonStrategy,
+    MasterpassButtonStrategy
+} from './strategies';
 
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
@@ -21,6 +29,7 @@ export default function createCheckoutButtonRegistry(
         new CheckoutRequestSender(requestSender),
         new ConfigActionCreator(new ConfigRequestSender(requestSender))
     );
+    const formPoster = createFormPoster();
 
     registry.register(CheckoutButtonMethodType.BRAINTREE_PAYPAL, () =>
         new BraintreePaypalButtonStrategy(
@@ -28,7 +37,7 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
             new PaypalScriptLoader(scriptLoader),
-            createFormPoster()
+            formPoster
         )
     );
 
@@ -38,7 +47,7 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
             new PaypalScriptLoader(scriptLoader),
-            createFormPoster(),
+            formPoster,
             true
         )
     );
@@ -48,6 +57,14 @@ export default function createCheckoutButtonRegistry(
             store,
             checkoutActionCreator,
             new MasterpassScriptLoader(scriptLoader)
+        ));
+
+    registry.register(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, () =>
+        new GooglePayBraintreeButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            createGooglePayPaymentProcessor(store)
         )
     );
 

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -1,5 +1,7 @@
 export enum CheckoutButtonMethodType {
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',
+    GOOGLEPAY_BRAINTREE = 'googlepaybraintree',
     MASTERPASS = 'masterpass',
+
 }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-options.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-options.ts
@@ -1,0 +1,18 @@
+import { ButtonColor, ButtonType } from '../../../payment/strategies/googlepay/googlepay';
+
+export interface GooglePayBraintreeButtonInitializeOptions {
+    /**
+     * The color of the GooglePay button that will be inserted.
+     *  black (default): a black button suitable for use on white or light backgrounds.
+     *  white: a white button suitable for use on colorful backgrounds.
+     */
+    buttonColor?: ButtonColor;
+
+    /**
+     * The size of the GooglePay button that will be inserted.
+     *  long: "Buy with Google Pay" button (default). A translated button label may appear
+     *         if a language specified in the viewer's browser matches an available language.
+     *  short: Google Pay payment button without the "Buy with" text.
+     */
+    buttonType?: ButtonType;
+}

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -1,0 +1,220 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { PaymentMethod } from '../../../payment';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { createGooglePayPaymentProcessor, ButtonType, GooglePaymentData, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import { CheckoutButtonMethodType } from '../checkout-button-method-type';
+
+import GooglePayBraintreeButtonStrategy from './googlepay-braintree-button-strategy';
+import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-braintree-button.mock';
+
+describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
+    let container: HTMLDivElement;
+    let formPoster: FormPoster;
+    let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+    let paymentMethod: PaymentMethod;
+    let paymentProcessor: GooglePayPaymentProcessor;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: GooglePayBraintreeButtonStrategy;
+    let walletButton: HTMLAnchorElement;
+
+    beforeEach(() => {
+        paymentMethod = getPaymentMethod();
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        requestSender = createRequestSender();
+
+        checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+        );
+
+        paymentProcessor = createGooglePayPaymentProcessor(store);
+
+        formPoster = createFormPoster();
+
+        strategy = new GooglePayBraintreeButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            paymentProcessor
+        );
+
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockReturnValue(Promise.resolve());
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethod);
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockReturnValue(Promise.resolve());
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
+        walletButton = document.createElement('a');
+        walletButton.setAttribute('id', 'mockButton');
+
+        jest.spyOn(paymentProcessor, 'createButton')
+            .mockReturnValue(walletButton);
+
+        jest.spyOn(paymentProcessor, 'deinitialize');
+
+        container.appendChild(walletButton);
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('creates an instance of GooglePayBraintreeButtonStrategy', () => {
+        expect(strategy).toBeInstanceOf(GooglePayBraintreeButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+
+        describe('Payment method exist', () => {
+
+            it('Creates the button', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions();
+
+                await strategy.initialize(checkoutButtonOptions);
+
+                expect(paymentProcessor.createButton).toHaveBeenCalled();
+            });
+
+            it('Validates if strategy is been initialized', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions();
+
+                await strategy.initialize(checkoutButtonOptions);
+
+                setTimeout(() => {
+                    strategy.initialize(checkoutButtonOptions);
+                }, 0);
+
+                strategy.initialize(checkoutButtonOptions);
+
+                expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
+            });
+
+            it('fails to initialize the strategy if no container id is supplied', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions(Mode.UndefinedContainer);
+
+                try {
+                    await strategy.initialize(checkoutButtonOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(InvalidArgumentError);
+                }
+            });
+
+            it('fails to initialize the strategy if no valid container id is supplied', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions(Mode.InvalidContainer);
+
+                try {
+                    await strategy.initialize(checkoutButtonOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(InvalidArgumentError);
+                }
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+
+        beforeEach(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions();
+        });
+
+        it('check if googlepay payment processor deinitialize is called', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize();
+
+            expect(paymentProcessor.deinitialize).toBeCalled();
+        });
+
+        it('succesfully deinitializes the strategy', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize();
+
+            if (checkoutButtonOptions.googlepaybraintree) {
+                const button = document.getElementById(checkoutButtonOptions.containerId);
+
+                if (button) {
+                    expect(button.firstChild).toBe(null);
+                }
+            }
+
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+
+        it('Validates if strategy is loaded before call deinitialize', async () => {
+            await strategy.deinitialize();
+
+            if (checkoutButtonOptions.googlepaybraintree) {
+                const button = document.getElementById(checkoutButtonOptions.containerId);
+
+                if (button) {
+                    expect(button.firstChild).toBe(null);
+                }
+            }
+
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        let googlePayOptions: CheckoutButtonInitializeOptions;
+        let paymentData: GooglePaymentData;
+
+        beforeEach(() => {
+            googlePayOptions = {
+                methodId: CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE,
+                containerId: 'googlePayCheckoutButton',
+                googlepaybraintree: {
+                    buttonType: ButtonType.Short,
+                },
+            };
+
+            paymentData = getGooglePaymentDataMock();
+        });
+
+        it('handles wallet button event', async () => {
+            jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(paymentData));
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+
+            await strategy.initialize(googlePayOptions).then(() => {
+                walletButton.click();
+            });
+
+            expect(paymentProcessor.initialize).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
@@ -1,0 +1,105 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { bindDecorator as bind } from '../../../common/utility';
+import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStrategy {
+    private _methodId?: string;
+    private _walletButton?: HTMLElement;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _formPoster: FormPoster,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _googlePayPaymentProcessor: GooglePayPaymentProcessor
+    ) {
+        super();
+    }
+
+    initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { containerId, methodId } = options;
+
+        if (!containerId || !methodId) {
+            throw new InvalidArgumentError('Unable to proceed because "containerId" argument is not provided.');
+        }
+
+        if (this._isInitialized[containerId]) {
+            return super.initialize(options);
+        }
+
+        this._methodId = methodId;
+
+        return this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout())
+            .then(() => this._googlePayPaymentProcessor.initialize(this._getMethodId())
+                .then(() => {
+                    this._walletButton = this._createSignInButton(containerId);
+                })
+            ).then(() => super.initialize(options));
+    }
+
+    deinitialize(): Promise<void> {
+        if (!this._isInitialized) {
+            return super.deinitialize();
+        }
+
+        if (this._walletButton && this._walletButton.parentNode) {
+            this._walletButton.parentNode.removeChild(this._walletButton);
+            this._walletButton = undefined;
+        }
+
+        return this._googlePayPaymentProcessor.deinitialize()
+            .then(() => super.deinitialize());
+    }
+
+    private _createSignInButton(containerId: string): HTMLElement {
+        const container = document.querySelector(`#${containerId}`);
+
+        if (!container) {
+            throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
+        }
+
+        const googlePayButton = this._googlePayPaymentProcessor.createButton(this._handleWalletButtonClick);
+
+        container.appendChild(googlePayButton);
+
+        return googlePayButton;
+    }
+
+    private _getMethodId(): string {
+        if (!this._methodId) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._methodId;
+    }
+
+    @bind
+    private _handleWalletButtonClick(event: Event): Promise<void> {
+        event.preventDefault();
+
+        return this._googlePayPaymentProcessor.displayWallet()
+            .then(paymentData => this._googlePayPaymentProcessor.handleSuccess(paymentData)
+            .then(() => this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress)))
+            .then(() => this._onPaymentSelectComplete())
+            .catch(error => this._onError(error));
+    }
+
+    private _onPaymentSelectComplete(): void {
+        this._formPoster.postForm('/checkout.php', {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+        });
+    }
+
+    private _onError(error?: Error): void {
+        if (error && error.message !== 'CANCELED') {
+            throw error;
+        }
+    }
+}

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button.mock.ts
@@ -1,0 +1,41 @@
+
+import { PaymentMethod } from '../../../payment';
+import { getGooglePay } from '../../../payment/payment-methods.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import { CheckoutButtonMethodType } from '../checkout-button-method-type';
+
+export function getPaymentMethod(): PaymentMethod {
+    return {
+        ...getGooglePay(),
+        initializationData: {
+            checkoutId: 'checkoutId',
+            allowedCardTypes: ['visa', 'amex', 'mastercard'],
+        },
+    };
+}
+
+export enum Mode {
+    Full,
+    UndefinedContainer,
+    InvalidContainer,
+}
+
+export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButtonInitializeOptions {
+    const methodId = { methodId: CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE };
+    const containerId = 'googlePayCheckoutButton';
+    const undefinedContainerId = { containerId : '' };
+    const invalidContainerId = { containerId: 'invalid_container' };
+    const googlepay = { googlepaybraintree: { } };
+
+    switch (mode) {
+        case Mode.UndefinedContainer: {
+            return { ...methodId, ...undefinedContainerId };
+        }
+        case Mode.InvalidContainer: {
+            return { ...methodId, ...invalidContainerId };
+        }
+        default: {
+            return { ...methodId, containerId, ...googlepay };
+        }
+    }
+}

--- a/src/checkout-buttons/strategies/index.ts
+++ b/src/checkout-buttons/strategies/index.ts
@@ -1,6 +1,8 @@
 export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
+export { default as GooglePayBraintreeButtonStrategy } from './googlepay/googlepay-braintree-button-strategy';
 export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
 export { default as MasterpassButtonStrategy } from './masterpass-button-strategy';
 export { CheckoutButtonMethodType } from './checkout-button-method-type';
 
 export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+export { GooglePayBraintreeButtonInitializeOptions } from './googlepay/googlepay-braintree-button-options';

--- a/src/common/error/errors/missing-data-error.ts
+++ b/src/common/error/errors/missing-data-error.ts
@@ -1,6 +1,7 @@
 import StandardError from './standard-error';
 
 export enum MissingDataErrorType {
+    MissingBillingAddress,
     MissingCart,
     MissingCheckout,
     MissingConsignments,
@@ -24,6 +25,9 @@ export default class MissingDataError extends StandardError {
 
 function getErrorMessage(type: MissingDataErrorType): string {
     switch (type) {
+    case MissingDataErrorType.MissingBillingAddress:
+        return 'Unable to proceed because billing address data is unavailable.';
+
     case MissingDataErrorType.MissingCart:
         return 'Unable to proceed because cart data is unavailable.';
 

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -4,6 +4,7 @@ import {
     AmazonPayCustomerInitializeOptions,
     BraintreeVisaCheckoutCustomerInitializeOptions,
     ChasePayCustomerInitializeOptions,
+    GooglePayCustomerInitializeOptions,
     MasterpassCustomerInitializeOptions
 } from './strategies';
 
@@ -47,4 +48,16 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      */
     chasepay?: ChasePayCustomerInitializeOptions;
     masterpass?: MasterpassCustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
+    googlepaybraintree?: GooglePayCustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
+    googlepaystripe?: GooglePayCustomerInitializeOptions;
 }

--- a/src/customer/strategies/googlepay/googlepay-braintree-customer-mock.ts
+++ b/src/customer/strategies/googlepay/googlepay-braintree-customer-mock.ts
@@ -1,0 +1,45 @@
+
+import PaymentMethod from '../../../payment/payment-method';
+import { getGooglePay } from '../../../payment/payment-methods.mock';
+import { CustomerInitializeOptions } from '../../customer-request-options';
+
+export function getPaymentMethod(): PaymentMethod {
+    return {
+        ...getGooglePay(),
+        initializationData: {
+            checkoutId: 'checkoutId',
+            allowedCardTypes: ['visa', 'amex', 'mastercard'],
+        },
+    };
+}
+
+export enum Mode {
+    Full,
+    UndefinedMethodId,
+    InvalidContainer,
+    Incomplete,
+}
+
+export function getCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
+    const methodId = { methodId: 'googlepaybraintree' };
+    const undefinedMethodId = { methodId: undefined };
+    const container = { container: 'googlePayCheckoutButton' };
+    const invalidContainer = { container: 'invalid_container' };
+    const googlepayBraintree = { googlepaybraintree: { ...container } };
+    const googlepayBraintreeWithInvalidContainer = { googlepaybraintree: { ...invalidContainer } };
+
+    switch (mode) {
+        case Mode.Incomplete: {
+            return { ...methodId };
+        }
+        case Mode.UndefinedMethodId: {
+            return { ...undefinedMethodId, ...googlepayBraintree };
+        }
+        case Mode.InvalidContainer: {
+            return { ...methodId, ...googlepayBraintreeWithInvalidContainer };
+        }
+        default: {
+            return { ...methodId, ...googlepayBraintree };
+        }
+     }
+}

--- a/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
@@ -1,0 +1,272 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { getConfigState } from '../../../config/configs.mock';
+import PaymentMethod from '../../../payment/payment-method';
+import { getPaymentMethod, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { createGooglePayPaymentProcessor, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { CustomerInitializeOptions } from '../../customer-request-options';
+import { getCustomerState } from '../../customers.mock';
+
+import { getCustomerInitializeOptions, Mode } from './googlepay-braintree-customer-mock';
+import GooglePayBraintreeCustomerStrategy from './googlepay-braintree-customer-strategy';
+
+describe('GooglePayBraintreeCustomerStrategy', () => {
+    let container: HTMLDivElement;
+    let formPoster: FormPoster;
+    let customerInitializeOptions: CustomerInitializeOptions;
+    let paymentMethod: PaymentMethod;
+    let paymentProcessor: GooglePayPaymentProcessor;
+    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: GooglePayBraintreeCustomerStrategy;
+    let walletButton: HTMLAnchorElement;
+
+    beforeEach(() => {
+        paymentMethod = getPaymentMethod();
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        requestSender = createRequestSender();
+
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+            new RemoteCheckoutRequestSender(requestSender)
+        );
+
+        paymentProcessor = createGooglePayPaymentProcessor(store);
+
+        formPoster = createFormPoster();
+
+        strategy = new GooglePayBraintreeCustomerStrategy(
+            store,
+            remoteCheckoutActionCreator,
+            paymentProcessor,
+            formPoster
+        );
+
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockReturnValue(Promise.resolve());
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethod);
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockReturnValue(Promise.resolve());
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
+        walletButton = document.createElement('a');
+        walletButton.setAttribute('id', 'mockButton');
+
+        jest.spyOn(paymentProcessor, 'createButton')
+            .mockReturnValue(walletButton);
+
+        container.appendChild(walletButton);
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('creates an instance of GooglePayBraintreeCustomerStrategy', () => {
+        expect(strategy).toBeInstanceOf(GooglePayBraintreeCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+
+        describe('Payment method exist', () => {
+
+            it('Creates the button', async () => {
+                customerInitializeOptions = getCustomerInitializeOptions();
+
+                await strategy.initialize(customerInitializeOptions);
+
+                expect(paymentProcessor.createButton).toHaveBeenCalled();
+            });
+
+            it('Validates if strategy is been initialized', async () => {
+                customerInitializeOptions = getCustomerInitializeOptions();
+
+                await strategy.initialize(customerInitializeOptions);
+
+                setTimeout(() => {
+                    strategy.initialize(customerInitializeOptions);
+                }, 0);
+
+                strategy.initialize(customerInitializeOptions);
+
+                expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
+            });
+
+            it('fails to initialize the strategy if no GooglePayBraintreeCustomerInitializeOptions is provided ', async () => {
+                customerInitializeOptions = getCustomerInitializeOptions(Mode.Incomplete);
+
+                try {
+                    await strategy.initialize(customerInitializeOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('fails to initialize the strategy if no methodid is supplied', async () => {
+                customerInitializeOptions = getCustomerInitializeOptions(Mode.UndefinedMethodId);
+
+                try {
+                    await strategy.initialize(customerInitializeOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('fails to initialize the strategy if no valid container id is supplied', async () => {
+                customerInitializeOptions = getCustomerInitializeOptions(Mode.InvalidContainer);
+
+                try {
+                    await strategy.initialize(customerInitializeOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(InvalidArgumentError);
+                }
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        let customerInitializeOptions: CustomerInitializeOptions;
+
+        beforeEach(() => {
+            customerInitializeOptions = getCustomerInitializeOptions();
+        });
+
+        it('succesfully deinitializes the strategy', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            strategy.deinitialize();
+
+            if (customerInitializeOptions.googlepaybraintree) {
+                const button = document.getElementById(customerInitializeOptions.googlepaybraintree.container);
+
+                if (button) {
+                    expect(button.firstChild).toBe(null);
+                }
+            }
+
+            // Prevent "After Each" failure
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+
+        it('Validates if strategy is loaded before call deinitialize', async () => {
+            await strategy.deinitialize();
+
+            if (customerInitializeOptions.googlepaybraintree) {
+                const button = document.getElementById(customerInitializeOptions.googlepaybraintree.container);
+
+                if (button) {
+                    expect(button.firstChild).toBe(null);
+                }
+            }
+
+            // Prevent "After Each" failure
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+    });
+
+    describe('#signIn()', () => {
+
+        it('throws error if trying to sign in programmatically', async () => {
+            customerInitializeOptions = getCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+
+            expect(() => strategy.signIn({ email: 'foo@bar.com', password: 'foobar' })).toThrowError();
+        });
+    });
+
+    describe('#signOut()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('throws error if trying to sign out programmatically', async () => {
+            const paymentId = {
+                providerId: 'googlepaybraintre',
+            };
+
+            jest.spyOn(store.getState().payment, 'getPaymentId')
+                .mockReturnValue(paymentId);
+
+            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+                .mockReturnValue('data');
+
+            const options = {
+                methodId: 'googlepaybraintre',
+            };
+
+            await strategy.signOut(options);
+
+            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('googlepaybraintre', options);
+            expect(store.dispatch).toHaveBeenCalled();
+        });
+
+        it('Returns state if no payment method exist', async () => {
+            const paymentId = undefined;
+            jest.spyOn(store, 'getState');
+
+            jest.spyOn(store.getState().payment, 'getPaymentId')
+                .mockReturnValue(paymentId);
+
+            const options = {
+                methodId: 'googlepaybraintre',
+            };
+
+            await strategy.signOut(options);
+
+            expect(store.getState).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        let googlePayOptions: CustomerInitializeOptions;
+
+        beforeEach(() => {
+            googlePayOptions = {
+                methodId: 'googlepaybraintre',
+                googlepaybraintree: {
+                    container: 'googlePayCheckoutButton',
+                },
+            };
+        });
+
+        it('handles wallet button event', async () => {
+            jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(getGooglePaymentDataMock()));
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+
+            await strategy.initialize(googlePayOptions).then(() => {
+                walletButton.click();
+            });
+
+            expect(paymentProcessor.initialize).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.ts
@@ -1,0 +1,114 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from '../../../common/error/errors';
+import { bindDecorator as bind } from '../../../common/utility';
+import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
+import CustomerCredentials from '../../customer-credentials';
+import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
+import CustomerStrategy from '../customer-strategy';
+
+export default class GooglePayBraintreeCustomerStrategy extends CustomerStrategy {
+    private _walletButton?: HTMLElement;
+
+    constructor(
+        store: CheckoutStore,
+        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
+        private _googlePayPaymentProcessor: GooglePayPaymentProcessor,
+        private _formPoster: FormPoster
+    ) {
+        super(store);
+    }
+
+    initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        if (this._isInitialized) {
+            return super.initialize(options);
+        }
+
+        const { googlepaybraintree, methodId }  = options;
+
+        if (!googlepaybraintree || !methodId) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return this._googlePayPaymentProcessor.initialize(methodId)
+            .then(() => {
+                this._walletButton = this._createSignInButton(googlepaybraintree.container);
+            })
+            .then(() => super.initialize(options));
+    }
+
+    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (!this._isInitialized) {
+            return super.deinitialize(options);
+        }
+
+        if (this._walletButton && this._walletButton.parentNode) {
+            this._walletButton.parentNode.removeChild(this._walletButton);
+            this._walletButton = undefined;
+        }
+
+        return this._googlePayPaymentProcessor.deinitialize()
+            .then(() => super.deinitialize(options));
+    }
+
+    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        throw new NotImplementedError(
+            'In order to sign in via Google Pay, the shopper must click on "Google Pay" button.'
+        );
+    }
+
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const payment = state.payment.getPaymentId();
+
+        if (!payment) {
+            return Promise.resolve(this._store.getState());
+        }
+
+        return this._store.dispatch(
+            this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    private _createSignInButton(containerId: string): HTMLElement {
+        const container = document.querySelector(`#${containerId}`);
+
+        if (!container) {
+            throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
+        }
+
+        const button = this._googlePayPaymentProcessor.createButton(this._handleWalletButtonClick);
+
+        container.appendChild(button);
+
+        return button;
+    }
+
+    private _onPaymentSelectComplete(): void {
+        this._formPoster.postForm('/checkout.php', {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+        });
+    }
+
+    private _onError(error?: Error): void {
+        if (error && error.message !== 'CANCELED') {
+            throw error;
+        }
+    }
+
+    @bind
+    private _handleWalletButtonClick(event: Event): Promise<void> {
+        event.preventDefault();
+
+        return this._googlePayPaymentProcessor.displayWallet()
+            .then(paymentData => this._googlePayPaymentProcessor.handleSuccess(paymentData)
+            .then(() => this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress)))
+            .then(() => this._onPaymentSelectComplete())
+            .catch(error => this._onError(error));
+    }
+}

--- a/src/customer/strategies/googlepay/googlepay-customer-initialize-options.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-initialize-options.ts
@@ -1,0 +1,8 @@
+export default interface GooglePayCustomerInitializeOptions {
+    /**
+     * This container is used to set an event listener, provide an element ID if you want
+     * users to be able to launch the GooglePay wallet modal by clicking on a button.
+     * It should be an HTML element.
+     */
+    container: string;
+}

--- a/src/customer/strategies/googlepay/index.ts
+++ b/src/customer/strategies/googlepay/index.ts
@@ -1,0 +1,2 @@
+export { default as GooglePayBraintreeCustomerStrategy } from './googlepay-braintree-customer-strategy';
+export { default as GooglePayCustomerInitializeOptions } from './googlepay-customer-initialize-options';

--- a/src/customer/strategies/index.ts
+++ b/src/customer/strategies/index.ts
@@ -6,3 +6,4 @@ export { default as ChasePayCustomerStrategy, ChasePayCustomerInitializeOptions 
 export { default as SquareCustomerStrategy } from './square-customer-strategy';
 export { default as MasterpassCustomerInitializeOptions} from './masterpass-customer-initialize-options';
 export { default as MasterpassCustomerStrategy } from './masterpass-customer-strategy';
+export { GooglePayBraintreeCustomerStrategy, GooglePayCustomerInitializeOptions } from './googlepay';

--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -9,6 +9,7 @@ import {
     AfterpayPaymentStrategy,
     AmazonPayPaymentStrategy,
     CreditCardPaymentStrategy,
+    GooglePayPaymentStrategy,
     KlarnaPaymentStrategy,
     LegacyPaymentStrategy,
     NoPaymentDataRequiredPaymentStrategy,
@@ -19,7 +20,6 @@ import {
     SagePayPaymentStrategy,
     SquarePaymentStrategy,
 } from './strategies';
-import { GooglePayPaymentStrategy } from './strategies/googlepay';
 
 describe('CreatePaymentStrategyRegistry', () => {
     let registry: PaymentStrategyRegistry;

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -1,10 +1,5 @@
-import {
-    GooglePaymentData,
-    GooglePayCreator,
-    GooglePayDataRequestV1,
-    GooglePayPaymentDataRequestV1,
-    TokenizePayload,
-} from '../googlepay';
+import { GooglePaymentData, GooglePayCreator, TokenizePayload } from '../googlepay';
+import { GooglePayBraintreeDataRequest, GooglePayBraintreePaymentDataRequestV1 } from '../googlepay/googlepay-braintree';
 import { PaypalAuthorizeData, PaypalSDK } from '../paypal';
 
 import {
@@ -85,7 +80,7 @@ export interface BraintreeVisaCheckout extends BraintreeModule {
 }
 
 export interface GooglePayBraintreeSDK extends BraintreeModule {
-    createPaymentDataRequest(request?: GooglePayDataRequestV1): GooglePayPaymentDataRequestV1;
+    createPaymentDataRequest(request?: GooglePayBraintreeDataRequest): GooglePayBraintreePaymentDataRequestV1;
     parseResponse(paymentData: GooglePaymentData): Promise<TokenizePayload>;
 }
 

--- a/src/payment/strategies/googlepay/create-googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/create-googlepay-payment-processor.ts
@@ -1,0 +1,39 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
+import { CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
+import { BraintreeScriptLoader, BraintreeSDKCreator } from '../braintree';
+
+import GooglePayBraintreeInitializer from './googlepay-braintree-initializer';
+import GooglePayPaymentProcessor from './googlepay-payment-processor';
+import GooglePayScriptLoader from './googlepay-script-loader';
+
+export default function createGooglePayPaymentProcessor(store: CheckoutStore): GooglePayPaymentProcessor {
+    const requestSender = createRequestSender();
+    const scriptLoader = getScriptLoader();
+
+    return new GooglePayPaymentProcessor(
+        store,
+        new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(requestSender)
+        ),
+        new GooglePayScriptLoader(scriptLoader),
+        new GooglePayBraintreeInitializer(
+            new BraintreeSDKCreator(
+                new BraintreeScriptLoader(scriptLoader)
+            )
+        ),
+        new BillingAddressActionCreator(
+            new BillingAddressRequestSender(requestSender)
+        ),
+        new ConsignmentActionCreator(
+            new ConsignmentRequestSender(requestSender),
+            new CheckoutRequestSender(requestSender)
+        ),
+        requestSender
+    );
+}

--- a/src/payment/strategies/googlepay/googlepay-braintree-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree-initializer.spec.ts
@@ -1,7 +1,7 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { PaymentMethod } from '../..';
 import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import PaymentMethod from '../../payment-method';
 import { BraintreeScriptLoader, BraintreeSDKCreator, GooglePayBraintreeSDK } from '../braintree';
 
 import GooglePayBraintreeInitializer from './googlepay-braintree-initializer';
@@ -10,7 +10,7 @@ import {
     getGooglePaymentDataMock,
     getGooglePaymentDataPayload,
     getGooglePayBraintreeMock,
-    getPaymentMethodMock
+    getPaymentMethodMock,
 } from './googlepay.mock';
 
 describe('GooglePayBraintreeInitializer', () => {
@@ -29,11 +29,10 @@ describe('GooglePayBraintreeInitializer', () => {
     });
 
     describe('#initialize', async () => {
-        let googlePayMock: GooglePayBraintreeSDK;
+        const googlePayMock = getGooglePayBraintreeMock();
         let googlePayBraintreeInitializer: GooglePayBraintreeInitializer;
 
         beforeEach(() => {
-            googlePayMock = getGooglePayBraintreeMock();
             braintreeSDKCreator.initialize = jest.fn();
             braintreeSDKCreator.getGooglePaymentComponent = jest.fn(() => Promise.resolve(googlePayMock));
             googlePayBraintreeInitializer = new GooglePayBraintreeInitializer(braintreeSDKCreator);
@@ -49,11 +48,11 @@ describe('GooglePayBraintreeInitializer', () => {
         });
 
         it('initializes the google pay configuration for braintree and fail to create google pay payload', async () => {
-            spyOn(googlePayMock, 'createPaymentDataRequest').and.returnValue(Promise.reject({message: 'error'}));
+            jest.spyOn(googlePayMock, 'createPaymentDataRequest').mockReturnValue(Promise.reject());
 
             await googlePayBraintreeInitializer.initialize(getCheckoutMock(), getPaymentMethodMock(), false)
                 .catch(error => {
-                    expect(error.message).toEqual('error');
+                    expect(error.message).toEqual(`Cannot read property 'authJwt' of undefined`);
                 });
         });
 
@@ -115,13 +114,20 @@ describe('GooglePayBraintreeInitializer', () => {
         });
 
         it('parses a response from google pay payload received', async () => {
-            spyOn(googlePayMock, 'parseResponse');
+            await googlePayBraintreeInitializer.initialize(getCheckoutMock(), getPaymentMethodMock(), false);
+            const tokenizePayload = googlePayBraintreeInitializer.parseResponse(getGooglePaymentDataMock());
+
+            expect(tokenizePayload).toBeTruthy();
+        });
+
+        it('parses a response from google pay payload received', async () => {
+            spyOn(googlePayBraintreeInitializer, 'parseResponse');
 
             await googlePayBraintreeInitializer.initialize(getCheckoutMock(), getPaymentMethodMock(), false);
-            await googlePayBraintreeInitializer.parseResponse(getGooglePaymentDataMock());
+            googlePayBraintreeInitializer.parseResponse(getGooglePaymentDataMock());
 
-            expect(googlePayMock.parseResponse).toHaveBeenCalled();
-            expect(googlePayMock.parseResponse).toHaveBeenCalledTimes(1);
+            expect(googlePayBraintreeInitializer.parseResponse).toHaveBeenCalled();
+            expect(googlePayBraintreeInitializer.parseResponse).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -1,18 +1,16 @@
+
 import { Checkout } from '../../../checkout';
-import {
-    MissingDataError,
-    MissingDataErrorType
-} from '../../../common/error/errors';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import PaymentMethod from '../../payment-method';
 import { BraintreeSDKCreator, GooglePayBraintreeSDK } from '../braintree';
 
 import {
     GooglePaymentData,
-    GooglePayDataRequestV1,
     GooglePayInitializer,
-    GooglePayPaymentDataRequestV1,
+    GooglePayPaymentDataRequestV2,
     TokenizePayload
 } from './googlepay';
+import { GooglePayBraintreeDataRequest, GooglePayBraintreePaymentDataRequestV1 } from './googlepay-braintree';
 
 export default class GooglePayBraintreeInitializer implements GooglePayInitializer {
     private _googlePaymentInstance!: GooglePayBraintreeSDK;
@@ -25,7 +23,7 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
         checkout: Checkout,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean
-    ): Promise<GooglePayPaymentDataRequestV1> {
+    ): Promise<GooglePayPaymentDataRequestV2> {
         if (!paymentMethod.clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
@@ -38,7 +36,7 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
 
                 return this._createGooglePayPayload(
                     checkout,
-                    paymentMethod.initializationData.platformToken,
+                    paymentMethod.initializationData,
                     hasShippingAddress
                 );
             });
@@ -48,22 +46,36 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
         return this._braintreeSDKCreator.teardown();
     }
 
-    parseResponse(paymentData: GooglePaymentData): Promise<TokenizePayload> {
-        return this._googlePaymentInstance.parseResponse(paymentData);
+    parseResponse(paymentData: GooglePaymentData): TokenizePayload {
+        const payload = JSON.parse(paymentData.paymentMethodData.tokenizationData.token).androidPayCards[0];
+
+        return {
+            nonce: payload.nonce,
+            type: payload.type,
+            description: payload.description,
+            details: {
+                cardType: payload.details.cardType,
+                lastFour: payload.details.lastFour,
+                lastTwo: payload.details.lastTwo,
+            },
+            binData: payload.binData,
+        };
     }
 
     private _createGooglePayPayload(
         checkout: Checkout,
-        platformToken: string,
+        initializationData: any,
         hasShippingAddress: boolean
-    ): GooglePayPaymentDataRequestV1 {
-        if (!platformToken) {
+    ): GooglePayPaymentDataRequestV2 {
+        if (!initializationData.platformToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const googlePaymentDataRequest: GooglePayDataRequestV1 = {
+        const googlePayBraintreePaymentDataRequest: GooglePayBraintreeDataRequest = {
             merchantInfo: {
-                authJwt: platformToken,
+                authJwt: initializationData.platformToken,
+                merchantName: initializationData.merchantName,
+                merchantId: initializationData.merchantId,
             },
             transactionInfo: {
                 currencyCode: checkout.cart.currency.code,
@@ -79,6 +91,48 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
             phoneNumberRequired: true,
         };
 
-        return this._googlePaymentInstance.createPaymentDataRequest(googlePaymentDataRequest);
+        return this._mapGooglePayBraintreeDataRequestToGooglePayDataRequestV2(
+            this._googlePaymentInstance.createPaymentDataRequest(googlePayBraintreePaymentDataRequest)
+        );
+    }
+
+    private _mapGooglePayBraintreeDataRequestToGooglePayDataRequestV2(googlePayBraintreeDataRequestV1: GooglePayBraintreePaymentDataRequestV1): GooglePayPaymentDataRequestV2 {
+        return {
+            apiVersion: 2,
+            apiVersionMinor: 0,
+            merchantInfo: {
+                authJwt: googlePayBraintreeDataRequestV1.merchantInfo.authJwt,
+                merchantId: googlePayBraintreeDataRequestV1.merchantInfo.googleMerchantId,
+                merchantName: googlePayBraintreeDataRequestV1.merchantInfo.googleMerchantName,
+            },
+            allowedPaymentMethods: [{
+                type: 'CARD',
+                parameters: {
+                    allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                    allowedCardNetworks: googlePayBraintreeDataRequestV1.cardRequirements.allowedCardNetworks,
+                    billingAddressRequired: true,
+                    billingAddressParameters: {
+                        format: 'FULL',
+                        phoneNumberRequired: true,
+                    },
+                },
+                tokenizationSpecification: {
+                    type: 'PAYMENT_GATEWAY',
+                    parameters: {
+                        gateway: 'braintree',
+                        'braintree:apiVersion': 'v1',
+                        'braintree:authorizationFingerprint': googlePayBraintreeDataRequestV1.paymentMethodTokenizationParameters.parameters['braintree:authorizationFingerprint'],
+                        'braintree:merchantId': googlePayBraintreeDataRequestV1.paymentMethodTokenizationParameters.parameters['braintree:merchantId'],
+                        'braintree:sdkVersion': googlePayBraintreeDataRequestV1.paymentMethodTokenizationParameters.parameters['braintree:sdkVersion'],
+                    },
+                },
+            }],
+            transactionInfo: googlePayBraintreeDataRequestV1.transactionInfo,
+            emailRequired: true,
+            shippingAddressRequired: googlePayBraintreeDataRequestV1.shippingAddressRequired,
+            shippingAddressParameters: {
+                phoneNumberRequired: googlePayBraintreeDataRequestV1.phoneNumberRequired,
+            },
+        };
     }
 }

--- a/src/payment/strategies/googlepay/googlepay-braintree.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree.ts
@@ -1,0 +1,60 @@
+type TotalPriceStatus = 'ESTIMATED' | 'FINAL' | 'NOT_CURRENTLY_KNOWN';
+type AddressFormat = 'FULL' | 'MIN';
+
+export interface GooglePayBraintreeDataRequest {
+    merchantInfo: {
+        authJwt?: string,
+        merchantId?: string,
+        merchantName?: string,
+    };
+    transactionInfo: {
+        currencyCode: string,
+        totalPriceStatus: TotalPriceStatus,
+        totalPrice: string,
+    };
+    cardRequirements: {
+        billingAddressRequired: boolean,
+        billingAddressFormat: AddressFormat,
+    };
+    emailRequired: boolean;
+    phoneNumberRequired: boolean;
+    shippingAddressRequired: boolean;
+}
+
+export interface GooglePayBraintreePaymentDataRequestV1 {
+    allowedPaymentMethods: string[];
+    apiVersion: number;
+    cardRequirements: {
+        allowedCardNetworks: string[];
+        billingAddressFormat: string;
+        billingAddressRequired: boolean;
+    };
+    enviroment: string;
+    i: {
+        googleTransactionId: string;
+        startTimeMs: number;
+    };
+    merchantInfo: {
+        googleMerchantId: string;
+        googleMerchantName: string;
+        authJwt?: string;
+    };
+    paymentMethodTokenizationParameters: {
+        parameters: {
+            'braintree:apiVersion': string;
+            'braintree:authorizationFingerprint': string;
+            'braintree:merchantId': string;
+            'braintree:metadata': string;
+            'braintree:sdkVersion': string;
+            gateway: string;
+        };
+        tokenizationType: string;
+    };
+    shippingAddressRequired: boolean;
+    phoneNumberRequired: boolean;
+    transactionInfo: {
+        currencyCode: string;
+        totalPrice: string;
+        totalPriceStatus: string;
+    };
+}

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { PaymentMethodActionCreator } from '../..';
+import { AddressRequestBody } from '../../../address';
 import { BillingAddressActionCreator, BillingAddressUpdateRequestBody } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
@@ -10,6 +10,10 @@ import {
     NotInitializedErrorType,
 } from '../../../common/error/errors';
 import { toFormUrlEncoded } from '../../../common/http-request/';
+import { RemoteCheckoutSynchronizationError } from '../../../remote-checkout/errors';
+import { ConsignmentActionCreator } from '../../../shipping';
+import PaymentMethodInvalidError from '../../errors/payment-method-invalid-error';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
 
 import {
     ButtonColor,
@@ -19,25 +23,26 @@ import {
     GooglePayAddress,
     GooglePayClient,
     GooglePayInitializer,
-    GooglePayPaymentDataRequestV1,
+    GooglePayPaymentDataRequestV2,
     GooglePaySDK,
     TokenizePayload
 } from './googlepay';
 import GooglePayScriptLoader from './googlepay-script-loader';
 
 export default class GooglePayPaymentProcessor {
-    private _googlePaymentsClient?: GooglePayClient;
+    private _googlePayClient?: GooglePayClient;
     private _methodId?: string;
-    private _googlePaymentDataRequest?: GooglePayPaymentDataRequestV1;
+    private _paymentDataRequest?: GooglePayPaymentDataRequestV2;
 
     constructor(
         private _store: CheckoutStore,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _googlePayScriptLoader: GooglePayScriptLoader,
         private _googlePayInitializer: GooglePayInitializer,
-        private _requestSender: RequestSender,
-        private _billingAddressActionCreator: BillingAddressActionCreator
-    ) { }
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _consigmentActionCreator: ConsignmentActionCreator,
+        private _requestSender: RequestSender
+    ) {}
 
     initialize(methodId: string): Promise<void> {
         this._methodId = methodId;
@@ -50,95 +55,42 @@ export default class GooglePayPaymentProcessor {
     }
 
     createButton(
-        onClick: () => {},
+        onClick: (event: Event) => Promise<void>,
         buttonType: ButtonType = ButtonType.Short,
         buttonColor: ButtonColor = ButtonColor.Default
     ): HTMLElement {
-        if (!this._googlePaymentsClient) {
+        if (!this._googlePayClient) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        return this._googlePaymentsClient.createButton({
-            buttonColor: ButtonColor.Default,
-            buttonType: ButtonType.Short,
+        return this._googlePayClient.createButton({
+            buttonColor,
+            buttonType,
             onClick,
         });
     }
 
     displayWallet(): Promise<GooglePaymentData> {
-        if (!this._googlePaymentsClient || !this._googlePaymentDataRequest || !this._googlePaymentDataRequest) {
+        if (!this._googlePayClient) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        const googlePaymentsClient = this._googlePaymentsClient;
-        const googlePaymentDataRequest = this._googlePaymentDataRequest;
-
-        return this._googlePaymentsClient.isReadyToPay({
-            allowedPaymentMethods: this._googlePaymentDataRequest.allowedPaymentMethods,
-        }).then(response => {
-            if (response.result) {
-                return googlePaymentsClient.loadPaymentData(googlePaymentDataRequest);
-            } else {
-                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-            }
-        });
+        return this._googlePayClient.loadPaymentData(this._getPaymentDataRequest());
     }
 
     handleSuccess(paymentData: GooglePaymentData): Promise<InternalCheckoutSelectors> {
-        return this._googlePayInitializer.parseResponse(paymentData)
-            .then(tokenizedPayload => this._postForm(tokenizedPayload))
-            .then(() => this.updateBillingAddress(paymentData.cardInfo.billingAddress));
+        return this._postForm(this._googlePayInitializer.parseResponse(paymentData))
+            .then(() => this._updateBillingAddress(paymentData));
     }
 
-    private updateBillingAddress(billingAddress: GooglePayAddress): Promise<InternalCheckoutSelectors> {
-        if (!this._methodId) {
-            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-        }
-
-        const remoteBillingAddress = this._store.getState().billingAddress.getBillingAddress();
-
-        if (!remoteBillingAddress) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
-
-        const googlePayAddressMapped = this._mapGooglePayAddressToBillingAddress(billingAddress, remoteBillingAddress.id);
-
+    updateShippingAddress(shippingAddress: GooglePayAddress): Promise<InternalCheckoutSelectors> {
         return this._store.dispatch(
-            this._billingAddressActionCreator.updateAddress(googlePayAddressMapped)
+            this._consigmentActionCreator.updateAddress(this._mapGooglePayAddressToShippingAddress(shippingAddress))
         );
     }
 
-    private _getCardInformation(cardInformation: { cardType: string, lastFour: string }) {
-        return {
-            type: cardInformation.cardType,
-            number: cardInformation.lastFour,
-        };
-    }
-
-    private _postForm(postPaymentData: TokenizePayload): Promise<Response<any>> {
-        const cardInformation = postPaymentData.details;
-
-        return this._requestSender.post('/checkout.php', {
-            headers: {
-                Accept: 'text/html',
-                'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            body: toFormUrlEncoded({
-                payment_type: postPaymentData.type,
-                nonce: postPaymentData.nonce,
-                provider: this._methodId,
-                action: 'set_external_checkout',
-                card_information: this._getCardInformation(cardInformation),
-            }),
-        });
-    }
-
     private _configureWallet(): Promise<void> {
-        if (!this._methodId) {
-            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-        }
-
-        const methodId = this._methodId;
+        const methodId = this._getMethodId();
 
         return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
             .then(state => {
@@ -154,20 +106,51 @@ export default class GooglePayPaymentProcessor {
                     throw new MissingDataError(MissingDataErrorType.MissingCheckout);
                 }
 
-                const testMode = paymentMethod.config.testMode;
+                const { testMode } = paymentMethod.config;
 
                 return Promise.all([
                     this._googlePayScriptLoader.load(),
                     this._googlePayInitializer.initialize(checkout, paymentMethod, hasShippingAddress),
-                ])
-                    .then(([googlePay, googlePayPaymentDataRequest]) => {
-                        this._googlePaymentsClient = this._getGooglePayClient(googlePay, testMode);
-                        this._googlePaymentDataRequest = googlePayPaymentDataRequest;
-                    })
-                    .catch((error: Error) => {
-                        throw error;
+                ]).then(([googlePay, paymentDataRequest]) => {
+                    this._googlePayClient = this._getGooglePayClient(googlePay, testMode);
+                    this._paymentDataRequest = paymentDataRequest;
+
+                    return this._googlePayClient.isReadyToPay({
+                        allowedPaymentMethods: [
+                            {
+                                type: paymentDataRequest.allowedPaymentMethods[0].type,
+                                parameters: {
+                                    allowedAuthMethods: paymentDataRequest.allowedPaymentMethods[0].parameters.allowedAuthMethods,
+                                    allowedCardNetworks: paymentDataRequest.allowedPaymentMethods[0].parameters.allowedCardNetworks,
+                                },
+                            },
+                        ],
+                        apiVersion: paymentDataRequest.apiVersion,
+                        apiVersionMinor: paymentDataRequest.apiVersionMinor,
+                    }).then(response => {
+                        if (response.result) {
+                            return;
+                        }
+
+                        throw new PaymentMethodInvalidError();
                     });
+                });
             });
+    }
+
+    private _getCardInformation(cardInformation: { cardType: string, lastFour: string }) {
+        return {
+            type: cardInformation.cardType,
+            number: cardInformation.lastFour,
+        };
+    }
+
+    private _getPaymentDataRequest(): GooglePayPaymentDataRequestV2 {
+        if (!this._paymentDataRequest) {
+            throw new RemoteCheckoutSynchronizationError();
+        }
+
+        return this._paymentDataRequest;
     }
 
     private _getGooglePayClient(google: GooglePaySDK, testMode?: boolean): GooglePayClient {
@@ -180,14 +163,40 @@ export default class GooglePayPaymentProcessor {
         return new google.payments.api.PaymentsClient({ environment });
     }
 
-    private _mapGooglePayAddressToBillingAddress(address: GooglePayAddress, id: string): BillingAddressUpdateRequestBody {
+    private _getMethodId(): string {
+        if (!this._methodId) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._methodId;
+    }
+
+    private _mapGooglePayAddressToBillingAddress(paymentData: GooglePaymentData, id: string): BillingAddressUpdateRequestBody {
         return {
             id,
+            firstName: paymentData.paymentMethodData.info.billingAddress.name.split(' ').slice(0, -1).join(' '),
+            lastName: paymentData.paymentMethodData.info.billingAddress.name.split(' ').slice(-1).join(' '),
+            company: paymentData.paymentMethodData.info.billingAddress.companyName,
+            address1: paymentData.paymentMethodData.info.billingAddress.address1,
+            address2: paymentData.paymentMethodData.info.billingAddress.address2 + paymentData.paymentMethodData.info.billingAddress.address3,
+            city: paymentData.paymentMethodData.info.billingAddress.locality,
+            stateOrProvince: paymentData.paymentMethodData.info.billingAddress.administrativeArea,
+            stateOrProvinceCode: paymentData.paymentMethodData.info.billingAddress.administrativeArea,
+            postalCode: paymentData.paymentMethodData.info.billingAddress.postalCode,
+            countryCode: paymentData.paymentMethodData.info.billingAddress.countryCode,
+            phone: paymentData.paymentMethodData.info.billingAddress.phoneNumber,
+            customFields: [],
+            email: paymentData.email,
+        };
+    }
+
+    private _mapGooglePayAddressToShippingAddress(address: GooglePayAddress): AddressRequestBody {
+        return {
             firstName: address.name.split(' ').slice(0, -1).join(' '),
             lastName: address.name.split(' ').slice(-1).join(' '),
             company: address.companyName,
             address1: address.address1,
-            address2: address.address2 + address.address3 + address.address4 + address.address5,
+            address2: address.address2 + address.address3,
             city: address.locality,
             stateOrProvince: address.administrativeArea,
             stateOrProvinceCode: address.administrativeArea,
@@ -196,5 +205,37 @@ export default class GooglePayPaymentProcessor {
             phone: address.phoneNumber,
             customFields: [],
         };
+    }
+
+    private _postForm(postPaymentData: TokenizePayload): Promise<Response<void>> {
+        const cardInformation = postPaymentData.details;
+
+        return this._requestSender.post('/checkout.php', {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: toFormUrlEncoded({
+                payment_type: postPaymentData.type,
+                nonce: postPaymentData.nonce,
+                provider: this._getMethodId(),
+                action: 'set_external_checkout',
+                card_information: this._getCardInformation(cardInformation),
+            }),
+        });
+    }
+
+    private _updateBillingAddress(paymentData: GooglePaymentData): Promise<InternalCheckoutSelectors> {
+        const remoteBillingAddress = this._store.getState().billingAddress.getBillingAddress();
+
+        if (!remoteBillingAddress) {
+            throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
+        }
+
+        const googlePayAddressMapped = this._mapGooglePayAddressToBillingAddress(paymentData, remoteBillingAddress.id);
+
+        return this._store.dispatch(
+            this._billingAddressActionCreator.updateAddress(googlePayAddressMapped)
+        );
     }
 }

--- a/src/payment/strategies/googlepay/googlepay-script-loader.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-script-loader.spec.ts
@@ -2,8 +2,8 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { StandardError } from '../../../common/error/errors';
 
-import { GooglePayScriptLoader } from './';
 import { GooglePayHostWindow, GooglePaySDK } from './googlepay';
+import GooglePayScriptLoader from './googlepay-script-loader';
 import { getGooglePaySDKMock } from './googlepay.mock';
 
 describe('GooglePayScriptLoader', () => {

--- a/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -14,9 +14,10 @@ import { GooglePayBraintreeSDK } from '../braintree';
 import {
     GooglePaymentData,
     GooglePayAddress,
-    GooglePayPaymentDataRequestV1,
-    GooglePaySDK
+    GooglePayPaymentDataRequestV2,
+    GooglePaySDK,
 } from './googlepay';
+import { GooglePayBraintreePaymentDataRequestV1 } from './googlepay-braintree';
 
 export function getGooglePaySDKMock(): GooglePaySDK {
     return {
@@ -30,9 +31,49 @@ export function getGooglePaySDKMock(): GooglePaySDK {
 
 export function getGooglePayBraintreeMock(): GooglePayBraintreeSDK {
     return {
-        createPaymentDataRequest: jest.fn(dataRequest => Promise.resolve(dataRequest as GooglePayPaymentDataRequestV1)),
+        createPaymentDataRequest: jest.fn(() => getGooglePayBraintreePaymentDataRequest()),
         parseResponse: jest.fn(),
         teardown: jest.fn(() => Promise.resolve()),
+    };
+}
+
+export function getGooglePayBraintreePaymentDataRequest(): GooglePayBraintreePaymentDataRequestV1 {
+    return {
+        allowedPaymentMethods: [],
+        apiVersion: 1,
+        cardRequirements: {
+            allowedCardNetworks: [],
+            billingAddressFormat: '',
+            billingAddressRequired: true,
+        },
+        enviroment: '',
+        i: {
+            googleTransactionId: '',
+            startTimeMs: 1,
+        },
+        merchantInfo: {
+            authJwt: '',
+            googleMerchantId: '',
+            googleMerchantName: '',
+        },
+        paymentMethodTokenizationParameters: {
+            parameters: {
+                'braintree:apiVersion': '',
+                'braintree:authorizationFingerprint': '',
+                'braintree:merchantId': '',
+                'braintree:metadata': '',
+                'braintree:sdkVersion': '',
+                gateway: '',
+            },
+            tokenizationType: '',
+        },
+        shippingAddressRequired: true,
+        phoneNumberRequired: true,
+        transactionInfo: {
+            currencyCode: '',
+            totalPrice: '',
+            totalPriceStatus: '',
+        },
     };
 }
 
@@ -74,6 +115,8 @@ export function getPaymentMethodMock(): PaymentMethod {
         nonce: 'nonce',
         initializationData: {
             platformToken: 'platformToken',
+            googleMerchantId: '123',
+            googleMerchantName: 'name',
         },
     };
 }
@@ -100,20 +143,23 @@ export function getGooglePaymentDataPayload() {
 
 export function getGooglePaymentDataMock(): GooglePaymentData {
     return {
-        cardInfo: {
-            cardClass: 'cardClass',
-            cardDescription: 'cardDescription',
-            cardDetails: 'cardDetails',
-            cardImageUri: 'cardImageUri',
-            cardNetwork: 'cardNetwork',
-            billingAddress: {} as GooglePayAddress,
+        apiVersion: 2,
+        apiVersionMinor: 0,
+        email: 'carlos.lopez@bigcommerce.com',
+        paymentMethodData: {
+            description: 'Mastercard •••• 0304',
+            info: {
+                billingAddress: getGooglePayAddressMock(),
+                cardDetails: '0304',
+                cardNetwork: 'MASTERCARD',
+            },
+            tokenizationData: {
+                token: `{"androidPayCards": [{"nonce": "nonce", "type": "AndroidPayCard", "description": "", "details": {"cardType": "type", "lastFour": "", "lastTwo": ""}}]}`,
+                type: 'PAYMENT_GATEWAY',
+            },
+            type: 'CARD',
         },
-        paymentMethodToken: {
-            token: 'token',
-            tokenizationType: 'tokenizationType',
-        },
-        shippingAddress: {} as GooglePayAddress,
-        email: 'email',
+        shippingAddress: getGooglePayAddressMock(),
     };
 }
 
@@ -128,8 +174,6 @@ export function getGooglePayAddressMock(): GooglePayAddress {
         address1: 'mock',
         address2: 'mock',
         address3: 'mock',
-        address4: 'mock',
-        address5: 'mock',
         administrativeArea: 'mock',
         companyName: 'mock',
         countryCode: 'mock',
@@ -141,41 +185,25 @@ export function getGooglePayAddressMock(): GooglePayAddress {
     };
 }
 
-export function getGooglePayPaymentDataRequestMock(): GooglePayPaymentDataRequestV1 {
+export function getGooglePayPaymentDataRequestMock(): GooglePayPaymentDataRequestV2 {
     return {
-        allowedPaymentMethods: [
-            'CreditCard',
-        ],
-        apiVersion: 1,
-        cardRequirements: {
-            allowedCardNetworks: [''],
-            billingAddressRequired: true,
-            billingAddressFormat: '',
-        },
-        enviroment: '',
-        i: {
-            googleTransactionId: '',
-            startTimeMs: 1,
-        },
-        merchantInfo: {
-            merchantId: '',
-        },
-        paymentMethodTokenizationParameters: {
+        apiVersion: 2,
+        apiVersionMinor: 0,
+        merchantInfo: { },
+        allowedPaymentMethods: [{
+            type: 'type',
             parameters: {
-                'braintree:apiVersion': '',
-                'braintree:authorizationFingerprint': '',
-                'braintree:merchantId': '',
-                'braintree:metadata': '',
-                'braintree:sdkVersion': '',
-                gateway: '',
+                allowedAuthMethods: [
+                    'dummy',
+                ],
+                allowedCardNetworks: [
+                    'dummy',
+                ],
             },
-            tokenizationType: '',
-        },
-        shippingAddressRequired: true,
+        }],
         transactionInfo: {
-            currencyCode: '',
-            totalPrice: '',
-            totalPriceStatus: '',
+            currencyCode: 'USD',
+            totalPriceStatus: 'FINAL',
         },
     };
 }

--- a/src/payment/strategies/googlepay/index.ts
+++ b/src/payment/strategies/googlepay/index.ts
@@ -5,3 +5,4 @@ export { default as GooglePayPaymentStrategy } from './googlepay-payment-strateg
 export { default as GooglePayBraintreeInitializer } from './googlepay-braintree-initializer';
 export { default as GooglePayPaymentInitializeOptions } from './googlepay-initialize-options';
 export { default as GooglePayPaymentProcessor } from './googlepay-payment-processor';
+export { default as createGooglePayPaymentProcessor } from './create-googlepay-payment-processor';

--- a/src/shipping/create-shipping-strategy-registry.spec.ts
+++ b/src/shipping/create-shipping-strategy-registry.spec.ts
@@ -1,0 +1,22 @@
+import createRequestSender from '../../node_modules/@bigcommerce/request-sender/lib/create-request-sender';
+import createCheckoutStore from '../checkout/create-checkout-store';
+import Registry from '../common/registry/registry';
+
+import createShippingStrategyRegistry from './create-shipping-strategy-registry';
+import AmazonPayShippingStrategy from './strategies/amazon-pay-shipping-strategy';
+import ShippingStrategy from './strategies/shipping-strategy';
+
+describe('CreateShippingStrategyRegistry', () => {
+    let registry: Registry<ShippingStrategy>;
+
+    beforeEach(() => {
+        const store = createCheckoutStore();
+        const requestSender = createRequestSender();
+        registry = createShippingStrategyRegistry(store, requestSender);
+    });
+
+    it('can instantiate amazon', () => {
+        const shippingStrategy = registry.get('amazon');
+        expect(shippingStrategy).toBeInstanceOf(AmazonPayShippingStrategy);
+    });
+});

--- a/src/shipping/create-shipping-strategy-registry.ts
+++ b/src/shipping/create-shipping-strategy-registry.ts
@@ -18,11 +18,12 @@ export default function createShippingStrategyRegistry(
     const registry = new Registry<ShippingStrategy>();
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const consignmentRequestSender = new ConsignmentRequestSender(requestSender);
+    const consignmentActionCreator = new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender);
 
     registry.register('amazon', () =>
         new AmazonPayShippingStrategy(
             store,
-            new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender),
+            consignmentActionCreator,
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
             new RemoteCheckoutActionCreator(new RemoteCheckoutRequestSender(requestSender)),
             new AmazonPayScriptLoader(getScriptLoader())
@@ -32,7 +33,7 @@ export default function createShippingStrategyRegistry(
     registry.register('default', () =>
         new DefaultShippingStrategy(
             store,
-            new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender)
+            consignmentActionCreator
         )
     );
 


### PR DESCRIPTION
# User Story
[INT-836](https://jira.bigcommerce.com/browse/INT-836)

## What?

As a guest (non-logged in) shopper I want to use Google Pay upon checkout through Braintree.
So that I can pay using my favorite wallet

## Why?

As a guest (non-logged in) customer, when Google Pay is enabled on Braintree, I can successfully checkout through Braintree using Google Pay from the Customer section of the checkout page.

## Testing / Proof

### Coverage

![image](https://user-images.githubusercontent.com/8570490/46897844-cc94b680-ce4a-11e8-8f5c-81001c2035c7.png)

### Test Cases

![image](https://user-images.githubusercontent.com/8570490/46898731-4b8ced80-ce51-11e8-87b2-e462b9e0fd9c.png)

## Dependencies
[INT-919 - Manage Google Pay JWT Generation](https://github.com/bigcommerce/bigcommerce/pull/26489)
[INT-1000 Add merchantId & merchantName as part of initializationData of GooglePay](https://github.com/bigcommerce/bigcommerce/pull/26654)
[feat(payments): INT-905 Set external checkout data interface for Google Pay](https://github.com/bigcommerce/bigcommerce/pull/26341)
[INT-835 UCO](https://github.com/bigcommerce-labs/ng-checkout/pull/928)
[INT-835 SDK](https://github.com/bigcommerce/checkout-sdk-js/pull/407)

## Sibling PR
[INT-835 UCO](https://github.com/bigcommerce-labs/ng-checkout/pull/973)

