### PR TITLE
CHECKOUT-3791: Convert customer strategy into plain interface

### DIFF
--- a/src/customer/customer-strategy-action-creator.ts
+++ b/src/customer/customer-strategy-action-creator.ts
@@ -1,6 +1,7 @@
-import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { Observable, Observer } from 'rxjs';
 
+import { InternalCheckoutSelectors } from '../checkout';
 import { Registry } from '../common/registry';
 
 import CustomerCredentials from './customer-credentials';
@@ -58,10 +59,15 @@ export default class CustomerStrategyActionCreator {
         });
     }
 
-    initialize(options?: CustomerInitializeOptions): Observable<CustomerStrategyInitializeAction> {
-        return Observable.create((observer: Observer<CustomerStrategyInitializeAction>) => {
+    initialize(options?: CustomerInitializeOptions): ThunkAction<CustomerStrategyInitializeAction, InternalCheckoutSelectors> {
+        return store => Observable.create((observer: Observer<CustomerStrategyInitializeAction>) => {
+            const state = store.getState();
             const methodId = options && options.methodId;
             const meta = { methodId };
+
+            if (methodId && state.customerStrategies.isInitialized(methodId)) {
+                return observer.complete();
+            }
 
             observer.next(createAction(CustomerStrategyActionType.InitializeRequested, undefined, meta));
 
@@ -77,10 +83,15 @@ export default class CustomerStrategyActionCreator {
         });
     }
 
-    deinitialize(options?: CustomerRequestOptions): Observable<CustomerStrategyDeinitializeAction> {
-        return Observable.create((observer: Observer<CustomerStrategyDeinitializeAction>) => {
+    deinitialize(options?: CustomerRequestOptions): ThunkAction<CustomerStrategyDeinitializeAction, InternalCheckoutSelectors> {
+        return store => Observable.create((observer: Observer<CustomerStrategyDeinitializeAction>) => {
+            const state = store.getState();
             const methodId = options && options.methodId;
             const meta = { methodId };
+
+            if (methodId && !state.customerStrategies.isInitialized(methodId)) {
+                return observer.complete();
+            }
 
             observer.next(createAction(CustomerStrategyActionType.DeinitializeRequested, undefined, meta));
 

--- a/src/customer/customer-strategy-reducer.spec.ts
+++ b/src/customer/customer-strategy-reducer.spec.ts
@@ -9,6 +9,7 @@ describe('customerStrategyReducer()', () => {
 
     beforeEach(() => {
         initialState = {
+            data: {},
             errors: {},
             statuses: {},
         };
@@ -37,6 +38,18 @@ describe('customerStrategyReducer()', () => {
         expect(customerStrategyReducer(initialState, action).statuses).toEqual({
             initializeMethodId: undefined,
             isInitializing: false,
+        });
+    });
+
+    it('returns initialization flag as true if customer has initialized successfully', () => {
+        const action = createAction(
+            CustomerStrategyActionType.InitializeSucceeded,
+            undefined,
+            { methodId: 'foobar' }
+        );
+
+        expect(customerStrategyReducer(initialState, action).data).toEqual({
+            foobar: { isInitialized: true },
         });
     });
 
@@ -80,6 +93,18 @@ describe('customerStrategyReducer()', () => {
         expect(customerStrategyReducer(initialState, action).statuses).toEqual({
             deinitializeMethodId: undefined,
             isDeinitializing: false,
+        });
+    });
+
+    it('returns initialization flag as false if customer has deinitialized successfully', () => {
+        const action = createAction(
+            CustomerStrategyActionType.DeinitializeSucceeded,
+            undefined,
+            { methodId: 'foobar' }
+        );
+
+        expect(customerStrategyReducer(initialState, action).data).toEqual({
+            foobar: { isInitialized: false },
         });
     });
 

--- a/src/customer/customer-strategy-reducer.ts
+++ b/src/customer/customer-strategy-reducer.ts
@@ -1,18 +1,44 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
 import { CustomerStrategyAction, CustomerStrategyActionType } from './customer-strategy-actions';
-import CustomerStrategyState, { CustomerStrategyErrorsState, CustomerStrategyStatusesState, DEFAULT_STATE } from './customer-strategy-state';
+import CustomerStrategyState, { CustomerStrategyDataState, CustomerStrategyErrorsState, CustomerStrategyStatusesState, DEFAULT_STATE } from './customer-strategy-state';
 
 export default function customerStrategyReducer(
     state: CustomerStrategyState = DEFAULT_STATE,
     action: CustomerStrategyAction
 ): CustomerStrategyState {
     const reducer = combineReducers<CustomerStrategyState, CustomerStrategyAction>({
+        data: dataReducer,
         errors: errorsReducer,
         statuses: statusesReducer,
     });
 
     return reducer(state, action);
+}
+
+function dataReducer(
+    data: CustomerStrategyDataState = DEFAULT_STATE.data,
+    action: CustomerStrategyAction
+): CustomerStrategyDataState {
+    switch (action.type) {
+    case CustomerStrategyActionType.InitializeSucceeded:
+        return {
+            ...data,
+            [action.meta && action.meta.methodId]: {
+                isInitialized: true,
+            },
+        };
+
+    case CustomerStrategyActionType.DeinitializeSucceeded:
+        return {
+            ...data,
+            [action.meta && action.meta.methodId]: {
+                isInitialized: false,
+            },
+        };
+    }
+
+    return data;
 }
 
 function errorsReducer(

--- a/src/customer/customer-strategy-selector.spec.ts
+++ b/src/customer/customer-strategy-selector.spec.ts
@@ -175,6 +175,27 @@ describe('CustomerStrategySelector', () => {
         });
     });
 
+    describe('#isInitialized()', () => {
+        it('returns true if method is initialized', () => {
+            selector = new CustomerStrategySelector({
+                ...state.customerStrategy,
+                data: { foobar: { isInitialized: true } },
+            });
+
+            expect(selector.isInitialized('foobar')).toEqual(true);
+        });
+
+        it('returns false if method is not initialized', () => {
+            selector = new CustomerStrategySelector({
+                ...state.customerStrategy,
+                data: { foobar: { isInitialized: false } },
+            });
+
+            expect(selector.isInitialized('foobar')).toEqual(false);
+            expect(selector.isInitialized('bar')).toEqual(false);
+        });
+    });
+
     describe('#isWidgetInteracting()', () => {
         it('returns true if any method is interacting with a widget', () => {
             selector = new CustomerStrategySelector({

--- a/src/customer/customer-strategy-selector.ts
+++ b/src/customer/customer-strategy-selector.ts
@@ -61,6 +61,13 @@ export default class CustomerStrategySelector {
         return !!this._customerStrategies.statuses.isInitializing;
     }
 
+    isInitialized(methodId: string): boolean {
+        return !!(
+            this._customerStrategies.data[methodId] &&
+            this._customerStrategies.data[methodId].isInitialized
+        );
+    }
+
     isWidgetInteracting(methodId?: string): boolean {
         if (methodId && this._customerStrategies.statuses.widgetInteractionMethodId !== methodId) {
             return false;

--- a/src/customer/customer-strategy-state.ts
+++ b/src/customer/customer-strategy-state.ts
@@ -1,6 +1,13 @@
 export default interface CustomerStrategyState {
+    data: CustomerStrategyDataState;
     errors: CustomerStrategyErrorsState;
     statuses: CustomerStrategyStatusesState;
+}
+
+export interface CustomerStrategyDataState {
+    [key: string]: {
+        isInitialized: boolean,
+    };
 }
 
 export interface CustomerStrategyErrorsState {
@@ -30,6 +37,7 @@ export interface CustomerStrategyStatusesState {
 }
 
 export const DEFAULT_STATE: CustomerStrategyState = {
+    data: {},
     errors: {},
     statuses: {},
 };

--- a/src/customer/internal-customers.mock.ts
+++ b/src/customer/internal-customers.mock.ts
@@ -60,6 +60,7 @@ export function getCustomerResponseBody(): InternalCustomerResponseBody {
 
 export function getCustomerStrategyState(): CustomerStrategyState {
     return {
+        data: {},
         errors: {},
         statuses: {},
     };

--- a/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.spec.ts
@@ -169,18 +169,6 @@ describe('AmazonPayCustomerStrategy', () => {
         }
     });
 
-    it('only initializes widget once until deinitialization', async () => {
-        await strategy.initialize({ methodId: 'amazon', amazon: { container: 'login' } });
-        await strategy.initialize({ methodId: 'amazon', amazon: { container: 'login' } });
-
-        expect(buttonConstructorSpy).toHaveBeenCalledTimes(1);
-
-        await strategy.deinitialize();
-        await strategy.initialize({ methodId: 'amazon', amazon: { container: 'login' } });
-
-        expect(buttonConstructorSpy).toHaveBeenCalledTimes(2);
-    });
-
     it('generates request token', async () => {
         await strategy.initialize({ methodId: 'amazon', amazon: { container: 'login' } });
 

--- a/src/customer/strategies/amazon-pay-customer-strategy.ts
+++ b/src/customer/strategies/amazon-pay-customer-strategy.ts
@@ -8,27 +8,21 @@ import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-r
 
 import CustomerStrategy from './customer-strategy';
 
-export default class AmazonPayCustomerStrategy extends CustomerStrategy {
+export default class AmazonPayCustomerStrategy implements CustomerStrategy {
     private _paymentMethod?: PaymentMethod;
     private _window: AmazonPayWindow;
 
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _remoteCheckoutRequestSender: RemoteCheckoutRequestSender,
         private _scriptLoader: AmazonPayScriptLoader
     ) {
-        super(store);
-
         this._window = window;
     }
 
     initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
-        if (this._isInitialized) {
-            return super.initialize(options);
-        }
-
         const { amazon: amazonOptions, methodId } = options;
 
         if (!amazonOptions || !methodId) {
@@ -59,17 +53,13 @@ export default class AmazonPayCustomerStrategy extends CustomerStrategy {
                 this._scriptLoader.loadWidget(this._paymentMethod, onReady)
                     .catch(reject);
             }))
-            .then(() => super.initialize(options));
+            .then(() => this._store.getState());
     }
 
     deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
-        if (!this._isInitialized) {
-            return super.deinitialize(options);
-        }
-
         this._paymentMethod = undefined;
 
-        return super.deinitialize(options);
+        return Promise.resolve(this._store.getState());
     }
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {

--- a/src/customer/strategies/chasepay-customer-strategy.ts
+++ b/src/customer/strategies/chasepay-customer-strategy.ts
@@ -6,26 +6,24 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplem
 import { toFormUrlEncoded } from '../../common/http-request';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../payment';
 import { ChasePayScriptLoader } from '../../payment/strategies/chasepay';
-import { ChasePaySuccessPayload } from '../../payment/strategies/chasepay/chasepay';
+import { ChasePaySuccessPayload } from '../../payment/strategies/chasepay';
 import { RemoteCheckoutActionCreator } from '../../remote-checkout';
 import CustomerCredentials from '../customer-credentials';
-import {CustomerInitializeOptions, CustomerRequestOptions} from '../customer-request-options';
+import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-request-options';
 
 import CustomerStrategy from './customer-strategy';
 
-export default class ChasePayCustomerStrategy extends CustomerStrategy {
+export default class ChasePayCustomerStrategy implements CustomerStrategy {
     private _paymentMethod?: PaymentMethod;
 
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _chasePayScriptLoader: ChasePayScriptLoader,
         private _requestSender: RequestSender,
         private _formPoster: FormPoster
-    ) {
-        super(store);
-    }
+    ) {}
 
     initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { chasepay: chasePayOptions, methodId } = options;
@@ -96,7 +94,11 @@ export default class ChasePayCustomerStrategy extends CustomerStrategy {
                         });
                     });
             })
-            .then(() => super.initialize(options));
+            .then(() => this._store.getState());
+    }
+
+    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
     }
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
@@ -105,7 +107,7 @@ export default class ChasePayCustomerStrategy extends CustomerStrategy {
         );
     }
 
-    signOut(options?: any): Promise<InternalCheckoutSelectors> {
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
         const state = this._store.getState();
         const payment = state.payment.getPaymentId();
 

--- a/src/customer/strategies/customer-strategy.ts
+++ b/src/customer/strategies/customer-strategy.ts
@@ -1,28 +1,14 @@
-import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
+import { InternalCheckoutSelectors } from '../../checkout';
 import CustomerCredentials from '../customer-credentials';
 
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-request-options';
 
-export default abstract class CustomerStrategy {
-    protected _isInitialized = false;
+export default interface CustomerStrategy {
+    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
 
-    constructor(
-        protected _store: CheckoutStore
-    ) {}
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
 
-    abstract signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
+    initialize(options?: CustomerInitializeOptions): Promise<InternalCheckoutSelectors>;
 
-    abstract signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
-
-    initialize(options?: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
-        this._isInitialized = true;
-
-        return Promise.resolve(this._store.getState());
-    }
-
-    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
-        this._isInitialized = false;
-
-        return Promise.resolve(this._store.getState());
-    }
+    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
 }

--- a/src/customer/strategies/default-customer-strategy.ts
+++ b/src/customer/strategies/default-customer-strategy.ts
@@ -1,17 +1,15 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
 import CustomerActionCreator from '../customer-action-creator';
 import CustomerCredentials from '../customer-credentials';
-import { CustomerRequestOptions } from '../customer-request-options';
+import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-request-options';
 
 import CustomerStrategy from './customer-strategy';
 
-export default class DefaultCustomerStrategy extends CustomerStrategy {
+export default class DefaultCustomerStrategy implements CustomerStrategy {
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _customerActionCreator: CustomerActionCreator
-    ) {
-        super(store);
-    }
+    ) {}
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
         return this._store.dispatch(
@@ -23,5 +21,13 @@ export default class DefaultCustomerStrategy extends CustomerStrategy {
         return this._store.dispatch(
             this._customerActionCreator.signOutCustomer(options)
         );
+    }
+
+    initialize(options?: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
     }
 }

--- a/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
@@ -110,20 +110,6 @@ describe('GooglePayCustomerStrategy', () => {
                 expect(paymentProcessor.createButton).toHaveBeenCalled();
             });
 
-            it('Validates if strategy is been initialized', async () => {
-                customerInitializeOptions = getBraintreeCustomerInitializeOptions();
-
-                await strategy.initialize(customerInitializeOptions);
-
-                setTimeout(() => {
-                    strategy.initialize(customerInitializeOptions);
-                }, 0);
-
-                strategy.initialize(customerInitializeOptions);
-
-                expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
-            });
-
             it('fails to initialize the strategy if no GooglePayCustomerInitializeOptions is provided ', async () => {
                 customerInitializeOptions = getBraintreeCustomerInitializeOptions(Mode.Incomplete);
 

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -11,23 +11,17 @@ import CustomerStrategy from '../customer-strategy';
 
 import GooglePayCustomerInitializeOptions from './googlepay-customer-initialize-options';
 
-export default class GooglePayCustomerStrategy extends CustomerStrategy {
+export default class GooglePayCustomerStrategy implements CustomerStrategy {
     private _walletButton?: HTMLElement;
 
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _googlePayPaymentProcessor: GooglePayPaymentProcessor,
         private _formPoster: FormPoster
-    ) {
-        super(store);
-    }
+    ) {}
 
     initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
-        if (this._isInitialized) {
-            return super.initialize(options);
-        }
-
         const { methodId }  = options;
 
         const googlePayOptions = this._getGooglePayOptions(options);
@@ -40,21 +34,17 @@ export default class GooglePayCustomerStrategy extends CustomerStrategy {
             .then(() => {
                 this._walletButton = this._createSignInButton(googlePayOptions.container);
             })
-            .then(() => super.initialize(options));
+            .then(() => this._store.getState());
     }
 
     deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
-        if (!this._isInitialized) {
-            return super.deinitialize(options);
-        }
-
         if (this._walletButton && this._walletButton.parentNode) {
             this._walletButton.parentNode.removeChild(this._walletButton);
             this._walletButton = undefined;
         }
 
         return this._googlePayPaymentProcessor.deinitialize()
-            .then(() => super.deinitialize(options));
+            .then(() => this._store.getState());
     }
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {

--- a/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
@@ -104,20 +104,6 @@ describe('GooglePayCustomerStrategy', () => {
                 expect(paymentProcessor.createButton).toHaveBeenCalled();
             });
 
-            it('Validates if strategy is been initialized', async () => {
-                customerInitializeOptions = getStripeCustomerInitializeOptions();
-
-                await strategy.initialize(customerInitializeOptions);
-
-                setTimeout(() => {
-                    strategy.initialize(customerInitializeOptions);
-                }, 0);
-
-                strategy.initialize(customerInitializeOptions);
-
-                expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
-            });
-
             it('fails to initialize the strategy if no GooglePayCustomerInitializeOptions is provided ', async () => {
                 customerInitializeOptions = getStripeCustomerInitializeOptions(Mode.Incomplete);
 

--- a/src/customer/strategies/masterpass-customer-strategy.ts
+++ b/src/customer/strategies/masterpass-customer-strategy.ts
@@ -13,18 +13,16 @@ import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-r
 
 import CustomerStrategy from './customer-strategy';
 
-export default class MasterpassCustomerStrategy extends CustomerStrategy {
+export default class MasterpassCustomerStrategy implements CustomerStrategy {
     private _signInButton?: HTMLElement;
     private _paymentMethod?: PaymentMethod;
 
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _masterpassScriptLoader: MasterpassScriptLoader
-    ) {
-        super(store);
-    }
+    ) {}
 
     initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { masterpass: masterpassOptions, methodId } = options;
@@ -66,21 +64,18 @@ export default class MasterpassCustomerStrategy extends CustomerStrategy {
                         });
                     });
             })
-            .then(() => super.initialize(options));
+            .then(() => this._store.getState());
     }
 
     deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
-        if (!this._isInitialized) {
-            return super.deinitialize(options);
-        }
-
         this._paymentMethod = undefined;
+
         if (this._signInButton && this._signInButton.parentNode) {
             this._signInButton.parentNode.removeChild(this._signInButton);
             this._signInButton = undefined;
         }
 
-        return super.deinitialize(options);
+        return Promise.resolve(this._store.getState());
     }
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {

--- a/src/customer/strategies/square-customer-strategy.ts
+++ b/src/customer/strategies/square-customer-strategy.ts
@@ -2,18 +2,16 @@ import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
 import { NotImplementedError} from '../../common/error/errors';
 import { RemoteCheckoutActionCreator } from '../../remote-checkout';
 import CustomerCredentials from '../customer-credentials';
-import { CustomerRequestOptions } from '../customer-request-options';
+import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-request-options';
 
 import CustomerStrategy from './customer-strategy';
 
-export default class SquareCustomerStrategy extends CustomerStrategy {
+export default class SquareCustomerStrategy implements CustomerStrategy {
 
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator
-    ) {
-        super(store);
-    }
+    ) {}
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
         throw new NotImplementedError(
@@ -21,7 +19,7 @@ export default class SquareCustomerStrategy extends CustomerStrategy {
         );
     }
 
-    signOut(options?: any): Promise<InternalCheckoutSelectors> {
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
         const state = this._store.getState();
         const payment = state.payment.getPaymentId();
 
@@ -32,5 +30,13 @@ export default class SquareCustomerStrategy extends CustomerStrategy {
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
         );
+    }
+
+    initialize(options?: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
     }
 }


### PR DESCRIPTION
## What?
1. Convert `CustomerStrategy` from an abstract class into a plain interface.
1. Check the `isInitialized` flag in a central location rather than checking it individually for every customer strategy.

## Why?
1. Prefer not to keep the abstract class around because it usually encourages us to move shared behaviours up to the parent class rather than sharing behaviours via composition.
1. Strategies shouldn't have to perform the initialisation check themselves. Currently we do, but often we forget to implement the check. So it's better to move the check out to the upper layer.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
