### PR TITLE
CHECKOUT-3804: Set unique container ID if not provided by client

### DIFF
--- a/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -53,6 +53,38 @@ describe('CheckoutButtonInitializer', () => {
         );
     });
 
+    it('dispatches multiple actions to initialize button strategy if multiple containers can be found', async () => {
+        const container = document.createElement('div');
+        container.className = 'checkout-button';
+
+        const containers: HTMLElement[] = [];
+        containers.push(container);
+        containers.push(container.cloneNode() as HTMLElement);
+        containers.push(container.cloneNode() as HTMLElement);
+        containers.forEach(container => document.body.appendChild(container));
+
+        const options = {
+            methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL,
+            containerId: '.checkout-button',
+        };
+
+        await initializer.initializeButton(options);
+
+        expect(buttonActionCreator.initialize).toHaveBeenCalledTimes(3);
+        expect(buttonActionCreator.initialize).toHaveBeenCalledWith({
+            ...options,
+            containerId: expect.stringMatching(new RegExp(`${options.methodId}-container.+`)),
+        });
+
+        expect(store.dispatch).toHaveBeenCalledTimes(3);
+        expect(store.dispatch).toHaveBeenCalledWith(
+            buttonActionCreator.initialize(options),
+            { queueId: expect.stringMatching(new RegExp(`checkoutButtonStrategy:${options.methodId}:${options.methodId}-container.+`)) }
+        );
+
+        containers.forEach(container => container.remove());
+    });
+
     it('dispatches action to deinitialize button strategy', async () => {
         const options = {
             methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL,

--- a/src/common/dom/index.ts
+++ b/src/common/dom/index.ts
@@ -1,0 +1,2 @@
+export { default as isElementId } from './is-element-id';
+export { default as setUniqueElementId } from './set-unique-element-id';

--- a/src/common/dom/is-element-id.spec.ts
+++ b/src/common/dom/is-element-id.spec.ts
@@ -1,0 +1,25 @@
+import isElementId from './is-element-id';
+
+describe('isElementId()', () => {
+    it('returns true if string is valid element ID', () => {
+        expect(isElementId('foobar'))
+            .toEqual(true);
+
+        expect(isElementId('FOOBAR'))
+            .toEqual(true);
+
+        expect(isElementId('foo-bar'))
+            .toEqual(true);
+    });
+
+    it('returns false if string is not valid element ID', () => {
+        expect(isElementId('.foobar'))
+            .toEqual(false);
+
+        expect(isElementId('[foobar]'))
+            .toEqual(false);
+
+        expect(isElementId('#foobar'))
+            .toEqual(false);
+    });
+});

--- a/src/common/dom/is-element-id.ts
+++ b/src/common/dom/is-element-id.ts
@@ -1,0 +1,3 @@
+export default function isElementId(id: string): boolean {
+    return /^\w[\w\-\:\.]*$/.test(id);
+}

--- a/src/common/dom/set-unique-element-id.spec.ts
+++ b/src/common/dom/set-unique-element-id.spec.ts
@@ -1,0 +1,53 @@
+import { uniq } from 'lodash';
+
+import setUniqueElementId from './set-unique-element-id';
+
+describe('setUniqueElementId()', () => {
+    let className: string;
+    let elements: HTMLElement[];
+
+    beforeEach(() => {
+        className = 'foobar';
+        elements = [];
+
+        const element = document.createElement('div');
+        element.className = className;
+
+        elements.push(element);
+        elements.push(element.cloneNode() as HTMLElement);
+        elements.push(element.cloneNode() as HTMLElement);
+        elements.forEach(element => document.body.appendChild(element));
+    });
+
+    afterEach(() => {
+        elements.forEach(element => element.remove());
+    });
+
+    it('sets element id if not already set', () => {
+        const output = setUniqueElementId(`.${className}`, 'container');
+
+        expect(output)
+            .toEqual([
+                expect.stringMatching(/^container.+/),
+                expect.stringMatching(/^container.+/),
+                expect.stringMatching(/^container.+/),
+            ]);
+
+        expect(uniq(output).length)
+            .toEqual(output.length);
+
+        expect(elements.map(element => element.id))
+            .toEqual(output);
+    });
+
+    it('does not set element id if already set', () => {
+        elements[0].id = 'hello-world';
+
+        expect(setUniqueElementId(`.${className}`, 'container'))
+            .toEqual([
+                'hello-world',
+                expect.stringMatching(/^container.+/),
+                expect.stringMatching(/^container.+/),
+            ]);
+    });
+});

--- a/src/common/dom/set-unique-element-id.ts
+++ b/src/common/dom/set-unique-element-id.ts
@@ -1,0 +1,20 @@
+import { uniqueId } from 'lodash';
+
+import { InvalidArgumentError } from '../error/errors';
+
+export default function setUniqueElementId(selector: string, idPrefix: string): string[] {
+    const containers = document.querySelectorAll(selector);
+
+    if (!containers.length) {
+        throw new InvalidArgumentError(`Unable to find any element with the specified selector: ${selector}`);
+    }
+
+    return Array.prototype.slice.call(containers)
+        .map((container: HTMLElement) => {
+            if (!container.id) {
+                container.id = uniqueId(idPrefix);
+            }
+
+            return container.id;
+        });
+}


### PR DESCRIPTION
## What?
* Set unique container ID if not provided by client.
* For example, you can now pass in a CSS selector instead of an element ID. If one or more elements can be found, each of them will be configured with an unique element ID and get initialised accordingly.
```js
initializer.initializeButton({
    methodId: 'braintreepaypal',
    containerId: '[data-braintree-paypal-container]',
});
```

## Why?
* This is because some themes render `cart.additional_checkout_buttons` snippet multiple times. We can't generate a unique ID for each snippet on the server side because we only render the snippet once. For multiple occurrences of `cart.additional_checkout_buttons`, we simply reuse the same rendered output. Therefore, we need to generate unique element IDs on the client side instead.

## Testing / Proof
* Unit
* Manual
<img width="161" alt="screen shot 2018-12-13 at 1 48 41 pm" src="https://user-images.githubusercontent.com/667603/49912999-113add80-fee0-11e8-9cd3-2c6f278c496f.png">

@bigcommerce/checkout @bigcommerce/payments
