### PR TITLE
chore(common): CHECKOUT-4171 Revert messageformat to v2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7958,19 +7958,14 @@
       }
     },
     "messageformat": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.2.1.tgz",
-      "integrity": "sha512-yMeuqLBgmn2IFqy51xKMeuQQYK/SLVX4mqT51VaaVp2bCOEaYs2/4qN5mSnVTvkMdDNvt7YwGw4wpGR0WjeT6A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.1.0.tgz",
+      "integrity": "sha512-AfH57I4eLJNtqpX7qlGfaWAQFjsImADhKzwJuNWJwjCQhWB7p4IgH8C5/Z9PUeRZsby3/lCPYJmVRYoXfi4Qbw==",
       "requires": {
         "make-plural": "^4.3.0",
-        "messageformat-formatters": "^2.0.0",
-        "messageformat-parser": "^4.1.1"
+        "messageformat-parser": "^4.1.0",
+        "reserved-words": "^0.1.2"
       }
-    },
-    "messageformat-formatters": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.0.tgz",
-      "integrity": "sha512-0AhoocUMk5CFKvqTubLfR6xKcoYAnbVFEMzXe2oNetLG0zlEHLg+gq4NQ3bBMy6T2qaOJRLjF2ZBT4Wzeof02A=="
     },
     "messageformat-parser": {
       "version": "4.1.1",
@@ -9662,6 +9657,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "reserved-words": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
+      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE="
     },
     "resolve": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "iframe-resizer": "^3.6.2",
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.11",
-    "messageformat": "^2.2.1",
+    "messageformat": "2.1.0",
     "rxjs": "^6.3.3",
     "tslib": "^1.8.0"
   },


### PR DESCRIPTION
## What?
- As per title

## Why?
The latest version of `messageformat` exports es6 in the `main` bundle.
We need to change our build to consume `browser` instead of `main`.

## Testing / Proof
- Manual / Unit

# Before
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/4542735/59314527-06c79800-8cf9-11e9-8fe0-467f4f4a3484.png">


# After
<img width="911" alt="image" src="https://user-images.githubusercontent.com/4542735/59314190-83f20d80-8cf7-11e9-9178-d0d533422c10.png">


@bigcommerce/checkout @bigcommerce/payments
