### PR TITLE
docs(checkout): Update readme to clarify continueAsGuest

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Alternatively, you can ask the customer to continue as a guest.
 ```js
 const state = await service.continueAsGuest({ email: 'foo@bar.com' });
 
-console.log(state.data.getCustomer());
+console.log(state.data.getCart());
 ```
 
 ### Set shipping details


### PR DESCRIPTION
## What?
Update README to reduce confusion around continueAsGuest method.

## Why?
The confusion comes about because the guest data is separated from the customer object in some ways but not in others. The customer object has a reference to isGuest, but doesn't also get utilised to store the guests email, the guest email is actually stored against the cart object when it's set with this method.

Logging getCustomer() after setting continueAsGuest({ email: 'foo@bar.com' }) can cause confusion as the returned data will have the email displayed as an empty string and the isGuest flag set to true.

Would it make sense to mention that the getCart() email will be updated to include the guest user email, and the getCustomer() isGuest will be updated to indicate the user is a guest so consumers of the API know where the separation lies?

## Testing / Proof
n/a

@bigcommerce/checkout @bigcommerce/payments
