### PR TITLE
feat(payment): INT-1736 Add ReferenceId in the jwt to initialize the Cardinal client

### DIFF
--- a/src/payment/strategies/cybersource/cardinal-client.ts
+++ b/src/payment/strategies/cybersource/cardinal-client.ts
@@ -38,6 +38,7 @@ export interface CardinalOrderData {
 
 export default class CardinalClient {
     private _sdk?: Promise<CardinalSDK>;
+    private _clientToken?: string;
 
     constructor(
         private _scriptLoader: CardinalScriptLoader
@@ -52,11 +53,14 @@ export default class CardinalClient {
     }
 
     configure(clientToken: string): Promise<void> {
+        if (this._clientToken) { return Promise.resolve(); }
+
         return this._getClientSDK()
             .then(client => new Promise<void>((resolve, reject) => {
                 client.on(CardinalEventType.SetupCompleted, () => {
                     client.off(CardinalEventType.SetupCompleted);
                     client.off(CardinalEventType.Validated);
+                    this._clientToken = clientToken;
 
                     resolve();
                 });
@@ -90,29 +94,25 @@ export default class CardinalClient {
             });
     }
 
+    getClientToken(): string {
+        if (!this._clientToken) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._clientToken;
+    }
+
     getThreeDSecureData(threeDSecureData: ThreeDsResult, orderData: CardinalOrderData): Promise<ThreeDSecureToken> {
         return this._getClientSDK()
             .then(client => {
                 return new Promise<ThreeDSecureToken>((resolve, reject) => {
                     client.on(CardinalEventType.Validated, (data: CardinalValidatedData, jwt: string) => {
                         client.off(CardinalEventType.Validated);
-                        switch (data.ActionCode) {
-                            case CardinalValidatedAction.Success:
-                                resolve({ token: jwt });
-                                break;
-                            case CardinalValidatedAction.NoAction:
-                                if (data.ErrorNumber > 0) {
-                                    reject(new StandardError(data.ErrorDescription));
-                                } else {
-                                    resolve({ token: jwt });
-                                }
-                                break;
-                            case CardinalValidatedAction.Failure:
-                                reject(new StandardError('User failed authentication or an error was encountered while processing the transaction'));
-                                break;
-                            case CardinalValidatedAction.Error:
-                                reject(new StandardError(data.ErrorDescription));
+                        if (!jwt) {
+                            reject(new StandardError('User failed authentication or an error was encountered while processing the transaction.'));
                         }
+
+                        resolve({ token: jwt });
                     });
 
                     const continueObject = {

--- a/src/payment/strategies/cybersource/cardinal.mock.ts
+++ b/src/payment/strategies/cybersource/cardinal.mock.ts
@@ -40,9 +40,8 @@ export function getCardinalBinProcessResponse(status: boolean): CardinalBinProce
     };
 }
 
-export function getCardinalValidatedData(actionCode: CardinalValidatedAction, status: boolean, errorNumber?: number): CardinalValidatedData {
+export function getCardinalValidatedData(status: boolean, errorNumber?: number): CardinalValidatedData {
     return {
-        ActionCode: actionCode,
         ErrorDescription: '',
         ErrorNumber: errorNumber ? errorNumber : 0,
         Validated: status,
@@ -51,6 +50,13 @@ export function getCardinalValidatedData(actionCode: CardinalValidatedAction, st
             Type: CardinalPaymentType.CCA,
         },
     };
+}
+
+export function getCardinalValidatedDataWithActionCode(actionCode: CardinalValidatedAction, status: boolean, errorNumber?: number): CardinalValidatedData {
+    const data = getCardinalValidatedData(status, errorNumber);
+    data.ActionCode = actionCode;
+
+    return data;
 }
 
 export function getCardinalThreeDSResult(): ThreeDsResult {

--- a/src/payment/strategies/cybersource/cardinal.ts
+++ b/src/payment/strategies/cybersource/cardinal.ts
@@ -66,7 +66,7 @@ export interface CardinalConfirmTypeData {
 }
 
 export interface CardinalValidatedData {
-    ActionCode: CardinalValidatedAction;
+    ActionCode?: CardinalValidatedAction;
     ErrorDescription: string;
     ErrorNumber: number;
     Validated: boolean;

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
@@ -227,6 +227,7 @@ describe('CyberSourcePaymentStrategy', () => {
 
                 jest.spyOn(cardinalClient, 'configure').mockReturnValue(Promise.resolve());
                 jest.spyOn(cardinalClient, 'runBinProcess').mockReturnValue(Promise.resolve());
+                jest.spyOn(cardinalClient, 'getClientToken').mockReturnValue('1234567890');
 
                 await strategy.initialize({ methodId: paymentMethodMock.id });
             });

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
@@ -88,6 +88,14 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
         return this._cardinalClient.configure(clientToken)
             .then(() => this._cardinalClient.runBinProcess(this._getBinNumber(paymentData)))
             .then(() => {
+                payment = {
+                    ...payment,
+                    paymentData: {
+                        ...paymentData,
+                        threeDSecure: { token: this._cardinalClient.getClientToken() },
+                    },
+                };
+
                 return this._placeOrder(order, payment, options)
                     .catch(error => {
                         if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'enrolled_card' })) {


### PR DESCRIPTION
[INT-1736](https://jira.bigcommerce.com/browse/INT-1736)

## What?
Add Reference Id in the jwt token used to initialize the Cardinal client and use the same Reference Id in the check_enrollment request to CyberSource. Also prevent that the Cardinal client is initialized multiple time with different tokens. According to the Cardinal documentation the `Cardinal.setup` method must only be called once in the page.

For CyberSource's Hybrid Flow, the response received from Cardinal after the User is Authenticated with 3DS will not have an "ActionCode" value. So we need to update the logic to handle this response so that "ActionCode" is NOT the primary value to verify the status of the transaction.

## Why?
Cardinal requires a reference Id value to be included in the JWT token when initializing the cardinal client. This value is needed for device data collection. For 3DS2.0 the same Reference Id value needs to match with the value sent in the check_enrollment request to CyberSource.

## Testing / Proof
![CyberSourceRefrenceId 2019-07-18 10_52_50](https://user-images.githubusercontent.com/36491284/61483566-afa18c80-a962-11e9-9225-29b9a248e865.gif)

![image](https://user-images.githubusercontent.com/36491284/61483616-cea01e80-a962-11e9-9da1-bbc80aff04be.png)

**Sibling PR**
[BigPay](https://github.com/bigcommerce/bigpay/pull/1760) must be deployed first

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
