### PR TITLE
CHECKOUT-4272: Bind methods to object instances to allow destructing

### DIFF
--- a/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -115,4 +115,14 @@ describe('CheckoutButtonInitializer', () => {
             statuses: expect.any(CheckoutButtonStatusSelector),
         });
     });
+
+    it('has methods that can be destructed', () => {
+        const { initializeButton } = initializer;
+
+        expect(() => initializeButton({
+            methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL,
+            containerId: 'checkout-button',
+        }))
+            .not.toThrow(TypeError);
+    });
 });

--- a/src/checkout-buttons/checkout-button-initializer.ts
+++ b/src/checkout-buttons/checkout-button-initializer.ts
@@ -1,11 +1,13 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../checkout';
 import { isElementId, setUniqueElementId } from '../common/dom';
+import { bindDecorator as bind } from '../common/utility';
 
 import { CheckoutButtonInitializeOptions, CheckoutButtonOptions } from './checkout-button-options';
 import CheckoutButtonSelectors from './checkout-button-selectors';
 import CheckoutButtonStrategyActionCreator from './checkout-button-strategy-action-creator';
 import createCheckoutButtonSelectors from './create-checkout-button-selectors';
 
+@bind
 export default class CheckoutButtonInitializer {
     private _state: CheckoutButtonSelectors;
 

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -249,6 +249,16 @@ describe('CheckoutService', () => {
             spamProtectionActionCreator
         );
     });
+
+    it('has methods that can be destructed', () => {
+        const { loadCheckout, loadOrder } = checkoutService;
+
+        expect(() => loadCheckout())
+            .not.toThrow(TypeError);
+        expect(() => loadOrder(123))
+            .not.toThrow(TypeError);
+    });
+
     describe('#getState()', () => {
         it('returns state', () => {
             expect(checkoutService.getState()).toEqual(expect.objectContaining({

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -5,6 +5,7 @@ import { AddressRequestBody } from '../address';
 import { BillingAddressActionCreator, BillingAddressRequestBody } from '../billing';
 import { ErrorActionCreator, ErrorMessageTransformer } from '../common/error';
 import { RequestOptions } from '../common/http-request';
+import { bindDecorator as bind } from '../common/utility';
 import { ConfigActionCreator } from '../config';
 import { CouponActionCreator, GiftCertificateActionCreator } from '../coupon';
 import { CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, CustomerStrategyActionCreator, GuestCredentials } from '../customer';
@@ -32,6 +33,7 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
  * checkout, such as shipping and billing information. It can also be used to
  * retrieve the current checkout state and subscribe to its changes.
  */
+@bind
 export default class CheckoutService {
     private _state: CheckoutSelectors;
     private _errorTransformer: ErrorMessageTransformer;

--- a/src/currency/currency-service.ts
+++ b/src/currency/currency-service.ts
@@ -1,3 +1,4 @@
+import { bindDecorator as bind } from '../common/utility';
 import { StoreConfig } from '../config';
 
 import CurrencyFormatter from './currency-formatter';
@@ -5,6 +6,7 @@ import CurrencyFormatter from './currency-formatter';
 /**
  * Responsible for formatting and converting currencies.
  */
+@bind
 export default class CurrencyService {
     private _customerFormatter: CurrencyFormatter;
     private _storeFormatter: CurrencyFormatter;

--- a/src/embedded-checkout/embedded-checkout.spec.ts
+++ b/src/embedded-checkout/embedded-checkout.spec.ts
@@ -309,6 +309,13 @@ describe('EmbeddedCheckout', () => {
         }
     });
 
+    it('has methods that can be destructed', () => {
+        const { attach } = embeddedCheckout;
+
+        expect(() => attach())
+            .not.toThrow(TypeError);
+    });
+
     describe('if login URL is passed', () => {
         beforeEach(() => {
             options = {

--- a/src/embedded-checkout/embedded-checkout.ts
+++ b/src/embedded-checkout/embedded-checkout.ts
@@ -3,6 +3,7 @@ import { IFrameComponent } from 'iframe-resizer';
 
 import { BrowserStorage } from '../common/storage';
 import { parseUrl } from '../common/url';
+import { bindDecorator as bind } from '../common/utility';
 
 import EmbeddedCheckoutError from './embedded-checkout-error';
 import { EmbeddedCheckoutEventMap, EmbeddedCheckoutEventType } from './embedded-checkout-events';
@@ -17,6 +18,7 @@ import ResizableIframeCreator from './resizable-iframe-creator';
 const CAN_RETRY_ALLOW_COOKIE = 'canRetryAllowCookie';
 const IS_COOKIE_ALLOWED_KEY = 'isCookieAllowed';
 
+@bind
 export default class EmbeddedCheckout {
     private _iframe?: IFrameComponent;
     private _isAttached: boolean;

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
@@ -126,4 +126,11 @@ describe('EmbeddedCheckoutMessenger', () => {
             payload: { contentId: 'foobar' },
         });
     });
+
+    it('has methods that can be destructed', () => {
+        const { postComplete } = messenger;
+
+        expect(() => postComplete())
+            .not.toThrow(TypeError);
+    });
 });

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.ts
@@ -1,4 +1,5 @@
 import { isCustomError, CustomError } from '../../common/error/errors';
+import { bindDecorator as bind } from '../../common/utility';
 import EmbeddedCheckoutError from '../embedded-checkout-error';
 import {
     EmbeddedCheckoutCompleteEvent,
@@ -19,6 +20,7 @@ import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
 import { EmbeddedContentEventMap, EmbeddedContentEventType } from './embedded-content-events';
 import EmbeddedContentOptions from './embedded-content-options';
 
+@bind
 export default class IframeEmbeddedCheckoutMessenger implements EmbeddedCheckoutMessenger {
     /**
      * @internal

--- a/src/embedded-checkout/iframe-content/noop-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/noop-embedded-checkout-messenger.ts
@@ -1,5 +1,8 @@
+import { bindDecorator as bind } from '../../common/utility';
+
 import EmbeddedCheckoutMessenger from './embedded-checkout-messenger';
 
+@bind
 export default class NoopEmbeddedCheckoutMessenger implements EmbeddedCheckoutMessenger {
     postComplete(): void {}
 

--- a/src/locale/language-service.spec.ts
+++ b/src/locale/language-service.spec.ts
@@ -34,6 +34,13 @@ describe('LanguageService', () => {
         langService = new LanguageService(config, logger);
     });
 
+    it('has methods that can be destructed', () => {
+        const { translate } = langService;
+
+        expect(() => translate('test.continue_as_guest_action'))
+            .not.toThrow(TypeError);
+    });
+
     describe('#translate()', () => {
         it('returns translated strings', () => {
             expect(langService.translate('test.continue_as_guest_action')).toEqual('Continue as guest');

--- a/src/locale/language-service.ts
+++ b/src/locale/language-service.ts
@@ -2,6 +2,7 @@ import { isObject, union } from 'lodash';
 import * as MessageFormat from 'messageformat';
 
 import Logger from '../common/log/logger';
+import { bindDecorator as bind } from '../common/utility';
 
 import LanguageConfig, { Locales, Translations } from './language-config';
 
@@ -17,6 +18,7 @@ const KEY_PREFIX = 'optimized_checkout';
  * The language strings provided to the object should follow [ICU
  * MessageFormat](http://userguide.icu-project.org/formatparse/messages) syntax.
  */
+@bind
 export default class LanguageService {
     private _locale: string;
     private _locales: Locales;


### PR DESCRIPTION
## What?
Bind methods to object instances to allow destructing.

## Why?
So you can destruct the objects, get hold of their methods and call them as if they are standalone functions. i.e.:
```ts
const { loadCheckout } = service;

loadCheckout();
```
It would be useful in cases where I want to pass the functions from one component into another component.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/payments
