### PR TITLE
chore(common): CHECKOUT-4097 Restrict ts-loader to the src folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ const assetConfig = {
 
     output: {
         filename: '[name].js',
-        library: "checkoutKit",
+        library: 'checkoutKit',
         libraryTarget: 'commonjs2',
         path: path.resolve(__dirname, 'dist'),
     },
@@ -34,7 +34,7 @@ const assetConfig = {
             },
             {
                 test: /\.(js|ts)$/,
-                exclude: /node_modules/,
+                include: path.resolve(__dirname, 'src'),
                 loader: 'ts-loader',
             },
         ],


### PR DESCRIPTION
## What?
Restrict `ts-loader` to the `src` folder of the project

## Why?
Packages linked using npm don't contain the `node_modules` string in
their path. This can cause problems if` ts-loader` tries to process non
es6 modules. It is more reliable to simply restrict `ts-loader` to files
within the `src` folder of the project.

## Testing / Proof
- Unit / Manual

Before:
<img width="825" alt="image" src="https://user-images.githubusercontent.com/4542735/57588875-a3621300-755e-11e9-9df0-3a1819a3f9dc.png">

After:
<img width="868" alt="image" src="https://user-images.githubusercontent.com/4542735/57588882-afe66b80-755e-11e9-96fb-f8aeb61b0a3b.png">

@bigcommerce/checkout @bigcommerce/payments
