### PR TITLE
CHECKOUT-4190 Add CODEOWNERS to github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bigcommerce/checkout


### PR DESCRIPTION
## What?
- As per title

## Why?
- So the checkout team gets pinged on new PRs

## Testing / Proof
- Manual

@bigcommerce/checkout @bigcommerce/payments
