### PR TITLE
INT-1092 Braintree merchantId is sent with the wrong name

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -73,8 +73,8 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
         const googlePayBraintreePaymentDataRequest: GooglePayBraintreeDataRequest = {
             merchantInfo: {
                 authJwt: initializationData.platformToken,
-                merchantName: initializationData.merchantName,
-                merchantId: initializationData.merchantId,
+                merchantName: initializationData.googleMerchantName,
+                merchantId: initializationData.googleMerchantId,
             },
             transactionInfo: {
                 currencyCode: checkout.cart.currency.code,
@@ -101,8 +101,8 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
             apiVersionMinor: 0,
             merchantInfo: {
                 authJwt: googlePayBraintreeDataRequestV1.merchantInfo.authJwt,
-                merchantId: googlePayBraintreeDataRequestV1.merchantInfo.googleMerchantId,
-                merchantName: googlePayBraintreeDataRequestV1.merchantInfo.googleMerchantName,
+                merchantId: googlePayBraintreeDataRequestV1.merchantInfo.merchantId,
+                merchantName: googlePayBraintreeDataRequestV1.merchantInfo.merchantName,
             },
             allowedPaymentMethods: [{
                 type: 'CARD',

--- a/src/payment/strategies/googlepay/googlepay-braintree.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree.ts
@@ -35,8 +35,8 @@ export interface GooglePayBraintreePaymentDataRequestV1 {
         startTimeMs: number;
     };
     merchantInfo: {
-        googleMerchantId: string;
-        googleMerchantName: string;
+        merchantId: string;
+        merchantName: string;
         authJwt?: string;
     };
     paymentMethodTokenizationParameters: {

--- a/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -54,8 +54,8 @@ export function getGooglePayBraintreePaymentDataRequest(): GooglePayBraintreePay
         },
         merchantInfo: {
             authJwt: '',
-            googleMerchantId: '',
-            googleMerchantName: '',
+            merchantId: '',
+            merchantName: '',
         },
         paymentMethodTokenizationParameters: {
             parameters: {
@@ -131,6 +131,8 @@ export function getGooglePaymentDataPayload() {
         emailRequired: true,
         merchantInfo: {
             authJwt: 'platformToken',
+            merchantId: '123',
+            merchantName: 'name',
         },
         phoneNumberRequired: true,
         shippingAddressRequired: true,


### PR DESCRIPTION
## What?
Braintree was sending googlePayMerchantId and in mapper of GooglePay it was received with merchantId

## Why?
Because is needed to map correctly merchantId and merchantName for Google Pay request payload

## Dependencies
https://github.com/bigcommerce/checkout-sdk-js/pull/463

@bigcommerce/checkout
