### PR TITLE
Update Address type to properly type nullable fields (fixes #420)

### DIFF
--- a/src/address/address.ts
+++ b/src/address/address.ts
@@ -7,11 +7,11 @@ export interface AddressRequestBody {
     lastName: string;
     company: string;
     address1: string;
-    address2: string;
+    address2: string | null;
     city: string;
     stateOrProvince: string;
     stateOrProvinceCode: string;
-    countryCode: string;
+    countryCode: string | null;
     postalCode: string;
     phone: string;
     customFields: Array<{


### PR DESCRIPTION
## What and Why
Address.address2 and Address.countryCode can be null. We had runtime errors caused by these wrong type so this PR defines types that match the reality.

@bigcommerce/checkout @bigcommerce/payments

https://github.com/bigcommerce/checkout-sdk-js/issues/420
