### PR TITLE
CHECKOUT-2934: Fix incorrect mock value for config requests

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -169,7 +169,7 @@ describe('CheckoutService', () => {
 
         configRequestSender = new ConfigRequestSender(requestSender);
 
-        jest.spyOn(configRequestSender, 'loadConfig').mockResolvedValue(getResponse(getCheckout()));
+        jest.spyOn(configRequestSender, 'loadConfig').mockResolvedValue(getResponse(getConfig()));
 
         paymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
 


### PR DESCRIPTION
## What?
* Fix incorrect mock value for config requests.

## Why?
* `ConfigRequestSender#loadConfig` should return the result of `getConfig()` rather than `getCheckout()`.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
