### PR TITLE
CHECKOUT-3462: Allow checkout buttons with different container ID to initialize in parallel

### DIFF
--- a/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -49,7 +49,7 @@ describe('CheckoutButtonInitializer', () => {
         expect(buttonActionCreator.initialize).toHaveBeenCalledWith(options);
         expect(store.dispatch).toHaveBeenCalledWith(
             Observable.of(createAction(CheckoutButtonActionType.InitializeButtonRequested)),
-            { queueId: `${CheckoutButtonMethodType.BRAINTREE_PAYPAL}ButtonStrategy` }
+            { queueId: `checkoutButtonStrategy:${CheckoutButtonMethodType.BRAINTREE_PAYPAL}:${options.containerId}` }
         );
     });
 
@@ -64,7 +64,7 @@ describe('CheckoutButtonInitializer', () => {
         expect(buttonActionCreator.deinitialize).toHaveBeenCalledWith(options);
         expect(store.dispatch).toHaveBeenCalledWith(
             Observable.of(createAction(CheckoutButtonActionType.DeinitializeButtonRequested)),
-            { queueId: `${CheckoutButtonMethodType.BRAINTREE_PAYPAL}ButtonStrategy` }
+            { queueId: `checkoutButtonStrategy:${CheckoutButtonMethodType.BRAINTREE_PAYPAL}` }
         );
     });
 

--- a/src/checkout-buttons/checkout-button-initializer.ts
+++ b/src/checkout-buttons/checkout-button-initializer.ts
@@ -102,8 +102,9 @@ export default class CheckoutButtonInitializer {
      */
     initializeButton(options: CheckoutButtonInitializeOptions): Promise<CheckoutButtonSelectors> {
         const action = this._buttonStrategyActionCreator.initialize(options);
+        const queueId = `checkoutButtonStrategy:${options.methodId}:${options.containerId}`;
 
-        return this._store.dispatch(action, { queueId: `${options.methodId}ButtonStrategy` })
+        return this._store.dispatch(action, { queueId })
             .then(() => this.getState());
     }
 
@@ -121,8 +122,9 @@ export default class CheckoutButtonInitializer {
      */
     deinitializeButton(options: CheckoutButtonOptions): Promise<CheckoutButtonSelectors> {
         const action = this._buttonStrategyActionCreator.deinitialize(options);
+        const queueId = `checkoutButtonStrategy:${options.methodId}`;
 
-        return this._store.dispatch(action, { queueId: `${options.methodId}ButtonStrategy` })
+        return this._store.dispatch(action, { queueId })
             .then(() => this.getState());
     }
 }


### PR DESCRIPTION
## What?
* Allow checkout buttons with different container ID to initialize in parallel.
* This PR requires #475 in order to retain the behaviour of using cached payment method data if available.

## Why?
* Some people could insert multiple buttons of the same type on the same page. We want to parallelize the load if possible.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
