### PR TITLE
fix(payment): CHECKOUT-4273 Fix PayPal Express modal does not load when recaptcha is enabled

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -2,7 +2,7 @@ import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender, createTimeout } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { map, merge } from 'lodash';
-import { of, Observable } from 'rxjs';
+import { from, of, Observable } from 'rxjs';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { getBillingAddress } from '../billing/billing-addresses.mock';
@@ -23,8 +23,7 @@ import { getCountriesResponseBody } from '../geography/countries.mock';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { getCompleteOrderResponseBody, getOrderRequestBody } from '../order/internal-orders.mock';
 import { getOrder } from '../order/orders.mock';
-import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionOptions } from '../order/spam-protection';
-import { SpamProtectionActionType } from '../order/spam-protection/spam-protection-actions';
+import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionActionType, SpamProtectionOptions } from '../order/spam-protection';
 import {
     createPaymentClient,
     PaymentMethodActionCreator,
@@ -432,6 +431,12 @@ describe('CheckoutService', () => {
             jest.spyOn(noPaymentDataRequiredPaymentStrategy, 'execute').mockResolvedValue(store.getState());
 
             paymentStrategyRegistry.get = jest.fn(() => noPaymentDataRequiredPaymentStrategy);
+
+            jest.spyOn(orderActionCreator, 'executeSpamProtection')
+                .mockReturnValue(() => from([
+                    createAction(SpamProtectionActionType.ExecuteRequested),
+                    createAction(SpamProtectionActionType.Completed, { token: 'spamProtectionToken' }),
+                ]));
         });
 
         it('finds payment strategy', async () => {

--- a/src/order/order-reducer.spec.ts
+++ b/src/order/order-reducer.spec.ts
@@ -9,7 +9,7 @@ import { FinalizeOrderAction, LoadOrderAction, LoadOrderPaymentsAction, OrderAct
 import orderReducer from './order-reducer';
 import OrderState from './order-state';
 import { getOrder } from './orders.mock';
-import { SpamProtectionAction, SpamProtectionActionType } from './spam-protection/spam-protection-actions';
+import { SpamProtectionAction, SpamProtectionActionType } from './spam-protection';
 
 describe('orderReducer()', () => {
     let initialState: OrderState;

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -5,7 +5,7 @@ import { clearErrorReducer } from '../common/error';
 
 import { OrderAction, OrderActionType } from './order-actions';
 import OrderState, { OrderDataState, OrderErrorsState, OrderMetaState, OrderStatusesState } from './order-state';
-import { SpamProtectionAction, SpamProtectionActionType } from './spam-protection/spam-protection-actions';
+import { SpamProtectionAction, SpamProtectionActionType } from './spam-protection';
 
 const DEFAULT_STATE: OrderState = {
     errors: {},

--- a/src/order/spam-protection/index.ts
+++ b/src/order/spam-protection/index.ts
@@ -1,3 +1,4 @@
+export * from './spam-protection-actions';
 export * from './spam-protection-options';
 
 export { default as createSpamProtection } from './create-spam-protection';


### PR DESCRIPTION
## What?
As per above.

## Why?
Paypal Express was initializing the modal before recaptcha is completed, and blocked the recaptcha challenge modal.

## Testing / Proof
Added unit tests.

![Screen Shot 2019-07-29 at 3 25 02 pm](https://user-images.githubusercontent.com/22089936/62023661-4567d200-b215-11e9-83e7-89b9e9554bff.png)


@bigcommerce/checkout @bigcommerce/payments
