### PR TITLE
PAYMENTS-1253: Pass order amount to Braintree client when going through 3DS flow

### DIFF
--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -95,19 +95,19 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
             return Promise.resolve(payment as Payment);
         }
 
-        const checkout = state.checkout.getCheckout();
+        const order = state.order.getOrder();
         const billingAddress = state.billingAddress.getBillingAddress();
 
-        if (!checkout) {
-            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+        if (!order) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrder);
         }
 
         if (!billingAddress) {
-            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+            throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
         }
 
         const tokenizedCard = this._is3dsEnabled ?
-            this._braintreePaymentProcessor.verifyCard(payment, billingAddress, checkout.grandTotal) :
+            this._braintreePaymentProcessor.verifyCard(payment, billingAddress, order.orderAmount) :
             this._braintreePaymentProcessor.tokenizeCard(payment, billingAddress);
 
         return this._braintreePaymentProcessor.appendSessionId(tokenizedCard)


### PR DESCRIPTION
## What?
* Pass the order amount to Braintree client when going through 3DS flow

## Why?
* It appears a [similar issue](https://github.com/bigcommerce/checkout-sdk-js/pull/546) affects 3DS flow as well - where the store credit amount is not reflected in the 3DS modal.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
