### PR TITLE
INT-1450 Add support for Stripe V3 + 3DS using payment Intents

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -46,6 +46,7 @@ import { OffsitePaymentStrategy } from './strategies/offsite';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy, PaypalScriptLoader } from './strategies/paypal';
 import { SagePayPaymentStrategy } from './strategies/sage-pay';
 import { SquarePaymentStrategy, SquareScriptLoader } from './strategies/square';
+import { StripeScriptLoader, StripeV3PaymentStrategy } from './strategies/stripev3';
 import { WepayPaymentStrategy, WepayRiskClient } from './strategies/wepay';
 import { ZipPaymentStrategy, ZipScriptLoader } from './strategies/zip';
 
@@ -322,6 +323,16 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             formPoster
+            )
+    );
+
+    registry.register(PaymentStrategyType.STRIPEV3, () =>
+        new StripeV3PaymentStrategy(
+            store,
+            paymentMethodActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            new StripeScriptLoader(scriptLoader)
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -381,6 +381,25 @@ export function getZip(): PaymentMethod {
     };
 }
 
+export function getStripeV3(): PaymentMethod {
+    return {
+        id: 'stripev3',
+        logoUrl: '',
+        method: 'stripev3',
+        supportedCards: [],
+        config: {
+            displayName: 'Stripe',
+            merchantId: '',
+            testMode: true,
+        },
+        initializationData: {
+            stripePublishableKey: 'key',
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'clientToken',
+    };
+}
+
 export function getPaymentMethod(): PaymentMethod {
     return getAuthorizenet();
 }
@@ -400,6 +419,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getKlarna(),
         getSquare(),
         getGooglePay(),
+        getStripeV3(),
     ];
 }
 

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -8,6 +8,7 @@ import { KlarnaPaymentInitializeOptions } from './strategies/klarna';
 import { MasterpassPaymentInitializeOptions } from './strategies/masterpass';
 import { PaypalExpressPaymentInitializeOptions } from './strategies/paypal';
 import { SquarePaymentInitializeOptions } from './strategies/square';
+import { StripeV3PaymentInitializeOptions } from './strategies/stripev3';
 
 /**
  * The set of options for configuring any requests related to the payment step of
@@ -92,4 +93,10 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support GooglePay.
      */
     googlepaystripe?: GooglePayPaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the Stripe payment method.
+     * They can be omitted unless you need to support StripeV3.
+     */
+    stripev3?: StripeV3PaymentInitializeOptions;
 }

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -12,6 +12,7 @@ enum PaymentStrategyType {
     PAYPAL_EXPRESS_CREDIT = 'paypalexpresscredit',
     SAGE_PAY = 'sagepay',
     SQUARE = 'squarev2',
+    STRIPEV3 = 'stripev3',
     NO_PAYMENT_DATA_REQUIRED = 'nopaymentdatarequired',
     BRAINTREE = 'braintree',
     BRAINTREE_PAYPAL = 'braintreepaypal',

--- a/src/payment/strategies/stripev3/index.ts
+++ b/src/payment/strategies/stripev3/index.ts
@@ -1,0 +1,5 @@
+export * from './stripev3';
+
+export { default as StripeScriptLoader } from './stripev3-script-loader';
+export { default as StripeV3PaymentStrategy } from './stripev3-payment-strategy';
+export { default as StripeV3PaymentInitializeOptions } from './stripev3-initialize-options';

--- a/src/payment/strategies/stripev3/stripev3-initialize-options.ts
+++ b/src/payment/strategies/stripev3/stripev3-initialize-options.ts
@@ -1,0 +1,20 @@
+import { StripeStyleProps } from './stripev3';
+
+/**
+ * A set of options that are required to initialize the Stripe payment method.
+ *
+ * Once Stripe payment is initialized, credit card form fields, provided by the
+ * payment provider as iframes, will be inserted into the current page. These
+ * options provide a location and styling for each of the form fields.
+ */
+export default interface StripeV3PaymentInitializeOptions {
+    /**
+     * The location to insert the credit card number form field.
+     */
+    containerId: string;
+
+    /**
+     * The set of CSS styles to apply to all form fields.
+     */
+    style?: StripeStyleProps;
+}

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -1,0 +1,252 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { getCartState } from '../../../cart/carts.mock';
+import {
+    createCheckoutStore,
+    CheckoutRequestSender,
+    CheckoutValidator
+} from '../../../checkout';
+import CheckoutStore from '../../../checkout/checkout-store';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    StandardError
+} from '../../../common/error/errors';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import OrderActionCreator from '../../../order/order-action-creator';
+import {
+    createPaymentClient,
+    PaymentInitializeOptions,
+    PaymentMethodRequestSender,
+    PaymentRequestSender
+} from '../../../payment';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { getPaymentMethodsState, getStripeV3 } from '../../payment-methods.mock';
+
+import { StripeResponse } from './stripev3';
+import StripeV3PaymentStrategy from './stripev3-payment-strategy';
+import StripeV3ScriptLoader from './stripev3-script-loader';
+import {
+    getStripeV3HandleCardResponse,
+    getStripeV3InitializeOptionsMock,
+    getStripeV3JsMock,
+    getStripeV3OrderRequestBodyMock
+} from './stripev3.mock';
+
+describe('StripeV3PaymentStrategy', () => {
+    let store: CheckoutStore;
+    let strategy: StripeV3PaymentStrategy;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let orderActionCreator: OrderActionCreator;
+    let stripeScriptLoader: StripeV3ScriptLoader;
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        const requestSender = createRequestSender();
+        const paymentMethodRequestSender: PaymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
+        const paymentClient = createPaymentClient(store);
+        const scriptLoader = createScriptLoader();
+
+        paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
+        paymentActionCreator = new PaymentActionCreator(new PaymentRequestSender(paymentClient), orderActionCreator);
+        orderActionCreator = new OrderActionCreator(
+            paymentClient,
+            new CheckoutValidator(
+                new CheckoutRequestSender(requestSender)
+            )
+        );
+        stripeScriptLoader = new StripeV3ScriptLoader(scriptLoader);
+
+        strategy = new StripeV3PaymentStrategy(
+            store,
+            paymentMethodActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            stripeScriptLoader
+        );
+    });
+
+    describe('#initialize()', () => {
+        const stripeV3JsMock = getStripeV3JsMock();
+        let stripeV3Options: PaymentInitializeOptions;
+
+        beforeEach(() => {
+            stripeV3Options = getStripeV3InitializeOptionsMock();
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getStripeV3());
+        });
+
+        it('loads stripe v3 script', async () => {
+            jest.spyOn(stripeScriptLoader, 'load').mockReturnValue(Promise.resolve(stripeV3JsMock));
+
+            const promise =  strategy.initialize(stripeV3Options);
+
+            expect(stripeScriptLoader.load).toHaveBeenCalled();
+
+            return expect(promise).resolves.toBe(store.getState());
+        });
+
+        it('does not load stripe V3 if initialization options are not provided', () => {
+            stripeV3Options.stripev3 = undefined;
+
+            expect(() => strategy.initialize(stripeV3Options))
+                .toThrow(InvalidArgumentError);
+        });
+
+        it('does not load stripe V3 if paymentMethod is not provided', () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(undefined);
+
+            expect(() => strategy.initialize(stripeV3Options))
+                .toThrow(MissingDataError);
+        });
+    });
+
+    describe('#execute', () => {
+        let stripeV3Options: PaymentInitializeOptions;
+        const stripeV3JsMock = getStripeV3JsMock();
+
+        beforeEach(() => {
+            stripeV3Options = getStripeV3InitializeOptionsMock();
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve());
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getStripeV3());
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+        });
+
+        it('creates the order and submit payment', async () => {
+            stripeV3JsMock.handleCardPayment = jest.fn(
+                () => Promise.resolve(getStripeV3HandleCardResponse())
+            );
+
+            jest.spyOn(stripeScriptLoader, 'load').mockReturnValue(Promise.resolve(stripeV3JsMock));
+
+            await strategy.initialize(stripeV3Options);
+            const response = await strategy.execute(getStripeV3OrderRequestBodyMock());
+
+            expect(store.getState().paymentMethods.getPaymentMethod).toHaveBeenCalled();
+            expect(stripeV3JsMock.handleCardPayment).toHaveBeenCalled();
+            expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+            expect(response).toBe(store.getState());
+        });
+
+        it('throws an error when payment is not set properly into payload', async () => {
+            const payload = {
+                payment: undefined,
+            };
+
+            expect(() => strategy.execute(payload))
+                .toThrow(PaymentArgumentInvalidError);
+        });
+
+        it('throws an error when store dispatch does not load paymentMethod', async () => {
+            const error = {message: 'error'};
+            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.reject(error));
+
+            const response = strategy.execute(getStripeV3OrderRequestBodyMock());
+
+            return expect(response).rejects.toBe(error);
+        });
+
+        it('throws an error when getPaymentMethod will not retrieve clientToken', async () => {
+            const stripeV3 = {
+                id: 'stripev3',
+                logoUrl: '',
+                method: 'stripev3',
+                supportedCards: [],
+                config: {
+                    displayName: 'Stripe',
+                    merchantId: '',
+                    testMode: true,
+                },
+                type: 'PAYMENT_TYPE_API',
+            };
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(stripeV3);
+
+            const response = strategy.execute(getStripeV3OrderRequestBodyMock());
+
+            return expect(response).rejects.toBeInstanceOf(StandardError);
+        });
+
+        it('throws an error when handleCardPayment retrieve an error', async () => {
+            const stripeV3HandleCardResponseError: StripeResponse = {
+                error: {
+                    type: 'error',
+                    code: 'ABC',
+                    message: 'Error from stripe js',
+                },
+                paymentIntent: {},
+            };
+            stripeV3JsMock.handleCardPayment = jest.fn(
+                () => Promise.resolve(stripeV3HandleCardResponseError)
+            );
+
+            jest.spyOn(stripeScriptLoader, 'load').mockReturnValue(Promise.resolve(stripeV3JsMock));
+
+            await strategy.initialize(stripeV3Options);
+            const response = strategy.execute(getStripeV3OrderRequestBodyMock());
+
+            return expect(response).rejects.toBeInstanceOf(StandardError);
+        });
+
+        it('throws an error when handleCardPayment will not retrieve a paymentIntent id', async () => {
+            const stripeV3HandleCardResponseError: StripeResponse = {
+                paymentIntent: {},
+            };
+            stripeV3JsMock.handleCardPayment = jest.fn(
+                () => Promise.resolve(stripeV3HandleCardResponseError)
+            );
+
+            jest.spyOn(stripeScriptLoader, 'load').mockReturnValue(Promise.resolve(stripeV3JsMock));
+
+            await strategy.initialize(stripeV3Options);
+            const response = strategy.execute(getStripeV3OrderRequestBodyMock());
+
+            return expect(response).rejects.toBeInstanceOf(StandardError);
+        });
+
+        it('throws an error when stripe js is not loaded', async () => {
+            const response = strategy.execute(getStripeV3OrderRequestBodyMock());
+
+            return expect(response).rejects.toBeInstanceOf(StandardError);
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            const promise = strategy.finalize();
+
+            return expect(promise).rejects.toBeInstanceOf(OrderFinalizationNotRequiredError);
+        });
+    });
+
+    describe('#deinitialize', () => {
+        it('deinitializes stripe payment strategy', async () => {
+            const stripeV3JsMock = getStripeV3JsMock();
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getStripeV3());
+            jest.spyOn(stripeScriptLoader, 'load').mockReturnValue(Promise.resolve(stripeV3JsMock));
+
+            await strategy.initialize(getStripeV3InitializeOptionsMock());
+            const promise = strategy.deinitialize();
+
+            return expect(promise).resolves.toBe(store.getState());
+        });
+    });
+});

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -1,0 +1,119 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedError, NotInitializedErrorType,
+    StandardError
+} from '../../../common/error/errors';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+import { StripeCardElement, StripeV3Client } from './stripev3';
+import StripeV3ScriptLoader from './stripev3-script-loader';
+
+export default class StripeV3PaymentStrategy implements PaymentStrategy {
+    private _stripeV3Client?: StripeV3Client;
+    private _cardElement?: StripeCardElement;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _orderActionCreator: OrderActionCreator,
+        private _stripeScriptLoader: StripeV3ScriptLoader
+    ) {}
+
+    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const stripeOptions = options.stripev3;
+
+        if (!stripeOptions) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.stripev3" argument is not provided.');
+        }
+
+        const paymentMethod = this._store.getState().paymentMethods.getPaymentMethod(options.methodId);
+
+        if (!paymentMethod) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return this._stripeScriptLoader.load(paymentMethod.initializationData.stripePublishableKey)
+            .then(stripeJs => {
+                this._stripeV3Client = stripeJs;
+                const elements = this._stripeV3Client.elements();
+                const cardElement = elements.create('card', {
+                    style: stripeOptions.style,
+                });
+
+                cardElement.mount(`#${stripeOptions.containerId}`);
+
+                this._cardElement = cardElement;
+
+                return Promise.resolve(this._store.getState());
+            });
+    }
+
+    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(payment.methodId))
+            .then(state => {
+                const paymentMethod = state.paymentMethods.getPaymentMethod(payment.methodId);
+
+                if (!paymentMethod || !paymentMethod.clientToken) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                if (!this._cardElement) {
+                    throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+                }
+
+                return this._getStripeJs().handleCardPayment(
+                    paymentMethod.clientToken, this._cardElement, {}
+                ).then(stripeResponse => {
+                    if (stripeResponse.error || !stripeResponse.paymentIntent.id) {
+                        throw new StandardError(stripeResponse.error && stripeResponse.error.message);
+                    }
+
+                    const paymentPayload = {
+                        methodId: payment.methodId,
+                        paymentData: { nonce: stripeResponse.paymentIntent.id },
+                    };
+
+                    return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
+                        .then(() =>
+                            this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload))
+                        );
+                });
+            });
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (this._cardElement) {
+            this._cardElement.unmount();
+        }
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _getStripeJs(): StripeV3Client {
+        if (!this._stripeV3Client) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._stripeV3Client;
+    }
+}

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -1,3 +1,5 @@
+import { Address } from '../../../address';
+import { BillingAddress } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
     InvalidArgumentError,
@@ -6,6 +8,7 @@ import {
     NotInitializedError, NotInitializedErrorType,
     StandardError
 } from '../../../common/error/errors';
+import { Customer } from '../../../customer';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
@@ -14,7 +17,14 @@ import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import { StripeCardElement, StripeV3Client } from './stripev3';
+import {
+    StripeAddress,
+    StripeBillingDetails,
+    StripeCardElement,
+    StripeHandleCardPaymentOptions,
+    StripeShippingDetails,
+    StripeV3Client
+} from './stripev3';
 import StripeV3ScriptLoader from './stripev3-script-loader';
 
 export default class StripeV3PaymentStrategy implements PaymentStrategy {
@@ -78,7 +88,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                 }
 
                 return this._getStripeJs().handleCardPayment(
-                    paymentMethod.clientToken, this._cardElement, {}
+                    paymentMethod.clientToken, this._cardElement, this._mapStripeCardPaymentOptions()
                 ).then(stripeResponse => {
                     if (stripeResponse.error || !stripeResponse.paymentIntent.id) {
                         throw new StandardError(stripeResponse.error && stripeResponse.error.message);
@@ -115,5 +125,141 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         }
 
         return this._stripeV3Client;
+    }
+
+    private _mapStripeBillingAddress(billingAddress: BillingAddress | undefined): StripeAddress | undefined {
+        if (!billingAddress) {
+            return undefined;
+        }
+
+        return {
+            city: billingAddress.city,
+            country: billingAddress.countryCode,
+            line1: billingAddress.address1,
+            line2: billingAddress.address2,
+            postal_code: billingAddress.postalCode,
+            state: billingAddress.postalCode,
+        };
+    }
+
+    private _mapStripeShippingAddress(shippingAddress: Address | undefined): StripeAddress {
+        if (!shippingAddress) {
+            return { };
+        }
+
+        return {
+            city: shippingAddress.city,
+            country: shippingAddress.countryCode,
+            line1: shippingAddress.address1,
+            line2: shippingAddress.address2,
+            postal_code: shippingAddress.postalCode,
+            state: shippingAddress.postalCode,
+        };
+    }
+
+    private _mapStripeBillingDetails({ billingAddress, customer }: { billingAddress?: BillingAddress; customer?: Customer; } = {}): StripeBillingDetails {
+        const stripeBillingDetails = {
+            address: this._mapStripeBillingAddress(billingAddress),
+        };
+
+        if (customer) {
+            return {
+                ...stripeBillingDetails,
+                email: customer.email,
+                name: `${customer.firstName} ${customer.lastName}`,
+            };
+        }
+
+        if (billingAddress) {
+            return {
+                ...stripeBillingDetails,
+                email: billingAddress.email,
+                name: `${billingAddress.firstName} ${billingAddress.lastName}`,
+            };
+        }
+
+        return {
+            name: 'Guest',
+        };
+    }
+
+    private _mapStripeShippingDetails({ shippingAddress, customer }: { shippingAddress?: Address ; customer?: Customer; } = {}): StripeShippingDetails {
+        const stripeShippingDetails = {
+            address: this._mapStripeShippingAddress(shippingAddress),
+        };
+
+        if (customer) {
+            return {
+                ...stripeShippingDetails,
+                name: `${customer.firstName} ${customer.lastName}`,
+            };
+        }
+
+        if (shippingAddress) {
+            return {
+                ...stripeShippingDetails,
+                name: `${shippingAddress.firstName} ${shippingAddress.lastName}`,
+            };
+        }
+
+        return {
+            ...stripeShippingDetails,
+            name: 'Guest',
+        };
+    }
+
+    private _getCustomer(): Customer | undefined {
+        const customer = this._store.getState().customer.getCustomer();
+
+        if (customer) {
+            if (customer.firstName === '' || customer.lastName === '' || customer.email === '') {
+                return undefined;
+            }
+        }
+
+        return customer;
+    }
+
+    private _mapStripeCardPaymentOptions(): StripeHandleCardPaymentOptions {
+        const customer = this._getCustomer();
+        const billingAddress = this._store.getState().billingAddress.getBillingAddress();
+        const shippingAddress = this._store.getState().shippingAddress.getShippingAddress();
+
+        const paymentMethodData = {
+            payment_method_data: {
+                billing_details: this._mapStripeBillingDetails({ billingAddress, customer }),
+            },
+        };
+
+        const shippingDetails = {
+            shipping: this._mapStripeShippingDetails({ shippingAddress, customer }),
+        };
+
+        if (billingAddress) {
+            if (customer) {
+                return {
+                    ...paymentMethodData,
+                    ...shippingDetails,
+                    receipt_email: customer.email,
+                };
+            } else {
+                return {
+                    ...paymentMethodData,
+                    ...shippingDetails,
+                    receipt_email: billingAddress.email,
+                };
+            }
+        }
+
+        if (customer) {
+            return {
+                ...shippingDetails,
+                receipt_email: customer.email,
+            };
+        } else {
+            return {
+                ...shippingDetails,
+            };
+        }
     }
 }

--- a/src/payment/strategies/stripev3/stripev3-script-loader.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-script-loader.spec.ts
@@ -1,0 +1,59 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { StandardError } from '../../../common/error/errors';
+
+import { StripeHostWindow, StripeV3JsOptions } from './stripev3';
+import StripeV3ScriptLoader from './stripev3-script-loader';
+import { getStripeV3JsMock } from './stripev3.mock';
+
+describe('StripeV3PayScriptLoader', () => {
+    let stripeV3ScriptLoader: StripeV3ScriptLoader;
+    let scriptLoader: ScriptLoader;
+    let mockWindow: StripeHostWindow;
+
+    beforeEach(() => {
+        mockWindow = { } as StripeHostWindow;
+        scriptLoader = {} as ScriptLoader;
+        stripeV3ScriptLoader = new StripeV3ScriptLoader(scriptLoader, mockWindow);
+    });
+
+    describe('#load()', () => {
+        const stripeV3JsMock = getStripeV3JsMock();
+
+        beforeEach(() => {
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.Stripe = jest.fn(
+                    (publishableKey: string, options: StripeV3JsOptions) => stripeV3JsMock
+                );
+
+                return Promise.resolve();
+            });
+        });
+
+        it('loads the JS', async () => {
+            await stripeV3ScriptLoader.load('publishableKey');
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('https://js.stripe.com/v3/');
+        });
+
+        it('returns the JS from the window', async () => {
+            const stripeJs = await stripeV3ScriptLoader.load('publishableKey');
+
+            expect(stripeJs).toBe(stripeV3JsMock);
+        });
+
+        it('throws an error when window is not set', async () => {
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.Stripe = undefined;
+
+                return Promise.resolve();
+            });
+
+            try {
+                await stripeV3ScriptLoader.load('publishableKey');
+            } catch (error) {
+                expect(error).toBeInstanceOf(StandardError);
+            }
+        });
+    });
+});

--- a/src/payment/strategies/stripev3/stripev3-script-loader.ts
+++ b/src/payment/strategies/stripev3/stripev3-script-loader.ts
@@ -1,0 +1,26 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { StandardError } from '../../../common/error/errors';
+
+import { StripeHostWindow, StripeV3Client } from './stripev3';
+
+export default class StripeV3ScriptLoader {
+    constructor(
+        private _scriptLoader: ScriptLoader,
+        private _window: StripeHostWindow = window
+    ) {}
+
+    load(publishableKey: string): Promise<StripeV3Client> {
+        return this._scriptLoader
+            .loadScript('https://js.stripe.com/v3/')
+            .then(() => {
+                if (!this._window.Stripe) {
+                    throw new StandardError();
+                }
+
+                return this._window.Stripe(publishableKey, {
+                    betas: ['payment_intent_beta_3'],
+                });
+            });
+    }
+}

--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -1,0 +1,63 @@
+import OrderRequestBody from '../../../order/order-request-body';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+
+import {
+    StripeResponse,
+    StripeV3Client
+} from './stripev3';
+
+export function getStripeV3JsMock(): StripeV3Client {
+    return {
+        elements: jest.fn(() => {
+            return {
+                create: jest.fn(() => {
+                    return {
+                        mount: jest.fn(),
+                        unmount: jest.fn(),
+                    };
+                }),
+            };
+        }),
+        handleCardPayment: jest.fn(),
+    };
+}
+
+export function getStripeV3InitializeOptionsMock(): PaymentInitializeOptions {
+    return {
+        methodId: 'stripev3',
+        stripev3: {
+            containerId: 'stripeContainerId',
+            style: {
+                base: {
+                    color: '#32325D',
+                    fontWeight: 500,
+                    fontFamily: 'Inter UI, Open Sans, Segoe UI, sans-serif',
+                    fontSize: '16px',
+                    fontSmoothing: 'antialiased',
+                    '::placeholder': {
+                        color: '#CFD7DF',
+                    },
+                },
+                invalid: {
+                    color: '#E25950',
+                },
+            },
+        },
+    };
+}
+
+export function getStripeV3OrderRequestBodyMock(): OrderRequestBody {
+    return {
+        payment: {
+            methodId: 'stripev3',
+        },
+    };
+}
+
+export function getStripeV3HandleCardResponse(): StripeResponse {
+    return {
+        paymentIntent: {
+            id: 'pi_1234',
+        },
+    };
+}

--- a/src/payment/strategies/stripev3/stripev3.ts
+++ b/src/payment/strategies/stripev3/stripev3.ts
@@ -27,39 +27,54 @@ export interface StripeElements {
     create(type: string, options: StripeElementsOptions): StripeCardElement;
 }
 
-export interface StripeHandleCardPaymentOptions {
-    payment_method_data?: {
-        billing_details: {
-            address?: {
-                city?: string;
-                country?: string;
-                line1?: string;
-                line2?: string;
-                postal_code?: string;
-                state?: string;
-            };
-            email?: string;
-            name?: string;
-            phone?: string;
-        };
-    };
-    shipping?: {
-        address: {
-            city: string;
-            country: string;
-            line1: string;
-            line2: string;
-            postal_code: string;
-            state: string;
-        };
-        name: string;
-        carrier?: string;
-        phone?: string;
-        tracking_number?: string;
-    };
-    receipt_email?: string;
-    save_payment_method?: string;
+export interface StripeAddress {
+    city?: string;
+    country?: string;
+    line1?: string;
+    line2?: string;
+    postal_code?: string;
+    state?: string;
+}
 
+export interface StripeBillingDetails {
+    address?: StripeAddress;
+    email?: string;
+    name?: string;
+    phone?: string;
+}
+export interface PaymentMethodData {
+    billing_details: StripeBillingDetails;
+}
+
+export interface StripeShippingDetails {
+    address: StripeAddress;
+    name: string;
+    carrier?: string;
+    phone?: string;
+    tracking_number?: string;
+}
+
+export interface StripeHandleCardPaymentOptions {
+    /*
+     * Use this parameter to supply additional data relevant to the payment method, such as billing details.
+     */
+    payment_method_data?: PaymentMethodData;
+
+    /*
+     * The shipping details for the payment, if collected.
+     */
+    shipping?: StripeShippingDetails;
+
+    /*
+     * Email address that the receipt for the resulting payment will be sent to.
+     */
+    receipt_email?: string;
+
+    /*
+     * If the PaymentIntent is associated with a customer and this parameter is set to true,
+     * the provided payment method will be attached to the customer. Default is false.
+     */
+    save_payment_method?: string;
 }
 
 export interface StripeElementsOptions {

--- a/src/payment/strategies/stripev3/stripev3.ts
+++ b/src/payment/strategies/stripev3/stripev3.ts
@@ -1,0 +1,187 @@
+export interface StripeHostWindow extends Window {
+    Stripe?(
+        stripePublishableKey: string,
+        options: StripeV3JsOptions
+    ): StripeV3Client;
+}
+
+export interface StripeV3JsOptions {
+    betas: string[];
+}
+
+export interface StripeV3Client {
+    elements(): StripeElements;
+    handleCardPayment(
+        clientToken: string,
+        cardElement: StripeCardElement,
+        options: StripeHandleCardPaymentOptions
+    ): Promise<StripeResponse>;
+}
+
+export interface StripeCardElement {
+    mount(containerId: string): HTMLElement;
+    unmount(): void;
+}
+
+export interface StripeElements {
+    create(type: string, options: StripeElementsOptions): StripeCardElement;
+}
+
+export interface StripeHandleCardPaymentOptions {
+    payment_method_data?: {
+        billing_details: {
+            address?: {
+                city?: string;
+                country?: string;
+                line1?: string;
+                line2?: string;
+                postal_code?: string;
+                state?: string;
+            };
+            email?: string;
+            name?: string;
+            phone?: string;
+        };
+    };
+    shipping?: {
+        address: {
+            city: string;
+            country: string;
+            line1: string;
+            line2: string;
+            postal_code: string;
+            state: string;
+        };
+        name: string;
+        carrier?: string;
+        phone?: string;
+        tracking_number?: string;
+    };
+    receipt_email?: string;
+    save_payment_method?: string;
+
+}
+
+export interface StripeElementsOptions {
+    style?: StripeStyleProps;
+}
+
+export interface StripeStyleProps {
+    /**
+     * The base class applied to the container.
+     * Defaults to StripeElement.
+     */
+    base?: CardElementProps;
+
+    /**
+     * The class name to apply when the Element is complete.
+     * Defaults to StripeElement--complete.
+     */
+    complete?: CardElementProps;
+
+    /**
+     * The class name to apply when the Element is empty.
+     * Defaults to StripeElement--empty.
+     */
+    empty?: CardElementProps;
+
+    /**
+     * The class name to apply when the Element is focused.
+     * Defaults to StripeElement--focus.
+     */
+    focus?: CardElementProps;
+
+    /**
+     * The class name to apply when the Element is invalid.
+     * Defaults to StripeElement--invalid.
+     */
+    invalid?: CardElementProps;
+
+    /**
+     * The class name to apply when the Element has its value
+     * autofilled by the browser (only on Chrome and Safari).
+     * Defaults to StripeElement--webkit-autofill.
+     */
+    webkitAutofill?: CardElementProps;
+}
+
+export interface PaymentIntent {
+    /*
+     * Unique identifier for the object.
+     */
+    id?: string;
+}
+
+export interface Error {
+    type: string;
+    code: string;
+    message: string;
+}
+
+export interface Properties {
+    color?: string;
+    fontFamily?: string;
+    fontSize?: string;
+    fontSmoothing?: string;
+    fontStyle?: string;
+    fontVariant?: string;
+    fontWeight?: string | number;
+    iconColor?: string;
+    lineHeight?: string | number;
+    letterSpacing?: string;
+    textAlign?: string;
+    padding?: string;
+    textDecoration?: string;
+    textShadow?: string;
+    textTransform?: string;
+}
+
+export interface StripeResponse {
+    paymentIntent: PaymentIntent;
+    error?: Error;
+}
+
+export interface MsClearProperties extends Properties {
+    display?: string;
+}
+
+export interface BaseProps extends Properties {
+    ':hover'?: Properties;
+    ':focus'?: Properties;
+    '::placeholder'?: Properties;
+    '::selection'?: Properties;
+    ':-webkit-autofill'?: Properties;
+    ':disabled'?: Properties;
+    '::ms-clear'?: MsClearProperties;
+}
+
+export interface CardElementProps extends BaseProps {
+    /*
+     * A pre-filled set of values to include in the input (e.g., {postalCode: '94110'}).
+     * Note that sensitive card information (card number, CVC, and expiration date) cannot
+     * be pre-filled.
+     */
+    value?: string;
+
+    /*
+     * Hide the postal code field. Default is false. If you are already collecting a full billing
+     * address or postal code elsewhere, set this to true.
+     */
+    hidePostalCode?: boolean;
+
+    /*
+     * Appearance of the icon in the Element. Either 'solid' or 'default'.
+     */
+    iconStyle?: string;
+
+    /*
+     * Hides the icon in the Element. Default is false.
+     */
+    hideIcon?: boolean;
+
+    /*
+     * Applies a disabled state to the Element such that user input is not accepted. Default is
+     * false.
+     */
+    disabled?: boolean;
+}


### PR DESCRIPTION
[INT-1450](https://jira.bigcommerce.com/browse/INT-1450)

## What?
Add support for Stripe V3 + 3DS that can handle stripe validations with stripe.js (handleCardPayment action)

## Why?
To support 3DS on Stripe is needed to add a new strategy that use Stripe.js elements and actions to handle 3DS flow and confirm a payment intent that previously was created from back-end

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/58435125-a394ff00-8084-11e9-9c6d-4c35b5ebea93.png)


## Sibling PRs
- [BCAPP](https://github.com/bigcommerce/bigcommerce/pull/29991)
- [NGCheckout](https://github.com/bigcommerce-labs/ng-checkout/pull/1227)
- [NGPayments](https://github.com/bigcommerce-labs/ng-payments/pull/799)
- [BigPay](https://github.com/bigcommerce/bigpay/pull/1649)

**Ping** @bigcommerce/intersys-integrations @bigcommerce/payments  @bigcommerce/checkout 

