### PR TITLE
CHECKOUT-3941: Post `frame_error` without target origin so that parent window can receive it in case the error is due to issue with current cart

### DIFF
--- a/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.ts
@@ -45,6 +45,7 @@ export default function createEmbeddedCheckoutMessenger(options: EmbeddedCheckou
     return new IframeEmbeddedCheckoutMessenger(
         new IframeEventListener<EmbeddedContentEventMap>(options.parentOrigin),
         new IframeEventPoster<EmbeddedCheckoutEvent>(options.parentOrigin, parentWindow),
+        new IframeEventPoster<EmbeddedCheckoutEvent>('*', parentWindow),
         { [EmbeddedCheckoutEventType.FrameLoaded]: handleFrameLoadedEvent }
     );
 }

--- a/src/embedded-checkout/iframe-event-poster.ts
+++ b/src/embedded-checkout/iframe-event-poster.ts
@@ -7,7 +7,7 @@ export default class IframeEventPoster<TEvent> {
         targetOrigin: string,
         private _targetWindow?: Window
     ) {
-        this._targetOrigin = parseUrl(targetOrigin).origin;
+        this._targetOrigin = targetOrigin === '*' ? '*' : parseUrl(targetOrigin).origin;
     }
 
     post(event: TEvent): void {


### PR DESCRIPTION
## What?
* Post `frame_error` without a target origin so that parent window can receive it in case the error is due to an issue with the current cart.

## Why?
* Otherwise, if we have a session issue, i.e.: (cart ID is missing), that prevents the iframe from being loaded, we won't be able to notify the parent window about such error.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
