### PR TITLE
CHECKOUT-3060 Make `methodId` a propety of `payment` in `submitOrder`

### DIFF
--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -216,8 +216,8 @@ export default class CheckoutService {
      * ```js
      * await service.initializePayment({ methodId: 'braintree' });
      * await service.submitOrder({
-     *     methodId: 'braintree',
      *     payment: {
+     *         methodId: 'braintree',
      *         paymentData: {
      *             ccExpiry: { month: 10, year: 20 },
      *             ccName: 'BigCommerce',


### PR DESCRIPTION
## What?
- Fix the documentation

## Why?
- It leads to confusion

## Testing / Proof
- 👀 

@bigcommerce/checkout @bigcommerce/payments
