### PR TITLE
CHECKOUT-3852 Expose proper error type for Coupon/GiftCertificates

### DIFF
--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -1,5 +1,6 @@
 import { BillingAddressSelector } from '../billing';
 import { CartSelector } from '../cart';
+import { RequestError } from '../common/error/errors';
 import { selector } from '../common/selector';
 import { ConfigSelector } from '../config';
 import { CouponSelector, GiftCertificateSelector } from '../coupon';
@@ -330,7 +331,7 @@ export default class CheckoutStoreErrorSelector {
      *
      * @returns The error object if unable to apply, otherwise undefined.
      */
-    getApplyCouponError(): Error | undefined {
+    getApplyCouponError(): RequestError | undefined {
         return this._coupons.getApplyError();
     }
 
@@ -339,7 +340,7 @@ export default class CheckoutStoreErrorSelector {
      *
      * @returns The error object if unable to remove, otherwise undefined.
      */
-    getRemoveCouponError(): Error | undefined {
+    getRemoveCouponError(): RequestError | undefined {
         return this._coupons.getRemoveError();
     }
 
@@ -348,7 +349,7 @@ export default class CheckoutStoreErrorSelector {
      *
      * @returns The error object if unable to apply, otherwise undefined.
      */
-    getApplyGiftCertificateError(): Error | undefined {
+    getApplyGiftCertificateError(): RequestError | undefined {
         return this._giftCertificates.getApplyError();
     }
 
@@ -357,7 +358,7 @@ export default class CheckoutStoreErrorSelector {
      *
      * @returns The error object if unable to remove, otherwise undefined.
      */
-    getRemoveGiftCertificateError(): Error | undefined {
+    getRemoveGiftCertificateError(): RequestError | undefined {
         return this._giftCertificates.getRemoveError();
     }
 

--- a/src/common/error/errors/map-from-storefront-error-response.ts
+++ b/src/common/error/errors/map-from-storefront-error-response.ts
@@ -7,7 +7,7 @@ import RequestError from './request-error';
 export default function mapFromStorefrontErrorResponse(
     response: Response<StorefrontErrorResponseBody>,
     message?: string
-): RequestError {
+): RequestError<StorefrontErrorResponseBody> {
     const { body } = response;
 
     return new RequestError(response, {

--- a/src/common/error/request-error-factory.ts
+++ b/src/common/error/request-error-factory.ts
@@ -25,7 +25,7 @@ export default class RequestErrorFactory {
         this._factoryMethods[type] = factoryMethod;
     }
 
-    createError(response: Response, message?: string): Error {
+    createError(response: Response, message?: string): RequestError {
         const factoryMethod = this._factoryMethods[this._getType(response)] || this._factoryMethods.default;
 
         return factoryMethod(response, message);

--- a/src/coupon/coupon-selector.spec.ts
+++ b/src/coupon/coupon-selector.spec.ts
@@ -1,3 +1,5 @@
+import { RequestError } from '../common/error/errors';
+
 import CouponSelector from './coupon-selector';
 import CouponState from './coupon-state';
 
@@ -14,7 +16,7 @@ describe('CouponSelector', () => {
 
     describe('#getApplyError()', () => {
         it('returns error if unable to apply', () => {
-            const applyCouponError = new Error();
+            const applyCouponError = new RequestError();
 
             couponSelector = new CouponSelector({
                 ...state,
@@ -50,7 +52,7 @@ describe('CouponSelector', () => {
 
     describe('#getRemoveError()', () => {
         it('returns error if unable to remove', () => {
-            const removeCouponError = new Error();
+            const removeCouponError = new RequestError();
 
             couponSelector = new CouponSelector({
                 ...state,

--- a/src/coupon/coupon-selector.ts
+++ b/src/coupon/coupon-selector.ts
@@ -1,3 +1,4 @@
+import { RequestError } from '../common/error/errors';
 import { selector } from '../common/selector';
 
 import Coupon from './coupon';
@@ -13,11 +14,11 @@ export default class CouponSelector {
         return this._coupon.data;
     }
 
-    getRemoveError(): Error | undefined {
+    getRemoveError(): RequestError | undefined {
         return this._coupon.errors.removeCouponError;
     }
 
-    getApplyError(): Error | undefined {
+    getApplyError(): RequestError | undefined {
         return this._coupon.errors.applyCouponError;
     }
 

--- a/src/coupon/coupon-state.ts
+++ b/src/coupon/coupon-state.ts
@@ -1,3 +1,6 @@
+import { StorefrontErrorResponseBody } from '../common/error';
+import { RequestError } from '../common/error/errors';
+
 import Coupon from './coupon';
 
 export default interface CouponState {
@@ -7,8 +10,8 @@ export default interface CouponState {
 }
 
 export interface CouponErrorsState {
-    applyCouponError?: Error;
-    removeCouponError?: Error;
+    applyCouponError?: RequestError<StorefrontErrorResponseBody>;
+    removeCouponError?: RequestError<StorefrontErrorResponseBody>;
 }
 
 export interface CouponStatusesState {

--- a/src/coupon/gift-certificate-actions.ts
+++ b/src/coupon/gift-certificate-actions.ts
@@ -1,6 +1,8 @@
 import { Action } from '@bigcommerce/data-store';
 
 import { Checkout } from '../checkout';
+import { StorefrontErrorResponseBody } from '../common/error';
+import { RequestError } from '../common/error/errors';
 
 export enum GiftCertificateActionType {
     ApplyGiftCertificateRequested = 'APPLY_GIFT_CERTIFICATE_REQUESTED',
@@ -34,7 +36,7 @@ export interface ApplyGiftCertificateSucceededAction extends Action<Checkout> {
     type: GiftCertificateActionType.ApplyGiftCertificateSucceeded;
 }
 
-export interface ApplyGiftCertificateFailedAction extends Action<Error> {
+export interface ApplyGiftCertificateFailedAction extends Action<RequestError<StorefrontErrorResponseBody>> {
     type: GiftCertificateActionType.ApplyGiftCertificateFailed;
 }
 
@@ -46,6 +48,6 @@ export interface RemoveGiftCertificateSucceededAction extends Action<Checkout> {
     type: GiftCertificateActionType.RemoveGiftCertificateSucceeded;
 }
 
-export interface RemoveGiftCertificateFailedAction extends Action<Error> {
+export interface RemoveGiftCertificateFailedAction extends Action<RequestError<StorefrontErrorResponseBody>> {
     type: GiftCertificateActionType.RemoveGiftCertificateFailed;
 }

--- a/src/coupon/gift-certificate-selector.ts
+++ b/src/coupon/gift-certificate-selector.ts
@@ -1,3 +1,5 @@
+import { StorefrontErrorResponseBody } from '../common/error';
+import { RequestError } from '../common/error/errors';
 import { selector } from '../common/selector';
 
 import GiftCertificate from './gift-certificate';
@@ -13,11 +15,11 @@ export default class GiftCertificateSelector {
         return this._giftCertificate.data;
     }
 
-    getRemoveError(): Error | undefined {
+    getRemoveError(): RequestError<StorefrontErrorResponseBody> | undefined {
         return this._giftCertificate.errors.removeGiftCertificateError;
     }
 
-    getApplyError(): Error | undefined {
+    getApplyError(): RequestError<StorefrontErrorResponseBody> | undefined {
         return this._giftCertificate.errors.applyGiftCertificateError;
     }
 

--- a/src/coupon/gift-certificate-state.ts
+++ b/src/coupon/gift-certificate-state.ts
@@ -1,3 +1,6 @@
+import { StorefrontErrorResponseBody } from '../common/error';
+import { RequestError } from '../common/error/errors';
+
 import GiftCertificate from './gift-certificate';
 
 export default interface GiftCertificateState {
@@ -7,8 +10,8 @@ export default interface GiftCertificateState {
 }
 
 export interface GiftCertificateErrorsState {
-    applyGiftCertificateError?: Error;
-    removeGiftCertificateError?: Error;
+    applyGiftCertificateError?: RequestError<StorefrontErrorResponseBody>;
+    removeGiftCertificateError?: RequestError<StorefrontErrorResponseBody>;
 }
 
 export interface GiftCertificateStatusesState {


### PR DESCRIPTION
## What?
As per title

## Why?
So consumers can access more information like why coupon failed

@bigcommerce/checkout