### PR TITLE
PAYMENTS-1253: Throw cancellation error when shopper closes PayPal popup

### DIFF
--- a/src/payment/errors/payment-method-cancelled-error.ts
+++ b/src/payment/errors/payment-method-cancelled-error.ts
@@ -1,8 +1,8 @@
 import { StandardError } from '../../common/error/errors';
 
 export default class PaymentMethodCancelledError extends StandardError {
-    constructor() {
-        super('Payment process was cancelled.');
+    constructor(message?: string) {
+        super(message || 'Payment process was cancelled.');
 
         this.type = 'payment_cancelled';
     }

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -8,6 +8,7 @@ import { MissingDataError, StandardError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { PaymentMethodCancelledError } from '../../errors';
 import { NonceInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
@@ -194,7 +195,25 @@ describe('BraintreePaypalPaymentStrategy', () => {
             try {
                 await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
             } catch (error) {
-                await expect(orderActionCreator.submitOrder).not.toHaveBeenCalled();
+                expect(error).toBeInstanceOf(StandardError);
+                expect(orderActionCreator.submitOrder).not.toHaveBeenCalled();
+            }
+        });
+
+        it('throws cancellation error if shopper dismisses PayPal modal before completing authorization flow', async () => {
+            jest.spyOn(braintreePaymentProcessorMock, 'paypal')
+                .mockRejectedValue({
+                    code: 'PAYPAL_POPUP_CLOSED',
+                    message: 'Customer closed PayPal popup before authorizing.',
+                    name: 'BraintreeError',
+                });
+
+            await braintreePaypalPaymentStrategy.initialize(options);
+
+            try {
+                await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodCancelledError);
             }
         });
 

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -192,7 +192,7 @@ export interface BraintreeVerifyPayload {
     liabilityShifted: boolean;
 }
 
-export interface BraintreeError {
+export interface BraintreeError extends Error {
     type: 'CUSTOMER' | 'MERCHANT' | 'NETWORK' | 'INTERNAL' | 'UNKNOWN';
     code: string;
     details: object;

--- a/src/payment/strategies/braintree/is-braintree-error.spec.ts
+++ b/src/payment/strategies/braintree/is-braintree-error.spec.ts
@@ -1,0 +1,19 @@
+import isBraintreeError from './is-braintree-error';
+
+describe('isBraintreeError()', () => {
+    it('returns true if error comes from Braintree', () => {
+        const error = new Error('An unknown error.');
+
+        error.name = 'BraintreeError';
+
+        expect(isBraintreeError(error))
+            .toEqual(true);
+    });
+
+    it('returns false if error is not from Braintree', () => {
+        const error = new Error('An unknown error.');
+
+        expect(isBraintreeError(error))
+            .toEqual(false);
+    });
+});

--- a/src/payment/strategies/braintree/is-braintree-error.ts
+++ b/src/payment/strategies/braintree/is-braintree-error.ts
@@ -1,0 +1,5 @@
+import { BraintreeError } from './braintree';
+
+export default function isBraintreeError(error: BraintreeError | Error): error is BraintreeError {
+    return error.name === 'BraintreeError';
+}


### PR DESCRIPTION
## What?
* Throw a cancellation error when the shopper closes the PayPal popup before completing the authorisation flow.

## Why?
* Client apps can choose to ignore the error by checking `type` property.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
