### PR TITLE
CHECKOUT-3790: Add missing properties to `StoreLinks` object

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -56,6 +56,8 @@ export interface PaymentSettings {
 export interface StoreLinks {
     cartLink: string;
     checkoutLink: string;
+    createAccountLink: string;
+    forgotPasswordLink: string;
     orderConfirmationLink: string;
 }
 

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -49,8 +49,10 @@ export function getConfig(): Config {
             },
             links: {
                 cartLink: 'https://store-k1drp8k8.bcapp.dev/cart.php',
-                checkoutLink: '/checkout',
-                orderConfirmationLink: '/checkout/order-confirmation',
+                checkoutLink: 'https://store-k1drp8k8.bcapp.dev/checkout',
+                createAccountLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=create_account',
+                forgotPasswordLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password',
+                orderConfirmationLink: 'https://store-k1drp8k8.bcapp.dev/checkout/order-confirmation',
             },
             paymentSettings: {
                 bigpayBaseUrl: 'https://bigpay.integration.zone',


### PR DESCRIPTION
## What?
* Add missing properties to `StoreLinks` object.

## Why?
* They exist in runtime. But they are not defined in the definition file, therefore not visible to the TS compiler.

## Testing / Proof
* Manual

@bigcommerce/checkout @bigcommerce/payments
