### PR TITLE
CHECKOUT-4201 Make FormField type easier to consume

### DIFF
--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -1,7 +1,6 @@
 import { find, reject } from 'lodash';
 
 import { FormField } from '../form';
-import { SystemFormField } from '../form/form-field';
 import { getFormFields } from '../form/form.mocks';
 import { getUnitedStates } from '../geography/countries.mock';
 import { getAustralia } from '../shipping/shipping-countries.mock';
@@ -116,7 +115,7 @@ describe('CheckoutStoreSelector', () => {
     it('returns shipping address fields', () => {
         const results = selector.getShippingAddressFields('AU');
         const predicate = ({ name }: FormField) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
-        const field = find(results, { name: 'stateOrProvinceCode' }) as SystemFormField;
+        const field = find(results, { name: 'stateOrProvinceCode' });
 
         expect(reject(results, predicate)).toEqual(reject(getFormFields(), predicate));
         expect(field && field.options && field.options.items)
@@ -126,7 +125,7 @@ describe('CheckoutStoreSelector', () => {
     it('returns billing address fields', () => {
         const results = selector.getBillingAddressFields('US');
         const predicate = ({ name }: FormField) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
-        const field = find(results, { name: 'stateOrProvinceCode' }) as SystemFormField;
+        const field = find(results, { name: 'stateOrProvinceCode' });
 
         expect(reject(results, predicate)).toEqual(reject(getFormFields(), predicate));
         expect(field && field.options && field.options.items)

--- a/src/form/form-field.ts
+++ b/src/form/form-field.ts
@@ -1,91 +1,40 @@
 import { AddressKey } from '../address';
 
-export default FormField;
+export type FormFieldFieldType =
+    'checkbox' |
+    'date' |
+    'text' |
+    'dropdown' |
+    'radio' |
+    'multiline';
 
-type FormField = SystemFormField | CustomFormField;
+export type FormFieldType =
+    'array' |
+    'date' |
+    'integer' |
+    'string';
 
-export enum FormFieldFieldType {
-    checkbox = 'checkbox',
-    date = 'date',
-    text = 'text',
-    dropdown = 'dropdown',
-    radio = 'radio',
-    multiline = 'multiline',
-}
-
-export enum FormFieldType {
-    array = 'array',
-    date = 'date',
-    number = 'integer',
-    string = 'string',
-}
-
-export interface BaseFormField {
-    name: string;
+export default interface FormField {
+    name: string | AddressKey;
     custom: boolean;
     id: string;
     label: string;
     required: boolean;
     default?: string;
     fieldType?: FormFieldFieldType;
-}
-
-export interface SystemFormField extends BaseFormField {
-    name: AddressKey;
-    custom: false;
-    maxLength?: number;
-    options?: FormFieldOptions;
-}
-
-export type CustomFormField = DateCustomFormField |
-    TextCustomFormField |
-    NumberCustomFormField |
-    MultilineCustomFormField |
-    ArrayCustomFormField;
-
-interface BaseCustomFormField extends BaseFormField {
-    custom: true;
     type?: FormFieldType;
-}
-
-export interface DateCustomFormField extends BaseCustomFormField {
-    min: number | string;
-    max: number | string;
-    fieldType: FormFieldFieldType.date;
-    type: FormFieldType.date;
-}
-
-export interface ArrayCustomFormField extends BaseCustomFormField {
-    fieldType: FormFieldFieldType.checkbox | FormFieldFieldType.radio | FormFieldFieldType.dropdown;
-    type: FormFieldType.array;
-    itemtype: 'string';
-    options: FormFieldOptions;
-}
-
-export interface TextCustomFormField extends BaseCustomFormField {
-    fieldType: FormFieldFieldType.text;
-    type: FormFieldType.string;
+    itemtype?: string;
     maxLength?: number;
     secret?: boolean;
-}
-
-export interface NumberCustomFormField extends BaseCustomFormField {
-    fieldType: FormFieldFieldType.text;
-    type: FormFieldType.number;
-    min?: number;
-    max?: number;
-    maxLength?: number;
-}
-
-export interface MultilineCustomFormField extends TextCustomFormField {
-    options: {
-        rows: number;
-    };
+    min?: string | number;
+    max?: string | number;
+    options?: FormFieldOptions;
 }
 
 export interface FormFieldOptions {
     helperLabel?: string;
-    items: FormFieldItem[];
+    items?: FormFieldItem[];
+    rows?: number;
 }
 
 export interface FormFieldItem {

--- a/src/form/form-selector.spec.ts
+++ b/src/form/form-selector.spec.ts
@@ -6,11 +6,9 @@ import { Country } from '../geography';
 import { getCountries } from '../geography/countries.mock';
 import { getShippingCountries } from '../shipping/shipping-countries.mock';
 
-import { SystemFormField } from './form-field';
 import FormSelector from './form-selector';
 import { getFormFields } from './form.mocks';
 
-// tslint:disable:no-unnecessary-type-assertion
 // tslint:disable:no-non-null-assertion
 
 describe('FormSelector', () => {
@@ -38,7 +36,7 @@ describe('FormSelector', () => {
 
         it('includes the countries as options for the country field', () => {
             const forms = formSelector.getShippingAddressFields(countries, '');
-            const country = find(forms, { name: 'countryCode' }) as SystemFormField;
+            const country = find(forms, { name: 'countryCode' });
 
             expect(country!.fieldType).toEqual('dropdown');
             expect(country!.options!.items).toEqual([
@@ -56,7 +54,7 @@ describe('FormSelector', () => {
 
         it('includes the provinces for the selected country', () => {
             const forms = formSelector.getShippingAddressFields(countries, 'AU');
-            const province = find(forms, { name: 'stateOrProvinceCode' }) as SystemFormField;
+            const province = find(forms, { name: 'stateOrProvinceCode' });
 
             expect(province!.required).toBe(true);
             expect(province!.fieldType).toEqual('dropdown');
@@ -106,7 +104,7 @@ describe('FormSelector', () => {
 
         it('includes the countries as options for the country field', () => {
             const forms = formSelector.getBillingAddressFields(countries, '');
-            const country = find(forms, { name: 'countryCode' }) as SystemFormField;
+            const country = find(forms, { name: 'countryCode' });
 
             expect(country!.fieldType).toBe('dropdown');
             expect(country!.options!.items).toEqual([
@@ -125,7 +123,7 @@ describe('FormSelector', () => {
 
         it('includes the provinces for the selected country', () => {
             const forms = formSelector.getBillingAddressFields(countries, 'AU');
-            const province = find(forms, { name: 'stateOrProvinceCode' }) as SystemFormField;
+            const province = find(forms, { name: 'stateOrProvinceCode' });
 
             expect(province!.required).toBe(true);
             expect(province!.fieldType).toBe('dropdown');

--- a/src/form/form-selector.ts
+++ b/src/form/form-selector.ts
@@ -4,7 +4,7 @@ import { selector } from '../common/selector';
 import { ConfigState } from '../config';
 import { Country } from '../geography';
 
-import FormField, { FormFieldFieldType, FormFieldType } from './form-field';
+import FormField from './form-field';
 
 @selector
 export default class FormSelector {
@@ -57,8 +57,8 @@ export default class FormSelector {
             ...field,
             options: { items },
             default: code,
-            type: FormFieldType.array,
-            fieldType: FormFieldFieldType.dropdown,
+            type: 'array',
+            fieldType: 'dropdown',
             itemtype: 'string',
         };
     }
@@ -83,8 +83,8 @@ export default class FormSelector {
             name: 'stateOrProvinceCode',
             options: { items },
             required: true,
-            type: FormFieldType.array,
-            fieldType: FormFieldFieldType.dropdown,
+            type: 'array',
+            fieldType: 'dropdown',
             itemtype: 'string',
         };
     }

--- a/src/form/form.mocks.ts
+++ b/src/form/form.mocks.ts
@@ -1,4 +1,4 @@
-import FormField, { FormFieldFieldType, FormFieldType } from './form-field';
+import FormField from './form-field';
 
 export function getFormFields(): FormField[] {
     return [{
@@ -75,8 +75,8 @@ export function getFormFields(): FormField[] {
         custom: true,
         label: 'picklist',
         required: false,
-        type: FormFieldType.array,
-        fieldType: FormFieldFieldType.dropdown,
+        type: 'array',
+        fieldType: 'dropdown',
         itemtype: 'string',
         options: {
             helperLabel: 'my pick list',


### PR DESCRIPTION
## What?
1. Unify `FormField` definition.
2. Use strings instead of enum

## Why?
1.  Recently we improved `FormField` type https://github.com/bigcommerce/checkout-sdk-js/pull/635. However those different types are hard to consume. It requires you need to do type checks in order to access different properties.
2. Enums force a new type, causing breaking changes / requiring refactoring. Also enums dont seem to get exported as expected (they are undefined).

## Testing / Proof
https://github.com/bigcommerce-labs/ng-checkout/pull/1311

@bigcommerce/checkout @bigcommerce/payments
