### PR TITLE
CHECKOUT-3890: Rehydrate shipping options after applying coupon

### DIFF
--- a/src/checkout/checkout-request-sender.ts
+++ b/src/checkout/checkout-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, RequestOptions } from '../common/http-request';
+import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
 
 import Checkout, { CheckoutRequestBody } from './checkout';
 import CHECKOUT_DEFAULT_INCLUDES from './checkout-default-includes';
@@ -18,7 +18,10 @@ export default class CheckoutRequestSender {
 
         return this._requestSender.get(url, {
             params: {
-                include: CHECKOUT_DEFAULT_INCLUDES.concat(params && params.include || []).join(','),
+                include: joinIncludes([
+                    ...CHECKOUT_DEFAULT_INCLUDES,
+                    ...(params && params.include || []),
+                ]),
             },
             headers,
             timeout,
@@ -37,7 +40,10 @@ export default class CheckoutRequestSender {
 
         return this._requestSender.put(url, {
             params: {
-                include: CHECKOUT_DEFAULT_INCLUDES.concat(params && params.include || []).join(','),
+                include: joinIncludes([
+                    ...CHECKOUT_DEFAULT_INCLUDES,
+                    ...(params && params.include || []),
+                ]),
             },
             body,
             headers,

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -1,9 +1,9 @@
 export * from './checkout-actions';
 
 export { default as Checkout, CheckoutPayment } from './checkout';
-export { default as CheckoutDefaultIncludes } from './checkout-default-includes';
+export { default as CHECKOUT_DEFAULT_INCLUDES } from './checkout-default-includes';
 export { default as CheckoutActionCreator } from './checkout-action-creator';
-export { default as CheckoutParams } from './checkout-params';
+export { default as CheckoutParams, CheckoutIncludes } from './checkout-params';
 export { default as checkoutReducer } from './checkout-reducer';
 export { default as CheckoutRequestSender } from './checkout-request-sender';
 export { default as CheckoutSelector } from './checkout-selector';

--- a/src/common/http-request/index.ts
+++ b/src/common/http-request/index.ts
@@ -3,4 +3,5 @@ export * from './internal-api-headers';
 export { default as InternalResponseBody } from './internal-response-body';
 export { default as ContentType } from './content-type';
 export { default as RequestOptions } from './request-options';
+export { default as joinIncludes } from './join-includes';
 export { default as toFormUrlEncoded } from './to-form-url-encoded';

--- a/src/common/http-request/join-includes.spec.ts
+++ b/src/common/http-request/join-includes.spec.ts
@@ -1,0 +1,13 @@
+import joinIncludes from './join-includes';
+
+describe('joinIncludes()', () => {
+    it('joins include params using comma as separator', () => {
+        expect(joinIncludes(['foo', 'bar', 'hello-world']))
+            .toEqual('foo,bar,hello-world');
+    });
+
+    it('returns string without duplicates', () => {
+        expect(joinIncludes(['foo', 'bar', 'foo']))
+            .toEqual('foo,bar');
+    });
+});

--- a/src/common/http-request/join-includes.ts
+++ b/src/common/http-request/join-includes.ts
@@ -1,0 +1,5 @@
+import { uniq } from 'lodash';
+
+export default function joinIncludes(includes: string[]): string {
+    return uniq(includes).join(',');
+}

--- a/src/coupon/coupon-request-sender.spec.ts
+++ b/src/coupon/coupon-request-sender.spec.ts
@@ -15,6 +15,7 @@ describe('Coupon Request Sender', () => {
         'customer',
         'payments',
         'promotions.banners',
+        'consignments.availableShippingOptions',
     ].join(',');
 
     beforeEach(() => {

--- a/src/coupon/coupon-request-sender.ts
+++ b/src/coupon/coupon-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { Checkout, CheckoutDefaultIncludes } from '../checkout';
-import { ContentType, RequestOptions } from '../common/http-request';
+import { Checkout, CheckoutIncludes, CHECKOUT_DEFAULT_INCLUDES } from '../checkout';
+import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
 
 export default class CouponRequestSender {
     constructor(
@@ -16,7 +16,10 @@ export default class CouponRequestSender {
             headers,
             timeout,
             params: {
-                include: CheckoutDefaultIncludes.join(','),
+                include: joinIncludes([
+                    ...CHECKOUT_DEFAULT_INCLUDES,
+                    CheckoutIncludes.AvailableShippingOptions,
+                ]),
             },
             body: { couponCode },
         });
@@ -30,7 +33,10 @@ export default class CouponRequestSender {
             headers,
             timeout,
             params: {
-                include: CheckoutDefaultIncludes.join(','),
+                include: joinIncludes([
+                    ...CHECKOUT_DEFAULT_INCLUDES,
+                    CheckoutIncludes.AvailableShippingOptions,
+                ]),
             },
         });
     }

--- a/src/coupon/gift-certificate-request-sender.ts
+++ b/src/coupon/gift-certificate-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { Checkout, CheckoutDefaultIncludes } from '../checkout';
-import { ContentType, RequestOptions } from '../common/http-request';
+import { Checkout, CHECKOUT_DEFAULT_INCLUDES } from '../checkout';
+import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
 
 export default class GiftCertificateRequestSender {
     constructor(
@@ -16,7 +16,7 @@ export default class GiftCertificateRequestSender {
             headers,
             timeout,
             params: {
-                include: CheckoutDefaultIncludes.join(','),
+                include: joinIncludes(CHECKOUT_DEFAULT_INCLUDES),
             },
             body: { giftCertificateCode },
         });
@@ -30,7 +30,7 @@ export default class GiftCertificateRequestSender {
             headers,
             timeout,
             params: {
-                include: CheckoutDefaultIncludes.join(','),
+                include: joinIncludes(CHECKOUT_DEFAULT_INCLUDES),
             },
         });
     }

--- a/src/shipping/consignment-reducer.spec.ts
+++ b/src/shipping/consignment-reducer.spec.ts
@@ -2,6 +2,7 @@ import { createAction } from '@bigcommerce/data-store';
 
 import { CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
+import { CouponActionType } from '../coupon';
 
 import { ConsignmentState } from '.';
 import { ConsignmentActionType } from './consignment-actions';
@@ -232,6 +233,22 @@ describe('consignmentReducer', () => {
                     foo: false,
                 },
             },
+        });
+    });
+
+    it('returns new data when coupon is applied', () => {
+        const action = createAction(CouponActionType.ApplyCouponSucceeded, getCheckout());
+
+        expect(consignmentReducer(initialState, action)).toMatchObject({
+            data: action.payload && action.payload.consignments,
+        });
+    });
+
+    it('returns new data when coupon is removed', () => {
+        const action = createAction(CouponActionType.RemoveCouponSucceeded, getCheckout());
+
+        expect(consignmentReducer(initialState, action)).toMatchObject({
+            data: action.payload && action.payload.consignments,
         });
     });
 });

--- a/src/shipping/consignment-reducer.ts
+++ b/src/shipping/consignment-reducer.ts
@@ -2,6 +2,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
+import { CouponAction, CouponActionType } from '../coupon';
 import { CustomerAction, CustomerActionType } from '../customer';
 
 import Consignment from './consignment';
@@ -36,7 +37,7 @@ export default function consignmentReducer(
 
 function dataReducer(
     data: Consignment[] | undefined,
-    action: ConsignmentAction | CheckoutAction | CustomerAction
+    action: ConsignmentAction | CheckoutAction | CouponAction | CustomerAction
 ): Consignment[] | undefined {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutSucceeded:
@@ -45,6 +46,8 @@ function dataReducer(
     case ConsignmentActionType.UpdateConsignmentSucceeded:
     case ConsignmentActionType.DeleteConsignmentSucceeded:
     case ConsignmentActionType.UpdateShippingOptionSucceeded:
+    case CouponActionType.ApplyCouponSucceeded:
+    case CouponActionType.RemoveCouponSucceeded:
         return action.payload ? action.payload.consignments : data;
 
     case CustomerActionType.SignOutCustomerSucceeded:


### PR DESCRIPTION
## What?
* Include available shipping options when applying or removing coupons.

## Why?
* We should rehydrate shipping options because coupons may affect shipping quotes.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
