### PR TITLE
CHECKOUT-3790: Return correct type for billing addresses

### DIFF
--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -1,5 +1,5 @@
 import { Address } from '../address';
-import { BillingAddressSelector } from '../billing';
+import { BillingAddress, BillingAddressSelector } from '../billing';
 import { Cart, CartSelector } from '../cart';
 import { selector } from '../common/selector';
 import { ConfigSelector } from '../config';
@@ -195,7 +195,7 @@ export default class CheckoutStoreSelector {
      *
      * @returns The billing address object if it is loaded, otherwise undefined.
      */
-    getBillingAddress(): Address | undefined {
+    getBillingAddress(): BillingAddress | undefined {
         return this._billingAddress.getBillingAddress();
     }
 


### PR DESCRIPTION
## What?
* Return correct type for billing addresses.

## Why?
* It should be `BillingAddress` rather than `Address`.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
