### PR TITLE
feat(payment): INT-1464 Port Elavon ng-checkout only implementation to checkout-sdk-js + ng-checkout

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -8,6 +8,7 @@ import PaymentStrategyRegistry from './payment-strategy-registry';
 import PaymentStrategyType from './payment-strategy-type';
 import { AfterpayPaymentStrategy } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy } from './strategies/amazon-pay';
+import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { GooglePayPaymentStrategy } from './strategies/googlepay';
 import { KlarnaPaymentStrategy } from './strategies/klarna';
@@ -101,5 +102,10 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate googlepaybraintree', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.BRAINTREE_GOOGLE_PAY);
         expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+
+    it('can instantiate converge', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CONVERGE);
+        expect(paymentStrategy).toBeInstanceOf(ConvergePaymentStrategy);
     });
 });

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -29,6 +29,7 @@ import {
     VisaCheckoutScriptLoader
 } from './strategies/braintree';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
+import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import {
     createGooglePayPaymentProcessor,
@@ -66,6 +67,7 @@ export default function createPaymentStrategyRegistry(
     const configActionCreator = new ConfigActionCreator(new ConfigRequestSender(requestSender));
     const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
     const paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
+    const formPoster = createFormPoster();
 
     registry.register(PaymentStrategyType.AFFIRM, () =>
         new AffirmPaymentStrategy(
@@ -168,7 +170,7 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
-            createFormPoster()
+            formPoster
         )
     );
 
@@ -309,6 +311,15 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             paymentMethodActionCreator,
             new ZipScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register(PaymentStrategyType.CONVERGE, () =>
+        new ConvergePaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formPoster
         )
     );
 

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -23,6 +23,7 @@ enum PaymentStrategyType {
     MASTERPASS = 'masterpass',
     STRIPE_GOOGLE_PAY = 'googlepaystripe',
     ZIP = 'zip',
+    CONVERGE = 'converge',
 }
 
 export default PaymentStrategyType;

--- a/src/payment/strategies/converge/converge-payment-strategy.spec.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.spec.ts
@@ -1,0 +1,202 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { omit } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getOrder } from '../../../order/orders.mock';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import PaymentRequestSender from '../../payment-request-sender';
+import * as paymentStatusTypes from '../../payment-status-types';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+
+import ConvergePaymentStrategy from './converge-payment-strategy';
+
+describe('ConvergeaymentStrategy', () => {
+    let finalizeOrderAction: Observable<FinalizeOrderAction>;
+    let formPoster: FormPoster;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let store: CheckoutStore;
+    let orderRequestSender: OrderRequestSender;
+    let strategy: ConvergePaymentStrategy;
+    let submitOrderAction: Observable<SubmitOrderAction>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+
+    beforeEach(() => {
+        orderRequestSender = new OrderRequestSender(createRequestSender());
+        orderActionCreator = new OrderActionCreator(
+            orderRequestSender,
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator
+        );
+
+        formPoster = createFormPoster();
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(store, 'dispatch');
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockImplementation((url, data, callback = () => {}) => callback());
+
+        jest.spyOn(orderActionCreator, 'finalizeOrder')
+            .mockReturnValue(finalizeOrderAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        strategy = new ConvergePaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formPoster
+        );
+    });
+
+    it('submits order without payment data', async () => {
+        const payload = getOrderRequestBody();
+        const options = { methodId: 'converge' };
+
+        await strategy.execute(payload, options);
+
+        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), options);
+        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    });
+
+    it('submits payment separately', async () => {
+        const payload = getOrderRequestBody();
+        const options = { methodId: 'converge' };
+
+        await strategy.execute(payload, options);
+
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payload.payment);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+    });
+
+    it('returns checkout state', async () => {
+        const output = await strategy.execute(getOrderRequestBody());
+
+        expect(output).toEqual(store.getState());
+    });
+
+    it('posts 3ds data to Converge if 3ds is enabled', async () => {
+        const error = new RequestError(getResponse({
+            ...getErrorPaymentResponseBody(),
+            errors: [
+                { code: 'three_d_secure_required' },
+            ],
+            three_ds_result: {
+                acs_url: 'https://acs/url',
+                callback_url: 'https://callback/url',
+                payer_auth_request: 'payer_auth_request',
+                merchant_data: 'merchant_data',
+            },
+            status: 'error',
+        }));
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+        strategy.execute(getOrderRequestBody());
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(formPoster.postForm).toHaveBeenCalledWith('https://acs/url', {
+            PaReq: 'payer_auth_request',
+            TermUrl: 'https://callback/url',
+            MD: 'merchant_data',
+        });
+    });
+
+    it('does not post 3ds data to Converge if 3ds is not enabled', async () => {
+        const response = new RequestError(getResponse(getErrorPaymentResponseBody()));
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, response)));
+
+        try {
+            await strategy.execute(getOrderRequestBody());
+        } catch (error) {
+            expect(error).toBeInstanceOf(RequestError);
+            expect(formPoster.postForm).not.toHaveBeenCalled();
+        }
+    });
+
+    it('finalizes order if order is created and payment is finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(getOrder());
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.FINALIZE);
+
+        await strategy.finalize();
+
+        expect(orderActionCreator.finalizeOrder).toHaveBeenCalled();
+        expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not created', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+            expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
+    });
+
+    it('does not finalize order if order is not finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.INITIALIZE);
+
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+            expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
+    });
+
+    it('throws error if order is missing', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
+    });
+});

--- a/src/payment/strategies/converge/converge-payment-strategy.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.ts
@@ -1,0 +1,67 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { some } from 'lodash';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { RequestError } from '../../../common/error/errors';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import * as paymentStatusTypes from '../../payment-status-types';
+import PaymentStrategy from '../payment-strategy';
+
+export default class ConvergePaymentStrategy implements PaymentStrategy {
+    constructor(
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _formPoster: FormPoster
+    ) {}
+
+    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+        const paymentData = payment && payment.paymentData;
+
+        if (!payment || !paymentData) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
+            .then(() =>
+                this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }))
+            )
+            .catch(error => {
+                if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
+                    return Promise.reject(error);
+                }
+
+                return new Promise(() => {
+                    this._formPoster.postForm(error.body.three_ds_result.acs_url, {
+                        PaReq: error.body.three_ds_result.payer_auth_request,
+                        TermUrl: error.body.three_ds_result.callback_url,
+                        MD: error.body.three_ds_result.merchant_data,
+                    });
+                });
+            });
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const order = state.order.getOrder();
+
+        if (order && state.payment.getPaymentStatus() === paymentStatusTypes.FINALIZE) {
+            return this._store.dispatch(this._orderActionCreator.finalizeOrder(order.orderId, options));
+        }
+
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+}

--- a/src/payment/strategies/converge/index.ts
+++ b/src/payment/strategies/converge/index.ts
@@ -1,0 +1,1 @@
+export { default as ConvergePaymentStrategy } from './converge-payment-strategy';


### PR DESCRIPTION
## What? [INT-1464](https://jira.bigcommerce.com/browse/INT-1464)
port Elavon ng-checkout only implementation to checkout-sdk-js + ng-checkout

## Why?
partners who use checkout-sdk-js + ng-checkout can use Elavon Converge

## Testing / Proof
![image](https://user-images.githubusercontent.com/8570490/57107210-03ea8800-6cf5-11e9-8f6a-875f7ac2130a.png)

![image](https://user-images.githubusercontent.com/8570490/57163452-dd8d2100-6db6-11e9-83c9-5395f066d8d6.png)

@bigcommerce/checkout @bigcommerce/payments
