### PR TITLE
CP-4028 & CP-4029 Populate brand & category names  to order confirmation/purchase for GAEE

### DIFF
--- a/src/cart/internal-carts.mock.ts
+++ b/src/cart/internal-carts.mock.ts
@@ -27,6 +27,7 @@ export function getCart(): InternalCart {
                 variantId: 71,
                 addedByPromotion: false,
                 productId: 103,
+                categoryNames: ['Cat 1'],
             },
             {
                 id: '667',
@@ -51,6 +52,7 @@ export function getCart(): InternalCart {
                 variantId: 71,
                 addedByPromotion: false,
                 productId: 103,
+                categoryNames: ['Cat 1'],
             },
             {
                 id: 'bd391ead-8c58-4105-b00e-d75d233b429a',

--- a/src/cart/internal-line-item.ts
+++ b/src/cart/internal-line-item.ts
@@ -12,6 +12,7 @@ export default interface InternalLineItem {
     name?: string;
     quantity: number;
     brand?: string;
+    categoryNames?: string[];
     type: string;
     variantId: number | null;
     productId?: number;

--- a/src/cart/line-item.ts
+++ b/src/cart/line-item.ts
@@ -48,6 +48,7 @@ export interface LineItem {
     url: string;
     quantity: number;
     brand: string;
+    categoryNames?: string[];
     isTaxable: boolean;
     imageUrl: string;
     discounts: Array<{ name: string, discountedAmount: number }>;

--- a/src/cart/line-items.mock.ts
+++ b/src/cart/line-items.mock.ts
@@ -29,6 +29,7 @@ export function getPhysicalItem(): PhysicalItem {
                 valueId: 3,
             },
         ],
+        categoryNames: ['Cat 1'],
     };
 }
 
@@ -63,6 +64,7 @@ export function getDigitalItem(): DigitalItem {
                 valueId: 3,
             },
         ],
+        categoryNames: ['Cat 1'],
     };
 }
 

--- a/src/cart/map-to-internal-line-item.ts
+++ b/src/cart/map-to-internal-line-item.ts
@@ -24,6 +24,7 @@ export default function mapToInternalLineItem(
         name: item.name,
         quantity: item.quantity,
         brand: item.brand,
+        categoryNames: item.categoryNames,
         variantId: item.variantId,
         productId: item.productId,
         attributes: (item.options || []).map(option => ({

--- a/src/checkout/checkout-params.ts
+++ b/src/checkout/checkout-params.ts
@@ -1,3 +1,9 @@
+export enum CheckoutIncludes {
+    AvailableShippingOptions = 'consignments.availableShippingOptions',
+    PhysicalItemsCategoryNames = 'cart.lineItems.physicalItems.categoryNames',
+    DigitalItemsCategoryNames = 'cart.lineItems.digitalItems.categoryNames',
+}
+
 export default interface CheckoutParams {
-    include?: Array<'consignments.availableShippingOptions'>;
+    include?: CheckoutIncludes[];
 }

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -10,6 +10,7 @@ import { CouponActionCreator, GiftCertificateActionCreator } from '../coupon';
 import { CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, CustomerStrategyActionCreator, GuestCredentials } from '../customer';
 import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
+import OrderParams from '../order/order-params';
 import { PaymentInitializeOptions, PaymentMethodActionCreator, PaymentRequestOptions, PaymentStrategyActionCreator } from '../payment';
 import { InstrumentActionCreator } from '../payment/instrument';
 import { ConsignmentsRequestBody, ConsignmentActionCreator, ShippingCountryActionCreator, ShippingInitializeOptions, ShippingRequestOptions, ShippingStrategyActionCreator } from '../shipping';
@@ -195,7 +196,7 @@ export default class CheckoutService {
      * @param options - Options for loading the order.
      * @returns A promise that resolves to the current state.
      */
-    loadOrder(orderId: number, options?: RequestOptions): Promise<CheckoutSelectors> {
+    loadOrder(orderId: number, options?: RequestOptions<OrderParams>): Promise<CheckoutSelectors> {
         const loadCheckoutAction = this._orderActionCreator.loadOrder(orderId, options);
         const loadConfigAction = this._configActionCreator.loadConfig(options);
 

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -17,6 +17,7 @@ import { ConsignmentAssignmentRequestBody, ConsignmentUpdateRequestBody } from '
 
 import { CheckoutRequestBody } from './checkout';
 import CheckoutActionCreator from './checkout-action-creator';
+import CheckoutParams from './checkout-params';
 import CheckoutSelectors from './checkout-selectors';
 import CheckoutStore from './checkout-store';
 import createCheckoutSelectors from './create-checkout-selectors';
@@ -151,7 +152,7 @@ export default class CheckoutService {
      * @param options - Options for loading the current checkout.
      * @returns A promise that resolves to the current state.
      */
-    loadCheckout(id?: string, options?: RequestOptions): Promise<CheckoutSelectors> {
+    loadCheckout(id?: string, options?: RequestOptions<CheckoutParams>): Promise<CheckoutSelectors> {
         return this._dispatch(id ?
             this._checkoutActionCreator.loadCheckout(id, options) :
             this._checkoutActionCreator.loadDefaultCheckout(options)

--- a/src/order/internal-orders.mock.ts
+++ b/src/order/internal-orders.mock.ts
@@ -89,6 +89,7 @@ export function getCompleteOrder(): InternalOrder {
                     },
                 ],
                 productId: 103,
+                categoryNames: ['Cat 1'],
             },
             {
                 id: 'bd391ead-8c58-4105-b00e-d75d233b429a',

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -14,6 +14,7 @@ import { RequestOptions } from '../common/http-request';
 
 import InternalOrderRequestBody from './internal-order-request-body';
 import { FinalizeOrderAction, LoadOrderAction, LoadOrderPaymentsAction, OrderActionType, SubmitOrderAction } from './order-actions';
+import OrderParams from './order-params';
 import OrderRequestBody from './order-request-body';
 import OrderRequestSender from './order-request-sender';
 
@@ -23,7 +24,7 @@ export default class OrderActionCreator {
         private _checkoutValidator: CheckoutValidator
     ) {}
 
-    loadOrder(orderId: number, options?: RequestOptions): Observable<LoadOrderAction> {
+    loadOrder(orderId: number, options?: RequestOptions<OrderParams>): Observable<LoadOrderAction> {
         return new Observable((observer: Observer<LoadOrderAction>) => {
             observer.next(createAction(OrderActionType.LoadOrderRequested));
 

--- a/src/order/order-default-includes.ts
+++ b/src/order/order-default-includes.ts
@@ -1,0 +1,9 @@
+const DEFAULT_INCLUDES = [
+    'payments',
+    'lineItems.physicalItems.socialMedia',
+    'lineItems.physicalItems.options',
+    'lineItems.digitalItems.socialMedia',
+    'lineItems.digitalItems.options',
+];
+
+export default DEFAULT_INCLUDES;

--- a/src/order/order-params.ts
+++ b/src/order/order-params.ts
@@ -1,0 +1,10 @@
+export enum OrderIncludes {
+    PhysicalItemsBrandName = 'lineItems.physicalItems.brands',
+    PhysicalItemsCategoryNames = 'lineItems.physicalItems.categoryNames',
+    DigitalItemsBrandName = 'lineItems.digitalItems.brands',
+    DigitalItemsCategoryNames = 'lineItems.digitalItems.categoryNames',
+}
+
+export default interface OrderParams {
+    include?: OrderIncludes[];
+}

--- a/src/order/order-request-sender.spec.ts
+++ b/src/order/order-request-sender.spec.ts
@@ -7,6 +7,7 @@ import { InternalOrderResponseBody } from './internal-order-responses';
 import { getCompleteOrderResponseBody } from './internal-orders.mock';
 import Order from './order';
 // import OrderDefaultIncludes from './order-default-includes';
+import { OrderIncludes } from './order-params';
 import OrderRequestSender from './order-request-sender';
 import { getOrder } from './orders.mock';
 
@@ -62,8 +63,37 @@ describe('OrderRequestSender', () => {
         });
 
         it('loads order including payment data', async () => {
-            await orderRequestSender.loadOrder(295, { params: { include: [] } });
+            const options = { params: { include : [] }};
+            await orderRequestSender.loadOrder(295, options);
 
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+                params: { include },
+                timeout: undefined,
+            });
+        });
+
+        it('loads order with product category names', async () => {
+            const options = { params: { include: [OrderIncludes.DigitalItemsCategoryNames, OrderIncludes.PhysicalItemsCategoryNames] } };
+            const output = await orderRequestSender.loadOrder(295, options);
+
+            expect(output).toEqual(response);
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+                params: { include },
+                timeout: undefined,
+            });
+        });
+
+        it('loads order with product brand name', async () => {
+            const options = { params: { include: [OrderIncludes.DigitalItemsBrandName, OrderIncludes.PhysicalItemsBrandName] } };
+            const output = await orderRequestSender.loadOrder(295, options);
+
+            expect(output).toEqual(response);
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
                 headers: {
                     Accept: ContentType.JsonV1,

--- a/src/order/order-request-sender.spec.ts
+++ b/src/order/order-request-sender.spec.ts
@@ -6,6 +6,7 @@ import { getResponse } from '../common/http-request/responses.mock';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import { getCompleteOrderResponseBody } from './internal-orders.mock';
 import Order from './order';
+// import OrderDefaultIncludes from './order-default-includes';
 import OrderRequestSender from './order-request-sender';
 import { getOrder } from './orders.mock';
 
@@ -61,7 +62,7 @@ describe('OrderRequestSender', () => {
         });
 
         it('loads order including payment data', async () => {
-            await orderRequestSender.loadOrder(295, { params: { include: ['payments'] } });
+            await orderRequestSender.loadOrder(295, { params: { include: [] } });
 
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
                 headers: {

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -5,27 +5,22 @@ import { ContentType, RequestOptions } from '../common/http-request';
 import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import Order from './order';
+import OrderDefaultIncludes from './order-default-includes';
+import OrderParams from './order-params';
 
 export default class OrderRequestSender {
     constructor(
         private _requestSender: RequestSender
     ) {}
 
-    loadOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response<Order>> {
+    loadOrder(orderId: number, { params, timeout }: RequestOptions<OrderParams> = {}): Promise<Response<Order>> {
         const url = `/api/storefront/orders/${orderId}`;
         const headers = { Accept: ContentType.JsonV1 };
-        const params = {
-            include: [
-                'payments',
-                'lineItems.physicalItems.socialMedia',
-                'lineItems.physicalItems.options',
-                'lineItems.digitalItems.socialMedia',
-                'lineItems.digitalItems.options',
-            ].join(','),
-        };
 
         return this._requestSender.get(url, {
-            params,
+            params: {
+                include: OrderDefaultIncludes.concat(params && params.include || []).join(','),
+            },
             headers,
             timeout,
         });

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -5,6 +5,7 @@ import { Observer } from 'rxjs/Observer';
 import { AddressRequestBody } from '../address';
 import { Cart } from '../cart';
 import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
+import { CheckoutIncludes } from '../checkout/checkout-params';
 import CheckoutRequestSender from '../checkout/checkout-request-sender';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
@@ -151,7 +152,7 @@ export default class ConsignmentActionCreator {
             this._checkoutRequestSender.loadCheckout(checkout.id, {
                 ...options,
                 params: {
-                    include: ['consignments.availableShippingOptions'],
+                    include: [CheckoutIncludes.AvailableShippingOptions],
                 },
             })
             .then(({ body }) => {


### PR DESCRIPTION
## What?
Populate brand & category names  to order confirmation/purchase for GAEE

## Why?
It will help merchant to get the details of the product brand and category information in the order confirmation. 

## Testing / Proof
will upload soon. 

@bigcommerce/checkout  @bigcommerce/payments  @bigcommerce/orders @lord2800 @davidchin @icatalina  @bc-vincent-zhao @dougep
