### PR TITLE
CHECKOUT-4254 Make sure changes to the public object don't affect the internal copies

### DIFF
--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -131,4 +131,15 @@ describe('CheckoutStoreSelector', () => {
         expect(field && field.options && field.options.items)
             .toEqual(getUnitedStates().subdivisions.map(({ code, name }) => ({ label: name, value: code })));
     });
+
+    it('changes to the public objects do not affect the private copy', () => {
+        const publicCheckout = selector.getCheckout();
+        const privateCheckout = internalSelectors.checkout.getCheckout();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        publicCheckout!.customer.email = 'should@notchange.com';
+
+        // tslint:disable-next-line:no-non-null-assertion
+        expect(privateCheckout!.customer.email).not.toEqual('should@notchange.com');
+    });
 });

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -2,6 +2,7 @@ import { Address } from '../address';
 import { BillingAddress, BillingAddressSelector } from '../billing';
 import { Cart, CartSelector } from '../cart';
 import { selector } from '../common/selector';
+import { clone } from '../common/utility';
 import { ConfigSelector } from '../config';
 import { StoreConfig } from '../config/config';
 import { Coupon, CouponSelector, GiftCertificate, GiftCertificateSelector } from '../coupon';
@@ -30,6 +31,7 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
  * checkout information, such as shipping and billing details.
  */
 @selector
+@clone
 export default class CheckoutStoreSelector {
     private _billingAddress: BillingAddressSelector;
     private _cart: CartSelector;

--- a/src/common/utility/clone-decorator.spec.ts
+++ b/src/common/utility/clone-decorator.spec.ts
@@ -1,0 +1,122 @@
+import { default as clone } from './clone-decorator';
+
+describe('cloneDecorator', () => {
+    describe('decorates whole classes', () => {
+        @clone
+        class Foo {
+            constructor(public obj: any) {}
+
+            getValue() {
+                return this.obj;
+            }
+        }
+
+        it('returns a cloned copy of the original object', () => {
+            const obj = { test: 123 };
+            const foo = new Foo(obj);
+
+            const result = foo.getValue();
+
+            expect(result).not.toBe(obj);
+            expect(result).toEqual(obj);
+        });
+
+        it('returns a deep cloned copy', () => {
+            const obj = { test: 123, deep: { clone: 456 } };
+            const foo = new Foo(obj);
+
+            const result = foo.getValue();
+            obj.deep.clone = 789;
+
+            expect(result.deep.clone).not.toEqual(obj.deep.clone);
+        });
+
+        it('returns a new cloned copy if the result of the method changes', () => {
+            const obj = { test: 123 };
+            const newObj = { new: 456 };
+            const foo = new Foo(obj);
+
+            const result = foo.getValue();
+            foo.obj = newObj;
+
+            const newResult = foo.getValue();
+
+            expect(newResult).not.toBe(newObj);
+            expect(newResult).toEqual(newObj);
+            expect(result).not.toEqual(newObj);
+        });
+
+        it('returns the same value if the object reference is the same', () => {
+            const obj = { test: 123 };
+            const foo = new Foo(obj);
+
+            const result = foo.getValue();
+            obj.test = 456;
+
+            const newResult = foo.getValue();
+
+            expect(result).toBe(newResult);
+            expect(result).not.toEqual({ test: 456 });
+        });
+    });
+
+    describe('decorates methods', () => {
+        // tslint:disable-next-line:max-classes-per-file
+        class Foo {
+            constructor(public obj: any) {}
+
+            @clone
+            getValue() {
+                return this.obj;
+            }
+        }
+
+        it('returns a cloned copy of the original object', () => {
+            const obj = { test: 123 };
+            const foo = new Foo(obj);
+
+            const result = foo.getValue();
+
+            expect(result).not.toBe(obj);
+            expect(result).toEqual(obj);
+        });
+
+        it('returns a deep cloned copy', () => {
+            const obj = { test: 123, deep: { clone: 456 } };
+            const foo = new Foo(obj);
+
+            const result = foo.getValue();
+            obj.deep.clone = 789;
+
+            expect(result.deep.clone).not.toEqual(obj.deep.clone);
+        });
+
+        it('returns a new cloned copy if the result of the method changes', () => {
+            const obj = { test: 123 };
+            const newObj = { new: 456 };
+            const foo = new Foo(obj);
+
+            const result = foo.getValue();
+            foo.obj = newObj;
+
+            const newResult = foo.getValue();
+
+            expect(newResult).not.toBe(newObj);
+            expect(newResult).toEqual(newObj);
+            expect(result).not.toEqual(newObj);
+        });
+
+        it('returns the same value if the object reference is the same', () => {
+            const obj = { test: 123 };
+            const foo = new Foo(obj);
+
+            const result = foo.getValue();
+            obj.test = 456;
+
+            const newResult = foo.getValue();
+
+            expect(result).toBe(newResult);
+            expect(result).not.toEqual({ test: 456 });
+        });
+    });
+});

--- a/src/common/utility/clone-decorator.ts
+++ b/src/common/utility/clone-decorator.ts
@@ -1,0 +1,68 @@
+import { cloneDeep, memoize } from 'lodash';
+
+export default function cloneDecorator<T extends Method>(target: object, key: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+export default function cloneDecorator<T extends Constructor<object>>(target: T): T;
+export default function cloneDecorator(target: any, key?: any, descriptor?: any): any {
+    if (!key || !descriptor) {
+        return cloneClassDecorator(target);
+    }
+
+    return cloneMethodDecorator(target, key, descriptor);
+}
+
+export function cloneClassDecorator<T extends Constructor<object>>(target: T): T {
+    const decoratedTarget = class extends target {};
+
+    Object.getOwnPropertyNames(target.prototype)
+        .forEach(key => {
+            const descriptor = Object.getOwnPropertyDescriptor(target.prototype, key);
+
+            if (!descriptor || key === 'constructor') {
+                return;
+            }
+
+            Object.defineProperty(
+                decoratedTarget.prototype,
+                key,
+                cloneMethodDecorator(target.prototype, key, descriptor)
+            );
+        });
+
+    return decoratedTarget;
+}
+
+export function cloneMethodDecorator<T extends Method>(target: object, key: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> {
+    if (typeof descriptor.value !== 'function') {
+        return descriptor;
+    }
+
+    let method = descriptor.value;
+    const memoizedCloneDeep = memoize(cloneDeep);
+
+    // Use WeakMap as the MapCache, this allows for better garbage collection
+    // There's a deprecated `clear` method in the lodash implementation
+    // of MapCache, hence the `any`
+    memoizedCloneDeep.cache = new WeakMap() as any;
+
+    return {
+        get() {
+            const value = ((...args: any[]) => {
+                const result = method.apply(this, args);
+
+                return result && typeof result === 'object'
+                    ? memoizedCloneDeep(result)
+                    : result;
+            }) as T;
+
+            Object.defineProperty(this, key, { ...descriptor, value });
+
+            return value;
+        },
+        set(value) {
+            method = value;
+        },
+    };
+}
+
+export type Constructor<T> = new (...args: any[]) => T;
+export type Method = (...args: any[]) => any;

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -1,5 +1,6 @@
 export { default as AmountTransformer } from './amount-transformer';
 export { default as bindDecorator } from './bind-decorator';
+export { default as clone } from './clone-decorator';
 export { default as createFreezeProxy, createFreezeProxies } from './create-freeze-proxy';
 export { default as CacheKeyResolver } from './cache-key-resolver';
 export { default as CancellablePromise } from './cancellable-promise';


### PR DESCRIPTION
## What?
- As per title

## Why?
- The internal state of the `checkout-sdk` should be shield from changes to the exposed objects.

## Testing / Proof
- Functional / Unit

Closes: #430 
Closes: #618 

@bigcommerce/checkout @bigcommerce/payments
