### PR TITLE
feat(payment): INT-1608 Modify Paypal Payments Pro's strategy for 3DS

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -31,14 +31,15 @@ import {
     BraintreeVisaCheckoutPaymentStrategy,
     VisaCheckoutScriptLoader
 } from './strategies/braintree';
-import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
-import { ConvergePaymentStrategy } from './strategies/converge';
-import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import {
     CardinalClient,
     CardinalScriptLoader,
-    CyberSourcePaymentStrategy
-} from './strategies/cybersource';
+    CardinalThreeDSecureFlow,
+} from './strategies/cardinal';
+import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
+import { ConvergePaymentStrategy } from './strategies/converge';
+import { CreditCardPaymentStrategy } from './strategies/credit-card';
+import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
 import {
     createGooglePayPaymentProcessor,
     GooglePayBraintreeInitializer,
@@ -125,10 +126,14 @@ export default function createPaymentStrategyRegistry(
     registry.register(PaymentStrategyType.CYBERSOURCE, () =>
         new CyberSourcePaymentStrategy(
             store,
-            paymentMethodActionCreator,
             orderActionCreator,
             paymentActionCreator,
-            new CardinalClient(new CardinalScriptLoader(scriptLoader))
+            new CardinalThreeDSecureFlow(
+                store,
+                paymentActionCreator,
+                paymentMethodActionCreator,
+                new CardinalClient(new CardinalScriptLoader(scriptLoader))
+            )
         )
     );
 
@@ -168,7 +173,13 @@ export default function createPaymentStrategyRegistry(
         new PaypalProPaymentStrategy(
             store,
             orderActionCreator,
-            paymentActionCreator
+            paymentActionCreator,
+            new CardinalThreeDSecureFlow(
+                store,
+                paymentActionCreator,
+                paymentMethodActionCreator,
+                new CardinalClient(new CardinalScriptLoader(scriptLoader))
+            )
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -90,6 +90,7 @@ export function getPaypal(): PaymentMethod {
         supportedCards: [],
         config: {
             testMode: false,
+            is3dsEnabled: true,
         },
         type: 'PAYMENT_TYPE_API',
         clientToken: 'foo',

--- a/src/payment/strategies/cardinal/cardinal-script-loader.spec.ts
+++ b/src/payment/strategies/cardinal/cardinal-script-loader.spec.ts
@@ -18,19 +18,19 @@ describe('CardinalScriptLoader', () => {
 
     it('loads widget test script', () => {
         const testMode = true;
-        cardinalScriptLoader.load(testMode);
+        cardinalScriptLoader.load('provider', testMode);
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            'https://songbirdstag.cardinalcommerce.com/edge/v1/songbird.js'
+            'https://songbirdstag.cardinalcommerce.com/edge/v1/songbird.js?v=provider'
         );
     });
 
     it('loads widget production script', () => {
         const testMode = false;
-        cardinalScriptLoader.load(testMode);
+        cardinalScriptLoader.load('provider', testMode);
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            'https://songbird.cardinalcommerce.com/edge/v1/songbird.js'
+            'https://songbird.cardinalcommerce.com/edge/v1/songbird.js?v=provider'
         );
     });
 
@@ -41,7 +41,7 @@ describe('CardinalScriptLoader', () => {
             return Promise.resolve();
         });
 
-        const script = await cardinalScriptLoader.load();
+        const script = await cardinalScriptLoader.load('provider');
         expect(script).toBe(cardinalWindow.Cardinal);
     });
 
@@ -51,7 +51,7 @@ describe('CardinalScriptLoader', () => {
         });
 
         try {
-            await cardinalScriptLoader.load();
+            await cardinalScriptLoader.load('provider');
         } catch (error) {
             expect(error).toBeInstanceOf(StandardError);
         }

--- a/src/payment/strategies/cardinal/cardinal-script-loader.ts
+++ b/src/payment/strategies/cardinal/cardinal-script-loader.ts
@@ -13,9 +13,11 @@ export default class CardinalScriptLoader {
         private _window: CardinalWindow = window
     ) {}
 
-    load(testMode?: boolean): Promise<CardinalSDK> {
+    load(provider: string, testMode?: boolean): Promise<CardinalSDK> {
+        const url = testMode ? SDK_TEST_URL : SDK_PROD_URL;
+
         return this._scriptLoader
-            .loadScript(testMode ? SDK_TEST_URL : SDK_PROD_URL)
+            .loadScript(url + '?v=' + provider)
             .then(() => {
                 if (!this._window.Cardinal) {
                     throw new StandardError();

--- a/src/payment/strategies/cardinal/cardinal-three-d-secure-flow.spec.ts
+++ b/src/payment/strategies/cardinal/cardinal-three-d-secure-flow.spec.ts
@@ -1,0 +1,320 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, Action } from '@bigcommerce/data-store';
+import createErrorAction from '@bigcommerce/data-store/lib/create-error-action';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of, Observable } from 'rxjs';
+
+import {
+    createCheckoutStore,
+    CheckoutRequestSender,
+    CheckoutStore,
+    CheckoutValidator,
+} from '../../../checkout';
+import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError, RequestError, StandardError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import {
+    OrderActionCreator,
+    OrderRequestSender,
+} from '../../../order';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection/index';
+import { PaymentMethodActionCreator, PaymentMethodActionType, PaymentMethodRequestSender, PaymentRequestSender } from '../../index';
+import Payment from '../../payment';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import PaymentMethod from '../../payment-method';
+import { getCybersource } from '../../payment-methods.mock';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+import { getErrorPaymentResponseBody, getPayment, getVaultedInstrument } from '../../payments.mock';
+import {
+    CardinalClient,
+    CardinalScriptLoader,
+    CardinalThreeDSecureFlow
+} from '../cardinal';
+
+describe('CardinalThreeDSecureFlow', () => {
+    let loadPaymentMethodAction: Observable<Action>;
+    let cardinalClient: CardinalClient;
+    let payment: Payment;
+    let orderActionCreator: OrderActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let scriptLoader: CardinalScriptLoader;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+    let store: CheckoutStore;
+    let paymentMethodMock: PaymentMethod;
+    let requestError: RequestError;
+    let cardinalFlow: CardinalThreeDSecureFlow;
+
+    beforeEach(() => {
+        paymentMethodMock = { ...getCybersource(), clientToken: 'foo' };
+        store = createCheckoutStore(getCheckoutStoreStateWithOrder());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
+        scriptLoader = new CardinalScriptLoader(createScriptLoader());
+        cardinalClient = new CardinalClient(scriptLoader);
+
+        orderActionCreator = new OrderActionCreator(
+            new OrderRequestSender(createRequestSender()),
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(
+                createSpamProtection(createScriptLoader())
+            )
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer()
+        );
+
+        cardinalFlow = new CardinalThreeDSecureFlow(
+            store,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            cardinalClient
+        );
+
+        payment = {
+            ...getPayment(),
+            methodId: paymentMethodMock.id,
+            gatewayId: paymentMethodMock.gateway,
+        };
+
+        loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: paymentMethodMock.id }));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+            .mockReturnValue(loadPaymentMethodAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        jest.spyOn(cardinalClient, 'initialize').mockReturnValue(Promise.resolve());
+        jest.spyOn(cardinalClient, 'configure').mockReturnValue(Promise.resolve());
+    });
+
+    describe('#prepare', () => {
+        it('initializes Cardinal correctly', async () => {
+            await cardinalFlow.prepare(paymentMethodMock.id);
+
+            expect(cardinalClient.initialize).toHaveBeenCalledWith('cybersource', true);
+            expect(cardinalClient.configure).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+        });
+
+        it('does not call loadPaymentMethod if already did', async () => {
+            await cardinalFlow.prepare(paymentMethodMock.id);
+            await cardinalFlow.prepare(paymentMethodMock.id);
+
+            expect(paymentMethodActionCreator.loadPaymentMethod).toBeCalledTimes(1);
+        });
+
+        it('throws missing data error when payment method is not defined', async () => {
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+                .mockReturnValue(of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, undefined)));
+
+            try {
+                await cardinalFlow.prepare(paymentMethodMock.id);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws missing data error when client token is not defined', async () => {
+            paymentMethodMock.clientToken = undefined;
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+                .mockReturnValue(of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock)));
+
+            try {
+                await cardinalFlow.prepare(paymentMethodMock.id);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+    });
+
+    describe('#start', () => {
+        beforeEach(async () => {
+            requestError = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [
+                    { code: 'three_d_secure_required' },
+                ],
+                three_ds_result: {
+                    acs_url: 'https://acs/url',
+                    callback_url: '',
+                    payer_auth_request: '',
+                    merchant_data: 'merchant_data',
+                },
+                status: 'error',
+            }));
+
+            jest.spyOn(cardinalClient, 'configure').mockReturnValue(Promise.resolve());
+            jest.spyOn(cardinalClient, 'runBinProcess').mockReturnValue(Promise.resolve());
+
+            await cardinalFlow.prepare(paymentMethodMock.id);
+        });
+
+        it('completes the purchase correctly if card is not enrolled', async () => {
+            jest.spyOn(cardinalClient, 'getThreeDSecureData');
+
+            await cardinalFlow.start(payment);
+
+            expect(cardinalClient.getThreeDSecureData).not.toHaveBeenCalled();
+        });
+
+        it('completes the purchase correctly if card is enrolled', async () => {
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+            jest.spyOn(cardinalClient, 'getThreeDSecureData').mockReturnValue(Promise.resolve('token'));
+
+            await cardinalFlow.start(payment);
+
+            expect(cardinalClient.getThreeDSecureData).toHaveBeenCalled();
+        });
+
+        it('does not complete the purchase if there was an error', async () => {
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, new StandardError('Custom Error'))));
+
+            try {
+                await cardinalFlow.start(payment);
+            } catch (error) {
+                expect(error).toBeInstanceOf(StandardError);
+                expect(error.message).toBe('Custom Error');
+            }
+        });
+
+        it('throws data missing error when payment data is undefined', async () => {
+            payment = {
+                methodId: paymentMethodMock.id,
+                gatewayId: paymentMethodMock.gateway,
+            };
+
+            try {
+                await cardinalFlow.start(payment);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws an error if payment data is not a credit card or vaulted instrument', async () => {
+            payment = {
+                methodId: paymentMethodMock.id,
+                gatewayId: paymentMethodMock.gateway,
+                paymentData: {
+                    nonce: 'string',
+                },
+            };
+
+            try {
+                await cardinalFlow.start(payment);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if client token is undefined', async () => {
+            cardinalFlow = new CardinalThreeDSecureFlow(
+                store,
+                paymentActionCreator,
+                paymentMethodActionCreator,
+                cardinalClient
+            );
+
+            try {
+                await cardinalFlow.start(payment);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws an error if order data is undefined', async () => {
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+
+            store = createCheckoutStore(getCheckoutStoreState());
+
+            cardinalFlow = new CardinalThreeDSecureFlow(
+                store,
+                paymentActionCreator,
+                paymentMethodActionCreator,
+                cardinalClient
+            );
+
+            await cardinalFlow.prepare(paymentMethodMock.id);
+
+            try {
+                await cardinalFlow.start(payment);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws an error if billing data is undefined', async () => {
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                billingAddress: undefined,
+            });
+
+            cardinalFlow = new CardinalThreeDSecureFlow(
+                store,
+                paymentActionCreator,
+                paymentMethodActionCreator,
+                cardinalClient
+            );
+
+            await cardinalFlow.prepare(paymentMethodMock.id);
+
+            try {
+                await cardinalFlow.start(payment);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws an error if checkout data is undefined', async () => {
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                checkout: undefined,
+            });
+
+            cardinalFlow = new CardinalThreeDSecureFlow(
+                store,
+                paymentActionCreator,
+                paymentMethodActionCreator,
+                cardinalClient
+            );
+
+            await cardinalFlow.prepare(paymentMethodMock.id);
+
+            try {
+                await cardinalFlow.start(payment);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('uses vaulted instrument as payment Data', async () => {
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
+            jest.spyOn(cardinalClient, 'getThreeDSecureData').mockReturnValue(Promise.resolve('token'));
+
+            payment = {
+                methodId: paymentMethodMock.id,
+                gatewayId: paymentMethodMock.gateway,
+                paymentData: getVaultedInstrument(),
+            };
+
+            await cardinalFlow.start(payment);
+
+            expect(cardinalClient.getThreeDSecureData).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/payment/strategies/cardinal/cardinal-three-d-secure-flow.ts
+++ b/src/payment/strategies/cardinal/cardinal-three-d-secure-flow.ts
@@ -1,0 +1,155 @@
+import { find, some } from 'lodash';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    RequestError
+} from '../../../common/error/errors';
+import isCreditCardLike from '../../is-credit-card-like';
+import isVaultedInstrument from '../../is-vaulted-instrument';
+import Payment from '../../payment';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+
+import {
+    CardinalClient,
+    CardinalOrderData,
+    CardinalSupportedPaymentInstrument
+} from './index';
+
+export default class CardinalThreeDSecureFlow {
+    private _paymentMethod?: PaymentMethod;
+    private _clientToken?: string;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _cardinalClient: CardinalClient
+    ) {}
+
+    prepare(methodId: string): Promise<void> {
+        if (this._clientToken) {
+            return Promise.resolve();
+        }
+
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
+            .then(state => {
+                this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+                if (!this._paymentMethod || !this._paymentMethod.config) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                return this._cardinalClient.initialize(methodId, this._paymentMethod.config.testMode);
+            })
+            .then(() => {
+                if (!this._paymentMethod || !this._paymentMethod.clientToken) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                this._clientToken = this._paymentMethod.clientToken;
+
+                return this._cardinalClient.configure(this._clientToken);
+            });
+    }
+
+    start(payment: Payment): Promise<InternalCheckoutSelectors> {
+        if (!payment.paymentData) {
+            throw new MissingDataError(MissingDataErrorType.MissingPayment);
+        }
+
+        if (!isCreditCardLike(payment.paymentData) && !isVaultedInstrument(payment.paymentData)) {
+            throw new InvalidArgumentError();
+        }
+
+        const paymentData = payment.paymentData;
+
+        return this._cardinalClient.runBinProcess(this._getBinNumber(paymentData))
+            .then(() => {
+                if (!this._clientToken) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                payment = {
+                    ...payment,
+                    paymentData: {
+                        ...paymentData,
+                        threeDSecure: { token: this._clientToken },
+                    },
+                };
+
+                return this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
+            })
+            .catch(error => {
+                if (!(error instanceof RequestError) || !some(error.body.errors, {code: 'three_d_secure_required'})) {
+                    return Promise.reject(error);
+                }
+
+                return this._cardinalClient.getThreeDSecureData(
+                    error.body.three_ds_result,
+                    this._getOrderData(paymentData)
+                )
+                .then(threeDSecure =>
+                    this._store.dispatch(this._paymentActionCreator.submitPayment({
+                        ...payment,
+                        paymentData: {
+                            ...paymentData,
+                            threeDSecure,
+                        },
+                    }))
+                );
+            });
+    }
+
+    private _getBinNumber(payment: CardinalSupportedPaymentInstrument): string {
+        if (isVaultedInstrument(payment)) {
+            const instruments = this._store.getState().instruments.getInstruments();
+
+            const { instrumentId } = payment;
+
+            const entry = find(instruments, { bigpayToken: instrumentId });
+
+            return entry && entry.iin || '';
+        }
+
+        return payment.ccNumber;
+    }
+
+    private _getOrderData(paymentData: CardinalSupportedPaymentInstrument): CardinalOrderData {
+        const state = this._store.getState();
+        const billingAddress = state.billingAddress.getBillingAddress();
+        const shippingAddress = state.shippingAddress.getShippingAddress();
+        const checkout = state.checkout.getCheckout();
+        const order = state.order.getOrder();
+
+        if (!billingAddress || !billingAddress.email) {
+            throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
+        }
+
+        if (!checkout) {
+            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+        }
+
+        if (!order) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrder);
+        }
+
+        const payment: CardinalOrderData = {
+            billingAddress,
+            shippingAddress,
+            currencyCode: checkout.cart.currency.code,
+            id: order.orderId.toString(),
+            amount: checkout.cart.cartAmount,
+        };
+
+        if (isCreditCardLike(paymentData)) {
+            payment.paymentData = paymentData;
+        }
+
+        return payment;
+    }
+}

--- a/src/payment/strategies/cardinal/cardinal.mock.ts
+++ b/src/payment/strategies/cardinal/cardinal.mock.ts
@@ -7,6 +7,7 @@ import {
     CardinalBinProcessResponse,
     CardinalOrderData,
     CardinalPaymentType,
+    CardinalSignatureVerification,
     CardinalSDK,
     CardinalValidatedAction,
     CardinalValidatedData,
@@ -40,23 +41,20 @@ export function getCardinalBinProcessResponse(status: boolean): CardinalBinProce
     };
 }
 
-export function getCardinalValidatedData(status: boolean, errorNumber?: number): CardinalValidatedData {
+export function getCardinalValidatedData(actionCode: CardinalValidatedAction, status: boolean, errorNumber?: number): CardinalValidatedData {
     return {
+        ActionCode: actionCode,
         ErrorDescription: '',
         ErrorNumber: errorNumber ? errorNumber : 0,
         Validated: status,
         Payment: {
+            ExtendedData: {
+                SignatureVerification: CardinalSignatureVerification.Yes,
+            },
             ProcessorTransactionId: '',
             Type: CardinalPaymentType.CCA,
         },
     };
-}
-
-export function getCardinalValidatedDataWithActionCode(actionCode: CardinalValidatedAction, status: boolean, errorNumber?: number): CardinalValidatedData {
-    const data = getCardinalValidatedData(status, errorNumber);
-    data.ActionCode = actionCode;
-
-    return data;
 }
 
 export function getCardinalThreeDSResult(): ThreeDsResult {

--- a/src/payment/strategies/cardinal/cardinal.ts
+++ b/src/payment/strategies/cardinal/cardinal.ts
@@ -74,6 +74,7 @@ export interface CardinalValidatedData {
 }
 
 export interface CardinalPayment {
+    ExtendedData?: CardinalCCAExtendedData;
     ProcessorTransactionId: string;
     Type: CardinalPaymentType;
 }
@@ -133,6 +134,15 @@ export interface CardinalOrderDetails {
     TransactionId?: string;
 }
 
+export type CardinalCCAExtendedData = Partial<{
+    CAVV: string;
+    ECIFlag: string;
+    PAResStatus: string;
+    SignatureVerification: string;
+    XID: string;
+    UCAFIndicator: string;
+}>;
+
 export enum CardinalEventType {
     SetupCompleted = 'payments.setupComplete',
     Validated = 'payments.validated',
@@ -160,4 +170,9 @@ export enum CardinalTriggerEvents {
 
 export enum CardinalPaymentBrand {
     CCA = 'cca',
+}
+
+export enum CardinalSignatureVerification {
+    Yes = 'Y',
+    No = 'N',
 }

--- a/src/payment/strategies/cardinal/index.ts
+++ b/src/payment/strategies/cardinal/index.ts
@@ -1,0 +1,5 @@
+export * from './cardinal';
+
+export { default as CardinalThreeDSecureFlow } from './cardinal-three-d-secure-flow';
+export { default as CardinalScriptLoader } from './cardinal-script-loader';
+export { default as CardinalClient, CardinalOrderData, CardinalSupportedPaymentInstrument } from './cardinal-client';

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
@@ -1,6 +1,5 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
-import createErrorAction from '@bigcommerce/data-store/lib/create-error-action';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
@@ -12,11 +11,8 @@ import {
     CheckoutStore,
     CheckoutValidator,
 } from '../../../checkout';
-import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
+import { getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
 import { MissingDataError } from '../../../common/error/errors';
-import RequestError from '../../../common/error/errors/request-error';
-import StandardError from '../../../common/error/errors/standard-error';
-import { getResponse } from '../../../common/http-request/responses.mock';
 import {
     OrderActionCreator,
     OrderActionType,
@@ -26,44 +22,33 @@ import {
 import OrderFinalizationNotRequiredError from '../../../order/errors/order-finalization-not-required-error';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
-import {
-    RemoteCheckoutActionCreator,
-    RemoteCheckoutActionType,
-    RemoteCheckoutRequestSender
-} from '../../../remote-checkout';
-import { PaymentRequestSender } from '../../index';
+import { PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender } from '../../index';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
-import PaymentMethodActionCreator from '../../payment-method-action-creator';
-import { PaymentMethodActionType } from '../../payment-method-actions';
-import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getCybersource } from '../../payment-methods.mock';
 import PaymentRequestTransformer from '../../payment-request-transformer';
-import { getErrorPaymentResponseBody, getVaultedInstrument } from '../../payments.mock';
-
 import {
     CardinalClient,
     CardinalScriptLoader,
-    CyberSourcePaymentStrategy
-} from './index';
+    CardinalThreeDSecureFlow
+} from '../cardinal';
+
+import { CyberSourcePaymentStrategy } from './index';
 
 describe('CyberSourcePaymentStrategy', () => {
-    let initializePaymentAction: Observable<Action>;
-    let loadPaymentMethodAction: Observable<Action>;
     let cardinalClient: CardinalClient;
-    let payload: OrderRequestBody;
+    let cardinalThreeDSecureFlow: CardinalThreeDSecureFlow;
     let orderActionCreator: OrderActionCreator;
-    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let payload: OrderRequestBody;
     let paymentActionCreator: PaymentActionCreator;
-    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentMethodMock: PaymentMethod;
     let scriptLoader: CardinalScriptLoader;
-    let submitOrderAction: Observable<Action>;
-    let submitPaymentAction: Observable<SubmitPaymentAction>;
     let store: CheckoutStore;
     let strategy: CyberSourcePaymentStrategy;
-    let paymentMethodMock: PaymentMethod;
-    let requestError: RequestError;
+    let submitOrderAction: Observable<Action>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
 
     beforeEach(() => {
         paymentMethodMock = { ...getCybersource(), clientToken: 'foo' };
@@ -71,10 +56,6 @@ describe('CyberSourcePaymentStrategy', () => {
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         scriptLoader = new CardinalScriptLoader(createScriptLoader());
         cardinalClient = new CardinalClient(scriptLoader);
-
-        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(createRequestSender())
-        );
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
@@ -90,12 +71,18 @@ describe('CyberSourcePaymentStrategy', () => {
             new PaymentRequestTransformer()
         );
 
+        cardinalThreeDSecureFlow = new CardinalThreeDSecureFlow(
+            store,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            cardinalClient
+        );
+
         strategy = new CyberSourcePaymentStrategy(
             store,
-            paymentMethodActionCreator,
             orderActionCreator,
             paymentActionCreator,
-            cardinalClient
+            cardinalThreeDSecureFlow
         );
 
         payload = merge({}, getOrderRequestBody(), {
@@ -105,16 +92,8 @@ describe('CyberSourcePaymentStrategy', () => {
             },
         });
 
-        loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: paymentMethodMock.id }));
-        initializePaymentAction = of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
-
-        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(loadPaymentMethodAction);
-
-        jest.spyOn(remoteCheckoutActionCreator, 'initializePayment')
-            .mockReturnValue(initializePaymentAction);
 
         jest.spyOn(orderActionCreator, 'submitOrder')
             .mockReturnValue(submitOrderAction);
@@ -122,16 +101,25 @@ describe('CyberSourcePaymentStrategy', () => {
         jest.spyOn(paymentActionCreator, 'submitPayment')
             .mockReturnValue(submitPaymentAction);
 
-        jest.spyOn(cardinalClient, 'initialize').mockReturnValue(Promise.resolve());
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethodMock);
+
+        jest.spyOn(cardinalThreeDSecureFlow, 'prepare').mockReturnValue(Promise.resolve());
+
+        jest.spyOn(cardinalThreeDSecureFlow, 'start').mockReturnValue(store.getState());
     });
 
     describe('#initialize', () => {
-        beforeEach(async () => {
-            await strategy.initialize({ methodId: paymentMethodMock.id });
+        it('initializes strategy successfully when 3DS is enabled', async () => {
+            await strategy.initialize({methodId: paymentMethodMock.id});
+
+            expect(cardinalThreeDSecureFlow.prepare).toHaveBeenCalled();
         });
 
-        it('initializes strategy successfully', () => {
-            expect(cardinalClient.initialize).toHaveBeenCalledWith(true);
+        it('initializes strategy successfully when 3DS is disabled', async () => {
+            paymentMethodMock.config.is3dsEnabled = false;
+            await strategy.initialize({methodId: paymentMethodMock.id});
+
+            expect(cardinalThreeDSecureFlow.prepare).not.toHaveBeenCalled();
         });
 
         it('throws data missing error when payment method is not defined', async () => {
@@ -146,14 +134,6 @@ describe('CyberSourcePaymentStrategy', () => {
     });
 
     describe('#execute', () => {
-        it('throws error to inform that payment data is missing', async () => {
-            try {
-                await strategy.execute(payload);
-            } catch (error) {
-                expect(error).toBeInstanceOf(MissingDataError);
-            }
-        });
-
         it('throws data missing error when payment is undefined', async () => {
             payload.payment = undefined;
 
@@ -165,234 +145,31 @@ describe('CyberSourcePaymentStrategy', () => {
             }
         });
 
-        describe('when 3DS is disabled', () => {
-            beforeEach(async () => {
-                const paymentMethod = paymentMethodMock;
-                paymentMethod.config.is3dsEnabled = false;
-
-                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethod);
-
-                strategy = new CyberSourcePaymentStrategy(
-                    store,
-                    paymentMethodActionCreator,
-                    orderActionCreator,
-                    paymentActionCreator,
-                    cardinalClient
-                );
-
-                await strategy.initialize({ methodId: paymentMethod.id });
-            });
-
-            it('completes the purchase successfully', async () => {
+        it('throws error to inform that payment data is missing', async () => {
+            try {
                 await strategy.execute(payload);
-
-                const { payment, ...order } = payload;
-
-                expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(order, undefined);
-                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payment);
-            });
-
-            it('throws data missing error when payment data is undefined', async () => {
-                payload = {
-                    payment: {
-                        methodId: paymentMethodMock.id,
-                        gatewayId: paymentMethodMock.gateway,
-                    },
-                };
-
-                await strategy.initialize({ methodId: paymentMethodMock.id });
-                try {
-                    await strategy.execute(payload);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(MissingDataError);
-                }
-            });
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
         });
 
-        describe('when 3DS is enabled', () => {
-            beforeEach(async () => {
-                requestError = new RequestError(getResponse({
-                    ...getErrorPaymentResponseBody(),
-                    errors: [
-                        { code: 'three_d_secure_required' },
-                    ],
-                    three_ds_result: {
-                        acs_url: 'https://acs/url',
-                        callback_url: '',
-                        payer_auth_request: '',
-                        merchant_data: 'merchant_data',
-                    },
-                    status: 'error',
-                }));
+        it('completes the purchase successfully when 3DS is disabled', async () => {
+            paymentMethodMock.config.is3dsEnabled = false;
+            await strategy.initialize({ methodId: paymentMethodMock.id });
 
-                jest.spyOn(cardinalClient, 'configure').mockReturnValue(Promise.resolve());
-                jest.spyOn(cardinalClient, 'runBinProcess').mockReturnValue(Promise.resolve());
-                jest.spyOn(cardinalClient, 'getClientToken').mockReturnValue('1234567890');
+            const result = await strategy.execute(payload);
 
-                await strategy.initialize({ methodId: paymentMethodMock.id });
-            });
+            expect(cardinalThreeDSecureFlow.start).not.toHaveBeenCalled();
+            expect(result).toBe(store.getState());
+        });
 
-            it('completes the purchase correctly if card is not enrolled', async () => {
-                jest.spyOn(cardinalClient, 'getThreeDSecureData');
+        it('completes the purchase successfully when 3DS is enabled', async () => {
+            await strategy.initialize({ methodId: paymentMethodMock.id });
 
-                await strategy.execute(payload);
+            const result = await strategy.execute(payload);
 
-                expect(cardinalClient.getThreeDSecureData).not.toHaveBeenCalled();
-            });
-
-            it('completes the purchase correctly if card is enrolled', async () => {
-                jest.spyOn(paymentActionCreator, 'submitPayment')
-                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
-                jest.spyOn(cardinalClient, 'getThreeDSecureData').mockReturnValue(Promise.resolve('token'));
-
-                await strategy.execute(payload);
-
-                expect(cardinalClient.getThreeDSecureData).toHaveBeenCalled();
-            });
-
-            it('does not complete the purchase if there was an error', async () => {
-                jest.spyOn(paymentActionCreator, 'submitPayment')
-                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, new StandardError('Custom Error'))));
-
-                try {
-                    await strategy.execute(payload);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(StandardError);
-                    expect(error.message).toBe('Custom Error');
-                }
-            });
-
-            it('throws data missing error when payment data is undefined', async () => {
-                payload = {
-                    payment: {
-                        methodId: paymentMethodMock.id,
-                        gatewayId: paymentMethodMock.gateway,
-                    },
-                };
-
-                await strategy.initialize({ methodId: paymentMethodMock.id });
-                try {
-                    await strategy.execute(payload);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(MissingDataError);
-                }
-            });
-
-            it('throws an error if client token is undefined', async () => {
-                const paymentMethod = paymentMethodMock;
-                paymentMethod.clientToken = undefined;
-
-                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethod);
-
-                strategy = new CyberSourcePaymentStrategy(
-                    store,
-                    paymentMethodActionCreator,
-                    orderActionCreator,
-                    paymentActionCreator,
-                    cardinalClient
-                );
-
-                await strategy.initialize({ methodId: paymentMethod.id });
-
-                try {
-                    await strategy.execute(payload);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(MissingDataError);
-                }
-            });
-
-            it('throws an error if order data is undefined', async () => {
-                jest.spyOn(paymentActionCreator, 'submitPayment')
-                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
-
-                store = createCheckoutStore(getCheckoutStoreState());
-
-                strategy = new CyberSourcePaymentStrategy(
-                    store,
-                    paymentMethodActionCreator,
-                    orderActionCreator,
-                    paymentActionCreator,
-                    cardinalClient
-                );
-
-                await strategy.initialize({ methodId: paymentMethodMock.id });
-
-                try {
-                    await strategy.execute(payload);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(MissingDataError);
-                }
-            });
-
-            it('throws an error if billing data is undefined', async () => {
-                jest.spyOn(paymentActionCreator, 'submitPayment')
-                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
-
-                store = createCheckoutStore({
-                    ...getCheckoutStoreState(),
-                    billingAddress: undefined,
-                });
-
-                strategy = new CyberSourcePaymentStrategy(
-                    store,
-                    paymentMethodActionCreator,
-                    orderActionCreator,
-                    paymentActionCreator,
-                    cardinalClient
-                );
-
-                await strategy.initialize({ methodId: paymentMethodMock.id });
-
-                try {
-                    await strategy.execute(payload);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(MissingDataError);
-                }
-            });
-
-            it('throws an error if checkout data is undefined', async () => {
-                jest.spyOn(paymentActionCreator, 'submitPayment')
-                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
-
-                store = createCheckoutStore({
-                    ...getCheckoutStoreState(),
-                    checkout: undefined,
-                });
-
-                strategy = new CyberSourcePaymentStrategy(
-                    store,
-                    paymentMethodActionCreator,
-                    orderActionCreator,
-                    paymentActionCreator,
-                    cardinalClient
-                );
-
-                await strategy.initialize({ methodId: paymentMethodMock.id });
-
-                try {
-                    await strategy.execute(payload);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(MissingDataError);
-                }
-            });
-
-            it('uses vaulted instrument as payment Data', async () => {
-                jest.spyOn(paymentActionCreator, 'submitPayment')
-                    .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, requestError)));
-                jest.spyOn(cardinalClient, 'getThreeDSecureData').mockReturnValue(Promise.resolve('token'));
-
-                payload = merge({}, getOrderRequestBody(), {
-                    payment: {
-                        methodId: paymentMethodMock.id,
-                        gatewayId: paymentMethodMock.gateway,
-                        paymentData: getVaultedInstrument(),
-                    },
-                });
-
-                await strategy.execute(payload);
-
-                expect(cardinalClient.getThreeDSecureData).toHaveBeenCalled();
-            });
+            expect(cardinalThreeDSecureFlow.start).toHaveBeenCalled();
+            expect(result).toBe(store.getState());
         });
     });
 

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
@@ -1,53 +1,37 @@
-import { find, some } from 'lodash';
-
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import {
-    MissingDataError,
-    MissingDataErrorType,
-    RequestError
-} from '../../../common/error/errors';
-import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import isCreditCardLike from '../../is-credit-card-like';
-import isVaultedInstrument from '../../is-vaulted-instrument';
-import { CreditCardInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
-import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { CardinalThreeDSecureFlow } from '../cardinal';
 import PaymentStrategy from '../payment-strategy';
-
-import {
-    CardinalClient,
-    CardinalOrderData,
-    CardinalSupportedPaymentInstrument
-} from './index';
 
 export default class CyberSourcePaymentStrategy implements PaymentStrategy {
     private _paymentMethod?: PaymentMethod;
 
     constructor(
         private _store: CheckoutStore,
-        private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
-        private _cardinalClient: CardinalClient
-    ) { }
+        private _threeDSecureFlow: CardinalThreeDSecureFlow
+    ) {}
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { methodId } = options;
+        this._paymentMethod = this._store.getState().paymentMethods.getPaymentMethod(methodId);
 
-        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
-            .then(state => {
-                this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+        if (!this._paymentMethod) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
 
-                if (!this._paymentMethod || !this._paymentMethod.config) {
-                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-                }
+        if (!this._paymentMethod.config.is3dsEnabled) {
+            return Promise.resolve(this._store.getState());
+        }
 
-                return this._cardinalClient.initialize(this._paymentMethod.config.testMode)
-                    .then(() => this._store.getState());
-            });
+        return this._threeDSecureFlow.prepare(methodId)
+            .then(() => this._store.getState());
     }
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
@@ -57,13 +41,16 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingPayment);
         }
 
-        if (!this._paymentMethod || !this._paymentMethod.config) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
+        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
+            .then(() => {
+                if (!this._paymentMethod) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
 
-        return this._paymentMethod.config.is3dsEnabled ?
-            this._placeOrderUsing3DS(order, payment, options, this._paymentMethod.clientToken) :
-            this._placeOrder(order, payment, options);
+                return this._paymentMethod.config.is3dsEnabled ?
+                    this._threeDSecureFlow.start(payment) :
+                    this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
+            });
     }
 
     finalize(): Promise<InternalCheckoutSelectors> {
@@ -72,106 +59,5 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
 
     deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
-    }
-
-    private _placeOrderUsing3DS(order: OrderRequestBody, payment: OrderPaymentRequestBody, options?: PaymentRequestOptions, clientToken?: string): Promise<InternalCheckoutSelectors> {
-        if (!clientToken) {
-            return Promise.reject(new MissingDataError(MissingDataErrorType.MissingPaymentMethod));
-        }
-
-        if (!payment.paymentData) {
-            return Promise.reject(new MissingDataError(MissingDataErrorType.MissingPayment));
-        }
-
-        const paymentData = payment.paymentData as CreditCardInstrument;
-
-        return this._cardinalClient.configure(clientToken)
-            .then(() => this._cardinalClient.runBinProcess(this._getBinNumber(paymentData)))
-            .then(() => {
-                payment = {
-                    ...payment,
-                    paymentData: {
-                        ...paymentData,
-                        threeDSecure: { token: this._cardinalClient.getClientToken() },
-                    },
-                };
-
-                return this._placeOrder(order, payment, options)
-                    .catch(error => {
-                        if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
-                            return Promise.reject(error);
-                        }
-
-                        return this._cardinalClient.getThreeDSecureData(error.body.three_ds_result, this._getOrderData(paymentData))
-                            .then(threeDSecure =>
-                                this._store.dispatch(this._paymentActionCreator.submitPayment({
-                                    ...payment,
-                                    paymentData: {
-                                        ...paymentData,
-                                        threeDSecure,
-                                    },
-                                }))
-                            );
-                    });
-            });
-    }
-
-    private _placeOrder(order: OrderRequestBody, payment: OrderPaymentRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        if (!payment.paymentData) {
-            return Promise.reject(new MissingDataError(MissingDataErrorType.MissingPayment));
-        }
-
-        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
-            .then(() =>
-                this._store.dispatch(this._paymentActionCreator.submitPayment(payment))
-            );
-    }
-
-    private _getBinNumber(payment: CardinalSupportedPaymentInstrument): string {
-        if (isVaultedInstrument(payment)) {
-            const instruments = this._store.getState().instruments.getInstruments();
-
-            const { instrumentId } = payment;
-
-            const entry = find(instruments, { bigpayToken: instrumentId });
-
-            return entry && entry.iin || '';
-        }
-
-        return payment.ccNumber;
-    }
-
-    private _getOrderData(paymentData: CardinalSupportedPaymentInstrument): CardinalOrderData {
-        const state = this._store.getState();
-        const billingAddress = state.billingAddress.getBillingAddress();
-        const shippingAddress = state.shippingAddress.getShippingAddress();
-        const checkout = state.checkout.getCheckout();
-        const order = state.order.getOrder();
-
-        if (!billingAddress || !billingAddress.email) {
-            throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
-        }
-
-        if (!checkout) {
-            throw new MissingDataError(MissingDataErrorType.MissingCheckout);
-        }
-
-        if (!order) {
-            throw new MissingDataError(MissingDataErrorType.MissingOrder);
-        }
-
-        const payment: CardinalOrderData = {
-            billingAddress,
-            shippingAddress,
-            currencyCode: checkout.cart.currency.code,
-            id: order.orderId.toString(),
-            amount: checkout.cart.cartAmount,
-        };
-
-        if (isCreditCardLike(paymentData)) {
-            payment.paymentData = paymentData;
-        }
-
-        return payment;
     }
 }

--- a/src/payment/strategies/cybersource/index.ts
+++ b/src/payment/strategies/cybersource/index.ts
@@ -1,5 +1,1 @@
-export * from './cardinal';
-
 export { default as CyberSourcePaymentStrategy } from './cybersource-payment-strategy';
-export { default as CardinalScriptLoader } from './cardinal-script-loader';
-export { default as CardinalClient, CardinalOrderData, CardinalSupportedPaymentInstrument } from './cardinal-client';

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
@@ -2,39 +2,55 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { omit } from 'lodash';
+import { merge } from 'lodash';
 import { of, Observable } from 'rxjs';
 
-import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStoreState, CheckoutValidator } from '../../../checkout';
-import { getCheckoutStoreState, getCheckoutWithPayments } from '../../../checkout/checkouts.mock';
-import { OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutStoreState, getCheckoutStoreStateWithOrder, getCheckoutWithPayments } from '../../../checkout/checkouts.mock';
+import { MissingDataError } from '../../../common/error/errors';
+import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
+import { getPaypal } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
+import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow } from '../cardinal';
 
 import PaypalProPaymentStrategy from './paypal-pro-payment-strategy';
 
 describe('PaypalProPaymentStrategy', () => {
+    let cardinalClient: CardinalClient;
+    let cardinalThreeDSecureFlow: CardinalThreeDSecureFlow;
     let orderActionCreator: OrderActionCreator;
+    let payload: OrderRequestBody;
     let paymentActionCreator: PaymentActionCreator;
-    let state: CheckoutStoreState;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let scriptLoader: CardinalScriptLoader;
     let store: CheckoutStore;
     let strategy: PaypalProPaymentStrategy;
     let submitOrderAction: Observable<SubmitOrderAction>;
     let submitPaymentAction: Observable<SubmitPaymentAction>;
 
     beforeEach(() => {
-        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+        paymentMethodMock = {...getPaypal(), clientToken: 'foo'};
+        store = createCheckoutStore(getCheckoutStoreStateWithOrder());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
+        scriptLoader = new CardinalScriptLoader(createScriptLoader());
+        cardinalClient = new CardinalClient(scriptLoader);
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
-            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
+            new SpamProtectionActionCreator(
+                createSpamProtection(createScriptLoader())
+            )
         );
 
         paymentActionCreator = new PaymentActionCreator(
@@ -43,86 +59,164 @@ describe('PaypalProPaymentStrategy', () => {
             new PaymentRequestTransformer()
         );
 
-        state = getCheckoutStoreState();
-        store = createCheckoutStore(state);
+        cardinalThreeDSecureFlow = new CardinalThreeDSecureFlow(
+            store,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            cardinalClient
+        );
 
-        strategy = new PaypalProPaymentStrategy(store, orderActionCreator, paymentActionCreator);
+        strategy = new PaypalProPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            cardinalThreeDSecureFlow
+        );
 
-        jest.spyOn(store, 'dispatch');
+        payload = merge({}, getOrderRequestBody(), {
+            payment: {
+                methodId: paymentMethodMock.id,
+                gatewayId: paymentMethodMock.gateway,
+            },
+        });
+
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
         jest.spyOn(orderActionCreator, 'submitOrder')
             .mockReturnValue(submitOrderAction);
 
         jest.spyOn(paymentActionCreator, 'submitPayment')
             .mockReturnValue(submitPaymentAction);
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethodMock);
+
+        jest.spyOn(cardinalThreeDSecureFlow, 'prepare').mockReturnValue(Promise.resolve());
+
+        jest.spyOn(cardinalThreeDSecureFlow, 'start').mockReturnValue(store.getState());
     });
 
-    it('submits order without payment data', async () => {
-        const payload = getOrderRequestBody();
+    describe('#initialize', () => {
+        it('initializes strategy successfully when 3DS is enabled', async () => {
+            await strategy.initialize({methodId: paymentMethodMock.id});
 
-        await strategy.execute(payload);
+            expect(cardinalThreeDSecureFlow.prepare).toHaveBeenCalled();
+        });
 
-        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), undefined);
-        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+        it('initializes strategy successfully when 3DS is disabled', async () => {
+            paymentMethodMock.config.is3dsEnabled = false;
+            await strategy.initialize({methodId: paymentMethodMock.id});
+
+            expect(cardinalThreeDSecureFlow.prepare).not.toHaveBeenCalled();
+        });
+
+        it('throws data missing error when payment method is not defined', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(undefined);
+
+            try {
+                await strategy.initialize({methodId: paymentMethodMock.id});
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
     });
 
-    it('submits payment separately', async () => {
-        const payload = getOrderRequestBody();
+    describe('#execute', () => {
+        it('throws data missing error when payment is undefined', async () => {
+            payload.payment = undefined;
 
-        await strategy.execute(payload);
+            await strategy.initialize({ methodId: paymentMethodMock.id });
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
 
-        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payload.payment);
-        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
-    });
+        it('throws error to inform that payment data is missing', async () => {
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
 
-    it('returns checkout state', async () => {
-        const output = await strategy.execute(getOrderRequestBody());
+        it('completes the purchase successfully when 3DS is disabled', async () => {
+            paymentMethodMock.config.is3dsEnabled = false;
+            await strategy.initialize({ methodId: paymentMethodMock.id });
 
-        expect(output).toEqual(store.getState());
-    });
+            const result = await strategy.execute(payload);
 
-    it('throws error to inform that order finalization is not required', async () => {
-        try {
-            await strategy.finalize();
-        } catch (error) {
-            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
-        }
-    });
+            expect(cardinalThreeDSecureFlow.start).not.toHaveBeenCalled();
+            expect(result).toBe(store.getState());
+        });
 
-    describe('if payment is acknowledged', () => {
-        beforeEach(() => {
-            store = createCheckoutStore({
-                ...getCheckoutStoreState(),
-                checkout: {
-                    ...state.checkout,
-                    data: getCheckoutWithPayments(),
-                },
+        it('completes the purchase successfully when 3DS is enabled', async () => {
+            await strategy.initialize({ methodId: paymentMethodMock.id });
+
+            const result = await strategy.execute(payload);
+
+            expect(cardinalThreeDSecureFlow.start).toHaveBeenCalled();
+            expect(result).toBe(store.getState());
+        });
+
+        describe('if payment is acknowledged', () => {
+            beforeEach(() => {
+                const state = getCheckoutStoreState();
+                store = createCheckoutStore({
+                    ...state,
+                    checkout: {
+                        ...state.checkout,
+                        data: getCheckoutWithPayments(),
+                    },
+                });
+
+                strategy = new PaypalProPaymentStrategy(
+                    store,
+                    orderActionCreator,
+                    paymentActionCreator,
+                    cardinalThreeDSecureFlow
+                );
+
+                jest.spyOn(store, 'dispatch');
             });
 
-            strategy = new PaypalProPaymentStrategy(store, orderActionCreator, paymentActionCreator);
+            it('submits order with payment method name', async () => {
+                const payload = getOrderRequestBody();
 
-            jest.spyOn(store, 'dispatch');
+                await strategy.execute(payload);
+
+                expect(orderActionCreator.submitOrder).toHaveBeenCalledWith({
+                    ...payload,
+                    payment: { methodId: payload.payment && payload.payment.methodId },
+                }, undefined);
+                expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+            });
+
+            it('does not submit payment separately', async () => {
+                const payload = getOrderRequestBody();
+
+                await strategy.execute(payload);
+
+                expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
+                expect(store.dispatch).not.toHaveBeenCalledWith(submitPaymentAction);
+            });
         });
+    });
 
-        it('submits order with payment method name', async () => {
-            const payload = getOrderRequestBody();
-
-            await strategy.execute(payload);
-
-            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith({
-                ...payload,
-                payment: { methodId: payload.payment && payload.payment.methodId },
-            }, undefined);
-            expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            expect(await strategy.deinitialize()).toEqual(store.getState());
         });
+    });
 
-        it('does not submit payment separately', async () => {
-            const payload = getOrderRequestBody();
-
-            await strategy.execute(payload);
-
-            expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
-            expect(store.dispatch).not.toHaveBeenCalledWith(submitPaymentAction);
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await strategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
         });
     });
 });

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.ts
@@ -1,18 +1,39 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentArgumentInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentRequestOptions } from '../../payment-request-options';
+import PaymentMethod from '../../payment-method';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import * as paymentStatusTypes from '../../payment-status-types';
+import { CardinalThreeDSecureFlow } from '../cardinal';
 import PaymentStrategy from '../payment-strategy';
 
 export default class PaypalProPaymentStrategy implements PaymentStrategy {
+    private _paymentMethod?: PaymentMethod;
+
     constructor(
         private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator,
-        private _paymentActionCreator: PaymentActionCreator
+        private _paymentActionCreator: PaymentActionCreator,
+        private _threeDSecureFlow: CardinalThreeDSecureFlow
     ) {}
+
+    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options;
+        this._paymentMethod = this._store.getState().paymentMethods.getPaymentMethod(methodId);
+
+        if (!this._paymentMethod) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        if (!this._paymentMethod.config.is3dsEnabled) {
+            return Promise.resolve(this._store.getState());
+        }
+
+        return this._threeDSecureFlow.prepare(methodId)
+            .then(() => this._store.getState());
+    }
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         if (this._isPaymentAcknowledged()) {
@@ -25,24 +46,25 @@ export default class PaypalProPaymentStrategy implements PaymentStrategy {
         }
 
         const { payment, ...order } = payload;
-        const paymentData = payment && payment.paymentData;
 
-        if (!payment || !paymentData) {
-            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        if (!payment) {
+            throw new MissingDataError(MissingDataErrorType.MissingPayment);
         }
 
         return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
-            .then(() =>
-                this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }))
-            );
+            .then(() => {
+                if (!this._paymentMethod) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+                }
+
+                return this._paymentMethod.config.is3dsEnabled ?
+                    this._threeDSecureFlow.start(payment) :
+                    this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
+            });
     }
 
     finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
-    }
-
-    initialize(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
     }
 
     deinitialize(): Promise<InternalCheckoutSelectors> {


### PR DESCRIPTION
## What? [INT-1608](https://jira.bigcommerce.com/browse/INT-1608)
Transform the existing Cybersource's stategy to be the Cardinal's one and also modify the existing Paypal's strategy to be extended from Cardinal's strategy

## Why?
Existing Cybersource's strategy contains all of the logic for Cardinal flow and it is totally transparent for other strategies who want to use it so we renamed it to Cardinal strategy and also extended Paypal Payments Pro's strategy from it

## Testing / Proof
[video | authorize](https://drive.google.com/open?id=14Wr6-X3cgo5V8Q9c8opUeyWY9ilQA3ew)
[video | purchase](https://drive.google.com/open?id=1LcC67x4A-PIeLTnap_V6FvHPKfETrg8W)

## Sibling PRs
[bigpay](https://github.com/bigcommerce/bigpay/pull/1711)
[bcapp](https://github.com/bigcommerce/bigcommerce/pull/30475)
[bigpay](https://github.com/bigcommerce/bigpay/pull/1724)
[ng-payments](https://github.com/bigcommerce-labs/ng-payments/pull/831)
[ng-checkout](https://github.com/bigcommerce-labs/ng-checkout/pull/1353)

@bigcommerce/checkout @bigcommerce/payments
