### PR TITLE
CHECKOUT-3481: Allow cross-origin iframe to invoke payment request API

### DIFF
--- a/src/embedded-checkout/resizable-iframe-creator.spec.ts
+++ b/src/embedded-checkout/resizable-iframe-creator.spec.ts
@@ -63,6 +63,19 @@ describe('iframeCreator.createFrame()', () => {
         expect(frame.iFrameResizer).toBeDefined();
     });
 
+    it('allows cross-origin iframe to use payment request API', async () => {
+        setTimeout(() => {
+            eventEmitter.emit('message', {
+                origin: 'http://mybigcommerce.com',
+                data: { type: EmbeddedCheckoutEventType.FrameLoaded },
+            });
+        });
+
+        const frame = await iframeCreator.createFrame(url, 'checkout');
+
+        expect(frame.allowPaymentRequest).toEqual(true);
+    });
+
     it('removes message listener if iframe is loaded successfully', async () => {
         jest.spyOn(window, 'removeEventListener');
 

--- a/src/embedded-checkout/resizable-iframe-creator.ts
+++ b/src/embedded-checkout/resizable-iframe-creator.ts
@@ -24,6 +24,7 @@ export default class ResizableIframeCreator {
         iframe.style.border = 'none';
         iframe.style.display = 'none';
         iframe.style.width = '100%';
+        iframe.allowPaymentRequest = true;
 
         container.appendChild(iframe);
 


### PR DESCRIPTION
## What?
* Allow cross-origin iframes to invoke payment request API.

## Why?
* Some payment methods use the payment request API, i.e.: Visa Checkout.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
