### PR TITLE
feat(payment): INT-1650 Adding IIN field to vaulted instrument strategy

### DIFF
--- a/src/payment/is-credit-card-like.spec.ts
+++ b/src/payment/is-credit-card-like.spec.ts
@@ -8,7 +8,7 @@ describe('isCreditCardLike', () => {
     });
 
     it('returns false if a Vaulted Instrument', () => {
-        const paymentData = { instrumentId: 'my_instrument_id', cvv: 123 };
+        const paymentData = { instrumentId: 'my_instrument_id', cvv: 123, iin: '123123' };
         expect(isCreditCardLike(paymentData)).toBeFalsy();
     });
 

--- a/src/payment/is-nonce-like.spec.ts
+++ b/src/payment/is-nonce-like.spec.ts
@@ -13,7 +13,7 @@ describe('isNonceLike', () => {
     });
 
     it('returns false if a Vaulted Instrument', () => {
-        const paymentData = { instrumentId: 'my_instrument_id', cvv: 123 };
+        const paymentData = { instrumentId: 'my_instrument_id', cvv: 123, iin: '123123' };
         expect(isNonceLike(paymentData)).toBeFalsy();
     });
 });

--- a/src/payment/is-vaulted-instrument.spec.ts
+++ b/src/payment/is-vaulted-instrument.spec.ts
@@ -3,7 +3,7 @@ import { getCreditCardInstrument } from './payments.mock';
 
 describe('isTokenizedCreditCardLike', () => {
     it('returns true if a Vaulted Instrument', () => {
-        const paymentData = { instrumentId: 'my_instrument_id', cvv: 123 };
+        const paymentData = { instrumentId: 'my_instrument_id', cvv: 123, iin: '123123' };
         expect(isVaultedInstrument(paymentData)).toBeTruthy();
     });
 

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -4,7 +4,7 @@ export default interface Payment {
     paymentData?: PaymentInstrument & PaymentInstrumentMeta;
 }
 
-export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument | HostedInstrument;
+export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument | HostedInstrument | ThreeDSVaultedInstrument;
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
@@ -33,6 +33,11 @@ export interface VaultedInstrument {
     instrumentId: string;
     ccCvv?: string;
     ccNumber?: string;
+}
+
+export interface ThreeDSVaultedInstrument extends VaultedInstrument {
+    iin?: string;
+    threeDSecure?: ThreeDSecure | ThreeDSecureToken;
 }
 
 export interface CryptogramInstrument {

--- a/src/payment/payments.mock.ts
+++ b/src/payment/payments.mock.ts
@@ -10,7 +10,7 @@ import { getConsignments } from '../shipping/consignments.mock';
 import { getFlatRateOption } from '../shipping/internal-shipping-options.mock';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 
-import Payment, { CreditCardInstrument } from './payment';
+import Payment, { CreditCardInstrument, ThreeDSVaultedInstrument, VaultedInstrument } from './payment';
 import { getAuthorizenet, getPaymentMethodsMeta } from './payment-methods.mock';
 import PaymentRequestBody from './payment-request-body';
 import PaymentResponseBody from './payment-response-body';
@@ -32,6 +32,12 @@ export function getCreditCardInstrument(): CreditCardInstrument {
         ccName: 'BigCommerce',
         ccNumber: '4111111111111111',
         ccCvv: '123',
+    };
+}
+
+export function getVaultedInstrument(): VaultedInstrument {
+    return {
+        instrumentId: '123',
     };
 }
 

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -157,6 +157,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
                     methodId: 'braintree',
                     paymentData: {
                         instrumentId: 'my_instrument_id',
+                        iin: '123123',
                     },
                 },
             };

--- a/src/payment/strategies/cybersource/cardinal-client.spec.ts
+++ b/src/payment/strategies/cybersource/cardinal-client.spec.ts
@@ -100,7 +100,7 @@ describe('CardinalClient', () => {
         });
     });
 
-    describe('#runBindProcess', () => {
+    describe('#runBinProcess', () => {
         beforeEach(async () => {
             sdk.on = jest.fn((type, callback) => {
                 if (type.toString() === CardinalEventType.SetupCompleted) {
@@ -119,7 +119,7 @@ describe('CardinalClient', () => {
         it('collects the data correctly', async () => {
             jest.spyOn(sdk, 'trigger').mockReturnValue(Promise.resolve(getCardinalBinProcessResponse(true)));
 
-            await client.runBindProcess('123456');
+            await client.runBinProcess('123456');
 
             expect(sdk.trigger).toHaveBeenCalledWith(CardinalTriggerEvents.BinProcess, '123456');
         });
@@ -128,7 +128,7 @@ describe('CardinalClient', () => {
             jest.spyOn(sdk, 'trigger').mockReturnValue(Promise.resolve(getCardinalBinProcessResponse(false)));
 
             try {
-                await client.runBindProcess('');
+                await client.runBinProcess('');
             } catch (error) {
                 expect(error).toBeInstanceOf(NotInitializedError);
             }
@@ -140,7 +140,7 @@ describe('CardinalClient', () => {
             });
 
             try {
-                await client.runBindProcess('');
+                await client.runBinProcess('');
             } catch (error) {
                 expect(error).toBeInstanceOf(NotInitializedError);
             }

--- a/src/payment/strategies/cybersource/cardinal-client.ts
+++ b/src/payment/strategies/cybersource/cardinal-client.ts
@@ -1,11 +1,12 @@
 import { includes } from 'lodash';
 
 import Address from '../../../address/address';
+import BillingAddress from '../../../billing/billing-address';
 import {
     MissingDataError, MissingDataErrorType, NotInitializedError,
     NotInitializedErrorType, StandardError
 } from '../../../common/error/errors';
-import { CreditCardInstrument, ThreeDSecureToken } from '../../payment';
+import { CreditCardInstrument, ThreeDSecureToken, VaultedInstrument } from '../../payment';
 import { ThreeDsResult } from '../../payment-response-body';
 
 import {
@@ -14,7 +15,6 @@ import {
     CardinalConsumer,
     CardinalEventType,
     CardinalInitializationType,
-    CardinalOrderData,
     CardinalPartialOrder,
     CardinalPaymentBrand,
     CardinalScriptLoader,
@@ -24,6 +24,17 @@ import {
     CardinalValidatedAction,
     CardinalValidatedData
 } from './index';
+
+export type CardinalSupportedPaymentInstrument = CreditCardInstrument | VaultedInstrument;
+
+export interface CardinalOrderData {
+    billingAddress: BillingAddress;
+    shippingAddress?: Address;
+    currencyCode: string;
+    id: string;
+    amount: number;
+    paymentData?: CreditCardInstrument;
+}
 
 export default class CardinalClient {
     private _sdk?: Promise<CardinalSDK>;
@@ -69,9 +80,9 @@ export default class CardinalClient {
         }));
     }
 
-    runBindProcess(ccNumber: string): Promise<void> {
+    runBinProcess(binNumber: string): Promise<void> {
         return this._getClientSDK()
-            .then(client => client.trigger(CardinalTriggerEvents.BinProcess, ccNumber).catch(() => {}))
+            .then(client => client.trigger(CardinalTriggerEvents.BinProcess, binNumber).catch(() => {}))
             .then(result => {
                 if (!result || !result.Status) {
                     throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
@@ -119,8 +130,11 @@ export default class CardinalClient {
     private _mapToPartialOrder(orderData: CardinalOrderData, transactionId: string): CardinalPartialOrder {
         const consumer: CardinalConsumer = {
             BillingAddress: this._mapToCardinalAddress(orderData.billingAddress),
-            Account: this._mapToCardinalAccount(orderData.paymentData),
         };
+
+        if (orderData.paymentData) {
+            consumer.Account = this._mapToCardinalAccount(orderData.paymentData);
+        }
 
         if (orderData.billingAddress.email) {
             consumer.Email1 = orderData.billingAddress.email;

--- a/src/payment/strategies/cybersource/cardinal.mock.ts
+++ b/src/payment/strategies/cybersource/cardinal.mock.ts
@@ -11,7 +11,7 @@ import {
     CardinalValidatedAction,
     CardinalValidatedData,
     CardinalWindow,
-} from './cardinal';
+} from '.';
 
 const CardinalWindowMock: CardinalWindow = window;
 

--- a/src/payment/strategies/cybersource/cardinal.ts
+++ b/src/payment/strategies/cybersource/cardinal.ts
@@ -1,7 +1,3 @@
-import Address from '../../../address/address';
-import BillingAddress from '../../../billing/billing-address';
-import { CreditCardInstrument } from '../../payment';
-
 export const CardinalSignatureValidationErrors = [100004, 1010, 1011, 1020];
 
 export interface CardinalSDK {
@@ -42,15 +38,6 @@ export interface CardinalSetupCompletedData {
 export interface CardinalModuleState {
     loaded: boolean;
     module: string;
-}
-
-export interface CardinalOrderData {
-    billingAddress: BillingAddress;
-    shippingAddress?: Address;
-    currencyCode: string;
-    id: string;
-    amount: number;
-    paymentData: CreditCardInstrument;
 }
 
 export enum CardinalInitializationType {
@@ -109,8 +96,8 @@ export interface CardinalConsumer {
     Email1?: string;
     Email2?: string;
     ShippingAddress?: CardinalAddress;
-    BillingAddress: CardinalAddress;
-    Account: CardinalAccount;
+    BillingAddress?: CardinalAddress;
+    Account?: CardinalAccount;
 }
 
 export interface CardinalAccount {

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
@@ -1,4 +1,4 @@
-import { some } from 'lodash';
+import { find, some } from 'lodash';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
@@ -8,14 +8,20 @@ import {
 } from '../../../common/error/errors';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import Payment, { CreditCardInstrument } from '../../payment';
+import isCreditCardLike from '../../is-credit-card-like';
+import isVaultedInstrument from '../../is-vaulted-instrument';
+import { CreditCardInstrument, VaultedInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import { CardinalClient, CardinalOrderData } from './index';
+import {
+    CardinalClient,
+    CardinalOrderData,
+    CardinalSupportedPaymentInstrument
+} from './index';
 
 export default class CyberSourcePaymentStrategy implements PaymentStrategy {
     private _paymentMethod?: PaymentMethod;
@@ -26,7 +32,7 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
         private _cardinalClient: CardinalClient
-    ) {}
+    ) { }
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { methodId } = options;
@@ -55,7 +61,8 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        return this._paymentMethod.config.is3dsEnabled ? this._placeOrderUsing3DS(order, payment, options, this._paymentMethod.clientToken) :
+        return this._paymentMethod.config.is3dsEnabled ?
+            this._placeOrderUsing3DS(order, payment, options, this._paymentMethod.clientToken) :
             this._placeOrder(order, payment, options);
     }
 
@@ -79,7 +86,7 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
         const paymentData = payment.paymentData as CreditCardInstrument;
 
         return this._cardinalClient.configure(clientToken)
-            .then(() => this._cardinalClient.runBindProcess(paymentData.ccNumber))
+            .then(() => this._cardinalClient.runBinProcess(this._getBinNumber(paymentData)))
             .then(() => {
                 return this._placeOrder(order, payment, options)
                     .catch(error => {
@@ -112,11 +119,26 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
             );
     }
 
-    private _getOrderData(paymentData: CreditCardInstrument): CardinalOrderData {
-        const billingAddress = this._store.getState().billingAddress.getBillingAddress();
-        const shippingAddress = this._store.getState().shippingAddress.getShippingAddress();
-        const checkout = this._store.getState().checkout.getCheckout();
-        const order = this._store.getState().order.getOrder();
+    private _getBinNumber(payment: CardinalSupportedPaymentInstrument): string {
+        if (isVaultedInstrument(payment)) {
+            const instruments = this._store.getState().instruments.getInstruments();
+
+            const { instrumentId } = payment;
+
+            const entry = find(instruments, { bigpayToken: instrumentId });
+
+            return entry && entry.iin || '';
+        }
+
+        return payment.ccNumber;
+    }
+
+    private _getOrderData(paymentData: CardinalSupportedPaymentInstrument): CardinalOrderData {
+        const state = this._store.getState();
+        const billingAddress = state.billingAddress.getBillingAddress();
+        const shippingAddress = state.shippingAddress.getShippingAddress();
+        const checkout = state.checkout.getCheckout();
+        const order = state.order.getOrder();
 
         if (!billingAddress || !billingAddress.email) {
             throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
@@ -130,13 +152,18 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingOrder);
         }
 
-        return {
+        const payment: CardinalOrderData = {
             billingAddress,
             shippingAddress,
             currencyCode: checkout.cart.currency.code,
             id: order.orderId.toString(),
             amount: checkout.cart.cartAmount,
-            paymentData,
         };
+
+        if (isCreditCardLike(paymentData)) {
+            payment.paymentData = paymentData;
+        }
+
+        return payment;
     }
 }

--- a/src/payment/strategies/cybersource/index.ts
+++ b/src/payment/strategies/cybersource/index.ts
@@ -2,4 +2,4 @@ export * from './cardinal';
 
 export { default as CyberSourcePaymentStrategy } from './cybersource-payment-strategy';
 export { default as CardinalScriptLoader } from './cardinal-script-loader';
-export { default as CardinalClient } from './cardinal-client';
+export { default as CardinalClient, CardinalOrderData, CardinalSupportedPaymentInstrument } from './cardinal-client';


### PR DESCRIPTION
## What?
Adding BIN Number for vaulted credit cards in the form of the issuer_identification_number (iin), already stored in the BigPay database.

## Why?
This iin value should be received by Checkout SDK strategy so it can be used in the Cardinal's BIN Detection step.

## Testing / Proof
![image](https://user-images.githubusercontent.com/51794862/60738788-254e3700-9f25-11e9-804d-40f588d0b6ad.png)


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations
