### PR TITLE
feat(payment): INT-1247 Checkout using Zip Registration Referred

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -311,7 +311,8 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             paymentMethodActionCreator,
             remoteCheckoutActionCreator,
-            new ZipScriptLoader(scriptLoader)
+            new ZipScriptLoader(scriptLoader),
+            requestSender
         )
     );
 

--- a/src/payment/strategies/zip/zip-payment-strategy.ts
+++ b/src/payment/strategies/zip/zip-payment-strategy.ts
@@ -1,3 +1,5 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
     InvalidArgumentError,
@@ -6,6 +8,7 @@ import {
     NotInitializedError,
     NotInitializedErrorType,
 } from '../../../common/error/errors';
+import { ContentType, INTERNAL_USE_ONLY } from '../../../common/http-request';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
@@ -29,7 +32,8 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
         private _paymentActionCreator: PaymentActionCreator,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
-        private _zipScriptLoader: ZipScriptLoader
+        private _zipScriptLoader: ZipScriptLoader,
+        private _requestSender: RequestSender
     ) { }
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -74,11 +78,16 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
                             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                         }
                     })
-                    .then(() => new Promise<string>((resolve, reject) => {
+                    .then(() => new Promise<string | undefined>((resolve, reject) => {
                         zipClient.Checkout.init({
                             onComplete: ({ checkoutId, state }) => {
                                 if (state === ZipModalEvent.CancelCheckout) {
                                     return reject(new PaymentMethodCancelledError());
+                                }
+
+                                if (state === ZipModalEvent.CheckoutReferred && checkoutId) {
+                                    return this._prepareForReferredRegistration(payment.methodId, checkoutId)
+                                        .then(() => resolve());
                                 }
 
                                 if (state === ZipModalEvent.CheckoutApproved && checkoutId) {
@@ -100,16 +109,37 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
                             },
                         });
                     })
-                    .then(nonce =>
-                        this._store.dispatch(this._paymentActionCreator.submitPayment({
-                            methodId: payment.methodId,
-                            paymentData: { nonce },
-                        }))
+                    .then(nonce => {
+                        if (nonce !== undefined) {
+                            return this._store.dispatch(this._paymentActionCreator.submitPayment({
+                                methodId: payment.methodId,
+                                paymentData: { nonce },
+                            }));
+                        }
+
+                        return this._store.getState();
+                    }
                     ));
             });
     }
 
     finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    private _prepareForReferredRegistration(provider: string, externalId: string): Promise<Response> {
+        const url = `/api/storefront/payment/${provider}/save-external-id`;
+        const options = {
+            headers: {
+                Accept: ContentType.JsonV1,
+                'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            },
+            body: {
+                externalId,
+                provider,
+            },
+        };
+
+        return this._requestSender.post(url, options);
     }
 }

--- a/src/payment/strategies/zip/zip.mock.ts
+++ b/src/payment/strategies/zip/zip.mock.ts
@@ -19,6 +19,14 @@ export function getZipScriptMock(status: string): Zip {
         };
         break;
 
+    case 'referred':
+        mockZipResponse = {
+            checkoutId: 'checkoutId',
+            customerId: '',
+            state: 'referred',
+        };
+        break;
+
     case 'declined':
         mockZipResponse = {
             checkoutId: '',

--- a/src/payment/strategies/zip/zip.ts
+++ b/src/payment/strategies/zip/zip.ts
@@ -28,6 +28,7 @@ export const enum ZipModalEvent {
     CancelCheckout = 'cancelled',
     CheckoutApproved = 'approved',
     CheckoutDeclined = 'declined',
+    CheckoutReferred = 'referred',
 }
 
 /**


### PR DESCRIPTION
## What?
Added additional handlers for `declined` and `referred` responses from the zip Lightbox. 
Referred flow sends a request to clear the cart and save the externalId and then redirects to order confirmation page.

## Why?
Zip referred registration flow requires the order to seem purchased and redirect to order confirmation page.

## Testing / Proof
[Pending Deploy]
<img width="831" alt="Screen Shot 2019-05-13 at 1 31 07 PM" src="https://user-images.githubusercontent.com/35502707/57646207-a9b7b580-7585-11e9-86bb-199ba798e62d.png">


@bigcommerce/checkout @bigcommerce/payments
