### PR TITLE
CHECKOUT-3844: Ignore order of line items when comparing cart content

### DIFF
--- a/src/cart/cart-comparator.spec.ts
+++ b/src/cart/cart-comparator.spec.ts
@@ -145,5 +145,18 @@ describe('CartComparator', () => {
 
             expect(comparator.isEqual(cartA, cartB)).toEqual(false);
         });
+
+        it('returns true if two carts have same items but only differ in their order', () => {
+            const cartA = getCart();
+            const cartB = {
+                ...cartA,
+                lineItems: {
+                    ...cartA.lineItems,
+                    physicalItems: cartA.lineItems.physicalItems.slice().reverse(),
+                },
+            };
+
+            expect(comparator.isEqual(cartA, cartB)).toEqual(true);
+        });
     });
 });

--- a/src/cart/cart-comparator.ts
+++ b/src/cart/cart-comparator.ts
@@ -18,23 +18,32 @@ export default class CartComparator {
             currency: cart.currency,
             id: cart.id,
             lineItems: {
-                digitalItems: cart.lineItems.digitalItems.map(item => ({
-                    extendedSalePrice: item.extendedSalePrice,
-                    productId: item.productId,
-                    quantity: item.quantity,
-                    variantId: item.variantId,
-                })),
-                giftCertificates: cart.lineItems.giftCertificates.map(item => ({
-                    amount: item.amount,
-                    recipient: item.recipient,
-                })),
-                physicalItems: cart.lineItems.physicalItems.map(item => ({
-                    extendedSalePrice: item.extendedSalePrice,
-                    productId: item.productId,
-                    quantity: item.quantity,
-                    variantId: item.variantId,
-                    giftWrapping: item.giftWrapping,
-                })),
+                digitalItems: cart.lineItems.digitalItems
+                    .slice()
+                    .sort((itemA, itemB) => `${itemA.id}`.localeCompare(`${itemB.id}`))
+                    .map(item => ({
+                        extendedSalePrice: item.extendedSalePrice,
+                        productId: item.productId,
+                        quantity: item.quantity,
+                        variantId: item.variantId,
+                    })),
+                giftCertificates: cart.lineItems.giftCertificates
+                    .slice()
+                    .sort((itemA, itemB) => `${itemA.id}`.localeCompare(`${itemB.id}`))
+                    .map(item => ({
+                        amount: item.amount,
+                        recipient: item.recipient,
+                    })),
+                physicalItems: cart.lineItems.physicalItems
+                    .slice()
+                    .sort((itemA, itemB) => `${itemA.id}`.localeCompare(`${itemB.id}`))
+                    .map(item => ({
+                        extendedSalePrice: item.extendedSalePrice,
+                        productId: item.productId,
+                        quantity: item.quantity,
+                        variantId: item.variantId,
+                        giftWrapping: item.giftWrapping,
+                    })),
             },
         };
     }


### PR DESCRIPTION
## What?
* Ignore the order of line items when comparing cached cart content with the latest cart content.

## Why?
* We are only interested in the the items themselves - not the order of them.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
