### PR TITLE
fix(payment): INT-1500 Pass all amounts in cents for Affirm & Platform metadata

### DIFF
--- a/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
+++ b/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
@@ -159,6 +159,89 @@ describe('AffirmPaymentStrategy', () => {
             });
         });
 
+        it('initializes the Affirm checkout call with the correct payload', async () => {
+            const checkoutPayload = {
+                billing: {
+                    address: {
+                        city: 'Some City',
+                        country: 'US',
+                        line1: '12345 Testing Way',
+                        line2: '',
+                        state: 'CA',
+                        zipcode: '95555',
+                    },
+                    email: 'test@bigcommerce.com',
+                    name: {
+                        first: 'Test',
+                        full: 'Test Tester',
+                        last: 'Tester',
+                    },
+                    phone_number: '555-555-5555',
+                },
+                discounts: {
+                    DISCOUNTED_AMOUNT: {
+                        discount_amount: 1000,
+                        discount_display_name: 'discount',
+                    },
+                },
+                items: [
+                    {
+                        display_name: 'Canvas Laundry Cart',
+                        item_image_url: '/images/canvas-laundry-cart.jpg',
+                        item_url: '/canvas-laundry-cart/',
+                        qty: 1,
+                        sku: 'CLC',
+                        unit_price: 20000,
+                    },
+                    {
+                        display_name: '$100 Gift Certificate',
+                        item_image_url: '',
+                        item_url: '',
+                        qty: 1,
+                        sku: '',
+                        unit_price: 10000,
+                    },
+                ],
+                merchant: {
+                    user_cancel_url: 'https://store-k1drp8k8.bcapp.dev/checkout',
+                    user_confirmation_url: 'https://store-k1drp8k8.bcapp.dev/checkout',
+                    user_confirmation_url_action: 'POST',
+                },
+                metadata: {
+                    mode: 'modal',
+                    platform_affirm: '',
+                    platform_type: 'BigCommerce',
+                    platform_version: '',
+                    shipping_type: 'shipping_flatrate',
+                },
+                order_id: '295',
+                shipping: {
+                    address: {
+                        city: 'Some City',
+                        country: 'US',
+                        line1: '12345 Testing Way',
+                        line2: '',
+                        state: 'CA',
+                        zipcode: '95555',
+                    },
+                    name: {
+                        first: 'Test',
+                        full: 'Test Tester',
+                        last: 'Tester',
+                    },
+                    phone_number: '555-555-5555',
+                },
+                shipping_amount: 1500,
+                tax_amount: 300,
+                total: 19000,
+            };
+
+            const options = { methodId: 'affirm', gatewayId: undefined };
+            await strategy.execute(payload, options);
+
+            expect(affirm.checkout).toHaveBeenCalledWith(checkoutPayload);
+        });
+
         it('returns cancel error on affirm if users cancel flow', () => {
             jest.spyOn(affirm.checkout, 'open').mockImplementation(({ onFail }) => {
                 onFail({
@@ -198,12 +281,6 @@ describe('AffirmPaymentStrategy', () => {
 
         it('does not create affirm object if billingAddress does not exist', () => {
             jest.spyOn(store.getState().billingAddress, 'getBillingAddress').mockReturnValue(undefined);
-
-            return expect(strategy.execute(payload)).rejects.toThrow(MissingDataError);
-        });
-
-        it('does not create affirm object if cart does not exist', () => {
-            jest.spyOn(store.getState().cart, 'getCart').mockReturnValue(undefined);
 
             return expect(strategy.execute(payload)).rejects.toThrow(MissingDataError);
         });

--- a/src/payment/strategies/affirm/affirm.ts
+++ b/src/payment/strategies/affirm/affirm.ts
@@ -46,9 +46,11 @@ export interface AffirmRequestData {
     metadata: {
         shipping_type: string,
         entity_name?: string,
-        platform_type?: string,
         webhook_session_id?: string,
         mode?: string,
+        platform_type: string,
+        platform_version: string,
+        platform_affirm: string,
     };
     order_id?: string;
     shipping_amount: number;


### PR DESCRIPTION
## What? [INT-1500](https://jira.bigcommerce.com/browse/INT-1500)

- Pass all amounts in cents for Affirm
- Add platform metadata for Affirm
- Pass billing address as shipping address when shipping address is not available (i.e digital products).

## Why?

After Affirm's team reviewed the test store, this changes were required to complete validation on the payment provider integration.

## Testing / Proof

https://drive.google.com/open?id=1tvHCItvS0R2hXR0phhQUA56rCie4S6Ph

@bigcommerce/checkout @bigcommerce/payments
