### PR TITLE
CHECKOUT-4062 Expose missing payment errors

### DIFF
--- a/src/common/error/errors/map-from-payment-error-response.ts
+++ b/src/common/error/errors/map-from-payment-error-response.ts
@@ -30,8 +30,3 @@ function joinErrors(errors: Array<{ code: string, message?: string }>): string |
         return result;
     }, []).join(' ');
 }
-
-export const PAYMENT_ERROR_CODES = [
-    'payment',
-    'transaction_declined',
-];

--- a/src/common/error/request-error-factory.ts
+++ b/src/common/error/request-error-factory.ts
@@ -7,7 +7,7 @@ import ErrorResponseBody, {
 } from './error-response-body';
 import { RequestError, TimeoutError } from './errors';
 import mapFromInternalErrorResponse from './errors/map-from-internal-error-response';
-import mapFromPaymentErrorResponse, { PAYMENT_ERROR_CODES } from './errors/map-from-payment-error-response';
+import mapFromPaymentErrorResponse from './errors/map-from-payment-error-response';
 import mapFromStorefrontErrorResponse from './errors/map-from-storefront-error-response';
 
 export default class RequestErrorFactory {
@@ -50,11 +50,11 @@ export default class RequestErrorFactory {
 
         const error = last(response.body && response.body.errors);
 
-        if (error && PAYMENT_ERROR_CODES.indexOf(error.code) !== -1) {
-            return 'payment';
+        if (error && error.code && this._factoryMethods[error.code]) {
+            return error.code;
         }
 
-        return error && error.code ? error.code : 'payment';
+        return 'payment';
     }
 
     private _isStorefrontErrorResponseBody(


### PR DESCRIPTION
## What?
Expose all errors coming from BigPay, unless we have manually registered a specific error with a specific code.

## Why?
https://github.com/bigcommerce/checkout-sdk-js/pull/499 aimed to fix surfacing payment errors that were not being properly exposed, by checking specific codes. We know that if BigPay surfaces error, they can be displayed to the shopper. Expose all these errors unless there is an override registered.

## Testing / Proof
- [x] unit

@bigcommerce/checkout 
<img width="763" alt="Screen Shot 2019-05-07 at 1 58 39 pm" src="https://user-images.githubusercontent.com/1621894/57274646-3aeae000-70df-11e9-915d-d60add37f644.png">
ommerce/payments

<img width="778" alt="Screen Shot 2019-05-07 at 3 46 24 pm" src="https://user-images.githubusercontent.com/1621894/57274669-4ccc8300-70df-11e9-9a8a-42f5c8831cf6.png">
