### PR TITLE
feat(order): CHECKOUT-2530 Add support for invisible recaptcha

### DIFF
--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -1071,10 +1071,7 @@ export default class CheckoutService {
      * @returns A promise that resolves to the current state.
      */
     initializeSpamProtection(options: SpamProtectionOptions): Promise<CheckoutSelectors> {
-        const action = this._spamProtectionActionCreator.initialize(options, {
-            onComplete: token => this._dispatch(this._spamProtectionActionCreator.complete(token), { queueId: 'spamProtection' }),
-            onExpire: () => this._dispatch(this._spamProtectionActionCreator.expire(), { queueId: 'spamProtection' }),
-        });
+        const action = this._spamProtectionActionCreator.initialize(options);
 
         return this._dispatch(action, { queueId: 'spamProtection' });
     }

--- a/src/common/dom/mutation-observer.ts
+++ b/src/common/dom/mutation-observer.ts
@@ -1,0 +1,18 @@
+export interface MutationObeserverCreator {
+    prototype: MutationObserver;
+    new(callback: MutationCallback): MutationObserver;
+}
+
+export interface MutationObserverWindow extends Window {
+    MutationObserver: MutationObeserverCreator;
+}
+
+export class MutationObserverFactory {
+    constructor(
+        private _window: MutationObserverWindow = window as MutationObserverWindow
+    ) {}
+
+    create(callback: MutationCallback): MutationObserver {
+        return new this._window.MutationObserver(callback);
+    }
+}

--- a/src/common/error/errors/not-initialized-error.ts
+++ b/src/common/error/errors/not-initialized-error.ts
@@ -5,6 +5,7 @@ export enum NotInitializedErrorType {
     CustomerNotInitialized,
     PaymentNotInitialized,
     ShippingNotInitialized,
+    SpamProtectionNotInitialized,
 }
 
 export default class NotInitializedError extends StandardError {
@@ -27,6 +28,9 @@ function getErrorMessage(type: NotInitializedErrorType): string {
 
     case NotInitializedErrorType.ShippingNotInitialized:
         return 'Unable to proceed because the shipping step of checkout has not been initialized.';
+
+    case NotInitializedErrorType.SpamProtectionNotInitialized:
+        return 'Unable to proceed because the checkout spam protection has not been initialized.';
 
     default:
         return 'Unable to proceed because the required component has not been initialized.';

--- a/src/order/order-reducer.spec.ts
+++ b/src/order/order-reducer.spec.ts
@@ -109,22 +109,6 @@ describe('orderReducer()', () => {
         }));
     });
 
-    it('clears spam protection token if spam protection expired', () => {
-        const action: SpamProtectionAction = {
-            type: SpamProtectionActionType.TokenExpired,
-        };
-
-        const state = { ...initialState, meta: {
-            spamProtectionToken: 'spamProtectionToken',
-        }};
-
-        expect(orderReducer(state, action)).toEqual(expect.objectContaining({
-            meta: {
-                spamProtectionToken: undefined,
-            },
-        }));
-    });
-
     describe('loadOrderPayments', () => {
         it('returns new status while fetching order', () => {
             const action: LoadOrderPaymentsAction = {

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -57,11 +57,6 @@ function metaReducer(
             orderToken: action.payload.order.token,
             payment: action.payload.order && action.payload.order.payment,
         } : meta;
-    case SpamProtectionActionType.TokenExpired:
-        return {
-            ...meta,
-            spamProtectionToken: undefined,
-        };
     case SpamProtectionActionType.Completed:
         return action.payload ? {
             ...meta,

--- a/src/order/spam-protection/create-spam-protection.ts
+++ b/src/order/spam-protection/create-spam-protection.ts
@@ -1,8 +1,13 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
+import { MutationObserverFactory } from '../../common/dom/mutation-observer';
+
 import GoogleRecaptcha from './google-recaptcha';
 import GoogleRecaptchaScriptLoader from './google-recaptcha-script-loader';
 
 export default function createSpamProtection(scriptLoader: ScriptLoader) {
-    return new GoogleRecaptcha(new GoogleRecaptchaScriptLoader(scriptLoader));
+    return new GoogleRecaptcha(
+        new GoogleRecaptchaScriptLoader(scriptLoader),
+        new MutationObserverFactory()
+    );
 }

--- a/src/order/spam-protection/errors/index.ts
+++ b/src/order/spam-protection/errors/index.ts
@@ -1,0 +1,2 @@
+export { default as SpamProtectionFailedError } from './spam-protection-failed-error';
+export { default as SpamProtectionNotCompletedError } from './spam-protection-not-completed-error';

--- a/src/order/spam-protection/errors/spam-protection-failed-error.ts
+++ b/src/order/spam-protection/errors/spam-protection-failed-error.ts
@@ -1,0 +1,9 @@
+import { StandardError } from '../../../common/error/errors';
+
+export default class SpamProtectionFailedError extends StandardError {
+    constructor() {
+        super('We were not able to complete our spam protection verification. Please try again.');
+
+        this.type = 'spam_protection_failed';
+    }
+}

--- a/src/order/spam-protection/errors/spam-protection-not-completed-error.ts
+++ b/src/order/spam-protection/errors/spam-protection-not-completed-error.ts
@@ -1,0 +1,9 @@
+import { StandardError } from '../../../common/error/errors';
+
+export default class SpamProtectionNotCompletedError extends StandardError {
+    constructor() {
+        super('You haven\'t complete our spam protection verification. Please try again.');
+
+        this.type = 'spam_protection_not_completed';
+    }
+}

--- a/src/order/spam-protection/google-recaptcha.ts
+++ b/src/order/spam-protection/google-recaptcha.ts
@@ -1,23 +1,90 @@
+import { Observable, Subject } from 'rxjs';
+
+import { MutationObserverFactory } from '../../common/dom/mutation-observer';
+import { NotInitializedError, NotInitializedErrorType } from '../../common/error/errors';
+
+import { SpamProtectionFailedError, SpamProtectionNotCompletedError } from './errors';
 import GoogleRecaptchaScriptLoader from './google-recaptcha-script-loader';
 
+export interface RecaptchaResult {
+    error?: Error;
+    token?: string;
+}
+
 export default class GoogleRecaptcha {
+    private _event$?: Subject<RecaptchaResult>;
+    private _recaptcha?: ReCaptchaV2.ReCaptcha;
+
     constructor(
-        private googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader
+        private googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader,
+        private mutationObserverFactory: MutationObserverFactory
     ) {}
 
-    render(containerId: string, sitekey: string, callbacks: GoogleRecaptchaCallbacks): Promise<void> {
+    load(containerId: string, sitekey: string): Promise<void> {
+        const event$ = new Subject<RecaptchaResult>();
+        this._event$ = event$;
+
         return this.googleRecaptchaScriptLoader.load()
             .then(recaptcha => {
                 recaptcha.render(containerId, {
                     sitekey,
-                    ...callbacks,
+                    size: 'invisible',
+                    callback: () => {
+                        event$.next({
+                            token: recaptcha.getResponse(),
+                        });
+                    },
+                    'error-callback': () => {
+                        event$.next({
+                            error: new SpamProtectionFailedError(),
+                        });
+                    },
                 });
+
+                this._recaptcha = recaptcha;
             });
     }
-}
 
-interface GoogleRecaptchaCallbacks {
-    callback(token: string): void;
-    'error-callback'?(): void;
-    'expired-callback'?(): void;
+    execute(): Observable<RecaptchaResult> {
+        if (!this._event$ || !this._recaptcha) {
+            throw new NotInitializedError(NotInitializedErrorType.SpamProtectionNotInitialized);
+        }
+
+        this._watchRecaptchaChallengeWindow(this._event$);
+
+        this._recaptcha.execute();
+
+        return this._event$;
+    }
+
+    private _watchRecaptchaChallengeWindow(event: Subject<RecaptchaResult>) {
+        const iframeElement = document.querySelector('iframe[title="recaptcha challenge"]');
+
+        if (!iframeElement) {
+            throw new Error('Recaptcha challenge iframe not found.');
+        }
+
+        const iframeContainer = iframeElement.parentElement;
+
+        if (!iframeContainer) {
+            throw new Error('Recaptcha challenge iframe container not found.');
+        }
+
+        const container = iframeContainer.parentElement;
+
+        if (!container) {
+            throw new Error('Recaptcha challenge container not found.');
+        }
+
+        this.mutationObserverFactory.create(() => {
+            // When customer closes the Google ReCaptcha challenge window, throw SpamProtectionNotCompletedError
+            if (container.style.visibility === 'hidden') {
+                event.next({
+                    error: new SpamProtectionNotCompletedError(),
+                });
+            }
+        })
+
+        .observe(container, { attributes: true, attributeFilter: ['style'] });
+    }
 }

--- a/src/order/spam-protection/spam-protection-actions.ts
+++ b/src/order/spam-protection/spam-protection-actions.ts
@@ -4,16 +4,18 @@ export enum SpamProtectionActionType {
     InitializeFailed = 'SPAM_PROTECTION_INITIALIZE_FAILED',
     InitializeSucceeded = 'SPAM_PROTECTION_INITIALIZE_SUCCEEDED',
     InitializeRequested = 'SPAM_PROTECTION_INITIALIZE_REQUESTED',
+    ExecuteRequested = 'SPAM_PROTECTION_EXECUTE_REQUESTED',
     Completed = 'SPAM_PROTECTION_COMPLETED',
-    TokenExpired = 'SPAM_PROTECTION_TOKEN_EXPIRED',
+    SubmitFailed = 'SPAM_PROTECTION_SUBMIT_FAILED',
 }
 
 export type SpamProtectionAction =
     InitializeRequestedAction |
     InitializeSucceededAction |
     InitializeFailedAction |
+    ExecuteRequestedAction |
     CompletedAction |
-    TokenExpiredAction;
+    SubmitFailedAction;
 
 export interface InitializeRequestedAction extends Action {
     type: SpamProtectionActionType.InitializeRequested;
@@ -27,10 +29,14 @@ export interface InitializeFailedAction extends Action<Error> {
     type: SpamProtectionActionType.InitializeFailed;
 }
 
+export interface ExecuteRequestedAction extends Action {
+    type: SpamProtectionActionType.ExecuteRequested;
+}
+
 export interface CompletedAction extends Action<string> {
     type: SpamProtectionActionType.Completed;
 }
 
-export interface TokenExpiredAction extends Action {
-    type: SpamProtectionActionType.TokenExpired;
+export interface SubmitFailedAction extends Action {
+    type: SpamProtectionActionType.SubmitFailed;
 }

--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -1,7 +1,9 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { createCheckoutStore } from '../checkout';
+import { createSpamProtection } from '../order/spam-protection';
 
 import createPaymentStrategyRegistry from './create-payment-strategy-registry';
 import PaymentStrategyRegistry from './payment-strategy-registry';
@@ -27,7 +29,8 @@ describe('CreatePaymentStrategyRegistry', () => {
         const store = createCheckoutStore();
         const requestSender = createRequestSender();
         const paymentClient = createPaymentClient();
-        registry = createPaymentStrategyRegistry(store, paymentClient, requestSender);
+        const spamProtection = createSpamProtection(createScriptLoader());
+        registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection);
     });
 
     it('can create a payment strategy registry', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -6,6 +6,8 @@ import { BillingAddressActionCreator, BillingAddressRequestSender } from '../bil
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { OrderActionCreator, OrderRequestSender } from '../order';
+import { createSpamProtection, SpamProtectionActionCreator } from '../order/spam-protection';
+import GoogleRecaptcha from '../order/spam-protection/google-recaptcha';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 
 import PaymentActionCreator from './payment-action-creator';
@@ -58,7 +60,8 @@ import { ZipPaymentStrategy, ZipScriptLoader } from './strategies/zip';
 export default function createPaymentStrategyRegistry(
     store: CheckoutStore,
     paymentClient: any,
-    requestSender: RequestSender
+    requestSender: RequestSender,
+    spamProtection: GoogleRecaptcha
 ) {
     const registry = new PaymentStrategyRegistry(store, { defaultToken: PaymentStrategyType.CREDIT_CARD });
     const scriptLoader = getScriptLoader();
@@ -66,7 +69,8 @@ export default function createPaymentStrategyRegistry(
     const braintreePaymentProcessor = createBraintreePaymentProcessor(scriptLoader);
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
-    const orderActionCreator = new OrderActionCreator(new OrderRequestSender(requestSender), checkoutValidator);
+    const spamProtectionActionCreator = new SpamProtectionActionCreator(spamProtection);
+    const orderActionCreator = new OrderActionCreator(new OrderRequestSender(requestSender), checkoutValidator, spamProtectionActionCreator);
     const paymentActionCreator = new PaymentActionCreator(new PaymentRequestSender(paymentClient), orderActionCreator);
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(new RemoteCheckoutRequestSender(requestSender));

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -7,6 +7,7 @@ import { getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
 import { getResponse } from '../common/http-request/responses.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../order';
 import { getOrder } from '../order/orders.mock';
+import { SpamProtectionActionCreator } from '../order/spam-protection';
 
 import createPaymentClient from './create-payment-client';
 import PaymentActionCreator from './payment-action-creator';
@@ -35,7 +36,7 @@ describe('PaymentActionCreator', () => {
         jest.spyOn(paymentRequestSender, 'submitPayment')
             .mockReturnValue(Promise.resolve(getResponse(getPaymentResponseBody())));
 
-        orderActionCreator = new OrderActionCreator(orderRequestSender, {} as CheckoutValidator);
+        orderActionCreator = new OrderActionCreator(orderRequestSender, {} as CheckoutValidator, {} as SpamProtectionActionCreator);
         paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator);
     });
 

--- a/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
+++ b/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
@@ -1,6 +1,7 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -14,6 +15,7 @@ import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSend
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getOrderState } from '../../../order/orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { getConsignmentsState } from '../../../shipping/consignments.mock';
 import { PaymentArgumentInvalidError, PaymentMethodCancelledError, PaymentMethodInvalidError } from '../../errors';
@@ -63,7 +65,11 @@ describe('AffirmPaymentStrategy', () => {
             order: getOrderState(),
         });
         checkoutRequestSender = new CheckoutRequestSender(requestSender);
-        orderActionCreator = new OrderActionCreator(orderRequestSender, new CheckoutValidator(checkoutRequestSender));
+        orderActionCreator = new OrderActionCreator(
+            orderRequestSender,
+            new CheckoutValidator(checkoutRequestSender),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
+        );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
             orderActionCreator

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -10,6 +10,7 @@ import { getCheckout, getCheckoutPayment, getCheckoutStoreState } from '../../..
 import { MissingDataError, NotInitializedError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
@@ -36,6 +37,7 @@ describe('AfterpayPaymentStrategy', () => {
     let paymentMethod: PaymentMethod;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let spamProtectionActionCreator: SpamProtectionActionCreator;
     let scriptLoader: AfterpayScriptLoader;
     let submitOrderAction: Observable<Action>;
     let submitPaymentAction: Observable<Action>;
@@ -53,7 +55,8 @@ describe('AfterpayPaymentStrategy', () => {
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
         checkoutValidator = new CheckoutValidator(checkoutRequestSender);
-        orderActionCreator = new OrderActionCreator(orderRequestSender, checkoutValidator);
+        spamProtectionActionCreator = new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()));
+        orderActionCreator = new OrderActionCreator(orderRequestSender, checkoutValidator, spamProtectionActionCreator);
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
             orderActionCreator

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -15,6 +15,7 @@ import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { getRemoteCheckoutState, getRemoteCheckoutStateData } from '../../../remote-checkout/remote-checkout.mock';
 import { getConsignmentsState } from '../../../shipping/consignments.mock';
@@ -94,7 +95,8 @@ describe('AmazonPayPaymentStrategy', () => {
         billingAddressActionCreator = new BillingAddressActionCreator(billingAddressRequestSender);
         orderActionCreator = new OrderActionCreator(
             orderRequestSender,
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
             new RemoteCheckoutRequestSender(createRequestSender())

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -1,6 +1,7 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge, omit } from 'lodash';
 import { from, of, Observable } from 'rxjs';
 
@@ -12,6 +13,7 @@ import { Order, OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequ
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getOrder } from '../../../order/orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
@@ -52,7 +54,8 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),

--- a/src/payment/strategies/converge/converge-payment-strategy.spec.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.spec.ts
@@ -2,6 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -13,6 +14,7 @@ import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestS
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getOrder } from '../../../order/orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentRequestSender from '../../payment-request-sender';
@@ -36,7 +38,8 @@ describe('ConvergeaymentStrategy', () => {
         orderRequestSender = new OrderRequestSender(createRequestSender());
         orderActionCreator = new OrderActionCreator(
             orderRequestSender,
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
 
         paymentActionCreator = new PaymentActionCreator(

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
@@ -1,6 +1,7 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -8,6 +9,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutVali
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentRequestSender from '../../payment-request-sender';
@@ -35,7 +37,8 @@ describe('CreditCardPaymentStrategy', () => {
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
 
         strategy = new CreditCardPaymentStrategy(store, orderActionCreator, paymentActionCreator);

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../order';
 import OrderFinalizationNotRequiredError from '../../../order/errors/order-finalization-not-required-error';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import {
     RemoteCheckoutActionCreator,
     RemoteCheckoutActionType,
@@ -76,7 +77,10 @@ describe('CyberSourcePaymentStrategy', () => {
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(
+                createSpamProtection(createScriptLoader())
+            )
         );
 
         paymentActionCreator = new PaymentActionCreator(

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { getCartState } from '../../../cart/carts.mock';
 import {
@@ -15,6 +16,7 @@ import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import {
     createPaymentClient,
     createPaymentStrategyRegistry,
@@ -62,7 +64,8 @@ describe('GooglePayPaymentStrategy', () => {
         const configActionCreator = new ConfigActionCreator(configRequestSender);
         const paymentMethodRequestSender: PaymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
         const paymentClient = createPaymentClient(store);
-        const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender);
+        const spamProtection = createSpamProtection(createScriptLoader());
+        const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection);
 
         checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
         paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
@@ -72,7 +75,8 @@ describe('GooglePayPaymentStrategy', () => {
             paymentClient,
             new CheckoutValidator(
                 new CheckoutRequestSender(requestSender)
-            )
+            ),
+            new SpamProtectionActionCreator(spamProtection)
         );
 
         googlePayPaymentProcessor = createGooglePayPaymentProcessor(

--- a/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
@@ -10,18 +10,18 @@ import {
     CheckoutStore,
     CheckoutValidator
 } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MissingDataError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { PaymentMethodCancelledError, PaymentMethodInvalidError } from '../../errors';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentMethodActionType } from '../../payment-method-actions';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
-
-import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { MissingDataError } from '../../../common/error/errors';
 import { getKlarna } from '../../payment-methods.mock';
 
 import KlarnaCredit from './klarna-credit';
@@ -58,7 +58,8 @@ describe('KlarnaPaymentStrategy', () => {
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(

--- a/src/payment/strategies/legacy/legacy-payment-strategy.spec.ts
+++ b/src/payment/strategies/legacy/legacy-payment-strategy.spec.ts
@@ -1,11 +1,13 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 
 import LegacyPaymentStrategy from './legacy-payment-strategy';
 
@@ -19,7 +21,8 @@ describe('LegacyPaymentStrategy', () => {
         store = createCheckoutStore();
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
@@ -16,6 +16,7 @@ import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import { PaymentActionType } from '../../payment-actions';
 import { getMasterpass, getPaymentMethodsState } from '../../payment-methods.mock';
 
@@ -59,7 +60,8 @@ describe('MasterpassPaymentStragegy', () => {
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethodMock);
 
         const checkoutValidator = new CheckoutValidator(new CheckoutRequestSender(createRequestSender()));
-        orderActionCreator = new OrderActionCreator(orderRequestSender, checkoutValidator);
+        const spamProtectionActionCreator = new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()));
+        orderActionCreator = new OrderActionCreator(orderRequestSender, checkoutValidator, spamProtectionActionCreator);
         const paymentRequestSender = new PaymentRequestSender(createPaymentClient());
         paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator);
 

--- a/src/payment/strategies/no-payment/no-payment-data-required-strategy.spec.ts
+++ b/src/payment/strategies/no-payment/no-payment-data-required-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -7,6 +8,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutVali
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 
 import NoPaymentDataRequiredPaymentStrategy from './no-payment-data-required-strategy';
 
@@ -20,7 +22,8 @@ describe('NoPaymentDataRequiredPaymentStrategy', () => {
         store = createCheckoutStore();
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 

--- a/src/payment/strategies/offline/offline-payment-strategy.spec.ts
+++ b/src/payment/strategies/offline/offline-payment-strategy.spec.ts
@@ -1,10 +1,12 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 
 import OfflinePaymentStrategy from './offline-payment-strategy';
 
@@ -18,7 +20,8 @@ describe('OfflinePaymentStrategy', () => {
         store = createCheckoutStore();
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 

--- a/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
@@ -1,6 +1,7 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge, omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -10,6 +11,7 @@ import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestB
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getIncompleteOrder, getOrderRequestBody, getSubmittedOrder } from '../../../order/internal-orders.mock';
 import { getOrder } from '../../../order/orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { InitializeOffsitePaymentAction, PaymentActionType } from '../../payment-actions';
 import { PaymentRequestOptions } from '../../payment-request-options';
@@ -33,7 +35,8 @@ describe('OffsitePaymentStrategy', () => {
         store = createCheckoutStore(getCheckoutStoreState());
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),

--- a/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
@@ -10,6 +10,7 @@ import { getCustomer } from '../../../customer/internal-customers.mock';
 import { FinalizeOrderAction, InternalOrder, OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody, getSubmittedOrder } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentMethod from '../../payment-method';
 import { getPaypalExpress } from '../../payment-methods.mock';
 import * as paymentStatusTypes from '../../payment-status-types';
@@ -34,7 +35,8 @@ describe('PaypalExpressPaymentStrategy', () => {
     beforeEach(() => {
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
 
         paypalSdk = {

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.spec.ts
@@ -2,6 +2,7 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -10,6 +11,7 @@ import { getCheckoutStoreState, getCheckoutWithPayments } from '../../../checkou
 import { OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentRequestSender from '../../payment-request-sender';
@@ -31,7 +33,8 @@ describe('PaypalProPaymentStrategy', () => {
 
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
 
         paymentActionCreator = new PaymentActionCreator(

--- a/src/payment/strategies/sage-pay/sage-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/sage-pay/sage-pay-payment-strategy.spec.ts
@@ -2,6 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -13,6 +14,7 @@ import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestS
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getOrder } from '../../../order/orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentRequestSender from '../../payment-request-sender';
@@ -36,7 +38,8 @@ describe('SagePayPaymentStrategy', () => {
         orderRequestSender = new OrderRequestSender(createRequestSender());
         orderActionCreator = new OrderActionCreator(
             orderRequestSender,
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
 
         paymentActionCreator = new PaymentActionCreator(

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -34,6 +34,7 @@ import ConfigRequestSender from '../../../config/config-request-sender';
 import { getConfigState } from '../../../config/configs.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import { getPaymentMethodsState, getSquare } from '../../../payment/payment-methods.mock';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
@@ -99,14 +100,16 @@ describe('SquarePaymentStrategy', () => {
 
         const requestSender = createRequestSender();
         const paymentClient = createPaymentClient(store);
-        const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender);
+        const spamProtection = createSpamProtection(createScriptLoader());
+        const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection);
         const checkoutRequestSender = new CheckoutRequestSender(requestSender);
         const configRequestSender = new ConfigRequestSender(requestSender);
         const configActionCreator = new ConfigActionCreator(configRequestSender);
 
         orderActionCreator = new OrderActionCreator(
             orderRequestSender,
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(spamProtection)
         );
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -19,6 +19,10 @@ import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import OrderActionCreator from '../../../order/order-action-creator';
 import {
+    createSpamProtection,
+    SpamProtectionActionCreator
+} from '../../../order/spam-protection';
+import {
     createPaymentClient,
     PaymentInitializeOptions,
     PaymentMethodRequestSender,
@@ -67,7 +71,8 @@ describe('StripeV3PaymentStrategy', () => {
             paymentClient,
             new CheckoutValidator(
                 new CheckoutRequestSender(requestSender)
-            )
+            ),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
         stripeScriptLoader = new StripeV3ScriptLoader(scriptLoader);
 

--- a/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
@@ -8,6 +8,7 @@ import { of, Observable } from 'rxjs';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
@@ -39,7 +40,8 @@ describe('WepayPaymentStrategy', () => {
         orderRequestSender = new OrderRequestSender(createRequestSender());
         orderActionCreator = new OrderActionCreator(
             orderRequestSender,
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
 
         paymentActionCreator = new PaymentActionCreator(

--- a/src/payment/strategies/zip/zip-payment-strategy.spec.ts
+++ b/src/payment/strategies/zip/zip-payment-strategy.spec.ts
@@ -13,6 +13,7 @@ import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { getPaymentMethodsState, getZip } from '../../../payment/payment-methods.mock';
 import { getZipScriptMock } from '../../../payment/strategies/zip/zip.mock';
@@ -65,7 +66,11 @@ describe('ZipPaymentStrategy', () => {
         const paymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
         const paymentRequestSender = new PaymentRequestSender(createPaymentClient());
 
-        orderActionCreator = new OrderActionCreator(paymentClient, new CheckoutValidator(new CheckoutRequestSender(createRequestSender())));
+        orderActionCreator = new OrderActionCreator(
+            paymentClient,
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender())),
+            new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
+        );
         paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator);
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
             new RemoteCheckoutRequestSender(createRequestSender())


### PR DESCRIPTION
## What?
Changing checkbox recaptcha to invisible recaptcha

## Why?
Invisible recaptcha will create less friction in checkout.

## Testing / Proof
<img width="1643" alt="Screen Shot 2019-07-04 at 4 32 35 pm" src="https://user-images.githubusercontent.com/22089936/60644403-5a9d4b00-9e79-11e9-8670-17e8b4b93c30.png">

<img width="1661" alt="Screen Shot 2019-07-04 at 4 32 21 pm" src="https://user-images.githubusercontent.com/22089936/60644397-57a25a80-9e79-11e9-8ea9-7e51a5595617.png">

<img width="1637" alt="Screen Shot 2019-07-04 at 4 33 29 pm" src="https://user-images.githubusercontent.com/22089936/60644443-7bfe3700-9e79-11e9-80ca-4a72aa0028f1.png">

<img width="1673" alt="Screen Shot 2019-07-04 at 4 31 36 pm" src="https://user-images.githubusercontent.com/22089936/60644372-3f324000-9e79-11e9-9e78-fb0f1d31a337.png">


@bigcommerce/checkout @bigcommerce/payments
