### PR TITLE
INT-1586 [SDK] 3DS on Amazon Pay

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -211,6 +211,7 @@ export function getAmazonPay(): PaymentMethod {
         supportedCards: [],
         config: {
             displayName: 'AmazonPay',
+            is3dsEnabled: false,
             merchantId: '0c173620-beb6-4421-99ef-03dc71a60685',
             testMode: false,
         },
@@ -433,9 +434,25 @@ export function getPaymentMethodsMeta() {
     };
 }
 
+export function getPaymentMethodsWith3ds(): PaymentMethod[] {
+    const amazon3ds = getAmazonPay();
+    amazon3ds.config.is3dsEnabled = true;
+
+    return [ amazon3ds ];
+}
+
 export function getPaymentMethodsState(): PaymentMethodState {
     return {
         data: getPaymentMethods(),
+        meta: getPaymentMethodsMeta(),
+        errors: {},
+        statuses: {},
+    };
+}
+
+export function getPaymentMethodsStateWith3ds(): PaymentMethodState {
+    return {
+        data: getPaymentMethodsWith3ds(),
         meta: getPaymentMethodsMeta(),
         errors: {},
         statuses: {},

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -434,7 +434,7 @@ export function getPaymentMethodsMeta() {
     };
 }
 
-export function getPaymentMethodsWith3ds(): PaymentMethod[] {
+export function getPaymentMethodsWith3dsMock(): PaymentMethod[] {
     const amazon3ds = getAmazonPay();
     amazon3ds.config.is3dsEnabled = true;
 
@@ -450,9 +450,9 @@ export function getPaymentMethodsState(): PaymentMethodState {
     };
 }
 
-export function getPaymentMethodsStateWith3ds(): PaymentMethodState {
+export function getPaymentMethodsStateWith3dsMock(): PaymentMethodState {
     return {
-        data: getPaymentMethodsWith3ds(),
+        data: getPaymentMethodsWith3dsMock(),
         meta: getPaymentMethodsMeta(),
         errors: {},
         statuses: {},

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -434,25 +434,9 @@ export function getPaymentMethodsMeta() {
     };
 }
 
-export function getPaymentMethodsWith3dsMock(): PaymentMethod[] {
-    const amazon3ds = getAmazonPay();
-    amazon3ds.config.is3dsEnabled = true;
-
-    return [ amazon3ds ];
-}
-
 export function getPaymentMethodsState(): PaymentMethodState {
     return {
         data: getPaymentMethods(),
-        meta: getPaymentMethodsMeta(),
-        errors: {},
-        statuses: {},
-    };
-}
-
-export function getPaymentMethodsStateWith3dsMock(): PaymentMethodState {
-    return {
-        data: getPaymentMethodsWith3dsMock(),
         meta: getPaymentMethodsMeta(),
         errors: {},
         statuses: {},

--- a/src/payment/strategies/amazon-pay/amazon-pay-confirmation-flow.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-confirmation-flow.ts
@@ -1,0 +1,4 @@
+export default interface AmazonPayConfirmationFlow {
+    success(): () => void;
+    failure(): () => void;
+}

--- a/src/payment/strategies/amazon-pay/amazon-pay-confirmation-flow.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-confirmation-flow.ts
@@ -1,4 +1,4 @@
 export default interface AmazonPayConfirmationFlow {
     success(): () => void;
-    failure(): () => void;
+    error(): () => void;
 }

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -476,18 +476,19 @@ describe('AmazonPayPaymentStrategy', () => {
             await strategy3ds.initialize({ methodId: paymentMethod.id, amazon: { container: 'wallet' } });
         });
 
-        // it('redirect to confirmation flow when support 3ds', async () => {
-        //     // tslint:disable-next-line:no-non-null-assertion
-        //     hostWindow.OffAmazonPayments!.initConfirmationFlow = jest.fn((sellerId, referenceId, callback) => {
-        //         callback(amazonConfirmationFlow).then(() => {
-        //             expect(amazonConfirmationFlow.success).toBeCalled();
-        //             expect(orderActionCreator.submitOrder).toHaveBeenCalled();
-        //             expect(remoteCheckoutActionCreator.initializePayment).toHaveBeenCalled();
-        //         });
-        //     });
-        //
-        //     await strategy3ds.execute(payload, options);
-        // });
+        it('redirect to confirmation flow when support 3ds', async () => {
+            // tslint:disable-next-line:no-non-null-assertion
+            hostWindow.OffAmazonPayments!.initConfirmationFlow = jest.fn((sellerId, referenceId, callback) => {
+                callback(amazonConfirmationFlow);
+            });
+
+            strategy3ds.execute(payload, options);
+
+            await new Promise(resolve => process.nextTick(resolve));
+            // tslint:disable-next-line:no-non-null-assertion
+            expect(hostWindow.OffAmazonPayments!.initConfirmationFlow).toHaveBeenCalled();
+
+        });
 
         it('redirect to confirmation flow  error when initializePayment fails', async () => {
             jest.spyOn(remoteCheckoutActionCreator, 'initializePayment')

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -476,18 +476,18 @@ describe('AmazonPayPaymentStrategy', () => {
             await strategy3ds.initialize({ methodId: paymentMethod.id, amazon: { container: 'wallet' } });
         });
 
-        it('redirect to confirmation flow when support 3ds', async () => {
-            // tslint:disable-next-line:no-non-null-assertion
-            hostWindow.OffAmazonPayments!.initConfirmationFlow = jest.fn((sellerId, referenceId, callback) => {
-                callback(amazonConfirmationFlow).then(() => {
-                    expect(amazonConfirmationFlow.success).toBeCalled();
-                    expect(orderActionCreator.submitOrder).toHaveBeenCalled();
-                    expect(remoteCheckoutActionCreator.initializePayment).toHaveBeenCalled();
-                });
-            });
-
-            await strategy3ds.execute(payload, options);
-        });
+        // it('redirect to confirmation flow when support 3ds', async () => {
+        //     // tslint:disable-next-line:no-non-null-assertion
+        //     hostWindow.OffAmazonPayments!.initConfirmationFlow = jest.fn((sellerId, referenceId, callback) => {
+        //         callback(amazonConfirmationFlow).then(() => {
+        //             expect(amazonConfirmationFlow.success).toBeCalled();
+        //             expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+        //             expect(remoteCheckoutActionCreator.initializePayment).toHaveBeenCalled();
+        //         });
+        //     });
+        //
+        //     await strategy3ds.execute(payload, options);
+        // });
 
         it('redirect to confirmation flow  error when initializePayment fails', async () => {
             jest.spyOn(remoteCheckoutActionCreator, 'initializePayment')

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -7,7 +7,13 @@ import { of, Observable } from 'rxjs';
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
 import { BillingAddressActionType } from '../../../billing/billing-address-actions';
 import { getBillingAddress, getBillingAddressState } from '../../../billing/billing-addresses.mock';
-import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../../checkout';
+import {
+    createCheckoutStore,
+    CheckoutRequestSender,
+    CheckoutStore,
+    CheckoutStoreState,
+    CheckoutValidator
+} from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import {
     InvalidArgumentError,
@@ -26,7 +32,11 @@ import {
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
-import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import {
+    RemoteCheckoutActionCreator,
+    RemoteCheckoutActionType,
+    RemoteCheckoutRequestSender
+} from '../../../remote-checkout';
 import { getRemoteCheckoutState, getRemoteCheckoutStateData } from '../../../remote-checkout/remote-checkout.mock';
 import { getConsignmentsState } from '../../../shipping/consignments.mock';
 import PaymentMethod from '../../payment-method';

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -40,11 +40,7 @@ import {
 import { getRemoteCheckoutState, getRemoteCheckoutStateData } from '../../../remote-checkout/remote-checkout.mock';
 import { getConsignmentsState } from '../../../shipping/consignments.mock';
 import PaymentMethod from '../../payment-method';
-import {
-    getAmazonPay,
-    getPaymentMethodsState,
-    getPaymentMethodsStateWith3dsMock
-} from '../../payment-methods.mock';
+import { getAmazonPay, getPaymentMethodsState } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 
 import { AmazonPayAddressBookConstructor } from './amazon-pay-address-book';
@@ -474,6 +470,34 @@ describe('AmazonPayPaymentStrategy', () => {
     });
 
     describe('When 3ds is enabled', () => {
+        const paymentMethodsState = {
+            data: [{
+                id: 'amazon',
+                logoUrl: '',
+                method: 'widget',
+                supportedCards: [],
+                config: {
+                    displayName: 'AmazonPay',
+                    is3dsEnabled: true,
+                    merchantId: '0c173620-beb6-4421-99ef-03dc71a60685',
+                    testMode: false,
+                },
+                type: 'PAYMENT_TYPE_API',
+                initializationData: {
+                    clientId: '087eccf4-7f68-4384-b0a9-5f2fd6b0d344',
+                    region: 'US',
+                    redirectUrl: '/remote-checkout/amazon/redirect',
+                    tokenPrefix: 'ABCD|',
+                },
+            }],
+            meta: {
+                geoCountryCode: 'AU',
+                deviceSessionId: 'a37230e9a8e4ea2d7765e2f3e19f7b1d',
+                sessionHash: 'cfbbbac580a920b395571fe086db1e06',
+            },
+            errors: {},
+            statuses: {},
+        };
         const payload = getOrderRequestBody();
         let options: PaymentInitializeOptions;
         let store3ds: CheckoutStore;
@@ -484,7 +508,7 @@ describe('AmazonPayPaymentStrategy', () => {
             options = { methodId: paymentMethod.id };
 
             store3ds = createCheckoutStore({
-                remoteCheckout: {data: {}}, paymentMethods: getPaymentMethodsStateWith3dsMock(),
+                remoteCheckout: {data: {}}, paymentMethods: paymentMethodsState,
             });
             strategy3ds = new AmazonPayPaymentStrategy(
                 store3ds,

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -1,9 +1,20 @@
 import { noop } from 'lodash';
 
-import { isInternalAddressEqual, mapFromInternalAddress, mapToInternalAddress } from '../../../address';
+import {
+    isInternalAddressEqual,
+    mapFromInternalAddress,
+    mapToInternalAddress
+} from '../../../address';
 import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    NotInitializedError,
+    NotInitializedErrorType,
+    RequestError
+} from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
@@ -88,7 +99,13 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
         const { payment: { paymentData, ...paymentPayload }, useStoreCredit = false } = payload;
 
         if (options && this._paymentMethod && this._paymentMethod.config.is3dsEnabled) {
-            return this._processPaymentWith3ds(sellerId, referenceId, paymentPayload.methodId, useStoreCredit, options);
+            return this._processPaymentWith3ds(
+                sellerId,
+                referenceId,
+                paymentPayload.methodId,
+                useStoreCredit,
+                options
+            );
         }
 
         return this._store.dispatch(
@@ -249,7 +266,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                         .catch(error => {
                             confirmationFlow.error();
 
-                            reject(error);
+                            return reject(error);
                         });
                 }
             );

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -243,7 +243,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                     .then(() => {
                         confirmationFlow.success();
 
-                        // resolve(this._store.getState());
+                        return new Promise<never>(() => {});
                     })
                     .catch(error => {
                         confirmationFlow.error();

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -243,7 +243,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                     .then(() => {
                         confirmationFlow.success();
 
-                        resolve(this._store.getState());
+                        // resolve(this._store.getState());
                     })
                     .catch(error => {
                         confirmationFlow.error();

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -224,32 +224,33 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
     private _processPaymentWith3ds(sellerId: string, referenceId: string, methodId: string, useStoreCredit: boolean, options: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         return new Promise((resolve, reject) => {
             if (!this._window.OffAmazonPayments) {
-                return Promise.reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+                return reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
             }
 
             return this._window.OffAmazonPayments.initConfirmationFlow(
-            sellerId,
-            referenceId,
-            (confirmationFlow: AmazonPayConfirmationFlow) => {
-                return this._store.dispatch(
-                    this._orderActionCreator.submitOrder({useStoreCredit}, options)
-                )
-                    .then(() => this._store.dispatch(
-                        this._remoteCheckoutActionCreator.initializePayment(methodId, {
-                            referenceId,
-                            useStoreCredit,
-                        }))
+                sellerId,
+                referenceId,
+                (confirmationFlow: AmazonPayConfirmationFlow) => {
+                    return this._store.dispatch(
+                        this._orderActionCreator.submitOrder({useStoreCredit}, options)
                     )
-                    .then(() => {
-                        confirmationFlow.success();
+                        .then(() => this._store.dispatch(
+                            this._remoteCheckoutActionCreator.initializePayment(methodId, {
+                                referenceId,
+                                useStoreCredit,
+                            }))
+                        )
+                        .then(() => {
+                            confirmationFlow.success();
 
-                        return new Promise<never>(() => {});
-                    })
-                    .catch(error => {
-                        confirmationFlow.error();
+                            return new Promise<never>(() => {
+                            });
+                        })
+                        .catch(error => {
+                            confirmationFlow.error();
 
-                        reject(error);
-                    });
+                            reject(error);
+                        });
                 }
             );
         });

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -84,11 +84,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
         const referenceId = this._getOrderReferenceId();
         const sellerId = this._getMerchantId();
 
-        if (!referenceId) {
-            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-        }
-
-        if (!sellerId) {
+        if (!referenceId || !sellerId) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
@@ -238,7 +234,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
         );
     }
 
-    private _processPaymentWith3ds(sellerId: string, referenceId: string, methodId: string, useStoreCredit: boolean, options: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    private _processPaymentWith3ds(sellerId: string, referenceId: string, methodId: string, useStoreCredit: boolean, options: PaymentRequestOptions): Promise<never> {
         return new Promise((resolve, reject) => {
             if (!this._window.OffAmazonPayments) {
                 return reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
@@ -260,8 +256,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                         .then(() => {
                             confirmationFlow.success();
 
-                            return new Promise<never>(() => {
-                            });
+                            return new Promise<never>(() => {});
                         })
                         .catch(error => {
                             confirmationFlow.error();

--- a/src/payment/strategies/amazon-pay/amazon-pay-script-loader.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-script-loader.spec.ts
@@ -105,6 +105,7 @@ describe('AmazonPayScriptLoader', () => {
                 AddressBook: jest.fn(),
                 Wallet: jest.fn(),
             },
+            initConfirmationFlow: jest.fn(),
         };
 
         amazonPayScriptLoader.loadWidget(getAmazonPay(), onReady);

--- a/src/payment/strategies/amazon-pay/amazon-pay-window.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-window.ts
@@ -1,4 +1,5 @@
 import { AmazonPayAddressBookConstructor } from './amazon-pay-address-book';
+import AmazonPayConfirmationFlow from './amazon-pay-confirmation-flow';
 import AmazonPayLogin from './amazon-pay-login';
 import { AmazonPayLoginButtonConstructor } from './amazon-pay-login-button';
 import { AmazonPayWalletConstructor } from './amazon-pay-wallet';
@@ -13,6 +14,7 @@ export default interface AmazonPayWindow extends Window {
             AddressBook: AmazonPayAddressBookConstructor;
             Wallet: AmazonPayWalletConstructor;
         };
+        initConfirmationFlow(sellerId: string, id: string, callback: (confirmationFlow: AmazonPayConfirmationFlow) => void): void;
     };
     onAmazonLoginReady?(): void;
     onAmazonPaymentsReady?(): void;

--- a/src/payment/strategies/amazon-pay/amazon-pay-window.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-window.ts
@@ -10,14 +10,16 @@ export default interface AmazonPayWindow extends Window {
     amazon?: {
         Login: AmazonPayLogin;
     };
-    OffAmazonPayments?: {
-        Button: AmazonPayLoginButtonConstructor;
-        Widgets: {
-            AddressBook: AmazonPayAddressBookConstructor;
-            Wallet: AmazonPayWalletConstructor;
-        };
-        initConfirmationFlow(sellerId: string, id: string, callback: (confirmationFlow: AmazonPayConfirmationFlow) => void): Promise<InternalCheckoutSelectors>;
-    };
+    OffAmazonPayments?: OffAmazonPayments;
     onAmazonLoginReady?(): void;
     onAmazonPaymentsReady?(): void;
+}
+
+export interface OffAmazonPayments {
+    Button: AmazonPayLoginButtonConstructor;
+    Widgets: {
+        AddressBook: AmazonPayAddressBookConstructor;
+        Wallet: AmazonPayWalletConstructor;
+    };
+    initConfirmationFlow(sellerId: string, id: string, callback: (confirmationFlow: AmazonPayConfirmationFlow) => void): Promise<InternalCheckoutSelectors>;
 }

--- a/src/payment/strategies/amazon-pay/amazon-pay-window.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-window.ts
@@ -1,3 +1,5 @@
+import InternalCheckoutSelectors from '../../../checkout/internal-checkout-selectors';
+
 import { AmazonPayAddressBookConstructor } from './amazon-pay-address-book';
 import AmazonPayConfirmationFlow from './amazon-pay-confirmation-flow';
 import AmazonPayLogin from './amazon-pay-login';
@@ -14,7 +16,7 @@ export default interface AmazonPayWindow extends Window {
             AddressBook: AmazonPayAddressBookConstructor;
             Wallet: AmazonPayWalletConstructor;
         };
-        initConfirmationFlow(sellerId: string, id: string, callback: (confirmationFlow: AmazonPayConfirmationFlow) => void): void;
+        initConfirmationFlow(sellerId: string, id: string, callback: (confirmationFlow: AmazonPayConfirmationFlow) => void): Promise<InternalCheckoutSelectors>;
     };
     onAmazonLoginReady?(): void;
     onAmazonPaymentsReady?(): void;

--- a/src/payment/strategies/amazon-pay/amazon-pay-window.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-window.ts
@@ -1,5 +1,3 @@
-import InternalCheckoutSelectors from '../../../checkout/internal-checkout-selectors';
-
 import { AmazonPayAddressBookConstructor } from './amazon-pay-address-book';
 import AmazonPayConfirmationFlow from './amazon-pay-confirmation-flow';
 import AmazonPayLogin from './amazon-pay-login';
@@ -21,5 +19,5 @@ export interface OffAmazonPayments {
         AddressBook: AmazonPayAddressBookConstructor;
         Wallet: AmazonPayWalletConstructor;
     };
-    initConfirmationFlow(sellerId: string, id: string, callback: (confirmationFlow: AmazonPayConfirmationFlow) => void): Promise<InternalCheckoutSelectors>;
+    initConfirmationFlow(sellerId: string, id: string, callback: (confirmationFlow: AmazonPayConfirmationFlow) => void): void;
 }


### PR DESCRIPTION
[INT-1586](https://jira.bigcommerce.com/browse/INT-1586)
## What?
Add flow when 3DS is enabled on amazonpay strategy 

## Why?
Because we want to to accept payment through Amazon Pay once the PSD2 European regulation takes effect on Sept 14, 2019.

## Testing / Proof
![Screen Shot 2019-06-27 at 4 15 23 PM](https://user-images.githubusercontent.com/39630835/60301381-d554ec00-98f6-11e9-82e9-c9aad8fc7ed8.png)

[LINK TO DEMO](https://drive.google.com/file/d/145eThy7OW22zL8SUHrtrMJugj21m7NPj/view)
## Siblings PR
[INT-1616](https://github.com/bigcommerce/bigcommerce/pull/30507)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations
