### PR TITLE
CHECKOUT-3660: Create no-op `EmbeddedCheckoutMessenger` if not inside iframe

### DIFF
--- a/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.spec.ts
@@ -1,9 +1,15 @@
 import createEmbeddedCheckoutMessenger from './create-embedded-checkout-messenger';
-import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
+import IframeEmbeddedCheckoutMessenger from './iframe-embedded-checkout-messenger';
+import NoopEmbeddedCheckoutMessenger from './noop-embedded-checkout-messenger';
 
 describe('createEmbeddedCheckoutMessenger()', () => {
-    it('creates embedded checkout messenger', () => {
+    it('creates no-op embedded checkout messenger if not inside iframe', () => {
         expect(createEmbeddedCheckoutMessenger({ parentOrigin: 'https://foobar.mybigcommerece.com' }))
-            .toBeInstanceOf(EmbeddedCheckoutMessenger);
+            .toBeInstanceOf(NoopEmbeddedCheckoutMessenger);
+    });
+
+    it('creates embedded checkout messenger if inside iframe', () => {
+        expect(createEmbeddedCheckoutMessenger({ parentOrigin: 'https://foobar.mybigcommerece.com', parentWindow: Object.create(window) }))
+            .toBeInstanceOf(IframeEmbeddedCheckoutMessenger);
     });
 });

--- a/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.ts
@@ -5,6 +5,8 @@ import IframeEventPoster from '../iframe-event-poster';
 import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
 import EmbeddedCheckoutMessengerOptions from './embedded-checkout-messenger-options';
 import { EmbeddedContentEventMap } from './embedded-content-events';
+import IframeEmbeddedCheckoutMessenger from './iframe-embedded-checkout-messenger';
+import NoopEmbeddedCheckoutMessenger from './noop-embedded-checkout-messenger';
 
 /**
  * Create an instance of `EmbeddedCheckoutMessenger`.
@@ -31,8 +33,15 @@ import { EmbeddedContentEventMap } from './embedded-content-events';
  * @returns - An instance of `EmbeddedCheckoutMessenger`
  */
 export default function createEmbeddedCheckoutMessenger(options: EmbeddedCheckoutMessengerOptions): EmbeddedCheckoutMessenger {
-    return new EmbeddedCheckoutMessenger(
+    const parentWindow = options.parentWindow || window.parent;
+
+    // Return a No-op messenger if it is not called inside an iframe
+    if (window === parentWindow) {
+        return new NoopEmbeddedCheckoutMessenger();
+    }
+
+    return new IframeEmbeddedCheckoutMessenger(
         new IframeEventListener<EmbeddedContentEventMap>(options.parentOrigin),
-        new IframeEventPoster<EmbeddedCheckoutEvent>(options.parentOrigin, window.parent)
+        new IframeEventPoster<EmbeddedCheckoutEvent>(options.parentOrigin, parentWindow)
     );
 }

--- a/src/embedded-checkout/iframe-content/embedded-checkout-messenger-options.ts
+++ b/src/embedded-checkout/iframe-content/embedded-checkout-messenger-options.ts
@@ -1,3 +1,4 @@
 export default interface EmbeddedCheckoutMessengerOptions {
     parentOrigin: string;
+    parentWindow?: Window;
 }

--- a/src/embedded-checkout/iframe-content/embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/embedded-checkout-messenger.ts
@@ -1,84 +1,11 @@
-import { isCustomError, CustomError } from '../../common/error/errors';
-import {
-    EmbeddedCheckoutCompleteEvent,
-    EmbeddedCheckoutError,
-    EmbeddedCheckoutErrorEvent,
-    EmbeddedCheckoutEvent,
-    EmbeddedCheckoutEventType,
-    EmbeddedCheckoutFrameErrorEvent,
-    EmbeddedCheckoutFrameLoadedEvent,
-    EmbeddedCheckoutLoadedEvent,
-} from '../embedded-checkout-events';
+import { CustomError } from '../../common/error/errors';
 import EmbeddedCheckoutStyles from '../embedded-checkout-styles';
-import IframeEventListener from '../iframe-event-listener';
-import IframeEventPoster from '../iframe-event-poster';
 
-import { EmbeddedContentEventMap, EmbeddedContentEventType } from './embedded-content-events';
-
-export default class EmbeddedCheckoutMessenger {
-    /**
-     * @internal
-     */
-    constructor(
-        private _messageListener: IframeEventListener<EmbeddedContentEventMap>,
-        private _messagePoster: IframeEventPoster<EmbeddedCheckoutEvent>
-    ) {
-        this._messageListener.listen();
-    }
-
-    postComplete(): void {
-        const message: EmbeddedCheckoutCompleteEvent = {
-            type: EmbeddedCheckoutEventType.CheckoutComplete,
-        };
-
-        this._messagePoster.post(message);
-    }
-
-    postError(payload: Error | CustomError): void {
-        const message: EmbeddedCheckoutErrorEvent = {
-            type: EmbeddedCheckoutEventType.CheckoutError,
-            payload: this._transformError(payload),
-        };
-
-        this._messagePoster.post(message);
-    }
-
-    postFrameError(payload: Error | CustomError): void {
-        const message: EmbeddedCheckoutFrameErrorEvent = {
-            type: EmbeddedCheckoutEventType.FrameError,
-            payload: this._transformError(payload),
-        };
-
-        this._messagePoster.post(message);
-    }
-
-    postFrameLoaded(): void {
-        const message: EmbeddedCheckoutFrameLoadedEvent = {
-            type: EmbeddedCheckoutEventType.FrameLoaded,
-        };
-
-        this._messagePoster.post(message);
-    }
-
-    postLoaded(): void {
-        const message: EmbeddedCheckoutLoadedEvent = {
-            type: EmbeddedCheckoutEventType.CheckoutLoaded,
-        };
-
-        this._messagePoster.post(message);
-    }
-
-    receiveStyles(handler: (styles: EmbeddedCheckoutStyles) => void): void {
-        this._messageListener.addListener(EmbeddedContentEventType.StyleConfigured, ({ payload }) => {
-            handler(payload);
-        });
-    }
-
-    private _transformError(error: Error | CustomError): EmbeddedCheckoutError {
-        return {
-            message: error.message,
-            type: isCustomError(error) ? error.type : undefined,
-            subtype: isCustomError(error) ? error.subtype : undefined,
-        };
-    }
+export default interface EmbeddedCheckoutMessenger {
+    postComplete(): void;
+    postError(payload: Error | CustomError): void;
+    postFrameError(payload: Error | CustomError): void;
+    postFrameLoaded(): void;
+    postLoaded(): void;
+    receiveStyles(handler: (styles: EmbeddedCheckoutStyles) => void): void;
 }

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
@@ -4,11 +4,11 @@ import { EmbeddedCheckoutEvent, EmbeddedCheckoutEventType } from '../embedded-ch
 import IframeEventListener from '../iframe-event-listener';
 import IframeEventPoster from '../iframe-event-poster';
 
-import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
 import { EmbeddedContentEventMap, EmbeddedContentEventType } from './embedded-content-events';
+import IframeEmbeddedCheckoutMessenger from './iframe-embedded-checkout-messenger';
 
 describe('EmbeddedCheckoutMessenger', () => {
-    let messenger: EmbeddedCheckoutMessenger;
+    let messenger: IframeEmbeddedCheckoutMessenger;
     let messageListener: IframeEventListener<EmbeddedContentEventMap>;
     let messagePoster: IframeEventPoster<EmbeddedCheckoutEvent>;
     let parentWindow: Window;
@@ -23,7 +23,7 @@ describe('EmbeddedCheckoutMessenger', () => {
         jest.spyOn(messagePoster, 'post');
         jest.spyOn(messageListener, 'addListener');
 
-        messenger = new EmbeddedCheckoutMessenger(messageListener, messagePoster);
+        messenger = new IframeEmbeddedCheckoutMessenger(messageListener, messagePoster);
     });
 
     it('posts `complete` event to parent window', () => {

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.ts
@@ -1,0 +1,85 @@
+import { isCustomError, CustomError } from '../../common/error/errors';
+import {
+    EmbeddedCheckoutCompleteEvent,
+    EmbeddedCheckoutError,
+    EmbeddedCheckoutErrorEvent,
+    EmbeddedCheckoutEvent,
+    EmbeddedCheckoutEventType,
+    EmbeddedCheckoutFrameErrorEvent,
+    EmbeddedCheckoutFrameLoadedEvent,
+    EmbeddedCheckoutLoadedEvent,
+} from '../embedded-checkout-events';
+import EmbeddedCheckoutStyles from '../embedded-checkout-styles';
+import IframeEventListener from '../iframe-event-listener';
+import IframeEventPoster from '../iframe-event-poster';
+
+import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
+import { EmbeddedContentEventMap, EmbeddedContentEventType } from './embedded-content-events';
+
+export default class IframeEmbeddedCheckoutMessenger implements EmbeddedCheckoutMessenger {
+    /**
+     * @internal
+     */
+    constructor(
+        private _messageListener: IframeEventListener<EmbeddedContentEventMap>,
+        private _messagePoster: IframeEventPoster<EmbeddedCheckoutEvent>
+    ) {
+        this._messageListener.listen();
+    }
+
+    postComplete(): void {
+        const message: EmbeddedCheckoutCompleteEvent = {
+            type: EmbeddedCheckoutEventType.CheckoutComplete,
+        };
+
+        this._messagePoster.post(message);
+    }
+
+    postError(payload: Error | CustomError): void {
+        const message: EmbeddedCheckoutErrorEvent = {
+            type: EmbeddedCheckoutEventType.CheckoutError,
+            payload: this._transformError(payload),
+        };
+
+        this._messagePoster.post(message);
+    }
+
+    postFrameError(payload: Error | CustomError): void {
+        const message: EmbeddedCheckoutFrameErrorEvent = {
+            type: EmbeddedCheckoutEventType.FrameError,
+            payload: this._transformError(payload),
+        };
+
+        this._messagePoster.post(message);
+    }
+
+    postFrameLoaded(): void {
+        const message: EmbeddedCheckoutFrameLoadedEvent = {
+            type: EmbeddedCheckoutEventType.FrameLoaded,
+        };
+
+        this._messagePoster.post(message);
+    }
+
+    postLoaded(): void {
+        const message: EmbeddedCheckoutLoadedEvent = {
+            type: EmbeddedCheckoutEventType.CheckoutLoaded,
+        };
+
+        this._messagePoster.post(message);
+    }
+
+    receiveStyles(handler: (styles: EmbeddedCheckoutStyles) => void): void {
+        this._messageListener.addListener(EmbeddedContentEventType.StyleConfigured, ({ payload }) => {
+            handler(payload);
+        });
+    }
+
+    private _transformError(error: Error | CustomError): EmbeddedCheckoutError {
+        return {
+            message: error.message,
+            type: isCustomError(error) ? error.type : undefined,
+            subtype: isCustomError(error) ? error.subtype : undefined,
+        };
+    }
+}

--- a/src/embedded-checkout/iframe-content/noop-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/noop-embedded-checkout-messenger.ts
@@ -1,0 +1,15 @@
+import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
+
+export default class NoopEmbeddedCheckoutMessenger implements EmbeddedCheckoutMessenger {
+    postComplete(): void {}
+
+    postError(): void {}
+
+    postFrameError(): void {}
+
+    postFrameLoaded(): void {}
+
+    postLoaded(): void {}
+
+    receiveStyles(): void {}
+}


### PR DESCRIPTION
## What?
* Return `NoopEmbeddedCheckoutMessenger` if `createEmbeddedCheckoutMessenger()` is not called inside an iframe.

## Why?
* So it doesn't do anything if it's not used an iframe. Otherwise, we need to wrap every call inside an `if` statement.
* To address this comment: https://github.com/bigcommerce/checkout-sdk-js/pull/428#discussion_r223244992

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
