### PR TITLE
feat(payment): INT-1398 Add shipping and billing address before Klarna authorization

### DIFF
--- a/src/payment/strategies/klarna/klarna-credit.ts
+++ b/src/payment/strategies/klarna/klarna-credit.ts
@@ -1,7 +1,8 @@
 export default interface KlarnaCredit {
     authorize(params: any, callback: (res: KlarnaAuthorizationResponse) => void): void;
     init(params: KlarnaInitParams): void;
-    load(params: KlarnaLoadParams, callback?: (res: KlarnaLoadResponse) => void): void;
+    load(params: KlarnaLoadParams, callback: (res: KlarnaLoadResponse) => void): void;
+    load(params: KlarnaLoadParams, data: KlarnaUpdateSessionParams, callback: (res: KlarnaLoadResponse) => void): void;
 }
 
 export interface KlarnaInitParams {
@@ -10,6 +11,10 @@ export interface KlarnaInitParams {
 
 export interface KlarnaLoadParams {
     container: string;
+    payment_method_category?: string;
+    payment_method_categories?: string;
+    instance_id?: string;
+    preferred_payment_method?: string;
 }
 
 export interface KlarnaLoadResponse {
@@ -26,4 +31,20 @@ export interface KlarnaAuthorizationResponse {
     error?: {
         invalid_fields: string[];
     };
+}
+
+export type KlarnaUpdateSessionParams = Partial<{
+    billing_address: KlarnaAddress;
+    shipping_address: KlarnaAddress;
+}>;
+
+export interface KlarnaAddress {
+    street_address: string;
+    city: string;
+    country: string;
+    given_name: string;
+    family_name: string;
+    postal_code: string;
+    region: string;
+    email?: string;
 }

--- a/src/payment/strategies/klarna/klarna.mock.ts
+++ b/src/payment/strategies/klarna/klarna.mock.ts
@@ -1,0 +1,48 @@
+import { BillingAddress } from '../../../billing/';
+
+import { KlarnaUpdateSessionParams } from './klarna-credit';
+
+export function getKlarnaUpdateSessionParams(): KlarnaUpdateSessionParams {
+    return {
+        billing_address: {
+            street_address: '12345 Testing Way',
+            city: 'Some City',
+            country: 'DE',
+            given_name: 'Test',
+            family_name: 'Tester',
+            postal_code: '95555',
+            region: 'Berlin',
+            email: 'test@bigcommerce.com',
+        },
+        shipping_address: {
+            street_address: '12345 Testing Way',
+            city: 'Some City',
+            country: 'US',
+            given_name: 'Test',
+            family_name: 'Tester',
+            postal_code: '95555',
+            region: 'California',
+            email: 'test@bigcommerce.com',
+        },
+    };
+}
+
+export function getEUBillingAddress(): BillingAddress {
+    return {
+        id: '55c96cda6f04c',
+        firstName: 'Test',
+        lastName: 'Tester',
+        email: 'test@bigcommerce.com',
+        company: 'Bigcommerce',
+        address1: '12345 Testing Way',
+        address2: '',
+        city: 'Some City',
+        stateOrProvince: 'Berlin',
+        stateOrProvinceCode: 'CA',
+        country: 'Germany',
+        countryCode: 'DE',
+        postalCode: '95555',
+        phone: '555-555-5555',
+        customFields: [],
+    };
+}


### PR DESCRIPTION
## What?
I added billing and shipping address to the payload of the `load` method for Klarna.

## Why?
According to Legal Privacy and Europe laws, Klarna must not receive PII data from BC until shopper selects option at checkout or authorizes so we no longer send this info during the `create_session` call instead of that we update the session with the info before open the Klarna's widget 

## Testing / Proof
Video: https://drive.google.com/open?id=1UWqsZfH08c3LSx9RqqZDDZ4Sn5ARWL7_

![image](https://user-images.githubusercontent.com/36899206/55663026-eb12b380-57d6-11e9-92ef-ef79bb32c232.png)

![image](https://user-images.githubusercontent.com/36899206/55742371-1d016100-59f5-11e9-9a7e-7dd7dfd7a88a.png)

Sibling PRs:
[BigPay INT-1398](https://github.com/bigcommerce/bigpay/pull/1585)

@bigcommerce/checkout @bigcommerce/payments
