### PR TITLE
Revert "fix(checkout-button): PAYMENTS-3071 Use the specified host for the paypal payment creation endpoint"

### DIFF
--- a/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -33,14 +33,13 @@ import createCheckoutButtonRegistry from './create-checkout-button-registry';
 export default function createCheckoutButtonInitializer(
     options?: CheckoutButtonInitializerOptions
 ): CheckoutButtonInitializer {
-    const host = options && options.host;
     const store = createCheckoutStore();
-    const requestSender = createRequestSender({ host });
+    const requestSender = createRequestSender({ host: options && options.host });
 
     return new CheckoutButtonInitializer(
         store,
         new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store, requestSender, host),
+            createCheckoutButtonRegistry(store, requestSender),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender))
         )
     );

--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -10,7 +10,7 @@ describe('createCheckoutButtonRegistry', () => {
     let registry: Registry<CheckoutButtonStrategy>;
 
     beforeEach(() => {
-        registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender(), 'https://example.com');
+        registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender());
     });
 
     it('returns registry with Braintree PayPal registered', () => {
@@ -19,19 +19,5 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with Braintree PayPal Credit registered', () => {
         expect(registry.get('braintreepaypalcredit')).toEqual(expect.any(BraintreePaypalButtonStrategy));
-    });
-
-    describe('without a provided host', () => {
-        beforeEach(() => {
-            registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender());
-        });
-
-        it('returns registry with Braintree PayPal registered', () => {
-            expect(registry.get('braintreepaypal')).toEqual(expect.any(BraintreePaypalButtonStrategy));
-        });
-
-        it('returns registry with Braintree PayPal Credit registered', () => {
-            expect(registry.get('braintreepaypalcredit')).toEqual(expect.any(BraintreePaypalButtonStrategy));
-        });
     });
 });

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -22,8 +22,7 @@ import {
 
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
-    requestSender: RequestSender,
-    host?: string
+    requestSender: RequestSender
 ): Registry<CheckoutButtonStrategy, CheckoutButtonMethodType> {
     const registry = new Registry<CheckoutButtonStrategy, CheckoutButtonMethodType>();
     const scriptLoader = getScriptLoader();
@@ -93,8 +92,7 @@ export default function createCheckoutButtonRegistry(
         new PaypalButtonStrategy(
             store,
             new PaypalScriptLoader(scriptLoader),
-            formPoster,
-            host
+            formPoster
         )
     );
 

--- a/src/checkout-buttons/strategies/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-button-strategy.spec.ts
@@ -63,11 +63,7 @@ describe('PaypalButtonStrategy', () => {
         jest.spyOn(paypal.Button, 'render')
             .mockImplementation((options: PaypalButtonOptions) => {
                 eventEmitter.on('payment', () => {
-                    options.payment({
-                        payerId: 'PAYER_ID',
-                        paymentID: 'PAYMENT_ID',
-                        payerID: 'PAYER_ID',
-                    }, actionsMock).catch(() => {});
+                    options.payment().catch(() => {});
                 });
 
                 eventEmitter.on('authorize', () => {
@@ -253,37 +249,6 @@ describe('PaypalButtonStrategy', () => {
                     disallowed: [],
                 },
             }, 'checkout-button');
-        });
-    });
-
-    it('sends requests to the relative url by default', async () => {
-        await strategy.initialize(options);
-
-        eventEmitter.emit('payment');
-
-        await new Promise(resolve => process.nextTick(resolve));
-
-        expect(actionsMock.request.post).toHaveBeenCalledWith('/api/storefront/paypal-payment/', expect.any(Object), expect.any(Object));
-    });
-
-    describe('with a provided host', () => {
-        beforeEach(() => {
-            strategy = new PaypalButtonStrategy(
-                store,
-                paypalScriptLoader,
-                formPoster,
-                'https://example.com'
-            );
-        });
-
-        it('sends requests to the absolute url instead of the relative url', async () => {
-            await strategy.initialize(options);
-
-            eventEmitter.emit('payment');
-
-            await new Promise(resolve => process.nextTick(resolve));
-
-            expect(actionsMock.request.post).toHaveBeenCalledWith('https://example.com/api/storefront/paypal-payment/', expect.any(Object), expect.any(Object));
         });
     });
 });

--- a/src/checkout-buttons/strategies/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-button-strategy.ts
@@ -3,7 +3,6 @@ import { pick } from 'lodash';
 
 import { CheckoutStore } from '../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../common/error/errors';
-import { INTERNAL_USE_ONLY } from '../../common/http-request';
 import { PaymentMethod } from '../../payment';
 import { PaypalActions, PaypalAuthorizeData, PaypalClientToken } from '../../payment/strategies/paypal';
 import { PaypalScriptLoader } from '../../payment/strategies/paypal';
@@ -17,8 +16,7 @@ export default class PaypalButtonStrategy extends CheckoutButtonStrategy {
     constructor(
         private _store: CheckoutStore,
         private _paypalScriptLoader: PaypalScriptLoader,
-        private _formPoster: FormPoster,
-        private _host: string = ''
+        private _formPoster: FormPoster
     ) {
         super();
     }
@@ -89,13 +87,7 @@ export default class PaypalButtonStrategy extends CheckoutButtonStrategy {
             throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);
         }
 
-        return actions.request.post(`${this._host}/api/storefront/paypal-payment/`, {
-            merchantId,
-        }, {
-            headers: {
-                'X-API-INTERNAL': INTERNAL_USE_ONLY,
-            },
-        })
+        return actions.request.post('/api/storefront/paypal-payment/', { merchantId })
             .then(res => res.id)
             .catch(error => {
                 if (onError) {

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -53,7 +53,7 @@ export interface PaypalPaymentActions {
 }
 
 export interface PaypalRequestActions {
-    post(url: string, payload?: object, options?: object): Promise<{ id: string }>;
+    post(url: string, payload?: object): Promise<{ id: string }>;
 }
 
 export interface PaypalTransaction {


### PR DESCRIPTION
Reverts bigcommerce/checkout-sdk-js#452

So @lord2800 reported there's still issue with the endpoint. We've decided to revert this PR until we can find a proper fix.