### PR TITLE
CHECKOUT-3790: Add ability to clear error state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@bigcommerce/data-store": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/data-store/-/data-store-0.2.5.tgz",
-      "integrity": "sha512-BtaxJ77b9L5SlnfcZlNtICQV6HRetIJCT07wsZbwhMZp0Eqz3Q1mk0+5Dx90EZe+r6s3grHQLzvRro77yEF9Aw==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/data-store/-/data-store-0.2.6.tgz",
+      "integrity": "sha512-d/fexe//wV+lBNwVMF7E4rwN5keW9SMr5zGbiddPRL46kqzVzb4RDxulsapA1Srf79dOYKFRUZNXq1tjA869ZA==",
       "requires": {
         "@types/lodash": "^4.14.92",
         "lodash": "^4.17.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@bigcommerce/bigpay-client": "^3.2.3",
-    "@bigcommerce/data-store": "^0.2.5",
+    "@bigcommerce/data-store": "^0.2.6",
     "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/request-sender": "^0.2.1",
     "@bigcommerce/script-loader": "^0.1.6",

--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -1,6 +1,7 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
+import { clearErrorReducer } from '../common/error';
 import { OrderAction, OrderActionType } from '../order';
 
 import BillingAddress from './billing-address';
@@ -14,11 +15,11 @@ const DEFAULT_STATE: BillingAddressState = {
 
 export default function billingAddressReducer(
     state: BillingAddressState = DEFAULT_STATE,
-    action: CheckoutAction | BillingAddressAction | OrderAction
+    action: Action
 ): BillingAddressState {
-    const reducer = combineReducers<BillingAddressState, CheckoutAction | BillingAddressAction | OrderAction>({
+    const reducer = combineReducers<BillingAddressState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/cart/cart-reducer.ts
+++ b/src/cart/cart-reducer.ts
@@ -1,7 +1,8 @@
-import { combineReducers, Action } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { BillingAddressAction, BillingAddressActionType } from '../billing/billing-address-actions';
 import { CheckoutAction, CheckoutActionType } from '../checkout';
+import { clearErrorReducer } from '../common/error';
 import { CouponAction, CouponActionType } from '../coupon/coupon-actions';
 import { GiftCertificateAction, GiftCertificateActionType } from '../coupon/gift-certificate-actions';
 import { ConsignmentAction, ConsignmentActionType } from '../shipping/consignment-actions';
@@ -20,7 +21,7 @@ export default function cartReducer(
 ): CartState {
     const reducer = combineReducers<CartState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/checkout/checkout-reducer.ts
+++ b/src/checkout/checkout-reducer.ts
@@ -1,7 +1,8 @@
-import { combineReducers, Action } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 import { omit } from 'lodash';
 
 import { BillingAddressAction, BillingAddressActionType } from '../billing';
+import { clearErrorReducer } from '../common/error';
 import { CouponAction, CouponActionType, GiftCertificateAction, GiftCertificateActionType } from '../coupon';
 import { OrderAction, OrderActionType } from '../order';
 import { ConsignmentAction, ConsignmentActionType } from '../shipping';
@@ -20,7 +21,7 @@ export default function checkoutReducer(
 ): CheckoutState {
     const reducer = combineReducers<CheckoutState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -5,6 +5,7 @@ import { of, Observable } from 'rxjs';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { getBillingAddress } from '../billing/billing-addresses.mock';
+import { ErrorActionCreator } from '../common/error';
 import { getResponse } from '../common/http-request/responses.mock';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { getConfig } from '../config/configs.mock';
@@ -75,6 +76,7 @@ describe('CheckoutService', () => {
     let configRequestSender: ConfigRequestSender;
     let couponRequestSender: CouponRequestSender;
     let customerStrategyActionCreator: CustomerStrategyActionCreator;
+    let errorActionCreator: ErrorActionCreator;
     let giftCertificateRequestSender: GiftCertificateRequestSender;
     let instrumentActionCreator: InstrumentActionCreator;
     let orderActionCreator: OrderActionCreator;
@@ -217,6 +219,8 @@ describe('CheckoutService', () => {
             createShippingStrategyRegistry(store, requestSender)
         );
 
+        errorActionCreator = new ErrorActionCreator();
+
         checkoutService = new CheckoutService(
             store,
             billingAddressActionCreator,
@@ -226,6 +230,7 @@ describe('CheckoutService', () => {
             new CountryActionCreator(countryRequestSender),
             new CouponActionCreator(couponRequestSender),
             customerStrategyActionCreator,
+            errorActionCreator,
             new GiftCertificateActionCreator(giftCertificateRequestSender),
             instrumentActionCreator,
             orderActionCreator,
@@ -950,6 +955,19 @@ describe('CheckoutService', () => {
 
             expect(instrumentActionCreator.deleteInstrument).toHaveBeenCalledWith(instrumentId);
             expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
+        });
+    });
+
+    describe('#clearError()', () => {
+        it('dispatches "clear error" action', () => {
+            jest.spyOn(errorActionCreator, 'clearError');
+
+            const error = new Error('Unexpected error');
+
+            checkoutService.clearError(error);
+
+            expect(errorActionCreator.clearError)
+                .toHaveBeenCalledWith(error);
         });
     });
 });

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 
 import { AddressRequestBody } from '../address';
 import { BillingAddressActionCreator, BillingAddressRequestBody } from '../billing';
-import { ErrorMessageTransformer } from '../common/error';
+import { ErrorActionCreator, ErrorMessageTransformer } from '../common/error';
 import { RequestOptions } from '../common/http-request';
 import { ConfigActionCreator } from '../config';
 import { CouponActionCreator, GiftCertificateActionCreator } from '../coupon';
@@ -47,6 +47,7 @@ export default class CheckoutService {
         private _countryActionCreator: CountryActionCreator,
         private _couponActionCreator: CouponActionCreator,
         private _customerStrategyActionCreator: CustomerStrategyActionCreator,
+        private _errorActionCreator: ErrorActionCreator,
         private _giftCertificateActionCreator: GiftCertificateActionCreator,
         private _instrumentActionCreator: InstrumentActionCreator,
         private _orderActionCreator: OrderActionCreator,
@@ -1035,13 +1036,31 @@ export default class CheckoutService {
     }
 
     /**
+     * Clear errors that have been collected from previous calls.
+     *
+     * ```js
+     * const state = await service.clearError(error);
+     *
+     * console.log(state.errors.getError());
+     * ```
+     *
+     * @param error - Specific error object to clear
+     * @returns A promise that resolves to the current state.
+     */
+    clearError(error: Error): Promise<CheckoutSelectors> {
+        const action = this._errorActionCreator.clearError(error);
+
+        return this._dispatch(action);
+    }
+
+    /**
      * Dispatches an action through the data store and returns the current state
      * once the action is dispatched.
      *
      * @param action - The action to dispatch.
      * @returns A promise that resolves to the current state.
      */
-    private _dispatch(action: Observable<Action> | ThunkAction<Action>, options?: { queueId?: string }): Promise<CheckoutSelectors> {
+    private _dispatch(action: Action | Observable<Action> | ThunkAction<Action>, options?: { queueId?: string }): Promise<CheckoutSelectors> {
         return this._store.dispatch(action, options)
             .then(() => this.getState())
             .catch(error => {

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -1,6 +1,7 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
+import { ErrorActionCreator } from '../common/error';
 import { getDefaultLogger } from '../common/log';
 import { getEnvironment } from '../common/utility';
 import { ConfigActionCreator, ConfigRequestSender, ConfigState } from '../config';
@@ -69,6 +70,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new CountryActionCreator(new CountryRequestSender(requestSender, { locale })),
         new CouponActionCreator(new CouponRequestSender(requestSender)),
         new CustomerStrategyActionCreator(createCustomerStrategyRegistry(store, requestSender)),
+        new ErrorActionCreator(),
         new GiftCertificateActionCreator(new GiftCertificateRequestSender(requestSender)),
         new InstrumentActionCreator(new InstrumentRequestSender(paymentClient, requestSender)),
         orderActionCreator,

--- a/src/common/error/clear-error-reducer.spec.ts
+++ b/src/common/error/clear-error-reducer.spec.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@bigcommerce/data-store';
+
+import clearErrorReducer from './clear-error-reducer';
+import ErrorActionCreator from './error-action-creator';
+
+describe('clearErrorReducer()', () => {
+    let actions: ErrorActionCreator;
+
+    beforeEach(() => {
+        actions = new ErrorActionCreator();
+    });
+
+    it('returns new state without error', () => {
+        const fooError = new Error('foo');
+        const barError = new Error('bar');
+        const action = actions.clearError(fooError);
+
+        expect(clearErrorReducer({ fooError, barError }, action))
+            .toEqual({ barError });
+    });
+
+    it('does nothing if action is not "clear error" action', () => {
+        const fooError = new Error('foo');
+        const barError = new Error('bar');
+        const action = createAction('FOOBAR');
+
+        expect(clearErrorReducer({ fooError, barError }, action))
+            .toEqual({ fooError, barError });
+    });
+
+    it('finds error recursively', () => {
+        const fooError = new Error('foo');
+        const barError = new Error('bar');
+        const action = actions.clearError(fooError);
+
+        expect(clearErrorReducer({ 123: { fooError, barError } }, action))
+            .toEqual({ 123: { barError } });
+    });
+});

--- a/src/common/error/clear-error-reducer.ts
+++ b/src/common/error/clear-error-reducer.ts
@@ -1,0 +1,20 @@
+import { Action } from '@bigcommerce/data-store';
+
+import { omitDeep } from '../utility';
+
+import { ClearErrorAction, ErrorActionType } from './error-actions';
+
+export default function clearErrorReducer<TState extends { [key: string]: any }, TAction extends Action>(
+    state: TState,
+    action: TAction
+): TState | undefined {
+    if (isClearErrorAction(action)) {
+        return omitDeep(state, value => value === action.payload);
+    }
+
+    return state;
+}
+
+function isClearErrorAction(action: Action): action is ClearErrorAction {
+    return action.type === ErrorActionType.ClearError;
+}

--- a/src/common/error/error-action-creator.spec.ts
+++ b/src/common/error/error-action-creator.spec.ts
@@ -1,0 +1,19 @@
+import { createAction } from '@bigcommerce/data-store';
+
+import ErrorActionCreator from './error-action-creator';
+import { ErrorActionType } from './error-actions';
+
+describe('ErrorActionCreator', () => {
+    let actions: ErrorActionCreator;
+
+    beforeEach(() => {
+        actions = new ErrorActionCreator();
+    });
+
+    it('creates "clear error" action', () => {
+        const error = new Error('Unexpected error');
+
+        expect(actions.clearError(error))
+            .toEqual(createAction(ErrorActionType.ClearError, error));
+    });
+});

--- a/src/common/error/error-action-creator.ts
+++ b/src/common/error/error-action-creator.ts
@@ -1,0 +1,10 @@
+import { ClearErrorAction, ErrorActionType } from './error-actions';
+
+export default class ErrorActionCreator {
+    clearError(error: Error): ClearErrorAction {
+        return {
+            type: ErrorActionType.ClearError,
+            payload: error,
+        };
+    }
+}

--- a/src/common/error/error-actions.ts
+++ b/src/common/error/error-actions.ts
@@ -1,0 +1,12 @@
+import { Action } from '@bigcommerce/data-store';
+
+export enum ErrorActionType {
+    ClearError = 'CLEAR_ERROR',
+}
+
+export type ErrorAction = ClearErrorAction;
+
+export interface ClearErrorAction extends Action {
+    type: ErrorActionType.ClearError;
+    payload: Error;
+}

--- a/src/common/error/index.ts
+++ b/src/common/error/index.ts
@@ -1,5 +1,9 @@
+export * from './error-actions';
+
+export { default as clearErrorReducer } from './clear-error-reducer';
 export { default as createRequestErrorFactory } from './create-request-error-factory';
 export { default as throwErrorAction } from './throw-error-action';
+export { default as ErrorActionCreator } from './error-action-creator';
 export { default as ErrorMessageTransformer } from './error-message-transformer';
 export {
     default as ErrorResponseBody,

--- a/src/common/utility/omit-deep.ts
+++ b/src/common/utility/omit-deep.ts
@@ -1,11 +1,11 @@
-import { omitBy, transform } from 'lodash';
+import { isPlainObject, omitBy, transform } from 'lodash';
 
 export default function omitDeep(object: any, predicate: (value: any, key: string) => boolean): any {
     if (Array.isArray(object)) {
         return object.map(value => omitDeep(value, predicate));
     }
 
-    if (typeof object === 'object') {
+    if (isPlainObject(object)) {
         return transform(omitBy(object, predicate), (result, value, key) => {
             result[key] = omitDeep(value, predicate);
         }, {});

--- a/src/config/config-reducer.ts
+++ b/src/config/config-reducer.ts
@@ -1,4 +1,6 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
 
 import Config from './config';
 import { ConfigActionType, LoadConfigAction } from './config-actions';
@@ -12,11 +14,11 @@ const DEFAULT_STATE: ConfigState = {
 
 export default function configReducer(
     state: ConfigState = DEFAULT_STATE,
-    action: LoadConfigAction
+    action: Action
 ): ConfigState {
-    const reducer = combineReducers<ConfigState, LoadConfigAction>({
+    const reducer = combineReducers<ConfigState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/coupon/coupon-reducer.ts
+++ b/src/coupon/coupon-reducer.ts
@@ -1,6 +1,7 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
+import { clearErrorReducer } from '../common/error';
 import { OrderAction, OrderActionType } from '../order';
 
 import Coupon from './coupon';
@@ -14,11 +15,11 @@ const DEFAULT_STATE: CouponState = {
 
 export default function couponReducer(
     state: CouponState = DEFAULT_STATE,
-    action: CouponAction | CheckoutAction | OrderAction
+    action: Action
 ): CouponState {
     const reducer = combineReducers<CouponState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/coupon/gift-certificate-reducer.ts
+++ b/src/coupon/gift-certificate-reducer.ts
@@ -1,6 +1,7 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
+import { clearErrorReducer } from '../common/error';
 import { ConsignmentAction, ConsignmentActionType } from '../shipping/consignment-actions';
 
 import { CouponAction, CouponActionType } from './coupon-actions';
@@ -15,11 +16,11 @@ const DEFAULT_STATE: GiftCertificateState = {
 
 export default function giftCertificateReducer(
     state: GiftCertificateState = DEFAULT_STATE,
-    action: CheckoutAction | GiftCertificateAction | ConsignmentAction | CouponAction
+    action: Action
 ): GiftCertificateState {
     const reducer = combineReducers<GiftCertificateState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/customer/customer-strategy-reducer.ts
+++ b/src/customer/customer-strategy-reducer.ts
@@ -1,15 +1,17 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
 
 import { CustomerStrategyAction, CustomerStrategyActionType } from './customer-strategy-actions';
 import CustomerStrategyState, { CustomerStrategyDataState, CustomerStrategyErrorsState, CustomerStrategyStatusesState, DEFAULT_STATE } from './customer-strategy-state';
 
 export default function customerStrategyReducer(
     state: CustomerStrategyState = DEFAULT_STATE,
-    action: CustomerStrategyAction
+    action: Action
 ): CustomerStrategyState {
     const reducer = combineReducers<CustomerStrategyState, CustomerStrategyAction>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/geography/country-reducer.ts
+++ b/src/geography/country-reducer.ts
@@ -1,4 +1,6 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
 
 import Country from './country';
 import { CountryActionType, LoadCountriesAction } from './country-actions';
@@ -11,11 +13,11 @@ const DEFAULT_STATE: CountryState = {
 
 export default function countryReducer(
     state: CountryState = DEFAULT_STATE,
-    action: LoadCountriesAction
+    action: Action
 ): CountryState {
     const reducer = combineReducers<CountryState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -1,5 +1,7 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 import { omit } from 'lodash';
+
+import { clearErrorReducer } from '../common/error';
 
 import { OrderAction, OrderActionType } from './order-actions';
 import OrderState, { OrderDataState, OrderErrorsState, OrderMetaState, OrderStatusesState } from './order-state';
@@ -12,11 +14,11 @@ const DEFAULT_STATE: OrderState = {
 
 export default function orderReducer(
     state: OrderState = DEFAULT_STATE,
-    action: OrderAction
+    action: Action
 ): OrderState {
     const reducer = combineReducers<OrderState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         meta: metaReducer,
         statuses: statusesReducer,
     });

--- a/src/payment/instrument/instrument-reducer.ts
+++ b/src/payment/instrument/instrument-reducer.ts
@@ -1,4 +1,6 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../../common/error';
 
 import Instrument from './instrument';
 import { InstrumentAction, InstrumentActionType } from './instrument-actions';
@@ -12,11 +14,11 @@ const DEFAULT_STATE = {
 
 export default function instrumentReducer(
     state: InstrumentState = DEFAULT_STATE,
-    action: InstrumentAction
+    action: Action
 ): InstrumentState {
     const reducer = combineReducers<InstrumentState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         meta: metaReducer,
         statuses: statusesReducer,
     });

--- a/src/payment/payment-method-reducer.ts
+++ b/src/payment/payment-method-reducer.ts
@@ -1,5 +1,6 @@
-import { combineReducers, Action } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
+import { clearErrorReducer } from '../common/error';
 import { mergeOrPush } from '../common/utility';
 
 import PaymentMethod from './payment-method';
@@ -18,7 +19,7 @@ export default function paymentMethodReducer(
 ): PaymentMethodState {
     const reducer = combineReducers<PaymentMethodState>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         meta: metaReducer,
         statuses: statusesReducer,
     });

--- a/src/payment/payment-strategy-reducer.ts
+++ b/src/payment/payment-strategy-reducer.ts
@@ -1,15 +1,17 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
 
 import { PaymentStrategyAction, PaymentStrategyActionType } from './payment-strategy-actions';
 import PaymentStrategyState, { DEFAULT_STATE, PaymentStrategyDataState, PaymentStrategyErrorsState, PaymentStrategyStatusesState } from './payment-strategy-state';
 
 export default function paymentStrategyReducer(
     state: PaymentStrategyState = DEFAULT_STATE,
-    action: PaymentStrategyAction
+    action: Action
 ): PaymentStrategyState {
     const reducer = combineReducers<PaymentStrategyState, PaymentStrategyAction>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/shipping/consignment-reducer.ts
+++ b/src/shipping/consignment-reducer.ts
@@ -1,6 +1,7 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
+import { clearErrorReducer } from '../common/error';
 import { CustomerAction, CustomerActionType } from '../customer';
 
 import Consignment from './consignment';
@@ -22,11 +23,11 @@ const DEFAULT_STATE: ConsignmentState = {
 
 export default function consignmentReducer(
     state: ConsignmentState = DEFAULT_STATE,
-    action: ConsignmentAction | CheckoutAction
+    action: Action
 ): ConsignmentState {
     const reducer = combineReducers<ConsignmentState, ConsignmentAction | CheckoutAction>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/shipping/shipping-country-reducer.ts
+++ b/src/shipping/shipping-country-reducer.ts
@@ -1,5 +1,6 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
+import { clearErrorReducer } from '../common/error';
 import { Country } from '../geography';
 
 import { LoadShippingCountriesAction, ShippingCountryActionType } from './shipping-country-actions';
@@ -12,11 +13,11 @@ const DEFAULT_STATE: ShippingCountryState = {
 
 export default function shippingCountryReducer(
     state: ShippingCountryState = DEFAULT_STATE,
-    action: LoadShippingCountriesAction
+    action: Action
 ): ShippingCountryState {
     const reducer = combineReducers<ShippingCountryState>({
-        errors: errorsReducer,
         data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 

--- a/src/shipping/shipping-strategy-reducer.ts
+++ b/src/shipping/shipping-strategy-reducer.ts
@@ -1,15 +1,17 @@
-import { combineReducers } from '@bigcommerce/data-store';
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
 
 import { ShippingStrategyAction, ShippingStrategyActionType } from './shipping-strategy-actions';
 import ShippingStrategyState, { DEFAULT_STATE, ShippingStrategyDataState, ShippingStrategyErrorsState, ShippingStrategyStatusesState } from './shipping-strategy-state';
 
 export default function shippingStrategyReducer(
     state: ShippingStrategyState = DEFAULT_STATE,
-    action: ShippingStrategyAction
+    action: Action
 ): ShippingStrategyState {
     const reducer = combineReducers<ShippingStrategyState, ShippingStrategyAction>({
         data: dataReducer,
-        errors: errorsReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
     });
 


### PR DESCRIPTION
## What?
* Add ability to clear error state. i.e.:
```js
service.clearError(error);
```

## Why?
* Currently, we automatically clear an error if the action causing the error is successfully carried out after a retry. But sometimes the user might not attempt the action again and decide to do something else instead. For example, the user fails to sign in and decides to continue as a guest. Therefore, we want a way to manually clear errors to accommodate such scenario.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
