### PR TITLE
CHECKOUT-3783: Remove alpha label from documentation

### DIFF
--- a/src/embedded-checkout/embed-checkout.ts
+++ b/src/embedded-checkout/embed-checkout.ts
@@ -26,10 +26,6 @@ import ResizableIframeCreator from './resizable-iframe-creator';
  * });
  * ```
  *
- * @alpha
- * Please note that this feature is currently in an early stage of development.
- * Therefore the API is unstable and not ready for public consumption.
- *
  * @param options - Options for embedding the checkout form.
  * @returns A promise that resolves to an instance of `EmbeddedCheckout`.
  */


### PR DESCRIPTION
## What?
* It has been running in production for some time now so this label can be removed.

## Why?
* Update documentation.

## Testing / Proof
* None

@bigcommerce/checkout @bigcommerce/payments
