### PR TITLE
CHECKOUT-3844: Don't throw error if no payment data is passed for offsite payment methods

### DIFF
--- a/src/payment/is-credit-card-like.spec.ts
+++ b/src/payment/is-credit-card-like.spec.ts
@@ -1,10 +1,10 @@
 import isCreditCardLike from './is-credit-card-like';
-import { getPayment } from './payments.mock';
+import { getCreditCardInstrument } from './payments.mock';
 
 describe('isCreditCardLike', () => {
     it('returns true if the object looks like a credit creditcard', () => {
-        const { paymentData } = getPayment();
-        expect(isCreditCardLike(paymentData)).toBeTruthy();
+        const paymentData = getCreditCardInstrument();
+        expect(paymentData && isCreditCardLike(paymentData)).toBeTruthy();
     });
 
     it('returns false if a Vaulted Instrument', () => {

--- a/src/payment/is-nonce-like.spec.ts
+++ b/src/payment/is-nonce-like.spec.ts
@@ -1,5 +1,5 @@
 import isNonceLike from './is-nonce-like';
-import { getPayment } from './payments.mock';
+import { getCreditCardInstrument } from './payments.mock';
 
 describe('isNonceLike', () => {
     it('returns true if a Tokenized Credit Card', () => {
@@ -8,7 +8,7 @@ describe('isNonceLike', () => {
     });
 
     it('returns false if the object looks like a credit creditcard', () => {
-        const { paymentData } = getPayment();
+        const paymentData = getCreditCardInstrument();
         expect(isNonceLike(paymentData)).toBeFalsy();
     });
 

--- a/src/payment/is-vaulted-instrument.spec.ts
+++ b/src/payment/is-vaulted-instrument.spec.ts
@@ -1,5 +1,5 @@
 import isVaultedInstrument from './is-vaulted-instrument';
-import { getPayment } from './payments.mock';
+import { getCreditCardInstrument } from './payments.mock';
 
 describe('isTokenizedCreditCardLike', () => {
     it('returns true if a Vaulted Instrument', () => {
@@ -13,7 +13,7 @@ describe('isTokenizedCreditCardLike', () => {
     });
 
     it('returns false if the object looks like a credit creditcard', () => {
-        const { paymentData } = getPayment();
+        const paymentData = getCreditCardInstrument();
         expect(isVaultedInstrument(paymentData)).toBeFalsy();
     });
 });

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -101,7 +101,8 @@ describe('PaymentActionCreator', () => {
 
     describe('#initializeOffsitePayment()', () => {
         it('dispatches actions to data store', async () => {
-            const actions = await from(paymentActionCreator.initializeOffsitePayment(getPayment())(store))
+            const payment = getPayment();
+            const actions = await from(paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId)(store))
                 .pipe(toArray())
                 .toPromise();
 
@@ -112,13 +113,14 @@ describe('PaymentActionCreator', () => {
         });
 
         it('dispatches error actions to data store if unsuccessful', async () => {
+            const error = new Error();
+
             jest.spyOn(paymentRequestSender, 'initializeOffsitePayment')
-                .mockReturnValue(
-                    Promise.reject(new Error())
-                );
+                .mockRejectedValue(error);
 
             const errorHandler = jest.fn(action => of(action));
-            const actions = await from(paymentActionCreator.initializeOffsitePayment(getPayment())(store))
+            const payment = getPayment();
+            const actions = await from(paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId)(store))
                 .pipe(
                     catchError(errorHandler),
                     toArray()
@@ -132,6 +134,7 @@ describe('PaymentActionCreator', () => {
                 },
                 {
                     type: PaymentActionType.InitializeOffsitePaymentFailed,
+                    payload: error,
                     error: true,
                 },
             ]);

--- a/src/payment/payment-request-body.ts
+++ b/src/payment/payment-request-body.ts
@@ -9,7 +9,7 @@ import PaymentMethod from './payment-method';
 
 export default interface PaymentRequestBody {
     authToken: string;
-    payment: PaymentInstrument;
+    payment?: PaymentInstrument;
     billingAddress?: InternalAddress;
     cart?: InternalCart;
     customer?: InternalCustomer;

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -6,10 +6,9 @@ import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
-import { LoadOrderPaymentsAction, OrderActionCreator, OrderRequestBody } from '../order';
+import { LoadOrderPaymentsAction, OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../order';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 
-import Payment from './payment';
 import { PaymentInitializeOptions, PaymentRequestOptions } from './payment-request-options';
 import {
     PaymentStrategyActionType,
@@ -32,7 +31,7 @@ export default class PaymentStrategyActionCreator {
     execute(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<PaymentStrategyExecuteAction, InternalCheckoutSelectors> {
         return store => new Observable((observer: Observer<PaymentStrategyExecuteAction>) => {
             const state = store.getState();
-            const { payment = {} as Payment, useStoreCredit } = payload;
+            const { payment = {} as OrderPaymentRequestBody, useStoreCredit } = payload;
             const meta = { methodId: payment.methodId };
 
             let strategy: PaymentStrategy;

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -1,7 +1,7 @@
 export default interface Payment {
     methodId: string;
     gatewayId?: string;
-    paymentData: PaymentInstrument & PaymentInstrumentMeta;
+    paymentData?: PaymentInstrument & PaymentInstrumentMeta;
 }
 
 export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument;

--- a/src/payment/payments.mock.ts
+++ b/src/payment/payments.mock.ts
@@ -19,15 +19,19 @@ import PaymentState from './payment-state';
 export function getPayment(): Payment {
     return {
         methodId: 'authorizenet',
-        paymentData: {
-            ccExpiry: {
-                month: '10',
-                year: '20',
-            },
-            ccName: 'BigCommerce',
-            ccNumber: '4111111111111111',
-            ccCvv: '123',
+        paymentData: getCreditCardInstrument(),
+    };
+}
+
+export function getCreditCardInstrument(): CreditCardInstrument {
+    return {
+        ccExpiry: {
+            month: '10',
+            year: '20',
         },
+        ccName: 'BigCommerce',
+        ccNumber: '4111111111111111',
+        ccCvv: '123',
     };
 }
 

--- a/src/payment/strategies/offsite/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.ts
@@ -17,16 +17,15 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const { payment, ...order } = payload;
-        const paymentData = payment && payment.paymentData;
         const orderPayload = this._shouldSubmitFullPayload(payment) ? payload : order;
 
-        if (!payment || !paymentData) {
-            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
         }
 
         return this._store.dispatch(this._orderActionCreator.submitOrder(orderPayload, options))
             .then(() =>
-                this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment({ ...payment, paymentData }))
+                this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId))
             );
     }
 


### PR DESCRIPTION
## What?
* Don't throw an error if no payment data is passed for offsite payment methods.

## Why?
* Because for offsite payment methods, we collect payment details from another website so we are not supposed to pass payment details via `submitOrder` method.
* Currently, we get around this issue by providing an empty object `i.e.: { paymentData: {} }`, which effectively prevents the error from being thrown. After this change, we won't require the workaround anymore.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
