### PR TITLE
CHECKOUT-3768 Surface the error details for RequestErrors

### DIFF
--- a/src/checkout/create-action-transformer.spec.ts
+++ b/src/checkout/create-action-transformer.spec.ts
@@ -14,36 +14,64 @@ describe('createActionTransformer()', () => {
         transformer = createActionTransformer(createRequestErrorFactory());
     });
 
-    it('transforms error response payload', () => {
-        const payload = getErrorResponse();
-        const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+    describe('when the payload is a response', () => {
+        it('transforms the error', () => {
+            const payload = getErrorResponse();
+            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
 
-        transformer(action$).subscribe({
-            error: action => {
-                expect(action.payload).toBeInstanceOf(Error);
-            },
+            transformer(action$).subscribe({
+                error: action => {
+                    expect(action.payload).toBeInstanceOf(Error);
+                },
+            });
+        });
+
+        it('sets the error message as the body.detail', () => {
+            const payload = getErrorResponse();
+            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+
+            transformer(action$).subscribe({
+                error: action => {
+                    expect(action.payload.message).toEqual(payload.body.detail);
+                },
+            });
+        });
+
+        it('uses the default message if none provided', () => {
+            const payload = getErrorResponse();
+            delete payload.body.detail;
+
+            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+
+            transformer(action$).subscribe({
+                error: action => {
+                    expect(action.payload.message).toEqual(expect.any(String));
+                },
+            });
         });
     });
 
-    it('does not transform if payload is `Error` instance', () => {
-        const payload = new Error();
-        const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+    describe('when the payload is NOT a response', () => {
+        it('does not transform if payload is `Error` instance', () => {
+            const payload = new Error();
+            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
 
-        transformer(action$).subscribe({
-            error: action => {
-                expect(action.payload).toEqual(payload);
-            },
+            transformer(action$).subscribe({
+                error: action => {
+                    expect(action.payload).toEqual(payload);
+                },
+            });
         });
-    });
 
-    it('does not transform if payload is not `Response`', () => {
-        const payload = {};
-        const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+        it('does not transform if payload is not `Response`', () => {
+            const payload = {};
+            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
 
-        transformer(action$).subscribe({
-            error: action => {
-                expect(action.payload).toEqual(payload);
-            },
+            transformer(action$).subscribe({
+                error: action => {
+                    expect(action.payload).toEqual(payload);
+                },
+            });
         });
     });
 });

--- a/src/checkout/create-action-transformer.ts
+++ b/src/checkout/create-action-transformer.ts
@@ -14,7 +14,9 @@ export default function createActionTransformer(
         }
 
         if (isResponse(action.payload)) {
-            throw { ...action, payload: requestErrorFactory.createError(action.payload) };
+            const message = action.payload.body && action.payload.body.detail;
+
+            throw { ...action, payload: requestErrorFactory.createError(action.payload, message) };
         }
 
         throw action;

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -329,7 +329,8 @@ describe('AmazonPayPaymentStrategy', () => {
         try {
             await strategy.execute(getOrderRequestBody());
         } catch (error) {
-            expect(error).toEqual(new RequestError(response));
+            expect(error).toBeInstanceOf(RequestError);
+            expect(error.body).toEqual(response.body);
         }
     });
 


### PR DESCRIPTION
## What?
- Surface response error details

## Why?
- So consumers can display more meaningful errors

## Testing / Proof
- Functional / Unit / Manual

### Manual Test
- [x] The returned error from POST order requests now contains the `detail` field as the error.message

@bigcommerce/checkout @bigcommerce/payments
