### PR TITLE
CHECKOUT-3791: Convert shipping strategy into plain interface

### DIFF
--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -133,7 +133,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         paymentStrategies: { errors: {}, statuses: {} },
         remoteCheckout: getRemoteCheckoutState(),
         shippingCountries: getShippingCountriesState(),
-        shippingStrategies: { errors: {}, statuses: {} },
+        shippingStrategies: { data: {}, errors: {}, statuses: {} },
     };
 }
 

--- a/src/shipping/shipping-strategy-action-creator.spec.ts
+++ b/src/shipping/shipping-strategy-action-creator.spec.ts
@@ -1,4 +1,5 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { merge } from 'lodash';
 import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
@@ -31,6 +32,9 @@ describe('ShippingStrategyActionCreator', () => {
 
         beforeEach(() => {
             strategy = registry.get();
+            store = createCheckoutStore(merge({}, state, {
+                shippingStrategies: { data: { amazon: { isInitialized: true } } },
+            }));
 
             jest.spyOn(strategy, 'initialize')
                 .mockReturnValue(Promise.resolve(store.getState()));
@@ -75,6 +79,19 @@ describe('ShippingStrategyActionCreator', () => {
             expect(strategy.initialize).toHaveBeenCalled();
         });
 
+        it('does not initialize if strategy is already initialized', async () => {
+            const actionCreator = new ShippingStrategyActionCreator(registry);
+            const strategy = registry.get('amazon');
+
+            jest.spyOn(strategy, 'initialize')
+                .mockReturnValue(Promise.resolve(store.getState()));
+
+            await from(actionCreator.initialize({ methodId: 'amazon' })(store))
+                .toPromise();
+
+            expect(strategy.initialize).not.toHaveBeenCalled();
+        });
+
         it('emits action to notify initialization progress', async () => {
             const actionCreator = new ShippingStrategyActionCreator(registry);
             const methodId = 'default';
@@ -117,6 +134,9 @@ describe('ShippingStrategyActionCreator', () => {
 
         beforeEach(() => {
             strategy = registry.get();
+            store = createCheckoutStore(merge({}, state, {
+                shippingStrategies: { data: { default: { isInitialized: true } } },
+            }));
 
             jest.spyOn(strategy, 'deinitialize')
                 .mockReturnValue(Promise.resolve(store.getState()));
@@ -141,6 +161,19 @@ describe('ShippingStrategyActionCreator', () => {
                 .toPromise();
 
             expect(strategy.deinitialize).toHaveBeenCalled();
+        });
+
+        it('does not deinitialize if strategy is not initialized', async () => {
+            const actionCreator = new ShippingStrategyActionCreator(registry);
+            const strategy = registry.get('amazon');
+
+            jest.spyOn(strategy, 'deinitialize')
+                .mockReturnValue(Promise.resolve(store.getState()));
+
+            await from(actionCreator.deinitialize({ methodId: 'amazon' })(store))
+                .toPromise();
+
+            expect(strategy.deinitialize).not.toHaveBeenCalled();
         });
 
         it('emits action to notify initialization progress', async () => {

--- a/src/shipping/shipping-strategy-action-creator.ts
+++ b/src/shipping/shipping-strategy-action-creator.ts
@@ -60,9 +60,14 @@ export default class ShippingStrategyActionCreator {
 
     initialize(options?: ShippingInitializeOptions): ThunkAction<ShippingStrategyInitializeAction, InternalCheckoutSelectors> {
         return store => Observable.create((observer: Observer<ShippingStrategyInitializeAction>) => {
-            const payment = store.getState().payment.getPaymentId();
+            const state = store.getState();
+            const payment = state.payment.getPaymentId();
             const methodId = options && options.methodId || payment && payment.providerId;
             const mergedOptions = { ...options, methodId };
+
+            if (methodId && state.shippingStrategies.isInitialized(methodId)) {
+                return observer.complete();
+            }
 
             observer.next(createAction(ShippingStrategyActionType.InitializeRequested, undefined, { methodId }));
 
@@ -80,8 +85,13 @@ export default class ShippingStrategyActionCreator {
 
     deinitialize(options?: ShippingRequestOptions): ThunkAction<ShippingStrategyDeinitializeAction, InternalCheckoutSelectors> {
         return store => Observable.create((observer: Observer<ShippingStrategyDeinitializeAction>) => {
-            const payment = store.getState().payment.getPaymentId();
+            const state = store.getState();
+            const payment = state.payment.getPaymentId();
             const methodId = options && options.methodId || payment && payment.providerId;
+
+            if (methodId && !state.shippingStrategies.isInitialized(methodId)) {
+                return observer.complete();
+            }
 
             observer.next(createAction(ShippingStrategyActionType.DeinitializeRequested, undefined, { methodId }));
 

--- a/src/shipping/shipping-strategy-reducer.spec.ts
+++ b/src/shipping/shipping-strategy-reducer.spec.ts
@@ -9,6 +9,7 @@ describe('shippingStrategyReducer()', () => {
 
     beforeEach(() => {
         initialState = {
+            data: {},
             errors: {},
             statuses: {},
         };
@@ -37,6 +38,18 @@ describe('shippingStrategyReducer()', () => {
         expect(shippingStrategyReducer(initialState, action).statuses).toEqual({
             initializeMethodId: undefined,
             isInitializing: false,
+        });
+    });
+
+    it('returns initialization flag as true if customer has initialized successfully', () => {
+        const action = createAction(
+            ShippingStrategyActionType.InitializeSucceeded,
+            undefined,
+            { methodId: 'foobar' }
+        );
+
+        expect(shippingStrategyReducer(initialState, action).data).toEqual({
+            foobar: { isInitialized: true },
         });
     });
 
@@ -80,6 +93,18 @@ describe('shippingStrategyReducer()', () => {
         expect(shippingStrategyReducer(initialState, action).statuses).toEqual({
             deinitializeMethodId: undefined,
             isDeinitializing: false,
+        });
+    });
+
+    it('returns initialization flag as false if customer has deinitialized successfully', () => {
+        const action = createAction(
+            ShippingStrategyActionType.DeinitializeSucceeded,
+            undefined,
+            { methodId: 'foobar' }
+        );
+
+        expect(shippingStrategyReducer(initialState, action).data).toEqual({
+            foobar: { isInitialized: false },
         });
     });
 

--- a/src/shipping/shipping-strategy-reducer.ts
+++ b/src/shipping/shipping-strategy-reducer.ts
@@ -1,18 +1,44 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
 import { ShippingStrategyAction, ShippingStrategyActionType } from './shipping-strategy-actions';
-import ShippingStrategyState, { DEFAULT_STATE, ShippingStrategyErrorsState, ShippingStrategyStatusesState } from './shipping-strategy-state';
+import ShippingStrategyState, { DEFAULT_STATE, ShippingStrategyDataState, ShippingStrategyErrorsState, ShippingStrategyStatusesState } from './shipping-strategy-state';
 
 export default function shippingStrategyReducer(
     state: ShippingStrategyState = DEFAULT_STATE,
     action: ShippingStrategyAction
 ): ShippingStrategyState {
     const reducer = combineReducers<ShippingStrategyState, ShippingStrategyAction>({
+        data: dataReducer,
         errors: errorsReducer,
         statuses: statusesReducer,
     });
 
     return reducer(state, action);
+}
+
+function dataReducer(
+    data: ShippingStrategyDataState = DEFAULT_STATE.data,
+    action: ShippingStrategyAction
+): ShippingStrategyDataState {
+    switch (action.type) {
+    case ShippingStrategyActionType.InitializeSucceeded:
+        return {
+            ...data,
+            [action.meta && action.meta.methodId]: {
+                isInitialized: true,
+            },
+        };
+
+    case ShippingStrategyActionType.DeinitializeSucceeded:
+        return {
+            ...data,
+            [action.meta && action.meta.methodId]: {
+                isInitialized: false,
+            },
+        };
+    }
+
+    return data;
 }
 
 function errorsReducer(

--- a/src/shipping/shipping-strategy-selector.spec.ts
+++ b/src/shipping/shipping-strategy-selector.spec.ts
@@ -144,4 +144,25 @@ describe('ShippingStrategySelector', () => {
             expect(selector.isInitializing()).toEqual(false);
         });
     });
+
+    describe('#isInitialized()', () => {
+        it('returns true if method is initialized', () => {
+            selector = new ShippingStrategySelector({
+                ...state.shippingStrategy,
+                data: { foobar: { isInitialized: true } },
+            });
+
+            expect(selector.isInitialized('foobar')).toEqual(true);
+        });
+
+        it('returns false if method is not initialized', () => {
+            selector = new ShippingStrategySelector({
+                ...state.shippingStrategy,
+                data: { foobar: { isInitialized: false } },
+            });
+
+            expect(selector.isInitialized('foobar')).toEqual(false);
+            expect(selector.isInitialized('bar')).toEqual(false);
+        });
+    });
 });

--- a/src/shipping/shipping-strategy-selector.ts
+++ b/src/shipping/shipping-strategy-selector.ts
@@ -55,4 +55,11 @@ export default class ShippingStrategySelector {
 
         return !!this._shippingStrategies.statuses.isInitializing;
     }
+
+    isInitialized(methodId: string): boolean {
+        return !!(
+            this._shippingStrategies.data[methodId] &&
+            this._shippingStrategies.data[methodId].isInitialized
+        );
+    }
 }

--- a/src/shipping/shipping-strategy-state.ts
+++ b/src/shipping/shipping-strategy-state.ts
@@ -1,6 +1,13 @@
 export default interface ShippingStrategyState {
+    data: ShippingStrategyDataState;
     errors: ShippingStrategyErrorsState;
     statuses: ShippingStrategyStatusesState;
+}
+
+export interface ShippingStrategyDataState {
+    [key: string]: {
+        isInitialized: boolean,
+    };
 }
 
 export interface ShippingStrategyErrorsState {
@@ -26,6 +33,7 @@ export interface ShippingStrategyStatusesState {
 }
 
 export const DEFAULT_STATE: ShippingStrategyState = {
+    data: {},
     errors: {},
     statuses: {},
 };

--- a/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon-pay-shipping-strategy.spec.ts
@@ -114,21 +114,6 @@ describe('AmazonPayShippingStrategy', () => {
         expect(scriptLoader.loadWidget).not.toHaveBeenCalledWith(paymentMethod);
     });
 
-    it('only initializes widget once until deinitialization', async () => {
-        const strategy = new AmazonPayShippingStrategy(store, consignmentActionCreator, paymentMethodActionCreator, remoteCheckoutActionCreator, scriptLoader);
-        const paymentMethod = getAmazonPay();
-
-        await strategy.initialize({ methodId: paymentMethod.id, amazon: { container: 'addressBook' } });
-        await strategy.initialize({ methodId: paymentMethod.id, amazon: { container: 'addressBook' } });
-
-        expect(addressBookSpy).toHaveBeenCalledTimes(1);
-
-        await strategy.deinitialize();
-        await strategy.initialize({ methodId: paymentMethod.id, amazon: { container: 'addressBook' } });
-
-        expect(addressBookSpy).toHaveBeenCalledTimes(2);
-    });
-
     it('rejects with error if initialization fails', async () => {
         const strategy = new AmazonPayShippingStrategy(store, consignmentActionCreator, paymentMethodActionCreator, remoteCheckoutActionCreator, scriptLoader);
         const paymentMethod = { ...getAmazonPay(), config: { merchantId: undefined } };

--- a/src/shipping/strategies/default-shipping-strategy.ts
+++ b/src/shipping/strategies/default-shipping-strategy.ts
@@ -5,13 +5,11 @@ import { ShippingRequestOptions } from '../shipping-request-options';
 
 import ShippingStrategy from './shipping-strategy';
 
-export default class DefaultShippingStrategy extends ShippingStrategy {
+export default class DefaultShippingStrategy implements ShippingStrategy {
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _consignmentActionCreator: ConsignmentActionCreator
-    ) {
-        super(store);
-    }
+    ) {}
 
     updateAddress(address: AddressRequestBody, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
         return this._store.dispatch(
@@ -23,5 +21,13 @@ export default class DefaultShippingStrategy extends ShippingStrategy {
         return this._store.dispatch(
             this._consignmentActionCreator.selectShippingOption(optionId, options)
         );
+    }
+
+    initialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
     }
 }

--- a/src/shipping/strategies/shipping-strategy.spec.ts
+++ b/src/shipping/strategies/shipping-strategy.spec.ts
@@ -1,21 +1,29 @@
-import { DataStore } from '@bigcommerce/data-store';
-
-import { Address } from '../../address';
-import { createCheckoutStore, InternalCheckoutSelectors } from '../../checkout';
-import { ShippingRequestOptions } from '../shipping-request-options';
+import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
 
 import ShippingStrategy from './shipping-strategy';
 
 describe('ShippingStrategy', () => {
-    let store: DataStore<InternalCheckoutSelectors>;
+    let store: CheckoutStore;
 
-    class FoobarShippingStrategy extends ShippingStrategy {
-        updateAddress(address: Address, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
-            return Promise.resolve(store.getState());
+    class FoobarShippingStrategy implements ShippingStrategy {
+        constructor(
+            private _store: CheckoutStore
+        ) {}
+
+        updateAddress(): Promise<InternalCheckoutSelectors> {
+            return Promise.resolve(this._store.getState());
         }
 
-        selectOption(optionId: string, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
-            return Promise.resolve(store.getState());
+        selectOption(): Promise<InternalCheckoutSelectors> {
+            return Promise.resolve(this._store.getState());
+        }
+
+        initialize(): Promise<InternalCheckoutSelectors> {
+            return Promise.resolve(this._store.getState());
+        }
+
+        deinitialize(): Promise<InternalCheckoutSelectors> {
+            return Promise.resolve(this._store.getState());
         }
     }
 

--- a/src/shipping/strategies/shipping-strategy.ts
+++ b/src/shipping/strategies/shipping-strategy.ts
@@ -1,28 +1,14 @@
 import { AddressRequestBody } from '../../address';
-import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
+import { InternalCheckoutSelectors } from '../../checkout';
 
 import { ShippingRequestOptions } from '../shipping-request-options';
 
-export default abstract class ShippingStrategy {
-    protected _isInitialized = false;
+export default interface ShippingStrategy {
+    updateAddress(address: AddressRequestBody, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors>;
 
-    constructor(
-        protected _store: CheckoutStore
-    ) {}
+    selectOption(optionId: string, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors>;
 
-    abstract updateAddress(address: AddressRequestBody, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors>;
+    initialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors>;
 
-    abstract selectOption(optionId: string, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors>;
-
-    initialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
-        this._isInitialized = true;
-
-        return Promise.resolve(this._store.getState());
-    }
-
-    deinitialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
-        this._isInitialized = false;
-
-        return Promise.resolve(this._store.getState());
-    }
+    deinitialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors>;
 }


### PR DESCRIPTION
## What?
1. Convert `ShippingStrategy` from an abstract class into a plain interface.
1. Check the `isInitialized` flag in a central location rather than checking it individually for every shipping strategy.

## Why?
1. Prefer not to keep the abstract class around because it usually encourages us to move shared behaviours up to the parent class rather than sharing behaviours via composition.
1. Strategies shouldn't have to perform the initialisation check themselves. Currently we do, but often we forget to implement the check. So it's better to move the check out to the upper layer.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
