### PR TITLE
CHECKOUT-3954 Use the redirect method instead of display when initialising AfterPay

### DIFF
--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -44,7 +44,7 @@ describe('AfterpayPaymentStrategy', () => {
 
     const afterpaySdk = {
         initialize: () => {},
-        display: () => {},
+        redirect: () => {},
     };
 
     beforeEach(() => {
@@ -126,7 +126,7 @@ describe('AfterpayPaymentStrategy', () => {
             .mockReturnValue(Promise.resolve(afterpaySdk));
 
         jest.spyOn(afterpaySdk, 'initialize').mockImplementation(() => {});
-        jest.spyOn(afterpaySdk, 'display').mockImplementation(() => {});
+        jest.spyOn(afterpaySdk, 'redirect').mockImplementation(() => {});
     });
 
     describe('#initialize()', () => {
@@ -150,7 +150,7 @@ describe('AfterpayPaymentStrategy', () => {
 
         it('displays the afterpay modal', () => {
             expect(afterpaySdk.initialize).toHaveBeenCalledWith({ countryCode: 'US' });
-            expect(afterpaySdk.display).toHaveBeenCalledWith({ token: paymentMethod.clientToken });
+            expect(afterpaySdk.redirect).toHaveBeenCalledWith({ token: paymentMethod.clientToken });
         });
 
         it('notifies store credit usage to remote checkout service', () => {

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -148,7 +148,7 @@ describe('AfterpayPaymentStrategy', () => {
             await new Promise(resolve => process.nextTick(resolve));
         });
 
-        it('displays the afterpay modal', () => {
+        it('redirects to Afterpay', () => {
             expect(afterpaySdk.initialize).toHaveBeenCalledWith({ countryCode: 'US' });
             expect(afterpaySdk.redirect).toHaveBeenCalledWith({ token: paymentMethod.clientToken });
         });

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
@@ -69,7 +69,7 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
             .then(() => this._store.dispatch(
                 this._paymentMethodActionCreator.loadPaymentMethod(paymentId, options)
             ))
-            .then(state => this._displayModal(storeCountryName, state.paymentMethods.getPaymentMethod(paymentId)))
+            .then(state => this._redirectToAfterpay(storeCountryName, state.paymentMethods.getPaymentMethod(paymentId)))
             // Afterpay will handle the rest of the flow so return a promise that doesn't really resolve
             .then(() => new Promise<never>(() => {}));
     }
@@ -107,7 +107,7 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
             });
     }
 
-    private _displayModal(countryName: string, paymentMethod?: PaymentMethod): void {
+    private _redirectToAfterpay(countryName: string, paymentMethod?: PaymentMethod): void {
         if (!this._afterpaySdk || !paymentMethod || !paymentMethod.clientToken) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
@@ -113,7 +113,7 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
         }
 
         this._afterpaySdk.initialize({ countryCode: this._mapCountryToISO2(countryName)});
-        this._afterpaySdk.display({ token: paymentMethod.clientToken });
+        this._afterpaySdk.redirect({ token: paymentMethod.clientToken });
     }
 
     private _mapCountryToISO2(countryName: string): string {

--- a/src/payment/strategies/afterpay/afterpay-sdk.ts
+++ b/src/payment/strategies/afterpay/afterpay-sdk.ts
@@ -1,6 +1,6 @@
 export default interface AfterpaySdk {
     initialize(options: AfterpayInitializeOptions): void;
-    display(options: AfterpayDisplayOptions): void;
+    redirect(options: AfterpayDisplayOptions): void;
 }
 
 export interface AfterpayDisplayOptions {


### PR DESCRIPTION
## What?
- As per title

## Why?
- Eventually the display method will be unsupported 

## Testing / Proof
- Unit / Manual

@bigcommerce/checkout @bigcommerce/payments
