### PR TITLE
fix(payments): INT-1573 Checkout load error when non-supported Klarna country is selected

### DIFF
--- a/src/payment/strategies/klarna/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.ts
@@ -116,12 +116,7 @@ export default class KlarnaPaymentStrategy implements PaymentStrategy {
                     if (onLoad) {
                         onLoad(response);
                     }
-
-                    if (!response.show_form) {
-                        reject(new PaymentMethodInvalidError());
-                    } else {
-                        resolve(response);
-                    }
+                    resolve(response);
                 });
             }));
     }


### PR DESCRIPTION
## What?
 - Remove reject(new PaymentMethodInvalidError())

## Why?
In the scenario when the merchant does not support the shopper's billing country based on their merchant agreement with Klarna the checkout page should not throw an error, instead it should just show the widget showing that the country is not supported.

## Testing / Proof
![Klarna-INT-1573](https://user-images.githubusercontent.com/46006236/58727647-86c13a00-83aa-11e9-8d7a-da79d8d4b8da.gif)


## Sibling PRs
[BCApp INT-1573](https://github.com/bigcommerce/bigcommerce/pull/30174)

@bigcommerce/checkout @bigcommerce/payments
