### PR TITLE
PAYMENTS-1253: Show overlay when Braintree PayPal modal is open

### DIFF
--- a/src/common/overlay/index.ts
+++ b/src/common/overlay/index.ts
@@ -1,0 +1,1 @@
+export { default as Overlay } from './overlay';

--- a/src/common/overlay/overlay.spec.ts
+++ b/src/common/overlay/overlay.spec.ts
@@ -1,0 +1,91 @@
+import Overlay from './overlay';
+
+// tslint:disable:no-non-null-assertion
+describe('Overlay', () => {
+    let overlay: Overlay;
+
+    beforeEach(() => {
+        overlay = new Overlay({
+            id: 'overlay',
+            transitionDuration: 400,
+        });
+    });
+
+    afterEach(() => {
+        const element = document.getElementById('overlay');
+
+        if (element) {
+            element.parentElement!.removeChild(element);
+        }
+    });
+
+    it('shows element on top of everything else', () => {
+        overlay.show();
+
+        const element = document.getElementById('overlay');
+
+        expect(element).toBeTruthy();
+        expect(element!.style.background).toEqual('rgba(0, 0, 0, 0.8)');
+        expect(element!.style.height).toEqual('100%');
+        expect(element!.style.left).toEqual('0px');
+        expect(element!.style.position).toEqual('fixed');
+        expect(element!.style.top).toEqual('0px');
+        expect(element!.style.width).toEqual('100%');
+        expect(element!.style.zIndex).toEqual('2147483647');
+    });
+
+    it('triggers click handler if it is provided', () => {
+        const onClick = jest.fn();
+
+        overlay.show({ onClick });
+
+        const element = document.getElementById('overlay');
+
+        element!.dispatchEvent(new MouseEvent('click'));
+
+        expect(onClick).toHaveBeenCalled();
+    });
+
+    it('fades element into view', async () => {
+        overlay.show();
+
+        const element = document.getElementById('overlay');
+
+        expect(element!.style.opacity).toEqual('0');
+
+        await new Promise(resolve => {
+            setTimeout(resolve, 400);
+        });
+
+        expect(element!.style.opacity).toEqual('1');
+    });
+
+    it('fades element out of view', async () => {
+        overlay.show();
+
+        const element = document.getElementById('overlay');
+
+        overlay.remove();
+
+        await new Promise(resolve => {
+            setTimeout(resolve, 400);
+        });
+
+        expect(element!.style.opacity).toEqual('0');
+    });
+
+    it('removes click handler when element is removed', () => {
+        const onClick = jest.fn();
+
+        overlay.show({ onClick });
+
+        const element = document.getElementById('overlay');
+
+        overlay.remove();
+
+        element!.dispatchEvent(new MouseEvent('click'));
+
+        expect(onClick).not.toHaveBeenCalled();
+    });
+});
+// tslint:enable:no-non-null-assertion

--- a/src/common/overlay/overlay.ts
+++ b/src/common/overlay/overlay.ts
@@ -1,0 +1,105 @@
+export interface OverlayOptions {
+    background?: string;
+    id?: string;
+    transitionDuration?: number;
+}
+
+export interface OverlayShowOptions {
+    onClick?(event: MouseEvent): void;
+}
+
+export default class Overlay {
+    private _element: HTMLElement;
+    private _unregisterClick?: () => void;
+
+    constructor(options?: OverlayOptions) {
+        this._element = this._createElement(options);
+    }
+
+    show(options?: OverlayShowOptions): void {
+        if (this._element.parentElement) {
+            return;
+        }
+
+        this._registerClick(options);
+
+        document.body.appendChild(this._element);
+
+        // Fade In
+        setTimeout(() => this._element.style.opacity = '1');
+    }
+
+    remove(): void {
+        if (!this._element.parentElement) {
+            return;
+        }
+
+        if (this._unregisterClick) {
+            this._unregisterClick();
+        }
+
+        this._removeAfterTransition();
+
+        setTimeout(() => this._element.style.opacity = '0');
+    }
+
+    private _createElement(options?: OverlayOptions): HTMLElement {
+        const element = document.createElement('div');
+        const {
+            background = 'rgba(0, 0, 0, 0.8)',
+            id = null,
+            transitionDuration = 400,
+        } = options || {};
+
+        element.style.background = background;
+        element.style.display = 'block';
+        element.style.height = '100%';
+        element.style.left = '0px';
+        element.style.opacity = '0';
+        element.style.position = 'fixed';
+        element.style.top = '0px';
+        element.style.transition = `opacity ${transitionDuration}ms ease-out`;
+        element.style.width = '100%';
+        element.style.zIndex = '2147483647';
+
+        if (id) {
+            element.id = id;
+        }
+
+        return element;
+    }
+
+    private _registerClick(options?: OverlayShowOptions): void {
+        if (this._unregisterClick) {
+            this._unregisterClick();
+        }
+
+        if (options && options.onClick) {
+            const { onClick } = options;
+
+            this._element.addEventListener('click', onClick);
+
+            this._unregisterClick = () => {
+                this._element.removeEventListener('click', onClick);
+                this._unregisterClick = undefined;
+            };
+        }
+    }
+
+    private _removeAfterTransition(): void {
+        const handeTransition: (event: Event) => void = event => {
+            // NOTE: `event` is not correctly typed in this version of TS
+            if ((event as TransitionEvent).propertyName !== 'opacity') {
+                return;
+            }
+
+            if (this._element.parentElement) {
+                this._element.parentElement.removeChild(this._element);
+            }
+
+            this._element.removeEventListener('transitionend', handeTransition);
+        };
+
+        this._element.addEventListener('transitionend', handeTransition);
+    }
+}

--- a/src/payment/strategies/braintree/create-braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/create-braintree-payment-processor.ts
@@ -1,5 +1,7 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
+import { Overlay } from '../../../common/overlay';
+
 import BraintreePaymentProcessor from './braintree-payment-processor';
 import BraintreeScriptLoader from './braintree-script-loader';
 import BraintreeSDKCreator from './braintree-sdk-creator';
@@ -7,6 +9,7 @@ import BraintreeSDKCreator from './braintree-sdk-creator';
 export default function createBraintreePaymentProcessor(scriptLoader: ScriptLoader) {
     const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader);
     const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+    const overlay = new Overlay();
 
-    return new BraintreePaymentProcessor(braintreeSDKCreator);
+    return new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
 }


### PR DESCRIPTION
## What?
* Show an overlay when PayPal modal is open.

## Why?
* So shoppers can't interact with the UI while the modal is open.
* I remember previously PayPal is responsible for showing the overlay. But I think at some point in the past we upgraded the client SDK (to support Google Pay). And the new version doesn't show the overlay anymore - it's now the client's responsibility.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
