### PR TITLE
CHECKOUT-3941: Redirect user to allow third party cookie to be set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -606,6 +606,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2396,8 +2397,7 @@
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -3517,7 +3517,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3538,12 +3539,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3558,17 +3561,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3685,7 +3691,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3697,6 +3704,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3711,6 +3719,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3718,12 +3727,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3742,6 +3753,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3822,7 +3834,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3834,6 +3847,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3919,7 +3933,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3955,6 +3970,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3974,6 +3990,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4017,12 +4034,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5753,6 +5772,14 @@
         "json5": "^0.5.0"
       }
     },
+    "local-storage-fallback": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/local-storage-fallback/-/local-storage-fallback-4.1.1.tgz",
+      "integrity": "sha512-Ka4rem1FOgvIaPMokxXTP8DgW8gjfAQSdJC8TGrplDug7vh3b0PZnY/9euG3O3cIGAvJLp33mMU6MJ13x6S+Pw==",
+      "requires": {
+        "cookie": "^0.3.1"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -5821,7 +5848,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/iframe-resizer": "^3.5.6",
     "@types/lodash": "^4.14.92",
     "iframe-resizer": "^3.6.2",
+    "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.4",
     "messageformat": "^2.0.4",
     "rxjs": "^6.3.3",

--- a/src/common/storage/browser-storage.spec.ts
+++ b/src/common/storage/browser-storage.spec.ts
@@ -1,0 +1,58 @@
+import BrowserStorage from './browser-storage';
+
+describe('BrowserStorage', () => {
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    it('stores item with key that is prefixed with namespace', () => {
+        const storage = new BrowserStorage('foobar');
+
+        storage.setItem('message', 'Hello world');
+
+        expect(localStorage.getItem('foobar.message'))
+            .toEqual(JSON.stringify('Hello world'));
+    });
+
+    it('stores item as JSON string and restores it back to its original type when it is retrieved', () => {
+        const storage = new BrowserStorage('foobar');
+
+        storage.setItem('flag', true);
+        storage.setItem('numbers', [1, 2, 3]);
+
+        expect(storage.getItem('flag'))
+            .toEqual(true);
+
+        expect(storage.getItem('numbers'))
+            .toEqual([1, 2, 3]);
+    });
+
+    it('retrieves item and removes it from storage', () => {
+        const storage = new BrowserStorage('foobar');
+
+        storage.setItem('message', 'Hello world');
+
+        expect(storage.getItemOnce('message'))
+            .toEqual('Hello world');
+
+        expect(storage.getItem('message'))
+            .toEqual(null);
+    });
+
+    it('removes item from storage', () => {
+        const storage = new BrowserStorage('foobar');
+
+        storage.setItem('message', 'Hello world');
+        storage.removeItem('message');
+
+        expect(storage.getItem('message'))
+            .toEqual(null);
+    });
+
+    it('returns null for unknown key', () => {
+        const storage = new BrowserStorage('foobar');
+
+        expect(storage.getItem('abc'))
+            .toEqual(null);
+    });
+});

--- a/src/common/storage/browser-storage.ts
+++ b/src/common/storage/browser-storage.ts
@@ -1,0 +1,44 @@
+import { default as storage } from 'local-storage-fallback';
+
+export default class BrowserStorage {
+    constructor(
+        private _namespace: string
+    ) {}
+
+    getItem<TValue = any>(key: string): TValue | null {
+        const rawValue = storage.getItem(this.withNamespace(key));
+
+        if (rawValue === null) {
+            return null;
+        }
+
+        try {
+            return JSON.parse(rawValue);
+        } catch (error) {
+            // Clean up invalid values
+            this.removeItem(this.withNamespace(key));
+
+            return null;
+        }
+    }
+
+    getItemOnce<TValue = any>(key: string): TValue | null {
+        const value = this.getItem(key);
+
+        this.removeItem(key);
+
+        return value;
+    }
+
+    setItem<TValue = any>(key: string, value: TValue): void {
+        return storage.setItem(this.withNamespace(key), JSON.stringify(value));
+    }
+
+    removeItem(key: string): void {
+        return storage.removeItem(this.withNamespace(key));
+    }
+
+    private withNamespace(key: string): string {
+        return `${this._namespace}.${key}`;
+    }
+}

--- a/src/common/storage/index.ts
+++ b/src/common/storage/index.ts
@@ -1,0 +1,1 @@
+export { default as BrowserStorage } from './browser-storage';

--- a/src/embedded-checkout/embed-checkout.spec.ts
+++ b/src/embedded-checkout/embed-checkout.spec.ts
@@ -1,5 +1,7 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
+import { BrowserStorage } from '../common/storage';
+
 import embedCheckout from './embed-checkout';
 import EmbeddedCheckout from './embedded-checkout';
 import EmbeddedCheckoutOptions from './embedded-checkout-options';
@@ -45,6 +47,8 @@ describe('embedCheckout()', () => {
             expect.any(IframeEventPoster),
             expect.any(LoadingIndicator),
             expect.any(RequestSender),
+            expect.any(BrowserStorage),
+            expect.any(Location),
             options
         );
     });

--- a/src/embedded-checkout/embed-checkout.ts
+++ b/src/embedded-checkout/embed-checkout.ts
@@ -1,5 +1,6 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
 
+import { BrowserStorage } from '../common/storage';
 import { parseUrl } from '../common/url';
 
 import EmbeddedCheckout from './embedded-checkout';
@@ -10,6 +11,8 @@ import IframeEventListener from './iframe-event-listener';
 import IframeEventPoster from './iframe-event-poster';
 import LoadingIndicator from './loading-indicator';
 import ResizableIframeCreator from './resizable-iframe-creator';
+
+const STORAGE_PREFIX = 'BigCommerce.EmbeddedCheckout';
 
 /**
  * Embed the checkout form in an iframe.
@@ -37,6 +40,8 @@ export default function embedCheckout(options: EmbeddedCheckoutOptions): Promise
         new IframeEventPoster<EmbeddedContentEvent>(origin),
         new LoadingIndicator({ styles: options.styles && options.styles.loadingIndicator }),
         createRequestSender(),
+        new BrowserStorage(STORAGE_PREFIX),
+        window.location,
         options
     );
 

--- a/src/embedded-checkout/embedded-checkout.spec.ts
+++ b/src/embedded-checkout/embedded-checkout.spec.ts
@@ -8,7 +8,7 @@ import EmbeddedCheckout from './embedded-checkout';
 import { EmbeddedCheckoutEventMap, EmbeddedCheckoutEventType } from './embedded-checkout-events';
 import EmbeddedCheckoutOptions from './embedded-checkout-options';
 import EmbeddedCheckoutStyles from './embedded-checkout-styles';
-import { InvalidLoginTokenError, NotEmbeddableError } from './errors';
+import { InvalidLoginTokenError, NotEmbeddableError, NotEmbeddableErrorType } from './errors';
 import { EmbeddedContentEvent, EmbeddedContentEventType } from './iframe-content/embedded-content-events';
 import IframeEventListener from './iframe-event-listener';
 import IframeEventPoster from './iframe-event-poster';
@@ -61,8 +61,8 @@ describe('EmbeddedCheckout', () => {
         jest.spyOn(location, 'replace')
             .mockImplementation(() => {});
 
-        jest.spyOn(storage, 'getItemOnce')
-            .mockImplementation(key => key === 'isCookieAllowed' ? true : false);
+        jest.spyOn(storage, 'getItem')
+            .mockImplementation(key => key === 'isCookieAllowed' ? true : null);
 
         embeddedCheckout = new EmbeddedCheckout(
             iframeCreator,
@@ -77,7 +77,7 @@ describe('EmbeddedCheckout', () => {
     });
 
     afterEach(() => {
-        (location.replace as jest.Mock).mockReset();
+        (location.replace as jest.Mock).mockRestore();
     });
 
     it('creates iframe element', async () => {
@@ -263,8 +263,8 @@ describe('EmbeddedCheckout', () => {
     });
 
     it('redirects user to allow third party cookie to be set', () => {
-        jest.spyOn(storage, 'getItemOnce')
-            .mockImplementation(key => key === 'isCookieAllowed' ? false : true);
+        jest.spyOn(storage, 'getItem')
+            .mockImplementation(key => key === 'isCookieAllowed' ? null : true);
 
         embeddedCheckout.attach();
 
@@ -277,6 +277,36 @@ describe('EmbeddedCheckout', () => {
 
         expect(location.replace)
             .not.toHaveBeenCalled();
+    });
+
+    it('retries once if cookie is flagged as allowed yet unable to load frame', async () => {
+        (storage.getItem as jest.Mock).mockRestore();
+        storage.setItem('isCookieAllowed', true);
+
+        jest.spyOn(iframeCreator, 'createFrame')
+            .mockRejectedValue(new NotEmbeddableError('Empty cart', NotEmbeddableErrorType.MissingContent));
+
+        embeddedCheckout.attach();
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(location.replace)
+            .toHaveBeenCalledWith(`https://mybigcommerce.com/embedded-checkout/allow-cookie?returnUrl=${encodeURIComponent(location.href)}`);
+    });
+
+    it('does not retry to renew cookie allowance if error is due to other issues', async () => {
+        (storage.getItem as jest.Mock).mockRestore();
+        storage.setItem('isCookieAllowed', true);
+
+        jest.spyOn(iframeCreator, 'createFrame')
+            .mockRejectedValue(new NotEmbeddableError('Invalid container', NotEmbeddableErrorType.MissingContainer));
+
+        try {
+            await embeddedCheckout.attach();
+        } catch (thrown) {
+            expect(location.replace)
+                .not.toBeCalled();
+        }
     });
 
     describe('if login URL is passed', () => {

--- a/src/embedded-checkout/embedded-checkout.ts
+++ b/src/embedded-checkout/embedded-checkout.ts
@@ -155,6 +155,7 @@ export default class EmbeddedCheckout {
         const { origin } = parseUrl(this._options.url);
         const redirectUrl = `${origin}/embedded-checkout/allow-cookie?returnUrl=${encodeURIComponent(this._location.href)}`;
 
+        document.body.style.visibility = 'hidden';
         this._location.replace(redirectUrl);
 
         return new Promise<never>(() => {});

--- a/src/embedded-checkout/errors/index.ts
+++ b/src/embedded-checkout/errors/index.ts
@@ -1,2 +1,2 @@
-export { default as NotEmbeddableError } from './not-embeddable-error';
+export { default as NotEmbeddableError, NotEmbeddableErrorType } from './not-embeddable-error';
 export { default as InvalidLoginTokenError } from './invalid-login-token-error';

--- a/src/embedded-checkout/errors/not-embeddable-error.ts
+++ b/src/embedded-checkout/errors/not-embeddable-error.ts
@@ -1,7 +1,16 @@
 import { StandardError } from '../../common/error/errors';
 
+export enum NotEmbeddableErrorType {
+    MissingContainer = 'missing_container',
+    MissingContent = 'missing_content',
+    UnknownError = 'unknown_error',
+}
+
 export default class NotEmbeddableError extends StandardError {
-    constructor(message?: string) {
+    constructor(
+        message?: string,
+        public subtype: NotEmbeddableErrorType = NotEmbeddableErrorType.UnknownError
+    ) {
         super(message || 'Unable to embed the checkout form.');
 
         this.type = 'not_embeddable';

--- a/src/embedded-checkout/resizable-iframe-creator.ts
+++ b/src/embedded-checkout/resizable-iframe-creator.ts
@@ -3,7 +3,7 @@ import { iframeResizer, IFrameComponent } from 'iframe-resizer';
 import { parseUrl } from '../common/url';
 
 import { EmbeddedCheckoutEventType } from './embedded-checkout-events';
-import { NotEmbeddableError } from './errors';
+import { NotEmbeddableError, NotEmbeddableErrorType } from './errors';
 import isIframeEvent from './is-iframe-event';
 
 export default class ResizableIframeCreator {
@@ -16,7 +16,10 @@ export default class ResizableIframeCreator {
         const { timeout = 60000 } = this._options || {};
 
         if (!container) {
-            throw new NotEmbeddableError('Unable to embed the iframe because the container element could not be found.');
+            throw new NotEmbeddableError(
+                'Unable to embed the iframe because the container element could not be found.',
+                NotEmbeddableErrorType.MissingContainer
+            );
         }
 
         const iframe = document.createElement('iframe');
@@ -52,7 +55,7 @@ export default class ResizableIframeCreator {
 
                 if (isIframeEvent(event.data, EmbeddedCheckoutEventType.FrameError)) {
                     teardown();
-                    reject(new NotEmbeddableError(event.data.payload.message));
+                    reject(new NotEmbeddableError(event.data.payload.message, NotEmbeddableErrorType.MissingContent));
                 }
 
                 if (isIframeEvent(event.data, EmbeddedCheckoutEventType.FrameLoaded)) {


### PR DESCRIPTION
## What?
* Redirect users to the domain of Embedded Checkout so that cookie can be set for browsers that have a restrictive third party cookie setting.
* It is possible that this workaround won't work with Safari's latest [ITP 2.0 feature](https://webkit.org/blog/8311/intelligent-tracking-prevention-2-0/). But so far, I'm unable to replicate the potential problem so it's possible that it's not applicable. I'll do further testing on that. Regardless, this workaround is still required for older versions of Safari.

## Why?
* This workaround is required for certain browsers (namely Safari) that prevent session cookies to be set for a third party website unless the user has recently visited such website. Therefore, before we attempt to login or set an active cart in the session, we need to first redirect the user to the domain of Embedded Checkout.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
