### PR TITLE
CHECKOUT-3747: Group checkout button strategies in folders

### DIFF
--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
@@ -1,6 +1,6 @@
-import { StandardError } from '../../common/error/errors';
-import { BraintreeError } from '../../payment/strategies/braintree';
-import { PaypalButtonStyleOptions } from '../../payment/strategies/paypal';
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
 
 export interface BraintreePaypalButtonInitializeOptions {
     /**

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -6,20 +6,20 @@ import { EventEmitter } from 'events';
 import { merge } from 'lodash';
 import { Observable } from 'rxjs';
 
-import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../checkout';
-import { getCheckout, getCheckoutStoreState } from '../../checkout/checkouts.mock';
-import { MissingDataError } from '../../common/error/errors';
-import { ConfigActionCreator, ConfigRequestSender } from '../../config';
-import { getBraintreePaypal } from '../../payment/payment-methods.mock';
-import { BraintreeDataCollector, BraintreePaypalCheckout, BraintreeScriptLoader, BraintreeSDKCreator } from '../../payment/strategies/braintree';
-import { getDataCollectorMock, getPaypalCheckoutMock } from '../../payment/strategies/braintree/braintree.mock';
-import { PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../payment/strategies/paypal';
-import { getPaypalMock } from '../../payment/strategies/paypal/paypal.mock';
-import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getBraintreePaypal } from '../../../payment/payment-methods.mock';
+import { BraintreeDataCollector, BraintreePaypalCheckout, BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
+import { getDataCollectorMock, getPaypalCheckoutMock } from '../../../payment/strategies/braintree/braintree.mock';
+import { PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../../payment/strategies/paypal';
+import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import { CheckoutButtonMethodType } from '../checkout-button-method-type';
 
 import { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
 import BraintreePaypalButtonStrategy from './braintree-paypal-button-strategy';
-import { CheckoutButtonMethodType } from './checkout-button-method-type';
 
 describe('BraintreePaypalButtonStrategy', () => {
     let braintreeSDKCreator: BraintreeSDKCreator;

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -16,7 +16,7 @@ import { getDataCollectorMock, getPaypalCheckoutMock } from '../../../payment/st
 import { PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../../payment/strategies/paypal';
 import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
-import { CheckoutButtonMethodType } from '../checkout-button-method-type';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
 
 import { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
 import BraintreePaypalButtonStrategy from './braintree-paypal-button-strategy';

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -1,15 +1,15 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 import { pick } from 'lodash';
 
-import { Address, LegacyAddress } from '../../address';
-import { CheckoutActionCreator, CheckoutStore } from '../../checkout';
-import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../common/error/errors';
-import { PaymentMethod } from '../../payment';
-import { BraintreeAddress, BraintreeError, BraintreePaypalCheckout, BraintreeSDKCreator, BraintreeTokenizePayload } from '../../payment/strategies/braintree';
-import { PaypalAuthorizeData, PaypalScriptLoader } from '../../payment/strategies/paypal';
-import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
+import { Address, LegacyAddress } from '../../../address';
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../../common/error/errors';
+import { PaymentMethod } from '../../../payment';
+import { BraintreeAddress, BraintreeError, BraintreePaypalCheckout, BraintreeSDKCreator, BraintreeTokenizePayload } from '../../../payment/strategies/braintree';
+import { PaypalAuthorizeData, PaypalScriptLoader } from '../../../payment/strategies/paypal';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
-import CheckoutButtonStrategy from './checkout-button-strategy';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 export default class BraintreePaypalButtonStrategy extends CheckoutButtonStrategy {
     private _paypalCheckout?: BraintreePaypalCheckout;

--- a/src/checkout-buttons/strategies/braintree/index.ts
+++ b/src/checkout-buttons/strategies/braintree/index.ts
@@ -1,0 +1,2 @@
+export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
+export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -1,4 +1,4 @@
-export enum CheckoutButtonMethodType {
+enum CheckoutButtonMethodType {
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',
     GOOGLEPAY_BRAINTREE = 'googlepaybraintree',
@@ -6,3 +6,5 @@ export enum CheckoutButtonMethodType {
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',
 }
+
+export default CheckoutButtonMethodType;

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -2,7 +2,7 @@ import { PaymentMethod } from '../../../payment';
 import { getGooglePay } from '../../../payment/payment-methods.mock';
 import { ButtonType } from '../../../payment/strategies/googlepay';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
-import { CheckoutButtonMethodType } from '../checkout-button-method-type';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
 
 export function getPaymentMethod(): PaymentMethod {
     return {

--- a/src/checkout-buttons/strategies/index.ts
+++ b/src/checkout-buttons/strategies/index.ts
@@ -1,8 +1,7 @@
-export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
-export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+export { BraintreePaypalButtonStrategy, BraintreePaypalButtonInitializeOptions } from './braintree';
 export { GooglePayButtonStrategy, GooglePayButtonInitializeOptions } from './googlepay';
+export { MasterpassButtonStrategy } from './masterpass';
+export { PaypalButtonStrategy, PaypalButtonInitializeOptions } from './paypal';
+
 export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
 export { CheckoutButtonMethodType } from './checkout-button-method-type';
-export { default as MasterpassButtonStrategy } from './masterpass-button-strategy';
-export { PaypalButtonInitializeOptions } from './paypal-button-options';
-export { default as PaypalButtonStrategy } from './paypal-button-strategy';

--- a/src/checkout-buttons/strategies/index.ts
+++ b/src/checkout-buttons/strategies/index.ts
@@ -4,4 +4,4 @@ export { MasterpassButtonStrategy } from './masterpass';
 export { PaypalButtonStrategy, PaypalButtonInitializeOptions } from './paypal';
 
 export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
-export { CheckoutButtonMethodType } from './checkout-button-method-type';
+export { default as CheckoutButtonMethodType } from './checkout-button-method-type';

--- a/src/checkout-buttons/strategies/masterpass/index.ts
+++ b/src/checkout-buttons/strategies/masterpass/index.ts
@@ -1,0 +1,1 @@
+export { default as MasterpassButtonStrategy } from './masterpass-button-strategy';

--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
@@ -18,9 +18,10 @@ import { PaymentMethod } from '../../../payment';
 import { getMasterpass, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { Masterpass, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
 import { getMasterpassScriptMock } from '../../../payment/strategies/masterpass/masterpass.mock';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
 
-import { CheckoutButtonStrategy, MasterpassButtonStrategy } from '..';
-import { CheckoutButtonMethodType } from '../checkout-button-method-type';
+import MasterpassButtonStrategy from './masterpass-button-strategy';
 
 describe('MasterpassCustomerStrategy', () => {
     let container: HTMLDivElement;

--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
@@ -1,25 +1,26 @@
+
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { CheckoutButtonInitializeOptions } from '../';
-import { getCartState } from '../../cart/carts.mock';
+import { CheckoutButtonInitializeOptions } from '../..';
+import { getCartState } from '../../../cart/carts.mock';
 import {
     createCheckoutStore,
     Checkout,
     CheckoutActionCreator,
     CheckoutRequestSender,
     CheckoutStore
-} from '../../checkout';
-import { getCheckout, getCheckoutState } from '../../checkout/checkouts.mock';
-import { InvalidArgumentError, MissingDataError } from '../../common/error/errors';
-import { ConfigActionCreator, ConfigRequestSender } from '../../config';
-import { PaymentMethod } from '../../payment';
-import { getMasterpass, getPaymentMethodsState } from '../../payment/payment-methods.mock';
-import { Masterpass, MasterpassScriptLoader } from '../../payment/strategies/masterpass';
-import { getMasterpassScriptMock } from '../../payment/strategies/masterpass/masterpass.mock';
+} from '../../../checkout';
+import { getCheckout, getCheckoutState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { PaymentMethod } from '../../../payment';
+import { getMasterpass, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { Masterpass, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
+import { getMasterpassScriptMock } from '../../../payment/strategies/masterpass/masterpass.mock';
 
-import { CheckoutButtonStrategy, MasterpassButtonStrategy } from './';
-import { CheckoutButtonMethodType } from './checkout-button-method-type';
+import { CheckoutButtonStrategy, MasterpassButtonStrategy } from '..';
+import { CheckoutButtonMethodType } from '../checkout-button-method-type';
 
 describe('MasterpassCustomerStrategy', () => {
     let container: HTMLDivElement;

--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.ts
@@ -1,16 +1,16 @@
-import { CheckoutButtonInitializeOptions } from '../';
-import { CheckoutActionCreator, CheckoutStore } from '../../checkout';
+import { CheckoutButtonInitializeOptions } from '../..';
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import {
     InvalidArgumentError,
     MissingDataError,
     MissingDataErrorType,
     NotInitializedError,
     NotInitializedErrorType
-} from '../../common/error/errors';
-import { bindDecorator as bind } from '../../common/utility';
-import { Masterpass, MasterpassCheckoutOptions, MasterpassScriptLoader } from '../../payment/strategies/masterpass';
+} from '../../../common/error/errors';
+import { bindDecorator as bind } from '../../../common/utility';
+import { Masterpass, MasterpassCheckoutOptions, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
 
-import CheckoutButtonStrategy from './checkout-button-strategy';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 export default class MasterpassButtonStrategy extends CheckoutButtonStrategy {
     private _masterpassClient?: Masterpass;

--- a/src/checkout-buttons/strategies/paypal/index.ts
+++ b/src/checkout-buttons/strategies/paypal/index.ts
@@ -1,0 +1,2 @@
+export { PaypalButtonInitializeOptions } from './paypal-button-options';
+export { default as PaypalButtonStrategy } from './paypal-button-strategy';

--- a/src/checkout-buttons/strategies/paypal/paypal-button-options.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-options.ts
@@ -1,5 +1,5 @@
-import { StandardError } from '../../common/error/errors';
-import { PaypalButtonStyleOptions } from '../../payment/strategies/paypal';
+import { StandardError } from '../../../common/error/errors';
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
 
 export interface PaypalButtonInitializeOptions {
     /**

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -3,15 +3,15 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 import { merge } from 'lodash';
 
-import { createCheckoutStore, CheckoutStore } from '../../checkout';
-import { getCheckoutStoreState } from '../../checkout/checkouts.mock';
-import { MissingDataError } from '../../common/error/errors';
-import { getPaypalExpress } from '../../payment/payment-methods.mock';
-import { PaypalActions, PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../payment/strategies/paypal';
-import { getPaypalMock } from '../../payment/strategies/paypal/paypal.mock';
-import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MissingDataError } from '../../../common/error/errors';
+import { getPaypalExpress } from '../../../payment/payment-methods.mock';
+import { PaypalActions, PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../../payment/strategies/paypal';
+import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import { CheckoutButtonMethodType } from '../checkout-button-method-type';
 
-import { CheckoutButtonMethodType } from './checkout-button-method-type';
 import { PaypalButtonInitializeOptions } from './paypal-button-options';
 import PaypalButtonStrategy from './paypal-button-strategy';
 

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -10,7 +10,7 @@ import { getPaypalExpress } from '../../../payment/payment-methods.mock';
 import { PaypalActions, PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../../payment/strategies/paypal';
 import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
-import { CheckoutButtonMethodType } from '../checkout-button-method-type';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
 
 import { PaypalButtonInitializeOptions } from './paypal-button-options';
 import PaypalButtonStrategy from './paypal-button-strategy';

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
@@ -1,14 +1,14 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 import { pick } from 'lodash';
 
-import { CheckoutStore } from '../../checkout';
-import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../common/error/errors';
-import { PaymentMethod } from '../../payment';
-import { PaypalActions, PaypalAuthorizeData, PaypalClientToken } from '../../payment/strategies/paypal';
-import { PaypalScriptLoader } from '../../payment/strategies/paypal';
-import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
+import { CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../../common/error/errors';
+import { PaymentMethod } from '../../../payment';
+import { PaypalScriptLoader } from '../../../payment/strategies/paypal';
+import { PaypalActions, PaypalAuthorizeData, PaypalClientToken } from '../../../payment/strategies/paypal';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
-import CheckoutButtonStrategy from './checkout-button-strategy';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 export default class PaypalButtonStrategy extends CheckoutButtonStrategy {
     private _paymentMethod?: PaymentMethod;


### PR DESCRIPTION
## What?
* Group checkout button strategies in folders

## Why?
* It's easier to look for files.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
