### PR TITLE
CHECKOUT-4165: Add names to custom error objects

### DIFF
--- a/src/cart/errors/cart-changed-error.spec.ts
+++ b/src/cart/errors/cart-changed-error.spec.ts
@@ -1,0 +1,9 @@
+import CartChangedError from './cart-changed-error';
+
+describe('CartChangedError', () => {
+    it('returns error name', () => {
+        const error = new CartChangedError();
+
+        expect(error.name).toEqual('CartChangedError');
+    });
+});

--- a/src/cart/errors/cart-changed-error.ts
+++ b/src/cart/errors/cart-changed-error.ts
@@ -4,6 +4,7 @@ export default class CartChangedError extends StandardError {
     constructor() {
         super('An update to your shopping cart has been detected and your available shipping costs have been updated.');
 
+        this.name = 'CartChangedError';
         this.type = 'cart_changed';
     }
 }

--- a/src/checkout/errors/checkout-not-available-error.spec.ts
+++ b/src/checkout/errors/checkout-not-available-error.spec.ts
@@ -9,6 +9,12 @@ describe('init', () => {
         expect(error.type).toEqual('checkout_not_available');
     });
 
+    it('returns error name', () => {
+        const error = new CheckoutNotAvailableError(getErrorResponse());
+
+        expect(error.name).toEqual('CheckoutNotAvailableError');
+    });
+
     it('sets the message as `body.title`', () => {
         const response = getErrorResponse();
         const error = new CheckoutNotAvailableError(response);

--- a/src/checkout/errors/checkout-not-available-error.ts
+++ b/src/checkout/errors/checkout-not-available-error.ts
@@ -7,6 +7,7 @@ export default class CheckoutNotAvailableError extends RequestError {
     constructor(response: Response<InternalErrorResponseBody>) {
         super(response, { message: response.body.title });
 
+        this.name = 'CheckoutNotAvailableError';
         this.type = 'checkout_not_available';
     }
 }

--- a/src/common/error/errors/invalid-argument-error.spec.ts
+++ b/src/common/error/errors/invalid-argument-error.spec.ts
@@ -1,0 +1,9 @@
+import InvalidArgumentError from './invalid-argument-error';
+
+describe('InvalidArgumentError', () => {
+    it('returns error name', () => {
+        const error = new InvalidArgumentError();
+
+        expect(error.name).toEqual('InvalidArgumentError');
+    });
+});

--- a/src/common/error/errors/invalid-argument-error.ts
+++ b/src/common/error/errors/invalid-argument-error.ts
@@ -4,6 +4,7 @@ export default class InvalidArgumentError extends StandardError {
     constructor(message?: string) {
         super(message || 'Invalid arguments have been provided.');
 
+        this.name = 'InvalidArgumentError';
         this.type = 'invalid_argument';
     }
 }

--- a/src/common/error/errors/missing-data-error.spec.ts
+++ b/src/common/error/errors/missing-data-error.spec.ts
@@ -1,0 +1,9 @@
+import MissingDataError, { MissingDataErrorType } from './missing-data-error';
+
+describe('MissingDataError', () => {
+    it('returns error name', () => {
+        const error = new MissingDataError(MissingDataErrorType.MissingCheckout);
+
+        expect(error.name).toEqual('MissingDataError');
+    });
+});

--- a/src/common/error/errors/missing-data-error.ts
+++ b/src/common/error/errors/missing-data-error.ts
@@ -21,6 +21,7 @@ export default class MissingDataError extends StandardError {
     ) {
         super(getErrorMessage(subtype));
 
+        this.name = 'MissingDataError';
         this.type = 'missing_data';
     }
 }

--- a/src/common/error/errors/not-implemented-error.spec.ts
+++ b/src/common/error/errors/not-implemented-error.spec.ts
@@ -1,0 +1,9 @@
+import NotImplementedError from './not-implemented-error';
+
+describe('NotImplementedError', () => {
+    it('returns error name', () => {
+        const error = new NotImplementedError();
+
+        expect(error.name).toEqual('NotImplementedError');
+    });
+});

--- a/src/common/error/errors/not-implemented-error.ts
+++ b/src/common/error/errors/not-implemented-error.ts
@@ -4,6 +4,7 @@ export default class NotImplementedError extends StandardError {
     constructor(message?: string) {
         super(message || 'Not implemented.');
 
+        this.name = 'NotImplementedError';
         this.type = 'not_implemented';
     }
 }

--- a/src/common/error/errors/not-initialized-error.spec.ts
+++ b/src/common/error/errors/not-initialized-error.spec.ts
@@ -1,0 +1,9 @@
+import NotInitializedError, { NotInitializedErrorType } from './not-initialized-error';
+
+describe('NotInitializedError', () => {
+    it('returns error name', () => {
+        const error = new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+
+        expect(error.name).toEqual('NotInitializedError');
+    });
+});

--- a/src/common/error/errors/not-initialized-error.ts
+++ b/src/common/error/errors/not-initialized-error.ts
@@ -14,6 +14,7 @@ export default class NotInitializedError extends StandardError {
     ) {
         super(getErrorMessage(subtype));
 
+        this.name = 'NotInitializedError';
         this.type = 'not_initialized';
     }
 }

--- a/src/common/error/errors/request-error.spec.ts
+++ b/src/common/error/errors/request-error.spec.ts
@@ -9,6 +9,12 @@ describe('RequestError', () => {
         expect(error.type).toEqual('request');
     });
 
+    it('sets name', () => {
+        const error = new RequestError(getErrorResponse());
+
+        expect(error.name).toEqual('RequestError');
+    });
+
     it('sets body', () => {
         const response = getErrorResponse();
         const error = new RequestError(response);

--- a/src/common/error/errors/request-error.ts
+++ b/src/common/error/errors/request-error.ts
@@ -25,6 +25,7 @@ export default class RequestError<TBody = any> extends StandardError {
 
         super(message || 'An unexpected error has occurred.');
 
+        this.name = 'RequestError';
         this.type = 'request';
         this.body = body;
         this.headers = headers;

--- a/src/common/error/errors/timeout-error.spec.ts
+++ b/src/common/error/errors/timeout-error.spec.ts
@@ -1,0 +1,9 @@
+import TimeoutError from './timeout-error';
+
+describe('TimeoutError', () => {
+    it('returns error name', () => {
+        const error = new TimeoutError();
+
+        expect(error.name).toEqual('TimeoutError');
+    });
+});

--- a/src/common/error/errors/timeout-error.ts
+++ b/src/common/error/errors/timeout-error.ts
@@ -8,6 +8,7 @@ export default class TimeoutError extends RequestError<{}> {
             message: 'The request has timed out or aborted.',
         });
 
+        this.name = 'TimeoutError';
         this.type = 'timeout';
     }
 }

--- a/src/common/error/errors/unrecoverable-error.spec.ts
+++ b/src/common/error/errors/unrecoverable-error.spec.ts
@@ -1,0 +1,11 @@
+import { getResponse } from '../../http-request/responses.mock';
+
+import UnrecoverableError from './unrecoverable-error';
+
+describe('UnrecoverableError', () => {
+    it('returns error name', () => {
+        const error = new UnrecoverableError(getResponse('Error'));
+
+        expect(error.name).toEqual('UnrecoverableError');
+    });
+});

--- a/src/common/error/errors/unrecoverable-error.ts
+++ b/src/common/error/errors/unrecoverable-error.ts
@@ -8,6 +8,7 @@ export default class UnrecoverableError extends RequestError {
             message: message || 'An unexpected error has occurred. The checkout process cannot continue as a result.',
         });
 
+        this.name = 'UnrecoverableError';
         this.type = 'unrecoverable';
     }
 }

--- a/src/common/error/errors/unsupported-browser-error.spec.ts
+++ b/src/common/error/errors/unsupported-browser-error.spec.ts
@@ -1,0 +1,9 @@
+import UnsupportedBrowserError from './unsupported-browser-error';
+
+describe('UnsupportedBrowserError', () => {
+    it('returns error name', () => {
+        const error = new UnsupportedBrowserError();
+
+        expect(error.name).toEqual('UnsupportedBrowserError');
+    });
+});

--- a/src/common/error/errors/unsupported-browser-error.ts
+++ b/src/common/error/errors/unsupported-browser-error.ts
@@ -4,6 +4,7 @@ export default class UnsupportedBrowserError extends StandardError {
     constructor(message?: string) {
         super(message || 'Unsupported browser error');
 
+        this.name = 'UnsupportedBrowserError';
         this.type = 'unsupported_browser';
     }
 }

--- a/src/embedded-checkout/errors/invalid-login-token-error.spec.ts
+++ b/src/embedded-checkout/errors/invalid-login-token-error.spec.ts
@@ -1,0 +1,16 @@
+import { getErrorResponse } from '../../common/http-request/responses.mock';
+
+import InvalidLoginTokenError from './invalid-login-token-error';
+
+describe('InvalidLoginTokenError', () => {
+    it('returns error name', () => {
+        const error = new InvalidLoginTokenError(getErrorResponse({
+            status: 400,
+            title: 'Invalid login token error',
+            type: 'invalid_login',
+            errors: ['Invalid details.'],
+        }));
+
+        expect(error.name).toEqual('InvalidLoginTokenError');
+    });
+});

--- a/src/embedded-checkout/errors/invalid-login-token-error.ts
+++ b/src/embedded-checkout/errors/invalid-login-token-error.ts
@@ -7,6 +7,7 @@ export default class InvalidLoginTokenError extends RequestError {
     constructor(response: Response<InternalErrorResponseBody>) {
         super(response, { message: response.body.title });
 
+        this.name = 'InvalidLoginTokenError';
         this.type = 'invalid_login_token';
     }
 }

--- a/src/embedded-checkout/errors/not-embeddable-error.spec.ts
+++ b/src/embedded-checkout/errors/not-embeddable-error.spec.ts
@@ -1,0 +1,9 @@
+import NotEmbeddableError from './not-embeddable-error';
+
+describe('NotEmbeddableError', () => {
+    it('returns error name', () => {
+        const error = new NotEmbeddableError();
+
+        expect(error.name).toEqual('NotEmbeddableError');
+    });
+});

--- a/src/embedded-checkout/errors/not-embeddable-error.ts
+++ b/src/embedded-checkout/errors/not-embeddable-error.ts
@@ -13,6 +13,7 @@ export default class NotEmbeddableError extends StandardError {
     ) {
         super(message || 'Unable to embed the checkout form.');
 
+        this.name = 'NotEmbeddableError';
         this.type = 'not_embeddable';
     }
 }

--- a/src/order/errors/order-finalization-not-required-error.spec.ts
+++ b/src/order/errors/order-finalization-not-required-error.spec.ts
@@ -1,0 +1,9 @@
+import OrderFinalizationNotRequiredError from './order-finalization-not-required-error';
+
+describe('OrderFinalizationNotRequiredError', () => {
+    it('returns error name', () => {
+        const error = new OrderFinalizationNotRequiredError();
+
+        expect(error.name).toEqual('OrderFinalizationNotRequiredError');
+    });
+});

--- a/src/order/errors/order-finalization-not-required-error.ts
+++ b/src/order/errors/order-finalization-not-required-error.ts
@@ -4,6 +4,7 @@ export default class OrderFinalizationNotRequiredError extends StandardError {
     constructor() {
         super('The current order does not need to be finalized at this stage.');
 
+        this.name = 'OrderFinalizationNotRequiredError';
         this.type = 'order_finalization_not_required';
     }
 }

--- a/src/order/spam-protection/errors/spam-protection-failed-error.spec.ts
+++ b/src/order/spam-protection/errors/spam-protection-failed-error.spec.ts
@@ -1,0 +1,9 @@
+import SpamProtectionFailedError from './spam-protection-failed-error';
+
+describe('SpamProtectionFailedError', () => {
+    it('returns error name', () => {
+        const error = new SpamProtectionFailedError();
+
+        expect(error.name).toEqual('SpamProtectionFailedError');
+    });
+});

--- a/src/order/spam-protection/errors/spam-protection-failed-error.ts
+++ b/src/order/spam-protection/errors/spam-protection-failed-error.ts
@@ -4,6 +4,7 @@ export default class SpamProtectionFailedError extends StandardError {
     constructor() {
         super('We were not able to complete our spam protection verification. Please try again.');
 
+        this.name = 'SpamProtectionFailedError';
         this.type = 'spam_protection_failed';
     }
 }

--- a/src/order/spam-protection/errors/spam-protection-not-completed-error.spec.ts
+++ b/src/order/spam-protection/errors/spam-protection-not-completed-error.spec.ts
@@ -1,0 +1,9 @@
+import SpamProtectionNotCompletedError from './spam-protection-not-completed-error';
+
+describe('SpamProtectionNotCompletedError', () => {
+    it('returns error name', () => {
+        const error = new SpamProtectionNotCompletedError();
+
+        expect(error.name).toEqual('SpamProtectionNotCompletedError');
+    });
+});

--- a/src/order/spam-protection/errors/spam-protection-not-completed-error.ts
+++ b/src/order/spam-protection/errors/spam-protection-not-completed-error.ts
@@ -4,6 +4,7 @@ export default class SpamProtectionNotCompletedError extends StandardError {
     constructor() {
         super('You haven\'t complete our spam protection verification. Please try again.');
 
+        this.name = 'SpamProtectionNotCompletedError';
         this.type = 'spam_protection_not_completed';
     }
 }

--- a/src/payment/errors/payment-argument-invalid-error.spec.ts
+++ b/src/payment/errors/payment-argument-invalid-error.spec.ts
@@ -1,0 +1,9 @@
+import PaymentArgumentInvalidError from './payment-argument-invalid-error';
+
+describe('PaymentArgumentInvalidError', () => {
+    it('returns error name', () => {
+        const error = new PaymentArgumentInvalidError();
+
+        expect(error.name).toEqual('PaymentArgumentInvalidError');
+    });
+});

--- a/src/payment/errors/payment-argument-invalid-error.ts
+++ b/src/payment/errors/payment-argument-invalid-error.ts
@@ -9,5 +9,7 @@ export default class PaymentArgumentInvalidError extends InvalidArgumentError {
         }
 
         super(message);
+
+        this.name = 'PaymentArgumentInvalidError';
     }
 }

--- a/src/payment/errors/payment-method-cancelled-error.spec.ts
+++ b/src/payment/errors/payment-method-cancelled-error.spec.ts
@@ -1,0 +1,9 @@
+import PaymentMethodCancelledError from './payment-method-cancelled-error';
+
+describe('PaymentMethodCancelledError', () => {
+    it('returns error name', () => {
+        const error = new PaymentMethodCancelledError();
+
+        expect(error.name).toEqual('PaymentMethodCancelledError');
+    });
+});

--- a/src/payment/errors/payment-method-cancelled-error.ts
+++ b/src/payment/errors/payment-method-cancelled-error.ts
@@ -4,6 +4,7 @@ export default class PaymentMethodCancelledError extends StandardError {
     constructor(message?: string) {
         super(message || 'Payment process was cancelled.');
 
+        this.name = 'PaymentMethodCancelledError';
         this.type = 'payment_cancelled';
     }
 }

--- a/src/payment/errors/payment-method-declined-error.spec.ts
+++ b/src/payment/errors/payment-method-declined-error.spec.ts
@@ -1,0 +1,9 @@
+import PaymentMethodDeclinedError from './payment-method-declined-error';
+
+describe('PaymentMethodDeclinedError', () => {
+    it('returns error name', () => {
+        const error = new PaymentMethodDeclinedError();
+
+        expect(error.name).toEqual('PaymentMethodDeclinedError');
+    });
+});

--- a/src/payment/errors/payment-method-declined-error.ts
+++ b/src/payment/errors/payment-method-declined-error.ts
@@ -4,6 +4,7 @@ export default class PaymentMethodDeclinedError extends StandardError {
     constructor(message?: string) {
         super(message || 'The selected payment method was declined. Please select another payment method.');
 
+        this.name = 'PaymentMethodDeclinedError';
         this.type = 'payment_declined';
     }
 }

--- a/src/payment/errors/payment-method-invalid-error.spec.ts
+++ b/src/payment/errors/payment-method-invalid-error.spec.ts
@@ -1,0 +1,9 @@
+import PaymentMethodInvalidError from './payment-method-invalid-error';
+
+describe('PaymentMethodInvalidError', () => {
+    it('returns error name', () => {
+        const error = new PaymentMethodInvalidError();
+
+        expect(error.name).toEqual('PaymentMethodInvalidError');
+    });
+});

--- a/src/payment/errors/payment-method-invalid-error.ts
+++ b/src/payment/errors/payment-method-invalid-error.ts
@@ -6,6 +6,7 @@ export default class PaymentMethodInvalidError extends RequestError {
     constructor(response?: Response) {
         super(response, { message: 'There is a problem processing your payment. Please try again later.' });
 
+        this.name = 'PaymentMethodInvalidError';
         this.type = 'payment_method_invalid';
     }
 }

--- a/src/remote-checkout/errors/remote-checkout-synchronization-error.spec.ts
+++ b/src/remote-checkout/errors/remote-checkout-synchronization-error.spec.ts
@@ -1,0 +1,9 @@
+import RemoteCheckoutSynchronizationError from './remote-checkout-synchronization-error';
+
+describe('RemoteCheckoutSynchronizationError', () => {
+    it('returns error name', () => {
+        const error = new RemoteCheckoutSynchronizationError();
+
+        expect(error.name).toEqual('RemoteCheckoutSynchronizationError');
+    });
+});

--- a/src/remote-checkout/errors/remote-checkout-synchronization-error.ts
+++ b/src/remote-checkout/errors/remote-checkout-synchronization-error.ts
@@ -6,6 +6,7 @@ export default class RemoteCheckoutSynchronizationError extends StandardError {
     ) {
         super('Unable to synchronize your checkout details with a third party provider. Please try again later.');
 
+        this.name = 'RemoteCheckoutSynchronizationError';
         this.type = 'remote_checkout_synchronization';
     }
 }


### PR DESCRIPTION
## What?
* Add names to custom error objects

## Why?
* By default, the `name` property of `Error` instances is set to "Error" unless it is overriden (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name). Other types of native JS errors have their `name` property overriden so it reflects the name of their class. i.e.: the name of `TypeError` is set to "TypeError".
* We want our custom errors to have the same behaviour - to have `name` property matching the name of their class. We want this behaviour because most error logging services use the `name` property for grouping and filtering errors. For example, using the Sentry client, we can inspect the `type` property of exception events to perform filtering; such property is derived from the `name` property of errors captured in the application.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
