### PR TITLE
PAYMENTS-4034 catch error when nonce return 400, squarev2

### DIFF
--- a/src/payment/strategies/square/square-payment-strategy-mock.ts
+++ b/src/payment/strategies/square/square-payment-strategy-mock.ts
@@ -72,6 +72,7 @@ export function getSquarePaymentInitializeOptions(): PaymentInitializeOptions {
             postalCode: {
                 elementId: 'postalCode',
             },
+            onError: jest.fn(),
             onPaymentSelect: () => { },
             masterpass: {
                 elementId: 'sq-masterpass',


### PR DESCRIPTION
## What?
catch error when the nonce request fail

## Why?
the nonce return an error for wrong card details entered, the error gets lost and the submit button stuck in spinning state.

## Testing / Proof
Coming...

@bigcommerce/checkout @bigcommerce/payments
