### PR TITLE
CHECKOUT-3573 Reload PaymentData if order payment failed

### DIFF
--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -374,7 +374,7 @@ describe('PaymentStrategyActionCreator', () => {
             ]);
         });
 
-        it('emits error action if unable to finalize', async () => {
+        it('emits error action and reloads payment data if unable to finalize', async () => {
             const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
             const method = getPaymentMethod();
             const finalizeError = new Error();
@@ -391,6 +391,7 @@ describe('PaymentStrategyActionCreator', () => {
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
                 { type: PaymentStrategyActionType.FinalizeRequested },
+                { type: OrderActionType.LoadOrderPaymentsRequested },
                 { type: OrderActionType.LoadOrderPaymentsRequested },
                 { type: PaymentStrategyActionType.FinalizeFailed, error: true, payload: finalizeError, meta: { methodId: method.id } },
             ]);

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -94,7 +94,10 @@ export default class PaymentStrategyActionCreator {
                 const state = store.getState();
                 const payment = state.payment.getPaymentId();
 
-                return throwErrorAction(PaymentStrategyActionType.FinalizeFailed, error, { methodId: payment && payment.providerId });
+                return concat(
+                    this._loadOrderPaymentsIfNeeded(store, options),
+                    throwErrorAction(PaymentStrategyActionType.FinalizeFailed, error, { methodId: payment && payment.providerId })
+                );
             })
         );
     }


### PR DESCRIPTION
## What?
- As per title

## Why?
- Some payment providers (eg. PaypalExpress) will change the payment status in the order if a payment fails. We need to reload the payment data afterwards to avoid being on an inconsistent state.

## Testing / Proof
- Unit / Functional / Manual 

### Manual Testing: 
- [x] Data gets updated after a failing payment

@bigcommerce/checkout @bigcommerce/payments
