### PR TITLE
CHECKOUT-3677: Notify parent frame when customer signs out

### DIFF
--- a/src/embedded-checkout/embedded-checkout-events.ts
+++ b/src/embedded-checkout/embedded-checkout-events.ts
@@ -4,6 +4,7 @@ export enum EmbeddedCheckoutEventType {
     CheckoutLoaded = 'CHECKOUT_LOADED',
     FrameError = 'FRAME_ERROR',
     FrameLoaded = 'FRAME_LOADED',
+    SignedOut = 'SIGNED_OUT',
 }
 
 export interface EmbeddedCheckoutEventMap {
@@ -12,6 +13,7 @@ export interface EmbeddedCheckoutEventMap {
     [EmbeddedCheckoutEventType.CheckoutLoaded]: EmbeddedCheckoutLoadedEvent;
     [EmbeddedCheckoutEventType.FrameError]: EmbeddedCheckoutFrameErrorEvent;
     [EmbeddedCheckoutEventType.FrameLoaded]: EmbeddedCheckoutFrameLoadedEvent;
+    [EmbeddedCheckoutEventType.SignedOut]: EmbeddedCheckoutSignedOutEvent;
 }
 
 export type EmbeddedCheckoutEvent = (
@@ -19,7 +21,8 @@ export type EmbeddedCheckoutEvent = (
     EmbeddedCheckoutErrorEvent |
     EmbeddedCheckoutFrameErrorEvent |
     EmbeddedCheckoutFrameLoadedEvent |
-    EmbeddedCheckoutLoadedEvent
+    EmbeddedCheckoutLoadedEvent |
+    EmbeddedCheckoutSignedOutEvent
 );
 
 export interface EmbeddedCheckoutCompleteEvent {
@@ -42,6 +45,10 @@ export interface EmbeddedCheckoutFrameErrorEvent {
 
 export interface EmbeddedCheckoutFrameLoadedEvent {
     type: EmbeddedCheckoutEventType.FrameLoaded;
+}
+
+export interface EmbeddedCheckoutSignedOutEvent {
+    type: EmbeddedCheckoutEventType.SignedOut;
 }
 
 export interface EmbeddedCheckoutError {

--- a/src/embedded-checkout/embedded-checkout-options.ts
+++ b/src/embedded-checkout/embedded-checkout-options.ts
@@ -4,6 +4,7 @@ import {
     EmbeddedCheckoutFrameErrorEvent,
     EmbeddedCheckoutFrameLoadedEvent,
     EmbeddedCheckoutLoadedEvent,
+    EmbeddedCheckoutSignedOutEvent,
 } from './embedded-checkout-events';
 import EmbeddedCheckoutStyles from './embedded-checkout-styles';
 
@@ -16,4 +17,5 @@ export default interface EmbeddedCheckoutOptions {
     onFrameError?(event: EmbeddedCheckoutFrameErrorEvent): void;
     onFrameLoad?(event: EmbeddedCheckoutFrameLoadedEvent): void;
     onLoad?(event: EmbeddedCheckoutLoadedEvent): void;
+    onSignOut?(event: EmbeddedCheckoutSignedOutEvent): void;
 }

--- a/src/embedded-checkout/embedded-checkout.spec.ts
+++ b/src/embedded-checkout/embedded-checkout.spec.ts
@@ -149,6 +149,7 @@ describe('EmbeddedCheckout', () => {
             onError: jest.fn(),
             onFrameLoad: jest.fn(),
             onLoad: jest.fn(),
+            onSignOut: jest.fn(),
         };
 
         embeddedCheckout = new EmbeddedCheckout(
@@ -170,6 +171,9 @@ describe('EmbeddedCheckout', () => {
 
         expect(messageListener.addListener)
             .toHaveBeenCalledWith(EmbeddedCheckoutEventType.FrameLoaded, options.onFrameLoad);
+
+        expect(messageListener.addListener)
+            .toHaveBeenCalledWith(EmbeddedCheckoutEventType.SignedOut, options.onSignOut);
     });
 
     it('configures styles when iframe is loaded', async () => {

--- a/src/embedded-checkout/embedded-checkout.ts
+++ b/src/embedded-checkout/embedded-checkout.ts
@@ -40,6 +40,10 @@ export default class EmbeddedCheckout {
             this._messageListener.addListener(EmbeddedCheckoutEventType.FrameLoaded, this._options.onFrameLoad);
         }
 
+        if (this._options.onSignOut) {
+            this._messageListener.addListener(EmbeddedCheckoutEventType.SignedOut, this._options.onSignOut);
+        }
+
         this._messageListener.addListener(EmbeddedCheckoutEventType.FrameLoaded, () => this._configureStyles());
     }
 

--- a/src/embedded-checkout/iframe-content/embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/embedded-checkout-messenger.ts
@@ -7,5 +7,6 @@ export default interface EmbeddedCheckoutMessenger {
     postFrameError(payload: Error | CustomError): void;
     postFrameLoaded(): void;
     postLoaded(): void;
+    postSignedOut(): void;
     receiveStyles(handler: (styles: EmbeddedCheckoutStyles) => void): void;
 }

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
@@ -78,6 +78,14 @@ describe('EmbeddedCheckoutMessenger', () => {
         });
     });
 
+    it('posts `signed_out` event to parent window', () => {
+        messenger.postSignedOut();
+
+        expect(messagePoster.post).toHaveBeenCalledWith({
+            type: EmbeddedCheckoutEventType.SignedOut,
+        });
+    });
+
     it('listens to `style_configured` event from parent window', () => {
         const handler = jest.fn();
         const styles = { body: { backgroundColor: '#00ff00' } };

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.ts
@@ -8,6 +8,7 @@ import {
     EmbeddedCheckoutFrameErrorEvent,
     EmbeddedCheckoutFrameLoadedEvent,
     EmbeddedCheckoutLoadedEvent,
+    EmbeddedCheckoutSignedOutEvent,
 } from '../embedded-checkout-events';
 import EmbeddedCheckoutStyles from '../embedded-checkout-styles';
 import IframeEventListener from '../iframe-event-listener';
@@ -64,6 +65,14 @@ export default class IframeEmbeddedCheckoutMessenger implements EmbeddedCheckout
     postLoaded(): void {
         const message: EmbeddedCheckoutLoadedEvent = {
             type: EmbeddedCheckoutEventType.CheckoutLoaded,
+        };
+
+        this._messagePoster.post(message);
+    }
+
+    postSignedOut(): void {
+        const message: EmbeddedCheckoutSignedOutEvent = {
+            type: EmbeddedCheckoutEventType.SignedOut,
         };
 
         this._messagePoster.post(message);

--- a/src/embedded-checkout/iframe-content/noop-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/noop-embedded-checkout-messenger.ts
@@ -11,5 +11,7 @@ export default class NoopEmbeddedCheckoutMessenger implements EmbeddedCheckoutMe
 
     postLoaded(): void {}
 
+    postSignedOut(): void {}
+
     receiveStyles(): void {}
 }


### PR DESCRIPTION
## What?
* Add the ability to notify parent frame when customer signs out

## Why?
* So the parent frame can hook into the callback and respond to the event. i.e.: WP can hook into the event and log out from WP session.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
