### PR TITLE
feat(payment): Create Cybersource's strategy for 3DS

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -32,6 +32,11 @@ import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chas
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import {
+    CardinalClient,
+    CardinalScriptLoader,
+    CyberSourcePaymentStrategy
+} from './strategies/cybersource';
+import {
     createGooglePayPaymentProcessor,
     GooglePayBraintreeInitializer,
     GooglePayPaymentStrategy,
@@ -107,6 +112,16 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator
+        )
+    );
+
+    registry.register(PaymentStrategyType.CYBERSOURCE, () =>
+        new CyberSourcePaymentStrategy(
+            store,
+            paymentMethodActionCreator,
+            orderActionCreator,
+            paymentActionCreator,
+            new CardinalClient(new CardinalScriptLoader(scriptLoader))
         )
     );
 

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -7,7 +7,7 @@ export { default as createPaymentClient } from './create-payment-client';
 export { default as createPaymentStrategyRegistry } from './create-payment-strategy-registry';
 export { default as isNonceLike } from './is-nonce-like';
 export { default as PaymentActionCreator } from './payment-action-creator';
-export { default as Payment, CreditCardInstrument, VaultedInstrument, PaymentInstrument, NonceInstrument } from './payment';
+export { default as Payment, CreditCardInstrument, VaultedInstrument, PaymentInstrument, NonceInstrument, ThreeDSecure, ThreeDSecureToken } from './payment';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -133,9 +133,11 @@ export function getCybersource(): PaymentMethod {
         supportedCards: [],
         config: {
             displayName: 'Cybersource',
-            testMode: false,
+            is3dsEnabled: true,
+            testMode: true,
         },
         type: 'PAYMENT_TYPE_API',
+        clientToken: 'cyberToken',
     };
 }
 

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -3,6 +3,7 @@ enum PaymentStrategyType {
     AFTERPAY = 'afterpay',
     AMAZON = 'amazon',
     CREDIT_CARD = 'creditcard',
+    CYBERSOURCE = 'cybersource',
     KLARNA = 'klarna',
     LEGACY = 'legacy',
     OFFLINE = 'offline',

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -21,6 +21,7 @@ export interface CreditCardInstrument {
     ccCvv?: string;
     shouldSaveInstrument?: boolean;
     extraData?: any;
+    threeDSecure?: ThreeDSecure | ThreeDSecureToken;
 }
 
 export interface NonceInstrument {
@@ -45,4 +46,17 @@ export interface CryptogramInstrument {
     ccNumber: string;
     accountMask: string;
     extraData?: any;
+}
+
+export interface ThreeDSecure {
+    version: string;
+    status: string;
+    vendor: string;
+    cavv: string;
+    eci: string;
+    xid: string;
+}
+
+export interface ThreeDSecureToken {
+    token: string;
 }

--- a/src/payment/strategies/cybersource/cardinal-client.spec.ts
+++ b/src/payment/strategies/cybersource/cardinal-client.spec.ts
@@ -1,0 +1,227 @@
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { NotInitializedError, StandardError } from '../../../common/error/errors';
+import MissingDataError from '../../../common/error/errors/missing-data-error';
+
+import {
+    getCardinalBinProcessResponse,
+    getCardinalOrderData,
+    getCardinalSDK,
+    getCardinalThreeDSResult,
+    getCardinalValidatedData,
+} from './cardinal.mock';
+import {
+    CardinalClient,
+    CardinalEventType,
+    CardinalInitializationType,
+    CardinalScriptLoader,
+    CardinalSDK,
+    CardinalTriggerEvents,
+    CardinalValidatedAction,
+    CardinalValidatedData
+} from './index';
+
+describe('CardinalClient', () => {
+    let client: CardinalClient;
+    let cardinalScriptLoader: CardinalScriptLoader;
+    let sdk: CardinalSDK;
+    let setupCall: () => {};
+    let validatedCall: (data: CardinalValidatedData, jwt: string) => {};
+
+    beforeEach(() => {
+        cardinalScriptLoader = new CardinalScriptLoader(createScriptLoader());
+        sdk = getCardinalSDK();
+        client = new CardinalClient(cardinalScriptLoader);
+
+        jest.spyOn(cardinalScriptLoader, 'load').mockReturnValue(Promise.resolve(sdk));
+    });
+
+    describe('#initialize', () => {
+        it('loads the cardinal sdk correctly', async () => {
+            await client.initialize(false);
+
+            expect(cardinalScriptLoader.load).toHaveBeenCalled();
+        });
+    });
+
+    describe('#configure', () => {
+        it('throws an error if test mode is not defined', async () => {
+            try {
+                await client.configure('token');
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
+        });
+
+        it('completes the setup process successfully', async () => {
+            let call: () => {};
+
+            sdk.on = jest.fn((type, callback) => {
+                if (type.toString() === CardinalEventType.SetupCompleted) {
+                    call = callback;
+                } else {
+                    jest.fn();
+                }
+            });
+
+            jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                call();
+            });
+
+            await client.initialize(true);
+            await client.configure('token');
+
+            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.SetupCompleted, expect.any(Function));
+            expect(sdk.setup).toHaveBeenCalledWith(CardinalInitializationType.Init, { jwt: 'token' });
+        });
+
+        it('completes the setup process incorrectly', async () => {
+            let call: (data: CardinalValidatedData, jwt: string) => {};
+
+            sdk.on = jest.fn((type, callback) => {
+                if (type.toString() === CardinalEventType.Validated) {
+                    call = callback;
+                } else {
+                    jest.fn();
+                }
+            });
+
+            jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                call(getCardinalValidatedData(CardinalValidatedAction.Error, false, 1020), '');
+            });
+
+            await client.initialize(true);
+
+            try {
+                await client.configure('token');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+    });
+
+    describe('#runBindProcess', () => {
+        beforeEach(async () => {
+            sdk.on = jest.fn((type, callback) => {
+                if (type.toString() === CardinalEventType.SetupCompleted) {
+                    setupCall = callback;
+                }
+            });
+
+            jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                setupCall();
+            });
+
+            await client.initialize(true);
+            await client.configure('token');
+        });
+
+        it('collects the data correctly', async () => {
+            jest.spyOn(sdk, 'trigger').mockReturnValue(Promise.resolve(getCardinalBinProcessResponse(true)));
+
+            await client.runBindProcess('123456');
+
+            expect(sdk.trigger).toHaveBeenCalledWith(CardinalTriggerEvents.BinProcess, '123456');
+        });
+
+        it('throws an error if data was not collected correctly', async () => {
+            jest.spyOn(sdk, 'trigger').mockReturnValue(Promise.resolve(getCardinalBinProcessResponse(false)));
+
+            try {
+                await client.runBindProcess('');
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
+        });
+
+        it('throws an error if cardinal throws an exception', async () => {
+            jest.spyOn(sdk, 'trigger').mockImplementation(() => {
+                return Promise.reject(new Error('Error'));
+            });
+
+            try {
+                await client.runBindProcess('');
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
+        });
+    });
+
+    describe('#getThreeDSecureData', () => {
+        beforeEach(async () => {
+            sdk.on = jest.fn((type, callback) => {
+                if (type.toString() === CardinalEventType.SetupCompleted) {
+                    setupCall = callback;
+                } else {
+                    validatedCall = callback;
+                }
+            });
+
+            jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                setupCall();
+            });
+
+            await client.initialize(true);
+            await client.configure('token');
+        });
+
+        it('returns a valid token', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(getCardinalValidatedData(CardinalValidatedAction.Success, true), 'token');
+            });
+
+            const promise = await client.getThreeDSecureData(getCardinalThreeDSResult(), getCardinalOrderData());
+
+            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.Validated, expect.any(Function));
+            expect(promise).toEqual({ token: 'token' });
+        });
+
+        it('returns a no action code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(getCardinalValidatedData(CardinalValidatedAction.NoAction, false, 0), 'token');
+            });
+
+            const promise = await client.getThreeDSecureData(getCardinalThreeDSResult(), getCardinalOrderData());
+
+            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.Validated, expect.any(Function));
+            expect(promise).toEqual({ token: 'token' });
+        });
+
+        it('returns an error and a no action code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(getCardinalValidatedData(CardinalValidatedAction.NoAction, false, 3002), '');
+            });
+
+            try {
+                await client.getThreeDSecureData(getCardinalThreeDSResult(), getCardinalOrderData());
+            } catch (error) {
+                expect(error).toBeInstanceOf(StandardError);
+            }
+        });
+
+        it('returns an error code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(getCardinalValidatedData(CardinalValidatedAction.Error, false, 3004), '');
+            });
+
+            try {
+                await client.getThreeDSecureData(getCardinalThreeDSResult(), getCardinalOrderData());
+            } catch (error) {
+                expect(error).toBeInstanceOf(StandardError);
+            }
+        });
+
+        it('returns a failure code', async () => {
+            jest.spyOn(sdk, 'continue').mockImplementation(() => {
+                validatedCall(getCardinalValidatedData(CardinalValidatedAction.Failure, false, 3004), '');
+            });
+
+            try {
+                await client.getThreeDSecureData(getCardinalThreeDSResult(), getCardinalOrderData());
+            } catch (error) {
+                expect(error).toBeInstanceOf(StandardError);
+                expect(error.message).toBe('User failed authentication or an error was encountered while processing the transaction');
+            }
+        });
+    });
+});

--- a/src/payment/strategies/cybersource/cardinal-client.ts
+++ b/src/payment/strategies/cybersource/cardinal-client.ts
@@ -1,0 +1,184 @@
+import { includes } from 'lodash';
+
+import Address from '../../../address/address';
+import {
+    MissingDataError, MissingDataErrorType, NotInitializedError,
+    NotInitializedErrorType, StandardError
+} from '../../../common/error/errors';
+import { CreditCardInstrument, ThreeDSecureToken } from '../../payment';
+import { ThreeDsResult } from '../../payment-response-body';
+
+import {
+    CardinalAccount,
+    CardinalAddress,
+    CardinalConsumer,
+    CardinalEventType,
+    CardinalInitializationType,
+    CardinalOrderData,
+    CardinalPartialOrder,
+    CardinalPaymentBrand,
+    CardinalScriptLoader,
+    CardinalSignatureValidationErrors,
+    CardinalSDK,
+    CardinalTriggerEvents,
+    CardinalValidatedAction,
+    CardinalValidatedData
+} from './index';
+
+export default class CardinalClient {
+    private _sdk?: Promise<CardinalSDK>;
+
+    constructor(
+        private _scriptLoader: CardinalScriptLoader
+    ) {}
+
+    initialize(testMode?: boolean): Promise<void> {
+        if (!this._sdk) {
+            this._sdk = this._scriptLoader.load(testMode);
+        }
+
+        return this._sdk.then(() => {});
+    }
+
+    configure(clientToken: string): Promise<void> {
+        return this._getClientSDK()
+            .then(client => new Promise<void>((resolve, reject) => {
+                client.on(CardinalEventType.SetupCompleted, () => {
+                    client.off(CardinalEventType.SetupCompleted);
+                    client.off(CardinalEventType.Validated);
+
+                    resolve();
+                });
+
+                client.on(CardinalEventType.Validated, (data: CardinalValidatedData) => {
+                    client.off(CardinalEventType.SetupCompleted);
+                    client.off(CardinalEventType.Validated);
+
+                    switch (data.ActionCode) {
+                        case CardinalValidatedAction.Error:
+                            if (includes(CardinalSignatureValidationErrors, data.ErrorNumber)) {
+                                reject(new MissingDataError(MissingDataErrorType.MissingPaymentMethod));
+                            }
+                            break;
+                    }
+                });
+
+                client.setup(CardinalInitializationType.Init, {
+                    jwt: clientToken,
+                });
+        }));
+    }
+
+    runBindProcess(ccNumber: string): Promise<void> {
+        return this._getClientSDK()
+            .then(client => client.trigger(CardinalTriggerEvents.BinProcess, ccNumber).catch(() => {}))
+            .then(result => {
+                if (!result || !result.Status) {
+                    throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+                }
+            });
+    }
+
+    getThreeDSecureData(threeDSecureData: ThreeDsResult, orderData: CardinalOrderData): Promise<ThreeDSecureToken> {
+        return this._getClientSDK()
+            .then(client => {
+                return new Promise<ThreeDSecureToken>((resolve, reject) => {
+                    client.on(CardinalEventType.Validated, (data: CardinalValidatedData, jwt: string) => {
+                        client.off(CardinalEventType.Validated);
+                        switch (data.ActionCode) {
+                            case CardinalValidatedAction.Success:
+                                resolve({ token: jwt });
+                                break;
+                            case CardinalValidatedAction.NoAction:
+                                if (data.ErrorNumber > 0) {
+                                    reject(new StandardError(data.ErrorDescription));
+                                } else {
+                                    resolve({ token: jwt });
+                                }
+                                break;
+                            case CardinalValidatedAction.Failure:
+                                reject(new StandardError('User failed authentication or an error was encountered while processing the transaction'));
+                                break;
+                            case CardinalValidatedAction.Error:
+                                reject(new StandardError(data.ErrorDescription));
+                        }
+                    });
+
+                    const continueObject = {
+                        AcsUrl: threeDSecureData.acs_url,
+                        Payload: threeDSecureData.merchant_data,
+                    };
+
+                    const partialOrder = this._mapToPartialOrder(orderData, threeDSecureData.payer_auth_request);
+
+                    client.continue(CardinalPaymentBrand.CCA, continueObject, partialOrder);
+                });
+        });
+    }
+
+    private _mapToPartialOrder(orderData: CardinalOrderData, transactionId: string): CardinalPartialOrder {
+        const consumer: CardinalConsumer = {
+            BillingAddress: this._mapToCardinalAddress(orderData.billingAddress),
+            Account: this._mapToCardinalAccount(orderData.paymentData),
+        };
+
+        if (orderData.billingAddress.email) {
+            consumer.Email1 = orderData.billingAddress.email;
+        }
+
+        if (orderData.shippingAddress) {
+            consumer.ShippingAddress = this._mapToCardinalAddress(orderData.shippingAddress);
+        }
+
+        return  {
+            Consumer: consumer,
+            OrderDetails: {
+                OrderNumber: orderData.id,
+                Amount: orderData.amount,
+                CurrencyCode: orderData.currencyCode,
+                OrderChannel: 'S',
+                TransactionId: transactionId,
+            },
+        };
+    }
+
+    private _mapToCardinalAccount(paymentData: CreditCardInstrument): CardinalAccount {
+        return {
+            AccountNumber: Number(paymentData.ccNumber),
+            ExpirationMonth: Number(paymentData.ccExpiry.month),
+            ExpirationYear: Number(paymentData.ccExpiry.year),
+            NameOnAccount: paymentData.ccName,
+            CardCode: Number(paymentData.ccCvv),
+        };
+    }
+
+    private _mapToCardinalAddress(address: Address): CardinalAddress {
+        const cardinalAddress: CardinalAddress = {
+            FirstName: address.firstName,
+            LastName: address.lastName,
+            Address1: address.address1,
+            City: address.city,
+            State: address.stateOrProvince,
+            PostalCode: address.postalCode,
+            CountryCode: address.countryCode,
+        };
+
+        if (address.address2) {
+            cardinalAddress.Address2 = address.address2;
+        }
+
+        if (address.phone) {
+            cardinalAddress.Phone1 = address.phone;
+        }
+
+        return cardinalAddress;
+    }
+
+    private _getClientSDK(): Promise<CardinalSDK> {
+        if (!this._sdk) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._sdk;
+    }
+}

--- a/src/payment/strategies/cybersource/cardinal-script-loader.spec.ts
+++ b/src/payment/strategies/cybersource/cardinal-script-loader.spec.ts
@@ -1,0 +1,59 @@
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { StandardError } from '../../../common/error/errors';
+
+import { getCardinalScriptMock } from './cardinal.mock';
+import { CardinalScriptLoader, CardinalWindow } from './index';
+
+describe('CardinalScriptLoader', () => {
+    const cardinalWindow: CardinalWindow = window;
+    const scriptLoader = createScriptLoader();
+    const scriptMock = getCardinalScriptMock();
+    let cardinalScriptLoader: CardinalScriptLoader;
+
+    beforeEach(() => {
+        cardinalScriptLoader = new CardinalScriptLoader(scriptLoader, cardinalWindow);
+        jest.spyOn(scriptLoader, 'loadScript').mockReturnValue(Promise.resolve(true));
+    });
+
+    it('loads widget test script', () => {
+        const testMode = true;
+        cardinalScriptLoader.load(testMode);
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            'https://songbirdstag.cardinalcommerce.com/edge/v1/songbird.js'
+        );
+    });
+
+    it('loads widget production script', () => {
+        const testMode = false;
+        cardinalScriptLoader.load(testMode);
+
+        expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+            'https://songbird.cardinalcommerce.com/edge/v1/songbird.js'
+        );
+    });
+
+    it('returns script from the window', async () => {
+        scriptLoader.loadScript = jest.fn(() => {
+            cardinalWindow.Cardinal = scriptMock.Cardinal;
+
+            return Promise.resolve();
+        });
+
+        const script = await cardinalScriptLoader.load();
+        expect(script).toBe(cardinalWindow.Cardinal);
+    });
+
+    it('throws error to inform that order finalization is not required', async () => {
+        scriptLoader.loadScript = jest.fn(() => {
+            throw new StandardError();
+        });
+
+        try {
+            await cardinalScriptLoader.load();
+        } catch (error) {
+            expect(error).toBeInstanceOf(StandardError);
+        }
+    });
+});

--- a/src/payment/strategies/cybersource/cardinal-script-loader.ts
+++ b/src/payment/strategies/cybersource/cardinal-script-loader.ts
@@ -1,0 +1,27 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { StandardError } from '../../../common/error/errors';
+
+import { CardinalSDK, CardinalWindow } from './cardinal';
+
+const SDK_TEST_URL = 'https://songbirdstag.cardinalcommerce.com/edge/v1/songbird.js';
+const SDK_PROD_URL = 'https://songbird.cardinalcommerce.com/edge/v1/songbird.js';
+
+export default class CardinalScriptLoader {
+    constructor(
+        private _scriptLoader: ScriptLoader,
+        private _window: CardinalWindow = window
+    ) {}
+
+    load(testMode?: boolean): Promise<CardinalSDK> {
+        return this._scriptLoader
+            .loadScript(testMode ? SDK_TEST_URL : SDK_PROD_URL)
+            .then(() => {
+                if (!this._window.Cardinal) {
+                    throw new StandardError();
+                }
+
+                return this._window.Cardinal;
+            });
+    }
+}

--- a/src/payment/strategies/cybersource/cardinal.mock.ts
+++ b/src/payment/strategies/cybersource/cardinal.mock.ts
@@ -1,0 +1,77 @@
+import { getBillingAddress } from '../../../billing/billing-addresses.mock';
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
+import { ThreeDsResult } from '../../payment-response-body';
+import { getCreditCardInstrument } from '../../payments.mock';
+
+import {
+    CardinalBinProcessResponse,
+    CardinalOrderData,
+    CardinalPaymentType,
+    CardinalSDK,
+    CardinalValidatedAction,
+    CardinalValidatedData,
+    CardinalWindow,
+} from './cardinal';
+
+const CardinalWindowMock: CardinalWindow = window;
+
+export function getCardinalScriptMock(): CardinalWindow {
+    return {
+        ... CardinalWindowMock,
+        Cardinal: getCardinalSDK(),
+    };
+}
+
+export function getCardinalSDK(): CardinalSDK {
+    return {
+        configure: jest.fn(),
+        on: jest.fn(),
+        setup: jest.fn(),
+        trigger: jest.fn(),
+        continue: jest.fn(),
+        off: jest.fn(),
+        start: jest.fn(),
+    };
+}
+
+export function getCardinalBinProcessResponse(status: boolean): CardinalBinProcessResponse {
+    return {
+        Status: status,
+    };
+}
+
+export function getCardinalValidatedData(actionCode: CardinalValidatedAction, status: boolean, errorNumber?: number): CardinalValidatedData {
+    return {
+        ActionCode: actionCode,
+        ErrorDescription: '',
+        ErrorNumber: errorNumber ? errorNumber : 0,
+        Validated: status,
+        Payment: {
+            ProcessorTransactionId: '',
+            Type: CardinalPaymentType.CCA,
+        },
+    };
+}
+
+export function getCardinalThreeDSResult(): ThreeDsResult {
+    return {
+        acs_url: 'https://',
+        payer_auth_request: 'auth_request',
+        merchant_data: 'merchant_data',
+        callback_url: '',
+    };
+}
+
+export function getCardinalOrderData(): CardinalOrderData {
+    const billingAddress = getBillingAddress();
+    billingAddress.address2 = 'Address 2';
+
+    return {
+        billingAddress,
+        shippingAddress: getShippingAddress(),
+        currencyCode: 'USD',
+        id: '123-abc',
+        amount: 12000,
+        paymentData: getCreditCardInstrument(),
+    };
+}

--- a/src/payment/strategies/cybersource/cardinal.ts
+++ b/src/payment/strategies/cybersource/cardinal.ts
@@ -1,0 +1,176 @@
+import Address from '../../../address/address';
+import BillingAddress from '../../../billing/billing-address';
+import { CreditCardInstrument } from '../../payment';
+
+export const CardinalSignatureValidationErrors = [100004, 1010, 1011, 1020];
+
+export interface CardinalSDK {
+    configure(params: CardinalConfiguration): void;
+    on(params: CardinalEventType, callback: CardinalEventMap[CardinalEventType]): void;
+    off(params: CardinalEventType): void;
+    setup<K extends keyof CardinalInitializationDataMap>(initializationType: K, initializationData: CardinalInitializationDataMap[K]): void;
+    trigger(event: CardinalTriggerEvents, data?: string): Promise<CardinalBinProcessResponse | void>;
+    continue(paymentBrand: CardinalPaymentBrand, continueObject: CardinalContinue, order: CardinalPartialOrder): void;
+    start(paymentBrand: CardinalPaymentBrand, order: CardinalPartialOrder, jwt?: string): void;
+}
+
+export interface CardinalWindow extends Window {
+    Cardinal?: CardinalSDK;
+}
+
+export interface CardinalEventMap {
+    [CardinalEventType.SetupCompleted](setupCompleteData: CardinalSetupCompletedData): void;
+    [CardinalEventType.Validated](data: CardinalValidatedData, jwt?: string): void;
+}
+
+export type CardinalConfiguration = Partial<{
+    logging: {
+        level: string,
+    };
+    payment: {
+        view: string,
+        framework: string,
+        displayLoading: boolean,
+    };
+}>;
+
+export interface CardinalSetupCompletedData {
+    sessionId: string;
+    modules: CardinalModuleState[];
+}
+
+export interface CardinalModuleState {
+    loaded: boolean;
+    module: string;
+}
+
+export interface CardinalOrderData {
+    billingAddress: BillingAddress;
+    shippingAddress?: Address;
+    currencyCode: string;
+    id: string;
+    amount: number;
+    paymentData: CreditCardInstrument;
+}
+
+export enum CardinalInitializationType {
+    Init = 'init',
+    Complete = 'complete',
+    Confirm = 'confirm',
+}
+
+export interface CardinalInitializationDataMap {
+    [CardinalInitializationType.Init]: CardinalInitTypeData;
+    [CardinalInitializationType.Complete]: CardinalCompleteTypeData;
+    [CardinalInitializationType.Confirm]: CardinalConfirmTypeData;
+}
+
+export interface CardinalInitTypeData {
+    jwt: string;
+}
+
+export interface CardinalCompleteTypeData {
+    Status: string;
+}
+
+export interface CardinalConfirmTypeData {
+    jwt: string;
+    cardinalResponseJwt: string;
+}
+
+export interface CardinalValidatedData {
+    ActionCode: CardinalValidatedAction;
+    ErrorDescription: string;
+    ErrorNumber: number;
+    Validated: boolean;
+    Payment?: CardinalPayment;
+}
+
+export interface CardinalPayment {
+    ProcessorTransactionId: string;
+    Type: CardinalPaymentType;
+}
+
+export interface CardinalBinProcessResponse {
+    Status: boolean;
+}
+
+export interface CardinalContinue {
+    AcsUrl: string;
+    Payload: string;
+}
+
+export interface CardinalPartialOrder {
+    OrderDetails: CardinalOrderDetails;
+    Consumer?: CardinalConsumer;
+}
+
+export interface CardinalConsumer {
+    Email1?: string;
+    Email2?: string;
+    ShippingAddress?: CardinalAddress;
+    BillingAddress: CardinalAddress;
+    Account: CardinalAccount;
+}
+
+export interface CardinalAccount {
+    AccountNumber: number;
+    ExpirationMonth: number;
+    ExpirationYear: number;
+    NameOnAccount: string;
+    CardCode: number;
+}
+
+export interface CardinalAddress {
+    FullName?: string;
+    FirstName: string;
+    MiddleName?: string;
+    LastName: string;
+    Address1: string;
+    Address2?: string;
+    Address3?: string;
+    City: string;
+    State: string;
+    PostalCode: string;
+    CountryCode: string;
+    Phone1?: string;
+    Phone2?: string;
+}
+
+export interface CardinalOrderDetails {
+    OrderNumber: string;
+    Amount: number;
+    CurrencyCode: string;
+    OrderDescription?: string;
+    OrderChannel: string;
+    TransactionId?: string;
+}
+
+export enum CardinalEventType {
+    SetupCompleted = 'payments.setupComplete',
+    Validated = 'payments.validated',
+}
+
+export enum CardinalValidatedAction {
+    Success = 'SUCCESS',
+    NoAction = 'NOACTION',
+    Failure = 'FAILURE',
+    Error = 'ERROR',
+}
+
+export enum CardinalPaymentType {
+    CCA = 'CCA',
+    Paypal = 'Paypal',
+    Wallet = 'Wallet',
+    VisaCheckout = 'VisaCheckout',
+    ApplePay = 'ApplePay',
+    DiscoverWallet = 'DiscoverWallet',
+}
+
+export enum CardinalTriggerEvents {
+    BinProcess = 'bin.process',
+}
+
+export enum CardinalPaymentBrand {
+    CCA = 'cca',
+}

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
@@ -1,0 +1,389 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, Action } from '@bigcommerce/data-store';
+import createErrorAction from '@bigcommerce/data-store/lib/create-error-action';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { merge } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import {
+    createCheckoutStore,
+    CheckoutRequestSender,
+    CheckoutStore,
+    CheckoutValidator,
+} from '../../../checkout';
+import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
+import { MissingDataError } from '../../../common/error/errors';
+import RequestError from '../../../common/error/errors/request-error';
+import StandardError from '../../../common/error/errors/standard-error';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import {
+    OrderActionCreator,
+    OrderActionType,
+    OrderRequestBody,
+    OrderRequestSender,
+} from '../../../order';
+import OrderFinalizationNotRequiredError from '../../../order/errors/order-finalization-not-required-error';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import {
+    RemoteCheckoutActionCreator,
+    RemoteCheckoutActionType,
+    RemoteCheckoutRequestSender
+} from '../../../remote-checkout';
+import { PaymentRequestSender } from '../../index';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentMethodActionType } from '../../payment-method-actions';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
+import { getCybersource } from '../../payment-methods.mock';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+
+import {
+    CardinalClient,
+    CardinalScriptLoader,
+    CyberSourcePaymentStrategy
+} from './index';
+
+describe('CyberSourcePaymentStrategy', () => {
+    let initializePaymentAction: Observable<Action>;
+    let loadPaymentMethodAction: Observable<Action>;
+    let cardinalClient: CardinalClient;
+    let payload: OrderRequestBody;
+    let orderActionCreator: OrderActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let scriptLoader: CardinalScriptLoader;
+    let submitOrderAction: Observable<Action>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+    let store: CheckoutStore;
+    let strategy: CyberSourcePaymentStrategy;
+    let paymentMethodMock: PaymentMethod;
+    let requestError: RequestError;
+
+    beforeEach(() => {
+        paymentMethodMock = { ...getCybersource(), clientToken: 'foo' };
+        store = createCheckoutStore(getCheckoutStoreStateWithOrder());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
+        scriptLoader = new CardinalScriptLoader(createScriptLoader());
+        cardinalClient = new CardinalClient(scriptLoader);
+
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+            new RemoteCheckoutRequestSender(createRequestSender())
+        );
+
+        orderActionCreator = new OrderActionCreator(
+            new OrderRequestSender(createRequestSender()),
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator
+        );
+
+        strategy = new CyberSourcePaymentStrategy(
+            store,
+            paymentMethodActionCreator,
+            orderActionCreator,
+            paymentActionCreator,
+            cardinalClient
+        );
+
+        payload = merge({}, getOrderRequestBody(), {
+            payment: {
+                methodId: paymentMethodMock.id,
+                gatewayId: paymentMethodMock.gateway,
+            },
+        });
+
+        loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: paymentMethodMock.id }));
+        initializePaymentAction = of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+            .mockReturnValue(loadPaymentMethodAction);
+
+        jest.spyOn(remoteCheckoutActionCreator, 'initializePayment')
+            .mockReturnValue(initializePaymentAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        jest.spyOn(cardinalClient, 'initialize').mockReturnValue(Promise.resolve());
+    });
+
+    describe('#initialize', () => {
+        beforeEach(async () => {
+            await strategy.initialize({ methodId: paymentMethodMock.id });
+        });
+
+        it('initializes strategy successfully', () => {
+            expect(cardinalClient.initialize).toHaveBeenCalledWith(true);
+        });
+
+        it('throws data missing error when payment method is not defined', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(undefined);
+
+            try {
+                await strategy.initialize({ methodId: paymentMethodMock.id });
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+    });
+
+    describe('#execute', () => {
+        it('throws error to inform that payment data is missing', async () => {
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws data missing error when payment is undefined', async () => {
+            payload.payment = undefined;
+
+            await strategy.initialize({ methodId: paymentMethodMock.id });
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        describe('when 3DS is disabled', () => {
+            beforeEach(async () => {
+                const paymentMethod = paymentMethodMock;
+                paymentMethod.config.is3dsEnabled = false;
+
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethod);
+
+                strategy = new CyberSourcePaymentStrategy(
+                    store,
+                    paymentMethodActionCreator,
+                    orderActionCreator,
+                    paymentActionCreator,
+                    cardinalClient
+                );
+
+                await strategy.initialize({ methodId: paymentMethod.id });
+            });
+
+            it('completes the purchase successfully', async () => {
+                await strategy.execute(payload);
+
+                const { payment, ...order } = payload;
+
+                expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(order, undefined);
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payment);
+            });
+
+            it('throws data missing error when payment data is undefined', async () => {
+                payload = {
+                    payment: {
+                        methodId: paymentMethodMock.id,
+                        gatewayId: paymentMethodMock.gateway,
+                    },
+                };
+
+                await strategy.initialize({ methodId: paymentMethodMock.id });
+                try {
+                    await strategy.execute(payload);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                }
+            });
+        });
+
+        describe('when 3DS is enabled', () => {
+            beforeEach(async () => {
+                requestError = new RequestError(getResponse({
+                    ...getErrorPaymentResponseBody(),
+                    errors: [
+                        { code: 'enrolled_card' },
+                    ],
+                    three_ds_result: {
+                        acs_url: 'https://acs/url',
+                        callback_url: '',
+                        payer_auth_request: '',
+                        merchant_data: 'merchant_data',
+                    },
+                    status: 'error',
+                }));
+
+                jest.spyOn(cardinalClient, 'configure').mockReturnValue(Promise.resolve());
+                jest.spyOn(cardinalClient, 'runBindProcess').mockReturnValue(Promise.resolve());
+
+                await strategy.initialize({ methodId: paymentMethodMock.id });
+            });
+
+            it('completes the purchase correctly if card is not enrolled', async () => {
+                jest.spyOn(cardinalClient, 'getThreeDSecureData');
+
+                await strategy.execute(payload);
+
+                expect(cardinalClient.getThreeDSecureData).not.toHaveBeenCalled();
+            });
+
+            it('completes the purchase correctly if card is enrolled', async () => {
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+                jest.spyOn(cardinalClient, 'getThreeDSecureData').mockReturnValue(Promise.resolve('token'));
+
+                await strategy.execute(payload);
+
+                expect(cardinalClient.getThreeDSecureData).toHaveBeenCalled();
+            });
+
+            it('does not complete the purchase if there was an error', async () => {
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, new StandardError('Custom Error'))));
+
+                try {
+                    await strategy.execute(payload);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(StandardError);
+                    expect(error.message).toBe('Custom Error');
+                }
+            });
+
+            it('throws data missing error when payment data is undefined', async () => {
+                payload = {
+                    payment: {
+                        methodId: paymentMethodMock.id,
+                        gatewayId: paymentMethodMock.gateway,
+                    },
+                };
+
+                await strategy.initialize({ methodId: paymentMethodMock.id });
+                try {
+                    await strategy.execute(payload);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('throws an error if client token is undefined', async () => {
+                const paymentMethod = paymentMethodMock;
+                paymentMethod.clientToken = undefined;
+
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethod);
+
+                strategy = new CyberSourcePaymentStrategy(
+                    store,
+                    paymentMethodActionCreator,
+                    orderActionCreator,
+                    paymentActionCreator,
+                    cardinalClient
+                );
+
+                await strategy.initialize({ methodId: paymentMethod.id });
+
+                try {
+                    await strategy.execute(payload);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('throws an error if order data is undefined', async () => {
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+
+                store = createCheckoutStore(getCheckoutStoreState());
+
+                strategy = new CyberSourcePaymentStrategy(
+                    store,
+                    paymentMethodActionCreator,
+                    orderActionCreator,
+                    paymentActionCreator,
+                    cardinalClient
+                );
+
+                await strategy.initialize({ methodId: paymentMethodMock.id });
+
+                try {
+                    await strategy.execute(payload);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('throws an error if billing data is undefined', async () => {
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+
+                store = createCheckoutStore({
+                    ...getCheckoutStoreState(),
+                    billingAddress: undefined,
+                });
+
+                strategy = new CyberSourcePaymentStrategy(
+                    store,
+                    paymentMethodActionCreator,
+                    orderActionCreator,
+                    paymentActionCreator,
+                    cardinalClient
+                );
+
+                await strategy.initialize({ methodId: paymentMethodMock.id });
+
+                try {
+                    await strategy.execute(payload);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('throws an error if checkout data is undefined', async () => {
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+
+                store = createCheckoutStore({
+                    ...getCheckoutStoreState(),
+                    checkout: undefined,
+                });
+
+                strategy = new CyberSourcePaymentStrategy(
+                    store,
+                    paymentMethodActionCreator,
+                    orderActionCreator,
+                    paymentActionCreator,
+                    cardinalClient
+                );
+
+                await strategy.initialize({ methodId: paymentMethodMock.id });
+
+                try {
+                    await strategy.execute(payload);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                }
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            expect(await strategy.deinitialize()).toEqual(store.getState());
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await strategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
+        });
+    });
+});

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
@@ -1,0 +1,142 @@
+import { some } from 'lodash';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import {
+    MissingDataError,
+    MissingDataErrorType,
+    RequestError
+} from '../../../common/error/errors';
+import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import Payment, { CreditCardInstrument } from '../../payment';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+import { CardinalClient, CardinalOrderData } from './index';
+
+export default class CyberSourcePaymentStrategy implements PaymentStrategy {
+    private _paymentMethod?: PaymentMethod;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _cardinalClient: CardinalClient
+    ) {}
+
+    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options;
+
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
+            .then(state => {
+                this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+                if (!this._paymentMethod || !this._paymentMethod.config) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                return this._cardinalClient.initialize(this._paymentMethod.config.testMode)
+                    .then(() => this._store.getState());
+            });
+    }
+
+    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+
+        if (!payment) {
+            throw new MissingDataError(MissingDataErrorType.MissingPayment);
+        }
+
+        if (!this._paymentMethod || !this._paymentMethod.config) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return this._paymentMethod.config.is3dsEnabled ? this._placeOrderUsing3DS(order, payment, options, this._paymentMethod.clientToken) :
+            this._placeOrder(order, payment, options);
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _placeOrderUsing3DS(order: OrderRequestBody, payment: OrderPaymentRequestBody, options?: PaymentRequestOptions, clientToken?: string): Promise<InternalCheckoutSelectors> {
+        if (!clientToken) {
+            return Promise.reject(new MissingDataError(MissingDataErrorType.MissingPaymentMethod));
+        }
+
+        if (!payment.paymentData) {
+            return Promise.reject(new MissingDataError(MissingDataErrorType.MissingPayment));
+        }
+
+        const paymentData = payment.paymentData as CreditCardInstrument;
+
+        return this._cardinalClient.configure(clientToken)
+            .then(() => this._cardinalClient.runBindProcess(paymentData.ccNumber))
+            .then(() => {
+                return this._placeOrder(order, payment, options)
+                    .catch(error => {
+                        if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'enrolled_card' })) {
+                            return Promise.reject(error);
+                        }
+
+                        return this._cardinalClient.getThreeDSecureData(error.body.three_ds_result, this._getOrderData(paymentData))
+                            .then(threeDSecure =>
+                                this._store.dispatch(this._paymentActionCreator.submitPayment({
+                                    ...payment,
+                                    paymentData: {
+                                        ...paymentData,
+                                        threeDSecure,
+                                    },
+                                }))
+                            );
+                    });
+            });
+    }
+
+    private _placeOrder(order: OrderRequestBody, payment: OrderPaymentRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (!payment.paymentData) {
+            return Promise.reject(new MissingDataError(MissingDataErrorType.MissingPayment));
+        }
+
+        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
+            .then(() =>
+                this._store.dispatch(this._paymentActionCreator.submitPayment(payment))
+            );
+    }
+
+    private _getOrderData(paymentData: CreditCardInstrument): CardinalOrderData {
+        const billingAddress = this._store.getState().billingAddress.getBillingAddress();
+        const shippingAddress = this._store.getState().shippingAddress.getShippingAddress();
+        const checkout = this._store.getState().checkout.getCheckout();
+        const order = this._store.getState().order.getOrder();
+
+        if (!billingAddress || !billingAddress.email) {
+            throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
+        }
+
+        if (!checkout) {
+            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+        }
+
+        if (!order) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrder);
+        }
+
+        return {
+            billingAddress,
+            shippingAddress,
+            currencyCode: checkout.cart.currency.code,
+            id: order.orderId.toString(),
+            amount: checkout.cart.cartAmount,
+            paymentData,
+        };
+    }
+}

--- a/src/payment/strategies/cybersource/index.ts
+++ b/src/payment/strategies/cybersource/index.ts
@@ -1,0 +1,5 @@
+export * from './cardinal';
+
+export { default as CyberSourcePaymentStrategy } from './cybersource-payment-strategy';
+export { default as CardinalScriptLoader } from './cardinal-script-loader';
+export { default as CardinalClient } from './cardinal-client';


### PR DESCRIPTION
## What? [INT-1479](https://jira.bigcommerce.com/browse/INT-1479)
Create the Cybersource's strategy and processors, also create a ThreeDSecure type and add it to the CreditCardInstrument payload: [Tech design](https://intranet.bigcommerce.com/display/IDT/Technical+Design+3-D+Secure+on+CyberSource#?lucidIFH-viewer-5f0ee3b2=1)

## Why?
To be able to process payments with Cybersource using 3DS being care to not call anything about 3DS when it is disabled in the configuration page

## Testing / Proof
[video](https://drive.google.com/file/d/1ndgU5RuHZqJebdxpLQMxeWVjDPE9WIhN/view?usp=sharing)

## Sibling PRs
[bcapp](https://github.com/bigcommerce/bigcommerce/pull/29976)
[bigpay](https://github.com/bigcommerce/bigpay/pull/1652)
[bigpay-client-js](https://github.com/bigcommerce/bigpay-client-js/pull/76)

@bigcommerce/checkout @bigcommerce/payments
