### PR TITLE
CHECKOUT-4209: Throw `OrderFinalizationNotRequiredError` if payment method is no longer available for shopper

### DIFF
--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -455,6 +455,26 @@ describe('PaymentStrategyActionCreator', () => {
                 expect(action.payload).toBeInstanceOf(OrderFinalizationNotRequiredError);
             }
         });
+
+        it('returns rejected promise if payment method referenced in order object no longer exists', async () => {
+            store = createCheckoutStore({
+                ...state,
+                order: getOrderState(),
+                paymentMethods: {
+                    ...state.paymentMethods,
+                    data: [],
+                },
+            });
+            registry = createPaymentStrategyRegistry(store, paymentClient, requestSender);
+
+            const actionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
+
+            try {
+                await from(actionCreator.finalize()(store)).toPromise();
+            } catch (action) {
+                expect(action.payload).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
+        });
     });
 
     describe('#widgetInteraction()', () => {


### PR DESCRIPTION
## What?
* Throw `OrderFinalizationNotRequiredError` if the selected payment method for an order is no longer available for the shopper.

## Why?
* It's a more suitable error to throw because order finalisation is actually not required if the payment method is no longer available for the shopper. That would allow shoppers to carry on as they can choose an alternative payment method to complete their order.
* This is required to fix an AfterPay bug, because the payment method has a special flow which could prevent the shopper from continuing unless they reset their checkout state.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
