### PR TITLE
CHECKOUT-3747: Post form data to host URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,9 @@
       }
     },
     "@bigcommerce/form-poster": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/form-poster/-/form-poster-1.2.3.tgz",
-      "integrity": "sha512-MXohUJDe7L9lb4t9M3tNDJgCvoFlXXepVPiB18UblVrbBCdKndYoj4KONcJX8/y2NE/GC9gZQra1JflECkYyrQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/form-poster/-/form-poster-1.3.0.tgz",
+      "integrity": "sha512-ewMghaxUyeJyBd1nMNfyJVtQ6JnZE3u72mTrxoDMxRzeugYiWMT8dQyjQdNACuKCjFEJYm1GDRFxLAH0jo4i6Q=="
     },
     "@bigcommerce/request-sender": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@bigcommerce/bigpay-client": "^3.2.3",
     "@bigcommerce/data-store": "^0.2.2",
-    "@bigcommerce/form-poster": "^1.2.3",
+    "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/request-sender": "^0.2.0",
     "@bigcommerce/script-loader": "^0.1.6",
     "@types/iframe-resizer": "^3.5.6",

--- a/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -1,4 +1,5 @@
 import { createAction } from '@bigcommerce/data-store';
+import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { Observable } from 'rxjs';
 
@@ -21,7 +22,7 @@ describe('CheckoutButtonInitializer', () => {
     beforeEach(() => {
         store = createCheckoutStore();
         buttonActionCreator = new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store, createRequestSender()),
+            createCheckoutButtonRegistry(store, createRequestSender(), createFormPoster()),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()))
         );
 

--- a/src/checkout-buttons/create-checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-initializer.spec.ts
@@ -1,8 +1,10 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 
 import CheckoutButtonInitializer from './checkout-button-initializer';
 import createCheckoutButtonInitializer from './create-checkout-button-initializer';
 
+jest.mock('@bigcommerce/form-poster');
 jest.mock('@bigcommerce/request-sender');
 
 describe('createCheckoutButtonInitializer()', () => {
@@ -21,6 +23,7 @@ describe('createCheckoutButtonInitializer()', () => {
 
         createCheckoutButtonInitializer({ host });
 
+        expect(createFormPoster).toHaveBeenCalledWith({ host });
         expect(createRequestSender).toHaveBeenCalledWith({ host });
     });
 });

--- a/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -1,3 +1,4 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { createCheckoutStore } from '../checkout';
@@ -33,13 +34,15 @@ import createCheckoutButtonRegistry from './create-checkout-button-registry';
 export default function createCheckoutButtonInitializer(
     options?: CheckoutButtonInitializerOptions
 ): CheckoutButtonInitializer {
+    const host = options && options.host;
     const store = createCheckoutStore();
-    const requestSender = createRequestSender({ host: options && options.host });
+    const requestSender = createRequestSender({ host });
+    const formPoster = createFormPoster({ host });
 
     return new CheckoutButtonInitializer(
         store,
         new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store, requestSender),
+            createCheckoutButtonRegistry(store, requestSender, formPoster),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender))
         )
     );

--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -1,3 +1,4 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { createCheckoutStore } from '../checkout';
@@ -10,7 +11,7 @@ describe('createCheckoutButtonRegistry', () => {
     let registry: Registry<CheckoutButtonStrategy>;
 
     beforeEach(() => {
-        registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender());
+        registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender(), createFormPoster());
     });
 
     it('returns registry with Braintree PayPal registered', () => {

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -1,4 +1,4 @@
-import { createFormPoster } from '@bigcommerce/form-poster';
+import { FormPoster } from '@bigcommerce/form-poster';
 import { RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
@@ -6,7 +6,6 @@ import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
-
 import { createGooglePayPaymentProcessor, GooglePayBraintreeInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
@@ -22,7 +21,8 @@ import {
 
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
-    requestSender: RequestSender
+    requestSender: RequestSender,
+    formPoster: FormPoster
 ): Registry<CheckoutButtonStrategy, CheckoutButtonMethodType> {
     const registry = new Registry<CheckoutButtonStrategy, CheckoutButtonMethodType>();
     const scriptLoader = getScriptLoader();
@@ -30,7 +30,6 @@ export default function createCheckoutButtonRegistry(
         new CheckoutRequestSender(requestSender),
         new ConfigActionCreator(new ConfigRequestSender(requestSender))
     );
-    const formPoster = createFormPoster();
 
     registry.register(CheckoutButtonMethodType.BRAINTREE_PAYPAL, () =>
         new BraintreePaypalButtonStrategy(


### PR DESCRIPTION
## What?
* Post form data to the specified host URL.

## Why?
* Currently you can pass `host` option when you call `createCheckoutButtonInitializer`, and we use that value when making AJAX requests. We should also use that value when posting HTML form data to the server.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
