### PR TITLE
CHECKOUT-4143 Update validate-commits to v2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -999,9 +999,9 @@
       }
     },
     "@bigcommerce/validate-commits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/validate-commits/-/validate-commits-2.0.3.tgz",
-      "integrity": "sha512-i0itS+ZgXabmStSh4S+cuGy6Zupcw2BLk2Sfa8s5gVMKizP2CLzTm16nEA9WMWnx9EMh700WxDp+pYm9hwFHjw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/validate-commits/-/validate-commits-2.1.1.tgz",
+      "integrity": "sha512-+x7klBXhAeSwq4N4Uy84HLHnkfE8OqdCzht113TJU5Mv45q6BEdntg//dUUUQp9cuBdKH8DxRDv7F8aeGquRRA==",
       "dev": true,
       "requires": {
         "chalk": "^2.1.0"
@@ -1506,6 +1506,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -4499,7 +4500,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4520,12 +4522,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4540,17 +4544,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4667,7 +4674,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4679,6 +4687,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4693,6 +4702,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4700,12 +4710,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4724,6 +4736,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4804,7 +4817,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4816,6 +4830,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4901,7 +4916,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4937,6 +4953,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4956,6 +4973,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4999,12 +5017,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6817,7 +6837,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/preset-env": "^7.4.5",
     "@bigcommerce/tslint-config": "^3.0.1",
     "@bigcommerce/typedoc-plugin-markdown": "^1.3.0",
-    "@bigcommerce/validate-commits": "^2.0.3",
+    "@bigcommerce/validate-commits": "^2.1.1",
     "@microsoft/api-extractor": "^6.3.0",
     "@types/jest": "^23.3.10",
     "@types/node": "^6.0.101",


### PR DESCRIPTION
## What?
- Update commit-validation@2.1.1

## Why?
- `dependabot` doesn't allow to configure the commit format

## Testing / Proof
- This PR should validate that the new version still runs
- As for dependabot commits: https://github.com/bigcommerce-labs/ng-checkout/pull/1234

@bigcommerce/checkout @bigcommerce/payments
