### PR TITLE
CHECKOUT-3967 Round properly when using CurrencyService

### DIFF
--- a/src/currency/currency-formatter.spec.ts
+++ b/src/currency/currency-formatter.spec.ts
@@ -23,20 +23,20 @@ describe('CurrencyFormater', () => {
                 expect(currencyFormatter.format(0)).toEqual('$0');
                 expect(currencyFormatter.format(10)).toEqual('$10');
                 expect(currencyFormatter.format(100.100)).toEqual('$100');
-                expect(currencyFormatter.format(999888777.666555)).toEqual('$999,888,777');
-                expect(currencyFormatter.format(99888777.666555)).toEqual('$99,888,777');
-                expect(currencyFormatter.format(9888777.666555)).toEqual('$9,888,777');
-                expect(currencyFormatter.format(888777.666555)).toEqual('$888,777');
+                expect(currencyFormatter.format(999888777.666555)).toEqual('$999,888,778');
+                expect(currencyFormatter.format(99888777.666555)).toEqual('$99,888,778');
+                expect(currencyFormatter.format(9888777.666555)).toEqual('$9,888,778');
+                expect(currencyFormatter.format(888777.666555)).toEqual('$888,778');
             });
 
             it('returns formatted negative number', () => {
                 expect(currencyFormatter.format(-0)).toEqual('$0');
                 expect(currencyFormatter.format(-10)).toEqual('-$10');
                 expect(currencyFormatter.format(-100.100)).toEqual('-$100');
-                expect(currencyFormatter.format(-999888777.666555)).toEqual('-$999,888,777');
-                expect(currencyFormatter.format(-99888777.666555)).toEqual('-$99,888,777');
-                expect(currencyFormatter.format(-9888777.666555)).toEqual('-$9,888,777');
-                expect(currencyFormatter.format(-888777.666555)).toEqual('-$888,777');
+                expect(currencyFormatter.format(-999888777.666555)).toEqual('-$999,888,778');
+                expect(currencyFormatter.format(-99888777.666555)).toEqual('-$99,888,778');
+                expect(currencyFormatter.format(-9888777.666555)).toEqual('-$9,888,778');
+                expect(currencyFormatter.format(-888777.666555)).toEqual('-$888,778');
             });
         });
 
@@ -59,20 +59,25 @@ describe('CurrencyFormater', () => {
                 expect(currencyFormatter.format(0)).toEqual('$0.00');
                 expect(currencyFormatter.format(10)).toEqual('$10.00');
                 expect(currencyFormatter.format(100.100)).toEqual('$100.10');
-                expect(currencyFormatter.format(999888777.666555)).toEqual('$999,888,777.66');
-                expect(currencyFormatter.format(99888777.666555)).toEqual('$99,888,777.66');
-                expect(currencyFormatter.format(9888777.666555)).toEqual('$9,888,777.66');
-                expect(currencyFormatter.format(888777.666555)).toEqual('$888,777.66');
+                expect(currencyFormatter.format(859.385)).toEqual('$859.39');
+                expect(currencyFormatter.format(999888777.666555)).toEqual('$999,888,777.67');
+                expect(currencyFormatter.format(99888777.666555)).toEqual('$99,888,777.67');
+                expect(currencyFormatter.format(9888777.666555)).toEqual('$9,888,777.67');
+                expect(currencyFormatter.format(888777.666555)).toEqual('$888,777.67');
             });
 
             it('returns formatted negative number', () => {
                 expect(currencyFormatter.format(-0)).toEqual('$0.00');
                 expect(currencyFormatter.format(-10)).toEqual('-$10.00');
                 expect(currencyFormatter.format(-100.100)).toEqual('-$100.10');
-                expect(currencyFormatter.format(-999888777.666555)).toEqual('-$999,888,777.66');
-                expect(currencyFormatter.format(-99888777.666555)).toEqual('-$99,888,777.66');
-                expect(currencyFormatter.format(-9888777.666555)).toEqual('-$9,888,777.66');
-                expect(currencyFormatter.format(-888777.666555)).toEqual('-$888,777.66');
+                expect(currencyFormatter.format(-999888777.666555)).toEqual('-$999,888,777.67');
+                expect(currencyFormatter.format(-99888777.666555)).toEqual('-$99,888,777.67');
+                expect(currencyFormatter.format(-9888777.666555)).toEqual('-$9,888,777.67');
+                expect(currencyFormatter.format(-888777.664444)).toEqual('-$888,777.66');
+            });
+
+            it('adds padding with 0s', () => {
+                expect(currencyFormatter.format(0.9)).toEqual('$0.90');
             });
         });
 
@@ -105,6 +110,10 @@ describe('CurrencyFormater', () => {
                 expect(currencyFormatter.format(-99888777.12345)).toEqual('-99 888 777;123@');
                 expect(currencyFormatter.format(-9888777.12345)).toEqual('-9 888 777;123@');
                 expect(currencyFormatter.format(-888777.12345)).toEqual('-888 777;123@');
+            });
+
+            it('adds padding with 0s', () => {
+                expect(currencyFormatter.format(-0.9)).toEqual('-0;900@');
             });
         });
     });

--- a/src/currency/currency-formatter.ts
+++ b/src/currency/currency-formatter.ts
@@ -57,22 +57,16 @@ export default class CurrencyFormatter {
 
     private _formatNumber(amount: number): string {
         const positiveAmount = Math.abs(amount);
-        const [ integerAmount, decimalAmount = '' ] = positiveAmount.toString().split('.');
+        const [ integerAmount, decimalAmount = '' ] = (this._toFixed(positiveAmount, this._decimalPlaces)).split('.');
         const parsedIntegerAmount = integerAmount.replace(/\B(?=(\d{3})+(?!\d))/g, this._thousandsSeparator);
 
         if (this._decimalPlaces < 1) {
             return parsedIntegerAmount;
         }
 
-        let decimalPadding = '';
-
-        for (let i = 0; i < this._decimalPlaces; i += 1) {
-            decimalPadding += '0';
-        }
-
         return [
             parsedIntegerAmount,
-            `${decimalAmount}${decimalPadding}`.slice(0, this._decimalPlaces),
+            decimalAmount,
         ].join(this._decimalSeparator);
     }
 
@@ -80,5 +74,9 @@ export default class CurrencyFormatter {
         return (this._symbolLocation.toLowerCase() === 'left') ?
             `${this._symbol}${formattedNumber}` :
             `${formattedNumber}${this._symbol}`;
+    }
+
+    private _toFixed(value: number, precision: number): string {
+        return (+(Math.round(+(value + 'e' + precision)) + 'e' + -precision)).toFixed(precision);
     }
 }


### PR DESCRIPTION
## What?
Make currency service round instead of truncate

## Why?
It's a more accurate behaviour

## Testing / Proof
Unit

@bigcommerce/checkout 
