### PR TITLE
CHECKOUT-3481: Opt into redirect flow for PayPal Express

### DIFF
--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -8,6 +8,7 @@ import {
     GooglePayPaymentInitializeOptions,
     KlarnaPaymentInitializeOptions,
     MasterpassPaymentInitializeOptions,
+    PaypalExpressPaymentInitializeOptions,
     SquarePaymentInitializeOptions,
 } from './strategies';
 
@@ -64,6 +65,12 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support Masterpass.
      */
     masterpass?: MasterpassPaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the PayPal Express payment method.
+     * They can be omitted unless you need to support PayPal Express.
+     */
+    paypalexpress?: PaypalExpressPaymentInitializeOptions;
 
     /**
      * The options that are required to initialize the Square payment method.

--- a/src/payment/strategies/index.ts
+++ b/src/payment/strategies/index.ts
@@ -21,7 +21,7 @@ export {
     GooglePayPaymentProcessor
 } from './googlepay';
 export { KlarnaPaymentStrategy, KlarnaPaymentInitializeOptions } from './klarna';
-export { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy } from './paypal';
+export { PaypalExpressPaymentStrategy, PaypalExpressPaymentInitializeOptions, PaypalProPaymentStrategy } from './paypal';
 export { ChasePayPaymentStrategy, ChasePayInitializeOptions } from './chasepay';
 export { SquarePaymentStrategy, SquarePaymentInitializeOptions } from './square';
 export { MasterpassPaymentStrategy, MasterpassPaymentInitializeOptions } from './masterpass';

--- a/src/payment/strategies/paypal/index.ts
+++ b/src/payment/strategies/paypal/index.ts
@@ -2,4 +2,5 @@ export * from './paypal-sdk';
 
 export { default as PaypalScriptLoader } from './paypal-script-loader';
 export { default as PaypalExpressPaymentStrategy } from './paypal-express-payment-strategy';
+export { default as PaypalExpressPaymentInitializeOptions } from './paypal-express-payment-initialize-options';
 export { default as PaypalProPaymentStrategy } from './paypal-pro-payment-strategy';

--- a/src/payment/strategies/paypal/paypal-express-payment-initialize-options.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-initialize-options.ts
@@ -1,0 +1,3 @@
+export default interface PaypalExpressPaymentInitializeOptions {
+    useRedirectFlow?: boolean;
+}


### PR DESCRIPTION
## What?
* Add the ability to opt into redirect flow for PayPal Express.

## Why?
* For Embedded Checkout, we can't really use the in-context flow. This is because during the in-context flow, it does a redirect to PayPal and back. We want to be able to do the redirect in the parent frame. Otherwise when we're redirected back from PayPal, we'll be showing the checkout page within the child frame. But there's no way of controlling that. So a workaround is to use the redirect flow instead, which we can't control which window to do the redirect.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
