### PR TITLE
CHECKOUT-3791: Convert checkout button strategy into plain interface

### DIFF
--- a/src/checkout-buttons/checkout-button-actions.ts
+++ b/src/checkout-buttons/checkout-button-actions.ts
@@ -31,15 +31,19 @@ export interface CheckoutButtonActionMeta {
     methodId: CheckoutButtonMethodType;
 }
 
-export interface InitializeButtonRequestedAction extends Action<undefined, CheckoutButtonActionMeta> {
+export interface InitializeButtonActionMeta extends CheckoutButtonActionMeta {
+    containerId: string;
+}
+
+export interface InitializeButtonRequestedAction extends Action<undefined, InitializeButtonActionMeta> {
     type: CheckoutButtonActionType.InitializeButtonRequested;
 }
 
-export interface InitializeButtonSucceededAction extends Action<undefined, CheckoutButtonActionMeta> {
+export interface InitializeButtonSucceededAction extends Action<undefined, InitializeButtonActionMeta> {
     type: CheckoutButtonActionType.InitializeButtonSucceeded;
 }
 
-export interface InitializeButtonFailedAction extends Action<Error, CheckoutButtonActionMeta> {
+export interface InitializeButtonFailedAction extends Action<Error, InitializeButtonActionMeta> {
     type: CheckoutButtonActionType.InitializeButtonFailed;
 }
 

--- a/src/checkout-buttons/checkout-button-reducer.spec.ts
+++ b/src/checkout-buttons/checkout-button-reducer.spec.ts
@@ -15,7 +15,8 @@ describe('checkoutButtonReducer', () => {
 
     it('returns new status state if button is initializing', () => {
         const methodId = CheckoutButtonMethodType.BRAINTREE_PAYPAL;
-        const action = createAction(CheckoutButtonActionType.InitializeButtonRequested, undefined, { methodId });
+        const containerId = 'foobar';
+        const action = createAction(CheckoutButtonActionType.InitializeButtonRequested, undefined, { methodId, containerId });
         const state = checkoutButtonReducer(initialState, action);
 
         expect(state.statuses).toEqual({ braintreepaypal: { isInitializing: true } });
@@ -32,10 +33,20 @@ describe('checkoutButtonReducer', () => {
         };
 
         const methodId = CheckoutButtonMethodType.BRAINTREE_PAYPAL;
-        const action = createAction(CheckoutButtonActionType.InitializeButtonSucceeded, undefined, { methodId });
+        const containerId = 'foobar';
+        const action = createAction(CheckoutButtonActionType.InitializeButtonSucceeded, undefined, { methodId, containerId });
         const state = checkoutButtonReducer(initialState, action);
 
         expect(state.statuses).toEqual({ braintreepaypal: { isInitializing: false } });
+    });
+
+    it('returns new initialization state if button is initialized', () => {
+        const methodId = CheckoutButtonMethodType.BRAINTREE_PAYPAL;
+        const containerId = 'foobar';
+        const action = createAction(CheckoutButtonActionType.InitializeButtonSucceeded, undefined, { methodId, containerId });
+        const state = checkoutButtonReducer(initialState, action);
+
+        expect(state.data).toEqual({ braintreepaypal: { initializedContainers: { [containerId]: true } } });
     });
 
     it('returns new status state if deinitializing button', () => {
@@ -63,10 +74,32 @@ describe('checkoutButtonReducer', () => {
         expect(state.statuses).toEqual({ braintreepaypal: { isDeinitializing: false } });
     });
 
+    it('returns new initialization state if button is deinitialized', () => {
+        const methodId = CheckoutButtonMethodType.BRAINTREE_PAYPAL;
+        const containerId = 'foobar';
+
+        initialState = {
+            ...initialState,
+            data: {
+                [methodId]: {
+                    initializedContainers: {
+                        [containerId]: true,
+                    },
+                },
+            },
+        };
+
+        const action = createAction(CheckoutButtonActionType.DeinitializeButtonSucceeded, undefined, { methodId });
+        const state = checkoutButtonReducer(initialState, action);
+
+        expect(state.data).toEqual({ braintreepaypal: { initializedContainers: {} } });
+    });
+
     it('returns new error state if button fails to initialize', () => {
         const error = new Error('Fail to initialize');
         const methodId = CheckoutButtonMethodType.BRAINTREE_PAYPAL;
-        const action = createAction(CheckoutButtonActionType.InitializeButtonFailed, error, { methodId });
+        const containerId = 'foobar';
+        const action = createAction(CheckoutButtonActionType.InitializeButtonFailed, error, { methodId, containerId });
         const state = checkoutButtonReducer(initialState, action);
 
         expect(state.errors).toEqual({ braintreepaypal: { initializeError: error } });
@@ -83,7 +116,8 @@ describe('checkoutButtonReducer', () => {
         };
 
         const methodId = CheckoutButtonMethodType.BRAINTREE_PAYPAL;
-        const action = createAction(CheckoutButtonActionType.InitializeButtonSucceeded, undefined, { methodId });
+        const containerId = 'foobar';
+        const action = createAction(CheckoutButtonActionType.InitializeButtonSucceeded, undefined, { methodId, containerId });
         const state = checkoutButtonReducer(initialState, action);
 
         expect(state.errors).toEqual({ braintreepaypal: { initializeError: undefined } });
@@ -92,7 +126,8 @@ describe('checkoutButtonReducer', () => {
     it('returns new error state if button fails to deinitialize', () => {
         const error = new Error('Fail to initialize');
         const methodId = CheckoutButtonMethodType.BRAINTREE_PAYPAL;
-        const action = createAction(CheckoutButtonActionType.DeinitializeButtonFailed, error, { methodId });
+        const containerId = 'foobar';
+        const action = createAction(CheckoutButtonActionType.DeinitializeButtonFailed, error, { methodId, containerId });
         const state = checkoutButtonReducer(initialState, action);
 
         expect(state.errors).toEqual({ braintreepaypal: { deinitializeError: error } });

--- a/src/checkout-buttons/checkout-button-reducer.ts
+++ b/src/checkout-buttons/checkout-button-reducer.ts
@@ -1,13 +1,15 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
 import { CheckoutButtonAction, CheckoutButtonActionType } from './checkout-button-actions';
-import CheckoutButtonState, { CheckoutButtonErrorsState, CheckoutButtonStatusesState } from './checkout-button-state';
+import CheckoutButtonState, { CheckoutButtonDataState, CheckoutButtonErrorsState, CheckoutButtonStatusesState } from './checkout-button-state';
 
 const DEFAULT_STATE: CheckoutButtonState = {
+    data: {},
     errors: {},
     statuses: {},
 };
 
+const DEFAULT_DATA_STATE: CheckoutButtonDataState = { initializedContainers: {} };
 const DEFAULT_ERROR_STATE: CheckoutButtonErrorsState = {};
 const DEFAULT_STATUS_STATE: CheckoutButtonStatusesState = {};
 
@@ -20,6 +22,9 @@ export default function checkoutButtonReducer(
     }
 
     const reducer = combineReducers<CheckoutButtonState>({
+        data: combineReducers({
+            [action.meta.methodId]: dataReducer,
+        }),
         errors: combineReducers({
             [action.meta.methodId]: errorsReducer,
         }),
@@ -29,6 +34,34 @@ export default function checkoutButtonReducer(
     });
 
     return reducer(state, action);
+}
+
+function dataReducer(
+    data: CheckoutButtonDataState = DEFAULT_DATA_STATE,
+    action: CheckoutButtonAction
+): CheckoutButtonDataState {
+    switch (action.type) {
+    case CheckoutButtonActionType.InitializeButtonSucceeded:
+        if (!action.meta || !action.meta.containerId) {
+            return data;
+        }
+
+        return {
+            ...data,
+            initializedContainers: {
+                ...data.initializedContainers,
+                [action.meta.containerId]: true,
+            },
+        };
+
+    case CheckoutButtonActionType.DeinitializeButtonSucceeded:
+        return {
+            ...data,
+            initializedContainers: {},
+        };
+    }
+
+    return data;
 }
 
 function errorsReducer(

--- a/src/checkout-buttons/checkout-button-selector.spec.ts
+++ b/src/checkout-buttons/checkout-button-selector.spec.ts
@@ -45,6 +45,35 @@ describe('CheckoutButtonSelector', () => {
         });
     });
 
+    describe('#isInitialized()', () => {
+        it('returns true if method is initialized', () => {
+            const selector = new CheckoutButtonSelector({
+                ...state,
+                data: {
+                    [CheckoutButtonMethodType.BRAINTREE_PAYPAL]: {
+                        initializedContainers: { isInitialized: true },
+                    },
+                },
+            });
+
+            expect(selector.isInitialized(CheckoutButtonMethodType.BRAINTREE_PAYPAL)).toEqual(true);
+        });
+
+        it('returns false if method is not initialized', () => {
+            const selector = new CheckoutButtonSelector({
+                ...state,
+                data: {
+                    [CheckoutButtonMethodType.BRAINTREE_PAYPAL]: {
+                        initializedContainers: { isInitialized: false },
+                    },
+                },
+            });
+
+            expect(selector.isInitialized(CheckoutButtonMethodType.BRAINTREE_PAYPAL)).toEqual(false);
+            expect(selector.isInitialized(CheckoutButtonMethodType.PAYPALEXPRESS)).toEqual(false);
+        });
+    });
+
     describe('#isDeinitializing()', () => {
         beforeEach(() => {
             state = {

--- a/src/checkout-buttons/checkout-button-selector.ts
+++ b/src/checkout-buttons/checkout-button-selector.ts
@@ -25,6 +25,20 @@ export default class CheckoutButtonSelector {
         return some(this._checkoutButton.statuses, { isInitializing: true });
     }
 
+    isInitialized(methodId: CheckoutButtonMethodType, containerId?: string): boolean {
+        const method = this._checkoutButton.data[methodId];
+
+        if (!method) {
+            return false;
+        }
+
+        if (!containerId) {
+            return some(method.initializedContainers, isInitialized => isInitialized === true);
+        }
+
+        return method.initializedContainers[containerId] === true;
+    }
+
     isDeinitializing(methodId?: CheckoutButtonMethodType): boolean {
         if (methodId) {
             const method = this._checkoutButton.statuses[methodId];

--- a/src/checkout-buttons/checkout-button-state.ts
+++ b/src/checkout-buttons/checkout-button-state.ts
@@ -1,11 +1,20 @@
 import { CheckoutButtonMethodType } from './strategies';
 
 export default interface CheckoutButtonState {
+    data: {
+        [key in CheckoutButtonMethodType]?: CheckoutButtonDataState | undefined
+    };
     errors: {
         [key in CheckoutButtonMethodType]?: CheckoutButtonErrorsState | undefined
     };
     statuses: {
         [key in CheckoutButtonMethodType]?: CheckoutButtonStatusesState | undefined
+    };
+}
+
+export interface CheckoutButtonDataState {
+    initializedContainers: {
+        [key: string]: boolean;
     };
 }
 

--- a/src/checkout-buttons/checkout-buttons.mock.ts
+++ b/src/checkout-buttons/checkout-buttons.mock.ts
@@ -2,6 +2,7 @@ import CheckoutButtonState from './checkout-button-state';
 
 export function getCheckoutButtonState(): CheckoutButtonState {
     return {
+        data: {},
         errors: {},
         statuses: {},
     };

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -155,22 +155,6 @@ describe('BraintreePaypalButtonStrategy', () => {
         }, 'checkout-button');
     });
 
-    it('renders PayPal checkout button once when same containerId is passed', async () => {
-        await strategy.initialize(options);
-        await strategy.initialize(options);
-
-        expect(paypal.Button.render).toHaveBeenCalledTimes(1);
-    });
-
-    it('renders PayPal checkout button once per containerId', async () => {
-        await strategy.initialize(options);
-        await strategy.initialize({ ...options, containerId: 'foo' });
-        await strategy.initialize(options);
-        await strategy.initialize({ ...options, containerId: 'foo' });
-
-        expect(paypal.Button.render).toHaveBeenCalledTimes(2);
-    });
-
     it('customizes style of PayPal checkout button', async () => {
         options = {
             ...options,

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -11,7 +11,7 @@ import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
-export default class BraintreePaypalButtonStrategy extends CheckoutButtonStrategy {
+export default class BraintreePaypalButtonStrategy implements CheckoutButtonStrategy {
     private _paypalCheckout?: BraintreePaypalCheckout;
     private _paymentMethod?: PaymentMethod;
 
@@ -22,15 +22,9 @@ export default class BraintreePaypalButtonStrategy extends CheckoutButtonStrateg
         private _paypalScriptLoader: PaypalScriptLoader,
         private _formPoster: FormPoster,
         private _offerCredit: boolean = false
-    ) {
-        super();
-    }
+    ) {}
 
     initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
-        if (this._isInitialized[options.containerId]) {
-            return super.initialize(options);
-        }
-
         const paypalOptions = (this._offerCredit ? options.braintreepaypalcredit : options.braintreepaypal) || {};
         const state = this._store.getState();
         const paymentMethod = this._paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId);
@@ -72,21 +66,16 @@ export default class BraintreePaypalButtonStrategy extends CheckoutButtonStrateg
                     payment: () => this._setupPayment(paypalOptions.onPaymentError),
                     onAuthorize: data => this._tokenizePayment(data, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
                 }, options.containerId);
-            })
-            .then(() => super.initialize(options));
+            });
     }
 
     deinitialize(): Promise<void> {
-        if (!Object.keys(this._isInitialized).length) {
-            return super.deinitialize();
-        }
-
         this._paypalCheckout = undefined;
         this._paymentMethod = undefined;
 
         this._braintreeSDKCreator.teardown();
 
-        return super.deinitialize();
+        return Promise.resolve();
     }
 
     private _setupPayment(onError?: (error: BraintreeError | StandardError) => void): Promise<string> {

--- a/src/checkout-buttons/strategies/checkout-button-strategy.ts
+++ b/src/checkout-buttons/strategies/checkout-button-strategy.ts
@@ -1,17 +1,7 @@
 import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
 
-export default abstract class CheckoutButtonStrategy {
-    protected _isInitialized: { [key: string]: boolean } = {};
+export default interface CheckoutButtonStrategy {
+    initialize(options: CheckoutButtonInitializeOptions): Promise<void>;
 
-    initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
-        this._isInitialized[options.containerId] = true;
-
-        return Promise.resolve();
-    }
-
-    deinitialize(): Promise<void> {
-        this._isInitialized = {};
-
-        return Promise.resolve();
-    }
+    deinitialize(): Promise<void>;
 }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -7,7 +7,7 @@ import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
-export default class GooglePayButtonStrategy extends CheckoutButtonStrategy {
+export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
     private _methodId?: string;
     private _walletButton?: HTMLElement;
 
@@ -16,9 +16,7 @@ export default class GooglePayButtonStrategy extends CheckoutButtonStrategy {
         private _formPoster: FormPoster,
         private _checkoutActionCreator: CheckoutActionCreator,
         private _googlePayPaymentProcessor: GooglePayPaymentProcessor
-    ) {
-        super();
-    }
+    ) {}
 
     initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
         const { containerId, methodId } = options;
@@ -27,32 +25,22 @@ export default class GooglePayButtonStrategy extends CheckoutButtonStrategy {
             throw new InvalidArgumentError('Unable to proceed because "containerId" argument is not provided.');
         }
 
-        if (this._isInitialized[containerId]) {
-            return super.initialize(options);
-        }
-
         this._methodId = methodId;
 
         return this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout())
-            .then(() => this._googlePayPaymentProcessor.initialize(this._getMethodId())
-                .then(() => {
-                    this._walletButton = this._createSignInButton(containerId);
-                })
-            ).then(() => super.initialize(options));
+            .then(() => this._googlePayPaymentProcessor.initialize(this._getMethodId()))
+            .then(() => {
+                this._walletButton = this._createSignInButton(containerId);
+            });
     }
 
     deinitialize(): Promise<void> {
-        if (!this._isInitialized) {
-            return super.deinitialize();
-        }
-
         if (this._walletButton && this._walletButton.parentNode) {
             this._walletButton.parentNode.removeChild(this._walletButton);
             this._walletButton = undefined;
         }
 
-        return this._googlePayPaymentProcessor.deinitialize()
-            .then(() => super.deinitialize());
+        return this._googlePayPaymentProcessor.deinitialize();
     }
 
     private _createSignInButton(containerId: string): HTMLElement {

--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
@@ -95,10 +95,6 @@ describe('MasterpassCustomerStrategy', () => {
         document.body.removeChild(containerFoo);
     });
 
-    it('creates an instance of MasterpassCustomerStrategy', () => {
-        expect(strategy).toBeInstanceOf(CheckoutButtonStrategy);
-    });
-
     describe('#initialize()', () => {
         let masterpassOptions: CheckoutButtonInitializeOptions;
         const methodId = CheckoutButtonMethodType.MASTERPASS;
@@ -123,34 +119,12 @@ describe('MasterpassCustomerStrategy', () => {
             expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(false);
         });
 
-        it('loads masterpass once per container', async () => {
-            paymentMethodMock.config.testMode = false;
-
-            await strategy.initialize(masterpassOptions);
-            await strategy.initialize({ ...masterpassOptions, containerId: 'foo' });
-            await strategy.initialize(masterpassOptions);
-            await strategy.initialize({ ...masterpassOptions, containerId: 'foo' });
-
-            expect(masterpassScriptLoader.load).toHaveBeenCalledTimes(2);
-        });
-
         it('fails to initialize the strategy if no container is supplied', async () => {
             masterpassOptions = { methodId, containerId: '' };
             try {
                 await strategy.initialize(masterpassOptions);
             } catch (e) {
                 expect(e).toBeInstanceOf(InvalidArgumentError);
-            }
-        });
-
-        it('fails to initialize the strategy if no cart is supplied', async () => {
-            jest.spyOn(store.getState().checkout, 'getCheckout')
-                .mockReturnValue(undefined);
-            try {
-                await strategy.initialize(masterpassOptions);
-                expect(strategy).toBeInstanceOf(CheckoutButtonStrategy);
-            } catch (e) {
-                expect(e).toBeInstanceOf(MissingDataError);
             }
         });
 

--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.ts
@@ -1,4 +1,3 @@
-import { CheckoutButtonInitializeOptions } from '../..';
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import {
     InvalidArgumentError,
@@ -8,16 +7,12 @@ import {
     NotInitializedErrorType
 } from '../../../common/error/errors';
 import { bindDecorator as bind } from '../../../common/utility';
-import {
-    getCallbackUrl,
-    Masterpass,
-    MasterpassCheckoutOptions,
-    MasterpassScriptLoader
-} from '../../../payment/strategies/masterpass';
+import { getCallbackUrl, Masterpass, MasterpassCheckoutOptions, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
-export default class MasterpassButtonStrategy extends CheckoutButtonStrategy {
+export default class MasterpassButtonStrategy implements CheckoutButtonStrategy {
     private _masterpassClient?: Masterpass;
     private _methodId?: string;
     private _signInButton?: HTMLElement;
@@ -26,19 +21,13 @@ export default class MasterpassButtonStrategy extends CheckoutButtonStrategy {
         private _store: CheckoutStore,
         private _checkoutActionCreator: CheckoutActionCreator,
         private _masterpassScriptLoader: MasterpassScriptLoader
-    ) {
-        super();
-    }
+    ) {}
 
     initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
         const { containerId, methodId } = options;
 
         if (!containerId || !methodId) {
             throw new InvalidArgumentError('Unable to proceed because "containerId" argument is not provided.');
-        }
-
-        if (this._isInitialized[containerId]) {
-            return super.initialize(options);
         }
 
         this._methodId = methodId;
@@ -56,23 +45,17 @@ export default class MasterpassButtonStrategy extends CheckoutButtonStrategy {
             .then(masterpass => {
                 this._masterpassClient = masterpass;
                 this._signInButton = this._createSignInButton(containerId);
-
-                return super.initialize(options);
             });
     }
 
     deinitialize(): Promise<void> {
-        if (!this._isInitialized) {
-            return super.deinitialize();
-        }
-
         if (this._signInButton && this._signInButton.parentNode) {
             this._signInButton.removeEventListener('click', this._handleWalletButtonClick);
             this._signInButton.parentNode.removeChild(this._signInButton);
             this._signInButton = undefined;
         }
 
-        return super.deinitialize();
+        return Promise.resolve();
     }
 
     private _createSignInButton(containerId: string): HTMLElement {

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
@@ -10,22 +10,16 @@ import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
-export default class PaypalButtonStrategy extends CheckoutButtonStrategy {
+export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
     private _paymentMethod?: PaymentMethod;
 
     constructor(
         private _store: CheckoutStore,
         private _paypalScriptLoader: PaypalScriptLoader,
         private _formPoster: FormPoster
-    ) {
-        super();
-    }
+    ) {}
 
     initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
-        if (this._isInitialized[options.containerId]) {
-            return super.initialize(options);
-        }
-
         const paypalOptions = options.paypal;
         const state = this._store.getState();
         const paymentMethod = this._paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId);
@@ -68,18 +62,13 @@ export default class PaypalButtonStrategy extends CheckoutButtonStrategy {
                     payment: (data, actions) => this._setupPayment(merchantId, actions, paypalOptions.onPaymentError),
                     onAuthorize: (data, actions) => this._tokenizePayment(data, actions, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
                 }, options.containerId);
-            })
-            .then(() => super.initialize(options));
+            });
     }
 
     deinitialize(): Promise<void> {
-        if (!Object.keys(this._isInitialized).length) {
-            return super.deinitialize();
-        }
-
         this._paymentMethod = undefined;
 
-        return super.deinitialize();
+        return Promise.resolve();
     }
 
     private _setupPayment(merchantId: string, actions?: PaypalActions, onError?: (error: StandardError) => void): Promise<string> {

--- a/src/payment/strategies/masterpass/get-callback-url.ts
+++ b/src/payment/strategies/masterpass/get-callback-url.ts
@@ -1,0 +1,3 @@
+export default function getCallbackUrl(origin: string): string {
+    return `${window.location.origin}/checkout.php?action=set_external_checkout&provider=masterpass&gateway=stripe&origin=${origin}`;
+}

--- a/src/payment/strategies/masterpass/index.ts
+++ b/src/payment/strategies/masterpass/index.ts
@@ -1,4 +1,6 @@
 export * from './masterpass';
+
+export { default as getCallbackUrl } from './get-callback-url';
 export { default as MasterpassScriptLoader } from './masterpass-script-loader';
 export { default as MasterpassPaymentStrategy } from './masterpass-payment-strategy';
-export { MasterpassPaymentInitializeOptions } from './masterpass-payment-initialize-options';
+export { default as MasterpassPaymentInitializeOptions } from './masterpass-payment-initialize-options';

--- a/src/payment/strategies/masterpass/masterpass-payment-initialize-options.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-initialize-options.ts
@@ -1,4 +1,4 @@
-export interface MasterpassPaymentInitializeOptions {
+export default interface MasterpassPaymentInitializeOptions {
     /**
      * This walletButton is used to set an event listener, provide an element ID if you want
      * users to be able to launch the ChasePay wallet modal by clicking on a button.

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.ts
@@ -11,7 +11,8 @@ import { bindDecorator as bind } from '../../../common/utility';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import PaymentMethod from '../../payment-method';
 
-import { getCallbackUrl, Masterpass, MasterpassCheckoutOptions } from './masterpass';
+import getCallbackUrl from './get-callback-url';
+import { Masterpass, MasterpassCheckoutOptions } from './masterpass';
 import MasterpassScriptLoader from './masterpass-script-loader';
 
 export default class MasterpassPaymentStrategy extends PaymentStrategy {

--- a/src/payment/strategies/masterpass/masterpass.ts
+++ b/src/payment/strategies/masterpass/masterpass.ts
@@ -52,7 +52,3 @@ export interface MasterpassCheckoutOptions {
      */
     suppressShippingAddress?: boolean;
 }
-
-export function getCallbackUrl(origin: string): string {
-    return `${window.location.origin}/checkout.php?action=set_external_checkout&provider=masterpass&gateway=stripe&origin=${origin}`;
-}


### PR DESCRIPTION
## What?
1. Convert `CheckoutButtonStrategy` from an abstract class into a plain interface.
1. Check the `isInitialized` flag in a central location rather than checking it individually for every shipping strategy.

## Why?
1. Prefer not to keep the abstract class around because it usually encourages us to move shared behaviours up to the parent class rather than sharing behaviours via composition.
1. Strategies shouldn't have to perform the initialisation check themselves. Currently we do, but often we forget to implement the check. So it's better to move the check out to the upper layer.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
