### PR TITLE
CHECKOUT-3842: Remove `ccType` from order submission payload

### DIFF
--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -222,7 +222,6 @@ export default class CheckoutService {
      *             ccExpiry: { month: 10, year: 20 },
      *             ccName: 'BigCommerce',
      *             ccNumber: '4111111111111111',
-     *             ccType: 'visa',
      *             ccCvv: 123,
      *         },
      *     },

--- a/src/payment/is-credit-card-like.ts
+++ b/src/payment/is-credit-card-like.ts
@@ -7,7 +7,6 @@ export default function isCreditCardLike(instrument: PaymentInstrument): instrum
     return !isVaultedInstrument(card) &&
         typeof card.ccName === 'string' &&
         typeof card.ccNumber === 'string' &&
-        typeof card.ccType === 'string' &&
         typeof card.ccExpiry === 'object' &&
         typeof card.ccExpiry.month === 'string' &&
         typeof card.ccExpiry.year === 'string';

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -17,7 +17,6 @@ export interface CreditCardInstrument {
     };
     ccName: string;
     ccNumber: string;
-    ccType: string;
     ccCvv?: string;
     shouldSaveInstrument?: boolean;
     extraData?: any;

--- a/src/payment/payments.mock.ts
+++ b/src/payment/payments.mock.ts
@@ -26,7 +26,6 @@ export function getPayment(): Payment {
             },
             ccName: 'BigCommerce',
             ccNumber: '4111111111111111',
-            ccType: 'visa',
             ccCvv: '123',
         },
     };


### PR DESCRIPTION
## What?
* Remove `ccType` from order submission payload.

## Why?
* We don't actually need to post `ccType`. Therefore, we should remove it from the TS interface.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
