### PR TITLE
PAYMENTS-1253: Pass store credit amount to PayPal

### DIFF
--- a/src/checkout/checkout-selector.spec.ts
+++ b/src/checkout/checkout-selector.spec.ts
@@ -1,3 +1,5 @@
+import { merge } from 'lodash';
+
 import CheckoutSelector from './checkout-selector';
 import CheckoutStoreState from './checkout-store-state';
 import { getCheckout, getCheckoutState, getCheckoutStoreState } from './checkouts.mock';
@@ -61,5 +63,28 @@ describe('CheckoutSelector', () => {
         }, selectors.billingAddress, selectors.cart, selectors.consignments, selectors.coupons, selectors.customer, selectors.giftCertificates);
 
         expect(selector.isUpdating()).toEqual(true);
+    });
+
+    it('returns grand total with store credit if flag is passed', () => {
+        state = merge(getCheckoutStoreState(), {
+            customer: { data: { storeCredit: 50 } },
+        });
+        selectors = createInternalCheckoutSelectors(state);
+
+        const selector = new CheckoutSelector(
+            state.checkout,
+            selectors.billingAddress,
+            selectors.cart,
+            selectors.consignments,
+            selectors.coupons,
+            selectors.customer,
+            selectors.giftCertificates
+        );
+
+        expect(selector.getGrandTotal(true))
+            .toEqual(140);
+
+        expect(selector.getGrandTotal())
+            .toEqual(190);
     });
 });

--- a/src/checkout/checkout-selector.ts
+++ b/src/checkout/checkout-selector.ts
@@ -44,6 +44,19 @@ export default class CheckoutSelector {
         };
     }
 
+    getGrandTotal(useStoreCredit?: boolean): number | undefined {
+        const checkout = this.getCheckout();
+
+        if (!checkout) {
+            return;
+        }
+
+        const grandTotal = checkout.grandTotal || 0;
+        const storeCredit = checkout.customer.storeCredit || 0;
+
+        return useStoreCredit ? Math.max(grandTotal - storeCredit, 0) : grandTotal;
+    }
+
     getLoadError(): Error | undefined {
         return this._checkout.errors.loadError;
     }

--- a/src/payment/payment-selector.ts
+++ b/src/payment/payment-selector.ts
@@ -62,16 +62,9 @@ export default class PaymentSelector {
     }
 
     isPaymentDataRequired(useStoreCredit: boolean = false): boolean {
-        const checkout = this._checkout.getCheckout();
+        const grandTotal = this._checkout.getGrandTotal(useStoreCredit);
 
-        if (!checkout) {
-            return false;
-        }
-
-        const grandTotal = checkout.grandTotal || 0;
-        const storeCredit = checkout.customer.storeCredit || 0;
-
-        return (useStoreCredit ? grandTotal - storeCredit : grandTotal) > 0;
+        return grandTotal ? grandTotal > 0 : false;
     }
 
     isPaymentDataSubmitted(paymentMethod?: PaymentMethod): boolean {


### PR DESCRIPTION
## What?
* Pass amount inclusive of store credit to PayPal.

## Why?
* Otherwise PayPal modal displays incorrect amount, which is confusing for the shopper.
* We can't create the order first because we can't perform any asynchronous actions before launching a popup window (otherwise it gets blocked by the browser). And we currently don't have a way to apply store credit before creating an order (that is a separate project which we plan to do soon). So as an interim solution, we have to deduct the store credit amount on the client-side.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
