### PR TITLE
feat(payment): INT-1050 & 1051 Masterpass callback url post launch

### DIFF
--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.ts
@@ -8,7 +8,12 @@ import {
     NotInitializedErrorType
 } from '../../../common/error/errors';
 import { bindDecorator as bind } from '../../../common/utility';
-import { Masterpass, MasterpassCheckoutOptions, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
+import {
+    getCallbackUrl,
+    Masterpass,
+    MasterpassCheckoutOptions,
+    MasterpassScriptLoader
+} from '../../../payment/strategies/masterpass';
 
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
@@ -108,6 +113,7 @@ export default class MasterpassButtonStrategy extends CheckoutButtonStrategy {
             currency: checkout.cart.currency.code,
             cartId: checkout.cart.id,
             suppressShippingAddress: false,
+            callbackUrl: getCallbackUrl('cart'),
         };
     }
 

--- a/src/customer/strategies/masterpass-customer-strategy.ts
+++ b/src/customer/strategies/masterpass-customer-strategy.ts
@@ -6,7 +6,7 @@ import {
     NotImplementedError
 } from '../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
-import { MasterpassScriptLoader } from '../../payment/strategies/masterpass';
+import { getCallbackUrl, MasterpassScriptLoader } from '../../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator } from '../../remote-checkout';
 import CustomerCredentials from '../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-request-options';
@@ -55,6 +55,7 @@ export default class MasterpassCustomerStrategy extends CustomerStrategy {
                     currency: cart.currency.code,
                     cartId: cart.id,
                     suppressShippingAddress: false,
+                    callbackUrl: getCallbackUrl('checkout'),
                 };
 
                 return this._masterpassScriptLoader.load(this._paymentMethod.config.testMode)

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
@@ -22,7 +22,7 @@ import { getMasterpass, getPaymentMethodsState, getStripe } from '../../payment-
 
 import { MasterpassCheckoutOptions, MasterpassPaymentStrategy, MasterpassScriptLoader } from './';
 import { Masterpass } from './masterpass';
-import { getMasterpassScriptMock } from './masterpass.mock';
+import { getCallbackUrlMock, getMasterpassScriptMock } from './masterpass.mock';
 
 describe('MasterpassPaymentStragegy', () => {
     let strategy: MasterpassPaymentStrategy;
@@ -123,6 +123,7 @@ describe('MasterpassPaymentStragegy', () => {
                     checkoutId: 'checkout-id',
                     currency: 'USD',
                     suppressShippingAddress: false,
+                    callbackUrl: getCallbackUrlMock(),
                 };
 
                 walletButton = document.createElement('a');

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.ts
@@ -11,7 +11,7 @@ import { bindDecorator as bind } from '../../../common/utility';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import PaymentMethod from '../../payment-method';
 
-import { Masterpass, MasterpassCheckoutOptions } from './masterpass';
+import { getCallbackUrl, Masterpass, MasterpassCheckoutOptions } from './masterpass';
 import MasterpassScriptLoader from './masterpass-script-loader';
 
 export default class MasterpassPaymentStrategy extends PaymentStrategy {
@@ -120,6 +120,7 @@ export default class MasterpassPaymentStrategy extends PaymentStrategy {
             currency: storeConfig.currency.code,
             cartId: checkout.cart.id,
             suppressShippingAddress: false,
+            callbackUrl: getCallbackUrl('checkout'),
         };
     }
 

--- a/src/payment/strategies/masterpass/masterpass.mock.ts
+++ b/src/payment/strategies/masterpass/masterpass.mock.ts
@@ -5,3 +5,7 @@ export function getMasterpassScriptMock(): Masterpass {
         checkout: jest.fn(),
     };
 }
+
+export function getCallbackUrlMock(): string {
+    return 'http://localhost/checkout.php?action=set_external_checkout&provider=masterpass&gateway=stripe&origin=checkout';
+}

--- a/src/payment/strategies/masterpass/masterpass.ts
+++ b/src/payment/strategies/masterpass/masterpass.ts
@@ -52,3 +52,7 @@ export interface MasterpassCheckoutOptions {
      */
     suppressShippingAddress?: boolean;
 }
+
+export function getCallbackUrl(origin: string): string {
+    return `${window.location.origin}/checkout.php?action=set_external_checkout&provider=masterpass&gateway=stripe&origin=${origin}`;
+}


### PR DESCRIPTION
## What?
When I click Masterpass button from the Quick Cart page, and then dismiss it,
I want to land back on the Quick Cart page, So that I can start where i left off.

## Why?
As a merchant, when I click the MP button from the Quick Cart Page and dismiss, I land back on the Quick Cart page with no changes made to my cart.

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/49309034-8f8a8f00-f49f-11e8-8714-d75df3e45b91.png)

DEPLOY => https://launchbay.bigcommerce.net/deployments/97603

@bigcommerce/checkout
