### PR TITLE
CHECKOUT-3790: Update Jest config

### DIFF
--- a/jest-config.js
+++ b/jest-config.js
@@ -1,8 +1,6 @@
 module.exports = {
     browser: true,
-    transform: {
-        '\\.(ts|js)$': '<rootDir>/node_modules/ts-jest/preprocessor.js',
-    },
+    preset: 'ts-jest',
     moduleFileExtensions: [
         'ts',
         'tsx',
@@ -10,7 +8,6 @@ module.exports = {
         'jsx',
         'json',
     ],
-    testRegex: 'src/.*\\.spec.(js|ts)$',
     setupTestFrameworkScriptFile: '<rootDir>/jest-setup.js',
     collectCoverageFrom: [
         'src/**/*.{js,ts}',
@@ -30,7 +27,7 @@ module.exports = {
     },
     globals: {
         'ts-jest': {
-            tsConfigFile: 'tsconfig-jest.json',
+            tsConfig: 'tsconfig-jest.json',
         },
     },
 };

--- a/src/common/http-request/error-response-body.typedef.js
+++ b/src/common/http-request/error-response-body.typedef.js
@@ -1,9 +1,0 @@
-/**
- * @typedef {Object} ErrorResponseBody
- * @property {string[] | Array<{ code: string, message: string }>} errors
- * @property {?number} status
- * @property {?string} detail
- * @property {?string} title
- * @property {?number} code
- * @property {?string} type
- */

--- a/src/common/utility/get-environment.spec.ts
+++ b/src/common/utility/get-environment.spec.ts
@@ -11,8 +11,8 @@ describe('getEnvironment', () => {
     });
 
     afterEach(() => {
-        process.env = savedEnvironment;
         global.process = savedProcess;
+        process.env = savedEnvironment;
     });
 
     it('returns the value set in process.env.NODE_ENV', () => {


### PR DESCRIPTION
## What?
* Adopt the Jest settings recommended by the newer version of `ts-jest`.

## Why?
* We updated `ts-jest` few weeks ago, but didn't switch over to the new settings. By switching over, we can get rid of the deprecation warnings.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
