### PR TITLE
fix(payments): INT-1119 Modify approach in Checkout Button Strategies to consume unique ids

### DIFF
--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -56,7 +56,7 @@ export default class GooglePayButtonStrategy extends CheckoutButtonStrategy {
     }
 
     private _createSignInButton(containerId: string): HTMLElement {
-        const container = document.querySelector(`#${containerId}`);
+        const container = document.getElementById(containerId);
 
         if (!container) {
             throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');

--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.ts
@@ -71,7 +71,7 @@ export default class MasterpassButtonStrategy extends CheckoutButtonStrategy {
     }
 
     private _createSignInButton(containerId: string): HTMLElement {
-        const buttonContainer = document.querySelector(`#${containerId}`);
+        const buttonContainer = document.getElementById(containerId);
 
         if (!buttonContainer) {
             throw new Error('Need a container to place the button');


### PR DESCRIPTION
## What? [INT-1119](https://jira.bigcommerce.com/browse/INT-1119)
This fixes the issue created by now using the unique ids on the templates for GooglePay and MasterPass.

## Why?
As per bigcommerce/bigcommerce#27267 we need to adjust both Masterpass & Google Pay checkout button strategies to consume unique ids

## Testing / Proof
![image](https://user-images.githubusercontent.com/1013633/48870464-98e07100-eda6-11e8-9efb-f40ddd7352a9.png)
![image](https://user-images.githubusercontent.com/1013633/48870545-ebba2880-eda6-11e8-91f6-3f37dfbda878.png)
![image](https://user-images.githubusercontent.com/1013633/48870553-f96fae00-eda6-11e8-9b25-22536713bc31.png)
![image](https://user-images.githubusercontent.com/1013633/48870571-042a4300-eda7-11e8-970d-5b1c29e92dec.png)

@bigcommerce/checkout
