### PR TITLE
fix(payment): INT-1079 Add taxTotal in map to internal order

### DIFF
--- a/src/order/internal-order.ts
+++ b/src/order/internal-order.ts
@@ -33,6 +33,10 @@ export default interface InternalOrder {
         amount: number;
     };
     taxes: Array<{ name: string, amount: number }>;
+    taxTotal: {
+        amount: number;
+        integerAmount: number;
+    };
     handling: {
         amount: number;
         integerAmount: number;

--- a/src/order/internal-orders.mock.ts
+++ b/src/order/internal-orders.mock.ts
@@ -170,6 +170,10 @@ export function getCompleteOrder(): InternalOrder {
                 amount: 3,
             },
         ],
+        taxTotal: {
+            amount: 0,
+            integerAmount: 0,
+        },
         handling: {
             amount: 8,
             integerAmount: 800,

--- a/src/order/internal-orders.mock.ts
+++ b/src/order/internal-orders.mock.ts
@@ -171,8 +171,8 @@ export function getCompleteOrder(): InternalOrder {
             },
         ],
         taxTotal: {
-            amount: 0,
-            integerAmount: 0,
+            amount: 3,
+            integerAmount: 300,
         },
         handling: {
             amount: 8,

--- a/src/order/map-to-internal-order.ts
+++ b/src/order/map-to-internal-order.ts
@@ -59,6 +59,10 @@ export default function mapToInternalOrder(order: Order, orderMeta: OrderMetaSta
             amount: mapToStoreCredit(order.payments),
         },
         taxes: order.taxes,
+        taxTotal: {
+            amount: order.taxTotal,
+            integerAmount: amountTransformer.toInteger(order.taxTotal),
+        },
         handling: {
             amount: order.handlingCostTotal,
             integerAmount: amountTransformer.toInteger(order.handlingCostTotal),

--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -26,6 +26,7 @@ export default interface Order {
     shippingCostBeforeDiscount: number;
     handlingCostTotal: number;
     taxes: Tax[];
+    taxTotal: number;
     payments?: OrderPayments;
     status: string;
 }

--- a/src/order/orders.mock.ts
+++ b/src/order/orders.mock.ts
@@ -43,7 +43,7 @@ export function getOrder(): Order {
                 amount: 3,
             },
         ],
-        taxTotal: 0,
+        taxTotal: 3,
         shippingCostTotal: 15,
         shippingCostBeforeDiscount: 20,
         handlingCostTotal: 8,

--- a/src/order/orders.mock.ts
+++ b/src/order/orders.mock.ts
@@ -43,6 +43,7 @@ export function getOrder(): Order {
                 amount: 3,
             },
         ],
+        taxTotal: 0,
         shippingCostTotal: 15,
         shippingCostBeforeDiscount: 20,
         handlingCostTotal: 8,


### PR DESCRIPTION
## What? [INT-1079](https://jira.bigcommerce.com/browse/INT-1079)
This PR adds the object `taxTotal` to the `map-to-internal-order`(also we add the interfaces for `order` and `internal-order` and their corresponding mocks), so once the information reach `bigpay-client`, it will catch the `taxTotal` and map it correctly. Currently `checkout-sdk-js` is not sending `taxTotal` as part of the payload received by `bigpay-client` and this creates a bug in `bigpay`.

## Why?
There was an issue where the transaction_rbits were not generated because `taxTotal` was not sent to `bigpay-client` and this creates a bug in `bigpay`. This fixes the issue on `checkout-sdk-js`.

## Testing / Proof
![image](https://user-images.githubusercontent.com/1013633/49907691-e9466e00-fe3c-11e8-82f0-d635bbb12f19.png)
![image](https://user-images.githubusercontent.com/1013633/49903063-87313d00-fe2b-11e8-8fe8-72d8ab1a3223.png)
[Video of a purchase using Chasepay+Wepay](https://drive.google.com/file/d/1GxGy0fU_u4amneDBVmfT6HUQ8L0dIUvf/view?usp=sharing)

This PR depends on bigcommerce/bigcommerce#27647

@vmparra @clopezh @cbandam  @bigcommerce/checkout 
