### PR TITLE
feat(payment): PAYMENTS-3071 Support the Paypal checkout button strategy for smart buttons

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -1,6 +1,6 @@
 import { RequestOptions } from '../common/http-request';
 
-import { BraintreePaypalButtonInitializeOptions, CheckoutButtonMethodType, GooglePayBraintreeButtonInitializeOptions } from './strategies';
+import { BraintreePaypalButtonInitializeOptions, CheckoutButtonMethodType, GooglePayBraintreeButtonInitializeOptions, PaypalButtonInitializeOptions } from './strategies';
 
 /**
  * The set of options for configuring the checkout button.
@@ -24,6 +24,12 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * omitted unless you need to support Braintree Credit.
      */
     braintreepaypalcredit?: BraintreePaypalButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate PayPal. They can be omitted
+     * unless you need to support Paypal.
+     */
+    paypal?: PaypalButtonInitializeOptions;
 
     /**
      * The ID of a container which the checkout button should be inserted.

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -16,7 +16,8 @@ import {
     CheckoutButtonMethodType,
     CheckoutButtonStrategy,
     GooglePayBraintreeButtonStrategy,
-    MasterpassButtonStrategy
+    MasterpassButtonStrategy,
+    PaypalButtonStrategy
 } from './strategies';
 
 export default function createCheckoutButtonRegistry(
@@ -65,6 +66,14 @@ export default function createCheckoutButtonRegistry(
             formPoster,
             checkoutActionCreator,
             createGooglePayPaymentProcessor(store)
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.PAYPALEXPRESS, () =>
+        new PaypalButtonStrategy(
+            store,
+            new PaypalScriptLoader(scriptLoader),
+            createFormPoster()
         )
     );
 

--- a/src/checkout-buttons/strategies/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree-paypal-button-strategy.spec.ts
@@ -423,6 +423,9 @@ describe('BraintreePaypalButtonStrategy', () => {
                 containerId: 'checkout-button',
                 braintreepaypalcredit: {
                     allowCredit: true,
+                    style: {
+                        label: 'credit',
+                    },
                 },
             };
 

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -3,5 +3,5 @@ export enum CheckoutButtonMethodType {
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',
     GOOGLEPAY_BRAINTREE = 'googlepaybraintree',
     MASTERPASS = 'masterpass',
-
+    PAYPALEXPRESS = 'paypalexpress',
 }

--- a/src/checkout-buttons/strategies/index.ts
+++ b/src/checkout-buttons/strategies/index.ts
@@ -1,8 +1,10 @@
 export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
 export { default as GooglePayBraintreeButtonStrategy } from './googlepay/googlepay-braintree-button-strategy';
+export { default as PaypalButtonStrategy } from './paypal-button-strategy';
 export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
 export { default as MasterpassButtonStrategy } from './masterpass-button-strategy';
 export { CheckoutButtonMethodType } from './checkout-button-method-type';
 
 export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
 export { GooglePayBraintreeButtonInitializeOptions } from './googlepay/googlepay-braintree-button-options';
+export { PaypalButtonInitializeOptions } from './paypal-button-options';

--- a/src/checkout-buttons/strategies/paypal-button-options.ts
+++ b/src/checkout-buttons/strategies/paypal-button-options.ts
@@ -1,0 +1,39 @@
+import { StandardError } from '../../common/error/errors';
+import { PaypalButtonStyleOptions } from '../../payment/strategies/paypal';
+
+export interface PaypalButtonInitializeOptions {
+    /**
+     * @internal
+     * This is an internal property and therefore subject to change. DO NOT USE.
+     */
+    shouldProcessPayment?: boolean;
+
+    /**
+     * The Client ID of the Paypal App
+     */
+    clientId: string;
+
+    /**
+     * Whether or not to show a credit button.
+     */
+    allowCredit?: boolean;
+
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: Pick<PaypalButtonStyleOptions, 'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons'>;
+
+    /**
+     * A callback that gets called if unable to authorize and tokenize payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onAuthorizeError?(error: StandardError): void;
+
+    /**
+     * A callback that gets called if unable to submit payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onPaymentError?(error: StandardError): void;
+}

--- a/src/checkout-buttons/strategies/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-button-strategy.spec.ts
@@ -1,0 +1,254 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+import { merge } from 'lodash';
+
+import { createCheckoutStore, CheckoutStore } from '../../checkout';
+import { getCheckoutStoreState } from '../../checkout/checkouts.mock';
+import { MissingDataError } from '../../common/error/errors';
+import { getPaypalExpress } from '../../payment/payment-methods.mock';
+import { PaypalActions, PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../payment/strategies/paypal';
+import { getPaypalMock } from '../../payment/strategies/paypal/paypal.mock';
+import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
+
+import { CheckoutButtonMethodType } from './checkout-button-method-type';
+import { PaypalButtonInitializeOptions } from './paypal-button-options';
+import PaypalButtonStrategy from './paypal-button-strategy';
+
+describe('PaypalButtonStrategy', () => {
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let options: CheckoutButtonInitializeOptions;
+    let paypalOptions: PaypalButtonInitializeOptions;
+    let paypal: PaypalSDK;
+    let paypalScriptLoader: PaypalScriptLoader;
+    let store: CheckoutStore;
+    let strategy: PaypalButtonStrategy;
+    let actionsMock: PaypalActions;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        formPoster = createFormPoster();
+        paypalScriptLoader = new PaypalScriptLoader(getScriptLoader());
+
+        paypalOptions = {
+            shouldProcessPayment: false,
+            clientId: 'abc',
+            onAuthorizeError: jest.fn(),
+            onPaymentError: jest.fn(),
+        };
+
+        options = {
+            containerId: 'checkout-button',
+            methodId: CheckoutButtonMethodType.PAYPALEXPRESS,
+            paypal: paypalOptions,
+        };
+
+        eventEmitter = new EventEmitter();
+        paypal = getPaypalMock();
+
+        actionsMock = {
+            payment: {
+                get: jest.fn().mockReturnValue(Promise.resolve({
+                    payer: {
+                        payer_info: 'PAYER_INFO',
+                    },
+                })),
+            },
+            request: {
+                post: jest.fn().mockReturnValue(Promise.resolve()),
+            },
+        };
+
+        jest.spyOn(paypal.Button, 'render')
+            .mockImplementation((options: PaypalButtonOptions) => {
+                eventEmitter.on('payment', () => {
+                    options.payment().catch(() => {});
+                });
+
+                eventEmitter.on('authorize', () => {
+                    options.onAuthorize({
+                        payerId: 'PAYER_ID',
+                        paymentID: 'PAYMENT_ID',
+                        payerID: 'PAYER_ID',
+                    }, actionsMock).catch(() => {});
+                });
+            });
+
+        jest.spyOn(paypalScriptLoader, 'loadPaypal')
+            .mockReturnValue(Promise.resolve(paypal));
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockImplementation(() => {});
+
+        strategy = new PaypalButtonStrategy(
+            store,
+            paypalScriptLoader,
+            formPoster
+        );
+    });
+
+    it('throws error if required data is not loaded', async () => {
+        try {
+            store = createCheckoutStore();
+            strategy = new PaypalButtonStrategy(
+                store,
+                paypalScriptLoader,
+                formPoster
+            );
+
+            await strategy.initialize(options);
+        } catch (error) {
+            expect(error).toBeInstanceOf(MissingDataError);
+        }
+    });
+
+    it('initializes Paypal and PayPal JS clients', async () => {
+        await strategy.initialize(options);
+
+        expect(paypalScriptLoader.loadPaypal).toHaveBeenCalled();
+    });
+
+    it('throws error if unable to initialize Paypal or PayPal JS client', async () => {
+        const expectedError = new Error('Unable to load JS client');
+
+        jest.spyOn(paypalScriptLoader, 'loadPaypal')
+            .mockReturnValue(Promise.reject(expectedError));
+
+        try {
+            await strategy.initialize(options);
+        } catch (error) {
+            expect(error).toEqual(expectedError);
+        }
+    });
+
+    it('renders PayPal checkout button', async () => {
+        await strategy.initialize(options);
+
+        expect(paypal.Button.render).toHaveBeenCalledWith({
+            env: 'production',
+            client: {
+                production: 'abc',
+            },
+            commit: false,
+            onAuthorize: expect.any(Function),
+            payment: expect.any(Function),
+            style: {
+                shape: 'rect',
+            },
+            funding: {
+                allowed: [],
+                disallowed: [paypal.FUNDING.CREDIT],
+            },
+        }, 'checkout-button');
+    });
+
+    it('customizes style of PayPal checkout button', async () => {
+        options = {
+            ...options,
+            paypal: {
+                ...paypalOptions,
+                style: {
+                    color: 'blue',
+                    shape: 'pill',
+                    size: 'responsive',
+                },
+            },
+        };
+
+        await strategy.initialize(options);
+
+        expect(paypal.Button.render).toHaveBeenCalledWith(expect.objectContaining({
+            style: {
+                color: 'blue',
+                shape: 'pill',
+                size: 'responsive',
+            },
+        }), 'checkout-button');
+    });
+
+    it('throws error if unable to render PayPal button', async () => {
+        const expectedError = new Error('Unable to render PayPal button');
+
+        jest.spyOn(paypal.Button, 'render')
+            .mockImplementation(() => {
+                throw expectedError;
+            });
+
+        try {
+            await strategy.initialize(options);
+        } catch (error) {
+            expect(error).toEqual(expectedError);
+        }
+    });
+
+    it('renders PayPal checkout button in sandbox environment if payment method is in test mode', async () => {
+        store = createCheckoutStore(merge({}, getCheckoutStoreState(), {
+            paymentMethods: {
+                data: [
+                    merge({}, getPaypalExpress(), { config: { testMode: true } }),
+                ],
+            },
+        }));
+
+        strategy = new PaypalButtonStrategy(
+            store,
+            paypalScriptLoader,
+            formPoster
+        );
+
+        await strategy.initialize(options);
+
+        expect(paypal.Button.render)
+            .toHaveBeenCalledWith(expect.objectContaining({ env: 'sandbox' }), 'checkout-button');
+    });
+
+    it('posts payment details to server to set checkout data when PayPal payment details are tokenized', async () => {
+        await strategy.initialize(options);
+
+        eventEmitter.emit('authorize');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+            payment_type: 'paypal',
+            provider: 'paypalexpress',
+            action: 'set_external_checkout',
+            paymentId: 'PAYMENT_ID',
+            payerId: 'PAYER_ID',
+            payerInfo: JSON.stringify('PAYER_INFO'),
+        }));
+    });
+    describe('if PayPal Credit is offered', () => {
+        beforeEach(() => {
+            options = {
+                ...options,
+                paypal: {
+                    ...paypalOptions,
+                    allowCredit: true,
+                },
+            };
+        });
+
+        it('renders PayPal Credit checkout button', async () => {
+            await strategy.initialize(options);
+
+            expect(paypal.Button.render).toHaveBeenCalledWith({
+                client: {
+                    production: 'abc',
+                },
+                commit: false,
+                env: 'production',
+                onAuthorize: expect.any(Function),
+                payment: expect.any(Function),
+                style: {
+                    shape: 'rect',
+                },
+                funding: {
+                    allowed: [paypal.FUNDING.CREDIT],
+                    disallowed: [],
+                },
+            }, 'checkout-button');
+        });
+    });
+});

--- a/src/checkout-buttons/strategies/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-button-strategy.ts
@@ -1,0 +1,132 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { pick } from 'lodash';
+
+import { CheckoutStore } from '../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../common/error/errors';
+import { PaymentMethod } from '../../payment';
+import { PaypalActions, PaypalAuthorizeData, PaypalClientToken } from '../../payment/strategies/paypal';
+import { PaypalScriptLoader } from '../../payment/strategies/paypal';
+import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
+
+import CheckoutButtonStrategy from './checkout-button-strategy';
+
+export default class PaypalButtonStrategy extends CheckoutButtonStrategy {
+    private _paymentMethod?: PaymentMethod;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _paypalScriptLoader: PaypalScriptLoader,
+        private _formPoster: FormPoster
+    ) {
+        super();
+    }
+
+    initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        if (this._isInitialized[options.containerId]) {
+            return super.initialize(options);
+        }
+
+        const paypalOptions = options.paypal;
+        const state = this._store.getState();
+        const paymentMethod = this._paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId);
+
+        if (!paypalOptions) {
+            throw new InvalidArgumentError();
+        }
+
+        return this._paypalScriptLoader.loadPaypal()
+            .then(paypal => {
+                if (!paymentMethod || !paymentMethod.config.merchantId) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                const merchantId = paymentMethod.config.merchantId;
+                const env = paymentMethod.config.testMode ? 'sandbox' : 'production';
+                const clientToken: PaypalClientToken = { [env]: paypalOptions.clientId };
+
+                const allowedSources = [];
+                const disallowedSources = [];
+
+                if (paypalOptions.allowCredit) {
+                    allowedSources.push(paypal.FUNDING.CREDIT);
+                } else {
+                    disallowedSources.push(paypal.FUNDING.CREDIT);
+                }
+
+                return paypal.Button.render({
+                    env,
+                    client: clientToken,
+                    commit: paypalOptions.shouldProcessPayment,
+                    funding: {
+                        allowed: allowedSources,
+                        disallowed: disallowedSources,
+                    },
+                    style: {
+                        shape: 'rect',
+                        ...pick(paypalOptions.style, 'layout', 'size', 'color', 'label', 'shape', 'tagline', 'fundingicons'),
+                    },
+                    payment: (data, actions) => this._setupPayment(merchantId, actions, paypalOptions.onPaymentError),
+                    onAuthorize: (data, actions) => this._tokenizePayment(data, actions, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
+                }, options.containerId);
+            })
+            .then(() => super.initialize(options));
+    }
+
+    deinitialize(): Promise<void> {
+        if (!Object.keys(this._isInitialized).length) {
+            return super.deinitialize();
+        }
+
+        this._paymentMethod = undefined;
+
+        return super.deinitialize();
+    }
+
+    private _setupPayment(merchantId: string, actions?: PaypalActions, onError?: (error: StandardError) => void): Promise<string> {
+        if (!actions) {
+            throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);
+        }
+
+        return actions.request.post('/api/storefront/paypal-payment/', { merchantId })
+            .then(res => res.id)
+            .catch(error => {
+                if (onError) {
+                    onError(error);
+                }
+
+                throw error;
+            });
+    }
+
+    private _tokenizePayment(
+        data: PaypalAuthorizeData,
+        actions?: PaypalActions,
+        shouldProcessPayment?: boolean,
+        onError?: (error: StandardError) => void
+    ): Promise<void> {
+        if (!this._paymentMethod) {
+            throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);
+        }
+
+        if (!actions) {
+            throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);
+        }
+
+        if (!data.paymentID || !data.payerID) {
+            throw new MissingDataError(MissingDataErrorType.MissingPayment);
+        }
+
+        const methodId = this._paymentMethod.id;
+
+        return actions.payment.get(data.paymentID).then(payload => {
+            this._formPoster.postForm('/checkout.php', {
+                payment_type: 'paypal',
+                provider: methodId,
+                action: shouldProcessPayment ? 'process_payment' : 'set_external_checkout',
+                paymentId: data.paymentID,
+                payerId: data.payerID,
+                payerInfo: JSON.stringify(payload.payer.payer_info),
+            });
+        });
+    }
+}

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -82,6 +82,20 @@ export function getPaypalExpress(): PaymentMethod {
     };
 }
 
+export function getPaypal(): PaymentMethod {
+    return {
+        id: 'paypal',
+        logoUrl: '',
+        method: 'paypal',
+        supportedCards: [],
+        config: {
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'foo',
+    };
+}
+
 export function getAdyenAmex(): PaymentMethod {
     return {
         id: 'amex',

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -18,8 +18,14 @@ export interface PaypalButtonOptions {
     commit?: boolean;
     style?: PaypalButtonStyleOptions;
     funding?: PaypalFundingType;
-    payment(): Promise<any>;
-    onAuthorize(data: PaypalAuthorizeData): Promise<any>;
+    client?: PaypalClientToken;
+    payment(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    onAuthorize(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+}
+
+export interface PaypalClientToken {
+    production?: string;
+    sandbox?: string;
 }
 
 export interface PaypalFundingType {
@@ -37,10 +43,83 @@ export interface PaypalButtonStyleOptions {
     fundingicons?: boolean;
 }
 
+export interface PaypalActions {
+    payment: PaypalPaymentActions;
+    request: PaypalRequestActions;
+}
+
+export interface PaypalPaymentActions {
+    get(id: string): Promise<PaypalPaymentPayload>;
+}
+
+export interface PaypalRequestActions {
+    post(url: string, payload?: object): Promise<{ id: string }>;
+}
+
+export interface PaypalTransaction {
+    amount?: PaypalAmount;
+    payee?: PaypalPayee;
+    description?: string;
+    note_to_payee?: string;
+    item_list?: PaypalItemList;
+}
+
+export interface PaypalItemList {
+    items?: PaypalItem[];
+    shipping_address?: PaypalAddress;
+}
+
+export interface PaypalItem {
+    sku?: string;
+    name?: string;
+    description?: string;
+    quantity: string;
+    price: string;
+    currency: string;
+    tax?: string;
+}
+
+export interface PaypalAmount {
+    currency: string;
+    total: string;
+}
+
+export interface PaypalPayer {
+    payer_info: object;
+}
+
+export interface PaypalPayee {
+    email?: string;
+    merchant_id?: string;
+}
+
+export interface PaypalAddress {
+    line1: string;
+    line2?: string;
+    city?: string;
+    country_code: string;
+    postal_code?: string;
+    state?: string;
+    phone?: string;
+    type?: string;
+}
+
+export interface PaypalPaymentPayload {
+    payment: PaypalPaymentPayload;
+    payer: PaypalPayer;
+}
+
+export interface PaypalPaymentPayload {
+    transactions?: PaypalTransaction[];
+}
+
 export interface PaypalAuthorizeData {
     payerId: string;
     paymentId?: string;
     billingToken?: string;
+    // the PayPal side of things uses uppercase ID instead of camel case Id
+    payerID?: string;
+    paymentID?: string;
 }
 
 export interface PaypalExpressCheckout {


### PR DESCRIPTION
## What?
Add support for the latest PayPal checkout button SDK.

## Why?
Enables the use of smart buttons for payment options.

## Testing / Proof
With a store that has PayPal Express enabled as a payment method, add an item to the cart via the quick view modal and observe that your buttons are customizable in the theme editor. Additionally, those same customizations apply to the cart page. Finally, you should be able to complete an order via all three flows: paypal button from the quick view modal, paypal button from the cart page, paypal payment option from the checkout page.

Also includes unit tests.

@bigcommerce/checkout @bigcommerce/payments
