### PR TITLE
CHECKOUT-3843: Add missing properties to `PaymentMethodConfig`

### DIFF
--- a/src/payment/payment-method-config.ts
+++ b/src/payment/payment-method-config.ts
@@ -4,6 +4,8 @@ export default interface PaymentMethodConfig {
     enablePaypal?: boolean;
     helpText?: string;
     is3dsEnabled?: boolean;
+    isVaultingCvvEnabled?: boolean;
+    isVaultingEnabled?: boolean;
     isVisaCheckoutEnabled?: boolean;
     merchantId?: string;
     redirectUrl?: string;


### PR DESCRIPTION
## What?
* Add missing properties to `PaymentMethodConfig`.

## Why?
* They are missing.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
