### PR TITLE
CHECKOUT-3843: Fix type definition for `VaultedInstrument`

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -29,7 +29,8 @@ export interface NonceInstrument {
 
 export interface VaultedInstrument {
     instrumentId: string;
-    cvv?: number;
+    ccCvv?: number;
+    ccNumber?: number;
 }
 
 export interface CryptogramInstrument {


### PR DESCRIPTION
## What?
* Fix type definition for `VaultedInstrument`

## Why?
* To have the correct fields.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
