### PR TITLE
feat(payment): INT-1138 Fix shipping address bug in google pay

### DIFF
--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -83,7 +83,11 @@ export default class GooglePayButtonStrategy extends CheckoutButtonStrategy {
 
         return this._googlePayPaymentProcessor.displayWallet()
             .then(paymentData => this._googlePayPaymentProcessor.handleSuccess(paymentData)
-                .then(() => this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress)))
+            .then(() => {
+                if (paymentData.shippingAddress) {
+                    this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress);
+                }
+            }))
             .then(() => this._onPaymentSelectComplete())
             .catch(error => this._onError(error));
     }

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -123,7 +123,11 @@ export default class GooglePayCustomerStrategy extends CustomerStrategy {
 
         return this._googlePayPaymentProcessor.displayWallet()
             .then(paymentData => this._googlePayPaymentProcessor.handleSuccess(paymentData)
-                .then(() => this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress)))
+            .then(() => {
+                if (paymentData.shippingAddress) {
+                    this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress);
+                }
+            }))
             .then(() => this._onPaymentSelectComplete())
             .catch(error => this._onError(error));
     }


### PR DESCRIPTION
[INT-1138](https://jira.bigcommerce.com/browse/INT-1138)

## What?
When checkout with Google Pay from the quick cart or cart page, then click edit cart on UCO and try to Sign In again on Google Pay from quick cart or cart page, Google pay will not redirect to UCO, then if go to UCO Google Pay session will be still there.

## Why?
Google pay will not redirect to UCO if a shipping address is already set

## Testing / Proof
BUG: https://drive.google.com/file/d/1oIg9jt_KcCYPbWkLS0PDj-PHq-U4okcz/view?usp=sharing
BUG FIXED: https://drive.google.com/file/d/1RpQOyJUEBXcUOIFWPxjrrSgBphOOek3a/view?usp=sharing

@bigcommerce/checkout 