### PR TITLE
CHECKOUT-3695: Ignore trailing slash and other irrelevant information when comparing event origin

### DIFF
--- a/src/embedded-checkout/iframe-event-listener.spec.ts
+++ b/src/embedded-checkout/iframe-event-listener.spec.ts
@@ -39,6 +39,27 @@ describe('IframeEventListener', () => {
         expect(handleComplete).not.toHaveBeenCalled();
     });
 
+    it('does not respond to event with unrecognized origin', () => {
+        eventEmitter.emit('message', {
+            origin: 'https://foobar.com',
+            data: {
+                type: EmbeddedCheckoutEventType.CheckoutLoaded,
+            },
+        });
+
+        expect(handleLoaded).not.toHaveBeenCalled();
+    });
+
+    it('triggers relevant listeners when origin URL has trailing slash', () => {
+        listener = new IframeEventListener(`${origin}/`);
+        listener.listen();
+        listener.addListener(EmbeddedCheckoutEventType.CheckoutLoaded, handleLoaded);
+
+        eventEmitter.emit('message', { origin, data: { type: EmbeddedCheckoutEventType.CheckoutLoaded } });
+
+        expect(handleLoaded).toHaveBeenCalled();
+    });
+
     it('does not respond to invalid event', () => {
         eventEmitter.emit('message', { origin, data: { type: 'FOOBAR' } });
 

--- a/src/embedded-checkout/iframe-event-listener.ts
+++ b/src/embedded-checkout/iframe-event-listener.ts
@@ -2,14 +2,17 @@ import { bindDecorator as bind } from '../common/utility';
 
 import { IframeEventMap } from './iframe-event';
 import isIframeEvent from './is-iframe-event';
+import parseOrigin from './parse-origin';
 
 export default class IframeEventListener<TEventMap extends IframeEventMap<keyof TEventMap>> {
     private _isListening: boolean;
     private _listeners: EventListeners<TEventMap>;
+    private _sourceOrigin: string;
 
     constructor(
-        private _origin: string
+        sourceOrigin: string
     ) {
+        this._sourceOrigin = parseOrigin(sourceOrigin);
         this._isListening = false;
         this._listeners = {};
     }
@@ -70,7 +73,7 @@ export default class IframeEventListener<TEventMap extends IframeEventMap<keyof 
 
     @bind
     private _handleMessage(event: MessageEvent): void {
-        if ((event.origin !== this._origin) || !isIframeEvent(event.data, event.data.type)) {
+        if ((event.origin !== this._sourceOrigin) || !isIframeEvent(event.data, event.data.type)) {
             return;
         }
 

--- a/src/embedded-checkout/iframe-event-poster.spec.ts
+++ b/src/embedded-checkout/iframe-event-poster.spec.ts
@@ -21,6 +21,19 @@ describe('IframeEventPoster', () => {
             .toHaveBeenCalledWith(message, origin);
     });
 
+    it('strips out irrelevant information from origin URL', () => {
+        const message = { type: 'FOOBAR' };
+        const targetWindow = Object.create(window);
+        const poster = new IframeEventPoster<IframeEvent>(`${origin}/url/path`, targetWindow);
+
+        jest.spyOn(targetWindow, 'postMessage');
+
+        poster.post(message);
+
+        expect(targetWindow.postMessage)
+            .toHaveBeenCalledWith(message, origin);
+    });
+
     it('does not post event to target window if it is same as current window', () => {
         const message = { type: 'FOOBAR' };
         const targetWindow = window;

--- a/src/embedded-checkout/iframe-event-poster.ts
+++ b/src/embedded-checkout/iframe-event-poster.ts
@@ -1,8 +1,14 @@
+import parseOrigin from './parse-origin';
+
 export default class IframeEventPoster<TEvent> {
+    private _targetOrigin: string;
+
     constructor(
-        private _targetOrigin: string,
+        targetOrigin: string,
         private _targetWindow?: Window
-    ) {}
+    ) {
+        this._targetOrigin = parseOrigin(targetOrigin);
+    }
 
     post(event: TEvent): void {
         if (window === this._targetWindow) {


### PR DESCRIPTION
## What?
* When checking if `message` event comes from the expected origin, make sure the configured origin URL is without a trailing slash or other irrelevant information. 

## Why?
* Otherwise, we'll ignore messages coming from `https://bc.wordpress.com` if the origin is configured to be `https://bc.wordpress.com/`.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
