### PR TITLE
CHECKOUT-3589 Allow un-assigning items from address

### DIFF
--- a/src/checkout/checkout-service.spec.js
+++ b/src/checkout/checkout-service.spec.js
@@ -774,6 +774,35 @@ describe('CheckoutService', () => {
         });
     });
 
+    describe('#unassignItemsToAddress()', () => {
+        it('dispatches action to update consignment', async () => {
+            const address = getShippingAddress();
+            const options = { timeout: createTimeout() };
+            const action = Observable.of(createAction('bar'));
+
+            jest.spyOn(consignmentActionCreator, 'unassignItemsByAddress')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const payload = {
+                shippingAddress: address,
+                lineItems: [{
+                    itemId: 'item-foo',
+                    quantity: 2,
+                }],
+            };
+
+            await checkoutService.unassignItemsToAddress(payload, options);
+
+            expect(consignmentActionCreator.unassignItemsByAddress)
+                .toHaveBeenCalledWith(payload, options);
+
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(action, { queueId: 'shippingStrategy' });
+        });
+    });
+
     describe('#createConsignments()', () => {
         it('dispatches action to create consignments', async () => {
             const consignments = [getConsignment()];

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -831,6 +831,26 @@ export default class CheckoutService {
     }
 
     /**
+     * Convenience method that unassigns items from a specific shipping address.
+     *
+     * Note: this method finds an existing consignment that matches the provided address
+     * and unassigns the specified items. If the consignment ends up with no line items
+     * after the unassignment, it will be deleted.
+     *
+     * @param consignment - The consignment data that will be used.
+     * @param options - Options for the request
+     * @returns A promise that resolves to the current state.
+     */
+    unassignItemsToAddress(
+        consignment: ConsignmentAssignmentRequestBody,
+        options?: RequestOptions
+    ): Promise<CheckoutSelectors> {
+        const action = this._consignmentActionCreator.unassignItemsByAddress(consignment, options);
+
+        return this._dispatch(action, { queueId: 'shippingStrategy' });
+    }
+
+    /**
      * Selects a shipping option for a given consignment.
      *
      * Note: this is used when items need to be shipped to multiple addresses,


### PR DESCRIPTION
## What?
Allow method `CheckoutService#assignItemsToAddress` to take negative quantities or empty payloads.

## Why?
So items can be un-assigned from addresses.

## Testing / Proof
unit
manual

@bigcommerce/checkout @bigcommerce/payments
