### PR TITLE
feat(payment): INT-1540 Zip Feedback, declined handler

### DIFF
--- a/src/payment/errors/index.ts
+++ b/src/payment/errors/index.ts
@@ -1,3 +1,4 @@
 export { default as PaymentArgumentInvalidError } from './payment-argument-invalid-error';
-export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';
 export { default as PaymentMethodCancelledError } from './payment-method-cancelled-error';
+export { default as PaymentMethodDeclinedError } from './payment-method-declined-error';
+export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';

--- a/src/payment/errors/payment-method-declined-error.ts
+++ b/src/payment/errors/payment-method-declined-error.ts
@@ -1,0 +1,9 @@
+import { StandardError } from '../../common/error/errors';
+
+export default class PaymentMethodDeclinedError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'The selected payment method was declined. Please select another payment method.');
+
+        this.type = 'payment_declined';
+    }
+}

--- a/src/payment/strategies/zip/zip-payment-strategy.ts
+++ b/src/payment/strategies/zip/zip-payment-strategy.ts
@@ -9,8 +9,7 @@ import {
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
-import { PaymentMethodCancelledError } from '../../errors';
-import PaymentMethodInvalidError from '../../errors/payment-method-invalid-error';
+import { PaymentMethodCancelledError, PaymentMethodDeclinedError, PaymentMethodInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
@@ -84,6 +83,10 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
 
                                 if (state === ZipModalEvent.CheckoutApproved && checkoutId) {
                                     return resolve(checkoutId);
+                                }
+
+                                if (state === ZipModalEvent.CheckoutDeclined) {
+                                    return reject(new PaymentMethodDeclinedError('Unfortunately your application was declined. Please select another payment method.'));
                                 }
 
                                 reject(new PaymentMethodInvalidError());

--- a/src/payment/strategies/zip/zip.mock.ts
+++ b/src/payment/strategies/zip/zip.mock.ts
@@ -19,6 +19,14 @@ export function getZipScriptMock(status: string): Zip {
         };
         break;
 
+    case 'declined':
+        mockZipResponse = {
+            checkoutId: '',
+            customerId: '',
+            state: 'declined',
+        };
+        break;
+
     case 'noCheckoutId':
         mockZipResponse = {
             checkoutId: '',

--- a/src/payment/strategies/zip/zip.ts
+++ b/src/payment/strategies/zip/zip.ts
@@ -27,6 +27,7 @@ export interface ZipPayload {
 export const enum ZipModalEvent {
     CancelCheckout = 'cancelled',
     CheckoutApproved = 'approved',
+    CheckoutDeclined = 'declined',
 }
 
 /**


### PR DESCRIPTION
## What?
Add a handler for a `cancelled order` case

## Why?
Its possible for an Zip account application to be declined instantly and it needs a handler to show an error message [as seen here](https://zip-online.api-docs.io/v1/checkout-and-registration/checkout-with-registration-decline).

## Testing / Proof
[Demo Video](https://drive.google.com/open?id=1PFETFnO7fkXJaJ_SLmZawarAd5ChYfLO)
<img width="1165" alt="Screen Shot 2019-05-22 at 3 38 17 PM" src="https://user-images.githubusercontent.com/35502707/58207135-b0da7400-7ca7-11e9-9557-8392e631b321.png">


@bigcommerce/checkout @bigcommerce/payments
