### PR TITLE
CHECKOUT-3706: Switch to different height calculation method if `contentId` is provided.

### DIFF
--- a/src/embedded-checkout/embedded-checkout-error.ts
+++ b/src/embedded-checkout/embedded-checkout-error.ts
@@ -1,0 +1,5 @@
+export default interface EmbeddedCheckoutError {
+    message: string;
+    type?: string;
+    subtype?: string;
+}

--- a/src/embedded-checkout/embedded-checkout-events.ts
+++ b/src/embedded-checkout/embedded-checkout-events.ts
@@ -1,3 +1,6 @@
+import EmbeddedCheckoutError from './embedded-checkout-error';
+import EmbeddedContentOptions from './iframe-content/embedded-content-options';
+
 export enum EmbeddedCheckoutEventType {
     CheckoutComplete = 'CHECKOUT_COMPLETE',
     CheckoutError = 'CHECKOUT_ERROR',
@@ -45,14 +48,9 @@ export interface EmbeddedCheckoutFrameErrorEvent {
 
 export interface EmbeddedCheckoutFrameLoadedEvent {
     type: EmbeddedCheckoutEventType.FrameLoaded;
+    payload?: EmbeddedContentOptions;
 }
 
 export interface EmbeddedCheckoutSignedOutEvent {
     type: EmbeddedCheckoutEventType.SignedOut;
-}
-
-export interface EmbeddedCheckoutError {
-    message: string;
-    type?: string;
-    subtype?: string;
 }

--- a/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.ts
@@ -1,10 +1,11 @@
-import { EmbeddedCheckoutEvent } from '../embedded-checkout-events';
+import { EmbeddedCheckoutEvent, EmbeddedCheckoutEventType } from '../embedded-checkout-events';
 import IframeEventListener from '../iframe-event-listener';
 import IframeEventPoster from '../iframe-event-poster';
 
 import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
 import EmbeddedCheckoutMessengerOptions from './embedded-checkout-messenger-options';
 import { EmbeddedContentEventMap } from './embedded-content-events';
+import handleFrameLoadedEvent from './handle-frame-loaded-event';
 import IframeEmbeddedCheckoutMessenger from './iframe-embedded-checkout-messenger';
 import NoopEmbeddedCheckoutMessenger from './noop-embedded-checkout-messenger';
 
@@ -42,6 +43,7 @@ export default function createEmbeddedCheckoutMessenger(options: EmbeddedCheckou
 
     return new IframeEmbeddedCheckoutMessenger(
         new IframeEventListener<EmbeddedContentEventMap>(options.parentOrigin),
-        new IframeEventPoster<EmbeddedCheckoutEvent>(options.parentOrigin, parentWindow)
+        new IframeEventPoster<EmbeddedCheckoutEvent>(options.parentOrigin, parentWindow),
+        { [EmbeddedCheckoutEventType.FrameLoaded]: handleFrameLoadedEvent }
     );
 }

--- a/src/embedded-checkout/iframe-content/embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/embedded-checkout-messenger.ts
@@ -1,11 +1,13 @@
 import { CustomError } from '../../common/error/errors';
 import EmbeddedCheckoutStyles from '../embedded-checkout-styles';
 
+import EmbeddedContentOptions from './embedded-content-options';
+
 export default interface EmbeddedCheckoutMessenger {
     postComplete(): void;
     postError(payload: Error | CustomError): void;
     postFrameError(payload: Error | CustomError): void;
-    postFrameLoaded(): void;
+    postFrameLoaded(payload?: EmbeddedContentOptions): void;
     postLoaded(): void;
     postSignedOut(): void;
     receiveStyles(handler: (styles: EmbeddedCheckoutStyles) => void): void;

--- a/src/embedded-checkout/iframe-content/embedded-content-options.ts
+++ b/src/embedded-checkout/iframe-content/embedded-content-options.ts
@@ -1,0 +1,3 @@
+export default interface EmbeddedContentOptions {
+    contentId?: string;
+}

--- a/src/embedded-checkout/iframe-content/handle-frame-loaded-event.spec.ts
+++ b/src/embedded-checkout/iframe-content/handle-frame-loaded-event.spec.ts
@@ -1,0 +1,37 @@
+import { EmbeddedCheckoutEventType } from '../embedded-checkout-events';
+
+import handleFrameLoadedEvent from './handle-frame-loaded-event';
+
+describe('handleFrameLoadedEvent()', () => {
+    let content: HTMLElement;
+
+    beforeEach(() => {
+        content = document.createElement('div');
+        content.id = 'foobar';
+        document.body.appendChild(content);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(content);
+    });
+
+    it('adds special marker to body element', () => {
+        handleFrameLoadedEvent({
+            type: EmbeddedCheckoutEventType.FrameLoaded,
+            payload: { contentId: content.id },
+        });
+
+        expect(content.hasAttribute('data-iframe-height'))
+            .toEqual(true);
+    });
+
+    it('does not throw error if `contentId` is not passed', () => {
+        expect(() => handleFrameLoadedEvent({ type: EmbeddedCheckoutEventType.FrameLoaded }))
+            .not.toThrow();
+    });
+
+    it('does not throw error if element cannot be found', () => {
+        expect(() => handleFrameLoadedEvent({ type: EmbeddedCheckoutEventType.FrameLoaded, payload: { contentId: 'abc' } }))
+            .not.toThrow();
+    });
+});

--- a/src/embedded-checkout/iframe-content/handle-frame-loaded-event.ts
+++ b/src/embedded-checkout/iframe-content/handle-frame-loaded-event.ts
@@ -1,0 +1,15 @@
+import { EmbeddedCheckoutFrameLoadedEvent } from '../embedded-checkout-events';
+
+export default function handleFrameLoadedEvent(message: EmbeddedCheckoutFrameLoadedEvent): void {
+    if (!message.payload || !message.payload.contentId) {
+        return;
+    }
+
+    const body = document.getElementById(message.payload.contentId);
+
+    if (!body || body.hasAttribute('data-iframe-height')) {
+        return;
+    }
+
+    body.setAttribute('data-iframe-height', '');
+}

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
@@ -101,4 +101,21 @@ describe('EmbeddedCheckoutMessenger', () => {
 
         expect(handler).toHaveBeenCalledWith(styles);
     });
+
+    it('invokes message callbacks if registered', () => {
+        const handler = jest.fn();
+
+        messenger = new IframeEmbeddedCheckoutMessenger(
+            messageListener,
+            messagePoster,
+            { [EmbeddedCheckoutEventType.FrameLoaded]: handler }
+        );
+
+        messenger.postFrameLoaded({ contentId: 'foobar' });
+
+        expect(handler).toHaveBeenCalledWith({
+            type: EmbeddedCheckoutEventType.FrameLoaded,
+            payload: { contentId: 'foobar' },
+        });
+    });
 });

--- a/src/embedded-checkout/resizable-iframe-creator.ts
+++ b/src/embedded-checkout/resizable-iframe-creator.ts
@@ -57,10 +57,11 @@ export default class ResizableIframeCreator {
                 if (isIframeEvent(event.data, EmbeddedCheckoutEventType.FrameLoaded)) {
                     iframe.style.display = '';
 
+                    const contentId = event.data.payload && event.data.payload.contentId;
                     const iframes = iframeResizer({
                         scrolling: false,
                         sizeWidth: false,
-                        heightCalculationMethod: 'lowestElement',
+                        heightCalculationMethod: contentId ? 'taggedElement' : 'lowestElement',
                     }, iframe);
 
                     teardown();


### PR DESCRIPTION
## What?
* Switch to a different method to calculate the height of the iframe if `bodyId` is passed.

## Why?
* You might want to exclude certain elements from the calculation. For example, you could have an element that's fixed to the bottom of the page. That could cause a problem if the calculation method is set to `lowestElement`. This is because when the page content shrinks, the fixed element will remain in the same position because its position is relative to the iframe rather than the content. Also, because it is the lowest element on the page, therefore the iframe itself won't reduce its height.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
