### PR TITLE
chore(common): INT-1016 Bumping bigpay-client-js to version 3.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-3.2.2.tgz",
-      "integrity": "sha512-U6KH7TofujQCwgdaL3/B+qUgHRkQFQ4x+s1Pdj9XgtVi4Zngy6tFypHQL1PptYcMnVBMumsROsOojeOCuEoSPg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-3.2.3.tgz",
+      "integrity": "sha512-M/iOvF7rP5wlLwAHJK1iEdNauBx1PMmEtGDSUVxTfNVMH2cE2M3y3LtBwcGDONAs5GhbsHq32xRvmpJ/G5RPLg==",
       "requires": {
         "@bigcommerce/form-poster": "^1.2.1",
         "deep-assign": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "validate-commits": "validate-commits"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^3.2.2",
+    "@bigcommerce/bigpay-client": "^3.2.3",
     "@bigcommerce/data-store": "^0.2.2",
     "@bigcommerce/form-poster": "^1.2.3",
     "@bigcommerce/request-sender": "^0.2.0",


### PR DESCRIPTION
## What / Why?
Bumping the bigpay-client since we updated Braintree to have Google Pay as a supported method.

New release => https://github.com/bigcommerce/bigpay-client-js/releases/tag/3.2.3

## Why?
To expose [https://github.com/bigcommerce/bigpay-client-js/pull/73](https://github.com/bigcommerce/bigpay-client-js/pull/73)

## Testing / Proof
n/a

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/integrations 
