### PR TITLE
feat(checkout): CHECKOUT-3670 adding parentId to LineItem interface

### DIFF
--- a/src/cart/line-item.ts
+++ b/src/cart/line-item.ts
@@ -62,6 +62,7 @@ export interface LineItem {
     socialMedia?: LineItemSocialData[];
     options?: LineItemOption[];
     addedByPromotion: boolean;
+    parentId?: string | null;
 }
 
 export interface LineItemOption {


### PR DESCRIPTION
## What?
As above

## Why?
It's a requirement to iterate over lineItems and filter where parentId is null. Currently as it is not defined within the LineItem interface TS gives us an error

## Testing / Proof


@bigcommerce/checkout
