### PR TITLE
CHECKOUT-3843: `ccNumber` and `ccCvv` should be string instead of number

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -30,8 +30,8 @@ export interface NonceInstrument {
 
 export interface VaultedInstrument {
     instrumentId: string;
-    ccCvv?: number;
-    ccNumber?: number;
+    ccCvv?: string;
+    ccNumber?: string;
 }
 
 export interface CryptogramInstrument {


### PR DESCRIPTION
## What?
* Like `CreditCardInstrument`, `ccNumber` and `ccCvv` should be string instead of number.

## Why?
* They are defined as `number` by mistake.

## Testing / Proof
* Travis

@bigcommerce/checkout @bigcommerce/payments
