### PR TITLE
INT-856, INT-857, INT-858 Add Google Pay + Stripe Support

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -1,6 +1,11 @@
 import { RequestOptions } from '../common/http-request';
 
-import { BraintreePaypalButtonInitializeOptions, CheckoutButtonMethodType, GooglePayBraintreeButtonInitializeOptions, PaypalButtonInitializeOptions } from './strategies';
+import {
+    BraintreePaypalButtonInitializeOptions,
+    CheckoutButtonMethodType,
+    GooglePayButtonInitializeOptions,
+    PaypalButtonInitializeOptions
+} from './strategies';
 
 /**
  * The set of options for configuring the checkout button.
@@ -40,5 +45,11 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * The options that are required to facilitate Braintree GooglePay. They can be
      * omitted unles you need to support Braintree GooglePay.
      */
-    googlepaybraintree?: GooglePayBraintreeButtonInitializeOptions;
+    googlepaybraintree?: GooglePayButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate Stripe GooglePay. They can be
+     * omitted unles you need to support Stripe GooglePay.
+     */
+    googlepaystripe?: GooglePayButtonInitializeOptions;
 }

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -7,7 +7,7 @@ import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
 
-import { createGooglePayPaymentProcessor } from '../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayBraintreeInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 
@@ -15,7 +15,7 @@ import {
     BraintreePaypalButtonStrategy,
     CheckoutButtonMethodType,
     CheckoutButtonStrategy,
-    GooglePayBraintreeButtonStrategy,
+    GooglePayButtonStrategy,
     MasterpassButtonStrategy,
     PaypalButtonStrategy
 } from './strategies';
@@ -61,11 +61,30 @@ export default function createCheckoutButtonRegistry(
         ));
 
     registry.register(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, () =>
-        new GooglePayBraintreeButtonStrategy(
+        new GooglePayButtonStrategy(
             store,
             formPoster,
             checkoutActionCreator,
-            createGooglePayPaymentProcessor(store)
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayBraintreeInitializer(
+                    new BraintreeSDKCreator(
+                        new BraintreeScriptLoader(scriptLoader)
+                    )
+                )
+            )
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.GOOGLEPAY_STRIPE, () =>
+        new GooglePayButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayStripeInitializer()
+            )
         )
     );
 
@@ -73,7 +92,7 @@ export default function createCheckoutButtonRegistry(
         new PaypalButtonStrategy(
             store,
             new PaypalScriptLoader(scriptLoader),
-            createFormPoster()
+            formPoster
         )
     );
 

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -2,6 +2,7 @@ export enum CheckoutButtonMethodType {
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',
     GOOGLEPAY_BRAINTREE = 'googlepaybraintree',
+    GOOGLEPAY_STRIPE = 'googlepaystripe',
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',
 }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-options.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-options.ts
@@ -1,6 +1,6 @@
 import { ButtonColor, ButtonType } from '../../../payment/strategies/googlepay/googlepay';
 
-export interface GooglePayBraintreeButtonInitializeOptions {
+export interface GooglePayButtonInitializeOptions {
     /**
      * The color of the GooglePay button that will be inserted.
      *  black (default): a black button suitable for use on white or light backgrounds.

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -7,7 +7,7 @@ import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
-export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStrategy {
+export default class GooglePayButtonStrategy extends CheckoutButtonStrategy {
     private _methodId?: string;
     private _walletButton?: HTMLElement;
 
@@ -83,7 +83,7 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
 
         return this._googlePayPaymentProcessor.displayWallet()
             .then(paymentData => this._googlePayPaymentProcessor.handleSuccess(paymentData)
-            .then(() => this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress)))
+                .then(() => this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress)))
             .then(() => this._onPaymentSelectComplete())
             .catch(error => this._onError(error));
     }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -1,6 +1,6 @@
-
 import { PaymentMethod } from '../../../payment';
 import { getGooglePay } from '../../../payment/payment-methods.mock';
+import { ButtonType } from '../../../payment/strategies/googlepay';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import { CheckoutButtonMethodType } from '../checkout-button-method-type';
 
@@ -18,14 +18,17 @@ export enum Mode {
     Full,
     UndefinedContainer,
     InvalidContainer,
+    GooglePayBraintree,
+    GooglePayStripe,
 }
 
 export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButtonInitializeOptions {
     const methodId = { methodId: CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE };
     const containerId = 'googlePayCheckoutButton';
-    const undefinedContainerId = { containerId : '' };
+    const undefinedContainerId = { containerId: '' };
     const invalidContainerId = { containerId: 'invalid_container' };
-    const googlepay = { googlepaybraintree: { } };
+    const googlepaybraintree = { googlepaybraintree: { buttonType: ButtonType.Short } };
+    const googlepaystripe = { googlepaystripe: { buttonType: ButtonType.Short } };
 
     switch (mode) {
         case Mode.UndefinedContainer: {
@@ -34,8 +37,14 @@ export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButton
         case Mode.InvalidContainer: {
             return { ...methodId, ...invalidContainerId };
         }
+        case Mode.GooglePayBraintree: {
+            return { ...methodId, containerId, ...googlepaybraintree };
+        }
+        case Mode.GooglePayStripe: {
+            return { ...methodId, containerId, ...googlepaystripe };
+        }
         default: {
-            return { ...methodId, containerId, ...googlepay };
+            return { ...methodId, containerId };
         }
     }
 }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
@@ -1,7 +1,6 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { createScriptLoader } from '../../../../node_modules/@bigcommerce/script-loader';
 import { getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
@@ -11,12 +10,11 @@ import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
-import { BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
 import {
     createGooglePayPaymentProcessor,
     GooglePaymentData,
-    GooglePayBraintreeInitializer,
-    GooglePayPaymentProcessor
+    GooglePayPaymentProcessor,
+    GooglePayStripeInitializer
 } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
@@ -56,11 +54,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
         paymentProcessor = createGooglePayPaymentProcessor(
             store,
-            new GooglePayBraintreeInitializer(
-                new BraintreeSDKCreator(
-                    new BraintreeScriptLoader(createScriptLoader())
-                )
-            )
+            new GooglePayStripeInitializer()
         );
 
         formPoster = createFormPoster();
@@ -158,7 +152,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         let checkoutButtonOptions: CheckoutButtonInitializeOptions;
 
         beforeEach(() => {
-            checkoutButtonOptions = getCheckoutButtonOptions(Mode.GooglePayBraintree);
+            checkoutButtonOptions = getCheckoutButtonOptions(Mode.GooglePayStripe);
         });
 
         it('check if googlepay payment processor deinitialize is called', async () => {
@@ -207,7 +201,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         let paymentData: GooglePaymentData;
 
         beforeEach(() => {
-            googlePayOptions = getCheckoutButtonOptions(Mode.GooglePayBraintree);
+            googlePayOptions = getCheckoutButtonOptions(Mode.GooglePayStripe);
 
             paymentData = getGooglePaymentDataMock();
         });

--- a/src/checkout-buttons/strategies/googlepay/index.ts
+++ b/src/checkout-buttons/strategies/googlepay/index.ts
@@ -1,0 +1,3 @@
+export { default as GooglePayButtonStrategy } from './googlepay-button-strategy';
+
+export { GooglePayButtonInitializeOptions } from './googlepay-button-options';

--- a/src/checkout-buttons/strategies/index.ts
+++ b/src/checkout-buttons/strategies/index.ts
@@ -1,10 +1,8 @@
 export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
-export { default as GooglePayBraintreeButtonStrategy } from './googlepay/googlepay-braintree-button-strategy';
-export { default as PaypalButtonStrategy } from './paypal-button-strategy';
-export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
-export { default as MasterpassButtonStrategy } from './masterpass-button-strategy';
-export { CheckoutButtonMethodType } from './checkout-button-method-type';
-
 export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
-export { GooglePayBraintreeButtonInitializeOptions } from './googlepay/googlepay-braintree-button-options';
+export { GooglePayButtonStrategy, GooglePayButtonInitializeOptions } from './googlepay';
+export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
+export { CheckoutButtonMethodType } from './checkout-button-method-type';
+export { default as MasterpassButtonStrategy } from './masterpass-button-strategy';
 export { PaypalButtonInitializeOptions } from './paypal-button-options';
+export { default as PaypalButtonStrategy } from './paypal-button-strategy';

--- a/src/customer/strategies/googlepay/googlepay-customer-mock.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-mock.ts
@@ -20,7 +20,7 @@ export enum Mode {
     Incomplete,
 }
 
-export function getCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
+export function getBraintreeCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
     const methodId = { methodId: 'googlepaybraintree' };
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
@@ -40,6 +40,30 @@ export function getCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerIn
         }
         default: {
             return { ...methodId, ...googlepayBraintree };
+        }
+     }
+}
+
+export function getStripeCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
+    const methodId = { methodId: 'googlepaystripe' };
+    const undefinedMethodId = { methodId: undefined };
+    const container = { container: 'googlePayCheckoutButton' };
+    const invalidContainer = { container: 'invalid_container' };
+    const googlepayStripe = { googlepaystripe: { ...container } };
+    const googlepayStripeWithInvalidContainer = { googlepaystripe: { ...invalidContainer } };
+
+    switch (mode) {
+        case Mode.Incomplete: {
+            return { ...methodId };
+        }
+        case Mode.UndefinedMethodId: {
+            return { ...undefinedMethodId, ...googlepayStripe };
+        }
+        case Mode.InvalidContainer: {
+            return { ...methodId, ...googlepayStripeWithInvalidContainer };
+        }
+        default: {
+            return { ...methodId, ...googlepayStripe };
         }
      }
 }

--- a/src/customer/strategies/googlepay/index.ts
+++ b/src/customer/strategies/googlepay/index.ts
@@ -1,2 +1,2 @@
-export { default as GooglePayBraintreeCustomerStrategy } from './googlepay-braintree-customer-strategy';
+export { default as GooglePayCustomerStrategy } from './googlepay-customer-strategy';
 export { default as GooglePayCustomerInitializeOptions } from './googlepay-customer-initialize-options';

--- a/src/customer/strategies/index.ts
+++ b/src/customer/strategies/index.ts
@@ -6,4 +6,4 @@ export { default as ChasePayCustomerStrategy, ChasePayCustomerInitializeOptions 
 export { default as SquareCustomerStrategy } from './square-customer-strategy';
 export { default as MasterpassCustomerInitializeOptions} from './masterpass-customer-initialize-options';
 export { default as MasterpassCustomerStrategy } from './masterpass-customer-strategy';
-export { GooglePayBraintreeCustomerStrategy, GooglePayCustomerInitializeOptions } from './googlepay';
+export { GooglePayCustomerStrategy, GooglePayCustomerInitializeOptions } from './googlepay';

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -35,9 +35,15 @@ import {
 } from './strategies';
 import { AfterpayScriptLoader } from './strategies/afterpay';
 import { AmazonPayScriptLoader } from './strategies/amazon-pay';
-import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, VisaCheckoutScriptLoader } from './strategies/braintree';
+import {
+    createBraintreePaymentProcessor,
+    createBraintreeVisaCheckoutPaymentProcessor,
+    BraintreeScriptLoader,
+    BraintreeSDKCreator,
+    VisaCheckoutScriptLoader
+} from './strategies/braintree';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
-import { createGooglePayPaymentProcessor } from './strategies/googlepay/';
+import { createGooglePayPaymentProcessor, GooglePayBraintreeInitializer, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaScriptLoader } from './strategies/klarna';
 import { MasterpassPaymentStrategy, MasterpassScriptLoader } from './strategies/masterpass';
 import { PaypalScriptLoader } from './strategies/paypal';
@@ -255,7 +261,14 @@ export default function createPaymentStrategyRegistry(
             paymentStrategyActionCreator,
             paymentActionCreator,
             orderActionCreator,
-            createGooglePayPaymentProcessor(store)
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayBraintreeInitializer(
+                    new BraintreeSDKCreator(
+                        new BraintreeScriptLoader(scriptLoader)
+                    )
+                )
+            )
         )
     );
 
@@ -275,6 +288,21 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             paymentMethodActionCreator,
             new MasterpassScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register('googlepaystripe', () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayStripeInitializer()
+            )
         )
     );
 

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -78,8 +78,14 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
     chasepay?: ChasePayInitializeOptions;
 
     /**
-     * The options that are required to initialize the GooglePay payment method.
+     * The options that are required to initialize the GooglePay Braintree payment method.
      * They can be omitted unless you need to support GooglePay.
      */
-    googlepay?: GooglePayPaymentInitializeOptions;
+    googlepaybraintree?: GooglePayPaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay Stripe payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
+    googlepaystripe?: GooglePayPaymentInitializeOptions;
 }

--- a/src/payment/strategies/googlepay/create-googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/create-googlepay-payment-processor.ts
@@ -6,13 +6,12 @@ import { CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
-import { BraintreeScriptLoader, BraintreeSDKCreator } from '../braintree';
 
-import GooglePayBraintreeInitializer from './googlepay-braintree-initializer';
+import { GooglePayInitializer } from './googlepay';
 import GooglePayPaymentProcessor from './googlepay-payment-processor';
 import GooglePayScriptLoader from './googlepay-script-loader';
 
-export default function createGooglePayPaymentProcessor(store: CheckoutStore): GooglePayPaymentProcessor {
+export default function createGooglePayPaymentProcessor(store: CheckoutStore, initializer: GooglePayInitializer): GooglePayPaymentProcessor {
     const requestSender = createRequestSender();
     const scriptLoader = getScriptLoader();
 
@@ -22,11 +21,7 @@ export default function createGooglePayPaymentProcessor(store: CheckoutStore): G
             new PaymentMethodRequestSender(requestSender)
         ),
         new GooglePayScriptLoader(scriptLoader),
-        new GooglePayBraintreeInitializer(
-            new BraintreeSDKCreator(
-                new BraintreeScriptLoader(scriptLoader)
-            )
-        ),
+        initializer,
         new BillingAddressActionCreator(
             new BillingAddressRequestSender(requestSender)
         ),

--- a/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -1,4 +1,3 @@
-
 import { Checkout } from '../../../checkout';
 import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import PaymentMethod from '../../payment-method';

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -41,13 +41,13 @@ export default class GooglePayPaymentStrategy extends PaymentStrategy {
 
         return this._googlePayPaymentProcessor.initialize(this._methodId)
             .then(() => {
-                if (!options.googlepay) {
+                this._googlePayOptions = this._getGooglePayOptions(options);
+
+                if (!this._googlePayOptions) {
                     throw new InvalidArgumentError('Unable to initialize payment because "options.googlepay" argument is not provided.');
                 }
 
-                this._googlePayOptions = options.googlepay;
-
-                const walletButton = options.googlepay.walletButton && document.getElementById(options.googlepay.walletButton);
+                const walletButton = this._googlePayOptions.walletButton && document.getElementById(this._googlePayOptions.walletButton);
 
                 if (walletButton) {
                     this._walletButton = walletButton;
@@ -115,6 +115,18 @@ export default class GooglePayPaymentStrategy extends PaymentStrategy {
                 this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
                 this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId)),
             ]));
+    }
+
+    private _getGooglePayOptions(options: PaymentInitializeOptions): GooglePayPaymentInitializeOptions {
+        if (options.methodId === 'googlepaybraintree' && options.googlepaybraintree) {
+            return options.googlepaybraintree;
+        }
+
+        if (options.methodId === 'googlepaystripe' && options.googlepaystripe) {
+            return options.googlepaystripe;
+        }
+
+        throw new InvalidArgumentError();
     }
 
     private _getPayment(): PaymentMethodData {

--- a/src/payment/strategies/googlepay/googlepay-stripe-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-stripe-initializer.spec.ts
@@ -1,0 +1,75 @@
+import { InvalidArgumentError } from '../../../common/error/errors';
+
+import GooglePayStripeInitializer from './googlepay-stripe-initializer';
+import {
+    getCheckoutMock,
+    getGooglePaymentDataMock,
+    getGooglePaymentStripeDataMock,
+    getGooglePayStripePaymentDataRequestMock,
+    getGooglePayTokenizePayloadStripe,
+    getPaymentMethodMock,
+} from './googlepay.mock';
+
+describe('GooglePayStripeInitializer', () => {
+    it('creates an instance of GooglePayStripeInitializer', () => {
+        const googlePayStripeInitializer = new GooglePayStripeInitializer();
+
+        expect(googlePayStripeInitializer).toBeInstanceOf(GooglePayStripeInitializer);
+    });
+
+    describe('#initialize', async () => {
+        let googlePayStripeInitializer: GooglePayStripeInitializer;
+
+        beforeEach(() => {
+            googlePayStripeInitializer = new GooglePayStripeInitializer();
+        });
+
+        it('initializes the google pay configuration for stripe', async () => {
+            const googlePayPaymentDataRequestV2 = await googlePayStripeInitializer.initialize(
+                getCheckoutMock(),
+                getPaymentMethodMock(),
+                false
+            );
+
+            expect(googlePayPaymentDataRequestV2).toEqual(getGooglePayStripePaymentDataRequestMock());
+        });
+    });
+
+    describe('#teardown', () => {
+        let googlePayStripeInitializer: GooglePayStripeInitializer;
+
+        beforeEach(() => {
+            googlePayStripeInitializer = new GooglePayStripeInitializer();
+        });
+
+        it('teardowns the initializer', async () => {
+            await googlePayStripeInitializer.teardown().then(() => {
+                expect(googlePayStripeInitializer.teardown).toBeDefined();
+            });
+        });
+    });
+
+    describe('#parseResponse', () => {
+        let googlePayStripeInitializer: GooglePayStripeInitializer;
+
+        beforeEach(() => {
+            googlePayStripeInitializer = new GooglePayStripeInitializer();
+        });
+
+        it('parses a response from google pay payload received', async () => {
+            const tokenizePayload = googlePayStripeInitializer.parseResponse(getGooglePaymentStripeDataMock());
+
+            expect(tokenizePayload).toBeTruthy();
+            expect(tokenizePayload).toEqual(getGooglePayTokenizePayloadStripe());
+        });
+
+        it('throws when try to parse a response from google pay payload received', async () => {
+            try {
+                googlePayStripeInitializer.parseResponse(getGooglePaymentDataMock());
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+                expect(error).toEqual(new InvalidArgumentError('Unable to parse response from Google Pay.'));
+            }
+        });
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
@@ -1,0 +1,91 @@
+import { Checkout } from '../../../checkout';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import PaymentMethod from '../../payment-method';
+
+import {
+    GooglePaymentData,
+    GooglePayInitializer,
+    GooglePayPaymentDataRequestV2,
+    TokenizePayload
+} from './googlepay';
+
+export default class GooglePayStripeInitializer implements GooglePayInitializer {
+    initialize(
+        checkout: Checkout,
+        paymentMethod: PaymentMethod,
+        hasShippingAddress: boolean
+    ): Promise<GooglePayPaymentDataRequestV2> {
+        return Promise.resolve(this._mapGooglePayStripeDataRequestToGooglePayDataRequestV2(
+            checkout,
+            paymentMethod.initializationData,
+            hasShippingAddress
+        ));
+    }
+
+    teardown(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    parseResponse(paymentData: GooglePaymentData): TokenizePayload {
+        try {
+            const payload = JSON.parse(paymentData.paymentMethodData.tokenizationData.token);
+
+            return {
+                nonce: payload.id,
+                type: payload.type,
+                details: {
+                    cardType: payload.card.brand,
+                    lastFour: payload.card.last4,
+                },
+            };
+        } catch (err) {
+            throw new InvalidArgumentError('Unable to parse response from Google Pay.');
+        }
+    }
+
+    private _mapGooglePayStripeDataRequestToGooglePayDataRequestV2(
+        checkout: Checkout,
+        initializationData: any,
+        hasShippingAddress: boolean
+    ): GooglePayPaymentDataRequestV2 {
+        return {
+            apiVersion: 2,
+            apiVersionMinor: 0,
+            merchantInfo: {
+                authJwt: initializationData.platformToken,
+                merchantId: initializationData.googleMerchantId,
+                merchantName: initializationData.googleMerchantName,
+            },
+            allowedPaymentMethods: [{
+                type: 'CARD',
+                parameters: {
+                    allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                    allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'],
+                    billingAddressRequired: true,
+                    billingAddressParameters: {
+                        format: 'FULL',
+                        phoneNumberRequired: true,
+                    },
+                },
+                tokenizationSpecification: {
+                    type: 'PAYMENT_GATEWAY',
+                    parameters: {
+                        gateway: 'stripe',
+                        'stripe:version': initializationData.stripeVersion,
+                        'stripe:publishableKey': initializationData.stripePublishableKey,
+                    },
+                },
+            }],
+            transactionInfo: {
+                currencyCode: checkout.cart.currency.code,
+                totalPriceStatus: 'FINAL',
+                totalPrice: checkout.grandTotal.toString(),
+            },
+            emailRequired: true,
+            shippingAddressRequired: !hasShippingAddress,
+            shippingAddressParameters: {
+                phoneNumberRequired: true,
+            },
+        };
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -16,6 +16,7 @@ import {
     GooglePayAddress,
     GooglePayPaymentDataRequestV2,
     GooglePaySDK,
+    TokenizePayload,
 } from './googlepay';
 import { GooglePayBraintreePaymentDataRequestV1 } from './googlepay-braintree';
 
@@ -204,6 +205,81 @@ export function getGooglePayPaymentDataRequestMock(): GooglePayPaymentDataReques
         transactionInfo: {
             currencyCode: 'USD',
             totalPriceStatus: 'FINAL',
+        },
+    };
+}
+
+export function getGooglePayStripePaymentDataRequestMock(): GooglePayPaymentDataRequestV2 {
+    return {
+        apiVersion: 2,
+        apiVersionMinor: 0,
+        merchantInfo: {
+            authJwt: 'platformToken',
+            merchantId: '123',
+            merchantName: 'name',
+        },
+        allowedPaymentMethods: [{
+            type: 'CARD',
+            parameters: {
+                allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'],
+                billingAddressRequired: true,
+                billingAddressParameters: {
+                    format: 'FULL',
+                    phoneNumberRequired: true,
+                },
+            },
+            tokenizationSpecification: {
+                type: 'PAYMENT_GATEWAY',
+                parameters: {
+                    gateway: 'stripe',
+                    'stripe:version': undefined,
+                    'stripe:publishableKey': undefined,
+                },
+            },
+        }],
+        transactionInfo: {
+            currencyCode: 'USD',
+            totalPriceStatus: 'FINAL',
+            totalPrice: '1',
+        },
+        emailRequired: true,
+        shippingAddressRequired: true,
+        shippingAddressParameters: {
+            phoneNumberRequired: true,
+        },
+    };
+}
+
+export function getGooglePaymentStripeDataMock(): GooglePaymentData {
+    return {
+        apiVersion: 2,
+        apiVersionMinor: 0,
+        email: 'carlos.lopez@bigcommerce.com',
+        paymentMethodData: {
+            description: 'Mastercard •••• 0304',
+            info: {
+                billingAddress: getGooglePayAddressMock(),
+                cardDetails: '0304',
+                cardNetwork: 'MASTERCARD',
+            },
+            tokenizationData: {
+                token: `{"id": "nonce", "type": "AndroidPayCard", "card": {"brand": "MasterCard", "last4": "1234"}}`,
+                type: 'PAYMENT_GATEWAY',
+            },
+            type: 'CARD',
+        },
+        shippingAddress: getGooglePayAddressMock(),
+    };
+}
+
+export function getGooglePayTokenizePayloadStripe(): TokenizePayload {
+    return {
+        nonce: 'nonce',
+        type: 'AndroidPayCard',
+        details: {
+            cardType: 'MasterCard',
+            lastFour: '1234',
         },
     };
 }

--- a/src/payment/strategies/googlepay/googlepay.ts
+++ b/src/payment/strategies/googlepay/googlepay.ts
@@ -47,11 +47,11 @@ export interface TokenizePayload {
     details: {
         cardType: string;
         lastFour: string;
-        lastTwo: string;
+        lastTwo?: string;
     };
-    description: string;
+    description?: string;
     type: TokenizeType;
-    binData: {
+    binData?: {
         commercial: string;
         countryOfIssuance: string;
         debit: string;
@@ -156,7 +156,7 @@ export interface GooglePayPaymentDataRequestV2 {
                 'braintree:sdkVersion'?: string;
                 'braintree:authorizationFingerprint'?: string;
                 'stripe:version'?: string;
-                'stripe.publishableKey'?: string;
+                'stripe:publishableKey'?: string;
             };
         };
     }];

--- a/src/payment/strategies/googlepay/index.ts
+++ b/src/payment/strategies/googlepay/index.ts
@@ -3,6 +3,7 @@ export * from './googlepay';
 export { default as GooglePayScriptLoader } from './googlepay-script-loader';
 export { default as GooglePayPaymentStrategy } from './googlepay-payment-strategy';
 export { default as GooglePayBraintreeInitializer } from './googlepay-braintree-initializer';
+export { default as GooglePayStripeInitializer } from './googlepay-stripe-initializer';
 export { default as GooglePayPaymentInitializeOptions } from './googlepay-initialize-options';
 export { default as GooglePayPaymentProcessor } from './googlepay-payment-processor';
 export { default as createGooglePayPaymentProcessor } from './create-googlepay-payment-processor';


### PR DESCRIPTION
## What?
Support Google Pay as a Wallet implementing a strategy. Google Pay needs to work with Stripe configuration and load the proper files.

## Why?
I want to be able to open the Google Pay Wallet, select a car and get a nonce from Google Pay using Stripe configuration and after that checkout using Google Pay as a Wallet and Stripe as a Provider.

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/47823596-9605d980-dd2e-11e8-812f-0d506b1f5e1d.png)
![image](https://user-images.githubusercontent.com/35146660/47823608-a1f19b80-dd2e-11e8-81d4-fdd636c6e7c1.png)



## Jira Ticket
[INT-856](https://jira.bigcommerce.com/browse/INT-856)
[INT-857](https://jira.bigcommerce.com/browse/INT-857)
[INT-858](https://jira.bigcommerce.com/browse/INT-858)

@bigcommerce/checkout
