### PR TITLE
CHECKOUT-3462: Bump `@bigcommerce/data-store` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@bigcommerce/data-store": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/data-store/-/data-store-0.2.2.tgz",
-      "integrity": "sha512-j6IdNebQIml4QewTO7Uniux2hBdOBAHLQ0/31ilpJHs4Gs281FD+rZnGnOEigDIhy3K5U3tutpLyy0ZjTiElmg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/data-store/-/data-store-0.2.4.tgz",
+      "integrity": "sha512-VrmRDGLDGladhEAZH/tSmAjypaWvoXe3O9zVYzBRrEtuM/ErALFceRX+Lbcd10dfIanX3hzvXgztGqe4ywhwsw==",
       "requires": {
         "@types/lodash": "^4.14.92",
         "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@bigcommerce/bigpay-client": "^3.2.3",
-    "@bigcommerce/data-store": "^0.2.2",
+    "@bigcommerce/data-store": "^0.2.4",
     "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/request-sender": "^0.2.0",
     "@bigcommerce/script-loader": "^0.1.6",


### PR DESCRIPTION
## What?
* Bump `@bigcommerce/data-store` version

## Why?
* Please see the [change log](https://github.com/bigcommerce/data-store-js/releases).

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
