### PR TITLE
feat(payment): INT-1768 Payment Intent creation refactor

### DIFF
--- a/src/payment/payment-request-sender.ts
+++ b/src/payment/payment-request-sender.ts
@@ -32,18 +32,6 @@ export default class PaymentRequestSender {
         });
     }
 
-    generatePaymentIntent(payload: any): Promise<Response> {
-        return new Promise((resolve, reject) => {
-            this._client.generatePaymentIntent(payload, (error: any, response: any) => {
-                if (error) {
-                    reject(this._transformResponse(error));
-                } else {
-                    resolve(this._transformResponse(response));
-                }
-            });
-        });
-    }
-
     private _transformResponse(response: any): Response {
         return {
             headers: {},


### PR DESCRIPTION
## What?
Remove action to create the Payment Intent needed for StripeV3, instead I'll use the existing `initializations` endpoint (BCApp - BigPay) to retrieve the payment intent

## Why?
We received a comment from David Aland @IamDavidovich in a PR of BigPay (related with Stripe V3) in why we created a new endpoint to create payment intents, so we had a discussion related with it and we decided to update the approach and use the existing endpoint in BigPay, so that change affects some repos one of them is Checkout-sdk-js

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/62242260-5f81eb80-b3a0-11e9-9123-a0b423b036c0.png)

## Siblings PRs
[BCApp]()
[BigPay-Client-PHP](https://github.com/bigcommerce-labs/bigpay-client-php/pull/135)
[BigPay-Client-JS](https://github.com/bigcommerce/bigpay-client-js/pull/81)
[BigPay](https://github.com/bigcommerce/bigpay/pull/1730)

@bigcommerce/checkout @bigcommerce/intersys-integrations 
