### PR TITLE
feat(checkout): INT-1520 Pass useStoreCredit flag when initialize payment

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -308,6 +308,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             paymentMethodActionCreator,
+            remoteCheckoutActionCreator,
             new ZipScriptLoader(scriptLoader)
         )
     );


### PR DESCRIPTION
## What? [INT-1520](https://jira.bigcommerce.com/browse/INT-1520)
Initialize payment sending the useStoreCredit flag

## Why?
In order to can update the total amount according to that

## Testing / Proof
![image](https://user-images.githubusercontent.com/6343437/57403202-bbbce100-719e-11e9-84e7-ab63bcadf3e0.png)

https://drive.google.com/open?id=1A8p5EifpG3RRWN3HQjP86JiWQRdkHu2l

@bigcommerce/checkout @bigcommerce/payments
