### PR TITLE
CHECKOUT-4272: Add dependencies needed for refactoring selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,6 +1213,11 @@
         "reselect": "*"
       }
     },
+    "@types/shallowequal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/shallowequal/-/shallowequal-1.1.1.tgz",
+      "integrity": "sha512-Lhni3aX80zbpdxRuWhnuYPm8j8UQaa571lHP/xI4W+7BAFhSIhRReXnqjEgT/XzPoXZTJkCqstFMJ8CZTK6IlQ=="
+    },
     "@types/shelljs": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.5.tgz",
@@ -10214,6 +10219,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1205,6 +1205,14 @@
       "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-5.1.0.tgz",
       "integrity": "sha512-9/sJK+T04pNq7uwReR0CLxqXj1dhxiTapZ1tIxA0trEsT6FRS0bz09YMcMb7tsVBTm4RJ0NEBYGsAjoEmqoFXg=="
     },
+    "@types/reselect": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/reselect/-/reselect-2.2.0.tgz",
+      "integrity": "sha1-xmcgbP3DgZDh03m6vgiGWyKIV18=",
+      "requires": {
+        "reselect": "*"
+      }
+    },
     "@types/shelljs": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.5.tgz",
@@ -9657,6 +9665,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "reserved-words": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/iframe-resizer": "^3.5.6",
     "@types/lodash": "^4.14.92",
     "@types/reselect": "^2.2.0",
+    "@types/shallowequal": "^1.1.1",
     "core-js": "^3.1.2",
     "iframe-resizer": "^3.6.2",
     "local-storage-fallback": "^4.1.1",
@@ -57,6 +58,7 @@
     "messageformat": "2.1.0",
     "reselect": "^4.0.0",
     "rxjs": "^6.3.3",
+    "shallowequal": "^1.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,11 +49,13 @@
     "@bigcommerce/script-loader": "^0.1.6",
     "@types/iframe-resizer": "^3.5.6",
     "@types/lodash": "^4.14.92",
+    "@types/reselect": "^2.2.0",
     "core-js": "^3.1.2",
     "iframe-resizer": "^3.6.2",
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.11",
     "messageformat": "2.1.0",
+    "reselect": "^4.0.0",
     "rxjs": "^6.3.3",
     "tslib": "^1.8.0"
   },

--- a/src/common/selector/create-selector.spec.ts
+++ b/src/common/selector/create-selector.spec.ts
@@ -1,0 +1,27 @@
+import createSelector from './create-selector';
+
+describe('createSelector()', () => {
+    interface TestState {
+        messages: string[];
+    }
+
+    it('creates selector that returns memorized function if combiner returns function', () => {
+        const selector = createSelector(
+            (state: TestState) => state.messages[0],
+            message => (anotherMessage: string) => ({ message, anotherMessage })
+        );
+
+        const resultFn = selector({ messages: ['a', 'b'] });
+        const resultFn2 = selector({ messages: ['a', 'b'] });
+
+        expect(resultFn('hello'))
+            .toEqual({ message: 'a', anotherMessage: 'hello' });
+        expect(resultFn('hello'))
+            .toBe(resultFn2('hello'));
+
+        expect(resultFn2('bye'))
+            .toEqual({ message: 'a', anotherMessage: 'bye' });
+        expect(resultFn2('bye'))
+            .not.toBe(resultFn('hello'));
+    });
+});

--- a/src/common/selector/create-selector.ts
+++ b/src/common/selector/create-selector.ts
@@ -1,0 +1,10 @@
+import { createSelector as defaultSelectorCreator } from 'reselect';
+
+import withMemoizedCombiner from './with-memoized-combiner';
+
+/**
+ * This is a decorated version of Reselect's default `createSelector` function.
+ * If the return value of the combiner function is a function, it will create a
+ * memorized version of that function and return it instead.
+ */
+export default withMemoizedCombiner(defaultSelectorCreator);

--- a/src/common/selector/create-shallow-equal-selector.spec.ts
+++ b/src/common/selector/create-shallow-equal-selector.spec.ts
@@ -1,0 +1,60 @@
+import createShallowEqualSelector from './create-shallow-equal-selector';
+
+describe('createShallowEqualSelector()', () => {
+    interface TestState {
+        items: Array<{ id: number }>;
+        messages: string[];
+    }
+
+    it('creates selector that does shallow comparison instead of strict comparison', () => {
+        const combiner = jest.fn((messages: string[]) => messages.join(', '));
+        const selector = createShallowEqualSelector(
+            (state: TestState) => state.messages,
+            combiner
+        );
+
+        const result = selector({ messages: ['a', 'b'], items: [] });
+        const result2 = selector({ messages: ['a', 'b'], items: [] });
+
+        expect(result)
+            .toEqual('a, b');
+        expect(result2)
+            .toEqual('a, b');
+        expect(combiner)
+            .toHaveBeenCalledTimes(1);
+
+        const result3 = selector({ messages: ['b', 'c'], items: [] });
+
+        expect(result3)
+            .toEqual('b, c');
+        expect(combiner)
+            .toHaveBeenCalledTimes(2);
+    });
+
+    it('creates selector that does shallow comparison instead of deep comparison', () => {
+        const combiner = jest.fn((items: TestState['items']) => items.map(item => item.id).join(', '));
+        const selector = createShallowEqualSelector(
+            (state: TestState) => state.items,
+            combiner
+        );
+
+        const item = { id: 1 };
+        const item2 = { id: 2 };
+        const result = selector({ items: [item, item2], messages: [] });
+        const result2 = selector({ items: [item, item2], messages: [] });
+
+        expect(result)
+            .toEqual('1, 2');
+        expect(result2)
+            .toEqual('1, 2');
+        expect(combiner)
+            .toHaveBeenCalledTimes(1);
+
+        const result3 = selector({ items: [{ ...item }, { ...item2 }], messages: [] });
+
+        expect(result3)
+            .toEqual('1, 2');
+        expect(combiner)
+            .toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/common/selector/create-shallow-equal-selector.ts
+++ b/src/common/selector/create-shallow-equal-selector.ts
@@ -1,9 +1,11 @@
 import { createSelectorCreator, defaultMemoize } from 'reselect';
 import * as shallowEqual from 'shallowequal';
 
+import withMemoizedCombiner from './with-memoized-combiner';
+
 const createShallowEqualSelector = createSelectorCreator(
     defaultMemoize,
     (a: any, b: any) => shallowEqual(a, b)
 );
 
-export default createShallowEqualSelector;
+export default withMemoizedCombiner(createShallowEqualSelector);

--- a/src/common/selector/create-shallow-equal-selector.ts
+++ b/src/common/selector/create-shallow-equal-selector.ts
@@ -1,0 +1,9 @@
+import { createSelectorCreator, defaultMemoize } from 'reselect';
+import * as shallowEqual from 'shallowequal';
+
+const createShallowEqualSelector = createSelectorCreator(
+    defaultMemoize,
+    (a: any, b: any) => shallowEqual(a, b)
+);
+
+export default createShallowEqualSelector;

--- a/src/common/selector/index.ts
+++ b/src/common/selector/index.ts
@@ -1,3 +1,4 @@
 export { default as selectorDecorator } from './selector-decorator';
 export { default as selector } from './selector-decorator';
+export { default as createSelector } from './create-selector';
 export { default as createShallowEqualSelector } from './create-shallow-equal-selector';

--- a/src/common/selector/index.ts
+++ b/src/common/selector/index.ts
@@ -1,2 +1,3 @@
 export { default as selectorDecorator } from './selector-decorator';
 export { default as selector } from './selector-decorator';
+export { default as createShallowEqualSelector } from './create-shallow-equal-selector';

--- a/src/common/selector/with-memoized-combiner.spec.ts
+++ b/src/common/selector/with-memoized-combiner.spec.ts
@@ -1,0 +1,29 @@
+import { createSelector } from 'reselect';
+
+import withMemoizedCombiner from './with-memoized-combiner';
+
+describe('createSelector()', () => {
+    interface TestState {
+        messages: string[];
+    }
+
+    it('decorates selector creator to return partially applied memoized combiner when selector is called', () => {
+        const selector = withMemoizedCombiner(createSelector)(
+            (state: TestState) => state.messages[0],
+            message => (anotherMessage: string) => ({ message, anotherMessage })
+        );
+
+        const resultFn = selector({ messages: ['a', 'b'] });
+        const resultFn2 = selector({ messages: ['a', 'b'] });
+
+        expect(resultFn('hello'))
+            .toEqual({ message: 'a', anotherMessage: 'hello' });
+        expect(resultFn('hello'))
+            .toBe(resultFn2('hello'));
+
+        expect(resultFn2('bye'))
+            .toEqual({ message: 'a', anotherMessage: 'bye' });
+        expect(resultFn2('bye'))
+            .not.toBe(resultFn('hello'));
+    });
+});

--- a/src/common/selector/with-memoized-combiner.ts
+++ b/src/common/selector/with-memoized-combiner.ts
@@ -1,0 +1,30 @@
+import { createSelector as defaultSelectorCreator } from 'reselect';
+
+import memoize from '../utility/memoize';
+
+/**
+ * Decorate selector creators with the ability to memoize the return value of
+ * their combiner if it is a function (which effectively works as a partially
+ * applied combiner).
+ */
+export default function withMemoizedCombiner<T extends typeof defaultSelectorCreator>(
+    creator: T
+): T {
+    return ((...args: any[]) => {
+        const combiner = args.pop();
+
+        // Reselect's default `createSelector` has many overloads. To avoid having
+        // to redefine all of them, we're using `any` to bypass the typechecker.
+        return (creator as any)(...args, (...combinerArgs: any[]) => {
+            // Although there are many overloads, all of them have the last argument
+            // as the combiner.
+            const result = combiner(...combinerArgs);
+
+            if (typeof result === 'function') {
+                return memoize(combiner(...combinerArgs));
+            }
+
+            return result;
+        });
+    }) as T;
+}

--- a/src/common/utility/cache-key-maps.ts
+++ b/src/common/utility/cache-key-maps.ts
@@ -1,0 +1,24 @@
+export interface RootCacheKeyMap {
+    maps: ChildCacheKeyMap[];
+}
+
+export interface IntermediateCacheKeyMap {
+    maps: ChildCacheKeyMap[];
+    parentMap: RootCacheKeyMap | IntermediateCacheKeyMap;
+    usedCount: number;
+    value: any;
+}
+
+export interface TerminalCacheKeyMap extends IntermediateCacheKeyMap {
+    cacheKey: string;
+}
+
+export type ChildCacheKeyMap = IntermediateCacheKeyMap | TerminalCacheKeyMap;
+
+export function isTerminalCacheKeyMap(map: ChildCacheKeyMap): map is TerminalCacheKeyMap {
+    return map.hasOwnProperty('cacheKey');
+}
+
+export function isRootCacheKeyMap(map: RootCacheKeyMap | ChildCacheKeyMap): map is RootCacheKeyMap {
+    return map.hasOwnProperty('parentMap');
+}

--- a/src/common/utility/cache-key-resolver.spec.ts
+++ b/src/common/utility/cache-key-resolver.spec.ts
@@ -38,6 +38,67 @@ describe('CacheKeyResolver', () => {
         expect(resolver.getKey(personB, personA, personC)).toEqual('3');
     });
 
+    it('works with functions', () => {
+        const resolver = new CacheKeyResolver();
+        const functionA = () => 'a';
+        const functionB = () => 'b';
+
+        expect(resolver.getKey('foobar', functionA)).toEqual('1');
+        expect(resolver.getKey('foobar', functionB)).toEqual('2');
+        expect(resolver.getKey('foobar', functionA)).toEqual('1');
+        expect(resolver.getKey('foobar', functionB)).toEqual('2');
+    });
+
+    it('works with unserializable objects with cyclical reference', () => {
+        const resolver = new CacheKeyResolver();
+        const objectB: any = { child: undefined };
+        const objectA: any = { child: objectB };
+
+        objectB.child = objectA;
+
+        expect(resolver.getKey(objectA, objectB)).toEqual('1');
+        expect(resolver.getKey(objectA, objectB)).toEqual('1');
+    });
+
+    it('returns same key if objects are shallowly equivalent', () => {
+        const resolver = new CacheKeyResolver();
+        const objectA = { id: 1 };
+        const objectB = { id: 1 };
+
+        expect(resolver.getKey('foobar', objectA)).toEqual(resolver.getKey('foobar', objectB));
+    });
+
+    it('returns different cache key for least recently used set of arguments', () => {
+        const resolver = new CacheKeyResolver({ maxSize: 2 });
+
+        expect(resolver.getKey('hello', 'world')).toEqual('1');
+        // This will return the cache key
+        expect(resolver.getKey('hello', 'world')).toEqual('1');
+        expect(resolver.getKey('hello', 'good')).toEqual('2');
+        expect(resolver.getKey('bad', 'guys')).toEqual('3');
+        // This will return a new cache key because the set of arguments is
+        // least recently used and the number of cache keys already exceed the
+        // maximum size
+        expect(resolver.getKey('hello', 'world')).toEqual('4');
+    });
+
+    it('only expires cache key if number of unique calls exceeds limit', () => {
+        const resolver = new CacheKeyResolver({ maxSize: 2 });
+
+        expect(resolver.getKey('hello', 'world')).toEqual('1');
+        expect(resolver.getKey('hello', 'world')).toEqual('1');
+        // The previous call should not expire the key because it is called with
+        // the same set of arguments
+        expect(resolver.getKey('hello', 'world')).toEqual('1');
+
+        expect(resolver.getKey('foo', 'bar')).toEqual('2');
+        expect(resolver.getKey('hello', 'bye')).toEqual('3');
+
+        // This call should return a new key because the previous two calls are
+        // made with different sets of arguments
+        expect(resolver.getKey('hello', 'world')).toEqual('4');
+    });
+
     it('returns cache key used count', () => {
         const resolver = new CacheKeyResolver();
 

--- a/src/common/utility/cache-key-resolver.ts
+++ b/src/common/utility/cache-key-resolver.ts
@@ -1,19 +1,51 @@
-import isEqual from './is-equal';
+import { noop } from 'lodash';
+import * as shallowEqual from 'shallowequal';
+
+import { isRootCacheKeyMap, isTerminalCacheKeyMap, ChildCacheKeyMap, IntermediateCacheKeyMap, RootCacheKeyMap, TerminalCacheKeyMap } from './cache-key-maps';
+
+export interface CacheKeyResolverOptions {
+    maxSize?: number;
+    onExpire?(key: string): void;
+    isEqual?(valueA: any, valueB: any): boolean;
+}
+
+interface ResolveResult {
+    index: number;
+    parentMap: RootCacheKeyMap | IntermediateCacheKeyMap;
+    map?: TerminalCacheKeyMap;
+}
 
 export default class CacheKeyResolver {
     private _lastId = 0;
-    private _maps: CacheKeyMap[] = [];
+    private _map: RootCacheKeyMap = { maps: [] };
+    private _usedMaps: TerminalCacheKeyMap[] = [];
+    private _options: Required<CacheKeyResolverOptions>;
+
+    constructor(options?: CacheKeyResolverOptions) {
+        this._options = {
+            maxSize: 0,
+            isEqual: shallowEqual,
+            onExpire: noop,
+            ...options,
+        };
+    }
 
     getKey(...args: any[]): string {
-        const { index, map, parentMaps } = this._resolveMap(...args);
+        const result = this._resolveMap(...args);
+        const { index, parentMap } = result;
+        let { map } = result;
 
         if (map && map.cacheKey) {
             map.usedCount++;
-
-            return map.cacheKey;
+        } else {
+            map = this._generateMap(parentMap, args.slice(index));
         }
 
-        return this._generateKey(parentMaps, args.slice(index));
+        // Keep track of the least used map so we can remove it if the size of
+        // the stack exceeds the maximum size.
+        this._removeLeastUsedMap(map);
+
+        return map.cacheKey;
     }
 
     getUsedCount(...args: any[]): number {
@@ -24,22 +56,34 @@ export default class CacheKeyResolver {
 
     private _resolveMap(...args: any[]): ResolveResult {
         let index = 0;
-        let parentMaps = this._maps;
+        let parentMap = this._map;
 
-        while (parentMaps.length) {
+        // Traverse the tree to find the linked list of maps that match the
+        // arguments of the call. Each intermediate or terminal map contains a
+        // value that could be used to match with the arguments. The last map in
+        // the list (the terminal) should contain a cache key. If it can does
+        // not exist, we will return a falsy value so that the caller could
+        // handle and generate a new cache key.
+        while (parentMap.maps.length) {
             let isMatched = false;
 
-            for (const map of parentMaps) {
-                if (!isEqual(map.value, args[index])) {
+            for (let mapIndex = 0; mapIndex < parentMap.maps.length; mapIndex++) {
+                const map = parentMap.maps[mapIndex];
+
+                if (!this._options.isEqual(map.value, args[index])) {
                     continue;
                 }
 
-                if ((args.length === 0 || index === args.length - 1) && map.cacheKey) {
-                    return { index, map, parentMaps };
+                // Move the most recently used map to the top of the stack for
+                // quicker access
+                parentMap.maps.unshift(...parentMap.maps.splice(mapIndex, 1));
+
+                if ((args.length === 0 || index === args.length - 1) && isTerminalCacheKeyMap(map)) {
+                    return { index, map, parentMap };
                 }
 
                 isMatched = true;
-                parentMaps = map.maps;
+                parentMap = map;
                 index++;
 
                 break;
@@ -50,42 +94,76 @@ export default class CacheKeyResolver {
             }
         }
 
-        return { index, parentMaps };
+        return { index, parentMap };
     }
 
-    private _generateKey(maps: CacheKeyMap[], args: any[]): string {
+    private _generateMap(parent: RootCacheKeyMap | IntermediateCacheKeyMap, args: any[]): TerminalCacheKeyMap {
         let index = 0;
-        let parentMaps = maps;
-        let map!: CacheKeyMap;
+        let parentMap = parent;
+        let map: IntermediateCacheKeyMap;
 
         do {
             map = {
+                maps: [],
+                parentMap,
                 usedCount: 1,
                 value: args[index],
-                maps: [],
             };
 
-            parentMaps.push(map);
+            // Continue to build the tree of maps so that it could be resolved
+            // next time when the function is called with the same set of
+            // arguments.
+            parentMap.maps.unshift(map);
 
-            parentMaps = map.maps;
+            parentMap = map;
             index++;
         } while (index < args.length);
 
-        map.cacheKey = `${++this._lastId}`;
+        const terminalMap = map as TerminalCacheKeyMap;
 
-        return map.cacheKey;
+        terminalMap.cacheKey = `${++this._lastId}`;
+
+        return terminalMap;
     }
-}
 
-interface CacheKeyMap {
-    maps: CacheKeyMap[];
-    value: any;
-    usedCount: number;
-    cacheKey?: string;
-}
+    private _removeLeastUsedMap(recentlyUsedMap: TerminalCacheKeyMap): void {
+        if (!this._options.maxSize) {
+            return;
+        }
 
-interface ResolveResult {
-    index: number;
-    parentMaps: CacheKeyMap[];
-    map?: CacheKeyMap;
+        const index = this._usedMaps.indexOf(recentlyUsedMap);
+
+        this._usedMaps.splice(
+            index === -1 ? 0 : index,
+            index === -1 ? 0 : 1,
+            recentlyUsedMap
+        );
+
+        if (this._usedMaps.length <= this._options.maxSize) {
+            return;
+        }
+
+        const map = this._usedMaps.pop();
+
+        if (!map) {
+            return;
+        }
+
+        this._removeMap(map);
+        this._options.onExpire(map.cacheKey);
+    }
+
+    private _removeMap(map: ChildCacheKeyMap): void {
+        if (!map.parentMap) {
+            return;
+        }
+
+        map.parentMap.maps.splice(map.parentMap.maps.indexOf(map), 1);
+
+        if (isRootCacheKeyMap(map.parentMap)) {
+            return;
+        }
+
+        this._removeMap(map.parentMap);
+    }
 }

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -5,7 +5,7 @@ export { default as createFreezeProxy, createFreezeProxies } from './create-free
 export { default as CacheKeyResolver } from './cache-key-resolver';
 export { default as CancellablePromise } from './cancellable-promise';
 export { default as getEnvironment } from './get-environment';
-export { default as memoize } from './memoize';
+export { default as memoize, memoizeOne, MemoizeOptions } from './memoize';
 export { default as isEqual } from './is-equal';
 export { default as isPrivate } from './is-private';
 export { default as mergeOrPush } from './merge-or-push';

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -5,6 +5,7 @@ export { default as createFreezeProxy, createFreezeProxies } from './create-free
 export { default as CacheKeyResolver } from './cache-key-resolver';
 export { default as CancellablePromise } from './cancellable-promise';
 export { default as getEnvironment } from './get-environment';
+export { default as memoize } from './memoize';
 export { default as isEqual } from './is-equal';
 export { default as isPrivate } from './is-private';
 export { default as mergeOrPush } from './merge-or-push';

--- a/src/common/utility/memoize.spec.ts
+++ b/src/common/utility/memoize.spec.ts
@@ -1,0 +1,38 @@
+import memoize from './memoize';
+
+describe('memoize', () => {
+    it('only calls function again if parameters are different', () => {
+        const add = jest.fn((a: number, b: number) => (a + b));
+        const memoizedAdd = memoize(add);
+
+        memoizedAdd(1, 1);
+        memoizedAdd(1, 1);
+
+        expect(add).toHaveBeenCalledTimes(1);
+
+        memoizedAdd(2, 2);
+
+        expect(add).toHaveBeenCalledTimes(2);
+    });
+
+    it('deletes cached result when key expires', () => {
+        const add = jest.fn((a: number, b: number) => (a + b));
+        const memoizedAdd = memoize(add, { maxSize: 1 });
+        const cache = memoizedAdd.cache as Map<string, number>;
+
+        memoizedAdd(1, 1);
+
+        expect(cache.values().next().value)
+            .toEqual(2);
+        expect(Array.from(cache.values()).length)
+            .toEqual(1);
+
+        // This call should remove the previous result from the cache
+        memoizedAdd(2, 2);
+
+        expect(cache.values().next().value)
+            .toEqual(4);
+        expect(Array.from(cache.values()).length)
+            .toEqual(1);
+    });
+});

--- a/src/common/utility/memoize.ts
+++ b/src/common/utility/memoize.ts
@@ -1,10 +1,36 @@
 import { memoize as lodashMemoize } from 'lodash';
+import * as shallowEqual from 'shallowequal';
+
+import { Omit } from '../types';
 
 import CacheKeyResolver from './cache-key-resolver';
 
-export default function memoize<T extends (...args: any[]) => any>(fn: T) {
-    const resolver = new CacheKeyResolver();
+export interface MemoizeOptions {
+    maxSize?: number;
+    isEqual?(valueA: any, valueB: any): boolean;
+}
+
+export default function memoize<T extends (...args: any[]) => any>(
+    fn: T,
+    options?: MemoizeOptions
+) {
+    const { maxSize, isEqual } = { maxSize: 0, isEqual: shallowEqual, ...options };
+    const cache = new Map();
+    const resolver = new CacheKeyResolver({
+        maxSize,
+        isEqual,
+        onExpire: key => cache.delete(key),
+    });
     const memoized = lodashMemoize(fn, (...args) => resolver.getKey(...args));
 
+    memoized.cache = cache;
+
     return memoized;
+}
+
+export function memoizeOne<T extends (...args: any[]) => any>(
+    fn: T,
+    options?: Omit<MemoizeOptions, 'maxSize'>
+) {
+    return memoize(fn, { ...options, maxSize: 1 });
 }

--- a/src/common/utility/memoize.ts
+++ b/src/common/utility/memoize.ts
@@ -1,0 +1,10 @@
+import { memoize as lodashMemoize } from 'lodash';
+
+import CacheKeyResolver from './cache-key-resolver';
+
+export default function memoize<T extends (...args: any[]) => any>(fn: T) {
+    const resolver = new CacheKeyResolver();
+    const memoized = lodashMemoize(fn, (...args) => resolver.getKey(...args));
+
+    return memoized;
+}


### PR DESCRIPTION
## What?
Add `reselect` dependency.

## Why?
This library can help us write more efficient selectors. Currently, we have selectors as objects; and we create them whenever there's a change in the state. But not all of the methods depend on the piece of state that's changed. i.e.:

```ts
@bind
class Selector {
    constructor(private state: { a: string, b: string }) {}

    getA() {
        return this.state.a;
    }

    getB(message: string) {
        return { value: this.state.b, message };
    }
}
```

In the example above, 'getA' depends on `state.a` and `getB` depends on `state.b`. When `state` changes, there is no way of knowing whether or not the output of `getA` or `getB` has changed, besides actually calling the methods and comparing the output with the previous result. 

Ideally, what we want is to produce a new `getA` and `getB` if `state.a` or `state.b` changes respectively. This allows us to pass the functions as values. This is useful in React as you can pass the getters as props into a component, and the component can detect whether there's a need to re-render by doing a strict equal comparison.

If we write the getters as separate functions, we can achieve what we want. `reselect` is a tool that could help us achieve what we want faster i.e.:

```ts
const getA = createSelector(
    state => state.a,
    a => () => a
);

const getB = createSelector(
    state => state.b,
    b => memoize((message: string) => { value: b, message })
);
```

Now we can explicitly specify the state dependency of `getA` and `getB`. And we only get new getter functions when the relevant state changes. Also, in the case of `getB`, I can ensure that we only produce new objects when depended inputs (`state.b` and `message`) are different. This means that not only I can pass getters into components, I can also pass in the outputs of these getters and React can easily figure out whether or not to re-render.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments