### PR TITLE
CHECKOUT-4062: Upgrade `messageformat` version to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -606,6 +606,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -3516,7 +3517,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3537,12 +3539,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3557,17 +3561,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3684,7 +3691,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3696,6 +3704,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3710,6 +3719,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3717,12 +3727,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3741,6 +3753,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3821,7 +3834,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3833,6 +3847,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3918,7 +3933,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3954,6 +3970,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3973,6 +3990,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4016,12 +4034,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5828,7 +5848,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -6088,19 +6109,24 @@
       }
     },
     "messageformat": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.0.4.tgz",
-      "integrity": "sha512-wQkS20LWX8atDHk3OdTh2tNzF38DZvoENPuKrWqqGDfXUEJc7JZRMqx9nkYY6lu3nwwZ/HMIfFJTEMVdXIidhg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.2.1.tgz",
+      "integrity": "sha512-yMeuqLBgmn2IFqy51xKMeuQQYK/SLVX4mqT51VaaVp2bCOEaYs2/4qN5mSnVTvkMdDNvt7YwGw4wpGR0WjeT6A==",
       "requires": {
-        "make-plural": "^4.2.0",
-        "messageformat-parser": "^3.0.0",
-        "reserved-words": "^0.1.2"
+        "make-plural": "^4.3.0",
+        "messageformat-formatters": "^2.0.0",
+        "messageformat-parser": "^4.1.1"
       }
     },
+    "messageformat-formatters": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.0.tgz",
+      "integrity": "sha512-0AhoocUMk5CFKvqTubLfR6xKcoYAnbVFEMzXe2oNetLG0zlEHLg+gq4NQ3bBMy6T2qaOJRLjF2ZBT4Wzeof02A=="
+    },
     "messageformat-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-3.0.0.tgz",
-      "integrity": "sha512-5KfDWGAHz5kzfKH5V4M7+o3CIFiykCfFDaLK+Ck2fkaxYfLWwKZMioxrSsMRnkfMr0ZaaC0gcxyOUb2d0GCy4A=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.1.tgz",
+      "integrity": "sha512-g5JfN4P58rrx0YVYo4S/tT23cYYm3NNeJLm2F2hhcFq1O1xieVGTssHa1QWMYeHCulTJ/1V7EMkOtItJa9LFUg=="
     },
     "methods": {
       "version": "1.1.2",
@@ -7674,11 +7700,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
-    },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE="
     },
     "resolve": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "iframe-resizer": "^3.6.2",
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.4",
-    "messageformat": "~2.0.4",
+    "messageformat": "^2.2.1",
     "rxjs": "^6.3.3",
     "tslib": "^1.8.0"
   },


### PR DESCRIPTION
## What?
* Upgrade `messageformat` version to 2.2.1

## Why?
* The issue with UglifyJS has been fixed: https://github.com/messageformat/messageformat/issues/237

## Testing / Proof
* Manual

@bigcommerce/checkout @bigcommerce/payments
