### PR TITLE
CHECKOUT-3842: Add missing field in `PaymentMethodConfig` interface

### DIFF
--- a/src/payment/payment-method-config.ts
+++ b/src/payment/payment-method-config.ts
@@ -7,6 +7,7 @@ export default interface PaymentMethodConfig {
     isVisaCheckoutEnabled?: boolean;
     merchantId?: string;
     redirectUrl?: string;
+    requireCustomerCode?: boolean;
     returnUrl?: string;
     testMode?: boolean;
 }


### PR DESCRIPTION
## What?
* Add `requireCustomerCode` field in `PaymentMethodConfig` interface.

## Why?
* It is missing in the interface but defined in the actual response.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
