### PR TITLE
CHECKOUT-1289 Fix config and checkout types

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -59,6 +59,7 @@ export interface StoreLinks {
     createAccountLink: string;
     forgotPasswordLink: string;
     loginLink: string;
+    siteLink: string;
     orderConfirmationLink: string;
 }
 
@@ -77,6 +78,7 @@ export interface StoreCurrency {
 }
 
 export interface CheckoutSettings {
+    features: { [featureName: string]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     guestCheckoutEnabled: boolean;

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -17,6 +17,7 @@ export function getConfig(): Config {
         storeConfig: {
             cdnPath: 'https://cdn.bcapp.dev/rHEAD',
             checkoutSettings: {
+                features: {},
                 enableOrderComments: true,
                 enableTermsAndConditions: false,
                 guestCheckoutEnabled: true,
@@ -55,6 +56,7 @@ export function getConfig(): Config {
                 createAccountLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=create_account',
                 forgotPasswordLink: 'https://store-k1drp8k8.bcapp.dev/login.php?action=reset_password',
                 loginLink: 'https://store-k1drp8k8.bcapp.dev/login.php',
+                siteLink: 'https://store-k1drp8k8.bcapp.dev/',
                 orderConfirmationLink: 'https://store-k1drp8k8.bcapp.dev/checkout/order-confirmation',
             },
             paymentSettings: {


### PR DESCRIPTION
## What?
Fix types 

## Why?
So they match current API payloads

@bigcommerce/checkout 