### PR TITLE
CHECKOUT-3843: Add missing `isTrustedShippingAddressEnabled` and `ccCustomerCode` fields

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -85,6 +85,7 @@ export interface CheckoutSettings {
     isCouponCodeCollapsed: boolean;
     isPaymentRequestEnabled: boolean;
     isPaymentRequestCanMakePaymentEnabled: boolean;
+    isTrustedShippingAddressEnabled: boolean;
     orderTermsAndConditions: string;
     orderTermsAndConditionsLink: string;
     orderTermsAndConditionsType: string;

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -25,6 +25,7 @@ export function getConfig(): Config {
                 isPaymentRequestEnabled: false,
                 isPaymentRequestCanMakePaymentEnabled: false,
                 isCouponCodeCollapsed: true,
+                isTrustedShippingAddressEnabled: false,
                 orderTermsAndConditions: '',
                 orderTermsAndConditionsLink: '',
                 orderTermsAndConditionsType: '',

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -11,6 +11,7 @@ export interface PaymentInstrumentMeta {
 }
 
 export interface CreditCardInstrument {
+    ccCustomerCode?: string;
     ccExpiry: {
         month: string,
         year: string,


### PR DESCRIPTION
## What?
* Add missing `isTrustedShippingAddressEnabled` and `ccCustomerCode` fields

## Why?
* They exist but missing from the TS definitions.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
