### PR TITLE
INT-1577 Support Stored Credit Card (vaulting) for Stripe V3

### DIFF
--- a/src/order/internal-order-request-body.ts
+++ b/src/order/internal-order-request-body.ts
@@ -6,6 +6,7 @@ export default interface InternalOrderRequestBody {
     customerMessage?: string;
     externalSource?: string;
     spamProtectionToken?: string;
+    shouldSaveInstrument?: boolean;
 }
 
 export interface InternalOrderPaymentRequestBody {

--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -1,4 +1,4 @@
-import { CreditCardInstrument, VaultedInstrument } from '../payment';
+import { CreditCardInstrument, HostedInstrument, VaultedInstrument } from '../payment';
 
 /**
  * An object that contains the information required for submitting an order.
@@ -39,5 +39,5 @@ export interface OrderPaymentRequestBody {
      * An object that contains the details of a credit card or vaulted payment
      * instrument.
      */
-    paymentData?: CreditCardInstrument | VaultedInstrument;
+    paymentData?: CreditCardInstrument | VaultedInstrument | HostedInstrument;
 }

--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -8,19 +8,31 @@ import { createSpamProtection } from '../order/spam-protection';
 import createPaymentStrategyRegistry from './create-payment-strategy-registry';
 import PaymentStrategyRegistry from './payment-strategy-registry';
 import PaymentStrategyType from './payment-strategy-type';
+import { AffirmPaymentStrategy } from './strategies/affirm';
 import { AfterpayPaymentStrategy } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy } from './strategies/amazon-pay';
+import {
+    BraintreeCreditCardPaymentStrategy,
+    BraintreePaypalPaymentStrategy,
+    BraintreeVisaCheckoutPaymentStrategy
+} from './strategies/braintree';
+import { ChasepayPaymentStrategy } from './strategies/chasepay';
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
+import { CyberSourcePaymentStrategy } from './strategies/cybersource';
 import { GooglePayPaymentStrategy } from './strategies/googlepay';
 import { KlarnaPaymentStrategy } from './strategies/klarna';
 import { LegacyPaymentStrategy } from './strategies/legacy';
+import { MasterpassPaymentStrategy } from './strategies/masterpass';
 import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
 import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy } from './strategies/paypal';
 import { SagePayPaymentStrategy } from './strategies/sage-pay';
 import { SquarePaymentStrategy } from './strategies/square';
+import { StripeV3PaymentStrategy } from './strategies/stripev3';
+import { WepayPaymentStrategy } from './strategies/wepay';
+import { ZipPaymentStrategy } from './strategies/zip';
 
 describe('CreatePaymentStrategyRegistry', () => {
     let registry: PaymentStrategyRegistry;
@@ -37,6 +49,11 @@ describe('CreatePaymentStrategyRegistry', () => {
         expect(registry).toEqual(expect.any(PaymentStrategyRegistry));
     });
 
+    it('can instantiate affirm', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.AFFIRM);
+        expect(paymentStrategy).toBeInstanceOf(AffirmPaymentStrategy);
+    });
+
     it('can instantiate amazon', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.AMAZON);
         expect(paymentStrategy).toBeInstanceOf(AmazonPayPaymentStrategy);
@@ -47,9 +64,44 @@ describe('CreatePaymentStrategyRegistry', () => {
         expect(paymentStrategy).toBeInstanceOf(AfterpayPaymentStrategy);
     });
 
+    it('can instantiate braintree', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.BRAINTREE);
+        expect(paymentStrategy).toBeInstanceOf(BraintreeCreditCardPaymentStrategy);
+    });
+
+    it('can instantiate braintreepaypal', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.BRAINTREE_PAYPAL);
+        expect(paymentStrategy).toBeInstanceOf(BraintreePaypalPaymentStrategy);
+    });
+
+    it('can instantiate braintreepaypaylcredit', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.BRAINTREE_PAYPAL_CREDIT);
+        expect(paymentStrategy).toBeInstanceOf(BraintreePaypalPaymentStrategy);
+    });
+
+    it('can instantiate braintreevisacheckout', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.BRAINTREE_VISA_CHECKOUT);
+        expect(paymentStrategy).toBeInstanceOf(BraintreeVisaCheckoutPaymentStrategy);
+    });
+
+    it('can instantiate chasepay', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CHASE_PAY);
+        expect(paymentStrategy).toBeInstanceOf(ChasepayPaymentStrategy);
+    });
+
+    it('can instantiate converge', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CONVERGE);
+        expect(paymentStrategy).toBeInstanceOf(ConvergePaymentStrategy);
+    });
+
     it('can instantiate creditcard', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.CREDIT_CARD);
         expect(paymentStrategy).toBeInstanceOf(CreditCardPaymentStrategy);
+    });
+
+    it('can instantiate cybersource', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CYBERSOURCE);
+        expect(paymentStrategy).toBeInstanceOf(CyberSourcePaymentStrategy);
     });
 
     it('can instantiate klarna', () => {
@@ -107,8 +159,28 @@ describe('CreatePaymentStrategyRegistry', () => {
         expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
     });
 
-    it('can instantiate converge', () => {
-        const paymentStrategy = registry.get(PaymentStrategyType.CONVERGE);
-        expect(paymentStrategy).toBeInstanceOf(ConvergePaymentStrategy);
+    it('can instantiate googlepaystripe', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.STRIPE_GOOGLE_PAY);
+        expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+
+    it('can instantiate stripev3', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.STRIPEV3);
+        expect(paymentStrategy).toBeInstanceOf(StripeV3PaymentStrategy);
+    });
+
+    it('can instantiate wepay', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.WE_PAY);
+        expect(paymentStrategy).toBeInstanceOf(WepayPaymentStrategy);
+    });
+
+    it('can instantiate masterpass', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.MASTERPASS);
+        expect(paymentStrategy).toBeInstanceOf(MasterpassPaymentStrategy);
+    });
+
+    it('can instantiate zip', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.ZIP);
+        expect(paymentStrategy).toBeInstanceOf(ZipPaymentStrategy);
     });
 });

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -7,7 +7,16 @@ export { default as createPaymentClient } from './create-payment-client';
 export { default as createPaymentStrategyRegistry } from './create-payment-strategy-registry';
 export { default as isNonceLike } from './is-nonce-like';
 export { default as PaymentActionCreator } from './payment-action-creator';
-export { default as Payment, CreditCardInstrument, VaultedInstrument, PaymentInstrument, NonceInstrument, ThreeDSecure, ThreeDSecureToken } from './payment';
+export {
+    default as Payment,
+    CreditCardInstrument,
+    HostedInstrument,
+    VaultedInstrument,
+    PaymentInstrument,
+    NonceInstrument,
+    ThreeDSecure,
+    ThreeDSecureToken
+} from './payment';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';
 export { default as PaymentMethodConfig } from './payment-method-config';

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -13,6 +13,7 @@ import createPaymentClient from './create-payment-client';
 import PaymentActionCreator from './payment-action-creator';
 import { PaymentActionType } from './payment-actions';
 import PaymentRequestSender from './payment-request-sender';
+import PaymentRequestTransformer from './payment-request-transformer';
 import { getErrorPaymentResponseBody, getPayment, getPaymentRequestBody, getPaymentResponseBody } from './payments.mock';
 
 describe('PaymentActionCreator', () => {
@@ -20,12 +21,14 @@ describe('PaymentActionCreator', () => {
     let orderActionCreator: OrderActionCreator;
     let paymentActionCreator: PaymentActionCreator;
     let paymentRequestSender: PaymentRequestSender;
+    let paymentRequestTransformer: PaymentRequestTransformer;
     let store: CheckoutStore;
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreStateWithOrder());
         orderRequestSender = new OrderRequestSender(createRequestSender());
         paymentRequestSender = new PaymentRequestSender(createPaymentClient(store));
+        paymentRequestTransformer = new PaymentRequestTransformer();
 
         jest.spyOn(orderRequestSender, 'loadOrder')
             .mockReturnValue(Promise.resolve(getResponse(getOrder())));
@@ -37,7 +40,7 @@ describe('PaymentActionCreator', () => {
             .mockReturnValue(Promise.resolve(getResponse(getPaymentResponseBody())));
 
         orderActionCreator = new OrderActionCreator(orderRequestSender, {} as CheckoutValidator, {} as SpamProtectionActionCreator);
-        paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator);
+        paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator, paymentRequestTransformer);
     });
 
     describe('#submitPayment()', () => {

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -1,36 +1,28 @@
 import { createAction, ThunkAction } from '@bigcommerce/data-store';
-import { pick } from 'lodash';
 import { concat, from, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
-import { mapToInternalAddress } from '../address';
-import { mapToInternalCart } from '../cart';
 import { InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
-import { StandardError } from '../common/error/errors';
-import { mapToInternalCustomer } from '../customer';
-import { mapToInternalOrder, OrderActionCreator } from '../order';
-import { mapToInternalShippingOption } from '../shipping';
+import { OrderActionCreator } from '../order';
 
-import isVaultedInstrument from './is-vaulted-instrument';
 import Payment from './payment';
 import { InitializeOffsitePaymentAction, PaymentActionType, SubmitPaymentAction } from './payment-actions';
-import PaymentMethod from './payment-method';
-import PaymentMethodSelector from './payment-method-selector';
-import PaymentRequestBody from './payment-request-body';
 import PaymentRequestSender from './payment-request-sender';
+import PaymentRequestTransformer from './payment-request-transformer';
 
 export default class PaymentActionCreator {
     constructor(
         private _paymentRequestSender: PaymentRequestSender,
-        private _orderActionCreator: OrderActionCreator
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentRequestTransformer: PaymentRequestTransformer
     ) {}
 
     submitPayment(payment: Payment): ThunkAction<SubmitPaymentAction, InternalCheckoutSelectors> {
         return store => concat(
             of(createAction(PaymentActionType.SubmitPaymentRequested)),
             from(this._paymentRequestSender.submitPayment(
-                this._getPaymentRequestBody(payment, store.getState())
+                this._paymentRequestTransformer.transform(payment, store.getState())
             ))
                 .pipe(
                     switchMap(({ body }) => concat(
@@ -48,7 +40,7 @@ export default class PaymentActionCreator {
         gatewayId?: string
     ): ThunkAction<InitializeOffsitePaymentAction, InternalCheckoutSelectors> {
         return store => {
-            const payload = this._getPaymentRequestBody({ gatewayId, methodId }, store.getState());
+            const payload = this._paymentRequestTransformer.transform({ gatewayId, methodId }, store.getState());
 
             return concat(
                 of(createAction(PaymentActionType.InitializeOffsitePaymentRequested)),
@@ -58,78 +50,5 @@ export default class PaymentActionCreator {
                 catchError(error => throwErrorAction(PaymentActionType.InitializeOffsitePaymentFailed, error))
             );
         };
-    }
-
-    private _getPaymentRequestBody(payment: Payment, state: InternalCheckoutSelectors): PaymentRequestBody {
-        const billingAddress = state.billingAddress.getBillingAddress();
-        const checkout = state.checkout.getCheckout();
-        const customer = state.customer.getCustomer();
-        const order = state.order.getOrder();
-        const paymentMethod = this._getPaymentMethod(state.paymentMethods, payment.methodId, payment.gatewayId);
-        const shippingAddress = state.shippingAddress.getShippingAddress();
-        const consignments = state.consignments.getConsignments();
-        const shippingOption = state.consignments.getShippingOption();
-        const storeConfig = state.config.getStoreConfig();
-        const contextConfig = state.config.getContextConfig();
-        const instrumentMeta = state.instruments.getInstrumentsMeta();
-        const paymentMeta = state.paymentMethods.getPaymentMethodsMeta();
-        const orderMeta = state.order.getOrderMeta();
-        const internalCustomer = customer && billingAddress && mapToInternalCustomer(customer, billingAddress);
-
-        const authToken = instrumentMeta && payment.paymentData && isVaultedInstrument(payment.paymentData) ?
-            `${state.payment.getPaymentToken()}, ${instrumentMeta.vaultAccessToken}` :
-            state.payment.getPaymentToken();
-
-        if (!authToken) {
-            throw new StandardError();
-        }
-
-        return {
-            authToken,
-            paymentMethod,
-            customer: internalCustomer,
-            billingAddress: billingAddress && mapToInternalAddress(billingAddress),
-            shippingAddress: shippingAddress && mapToInternalAddress(shippingAddress, consignments),
-            shippingOption: shippingOption && mapToInternalShippingOption(shippingOption, true),
-            cart: checkout && mapToInternalCart(checkout),
-            order: order && mapToInternalOrder(order, orderMeta),
-            orderMeta,
-            payment: payment.paymentData,
-            quoteMeta: {
-                request: {
-                    ...paymentMeta,
-                    geoCountryCode: contextConfig && contextConfig.geoCountryCode,
-                },
-            },
-            source: 'bigcommerce-checkout-js-sdk',
-            store: pick(storeConfig && storeConfig.storeProfile, [
-                'storeHash',
-                'storeId',
-                'storeLanguage',
-                'storeName',
-            ]),
-        };
-    }
-
-    private _getPaymentMethod(
-        paymentMethodSelector: PaymentMethodSelector,
-        methodId: string,
-        gatewayId?: string
-    ): PaymentMethod | undefined {
-        const paymentMethod = paymentMethodSelector.getPaymentMethod(methodId, gatewayId);
-
-        if (!paymentMethod) {
-            return;
-        }
-
-        if (paymentMethod.method === 'multi-option' && !paymentMethod.gateway) {
-            return { ...paymentMethod, gateway: paymentMethod.id };
-        }
-
-        if (paymentMethod.initializationData && paymentMethod.initializationData.gateway) {
-            return { ...paymentMethod, id: paymentMethod.initializationData.gateway };
-        }
-
-        return paymentMethod;
     }
 }

--- a/src/payment/payment-request-sender.ts
+++ b/src/payment/payment-request-sender.ts
@@ -32,6 +32,18 @@ export default class PaymentRequestSender {
         });
     }
 
+    generatePaymentIntent(payload: any): Promise<Response> {
+        return new Promise((resolve, reject) => {
+            this._client.generatePaymentIntent(payload, (error: any, response: any) => {
+                if (error) {
+                    reject(this._transformResponse(error));
+                } else {
+                    resolve(this._transformResponse(response));
+                }
+            });
+        });
+    }
+
     private _transformResponse(response: any): Response {
         return {
             headers: {},

--- a/src/payment/payment-request-transformer.spec.ts
+++ b/src/payment/payment-request-transformer.spec.ts
@@ -1,0 +1,120 @@
+import { getBillingAddress } from '../billing/billing-addresses.mock';
+import { createInternalCheckoutSelectors, CheckoutStoreState, InternalCheckoutSelectors } from '../checkout';
+import { getCheckoutStoreStateWithOrder, getCheckoutWithGiftCertificates } from '../checkout/checkouts.mock';
+import { StandardError } from '../common/error/errors';
+import { getConfig } from '../config/configs.mock';
+import { getCustomer } from '../customer/customers.mock';
+import { getOrder, getOrderMeta } from '../order/orders.mock';
+import { getConsignments } from '../shipping/consignments.mock';
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
+import { getShippingOption } from '../shipping/shipping-options.mock';
+
+import { getInstrumentsMeta } from './instrument/instrument.mock';
+import Payment from './payment';
+import { getAdyenAmex, getAuthorizenet, getPaymentMethodsMeta } from './payment-methods.mock';
+import PaymentRequestTransformer from './payment-request-transformer';
+import { getPayment, getPaymentRequestBody } from './payments.mock';
+
+describe('PaymentRequestTransformer', () => {
+    let state: CheckoutStoreState;
+    let selectors: InternalCheckoutSelectors;
+    let payment: Payment;
+    let paymentRequestTransformer: PaymentRequestTransformer;
+
+    beforeEach(() => {
+        state = getCheckoutStoreStateWithOrder();
+        selectors = createInternalCheckoutSelectors(state);
+        payment = {
+            methodId: 'methodId',
+            paymentData: getPayment().paymentData,
+        };
+        paymentRequestTransformer = new PaymentRequestTransformer();
+
+        jest.spyOn(selectors.billingAddress, 'getBillingAddress')
+            .mockReturnValue(getBillingAddress());
+        jest.spyOn(selectors.checkout, 'getCheckout')
+            .mockReturnValue(getCheckoutWithGiftCertificates());
+        jest.spyOn(selectors.customer, 'getCustomer')
+            .mockReturnValue(getCustomer());
+        jest.spyOn(selectors.order, 'getOrder')
+            .mockReturnValue(getOrder());
+        jest.spyOn(selectors.paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(getAuthorizenet());
+        jest.spyOn(selectors.shippingAddress, 'getShippingAddress')
+            .mockReturnValue(getShippingAddress());
+        jest.spyOn(selectors.consignments, 'getConsignments')
+            .mockReturnValue(getConsignments());
+        jest.spyOn(selectors.consignments, 'getShippingOption')
+            .mockReturnValue(getShippingOption());
+        jest.spyOn(selectors.config, 'getStoreConfig')
+            .mockReturnValue(getConfig().storeConfig);
+        jest.spyOn(selectors.config, 'getContextConfig')
+            .mockReturnValue(getConfig().context);
+        jest.spyOn(selectors.instruments, 'getInstrumentsMeta')
+            .mockReturnValue(getInstrumentsMeta());
+        jest.spyOn(selectors.paymentMethods, 'getPaymentMethodsMeta')
+            .mockReturnValue(getPaymentMethodsMeta());
+        jest.spyOn(selectors.order, 'getOrderMeta')
+            .mockReturnValue(getOrderMeta());
+    });
+
+    it('transform a payload to PaymentRequestBody', () => {
+        const paymentRequestBodyResponse = paymentRequestTransformer.transform(payment, selectors);
+
+        expect(paymentRequestBodyResponse).toEqual(getPaymentRequestBody());
+    });
+
+    it('throws when authToken is not generated', () => {
+        jest.spyOn(selectors.payment, 'getPaymentToken')
+            .mockReturnValue(undefined);
+
+        expect(() => paymentRequestTransformer.transform(payment, selectors)).toThrow(StandardError);
+    });
+
+    it('returns paymentMethod as undefined when state does not have paymentMethods', () => {
+        jest.spyOn(selectors.paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(undefined);
+
+        const expectedPaymentRequestBody = getPaymentRequestBody();
+        expectedPaymentRequestBody.paymentMethod = undefined;
+
+        const paymentRequestBodyResponse = paymentRequestTransformer.transform(payment, selectors);
+
+        expect(paymentRequestBodyResponse).toEqual(expectedPaymentRequestBody);
+    });
+
+    it('returns paymentMethod format when is a multi-option gateway', () => {
+        const paymentMethod = getAdyenAmex();
+        paymentMethod.gateway = undefined;
+
+        jest.spyOn(selectors.paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethod);
+
+        const expectedPaymentRequestBody = getPaymentRequestBody();
+        expectedPaymentRequestBody.paymentMethod = { ...paymentMethod, gateway: paymentMethod.id };
+
+        const paymentRequestBodyResponse = paymentRequestTransformer.transform(payment, selectors);
+
+        expect(paymentRequestBodyResponse.paymentMethod).toEqual(expectedPaymentRequestBody.paymentMethod);
+    });
+
+    it('returns paymentMethod format when contains initializationData', () => {
+        const paymentMethod = getAuthorizenet();
+        paymentMethod.initializationData = {
+            gateway: 'authnet',
+        };
+
+        jest.spyOn(selectors.paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethod);
+
+        const expectedPaymentRequestBody = getPaymentRequestBody();
+        expectedPaymentRequestBody.paymentMethod = {
+            ...paymentMethod,
+            id: paymentMethod.initializationData.gateway,
+        };
+
+        const paymentRequestBodyResponse = paymentRequestTransformer.transform(payment, selectors);
+
+        expect(paymentRequestBodyResponse.paymentMethod).toEqual(expectedPaymentRequestBody.paymentMethod);
+    });
+});

--- a/src/payment/payment-request-transformer.ts
+++ b/src/payment/payment-request-transformer.ts
@@ -1,0 +1,90 @@
+import { pick } from 'lodash';
+
+import { mapToInternalAddress } from '../address';
+import { mapToInternalCart } from '../cart';
+import InternalCheckoutSelectors from '../checkout/internal-checkout-selectors';
+import { StandardError } from '../common/error/errors';
+import { mapToInternalCustomer } from '../customer';
+import { mapToInternalOrder } from '../order';
+import { mapToInternalShippingOption } from '../shipping';
+
+import isVaultedInstrument from './is-vaulted-instrument';
+import Payment from './payment';
+import PaymentMethod from './payment-method';
+import PaymentMethodSelector from './payment-method-selector';
+import PaymentRequestBody from './payment-request-body';
+
+export default class PaymentRequestTransformer {
+    transform(payment: Payment, checkoutState: InternalCheckoutSelectors): PaymentRequestBody {
+        const billingAddress = checkoutState.billingAddress.getBillingAddress();
+        const checkout = checkoutState.checkout.getCheckout();
+        const customer = checkoutState.customer.getCustomer();
+        const order = checkoutState.order.getOrder();
+        const paymentMethod = this._getPaymentMethod(checkoutState.paymentMethods, payment.methodId, payment.gatewayId);
+        const shippingAddress = checkoutState.shippingAddress.getShippingAddress();
+        const consignments = checkoutState.consignments.getConsignments();
+        const shippingOption = checkoutState.consignments.getShippingOption();
+        const storeConfig = checkoutState.config.getStoreConfig();
+        const contextConfig = checkoutState.config.getContextConfig();
+        const instrumentMeta = checkoutState.instruments.getInstrumentsMeta();
+        const paymentMeta = checkoutState.paymentMethods.getPaymentMethodsMeta();
+        const orderMeta = checkoutState.order.getOrderMeta();
+        const internalCustomer = customer && billingAddress && mapToInternalCustomer(customer, billingAddress);
+
+        const authToken = instrumentMeta && payment.paymentData && isVaultedInstrument(payment.paymentData) ?
+            `${checkoutState.payment.getPaymentToken()}, ${instrumentMeta.vaultAccessToken}` :
+            checkoutState.payment.getPaymentToken();
+
+        if (!authToken) {
+            throw new StandardError();
+        }
+
+        return {
+            authToken,
+            paymentMethod,
+            customer: internalCustomer,
+            billingAddress: billingAddress && mapToInternalAddress(billingAddress),
+            shippingAddress: shippingAddress && mapToInternalAddress(shippingAddress, consignments),
+            shippingOption: shippingOption && mapToInternalShippingOption(shippingOption, true),
+            cart: checkout && mapToInternalCart(checkout),
+            order: order && mapToInternalOrder(order, orderMeta),
+            orderMeta,
+            payment: payment.paymentData,
+            quoteMeta: {
+                request: {
+                    ...paymentMeta,
+                    geoCountryCode: contextConfig && contextConfig.geoCountryCode,
+                },
+            },
+            source: 'bigcommerce-checkout-js-sdk',
+            store: pick(storeConfig && storeConfig.storeProfile, [
+                'storeHash',
+                'storeId',
+                'storeLanguage',
+                'storeName',
+            ]),
+        };
+    }
+
+    private _getPaymentMethod(
+        paymentMethodSelector: PaymentMethodSelector,
+        methodId: string,
+        gatewayId?: string
+    ): PaymentMethod | undefined {
+        const paymentMethod = paymentMethodSelector.getPaymentMethod(methodId, gatewayId);
+
+        if (!paymentMethod) {
+            return;
+        }
+
+        if (paymentMethod.method === 'multi-option' && !paymentMethod.gateway) {
+            return { ...paymentMethod, gateway: paymentMethod.id };
+        }
+
+        if (paymentMethod.initializationData && paymentMethod.initializationData.gateway) {
+            return { ...paymentMethod, id: paymentMethod.initializationData.gateway };
+        }
+
+        return paymentMethod;
+    }
+}

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -21,6 +21,7 @@ import createPaymentStrategyRegistry from './create-payment-strategy-registry';
 import PaymentActionCreator from './payment-action-creator';
 import { getPaymentMethod } from './payment-methods.mock';
 import PaymentRequestSender from './payment-request-sender';
+import PaymentRequestTransformer from './payment-request-transformer';
 import PaymentStrategyActionCreator from './payment-strategy-action-creator';
 import { PaymentStrategyActionType } from './payment-strategy-actions';
 import PaymentStrategyRegistry from './payment-strategy-registry';
@@ -57,7 +58,8 @@ describe('PaymentStrategyActionCreator', () => {
             orderActionCreator,
             new PaymentActionCreator(
                 new PaymentRequestSender(createPaymentClient()),
-                orderActionCreator
+                orderActionCreator,
+                new PaymentRequestTransformer()
             )
         );
         noPaymentDataStrategy = new NoPaymentDataRequiredPaymentStrategy(

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -4,7 +4,7 @@ export default interface Payment {
     paymentData?: PaymentInstrument & PaymentInstrumentMeta;
 }
 
-export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument;
+export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument | HostedInstrument;
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
@@ -59,4 +59,8 @@ export interface ThreeDSecure {
 
 export interface ThreeDSecureToken {
     token: string;
+}
+
+export interface HostedInstrument {
+    shouldSaveInstrument?: boolean;
 }

--- a/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
+++ b/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
@@ -26,6 +26,7 @@ import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getAffirm } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import { Affirm } from './affirm';
 import AffirmPaymentStrategy from './affirm-payment-strategy';
@@ -72,7 +73,8 @@ describe('AffirmPaymentStrategy', () => {
         );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
         affirmScriptLoader = new AffirmScriptLoader();

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -20,6 +20,7 @@ import { PaymentMethodActionType } from '../../payment-method-actions';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getAfterpay } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import AfterpayPaymentStrategy from './afterpay-payment-strategy';
 import AfterpayScriptLoader from './afterpay-script-loader';
@@ -59,7 +60,8 @@ describe('AfterpayPaymentStrategy', () => {
         orderActionCreator = new OrderActionCreator(orderRequestSender, checkoutValidator, spamProtectionActionCreator);
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
             new RemoteCheckoutRequestSender(createRequestSender())

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -23,6 +23,7 @@ import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getBraintree } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import BraintreeCreditCardPaymentStrategy from './braintree-credit-card-payment-strategy';
 import BraintreePaymentProcessor from './braintree-payment-processor';
@@ -59,7 +60,8 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
         );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
 

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -23,6 +23,7 @@ import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getBraintreeVisaCheckout } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
 import { PaymentStrategyActionType } from '../../payment-strategy-actions';
 
@@ -85,7 +86,8 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient(store)),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
 
         strategy = new BraintreeVisaCheckoutPaymentStrategy(

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
@@ -23,6 +23,7 @@ import { PaymentActionType } from '../../payment-actions';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
 import PaymentStrategy from '../payment-strategy';
 import WepayRiskClient from '../wepay/wepay-risk-client';
@@ -102,7 +103,11 @@ describe('ChasePayPaymentStrategy', () => {
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
             new SpamProtectionActionCreator(spamProtection)
         );
-        paymentActionCreator = new PaymentActionCreator(new PaymentRequestSender(paymentClient), orderActionCreator);
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(paymentClient),
+            orderActionCreator,
+            new PaymentRequestTransformer()
+        );
         checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
 

--- a/src/payment/strategies/converge/converge-payment-strategy.spec.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.spec.ts
@@ -18,6 +18,7 @@ import { createSpamProtection, SpamProtectionActionCreator } from '../../../orde
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 import * as paymentStatusTypes from '../../payment-status-types';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
 
@@ -44,7 +45,8 @@ describe('ConvergeaymentStrategy', () => {
 
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
 
         formPoster = createFormPoster();

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
@@ -13,6 +13,7 @@ import { createSpamProtection, SpamProtectionActionCreator } from '../../../orde
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import CreditCardPaymentStrategy from './credit-card-payment-strategy';
 
@@ -29,7 +30,8 @@ describe('CreditCardPaymentStrategy', () => {
 
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
 
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
@@ -39,6 +39,7 @@ import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentMethodActionType } from '../../payment-method-actions';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getCybersource } from '../../payment-methods.mock';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
 
 import {
@@ -85,7 +86,8 @@ describe('CyberSourcePaymentStrategy', () => {
 
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
 
         strategy = new CyberSourcePaymentStrategy(

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -29,6 +29,7 @@ import {
     PaymentStrategyActionCreator
 } from '../../../payment';
 import { getGooglePay, getPaymentMethodsState } from '../../payment-methods.mock';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import createGooglePayPaymentProcessor from './create-googlepay-payment-processor';
 import GooglePayPaymentProcessor from './googlepay-payment-processor';
@@ -70,7 +71,11 @@ describe('GooglePayPaymentStrategy', () => {
         checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
         paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
-        paymentActionCreator = new PaymentActionCreator(new PaymentRequestSender(paymentClient), orderActionCreator);
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(paymentClient),
+            orderActionCreator,
+            new PaymentRequestTransformer()
+        );
         orderActionCreator = new OrderActionCreator(
             paymentClient,
             new CheckoutValidator(

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
@@ -19,6 +19,7 @@ import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import { PaymentActionType } from '../../payment-actions';
 import { getMasterpass, getPaymentMethodsState } from '../../payment-methods.mock';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import { MasterpassCheckoutOptions, MasterpassPaymentStrategy, MasterpassScriptLoader } from './';
 import { Masterpass } from './masterpass';
@@ -63,7 +64,11 @@ describe('MasterpassPaymentStrategy', () => {
         const spamProtectionActionCreator = new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()));
         orderActionCreator = new OrderActionCreator(orderRequestSender, checkoutValidator, spamProtectionActionCreator);
         const paymentRequestSender = new PaymentRequestSender(createPaymentClient());
-        paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator);
+        paymentActionCreator = new PaymentActionCreator(
+            paymentRequestSender,
+            orderActionCreator,
+            new PaymentRequestTransformer()
+        );
 
         scriptLoader = new MasterpassScriptLoader(createScriptLoader());
         masterpassScript = getMasterpassScriptMock();

--- a/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
@@ -16,6 +16,7 @@ import PaymentActionCreator from '../../payment-action-creator';
 import { InitializeOffsitePaymentAction, PaymentActionType } from '../../payment-actions';
 import { PaymentRequestOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 import * as paymentStatusTypes from '../../payment-status-types';
 
 import OffsitePaymentStrategy from './offsite-payment-strategy';
@@ -40,7 +41,8 @@ describe('OffsitePaymentStrategy', () => {
         );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
         initializeOffsitePaymentAction = of(createAction(PaymentActionType.InitializeOffsitePaymentRequested));

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
@@ -1,4 +1,3 @@
-
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
@@ -15,6 +14,7 @@ import { createSpamProtection, SpamProtectionActionCreator } from '../../../orde
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import PaypalProPaymentStrategy from './paypal-pro-payment-strategy';
 
@@ -39,7 +39,8 @@ describe('PaypalProPaymentStrategy', () => {
 
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
 
         state = getCheckoutStoreState();

--- a/src/payment/strategies/sage-pay/sage-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/sage-pay/sage-pay-payment-strategy.spec.ts
@@ -18,6 +18,7 @@ import { createSpamProtection, SpamProtectionActionCreator } from '../../../orde
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 import * as paymentStatusTypes from '../../payment-status-types';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
 
@@ -44,7 +45,8 @@ describe('SagePayPaymentStrategy', () => {
 
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
 
         formPoster = createFormPoster();

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -38,6 +38,7 @@ import { createSpamProtection, SpamProtectionActionCreator } from '../../../orde
 import { getPaymentMethodsState, getSquare } from '../../../payment/payment-methods.mock';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import { SquarePaymentForm, SquarePaymentStrategy, SquareScriptLoader } from './';
 import { DigitalWalletType, SquareFormCallbacks, SquareFormOptions } from './square-form';
@@ -113,7 +114,8 @@ describe('SquarePaymentStrategy', () => {
         );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
         initOptions = getSquarePaymentInitializeOptions();
         paymentMethodActionCreator = new PaymentMethodActionCreator(

--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -1,8 +1,13 @@
+import { getBillingAddress } from '../../../billing/billing-addresses.mock';
+import { getCustomer } from '../../../customer/customers.mock';
 import OrderRequestBody from '../../../order/order-request-body';
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 
 import {
-    StripeResponse,
+    StripeHandleCardPaymentOptions,
+    StripePaymentIntentResponse,
+    StripePaymentMethodData,
     StripeV3Client
 } from './stripev3';
 
@@ -19,6 +24,7 @@ export function getStripeV3JsMock(): StripeV3Client {
             };
         }),
         handleCardPayment: jest.fn(),
+        createPaymentMethod: jest.fn(),
     };
 }
 
@@ -50,14 +56,112 @@ export function getStripeV3OrderRequestBodyMock(): OrderRequestBody {
     return {
         payment: {
             methodId: 'stripev3',
+            paymentData: {
+                shouldSaveInstrument: false,
+            },
         },
     };
 }
 
-export function getStripeV3HandleCardResponse(): StripeResponse {
+export function getStripeV3HandleCardResponse(): StripePaymentIntentResponse {
     return {
         paymentIntent: {
             id: 'pi_1234',
+        },
+    };
+}
+
+export function getStripePaymentMethodOptionsWithSignedUser(): StripePaymentMethodData {
+    const billingAddress = getBillingAddress();
+    const customer = getCustomer();
+
+    return {
+        billing_details: {
+            address: {
+                city: billingAddress.city,
+                country: billingAddress.countryCode,
+                line1: billingAddress.address1,
+                line2: billingAddress.address2,
+                postal_code: billingAddress.postalCode,
+                state: billingAddress.stateOrProvinceCode,
+            },
+            email: customer.email,
+            name: `${customer.firstName} ${customer.lastName}`,
+        },
+    };
+}
+
+export function getStripePaymentMethodOptionsWithGuestUser(): StripePaymentMethodData {
+    const billingAddress = getBillingAddress();
+
+    return {
+        billing_details: {
+            address: {
+                city: billingAddress.city,
+                country: billingAddress.countryCode,
+                line1: billingAddress.address1,
+                line2: billingAddress.address2,
+                postal_code: billingAddress.postalCode,
+                state: billingAddress.stateOrProvinceCode,
+            },
+            email: billingAddress.email,
+            name: `${billingAddress.firstName} ${billingAddress.lastName}`,
+        },
+    };
+}
+
+export function getStripePaymentMethodOptionsWithGuestUserWithoutAddress(): StripePaymentMethodData {
+    return {
+        billing_details: {
+            name: 'Guest',
+        },
+    };
+}
+
+export function getStripeCardPaymentOptionsWithSignedUser(): StripeHandleCardPaymentOptions {
+    const customer = getCustomer();
+    const shippingAddress = getShippingAddress();
+
+    return {
+        shipping: {
+            address: {
+                city: shippingAddress.city,
+                country: shippingAddress.countryCode,
+                line1: shippingAddress.address1,
+                line2: shippingAddress.address2,
+                postal_code: shippingAddress.postalCode,
+                state: shippingAddress.stateOrProvinceCode,
+            },
+            name: `${customer.firstName} ${customer.lastName}`,
+        },
+        receipt_email: customer.email,
+        save_payment_method: false,
+    };
+}
+
+export function getStripeCardPaymentOptionsWithGuestUser(): StripeHandleCardPaymentOptions {
+    const shippingAddress = getShippingAddress();
+
+    return {
+        shipping: {
+            address: {
+                city: shippingAddress.city,
+                country: shippingAddress.countryCode,
+                line1: shippingAddress.address1,
+                line2: shippingAddress.address2,
+                postal_code: shippingAddress.postalCode,
+                state: shippingAddress.stateOrProvinceCode,
+            },
+            name: `${shippingAddress.firstName} ${shippingAddress.lastName}`,
+        },
+    };
+}
+
+export function getStripeCardPaymentOptionsWithGuestUserWithoutAddress(): StripeHandleCardPaymentOptions {
+    return {
+        shipping: {
+            address: { },
+            name: 'Guest',
         },
     };
 }

--- a/src/payment/strategies/stripev3/stripev3.ts
+++ b/src/payment/strategies/stripev3/stripev3.ts
@@ -13,9 +13,13 @@ export interface StripeV3Client {
     elements(): StripeElements;
     handleCardPayment(
         clientToken: string,
-        cardElement: StripeCardElement,
         options: StripeHandleCardPaymentOptions
-    ): Promise<StripeResponse>;
+    ): Promise<StripePaymentIntentResponse>;
+    createPaymentMethod(
+        type: string,
+        cardElement: StripeCardElement,
+        options: StripePaymentMethodData
+    ): Promise<StripePaymentMethodResponse>;
 }
 
 export interface StripeCardElement {
@@ -42,7 +46,7 @@ export interface StripeBillingDetails {
     name?: string;
     phone?: string;
 }
-export interface PaymentMethodData {
+export interface StripePaymentMethodData {
     billing_details: StripeBillingDetails;
 }
 
@@ -74,7 +78,7 @@ export interface StripeHandleCardPaymentOptions {
      * If the PaymentIntent is associated with a customer and this parameter is set to true,
      * the provided payment method will be attached to the customer. Default is false.
      */
-    save_payment_method?: string;
+    save_payment_method?: boolean;
 }
 
 export interface StripeElementsOptions {
@@ -127,6 +131,13 @@ export interface PaymentIntent {
     id?: string;
 }
 
+export interface PaymentMethod {
+    /*
+     * Unique identifier for the object.
+     */
+    id?: string;
+}
+
 export interface Error {
     type: string;
     code: string;
@@ -151,8 +162,13 @@ export interface Properties {
     textTransform?: string;
 }
 
-export interface StripeResponse {
+export interface StripePaymentIntentResponse {
     paymentIntent: PaymentIntent;
+    error?: Error;
+}
+
+export interface StripePaymentMethodResponse {
+    paymentMethod: PaymentMethod;
     error?: Error;
 }
 

--- a/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
@@ -14,6 +14,7 @@ import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
 import { getWepay } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import WepayPaymentStrategy from './wepay-payment-strategy';
 import WepayRiskClient from './wepay-risk-client';
@@ -46,7 +47,8 @@ describe('WepayPaymentStrategy', () => {
 
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator
+            orderActionCreator,
+            new PaymentRequestTransformer()
         );
 
         strategy = new WepayPaymentStrategy(

--- a/src/payment/strategies/zip/zip-payment-strategy.spec.ts
+++ b/src/payment/strategies/zip/zip-payment-strategy.spec.ts
@@ -24,6 +24,7 @@ import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentRequestTransformer from '../../payment-request-transformer';
 import PaymentStrategy from '../payment-strategy';
 
 import { Zip } from './zip';
@@ -71,7 +72,11 @@ describe('ZipPaymentStrategy', () => {
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
             new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
-        paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator);
+        paymentActionCreator = new PaymentActionCreator(
+            paymentRequestSender,
+            orderActionCreator,
+            new PaymentRequestTransformer()
+        );
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
             new RemoteCheckoutRequestSender(createRequestSender())
         );


### PR DESCRIPTION
[INT-1577](https://jira.bigcommerce.com/browse/INT-1577)
## What?
Add support for Stripe V3 + Vault that can handle stripe validations with stripe.js (createPaymentMethod & handleCardPayment actions)

## Why?
To support Vaulting on Stripe V3 is needed to modify the existing strategy that use Stripe.js elements and actions to handle 3DS flow and confirm a payment intent that previously was created from back-end (which used a new end point created on BigPay). Also a change into ng-checkout was required to support instruments into `HostedWidgetPaymentMethod`

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/61543279-c7cbe700-aa08-11e9-8f80-207d22b7514e.png)

![image](https://user-images.githubusercontent.com/35146660/61542964-2fcdfd80-aa08-11e9-8062-f797e0e6ef1b.png)

![image](https://user-images.githubusercontent.com/35146660/61544124-5b51e780-aa0a-11e9-9e45-2cd17524ff0a.png)



![ezgif com-video-to-gif](https://user-images.githubusercontent.com/35146660/60542794-61418c00-9cda-11e9-9d03-4c2cc3976de1.gif)

## Sibling PRs
- [BigPay-Client-JS](https://github.com/bigcommerce/bigpay-client-js/pull/79)
- [NGCheckout](https://github.com/bigcommerce-labs/ng-checkout/pull/1282)
- [BigPay](https://github.com/bigcommerce/bigpay/pull/1730)

@bigcommerce/checkout @bigcommerce/intersys-integrations 
