### PR TITLE
PAYMENTS-3663 enable default instrument property

### DIFF
--- a/src/payment/instrument/instrument-response-body.ts
+++ b/src/payment/instrument/instrument-response-body.ts
@@ -7,6 +7,7 @@ export type InstrumentError = Array<{
 
 export interface RawInstrumentResponseBody {
     bigpay_token: string;
+    default_instrument: boolean;
     provider: string;
     iin: string;
     last_4: string;

--- a/src/payment/instrument/instrument-response-transformer.ts
+++ b/src/payment/instrument/instrument-response-transformer.ts
@@ -28,6 +28,7 @@ export default class InstrumentResponseTransformer {
     private _transformVaultedInstruments(vaultedInstruments: RawInstrumentResponseBody[] = []): Instrument[] {
         return vaultedInstruments.map(instrument => ({
             bigpayToken: instrument.bigpay_token,
+            defaultInstrument: instrument.default_instrument,
             provider: instrument.provider,
             iin: instrument.iin,
             last4: instrument.last_4,

--- a/src/payment/instrument/instrument.mock.ts
+++ b/src/payment/instrument/instrument.mock.ts
@@ -16,6 +16,7 @@ export function getInstruments() {
             expiryYear: '2020',
             brand: 'test',
             trustedShippingAddress: true,
+            defaultInstrument: true,
         },
         {
             bigpayToken: '111',
@@ -26,6 +27,7 @@ export function getInstruments() {
             expiryYear: '2024',
             brand: 'test',
             trustedShippingAddress: false,
+            defaultInstrument: false,
         },
     ];
 }
@@ -84,6 +86,7 @@ export function getRawInstrumentsResponseBody() {
                 expiry_year: '2020',
                 brand: 'test',
                 trusted_shipping_address: true,
+                default_instrument: true,
             },
             {
                 bigpay_token: '111',
@@ -94,6 +97,7 @@ export function getRawInstrumentsResponseBody() {
                 expiry_year: '2024',
                 brand: 'test',
                 trusted_shipping_address: false,
+                default_instrument: false,
             },
         ],
     };

--- a/src/payment/instrument/instrument.ts
+++ b/src/payment/instrument/instrument.ts
@@ -1,5 +1,6 @@
 export default interface Instrument {
     bigpayToken: string;
+    defaultInstrument: boolean;
     provider: string;
     iin: string;
     last4: string;


### PR DESCRIPTION
## What?
Support default instrument for stored instruments, whitelist property.

## Why?
The credit card is editable and enables to default instrument functionality.

## Testing / Proof
Payment Method List
<img width="908" alt="screen shot 2018-11-08 at 5 08 55 pm" src="https://user-images.githubusercontent.com/2579218/48180800-2ec4d680-e379-11e8-86ba-2c3ab274d0a6.png">

Checkout Credit Card Default
<img width="551" alt="screen shot 2018-11-08 at 5 09 16 pm" src="https://user-images.githubusercontent.com/2579218/48180810-40a67980-e379-11e8-96c0-ce652e4e3d96.png">




