### PR TITLE
Update Readme: Customer signin actions require named parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ console.log(state.data.getConfig());
 Before you can collect other checkout information from the customer, you should first ask them to sign in. Once they are signed in, the checkout state will be populated with their personal details, such as their addresses.
 
 ```js
-const state = await service.signInCustomer('foo@bar.com', 'password123');
+const state = await service.signInCustomer({email: 'foo@bar.com', password: 'password123'});
 
 console.log(state.data.getCustomer());
 ```
@@ -141,7 +141,7 @@ console.log(state.data.getCustomer());
 Alternatively, you can ask the customer to continue as a guest.
 
 ```js
-const state = await service.signInCustomer('foo@bar.com');
+const state = await service.signInCustomer({email: 'foo@bar.com'});
 
 console.log(state.data.getCustomer());
 ```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ console.log(state.data.getConfig());
 Before you can collect other checkout information from the customer, you should first ask them to sign in. Once they are signed in, the checkout state will be populated with their personal details, such as their addresses.
 
 ```js
-const state = await service.signInCustomer({email: 'foo@bar.com', password: 'password123'});
+const state = await service.signInCustomer({ email: 'foo@bar.com', password: 'password123' });
 
 console.log(state.data.getCustomer());
 ```
@@ -141,7 +141,7 @@ console.log(state.data.getCustomer());
 Alternatively, you can ask the customer to continue as a guest.
 
 ```js
-const state = await service.signInCustomer({email: 'foo@bar.com'});
+const state = await service.continueAsGuest({ email: 'foo@bar.com' });
 
 console.log(state.data.getCustomer());
 ```
@@ -189,7 +189,7 @@ Then, you can ask the customer to select a shipping option from the list.
 ```js
 const address = state.data.getShippingAddress();
 const options = state.data.getShippingOptions();
-const newState = await service.selectShippingOption(address.id, options[address.id].id);
+const newState = await service.selectShippingOption(options[address.id].id);
 
 console.log(newState.checkout.getSelectedShippingOption());
 ```


### PR DESCRIPTION
## What?
Update to Readme

## Why?
Described incorrect parameters required for `signInCustomer`

Update name of method to sign in guest from `signInCustomer` to `continueAsGuest`

Update `selectShippingOption` to no longer accept `address.id` as a paremeter.

## Testing / Proof
Could only get it to work using named parameters.

@bigcommerce/checkout @bigcommerce/payments
