### PR TITLE
CHECKOUT-3135: Upgrade Rx to version 6 to bring in various performance improvements and bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,13 +43,13 @@
       }
     },
     "@bigcommerce/data-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/data-store/-/data-store-0.2.4.tgz",
-      "integrity": "sha512-VrmRDGLDGladhEAZH/tSmAjypaWvoXe3O9zVYzBRrEtuM/ErALFceRX+Lbcd10dfIanX3hzvXgztGqe4ywhwsw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/data-store/-/data-store-0.2.5.tgz",
+      "integrity": "sha512-BtaxJ77b9L5SlnfcZlNtICQV6HRetIJCT07wsZbwhMZp0Eqz3Q1mk0+5Dx90EZe+r6s3grHQLzvRro77yEF9Aw==",
       "requires": {
         "@types/lodash": "^4.14.92",
         "lodash": "^4.17.4",
-        "rxjs": "^5.5.5",
+        "rxjs": "^6.3.3",
         "tslib": "^1.8.0"
       }
     },
@@ -7461,11 +7461,11 @@
       }
     },
     "rxjs": {
-      "version": "5.5.10",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
-      "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -8563,11 +8563,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@bigcommerce/bigpay-client": "^3.2.3",
-    "@bigcommerce/data-store": "^0.2.4",
+    "@bigcommerce/data-store": "^0.2.5",
     "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/request-sender": "^0.2.1",
     "@bigcommerce/script-loader": "^0.1.6",
@@ -49,7 +49,7 @@
     "iframe-resizer": "^3.6.2",
     "lodash": "^4.17.4",
     "messageformat": "^2.0.4",
-    "rxjs": "^5.5.5",
+    "rxjs": "^6.3.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/src/billing/billing-address-action-creator.spec.ts
+++ b/src/billing/billing-address-action-creator.spec.ts
@@ -1,6 +1,7 @@
 import { createRequestSender, Response } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { AddressRequestBody } from '../address';
 import { createCheckoutStore, Checkout, CheckoutStore, CheckoutStoreState } from '../checkout';
@@ -47,7 +48,7 @@ describe('BillingAddressActionCreator', () => {
 
             it('throws an exception, emit no actions and does not send a request', async () => {
                 try {
-                    actions = await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
+                    actions = await from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
                         .toPromise();
                 } catch (exception) {
                     expect(exception).toBeInstanceOf(MissingDataError);
@@ -64,7 +65,7 @@ describe('BillingAddressActionCreator', () => {
 
             it('throws an exception, emit no actions and does not send a request', async () => {
                 try {
-                    actions = await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
+                    actions = await from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
                         .toPromise();
                 } catch (exception) {
                     expect(exception).toBeInstanceOf(StandardError);
@@ -90,8 +91,8 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('emits actions if able to continue as guest', async () => {
-                actions = await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
-                    .toArray()
+                actions = await from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
+                    .pipe(toArray())
                     .toPromise();
 
                 expect(actions).toEqual([
@@ -106,13 +107,15 @@ describe('BillingAddressActionCreator', () => {
 
                 const errorHandler = jest.fn();
 
-                actions = await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
-                    .catch((action: UpdateBillingAddressAction) => {
-                        errorHandler();
+                actions = await from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
+                    .pipe(
+                        catchError((action: UpdateBillingAddressAction) => {
+                            errorHandler();
 
-                        return Observable.of(action);
-                    })
-                    .toArray()
+                            return of(action);
+                        }),
+                        toArray()
+                    )
                     .toPromise();
 
                 expect(errorHandler).toHaveBeenCalled();
@@ -123,7 +126,7 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('sends request to create billing address', async () => {
-                await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials, {})(store))
+                await from(billingAddressActionCreator.continueAsGuest(guestCredentials, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.createAddress).toHaveBeenCalledWith(getCheckout().id, guestCredentials, {});
@@ -146,8 +149,8 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('emits actions if able to update billing address', async () => {
-                actions = await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
-                    .toArray()
+                actions = await from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
+                    .pipe(toArray())
                     .toPromise();
 
                 expect(actions).toEqual([
@@ -162,13 +165,15 @@ describe('BillingAddressActionCreator', () => {
 
                 const errorHandler = jest.fn();
 
-                actions = await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
-                    .catch((action: BillingAddressAction) => {
-                        errorHandler();
+                actions = await from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
+                    .pipe(
+                        catchError((action: BillingAddressAction) => {
+                            errorHandler();
 
-                        return Observable.of(action);
-                    })
-                    .toArray()
+                            return of(action);
+                        }),
+                        toArray()
+                    )
                     .toPromise();
 
                 expect(errorHandler).toHaveBeenCalled();
@@ -179,7 +184,7 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('sends request to update billing address, using billing address email if not provided', async () => {
-                await Observable.from(billingAddressActionCreator.continueAsGuest(guestCredentials, {})(store))
+                await from(billingAddressActionCreator.continueAsGuest(guestCredentials, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.updateAddress).toHaveBeenCalledWith(
@@ -204,7 +209,7 @@ describe('BillingAddressActionCreator', () => {
 
             it('throws an exception, emit no actions and does not send a request', async () => {
                 try {
-                    actions = await Observable.from(
+                    actions = await from(
                             billingAddressActionCreator.updateAddress(address)(createCheckoutStore({}))
                         ).toPromise();
                 } catch (exception) {
@@ -223,8 +228,8 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('emits actions if able to update billing address', async () => {
-                actions = await Observable.from(billingAddressActionCreator.updateAddress(address)(store))
-                    .toArray()
+                actions = await from(billingAddressActionCreator.updateAddress(address)(store))
+                    .pipe(toArray())
                     .toPromise();
 
                 expect(actions).toEqual([
@@ -239,13 +244,15 @@ describe('BillingAddressActionCreator', () => {
 
                 const errorHandler = jest.fn();
 
-                actions = await Observable.from(billingAddressActionCreator.updateAddress(address)(store))
-                    .catch((action: UpdateBillingAddressAction) => {
-                        errorHandler();
+                actions = await from(billingAddressActionCreator.updateAddress(address)(store))
+                    .pipe(
+                        catchError((action: UpdateBillingAddressAction) => {
+                            errorHandler();
 
-                        return Observable.of(action);
-                    })
-                    .toArray()
+                            return of(action);
+                        }),
+                        toArray()
+                    )
                     .toPromise();
 
                 expect(errorHandler).toHaveBeenCalled();
@@ -256,7 +263,7 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('sends request to create billing address', async () => {
-                await Observable.from(billingAddressActionCreator.updateAddress(address, {})(store))
+                await from(billingAddressActionCreator.updateAddress(address, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.createAddress).toHaveBeenCalledWith(getCheckout().id, address, {});
@@ -264,7 +271,7 @@ describe('BillingAddressActionCreator', () => {
 
             it('sends request to update email', async () => {
                 const payload = { email: 'foo' };
-                await Observable.from(billingAddressActionCreator.updateAddress(payload, {})(store))
+                await from(billingAddressActionCreator.updateAddress(payload, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.createAddress).toHaveBeenCalledWith(getCheckout().id, payload, {});
@@ -277,8 +284,8 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('emits actions if able to update billing address', async () => {
-                actions = await Observable.from(billingAddressActionCreator.updateAddress(address)(store))
-                    .toArray()
+                actions = await from(billingAddressActionCreator.updateAddress(address)(store))
+                    .pipe(toArray())
                     .toPromise();
 
                 expect(actions).toEqual([
@@ -293,13 +300,15 @@ describe('BillingAddressActionCreator', () => {
 
                 const errorHandler = jest.fn();
 
-                actions = await Observable.from(billingAddressActionCreator.updateAddress(address)(store))
-                    .catch((action: UpdateBillingAddressAction) => {
-                        errorHandler();
+                actions = await from(billingAddressActionCreator.updateAddress(address)(store))
+                    .pipe(
+                        catchError((action: UpdateBillingAddressAction) => {
+                            errorHandler();
 
-                        return Observable.of(action);
-                    })
-                    .toArray()
+                            return of(action);
+                        }),
+                        toArray()
+                    )
                     .toPromise();
 
                 expect(errorHandler).toHaveBeenCalled();
@@ -310,7 +319,7 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('sends request to update billing address, using billing address email if not provided', async () => {
-                await Observable.from(billingAddressActionCreator.updateAddress(address, {})(store))
+                await from(billingAddressActionCreator.updateAddress(address, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.updateAddress).toHaveBeenCalledWith(
@@ -326,7 +335,7 @@ describe('BillingAddressActionCreator', () => {
 
             it('sends request to update billing address, using blank email when provided', async () => {
                 const email = '';
-                await Observable.from(billingAddressActionCreator.updateAddress({ ...address, email }, {})(store))
+                await from(billingAddressActionCreator.updateAddress({ ...address, email }, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.updateAddress).toHaveBeenCalledWith(
@@ -342,7 +351,7 @@ describe('BillingAddressActionCreator', () => {
 
             it('sends request to update billing address, using provided email', async () => {
                 const email = 'foo@bar.com';
-                await Observable.from(billingAddressActionCreator.updateAddress({ ...address, email }, {})(store))
+                await from(billingAddressActionCreator.updateAddress({ ...address, email }, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.updateAddress).toHaveBeenCalledWith(
@@ -368,7 +377,7 @@ describe('BillingAddressActionCreator', () => {
             it('sends request to create a billing address, using provided email', async () => {
                 const email = 'foo@bar.com';
 
-                await Observable.from(billingAddressActionCreator.updateAddress({ ...address, email }, {})(store))
+                await from(billingAddressActionCreator.updateAddress({ ...address, email }, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.updateAddress).toHaveBeenCalledWith(
@@ -383,7 +392,7 @@ describe('BillingAddressActionCreator', () => {
             });
 
             it('sends request to create a billing address, using previous email', async () => {
-                await Observable.from(billingAddressActionCreator.updateAddress(address, {})(store))
+                await from(billingAddressActionCreator.updateAddress(address, {})(store))
                     .toPromise();
 
                 expect(billingAddressRequestSender.updateAddress).toHaveBeenCalledWith(

--- a/src/billing/billing-address-action-creator.ts
+++ b/src/billing/billing-address-action-creator.ts
@@ -1,7 +1,6 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { Response } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { Checkout, InternalCheckoutSelectors } from '../checkout';
 import { MissingDataError, MissingDataErrorType, StandardError } from '../common/error/errors';

--- a/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
 
 import { createCheckoutStore, CheckoutStore } from '../checkout';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
@@ -30,10 +30,10 @@ describe('CheckoutButtonInitializer', () => {
         jest.spyOn(store, 'subscribe');
 
         jest.spyOn(buttonActionCreator, 'initialize')
-            .mockReturnValue(Observable.of(createAction(CheckoutButtonActionType.InitializeButtonRequested)));
+            .mockReturnValue(of(createAction(CheckoutButtonActionType.InitializeButtonRequested)));
 
         jest.spyOn(buttonActionCreator, 'deinitialize')
-            .mockReturnValue(Observable.of(createAction(CheckoutButtonActionType.DeinitializeButtonRequested)));
+            .mockReturnValue(of(createAction(CheckoutButtonActionType.DeinitializeButtonRequested)));
 
         initializer = new CheckoutButtonInitializer(store, buttonActionCreator);
     });
@@ -48,7 +48,7 @@ describe('CheckoutButtonInitializer', () => {
 
         expect(buttonActionCreator.initialize).toHaveBeenCalledWith(options);
         expect(store.dispatch).toHaveBeenCalledWith(
-            Observable.of(createAction(CheckoutButtonActionType.InitializeButtonRequested)),
+            buttonActionCreator.initialize(options),
             { queueId: `checkoutButtonStrategy:${CheckoutButtonMethodType.BRAINTREE_PAYPAL}:${options.containerId}` }
         );
     });
@@ -63,7 +63,7 @@ describe('CheckoutButtonInitializer', () => {
 
         expect(buttonActionCreator.deinitialize).toHaveBeenCalledWith(options);
         expect(store.dispatch).toHaveBeenCalledWith(
-            Observable.of(createAction(CheckoutButtonActionType.DeinitializeButtonRequested)),
+            buttonActionCreator.deinitialize(options),
             { queueId: `checkoutButtonStrategy:${CheckoutButtonMethodType.BRAINTREE_PAYPAL}` }
         );
     });

--- a/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -1,9 +1,6 @@
 import { createAction } from '@bigcommerce/data-store';
-import { concat } from 'rxjs/observable/concat';
-import { defer } from 'rxjs/observable/defer';
-import { of } from 'rxjs/observable/of';
+import { concat, defer, of, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { Observable } from 'rxjs/Observable';
 
 import { throwErrorAction } from '../common/error';
 import { Registry } from '../common/registry';

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -4,7 +4,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 import { merge } from 'lodash';
-import { Observable } from 'rxjs';
+import { from } from 'rxjs';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
@@ -73,7 +73,7 @@ describe('BraintreePaypalButtonStrategy', () => {
             });
 
         jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout')
-            .mockReturnValue(() => Observable.from([
+            .mockReturnValue(() => from([
                 createAction(CheckoutActionType.LoadCheckoutRequested),
                 createAction(CheckoutActionType.LoadCheckoutSucceeded, getCheckout()),
             ]));

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { createScriptLoader } from '../../../../node_modules/@bigcommerce/script-loader';
 import { getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';

--- a/src/checkout/checkout-action-creator.ts
+++ b/src/checkout/checkout-action-creator.ts
@@ -1,10 +1,6 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { concat } from 'rxjs/observable/concat';
-import { defer } from 'rxjs/observable/defer';
-import { merge } from 'rxjs/observable/merge';
-import { of } from 'rxjs/observable/of';
+import { concat, defer, merge, of, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { Observable } from 'rxjs/Observable';
 
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType, StandardError } from '../common/error/errors';

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender, createTimeout } from '@bigcommerce/request-sender';
 import { map, merge } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { getBillingAddress } from '../billing/billing-addresses.mock';
@@ -573,7 +573,7 @@ describe('CheckoutService', () => {
     describe('#initializeCustomer()', () => {
         it('dispatches action to initialize customer', async () => {
             const options = { methodId: getPaymentMethod().id };
-            const action = Observable.of(createAction('INITIALIZE_CUSTOMER'));
+            const action = of(createAction('INITIALIZE_CUSTOMER'));
 
             jest.spyOn(customerStrategyActionCreator, 'initialize')
                 .mockReturnValue(action);
@@ -590,7 +590,7 @@ describe('CheckoutService', () => {
     describe('#deinitializeCustomer()', () => {
         it('dispatches action to deinitialize customer', async () => {
             const options = { methodId: getPaymentMethod().id };
-            const action = Observable.of(createAction('DEINITIALIZE_CUSTOMER'));
+            const action = of(createAction('DEINITIALIZE_CUSTOMER'));
 
             jest.spyOn(customerStrategyActionCreator, 'deinitialize')
                 .mockReturnValue(action);
@@ -606,7 +606,7 @@ describe('CheckoutService', () => {
 
     describe('#continueAsGuest()', () => {
         it('dispatches action to continue as guest', async () => {
-            const action = Observable.of(createAction('SIGN_IN_GUEST'));
+            const action = of(createAction('SIGN_IN_GUEST'));
 
             jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
                 .mockReturnValue(action);
@@ -623,7 +623,7 @@ describe('CheckoutService', () => {
     describe('#signInCustomer()', () => {
         it('dispatches action to sign in customer', async () => {
             const options = { methodId: getPaymentMethod().id };
-            const action = Observable.of(createAction('SIGN_IN_CUSTOMER'));
+            const action = of(createAction('SIGN_IN_CUSTOMER'));
 
             jest.spyOn(customerStrategyActionCreator, 'signIn')
                 .mockReturnValue(action);
@@ -640,7 +640,7 @@ describe('CheckoutService', () => {
     describe('#signOutCustomer()', () => {
         it('dispatches action to sign out customer', async () => {
             const options = { methodId: getPaymentMethod().id };
-            const action = Observable.of(createAction('SIGN_OUT_CUSTOMER'));
+            const action = of(createAction('SIGN_OUT_CUSTOMER'));
 
             jest.spyOn(customerStrategyActionCreator, 'signOut')
                 .mockReturnValue(action);
@@ -666,7 +666,7 @@ describe('CheckoutService', () => {
     describe('#initializeShipping()', () => {
         it('dispatches action to initialize shipping', async () => {
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('INITIALIZE_SHIPPING'));
+            const action = of(createAction('INITIALIZE_SHIPPING'));
 
             jest.spyOn(shippingStrategyActionCreator, 'initialize')
                 .mockReturnValue(action);
@@ -683,7 +683,7 @@ describe('CheckoutService', () => {
     describe('#deinitializeShipping()', () => {
         it('dispatches action to deinitialize shipping', async () => {
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('DEINITIALIZE_SHIPPING'));
+            const action = of(createAction('DEINITIALIZE_SHIPPING'));
 
             jest.spyOn(shippingStrategyActionCreator, 'deinitialize')
                 .mockReturnValue(action);
@@ -700,7 +700,7 @@ describe('CheckoutService', () => {
     describe('#selectConsignmentShippingOption()', () => {
         it('dispatches action to update shipping option for a consignment', async () => {
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('UPDATE_CONSIGNMENT'));
+            const action = of(createAction('UPDATE_CONSIGNMENT'));
 
             jest.spyOn(consignmentActionCreator, 'updateShippingOption')
                 .mockReturnValue(action);
@@ -722,7 +722,7 @@ describe('CheckoutService', () => {
         it('dispatches action to update address for a consignment', async () => {
             const address = getShippingAddress();
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('UPDATE_CONSIGNMENT'));
+            const action = of(createAction('UPDATE_CONSIGNMENT'));
 
             jest.spyOn(consignmentActionCreator, 'updateConsignment')
                 .mockReturnValue(action);
@@ -749,7 +749,7 @@ describe('CheckoutService', () => {
         it('dispatches action to update consignment', async () => {
             const address = getShippingAddress();
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('bar'));
+            const action = of(createAction('bar'));
 
             jest.spyOn(consignmentActionCreator, 'assignItemsByAddress')
                 .mockReturnValue(action);
@@ -778,7 +778,7 @@ describe('CheckoutService', () => {
         it('dispatches action to update consignment', async () => {
             const address = getShippingAddress();
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('bar'));
+            const action = of(createAction('bar'));
 
             jest.spyOn(consignmentActionCreator, 'unassignItemsByAddress')
                 .mockReturnValue(action);
@@ -810,7 +810,7 @@ describe('CheckoutService', () => {
                 shippingAddress: getShippingAddress(),
             }];
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('CREATE_CONSIGNMENTS'));
+            const action = of(createAction('CREATE_CONSIGNMENTS'));
 
             jest.spyOn(consignmentActionCreator, 'createConsignments')
                 .mockReturnValue(action);
@@ -829,7 +829,7 @@ describe('CheckoutService', () => {
         it('dispatches action to update shipping address', async () => {
             const address = getShippingAddress();
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('UPDATE_SHIPPING_ADDRESS'));
+            const action = of(createAction('UPDATE_SHIPPING_ADDRESS'));
 
             jest.spyOn(shippingStrategyActionCreator, 'updateAddress')
                 .mockReturnValue(action);
@@ -847,7 +847,7 @@ describe('CheckoutService', () => {
         it('dispatches action to select shipping option', async () => {
             const shippingOptionId = 'shipping-option-id-456';
             const options = { timeout: createTimeout() };
-            const action = Observable.of(createAction('SELECT_SHIPPING_OPTION'));
+            const action = of(createAction('SELECT_SHIPPING_OPTION'));
 
             jest.spyOn(shippingStrategyActionCreator, 'selectOption')
                 .mockReturnValue(action);
@@ -918,7 +918,7 @@ describe('CheckoutService', () => {
 
     describe('#loadInstruments()', () => {
         it('loads instruments', async () => {
-            const action = Observable.of(createAction('LOAD_INSTRUMENTS'));
+            const action = of(createAction('LOAD_INSTRUMENTS'));
 
             jest.spyOn(instrumentActionCreator, 'loadInstruments')
                 .mockReturnValue(action);
@@ -935,7 +935,7 @@ describe('CheckoutService', () => {
     describe('#deleteInstrument()', () => {
         it('deletes an instrument', async () => {
             const instrumentId = '456';
-            const action = Observable.of(createAction('DELETE_INSTRUMENT'));
+            const action = of(createAction('DELETE_INSTRUMENT'));
 
             jest.spyOn(instrumentActionCreator, 'deleteInstrument')
                 .mockReturnValue(action);

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -1,5 +1,5 @@
 import { Action, ThunkAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 
 import { AddressRequestBody } from '../address';
 import { BillingAddressActionCreator, BillingAddressRequestBody } from '../billing';

--- a/src/checkout/create-action-transformer.spec.ts
+++ b/src/checkout/create-action-transformer.spec.ts
@@ -1,6 +1,6 @@
+
 import { createErrorAction, Action } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs';
-import { Subscribable } from 'rxjs/Observable';
+import { throwError, Observable, Subscribable } from 'rxjs';
 
 import { createRequestErrorFactory } from '../common/error';
 import { getErrorResponse } from '../common/http-request/responses.mock';
@@ -17,7 +17,7 @@ describe('createActionTransformer()', () => {
     describe('when the payload is a response', () => {
         it('transforms the error', () => {
             const payload = getErrorResponse();
-            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+            const action$ = throwError(createErrorAction('FOOBAR', payload));
 
             transformer(action$).subscribe({
                 error: action => {
@@ -28,7 +28,7 @@ describe('createActionTransformer()', () => {
 
         it('sets the error message as the body.detail', () => {
             const payload = getErrorResponse();
-            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+            const action$ = throwError(createErrorAction('FOOBAR', payload));
 
             transformer(action$).subscribe({
                 error: action => {
@@ -41,7 +41,7 @@ describe('createActionTransformer()', () => {
             const payload = getErrorResponse();
             delete payload.body.detail;
 
-            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+            const action$ = throwError(createErrorAction('FOOBAR', payload));
 
             transformer(action$).subscribe({
                 error: action => {
@@ -54,7 +54,7 @@ describe('createActionTransformer()', () => {
     describe('when the payload is NOT a response', () => {
         it('does not transform if payload is `Error` instance', () => {
             const payload = new Error();
-            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+            const action$ = throwError(createErrorAction('FOOBAR', payload));
 
             transformer(action$).subscribe({
                 error: action => {
@@ -65,7 +65,7 @@ describe('createActionTransformer()', () => {
 
         it('does not transform if payload is not `Response`', () => {
             const payload = {};
-            const action$ = Observable.throw(createErrorAction('FOOBAR', payload));
+            const action$ = throwError(createErrorAction('FOOBAR', payload));
 
             transformer(action$).subscribe({
                 error: action => {

--- a/src/checkout/create-action-transformer.ts
+++ b/src/checkout/create-action-transformer.ts
@@ -1,7 +1,6 @@
 import { Action } from '@bigcommerce/data-store';
-import { from } from 'rxjs/observable/from';
+import { from, Observable, Subscribable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { Observable, Subscribable } from 'rxjs/Observable';
 
 import { RequestErrorFactory } from '../common/error';
 

--- a/src/checkout/create-checkout-store.spec.ts
+++ b/src/checkout/create-checkout-store.spec.ts
@@ -1,5 +1,6 @@
+
 import { createErrorAction, DataStore } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs';
+import { throwError } from 'rxjs';
 
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
@@ -14,7 +15,7 @@ describe('createCheckoutStore()', () => {
 
     it('creates `CheckoutStore` with action transformer', async () => {
         const store = createCheckoutStore();
-        const action$ = Observable.throw(createErrorAction('SUBMIT_ORDER_FAILED', getErrorResponse()));
+        const action$ = throwError(createErrorAction('SUBMIT_ORDER_FAILED', getErrorResponse()));
 
         try {
             await store.dispatch(action$);

--- a/src/common/action/cachable-action-decorator.spec.ts
+++ b/src/common/action/cachable-action-decorator.spec.ts
@@ -1,8 +1,6 @@
 import { createAction, Action } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs';
-import { concat } from 'rxjs/observable/concat';
-import { from } from 'rxjs/observable/from';
-import { map } from 'rxjs/operators';
+import { concat, from, Observable } from 'rxjs';
+import { map, toArray } from 'rxjs/operators';
 
 import ActionOptions from './action-options';
 import { default as cachableAction } from './cachable-action-decorator';
@@ -39,7 +37,7 @@ describe('cachableActionDecorator()', () => {
             foo.loadMessage('Foo', { useCache: true }),
             foo.loadMessage('Foo', { useCache: true })
         )
-            .toArray()
+            .pipe(toArray())
             .toPromise();
 
         expect(fetch).toHaveBeenCalledTimes(1);
@@ -56,7 +54,7 @@ describe('cachableActionDecorator()', () => {
             foo.loadMessage('Foo', { useCache: true }),
             foo.loadMessage('Bar', { useCache: true })
         )
-            .toArray()
+            .pipe(toArray())
             .toPromise();
 
         expect(fetch).toHaveBeenCalledTimes(2);
@@ -75,7 +73,7 @@ describe('cachableActionDecorator()', () => {
             foo.loadUppercaseMessage('Foo', { useCache: true }),
             foo.loadUppercaseMessage('Foo', { useCache: true })
         )
-            .toArray()
+            .pipe(toArray())
             .toPromise();
 
         expect(fetch).toHaveBeenCalledTimes(2);
@@ -92,7 +90,7 @@ describe('cachableActionDecorator()', () => {
             foo.loadMessage('Foo'),
             foo.loadMessage('Foo')
         )
-            .toArray()
+            .pipe(toArray())
             .toPromise();
 
         expect(fetch).toHaveBeenCalledTimes(2);

--- a/src/common/action/cache-action.spec.ts
+++ b/src/common/action/cache-action.spec.ts
@@ -1,5 +1,5 @@
 import { createAction, createDataStore } from '@bigcommerce/data-store';
-import { defer } from 'rxjs/observable/defer';
+import { defer } from 'rxjs';
 
 import cacheAction from './cache-action';
 

--- a/src/common/action/cache-action.ts
+++ b/src/common/action/cache-action.ts
@@ -1,7 +1,6 @@
 import { Action, ThunkAction } from '@bigcommerce/data-store';
 import { memoize } from 'lodash';
-import { Observable } from 'rxjs';
-import { from } from 'rxjs/observable/from';
+import { from, Observable } from 'rxjs';
 import { shareReplay } from 'rxjs/operators';
 
 import { CacheKeyResolver } from '../utility';

--- a/src/common/error/throw-error-action.ts
+++ b/src/common/error/throw-error-action.ts
@@ -1,8 +1,5 @@
 import { createErrorAction, Action } from '@bigcommerce/data-store';
-import { concat } from 'rxjs/observable/concat';
-import { of } from 'rxjs/observable/of';
-import { _throw } from 'rxjs/observable/throw';
-import { Observable } from 'rxjs/Observable';
+import { concat, of, throwError, Observable } from 'rxjs';
 
 export default function throwErrorAction<TPayload, TMeta, TType extends string>(
     type: TType,
@@ -10,10 +7,10 @@ export default function throwErrorAction<TPayload, TMeta, TType extends string>(
     meta?: TMeta
 ): Observable<Action<TPayload, TMeta, TType>> {
     if (isErrorAction(error)) {
-        return concat(of(error), _throw(createErrorAction(type, error.payload, meta)));
+        return concat(of(error), throwError(createErrorAction(type, error.payload, meta)));
     }
 
-    return _throw(createErrorAction(type, error, meta));
+    return throwError(createErrorAction(type, error, meta));
 }
 
 function isErrorAction(action: any): action is Action {

--- a/src/config/config-action-creator.ts
+++ b/src/config/config-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { cachableAction, ActionOptions } from '../common/action';
 import { RequestOptions } from '../common/http-request';

--- a/src/coupon/coupon-action-creator.spec.ts
+++ b/src/coupon/coupon-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, Response } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { createCheckoutStore, Checkout, CheckoutStore, CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState, getCheckoutWithCoupons } from '../checkout/checkouts.mock';
@@ -38,8 +39,8 @@ describe('CouponActionCreator', () => {
         it('emits actions if able to apply coupon', () => {
             const coupon = 'myCouponCode1234';
 
-            Observable.from(couponActionCreator.applyCoupon(coupon)(store))
-                .toArray()
+            from(couponActionCreator.applyCoupon(coupon)(store))
+                .pipe(toArray())
                 .subscribe(actions => {
                     expect(actions).toEqual([
                         { type: CouponActionType.ApplyCouponRequested },
@@ -52,11 +53,13 @@ describe('CouponActionCreator', () => {
             jest.spyOn(requestSender, 'applyCoupon').mockReturnValue(Promise.reject(errorResponse));
 
             const coupon = 'myCouponCode1234';
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
-            Observable.from(couponActionCreator.applyCoupon(coupon)(store))
-                .catch(errorHandler)
-                .toArray()
+            from(couponActionCreator.applyCoupon(coupon)(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .subscribe(actions => {
                     expect(errorHandler).toHaveBeenCalled();
                     expect(actions).toEqual([
@@ -75,8 +78,8 @@ describe('CouponActionCreator', () => {
         it('emits actions if able to remove coupon', () => {
             const coupon = 'myCouponCode1234';
 
-            Observable.from(couponActionCreator.removeCoupon(coupon)(store))
-                .toArray()
+            from(couponActionCreator.removeCoupon(coupon)(store))
+                .pipe(toArray())
                 .subscribe(actions => {
                     expect(actions).toEqual([
                         { type: CouponActionType.RemoveCouponRequested },
@@ -89,11 +92,13 @@ describe('CouponActionCreator', () => {
             jest.spyOn(requestSender, 'removeCoupon').mockReturnValue(Promise.reject(errorResponse));
 
             const coupon = 'myCouponCode1234';
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
-            Observable.from(couponActionCreator.removeCoupon(coupon)(store))
-                .catch(errorHandler)
-                .toArray()
+            from(couponActionCreator.removeCoupon(coupon)(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .subscribe(actions => {
                     expect(errorHandler).toHaveBeenCalled();
                     expect(actions).toEqual([

--- a/src/coupon/coupon-action-creator.ts
+++ b/src/coupon/coupon-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { InternalCheckoutSelectors } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';

--- a/src/coupon/gift-certificate-action-creator.spec.ts
+++ b/src/coupon/gift-certificate-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, Response } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { createCheckoutStore, CheckoutStore, CheckoutStoreState } from '../checkout';
 import { getCheckout, getCheckoutStoreState, getCheckoutWithGiftCertificates } from '../checkout/checkouts.mock';
@@ -38,8 +39,8 @@ describe('GiftCertificateActionCreator', () => {
 
         it('emits actions if able to apply giftCertificate', async () => {
             const giftCertificate = 'myGiftCertificate1234';
-            const actions = await Observable.from(giftCertificateActionCreator.applyGiftCertificate(giftCertificate)(store))
-                .toArray()
+            const actions = await from(giftCertificateActionCreator.applyGiftCertificate(giftCertificate)(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -53,10 +54,12 @@ describe('GiftCertificateActionCreator', () => {
                 .mockReturnValue(Promise.reject(errorResponse));
 
             const giftCertificate = 'myGiftCertificate1234';
-            const errorHandler = jest.fn(action => Observable.of(action));
-            const actions = await Observable.from(giftCertificateActionCreator.applyGiftCertificate(giftCertificate)(store))
-                .catch(errorHandler)
-                .toArray()
+            const errorHandler = jest.fn(action => of(action));
+            const actions = await from(giftCertificateActionCreator.applyGiftCertificate(giftCertificate)(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -79,8 +82,8 @@ describe('GiftCertificateActionCreator', () => {
 
         it('emits actions if able to remove giftCertificate', async () => {
             const giftCertificate = 'myGiftCertificate1234';
-            const actions = await Observable.from(giftCertificateActionCreator.removeGiftCertificate(giftCertificate)(store))
-                .toArray()
+            const actions = await from(giftCertificateActionCreator.removeGiftCertificate(giftCertificate)(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -94,10 +97,12 @@ describe('GiftCertificateActionCreator', () => {
                 .mockReturnValue(Promise.reject(errorResponse));
 
             const giftCertificate = 'myGiftCertificate1234';
-            const errorHandler = jest.fn(action => Observable.of(action));
-            const actions = await Observable.from(giftCertificateActionCreator.removeGiftCertificate(giftCertificate)(store))
-                .catch(errorHandler)
-                .toArray()
+            const errorHandler = jest.fn(action => of(action));
+            const actions = await from(giftCertificateActionCreator.removeGiftCertificate(giftCertificate)(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();

--- a/src/coupon/gift-certificate-action-creator.ts
+++ b/src/coupon/gift-certificate-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable ,  Observer } from 'rxjs';
 
 import { InternalCheckoutSelectors } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';

--- a/src/customer/customer-action-creator.ts
+++ b/src/customer/customer-action-creator.ts
@@ -1,7 +1,5 @@
 import { createAction, ThunkAction } from '@bigcommerce/data-store';
-import { concat } from 'rxjs/observable/concat';
-import { from } from 'rxjs/observable/from';
-import { of } from 'rxjs/observable/of';
+import { concat, from, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
 import { CheckoutActionCreator, InternalCheckoutSelectors } from '../checkout';

--- a/src/customer/customer-strategy-action-creator.spec.ts
+++ b/src/customer/customer-strategy-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
@@ -53,7 +54,7 @@ describe('CustomerStrategyActionCreator', () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
 
             await actionCreator.initialize({ methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith('default');
@@ -64,7 +65,7 @@ describe('CustomerStrategyActionCreator', () => {
             const options = { methodId: 'default' };
 
             await actionCreator.initialize(options)
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(strategy.initialize).toHaveBeenCalledWith(options);
@@ -73,7 +74,7 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits action to notify initialization progress', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const actions = await actionCreator.initialize({ methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -85,14 +86,16 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits error action if unable to initialize', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const initializeError = new Error();
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             jest.spyOn(strategy, 'initialize')
                 .mockReturnValue(Promise.reject(initializeError));
 
             const actions = await actionCreator.initialize({ methodId: 'default' })
-                .catch(errorHandler)
-                .toArray()
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -113,7 +116,7 @@ describe('CustomerStrategyActionCreator', () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
 
             await actionCreator.deinitialize({ methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith('default');
@@ -124,7 +127,7 @@ describe('CustomerStrategyActionCreator', () => {
             const options = { methodId: 'default' };
 
             await actionCreator.deinitialize(options)
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(strategy.deinitialize).toHaveBeenCalledWith(options);
@@ -133,7 +136,7 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits action to notify initialization progress', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const actions = await actionCreator.deinitialize({ methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -145,14 +148,16 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits error action if unable to deinitialize', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const deinitializeError = new Error();
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             jest.spyOn(strategy, 'deinitialize')
                 .mockReturnValue(Promise.reject(deinitializeError));
 
             const actions = await actionCreator.deinitialize({ methodId: 'default' })
-                .catch(errorHandler)
-                .toArray()
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -173,7 +178,7 @@ describe('CustomerStrategyActionCreator', () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
 
             await actionCreator.signIn({ email: 'foo@bar.com', password: 'password1' }, { methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith('default');
@@ -185,7 +190,7 @@ describe('CustomerStrategyActionCreator', () => {
             const options = { methodId: 'default' };
 
             await actionCreator.signIn(credentials, options)
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(strategy.signIn).toHaveBeenCalledWith(credentials, options);
@@ -194,7 +199,7 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits action to notify sign-in progress', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const actions = await actionCreator.signIn({ email: 'foo@bar.com', password: 'password1' }, { methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -206,14 +211,16 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits error action if unable to sign in', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const signInError = new Error();
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             jest.spyOn(strategy, 'signIn')
                 .mockReturnValue(Promise.reject(signInError));
 
             const actions = await actionCreator.signIn({ email: 'foo@bar.com', password: 'password1' }, { methodId: 'default' })
-                .catch(errorHandler)
-                .toArray()
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -234,7 +241,7 @@ describe('CustomerStrategyActionCreator', () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
 
             await actionCreator.signOut({ methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith('default');
@@ -245,7 +252,7 @@ describe('CustomerStrategyActionCreator', () => {
             const options = { methodId: 'default' };
 
             await actionCreator.signOut(options)
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(strategy.signOut).toHaveBeenCalledWith(options);
@@ -254,7 +261,7 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits action to notify sign-out progress', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const actions = await actionCreator.signOut({ methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -266,14 +273,16 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits error action if unable to sign out', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const signOutError = new Error();
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             jest.spyOn(strategy, 'signOut')
                 .mockReturnValue(Promise.reject(signOutError));
 
             const actions = await actionCreator.signOut({ methodId: 'default' })
-                .catch(errorHandler)
-                .toArray()
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -290,7 +299,7 @@ describe('CustomerStrategyActionCreator', () => {
             const options = { methodId: 'default' };
             const fakeMethod = jest.fn(() => Promise.resolve());
             await actionCreator.widgetInteraction(fakeMethod, options)
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(fakeMethod).toHaveBeenCalled();
@@ -299,7 +308,7 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits action to notify widget interaction in progress', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const actions = await actionCreator.widgetInteraction(jest.fn(() => Promise.resolve()), { methodId: 'default' })
-                .toArray()
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -311,11 +320,13 @@ describe('CustomerStrategyActionCreator', () => {
         it('emits error action if widget interaction fails', async () => {
             const actionCreator = new CustomerStrategyActionCreator(registry);
             const signInError = new Error();
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             const actions = await actionCreator.widgetInteraction(jest.fn(() => Promise.reject(signInError)), { methodId: 'default' })
-                .catch(errorHandler)
-                .toArray()
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();

--- a/src/customer/customer-strategy-action-creator.ts
+++ b/src/customer/customer-strategy-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { Registry } from '../common/registry';
 

--- a/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
 
 import { createCheckoutStore, CheckoutState, CheckoutStore, CheckoutStoreState } from '../../checkout';
 import { getCheckoutStoreState, getCheckoutWithPayments } from '../../checkout/checkouts.mock';
@@ -103,7 +103,7 @@ describe('AmazonPayCustomerStrategy', () => {
             .mockReturnValue(Promise.resolve(getResponse('')));
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(Observable.of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod)));
+            .mockReturnValue(of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod)));
     });
 
     afterEach(() => {
@@ -111,7 +111,7 @@ describe('AmazonPayCustomerStrategy', () => {
     });
 
     it('loads payment method', async () => {
-        const action = Observable.of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod));
+        const action = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod));
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
             .mockReturnValue(action);
@@ -128,7 +128,7 @@ describe('AmazonPayCustomerStrategy', () => {
         const response = getErrorResponse();
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(Observable.of(createErrorAction(PaymentMethodActionType.LoadPaymentMethodFailed, response)));
+            .mockReturnValue(of(createErrorAction(PaymentMethodActionType.LoadPaymentMethodFailed, response)));
 
         try {
             await strategy.initialize({ methodId: 'amazon', amazon: { container: 'login' } });
@@ -160,7 +160,7 @@ describe('AmazonPayCustomerStrategy', () => {
         paymentMethod = { ...paymentMethod, config: { merchantId: undefined } };
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(Observable.of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod)));
+            .mockReturnValue(of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod)));
 
         try {
             await strategy.initialize({ methodId: 'amazon', amazon: { container: 'login' } });
@@ -226,7 +226,7 @@ describe('AmazonPayCustomerStrategy', () => {
     });
 
     it('signs out from remote checkout provider', async () => {
-        const action = Observable.of(createAction(RemoteCheckoutActionType.SignOutRemoteCustomerSucceeded));
+        const action = of(createAction(RemoteCheckoutActionType.SignOutRemoteCustomerSucceeded));
 
         store = createCheckoutStore({
             ...state,
@@ -263,7 +263,7 @@ describe('AmazonPayCustomerStrategy', () => {
     });
 
     it('does nothing if already signed out from remote checkout provider', async () => {
-        const action = Observable.of(createAction(RemoteCheckoutActionType.SignOutRemoteCustomerSucceeded));
+        const action = of(createAction(RemoteCheckoutActionType.SignOutRemoteCustomerSucceeded));
 
         jest.spyOn(remoteCheckoutActionCreator, 'signOut')
             .mockReturnValue(action);

--- a/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree-visacheckout-customer-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
 
 import { createCustomerStrategyRegistry, CustomerInitializeOptions, CustomerStrategyActionCreator } from '..';
 import { getBillingAddress } from '../../billing/billing-addresses.mock';
@@ -187,7 +187,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
             });
 
             it('triggers a widgetInteraction action', async () => {
-                const widgetInteractionAction = Observable.of(createAction(CustomerStrategyActionType.WidgetInteractionStarted));
+                const widgetInteractionAction = of(createAction(CustomerStrategyActionType.WidgetInteractionStarted));
                 jest.spyOn(customerStrategyActionCreator, 'widgetInteraction').mockImplementation(() => widgetInteractionAction);
 
                 await strategy.initialize(visaCheckoutOptions);

--- a/src/customer/strategies/default-customer-strategy.spec.ts
+++ b/src/customer/strategies/default-customer-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../checkout';
 import { ConfigActionCreator, ConfigRequestSender } from '../../config';
@@ -35,7 +35,7 @@ describe('DefaultCustomerStrategy', () => {
         const strategy = new DefaultCustomerStrategy(store, customerActionCreator);
         const credentials = { email: 'foo@bar.com', password: 'foobar' };
         const options = {};
-        const action = Observable.of(createAction(CustomerActionType.SignInCustomerRequested, getQuote()));
+        const action = of(createAction(CustomerActionType.SignInCustomerRequested, getQuote()));
 
         jest.spyOn(customerActionCreator, 'signInCustomer')
             .mockReturnValue(action);
@@ -52,7 +52,7 @@ describe('DefaultCustomerStrategy', () => {
     it('dispatches action to sign out customer', async () => {
         const strategy = new DefaultCustomerStrategy(store, customerActionCreator);
         const options = {};
-        const action = Observable.of(createAction(CustomerActionType.SignOutCustomerRequested, getQuote()));
+        const action = of(createAction(CustomerActionType.SignOutCustomerRequested, getQuote()));
 
         jest.spyOn(customerActionCreator, 'signOutCustomer')
             .mockReturnValue(action);

--- a/src/geography/country-action-creator.spec.ts
+++ b/src/geography/country-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, Response } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
@@ -27,7 +28,7 @@ describe('CountryActionCreator', () => {
     describe('#loadCountries()', () => {
         it('emits actions if able to load countries', () => {
             countryActionCreator.loadCountries()
-                .toArray()
+                .pipe(toArray())
                 .subscribe(actions => {
                     expect(actions).toEqual([
                         { type: CountryActionType.LoadCountriesRequested },
@@ -39,11 +40,13 @@ describe('CountryActionCreator', () => {
         it('emits error actions if unable to load countries', () => {
             jest.spyOn(countryRequestSender, 'loadCountries').mockReturnValue(Promise.reject(errorResponse));
 
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             countryActionCreator.loadCountries()
-                .catch(errorHandler)
-                .toArray()
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .subscribe(actions => {
                     expect(actions).toEqual([
                         { type: CountryActionType.LoadCountriesRequested },

--- a/src/geography/country-action-creator.ts
+++ b/src/geography/country-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { RequestOptions } from '../common/http-request';
 

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -1,11 +1,6 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { concat } from 'rxjs/observable/concat';
-import { defer } from 'rxjs/observable/defer';
-import { from } from 'rxjs/observable/from';
-import { of } from 'rxjs/observable/of';
+import { concat, defer, from, of, Observable, Observer } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
 
 import { CheckoutValidator, InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';

--- a/src/payment/instrument/instrument-action-creator.spec.ts
+++ b/src/payment/instrument/instrument-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, Response } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { Address } from '../../address';
 import { createCheckoutStore, CheckoutStore, CheckoutStoreState } from '../../checkout';
@@ -67,7 +68,7 @@ describe('InstrumentActionCreator', () => {
 
     describe('#loadInstruments()', () => {
         it('sends a request to get a list of instruments', async () => {
-            await Observable.from(instrumentActionCreator.loadInstruments()(store))
+            await from(instrumentActionCreator.loadInstruments()(store))
                 .toPromise();
 
             expect(instrumentRequestSender.getVaultAccessToken).toHaveBeenCalled();
@@ -89,7 +90,7 @@ describe('InstrumentActionCreator', () => {
                 },
             });
 
-            await Observable.from(instrumentActionCreator.loadInstruments()(store))
+            await from(instrumentActionCreator.loadInstruments()(store))
                 .toPromise();
 
             expect(instrumentRequestSender.getVaultAccessToken).not.toHaveBeenCalled();
@@ -100,8 +101,8 @@ describe('InstrumentActionCreator', () => {
         });
 
         it('emits actions if able to load instruments', async () => {
-            const actions = await Observable.from(instrumentActionCreator.loadInstruments()(store))
-                .toArray()
+            const actions = await from(instrumentActionCreator.loadInstruments()(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -119,10 +120,12 @@ describe('InstrumentActionCreator', () => {
         it('emits error actions if unable to load instruments', async () => {
             jest.spyOn(instrumentRequestSender, 'loadInstruments').mockRejectedValue(errorResponse);
 
-            const errorHandler = jest.fn(action => Observable.of(action));
-            const actions = await Observable.from(instrumentActionCreator.loadInstruments()(store))
-                .catch(errorHandler)
-                .toArray()
+            const errorHandler = jest.fn(action => of(action));
+            const actions = await from(instrumentActionCreator.loadInstruments()(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -136,8 +139,8 @@ describe('InstrumentActionCreator', () => {
             store = createCheckoutStore();
 
             try {
-                await Observable.from(instrumentActionCreator.loadInstruments()(store))
-                    .toArray()
+                await from(instrumentActionCreator.loadInstruments()(store))
+                    .pipe(toArray())
                     .toPromise();
             } catch (e) {
                 expect(e.type).toEqual('missing_data');
@@ -147,7 +150,7 @@ describe('InstrumentActionCreator', () => {
 
     describe('#deleteInstrument()', () => {
         it('deletes an instrument', async () => {
-            await Observable.from(instrumentActionCreator.deleteInstrument(instrumentId)(store))
+            await from(instrumentActionCreator.deleteInstrument(instrumentId)(store))
                 .toPromise();
 
             expect(instrumentRequestSender.getVaultAccessToken).toHaveBeenCalled();
@@ -173,7 +176,7 @@ describe('InstrumentActionCreator', () => {
                 },
             });
 
-            await Observable.from(instrumentActionCreator.deleteInstrument(instrumentId)(store))
+            await from(instrumentActionCreator.deleteInstrument(instrumentId)(store))
                 .toPromise();
 
             expect(instrumentRequestSender.getVaultAccessToken).not.toHaveBeenCalled();
@@ -188,8 +191,8 @@ describe('InstrumentActionCreator', () => {
         });
 
         it('emits actions if able to delete an instrument', async () => {
-            const actions = await Observable.from(instrumentActionCreator.deleteInstrument(instrumentId)(store))
-                .toArray()
+            const actions = await from(instrumentActionCreator.deleteInstrument(instrumentId)(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -208,10 +211,12 @@ describe('InstrumentActionCreator', () => {
         it('emits error actions if unable to delete an instrument', async () => {
             jest.spyOn(instrumentRequestSender, 'deleteInstrument').mockRejectedValue(errorResponse);
 
-            const errorHandler = jest.fn(action => Observable.of(action));
-            const actions = await Observable.from(instrumentActionCreator.deleteInstrument(instrumentId)(store))
-                .catch(errorHandler)
-                .toArray()
+            const errorHandler = jest.fn(action => of(action));
+            const actions = await from(instrumentActionCreator.deleteInstrument(instrumentId)(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -233,8 +238,8 @@ describe('InstrumentActionCreator', () => {
             store = createCheckoutStore({});
 
             try {
-                await Observable.from(instrumentActionCreator.deleteInstrument('')(store))
-                    .toArray()
+                await from(instrumentActionCreator.deleteInstrument('')(store))
+                    .pipe(toArray())
                     .toPromise();
             } catch (e) {
                 expect(e.type).toEqual('missing_data');

--- a/src/payment/instrument/instrument-action-creator.ts
+++ b/src/payment/instrument/instrument-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { Address } from '../../address';
 import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../../checkout';

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { createCheckoutStore, CheckoutStore, CheckoutValidator } from '../checkout';
 import { getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
@@ -40,8 +41,8 @@ describe('PaymentActionCreator', () => {
 
     describe('#submitPayment()', () => {
         it('dispatches actions to data store', async () => {
-            const actions = await Observable.from(paymentActionCreator.submitPayment(getPayment())(store))
-                .toArray()
+            const actions = await from(paymentActionCreator.submitPayment(getPayment())(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -67,10 +68,12 @@ describe('PaymentActionCreator', () => {
                 Promise.reject(getResponse(getErrorPaymentResponseBody()))
             );
 
-            const errorHandler = jest.fn(action => Observable.of(action));
-            const actions = await Observable.from(paymentActionCreator.submitPayment(getPayment())(store))
-                .catch(errorHandler)
-                .toArray()
+            const errorHandler = jest.fn(action => of(action));
+            const actions = await from(paymentActionCreator.submitPayment(getPayment())(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -87,8 +90,8 @@ describe('PaymentActionCreator', () => {
         });
 
         it('sends request to submit payment', async () => {
-            await Observable.from(paymentActionCreator.submitPayment(getPayment())(store))
-                .toArray()
+            await from(paymentActionCreator.submitPayment(getPayment())(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(paymentRequestSender.submitPayment)
@@ -98,8 +101,8 @@ describe('PaymentActionCreator', () => {
 
     describe('#initializeOffsitePayment()', () => {
         it('dispatches actions to data store', async () => {
-            const actions = await Observable.from(paymentActionCreator.initializeOffsitePayment(getPayment())(store))
-                .toArray()
+            const actions = await from(paymentActionCreator.initializeOffsitePayment(getPayment())(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -114,10 +117,12 @@ describe('PaymentActionCreator', () => {
                     Promise.reject(new Error())
                 );
 
-            const errorHandler = jest.fn(action => Observable.of(action));
-            const actions = await Observable.from(paymentActionCreator.initializeOffsitePayment(getPayment())(store))
-                .catch(errorHandler)
-                .toArray()
+            const errorHandler = jest.fn(action => of(action));
+            const actions = await from(paymentActionCreator.initializeOffsitePayment(getPayment())(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -1,11 +1,7 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { pick } from 'lodash';
-import { concat } from 'rxjs/observable/concat';
-import { from } from 'rxjs/observable/from';
-import { of } from 'rxjs/observable/of';
+import { concat, from, of, Observable, Observer } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
 
 import { mapToInternalAddress } from '../address';
 import { mapToInternalCart } from '../cart';

--- a/src/payment/payment-method-action-creator.ts
+++ b/src/payment/payment-method-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { cachableAction, ActionOptions } from '../common/action';
 import { RequestOptions } from '../common/http-request';

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -1,11 +1,6 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { concat } from 'rxjs/observable/concat';
-import { defer } from 'rxjs/observable/defer';
-import { empty } from 'rxjs/observable/empty';
-import { of } from 'rxjs/observable/of';
+import { concat, defer, empty, of, Observable, Observer } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
 
 import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
 import { throwErrorAction } from '../common/error';

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -3,7 +3,7 @@ import { createAction, createErrorAction, Action } from '@bigcommerce/data-store
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckout, getCheckoutPayment, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
@@ -81,19 +81,19 @@ describe('AfterpayPaymentStrategy', () => {
             },
         });
 
-        initializePaymentAction = Observable.of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
-        loadPaymentMethodAction = Observable.of(createAction(
+        initializePaymentAction = of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
+        loadPaymentMethodAction = of(createAction(
             PaymentMethodActionType.LoadPaymentMethodSucceeded,
             { ...paymentMethod, id: 'afterpay' },
             { methodId: paymentMethod.gateway }
         ));
-        loadRemoteSettingsAction = Observable.of(createAction(
+        loadRemoteSettingsAction = of(createAction(
             RemoteCheckoutActionType.LoadRemoteSettingsSucceeded,
             { useStoreCredit: false },
             { methodId: paymentMethod.gateway }
         ));
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         payload = merge({}, getOrderRequestBody(), {
             payment: {
@@ -168,7 +168,7 @@ describe('AfterpayPaymentStrategy', () => {
 
         it('rejects with error if execution is unsuccessful', async () => {
             jest.spyOn(remoteCheckoutActionCreator, 'initializePayment')
-                .mockReturnValue(Observable.of(createErrorAction(RemoteCheckoutActionType.InitializeRemotePaymentFailed, new Error())));
+                .mockReturnValue(of(createErrorAction(RemoteCheckoutActionType.InitializeRemotePaymentFailed, new Error())));
 
             const errorHandler = jest.fn();
 

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createAction, createErrorAction, Action } from '@bigcommerce/data-store
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge, omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
 import { BillingAddressActionType } from '../../../billing/billing-address-actions';
@@ -115,10 +115,10 @@ describe('AmazonPayPaymentStrategy', () => {
         };
 
         paymentMethod = getAmazonPay();
-        initializeBillingAction = Observable.of(createAction(RemoteCheckoutActionType.InitializeRemoteBillingRequested));
-        initializePaymentAction = Observable.of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
-        updateAddressAction = Observable.of(createAction(BillingAddressActionType.UpdateBillingAddressRequested));
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+        initializeBillingAction = of(createAction(RemoteCheckoutActionType.InitializeRemoteBillingRequested));
+        initializePaymentAction = of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
+        updateAddressAction = of(createAction(BillingAddressActionType.UpdateBillingAddressRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 
         container.setAttribute('id', 'wallet');
         document.body.appendChild(container);
@@ -266,7 +266,7 @@ describe('AmazonPayPaymentStrategy', () => {
         await strategy.initialize({ methodId: paymentMethod.id, amazon: { container: 'wallet', onError } });
 
         jest.spyOn(remoteCheckoutActionCreator, 'initializeBilling')
-            .mockReturnValue(Observable.of(createErrorAction(RemoteCheckoutActionType.InitializeRemoteBillingFailed, new Error())));
+            .mockReturnValue(of(createErrorAction(RemoteCheckoutActionType.InitializeRemoteBillingFailed, new Error())));
 
         if (element) {
             element.dispatchEvent(new CustomEvent('paymentSelect'));

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { merge, omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
@@ -57,9 +57,9 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
         );
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
 
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
-        loadPaymentMethodAction = Observable.of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: paymentMethodMock.id }));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+        loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: paymentMethodMock.id }));
 
         jest.spyOn(store, 'dispatch');
 

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { createAction, Action } from '@bigcommerce/data-store';
 import { merge, omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
@@ -40,9 +40,9 @@ describe('BraintreePaypalPaymentStrategy', () => {
         braintreePaymentProcessorMock.deinitialize = jest.fn();
 
         paymentMethodMock = { ...getBraintreePaypal(), clientToken: 'myToken' };
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
-        loadPaymentMethodAction = Observable.of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: paymentMethodMock.id }));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+        loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: paymentMethodMock.id }));
 
         store = createCheckoutStore(getCheckoutStoreState());
 

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import {
     createPaymentClient,
@@ -197,7 +197,7 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
             });
 
             it('triggers a widgetInteraction action', async () => {
-                const widgetInteractionAction = Observable.of(createAction(PaymentStrategyActionType.WidgetInteractionStarted));
+                const widgetInteractionAction = of(createAction(PaymentStrategyActionType.WidgetInteractionStarted));
                 jest.spyOn(paymentStrategyActionCreator, 'widgetInteraction').mockImplementation(() => widgetInteractionAction);
 
                 await strategy.initialize(visaCheckoutOptions);
@@ -248,8 +248,8 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
 
         beforeEach(() => {
             orderRequestBody = getOrderRequestBody();
-            submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-            submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+            submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+            submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
             paymentMethodMock.initializationData = { nonce: 'payment-nonce-for-visacheckout' };
 
             visaCheckoutOptions = { methodId: 'braintreevisacheckout', braintreevisacheckout: {} };

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
@@ -321,8 +321,8 @@ describe('ChasePayPaymentStrategy', () => {
 
         beforeEach(async () => {
             orderRequestBody = getOrderRequestBody();
-            submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-            submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+            submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+            submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
             chasePayOptions = { methodId: 'chasepay', chasepay: { logoContainer: 'login', walletButton: 'mockButton' } };
             paymentMethodMock.initializationData = {
                 paymentCryptogram: '11111111111111',
@@ -428,7 +428,7 @@ describe('ChasePayPaymentStrategy', () => {
 
         beforeEach(async () => {
             chasePayOptions = { methodId: 'chasepay', chasepay: { logoContainer: 'login', walletButton: 'mockButton' } };
-            submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+            submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
             orderActionCreator.submitOrder = jest.fn(() => submitOrderAction);
 
             await strategy.initialize(chasePayOptions);

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
@@ -1,5 +1,6 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 import { Subject } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
@@ -154,7 +155,8 @@ export default class ChasePayPaymentStrategy extends PaymentStrategy {
 
             // Wait for payment selection
             return new Promise((resolve, reject) => {
-                this._walletEvent$.take(1)
+                this._walletEvent$
+                    .pipe(take(1))
                     .subscribe((event: { type: ChasePayEventType }) => {
                         if (event.type === ChasePayEventType.CancelCheckout) {
                             reject(new PaymentMethodCancelledError());

--- a/src/payment/strategies/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../order';
@@ -29,8 +29,8 @@ describe('CreditCardPaymentStrategy', () => {
             orderActionCreator
         );
 
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),

--- a/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge, omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import {
     createCheckoutStore,
@@ -74,9 +74,9 @@ describe('KlarnaPaymentStrategy', () => {
             },
         });
 
-        loadPaymentMethodAction = Observable.of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod, { methodId: paymentMethod.id }));
-        initializePaymentAction = Observable.of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+        loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod, { methodId: paymentMethod.id }));
+        initializePaymentAction = of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 
         jest.spyOn(store, 'dispatch');
 

--- a/src/payment/strategies/legacy-payment-strategy.spec.ts
+++ b/src/payment/strategies/legacy-payment-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../order';
@@ -20,7 +20,7 @@ describe('LegacyPaymentStrategy', () => {
             new OrderRequestSender(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 
         jest.spyOn(orderActionCreator, 'submitOrder')
             .mockReturnValue(submitOrderAction);

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import {
     PaymentActionCreator, PaymentInitializeOptions,
@@ -188,10 +188,10 @@ describe('MasterpassPaymentStragegy', () => {
                     useStoreCredit: true,
                 };
 
-                submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+                submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
                 orderActionCreator.submitOrder = jest.fn(() => submitOrderAction);
 
-                loadPaymentMethodAction = Observable.of(
+                loadPaymentMethodAction = of(
                     createAction(
                         PaymentMethodActionType.LoadPaymentMethodSucceeded,
                         stripePaymentMethodMock,
@@ -200,7 +200,7 @@ describe('MasterpassPaymentStragegy', () => {
                 );
                 jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(loadPaymentMethodAction);
 
-                submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+                submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
                 paymentActionCreator.submitPayment = jest.fn(() => submitPaymentAction);
             }
         );
@@ -256,7 +256,7 @@ describe('MasterpassPaymentStragegy', () => {
                 checkoutId: 'checkout-id',
             };
 
-            const submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+            const submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
             orderActionCreator.submitOrder = jest.fn(() => submitOrderAction);
         });
 

--- a/src/payment/strategies/no-payment-data-required-strategy.spec.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../order';
@@ -21,7 +21,7 @@ describe('NoPaymentDataRequiredPaymentStrategy', () => {
             new OrderRequestSender(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 
         jest.spyOn(orderActionCreator, 'submitOrder')
             .mockReturnValue(submitOrderAction);

--- a/src/payment/strategies/offline-payment-strategy.spec.ts
+++ b/src/payment/strategies/offline-payment-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../order';
@@ -20,7 +20,7 @@ describe('OfflinePaymentStrategy', () => {
             new OrderRequestSender(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 
         jest.spyOn(orderActionCreator, 'submitOrder')
             .mockReturnValue(submitOrderAction);

--- a/src/payment/strategies/offsite-payment-strategy.spec.ts
+++ b/src/payment/strategies/offsite-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { merge, omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { getCheckoutStoreState } from '../../checkout/checkouts.mock';
@@ -36,9 +36,9 @@ describe('OffsitePaymentStrategy', () => {
             new PaymentRequestSender(createPaymentClient()),
             orderActionCreator
         );
-        finalizeOrderAction = Observable.of(createAction(OrderActionType.FinalizeOrderRequested));
-        initializeOffsitePaymentAction = Observable.of(createAction(PaymentActionType.InitializeOffsitePaymentRequested));
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        initializeOffsitePaymentAction = of(createAction(PaymentActionType.InitializeOffsitePaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 
         jest.spyOn(store, 'dispatch');
 

--- a/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../../checkout';
 import { getCheckoutPayment, getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
@@ -73,8 +73,8 @@ describe('PaypalExpressPaymentStrategy', () => {
         } as Window;
 
         paymentMethod = getPaypalExpress();
-        finalizeOrderAction = Observable.of(createAction(OrderActionType.FinalizeOrderRequested));
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderSucceeded, { customer: getCustomer(), order }));
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderSucceeded, { customer: getCustomer(), order }));
 
         jest.spyOn(scriptLoader, 'loadPaypal')
             .mockImplementation(() => {

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
@@ -3,7 +3,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState, getCheckoutWithPayments } from '../../../checkout/checkouts.mock';
@@ -25,8 +25,8 @@ describe('PaypalProPaymentStrategy', () => {
     let submitPaymentAction: Observable<SubmitPaymentAction>;
 
     beforeEach(() => {
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),

--- a/src/payment/strategies/sage-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/sage-pay-payment-strategy.spec.ts
@@ -3,7 +3,7 @@ import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { getCheckoutStoreState } from '../../checkout/checkouts.mock';
@@ -47,9 +47,9 @@ describe('SagePayPaymentStrategy', () => {
         formPoster = createFormPoster();
         store = createCheckoutStore(getCheckoutStoreState());
 
-        finalizeOrderAction = Observable.of(createAction(OrderActionType.FinalizeOrderRequested));
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         jest.spyOn(store, 'dispatch');
 
@@ -115,7 +115,7 @@ describe('SagePayPaymentStrategy', () => {
         }));
 
         jest.spyOn(paymentActionCreator, 'submitPayment')
-            .mockReturnValue(Observable.of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
 
         strategy.execute(getOrderRequestBody());
 
@@ -132,7 +132,7 @@ describe('SagePayPaymentStrategy', () => {
         const respons = new RequestError(getResponse(getErrorPaymentResponseBody()));
 
         jest.spyOn(paymentActionCreator, 'submitPayment')
-            .mockReturnValue(Observable.of(createErrorAction(PaymentActionType.SubmitPaymentFailed, respons)));
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, respons)));
 
         try {
             await strategy.execute(getOrderRequestBody());

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import {
     createPaymentStrategyRegistry,
@@ -129,8 +129,8 @@ describe('SquarePaymentStrategy', () => {
             requestSender,
             scriptLoader
         );
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         jest.spyOn(orderActionCreator, 'submitOrder')
             .mockReturnValue(submitOrderAction);

--- a/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
@@ -3,7 +3,7 @@ import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
-import { Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
@@ -63,8 +63,8 @@ describe('WepayPaymentStrategy', () => {
             },
         });
 
-        submitOrderAction = Observable.of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = Observable.of(createAction(PaymentActionType.SubmitPaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         jest.spyOn(wepayRiskClient, 'initialize')
             .mockReturnValue(Promise.resolve(wepayRiskClient));

--- a/src/remote-checkout/remote-checkout-action-creator.spec.ts
+++ b/src/remote-checkout/remote-checkout-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, createTimeout } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
@@ -26,7 +27,7 @@ describe('RemoteCheckoutActionCreator', () => {
             .mockReturnValue(Promise.resolve(response));
 
         const actions = await actionCreator.initializeBilling('amazon', params, options)
-            .toArray()
+            .pipe(toArray())
             .toPromise();
 
         expect(requestSender.initializeBilling).toHaveBeenCalledWith('amazon', params, options);
@@ -38,14 +39,16 @@ describe('RemoteCheckoutActionCreator', () => {
 
     it('emits error action if unable to initialize billing', async () => {
         const response = getErrorResponse();
-        const errorHandler = jest.fn(action => Observable.of(action));
+        const errorHandler = jest.fn(action => of(action));
 
         jest.spyOn(requestSender, 'initializeBilling')
             .mockReturnValue(Promise.reject(response));
 
-        const actions = await Observable.from(actionCreator.initializeBilling('amazon'))
-            .catch(errorHandler)
-            .toArray()
+        const actions = await from(actionCreator.initializeBilling('amazon'))
+            .pipe(
+                catchError(errorHandler),
+                toArray()
+            )
             .toPromise();
 
         expect(errorHandler).toHaveBeenCalled();
@@ -64,7 +67,7 @@ describe('RemoteCheckoutActionCreator', () => {
             .mockReturnValue(Promise.resolve(response));
 
         const actions = await actionCreator.initializeShipping('amazon', params, options)
-            .toArray()
+            .pipe(toArray())
             .toPromise();
 
         expect(requestSender.initializeShipping).toHaveBeenCalledWith('amazon', params, options);
@@ -76,14 +79,16 @@ describe('RemoteCheckoutActionCreator', () => {
 
     it('emits error action if unable to initialize shipping', async () => {
         const response = getErrorResponse();
-        const errorHandler = jest.fn(action => Observable.of(action));
+        const errorHandler = jest.fn(action => of(action));
 
         jest.spyOn(requestSender, 'initializeShipping')
             .mockReturnValue(Promise.reject(response));
 
         const actions = await actionCreator.initializeShipping('amazon')
-            .catch(errorHandler)
-            .toArray()
+            .pipe(
+                catchError(errorHandler),
+                toArray()
+            )
             .toPromise();
 
         expect(actions).toEqual([
@@ -101,7 +106,7 @@ describe('RemoteCheckoutActionCreator', () => {
             .mockReturnValue(Promise.resolve(response));
 
         const actions = await actionCreator.initializePayment('amazon', params, options)
-            .toArray()
+            .pipe(toArray())
             .toPromise();
 
         expect(requestSender.initializePayment).toHaveBeenCalledWith('amazon', params, options);
@@ -113,14 +118,16 @@ describe('RemoteCheckoutActionCreator', () => {
 
     it('emits error action if unable to initialize payment', async () => {
         const response = getErrorResponse();
-        const errorHandler = jest.fn(action => Observable.of(action));
+        const errorHandler = jest.fn(action => of(action));
 
         jest.spyOn(requestSender, 'initializePayment')
             .mockReturnValue(Promise.reject(response));
 
         const actions = await actionCreator.initializePayment('amazon')
-            .catch(errorHandler)
-            .toArray()
+            .pipe(
+                catchError(errorHandler),
+                toArray()
+            )
             .toPromise();
 
         expect(errorHandler).toHaveBeenCalled();
@@ -138,7 +145,7 @@ describe('RemoteCheckoutActionCreator', () => {
             .mockReturnValue(Promise.resolve(response));
 
         const actions = await actionCreator.signOut('amazon', options)
-            .toArray()
+            .pipe(toArray())
             .toPromise();
 
         expect(requestSender.signOut).toHaveBeenCalledWith('amazon', options);
@@ -150,14 +157,16 @@ describe('RemoteCheckoutActionCreator', () => {
 
     it('emits error action if unable to sign out', async () => {
         const response = getErrorResponse();
-        const errorHandler = jest.fn(action => Observable.of(action));
+        const errorHandler = jest.fn(action => of(action));
 
         jest.spyOn(requestSender, 'signOut')
             .mockReturnValue(Promise.reject(response));
 
         const actions = await actionCreator.signOut('amazon')
-            .catch(errorHandler)
-            .toArray()
+            .pipe(
+                catchError(errorHandler),
+                toArray()
+            )
             .toPromise();
 
         expect(errorHandler).toHaveBeenCalled();

--- a/src/remote-checkout/remote-checkout-action-creator.ts
+++ b/src/remote-checkout/remote-checkout-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { RequestOptions } from '../common/http-request';
 

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { AddressRequestBody } from '../address';
 import { Cart } from '../cart';

--- a/src/shipping/create-shipping-strategy-registry.spec.ts
+++ b/src/shipping/create-shipping-strategy-registry.spec.ts
@@ -1,4 +1,5 @@
-import createRequestSender from '../../node_modules/@bigcommerce/request-sender/lib/create-request-sender';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
 import createCheckoutStore from '../checkout/create-checkout-store';
 import Registry from '../common/registry/registry';
 

--- a/src/shipping/shipping-country-action-creator.spec.ts
+++ b/src/shipping/shipping-country-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, Response } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { ErrorResponseBody } from '../common/error';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
@@ -29,7 +30,7 @@ describe('ShippingCountryActionCreator', () => {
     describe('#loadCountries()', () => {
         it('emits actions if able to load countries', () => {
             shippingCountryActionCreator.loadCountries()
-                .toArray()
+                .pipe(toArray())
                 .subscribe(actions => {
                     expect(actions).toEqual([
                         { type: ShippingCountryActionType.LoadShippingCountriesRequested },
@@ -41,11 +42,13 @@ describe('ShippingCountryActionCreator', () => {
         it('emits error actions if unable to load countries', () => {
             jest.spyOn(requestSender, 'loadCountries').mockReturnValue(Promise.reject(errorResponse));
 
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             shippingCountryActionCreator.loadCountries()
-                .catch(errorHandler)
-                .toArray()
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .subscribe(actions => {
                     expect(errorHandler).toHaveBeenCalled();
                     expect(actions).toEqual([

--- a/src/shipping/shipping-country-action-creator.ts
+++ b/src/shipping/shipping-country-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { RequestOptions } from '../common/http-request';
 

--- a/src/shipping/shipping-strategy-action-creator.spec.ts
+++ b/src/shipping/shipping-strategy-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
 
 import { createCheckoutStore, CheckoutStore, CheckoutStoreState } from '../checkout';
 import { getCheckoutState, getCheckoutStoreState, getCheckoutWithPayments } from '../checkout/checkouts.mock';
@@ -41,7 +42,7 @@ describe('ShippingStrategyActionCreator', () => {
 
             jest.spyOn(registry, 'get');
 
-            await Observable.from(actionCreator.initialize({ methodId })(store))
+            await from(actionCreator.initialize({ methodId })(store))
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith(methodId);
@@ -58,7 +59,7 @@ describe('ShippingStrategyActionCreator', () => {
 
             jest.spyOn(registry, 'get');
 
-            await Observable.from(actionCreator.initialize()(store))
+            await from(actionCreator.initialize()(store))
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith(methodId);
@@ -68,7 +69,7 @@ describe('ShippingStrategyActionCreator', () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const strategy = registry.get();
 
-            await Observable.from(actionCreator.initialize()(store))
+            await from(actionCreator.initialize()(store))
                 .toPromise();
 
             expect(strategy.initialize).toHaveBeenCalled();
@@ -77,8 +78,8 @@ describe('ShippingStrategyActionCreator', () => {
         it('emits action to notify initialization progress', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const methodId = 'default';
-            const actions = await Observable.from(actionCreator.initialize({ methodId })(store))
-                .toArray()
+            const actions = await from(actionCreator.initialize({ methodId })(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -91,14 +92,16 @@ describe('ShippingStrategyActionCreator', () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const initializeError = new Error();
             const methodId = 'default';
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             jest.spyOn(strategy, 'initialize')
                 .mockReturnValue(Promise.reject(initializeError));
 
-            const actions = await Observable.from(actionCreator.initialize({ methodId })(store))
-                .catch(errorHandler)
-                .toArray()
+            const actions = await from(actionCreator.initialize({ methodId })(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -125,7 +128,7 @@ describe('ShippingStrategyActionCreator', () => {
 
             jest.spyOn(registry, 'get');
 
-            await Observable.from(actionCreator.deinitialize({ methodId })(store))
+            await from(actionCreator.deinitialize({ methodId })(store))
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith(methodId);
@@ -134,7 +137,7 @@ describe('ShippingStrategyActionCreator', () => {
         it('deinitializes shipping strategy by default', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
 
-            await Observable.from(actionCreator.deinitialize()(store))
+            await from(actionCreator.deinitialize()(store))
                 .toPromise();
 
             expect(strategy.deinitialize).toHaveBeenCalled();
@@ -143,8 +146,8 @@ describe('ShippingStrategyActionCreator', () => {
         it('emits action to notify initialization progress', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const methodId = 'default';
-            const actions = await Observable.from(actionCreator.deinitialize({ methodId })(store))
-                .toArray()
+            const actions = await from(actionCreator.deinitialize({ methodId })(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -157,14 +160,16 @@ describe('ShippingStrategyActionCreator', () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const deinitializeError = new Error();
             const methodId = 'default';
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             jest.spyOn(strategy, 'deinitialize')
                 .mockReturnValue(Promise.reject(deinitializeError));
 
-            const actions = await Observable.from(actionCreator.deinitialize({ methodId })(store))
-                .catch(errorHandler)
-                .toArray()
+            const actions = await from(actionCreator.deinitialize({ methodId })(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -191,7 +196,7 @@ describe('ShippingStrategyActionCreator', () => {
 
             jest.spyOn(registry, 'get');
 
-            await Observable.from(actionCreator.updateAddress(getShippingAddress(), { methodId })(store))
+            await from(actionCreator.updateAddress(getShippingAddress(), { methodId })(store))
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith('default');
@@ -202,7 +207,7 @@ describe('ShippingStrategyActionCreator', () => {
             const options = { methodId: 'default' };
             const address = getShippingAddress();
 
-            await Observable.from(actionCreator.updateAddress(address, options)(store))
+            await from(actionCreator.updateAddress(address, options)(store))
                 .toPromise();
 
             expect(strategy.updateAddress).toHaveBeenCalledWith(address, options);
@@ -211,8 +216,8 @@ describe('ShippingStrategyActionCreator', () => {
         it('emits action to notify sign-in progress', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const methodId = 'default';
-            const actions = await Observable.from(actionCreator.updateAddress(getShippingAddress(), { methodId })(store))
-                .toArray()
+            const actions = await from(actionCreator.updateAddress(getShippingAddress(), { methodId })(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -224,14 +229,16 @@ describe('ShippingStrategyActionCreator', () => {
         it('emits error action if unable to sign in', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const updateAddressError = new Error();
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             jest.spyOn(strategy, 'updateAddress')
                 .mockReturnValue(Promise.reject(updateAddressError));
 
-            const actions = await Observable.from(actionCreator.updateAddress(getShippingAddress(), { methodId: 'default' })(store))
-                .catch(errorHandler)
-                .toArray()
+            const actions = await from(actionCreator.updateAddress(getShippingAddress(), { methodId: 'default' })(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();
@@ -260,7 +267,7 @@ describe('ShippingStrategyActionCreator', () => {
 
             jest.spyOn(registry, 'get');
 
-            await Observable.from(actionCreator.selectOption(shippingOptionId, { methodId })(store))
+            await from(actionCreator.selectOption(shippingOptionId, { methodId })(store))
                 .toPromise();
 
             expect(registry.get).toHaveBeenCalledWith(methodId);
@@ -269,7 +276,7 @@ describe('ShippingStrategyActionCreator', () => {
         it('executes shipping strategy by default', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
 
-            await Observable.from(actionCreator.selectOption(shippingOptionId)(store))
+            await from(actionCreator.selectOption(shippingOptionId)(store))
                 .toPromise();
 
             expect(strategy.selectOption).toHaveBeenCalledWith(shippingOptionId, { methodId: undefined });
@@ -277,8 +284,8 @@ describe('ShippingStrategyActionCreator', () => {
 
         it('emits action to notify sign-out progress', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
-            const actions = await Observable.from(actionCreator.selectOption(shippingOptionId, { methodId: 'default' })(store))
-                .toArray()
+            const actions = await from(actionCreator.selectOption(shippingOptionId, { methodId: 'default' })(store))
+                .pipe(toArray())
                 .toPromise();
 
             expect(actions).toEqual([
@@ -290,14 +297,16 @@ describe('ShippingStrategyActionCreator', () => {
         it('emits error action if unable to sign out', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const selectOptionError = new Error();
-            const errorHandler = jest.fn(action => Observable.of(action));
+            const errorHandler = jest.fn(action => of(action));
 
             jest.spyOn(strategy, 'selectOption')
                 .mockReturnValue(Promise.reject(selectOptionError));
 
-            const actions = await Observable.from(actionCreator.selectOption(shippingOptionId, { methodId: 'default' })(store))
-                .catch(errorHandler)
-                .toArray()
+            const actions = await from(actionCreator.selectOption(shippingOptionId, { methodId: 'default' })(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
                 .toPromise();
 
             expect(errorHandler).toHaveBeenCalled();

--- a/src/shipping/shipping-strategy-action-creator.ts
+++ b/src/shipping/shipping-strategy-action-creator.ts
@@ -1,6 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 import { AddressRequestBody } from '../address';
 import { InternalCheckoutSelectors } from '../checkout';

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ConsignmentRequestSender } from '..';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState } from '../../checkout';
@@ -98,7 +98,7 @@ describe('AmazonPayShippingStrategy', () => {
         });
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(Observable.of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, getAmazonPay())));
+            .mockReturnValue(of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, getAmazonPay())));
     });
 
     afterEach(() => {
@@ -134,7 +134,7 @@ describe('AmazonPayShippingStrategy', () => {
         const paymentMethod = { ...getAmazonPay(), config: { merchantId: undefined } };
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(Observable.of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod)));
+            .mockReturnValue(of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod)));
 
         try {
             await strategy.initialize({ methodId: paymentMethod.id, amazon: { container: 'addressBook' } });
@@ -157,8 +157,8 @@ describe('AmazonPayShippingStrategy', () => {
     it('synchronizes checkout address when selecting new address', async () => {
         const strategy = new AmazonPayShippingStrategy(store, consignmentActionCreator, paymentMethodActionCreator, remoteCheckoutActionCreator, scriptLoader);
         const paymentMethod = getAmazonPay();
-        const initializeShippingAction = Observable.of(createAction(RemoteCheckoutActionType.InitializeRemoteShippingRequested));
-        const updateAddressAction = Observable.of(createAction(ConsignmentActionType.CreateConsignmentsRequested));
+        const initializeShippingAction = of(createAction(RemoteCheckoutActionType.InitializeRemoteShippingRequested));
+        const updateAddressAction = of(createAction(ConsignmentActionType.CreateConsignmentsRequested));
 
         jest.spyOn(remoteCheckoutActionCreator, 'initializeShipping')
             .mockReturnValue(initializeShippingAction);
@@ -195,10 +195,10 @@ describe('AmazonPayShippingStrategy', () => {
         const paymentMethod = getAmazonPay();
 
         jest.spyOn(remoteCheckoutActionCreator, 'initializeShipping')
-            .mockReturnValue(Observable.of(createAction(RemoteCheckoutActionType.InitializeRemoteShippingRequested)));
+            .mockReturnValue(of(createAction(RemoteCheckoutActionType.InitializeRemoteShippingRequested)));
 
         jest.spyOn(consignmentActionCreator, 'updateAddress')
-            .mockReturnValue(Observable.of(createAction(ConsignmentActionType.CreateConsignmentsRequested)));
+            .mockReturnValue(of(createAction(ConsignmentActionType.CreateConsignmentsRequested)));
 
         jest.spyOn(store, 'dispatch');
 
@@ -277,7 +277,7 @@ describe('AmazonPayShippingStrategy', () => {
         const strategy = new AmazonPayShippingStrategy(store, consignmentActionCreator, paymentMethodActionCreator, remoteCheckoutActionCreator, scriptLoader);
         const method = getFlatRateOption();
         const options = {};
-        const action = Observable.of(createAction(ConsignmentActionType.UpdateConsignmentRequested));
+        const action = of(createAction(ConsignmentActionType.UpdateConsignmentRequested));
 
         jest.spyOn(consignmentActionCreator, 'selectShippingOption')
             .mockReturnValue(action);

--- a/src/shipping/strategies/default-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/default-shipping-strategy.spec.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ConsignmentRequestSender } from '..';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore } from '../../checkout';
@@ -27,7 +27,7 @@ describe('DefaultShippingStrategy', () => {
         const strategy = new DefaultShippingStrategy(store, consignmentActionCreator);
         const address = getShippingAddress();
         const options = {};
-        const action = Observable.of(createAction(ConsignmentActionType.CreateConsignmentsRequested));
+        const action = of(createAction(ConsignmentActionType.CreateConsignmentsRequested));
 
         jest.spyOn(consignmentActionCreator, 'updateAddress')
             .mockReturnValue(action);
@@ -45,7 +45,7 @@ describe('DefaultShippingStrategy', () => {
         const strategy = new DefaultShippingStrategy(store, consignmentActionCreator);
         const method = getFlatRateOption();
         const options = {};
-        const action = Observable.of(createAction(ConsignmentActionType.UpdateConsignmentRequested));
+        const action = of(createAction(ConsignmentActionType.UpdateConsignmentRequested));
 
         jest.spyOn(consignmentActionCreator, 'selectShippingOption')
             .mockReturnValue(action);


### PR DESCRIPTION
## What?
* Upgrade `rxjs` to version 6 to bring in various performance improvements and bug fixes.
* Upgrade `@bigcommerce/data-store` for the same reason.
* Make the changes required for the RxJS major version upgrade.

## Why?
* To keep our dependencies up to date. Otherwise, it'd much more difficult to upgrade later on if Rx introduces more breaking changes in the future.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
