### PR TITLE
fix(checkout-button): PAYMENTS-3071 Use the specified host for the paypal payment creation endpoint

### DIFF
--- a/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -33,13 +33,14 @@ import createCheckoutButtonRegistry from './create-checkout-button-registry';
 export default function createCheckoutButtonInitializer(
     options?: CheckoutButtonInitializerOptions
 ): CheckoutButtonInitializer {
+    const host = options && options.host;
     const store = createCheckoutStore();
-    const requestSender = createRequestSender({ host: options && options.host });
+    const requestSender = createRequestSender({ host });
 
     return new CheckoutButtonInitializer(
         store,
         new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store, requestSender),
+            createCheckoutButtonRegistry(store, requestSender, host),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender))
         )
     );

--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -10,7 +10,7 @@ describe('createCheckoutButtonRegistry', () => {
     let registry: Registry<CheckoutButtonStrategy>;
 
     beforeEach(() => {
-        registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender());
+        registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender(), 'https://example.com');
     });
 
     it('returns registry with Braintree PayPal registered', () => {
@@ -19,5 +19,19 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with Braintree PayPal Credit registered', () => {
         expect(registry.get('braintreepaypalcredit')).toEqual(expect.any(BraintreePaypalButtonStrategy));
+    });
+
+    describe('without a provided host', () => {
+        beforeEach(() => {
+            registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender());
+        });
+
+        it('returns registry with Braintree PayPal registered', () => {
+            expect(registry.get('braintreepaypal')).toEqual(expect.any(BraintreePaypalButtonStrategy));
+        });
+
+        it('returns registry with Braintree PayPal Credit registered', () => {
+            expect(registry.get('braintreepaypalcredit')).toEqual(expect.any(BraintreePaypalButtonStrategy));
+        });
     });
 });

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -22,7 +22,8 @@ import {
 
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
-    requestSender: RequestSender
+    requestSender: RequestSender,
+    host?: string
 ): Registry<CheckoutButtonStrategy, CheckoutButtonMethodType> {
     const registry = new Registry<CheckoutButtonStrategy, CheckoutButtonMethodType>();
     const scriptLoader = getScriptLoader();
@@ -92,7 +93,8 @@ export default function createCheckoutButtonRegistry(
         new PaypalButtonStrategy(
             store,
             new PaypalScriptLoader(scriptLoader),
-            formPoster
+            formPoster,
+            host
         )
     );
 

--- a/src/checkout-buttons/strategies/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-button-strategy.ts
@@ -3,6 +3,7 @@ import { pick } from 'lodash';
 
 import { CheckoutStore } from '../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../common/error/errors';
+import { INTERNAL_USE_ONLY } from '../../common/http-request';
 import { PaymentMethod } from '../../payment';
 import { PaypalActions, PaypalAuthorizeData, PaypalClientToken } from '../../payment/strategies/paypal';
 import { PaypalScriptLoader } from '../../payment/strategies/paypal';
@@ -16,7 +17,8 @@ export default class PaypalButtonStrategy extends CheckoutButtonStrategy {
     constructor(
         private _store: CheckoutStore,
         private _paypalScriptLoader: PaypalScriptLoader,
-        private _formPoster: FormPoster
+        private _formPoster: FormPoster,
+        private _host: string = ''
     ) {
         super();
     }
@@ -87,7 +89,13 @@ export default class PaypalButtonStrategy extends CheckoutButtonStrategy {
             throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);
         }
 
-        return actions.request.post('/api/storefront/paypal-payment/', { merchantId })
+        return actions.request.post(`${this._host}/api/storefront/paypal-payment/`, {
+            merchantId,
+        }, {
+            headers: {
+                'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            },
+        })
             .then(res => res.id)
             .catch(error => {
                 if (onError) {

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -53,7 +53,7 @@ export interface PaypalPaymentActions {
 }
 
 export interface PaypalRequestActions {
-    post(url: string, payload?: object): Promise<{ id: string }>;
+    post(url: string, payload?: object, options?: object): Promise<{ id: string }>;
 }
 
 export interface PaypalTransaction {


### PR DESCRIPTION
## What?
Use the specified host from `createCheckoutButtonInitializer` options to send the request to create the payment method instead of a relative one.

## Why?
CORS errors abound when using the relative host because of the double redirect.

## Testing / Proof
Unit tested. Also:
<img width="1528" alt="screen shot 2018-11-05 at 3 41 12 pm" src="https://user-images.githubusercontent.com/715922/48033727-4c900280-e111-11e8-8ed5-26df77a7931e.png">

@bigcommerce/checkout @bigcommerce/payments
