### PR TITLE
CHECKOUT-3791: Convert payment strategy into interface

### DIFF
--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -130,7 +130,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         order: { errors: {}, statuses: {} },
         payment: getPaymentState(),
         paymentMethods: getPaymentMethodsState(),
-        paymentStrategies: { errors: {}, statuses: {} },
+        paymentStrategies: { data: {}, errors: {}, statuses: {} },
         remoteCheckout: getRemoteCheckoutState(),
         shippingCountries: getShippingCountriesState(),
         shippingStrategies: { data: {}, errors: {}, statuses: {} },

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -104,6 +104,10 @@ export default class PaymentStrategyActionCreator {
                 throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
             }
 
+            if (methodId && state.paymentStrategies.isInitialized(methodId)) {
+                return observer.complete();
+            }
+
             observer.next(createAction(PaymentStrategyActionType.InitializeRequested, undefined, { methodId }));
 
             this._strategyRegistry.getByMethod(method)
@@ -126,6 +130,10 @@ export default class PaymentStrategyActionCreator {
 
             if (!method) {
                 throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            if (methodId && !state.paymentStrategies.isInitialized(methodId)) {
+                return observer.complete();
             }
 
             observer.next(createAction(PaymentStrategyActionType.DeinitializeRequested, undefined, { methodId }));

--- a/src/payment/payment-strategy-reducer.ts
+++ b/src/payment/payment-strategy-reducer.ts
@@ -1,18 +1,44 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
 import { PaymentStrategyAction, PaymentStrategyActionType } from './payment-strategy-actions';
-import PaymentStrategyState, { DEFAULT_STATE, PaymentStrategyErrorsState, PaymentStrategyStatusesState } from './payment-strategy-state';
+import PaymentStrategyState, { DEFAULT_STATE, PaymentStrategyDataState, PaymentStrategyErrorsState, PaymentStrategyStatusesState } from './payment-strategy-state';
 
 export default function paymentStrategyReducer(
     state: PaymentStrategyState = DEFAULT_STATE,
     action: PaymentStrategyAction
 ): PaymentStrategyState {
     const reducer = combineReducers<PaymentStrategyState, PaymentStrategyAction>({
+        data: dataReducer,
         errors: errorsReducer,
         statuses: statusesReducer,
     });
 
     return reducer(state, action);
+}
+
+function dataReducer(
+    data: PaymentStrategyDataState = DEFAULT_STATE.data,
+    action: PaymentStrategyAction
+): PaymentStrategyDataState {
+    switch (action.type) {
+    case PaymentStrategyActionType.InitializeSucceeded:
+        return {
+            ...data,
+            [action.meta && action.meta.methodId]: {
+                isInitialized: true,
+            },
+        };
+
+    case PaymentStrategyActionType.DeinitializeSucceeded:
+        return {
+            ...data,
+            [action.meta && action.meta.methodId]: {
+                isInitialized: false,
+            },
+        };
+    }
+
+    return data;
 }
 
 function errorsReducer(

--- a/src/payment/payment-strategy-selector.ts
+++ b/src/payment/payment-strategy-selector.ts
@@ -48,6 +48,13 @@ export default class PaymentStrategySelector {
         return !!this._paymentStrategies.statuses.isInitializing;
     }
 
+    isInitialized(methodId: string): boolean {
+        return !!(
+            this._paymentStrategies.data[methodId] &&
+            this._paymentStrategies.data[methodId].isInitialized
+        );
+    }
+
     isExecuting(methodId?: string): boolean {
         if (methodId && this._paymentStrategies.statuses.executeMethodId !== methodId) {
             return false;

--- a/src/payment/payment-strategy-state.ts
+++ b/src/payment/payment-strategy-state.ts
@@ -1,6 +1,13 @@
 export default interface PaymentStrategyState {
+    data: PaymentStrategyDataState;
     errors: PaymentStrategyErrorsState;
     statuses: PaymentStrategyStatusesState;
+}
+
+export interface PaymentStrategyDataState {
+    [key: string]: {
+        isInitialized: boolean,
+    };
 }
 
 export interface PaymentStrategyErrorsState {
@@ -30,6 +37,7 @@ export interface PaymentStrategyStatusesState {
 }
 
 export const DEFAULT_STATE: PaymentStrategyState = {
+    data: {},
     errors: {},
     statuses: {},
 };

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -13,6 +13,7 @@ import { InvalidArgumentError, MissingDataError, RequestError } from '../../../c
 import { getErrorResponse } from '../../../common/http-request/responses.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { getRemoteCheckoutState, getRemoteCheckoutStateData } from '../../../remote-checkout/remote-checkout.mock';
@@ -425,5 +426,13 @@ describe('AmazonPayPaymentStrategy', () => {
 
         expect(store.dispatch).toHaveBeenCalledWith(initializeBillingAction);
         expect(store.dispatch).not.toHaveBeenCalledWith(updateAddressAction);
+    });
+
+    it('throws error to inform that order finalization is not required', async () => {
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
     });
 });

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -9,6 +9,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutVali
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { MissingDataError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
@@ -220,6 +221,16 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
             await braintreeCreditCardPaymentStrategy.deinitialize();
 
             expect(braintreePaymentProcessorMock.deinitialize).toHaveBeenCalled();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await braintreeCreditCardPaymentStrategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
         });
     });
 });

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -6,6 +6,7 @@ import { createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { MissingDataError, StandardError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { NonceInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
@@ -236,6 +237,16 @@ describe('BraintreePaypalPaymentStrategy', () => {
             await braintreePaypalPaymentStrategy.deinitialize({ methodId: paymentMethodMock.id });
 
             expect(braintreePaymentProcessorMock.deinitialize).toHaveBeenCalled();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await braintreePaypalPaymentStrategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
         });
     });
 });

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -3,36 +3,33 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { of, Observable } from 'rxjs';
 
-import {
-    createPaymentClient,
-    createPaymentStrategyRegistry,
-    PaymentActionCreator,
-    PaymentInitializeOptions,
-    PaymentMethod,
-    PaymentMethodActionCreator,
-    PaymentRequestSender,
-    PaymentStrategyActionCreator,
-} from '../..';
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
+import createPaymentClient from '../../create-payment-client';
+import createPaymentStrategyRegistry from '../../create-payment-strategy-registry';
+import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getBraintreeVisaCheckout } from '../../payment-methods.mock';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
 import { PaymentStrategyActionType } from '../../payment-strategy-actions';
 
-import {
-    createBraintreeVisaCheckoutPaymentProcessor,
-    BraintreeVisaCheckoutPaymentProcessor,
-    BraintreeVisaCheckoutPaymentStrategy,
-    VisaCheckoutScriptLoader,
-} from '.';
+import BraintreeVisaCheckoutPaymentProcessor from './braintree-visacheckout-payment-processor';
+import BraintreeVisaCheckoutPaymentStrategy from './braintree-visacheckout-payment-strategy';
+import createBraintreeVisaCheckoutPaymentProcessor from './create-braintree-visacheckout-payment-processor';
 import { VisaCheckoutSDK } from './visacheckout';
+import VisaCheckoutScriptLoader from './visacheckout-script-loader';
 
 describe('BraintreeVisaCheckoutPaymentStrategy', () => {
     let braintreeVisaCheckoutPaymentProcessor: BraintreeVisaCheckoutPaymentProcessor;
@@ -311,6 +308,16 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
         it('deinitializes BraintreeVisaCheckoutPaymentProcessor', async () => {
             await strategy.deinitialize();
             expect(braintreeVisaCheckoutPaymentProcessor.deinitialize).toHaveBeenCalled();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await strategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
         });
     });
 });

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
@@ -12,6 +12,7 @@ import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createPaymentClient, createPaymentStrategyRegistry, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { getChasePay, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
@@ -452,7 +453,15 @@ describe('ChasePayPaymentStrategy', () => {
             await strategy.deinitialize();
             expect(await strategy.deinitialize()).toEqual(store.getState());
         });
-
     });
 
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await strategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
+        });
+    });
 });

--- a/src/payment/strategies/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card-payment-strategy.spec.ts
@@ -6,6 +6,7 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../order';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import { getOrderRequestBody } from '../../order/internal-orders.mock';
 import PaymentActionCreator from '../payment-action-creator';
 import { PaymentActionType } from '../payment-actions';
@@ -70,5 +71,13 @@ describe('CreditCardPaymentStrategy', () => {
         const output = await strategy.execute(getOrderRequestBody());
 
         expect(output).toEqual(store.getState());
+    });
+
+    it('throws error to inform that order finalization is not required', async () => {
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
     });
 });

--- a/src/payment/strategies/credit-card-payment-strategy.ts
+++ b/src/payment/strategies/credit-card-payment-strategy.ts
@@ -1,19 +1,18 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
 import { OrderActionCreator, OrderRequestBody } from '../../order';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import { PaymentArgumentInvalidError } from '../errors';
 import PaymentActionCreator from '../payment-action-creator';
-import { PaymentRequestOptions } from '../payment-request-options';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../payment-request-options';
 
 import PaymentStrategy from './payment-strategy';
 
-export default class CreditCardPaymentStrategy extends PaymentStrategy {
+export default class CreditCardPaymentStrategy implements PaymentStrategy {
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator
-    ) {
-        super(store);
-    }
+    ) {}
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const { payment, ...order } = payload;
@@ -27,5 +26,17 @@ export default class CreditCardPaymentStrategy extends PaymentStrategy {
             .then(() =>
                 this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }))
             );
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -14,6 +14,7 @@ import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import {
     createPaymentClient,
     createPaymentStrategyRegistry,
@@ -25,7 +26,6 @@ import {
     PaymentRequestSender,
     PaymentStrategyActionCreator
 } from '../../../payment';
-
 import { getGooglePay, getPaymentMethodsState } from '../../payment-methods.mock';
 
 import createGooglePayPaymentProcessor from './create-googlepay-payment-processor';
@@ -346,6 +346,16 @@ describe('GooglePayPaymentStrategy', () => {
             } catch (error) {
                 expect(error).toBeInstanceOf(MissingDataError);
                 expect(error).toEqual(new MissingDataError(MissingDataErrorType.MissingPayment));
+            }
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await strategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
             }
         });
     });

--- a/src/payment/strategies/legacy-payment-strategy.spec.ts
+++ b/src/payment/strategies/legacy-payment-strategy.spec.ts
@@ -4,6 +4,7 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../order';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import { getOrderRequestBody } from '../../order/internal-orders.mock';
 
 import LegacyPaymentStrategy from './legacy-payment-strategy';
@@ -41,5 +42,13 @@ describe('LegacyPaymentStrategy', () => {
         const output = await strategy.execute(getOrderRequestBody());
 
         expect(output).toEqual(store.getState());
+    });
+
+    it('throws error to inform that order finalization is not required', async () => {
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
     });
 });

--- a/src/payment/strategies/legacy-payment-strategy.ts
+++ b/src/payment/strategies/legacy-payment-strategy.ts
@@ -1,18 +1,29 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
 import { OrderActionCreator, OrderRequestBody } from '../../order';
-import { PaymentRequestOptions } from '../payment-request-options';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../payment-request-options';
 
 import PaymentStrategy from './payment-strategy';
 
-export default class LegacyPaymentStrategy extends PaymentStrategy {
+export default class LegacyPaymentStrategy implements PaymentStrategy {
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator
-    ) {
-        super(store);
-    }
+    ) {}
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         return this._store.dispatch(this._orderActionCreator.submitOrder(payload, options));
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/no-payment-data-required-strategy.spec.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.spec.ts
@@ -5,6 +5,7 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../order';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
 import { getOrderRequestBody } from '../../order/internal-orders.mock';
 
 import { NoPaymentDataRequiredPaymentStrategy } from '.';
@@ -44,6 +45,16 @@ describe('NoPaymentDataRequiredPaymentStrategy', () => {
             await noPaymentDataRequiredPaymentStrategy.execute(getOrderRequestBody(), options);
 
             expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(expect.any(Object), options);
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await noPaymentDataRequiredPaymentStrategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
         });
     });
 });

--- a/src/payment/strategies/no-payment-data-required-strategy.ts
+++ b/src/payment/strategies/no-payment-data-required-strategy.ts
@@ -2,21 +2,32 @@ import { omit } from 'lodash';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
 import { OrderActionCreator, OrderRequestBody } from '../../order';
-import { PaymentRequestOptions } from '../payment-request-options';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../payment-request-options';
 
 import PaymentStrategy from './payment-strategy';
 
-export default class NoPaymentDataRequiredPaymentStrategy extends PaymentStrategy {
+export default class NoPaymentDataRequiredPaymentStrategy implements PaymentStrategy {
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator
-    ) {
-        super(store);
-    }
+    ) {}
 
     execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         return this._store.dispatch(
             this._orderActionCreator.submitOrder(omit(orderRequest, 'payment'), options)
         );
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/offline-payment-strategy.ts
+++ b/src/payment/strategies/offline-payment-strategy.ts
@@ -1,16 +1,15 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
 import { OrderActionCreator, OrderRequestBody } from '../../order';
-import { PaymentRequestOptions } from '../payment-request-options';
+import { OrderFinalizationNotRequiredError } from '../../order/errors';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../payment-request-options';
 
 import PaymentStrategy from './payment-strategy';
 
-export default class OfflinePaymentStrategy extends PaymentStrategy {
+export default class OfflinePaymentStrategy implements PaymentStrategy {
     constructor(
-        store: CheckoutStore,
+        private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator
-    ) {
-        super(store);
-    }
+    ) {}
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const action = this._orderActionCreator.submitOrder({
@@ -19,5 +18,17 @@ export default class OfflinePaymentStrategy extends PaymentStrategy {
         }, options);
 
         return this._store.dispatch(action);
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/payment-strategy.ts
+++ b/src/payment/strategies/payment-strategy.ts
@@ -1,31 +1,14 @@
-import { CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
+import { InternalCheckoutSelectors } from '../../checkout';
 import { OrderRequestBody } from '../../order';
-import { OrderFinalizationNotRequiredError } from '../../order/errors';
 
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../payment-request-options';
 
-export default abstract class PaymentStrategy {
-    protected _isInitialized = false;
+export default interface PaymentStrategy {
+    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>;
 
-    constructor(
-        protected _store: CheckoutStore
-    ) {}
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>;
 
-    abstract execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>;
+    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors>;
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        return Promise.reject(new OrderFinalizationNotRequiredError());
-    }
-
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
-        this._isInitialized = true;
-
-        return Promise.resolve(this._store.getState());
-    }
-
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        this._isInitialized = false;
-
-        return Promise.resolve(this._store.getState());
-    }
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>;
 }

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
@@ -8,6 +8,7 @@ import { of, Observable } from 'rxjs';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState, getCheckoutWithPayments } from '../../../checkout/checkouts.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
@@ -74,6 +75,14 @@ describe('PaypalProPaymentStrategy', () => {
         const output = await strategy.execute(getOrderRequestBody());
 
         expect(output).toEqual(store.getState());
+    });
+
+    it('throws error to inform that order finalization is not required', async () => {
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
     });
 
     describe('if payment is acknowledged', () => {

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -34,12 +34,12 @@ import ConfigActionCreator from '../../../config/config-action-creator';
 import ConfigRequestSender from '../../../config/config-request-sender';
 import { getConfigState } from '../../../config/configs.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getPaymentMethodsState, getSquare } from '../../../payment/payment-methods.mock';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
 
 import { SquarePaymentForm, SquarePaymentStrategy, SquareScriptLoader } from './';
-
 import { DigitalWalletType, SquareFormCallbacks, SquareFormOptions } from './square-form';
 import {
     getCardData,
@@ -390,6 +390,16 @@ describe('SquarePaymentStrategy', () => {
                     });
                 });
             });
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await strategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
         });
     });
 });


### PR DESCRIPTION
## What?
1. Convert `PaymentStrategy` from an abstract class into a plain interface.
1. Check the `isInitialized` flag in a central location rather than checking it individually for every shipping strategy.

## Why?
1. Prefer not to keep the abstract class around because it usually encourages us to move shared behaviours up to the parent class rather than sharing behaviours via composition.
1. Strategies shouldn't have to perform the initialisation check themselves. Currently we do, but often we forget to implement the check. So it's better to move the check out to the upper layer.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
