### PR TITLE
CHECKOUT-3850 make customItems optional

### DIFF
--- a/src/cart/line-item-map.ts
+++ b/src/cart/line-item-map.ts
@@ -3,6 +3,6 @@ import { CustomItem, DigitalItem, GiftCertificateItem, PhysicalItem } from './li
 export default interface LineItemMap {
     physicalItems: PhysicalItem[];
     digitalItems: DigitalItem[];
-    customItems: CustomItem[];
+    customItems?: CustomItem[];
     giftCertificates: GiftCertificateItem[];
 }


### PR DESCRIPTION
## What?
Make them optional

## Why?
Because they are not always in the payload (order endpoint)