### PR TITLE
fix(checkout-button): PAYMENTS-3071 Use the specified host for paypal payment creation

### DIFF
--- a/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -43,7 +43,7 @@ export default function createCheckoutButtonInitializer(
     return new CheckoutButtonInitializer(
         store,
         new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store, requestSender, formPoster),
+            createCheckoutButtonRegistry(store, requestSender, formPoster, host),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender))
         )
     );

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -19,7 +19,8 @@ import { PaypalButtonStrategy } from './strategies/paypal';
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
     requestSender: RequestSender,
-    formPoster: FormPoster
+    formPoster: FormPoster,
+    host?: string
 ): Registry<CheckoutButtonStrategy, CheckoutButtonMethodType> {
     const registry = new Registry<CheckoutButtonStrategy, CheckoutButtonMethodType>();
     const scriptLoader = getScriptLoader();
@@ -87,8 +88,10 @@ export default function createCheckoutButtonRegistry(
     registry.register(CheckoutButtonMethodType.PAYPALEXPRESS, () =>
         new PaypalButtonStrategy(
             store,
+            checkoutActionCreator,
             new PaypalScriptLoader(scriptLoader),
-            formPoster
+            formPoster,
+            host
         )
     );
 

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
@@ -1,13 +1,13 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 import { pick } from 'lodash';
 
-import { CheckoutStore } from '../../../checkout';
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../../common/error/errors';
+import { INTERNAL_USE_ONLY } from '../../../common/http-request';
 import { PaymentMethod } from '../../../payment';
-import { PaypalScriptLoader } from '../../../payment/strategies/paypal';
 import { PaypalActions, PaypalAuthorizeData, PaypalClientToken } from '../../../payment/strategies/paypal';
+import { PaypalScriptLoader } from '../../../payment/strategies/paypal';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
-
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
@@ -15,8 +15,10 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
 
     constructor(
         private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
         private _paypalScriptLoader: PaypalScriptLoader,
-        private _formPoster: FormPoster
+        private _formPoster: FormPoster,
+        private _host: string = ''
     ) {}
 
     initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
@@ -76,7 +78,17 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
             throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);
         }
 
-        return actions.request.post('/api/storefront/paypal-payment/', { merchantId })
+        return this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout())
+            .then(state => {
+                const cart = state.cart.getCart();
+                const cartId = cart ? cart.id : '';
+
+                return actions.request.post(`${this._host}/api/storefront/payment/paypalexpress`, { merchantId, cartId }, {
+                    headers: {
+                        'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    },
+                });
+            })
             .then(res => res.id)
             .catch(error => {
                 if (onError) {

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -53,7 +53,7 @@ export interface PaypalPaymentActions {
 }
 
 export interface PaypalRequestActions {
-    post(url: string, payload?: object): Promise<{ id: string }>;
+    post(url: string, payload?: object, options?: object): Promise<{ id: string }>;
 }
 
 export interface PaypalTransaction {


### PR DESCRIPTION
## What?
Use the specified host for paypal payment creation and provide the cart id to it along with the internal-only header.

## Why?
The endpoint used to rely on the session to retrieve the current cart, which is a bad idea.

## Testing / Proof
Unit tested.

@bigcommerce/checkout @bigcommerce/payments
