### PR TITLE
CHECKOUT-4272: Optimise billing selector and reducer

### DIFF
--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -6,12 +6,7 @@ import { OrderAction, OrderActionType } from '../order';
 
 import BillingAddress from './billing-address';
 import { BillingAddressAction, BillingAddressActionType } from './billing-address-actions';
-import BillingAddressState, { BillingAddressErrorsState, BillingAddressStatusesState } from './billing-address-state';
-
-const DEFAULT_STATE: BillingAddressState = {
-    errors: {},
-    statuses: {},
-};
+import BillingAddressState, { BillingAddressErrorsState, BillingAddressStatusesState, DEFAULT_STATE } from './billing-address-state';
 
 export default function billingAddressReducer(
     state: BillingAddressState = DEFAULT_STATE,

--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -2,6 +2,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
+import { objectSet, replace } from '../common/utility';
 import { OrderAction, OrderActionType } from '../order';
 
 import BillingAddress from './billing-address';
@@ -30,7 +31,7 @@ function dataReducer(
     case BillingAddressActionType.ContinueAsGuestSucceeded:
     case CheckoutActionType.LoadCheckoutSucceeded:
     case OrderActionType.LoadOrderSucceeded:
-        return action.payload ? action.payload.billingAddress : data;
+        return replace(data, action.payload && action.payload.billingAddress);
 
     default:
         return data;
@@ -44,24 +45,24 @@ function errorsReducer(
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
     case CheckoutActionType.LoadCheckoutSucceeded:
-        return { ...errors, loadError: undefined };
+        return objectSet(errors, 'loadError', undefined);
 
     case CheckoutActionType.LoadCheckoutFailed:
-        return { ...errors, loadError: action.payload };
+        return objectSet(errors, 'loadError', action.payload);
 
     case BillingAddressActionType.UpdateBillingAddressRequested:
     case BillingAddressActionType.UpdateBillingAddressSucceeded:
-        return { ...errors, updateError: undefined };
+        return objectSet(errors, 'updateError', undefined);
 
     case BillingAddressActionType.UpdateBillingAddressFailed:
-        return { ...errors, updateError: action.payload };
+        return objectSet(errors, 'updateError', action.payload);
 
     case BillingAddressActionType.ContinueAsGuestRequested:
     case BillingAddressActionType.ContinueAsGuestSucceeded:
-        return { ...errors, continueAsGuestError: undefined };
+        return objectSet(errors, 'continueAsGuestError', undefined);
 
     case BillingAddressActionType.ContinueAsGuestFailed:
-        return { ...errors, continueAsGuestError: action.payload };
+        return objectSet(errors, 'continueAsGuestError', action.payload);
 
     default:
         return errors;
@@ -74,25 +75,25 @@ function statusesReducer(
 ): BillingAddressStatusesState {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
-        return { ...statuses, isLoading: true };
+        return objectSet(statuses, 'isLoading', true);
 
     case CheckoutActionType.LoadCheckoutSucceeded:
     case CheckoutActionType.LoadCheckoutFailed:
-        return { ...statuses, isLoading: false };
+        return objectSet(statuses, 'isLoading', false);
 
     case BillingAddressActionType.UpdateBillingAddressRequested:
-        return { ...statuses, isUpdating: true };
+        return objectSet(statuses, 'isUpdating', true);
 
     case BillingAddressActionType.UpdateBillingAddressFailed:
     case BillingAddressActionType.UpdateBillingAddressSucceeded:
-        return { ...statuses, isUpdating: false };
+        return objectSet(statuses, 'isUpdating', false);
 
     case BillingAddressActionType.ContinueAsGuestRequested:
-        return { ...statuses, isContinuingAsGuest: true };
+        return objectSet(statuses, 'isContinuingAsGuest', true);
 
     case BillingAddressActionType.ContinueAsGuestFailed:
     case BillingAddressActionType.ContinueAsGuestSucceeded:
-        return { ...statuses, isContinuingAsGuest: false };
+        return objectSet(statuses, 'isContinuingAsGuest', false);
 
     default:
         return statuses;

--- a/src/billing/billing-address-selector.spec.ts
+++ b/src/billing/billing-address-selector.spec.ts
@@ -1,25 +1,27 @@
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
-import BillingAddressSelector from './billing-address-selector';
+import BillingAddressSelector, { createBillingAddressSelectorFactory, BillingAddressSelectorFactory } from './billing-address-selector';
 
 describe('BillingAddressSelector', () => {
     let billingAddressSelector: BillingAddressSelector;
+    let createBillingAddressSelector: BillingAddressSelectorFactory;
     let state: CheckoutStoreState;
 
     beforeEach(() => {
+        createBillingAddressSelector = createBillingAddressSelectorFactory();
         state = getCheckoutStoreState();
     });
 
     describe('#getBillingAddress()', () => {
         it('returns the current billing address', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = createBillingAddressSelector(state.billingAddress);
 
             expect(billingAddressSelector.getBillingAddress()).toEqual(state.billingAddress.data);
         });
 
         it('returns undefined if quote is not available', () => {
-            billingAddressSelector = new BillingAddressSelector({ ...state.billingAddress, data: undefined });
+            billingAddressSelector = createBillingAddressSelector({ ...state.billingAddress, data: undefined });
 
             expect(billingAddressSelector.getBillingAddress()).toBeFalsy();
         });
@@ -29,7 +31,7 @@ describe('BillingAddressSelector', () => {
         it('returns error if unable to update', () => {
             const updateError = new Error();
 
-            billingAddressSelector = new BillingAddressSelector({
+            billingAddressSelector = createBillingAddressSelector({
                 ...state.billingAddress,
                 errors: { updateError },
             });
@@ -38,7 +40,7 @@ describe('BillingAddressSelector', () => {
         });
 
         it('does not returns error if able to update', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = createBillingAddressSelector(state.billingAddress);
 
             expect(billingAddressSelector.getUpdateError()).toBeUndefined();
         });
@@ -48,7 +50,7 @@ describe('BillingAddressSelector', () => {
         it('returns error if unable to update', () => {
             const continueAsGuestError = new Error();
 
-            billingAddressSelector = new BillingAddressSelector({
+            billingAddressSelector = createBillingAddressSelector({
                 ...state.billingAddress,
                 errors: { continueAsGuestError },
             });
@@ -57,7 +59,7 @@ describe('BillingAddressSelector', () => {
         });
 
         it('does not returns error if able to update', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = createBillingAddressSelector(state.billingAddress);
 
             expect(billingAddressSelector.getContinueAsGuestError()).toBeUndefined();
         });
@@ -65,7 +67,7 @@ describe('BillingAddressSelector', () => {
 
     describe('#isUpdating()', () => {
         it('returns true if updating billing address', () => {
-            billingAddressSelector = new BillingAddressSelector({
+            billingAddressSelector = createBillingAddressSelector({
                 ...state.billingAddress,
                 statuses: { isUpdating: true },
             });
@@ -74,7 +76,7 @@ describe('BillingAddressSelector', () => {
         });
 
         it('returns false if not updating billing address', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = createBillingAddressSelector(state.billingAddress);
 
             expect(billingAddressSelector.isUpdating()).toEqual(false);
         });
@@ -82,7 +84,7 @@ describe('BillingAddressSelector', () => {
 
     describe('#isContinuingAsGuest()', () => {
         it('returns true if updating billing address', () => {
-            billingAddressSelector = new BillingAddressSelector({
+            billingAddressSelector = createBillingAddressSelector({
                 ...state.billingAddress,
                 statuses: { isContinuingAsGuest: true },
             });
@@ -91,7 +93,7 @@ describe('BillingAddressSelector', () => {
         });
 
         it('returns false if not updating billing address', () => {
-            billingAddressSelector = new BillingAddressSelector(state.billingAddress);
+            billingAddressSelector = createBillingAddressSelector(state.billingAddress);
 
             expect(billingAddressSelector.isContinuingAsGuest()).toEqual(false);
         });

--- a/src/billing/billing-address-selector.ts
+++ b/src/billing/billing-address-selector.ts
@@ -1,39 +1,68 @@
-import { selector } from '../common/selector';
+import { createSelector } from '../common/selector';
+import { memoizeOne } from '../common/utility';
 
 import BillingAddress from './billing-address';
-import BillingAddressState from './billing-address-state';
+import BillingAddressState, { DEFAULT_STATE } from './billing-address-state';
 
-@selector
-export default class BillingAddressSelector {
-    constructor(
-        private _billingAddress: BillingAddressState
-    ) {}
+export default interface BillingAddressSelector {
+    getBillingAddress(): BillingAddress | undefined;
+    getUpdateError(): Error | undefined;
+    getContinueAsGuestError(): Error | undefined;
+    getLoadError(): Error | undefined;
+    isUpdating(): boolean;
+    isContinuingAsGuest(): boolean;
+    isLoading(): boolean;
+}
 
-    getBillingAddress(): BillingAddress | undefined {
-        return this._billingAddress.data;
-    }
+export type BillingAddressSelectorFactory = (state: BillingAddressState) => BillingAddressSelector;
 
-    getUpdateError(): Error | undefined {
-        return this._billingAddress.errors.updateError;
-    }
+export function createBillingAddressSelectorFactory(): BillingAddressSelectorFactory {
+    const getBillingAddress = createSelector(
+        (state: BillingAddressState) => state.data,
+        data => () => data
+    );
 
-    getContinueAsGuestError(): Error | undefined {
-        return this._billingAddress.errors.continueAsGuestError;
-    }
+    const getUpdateError = createSelector(
+        (state: BillingAddressState) => state.errors.updateError,
+        error => () => error
+    );
 
-    getLoadError(): Error | undefined {
-        return this._billingAddress.errors.loadError;
-    }
+    const getContinueAsGuestError = createSelector(
+        (state: BillingAddressState) => state.errors.continueAsGuestError,
+        error => () => error
+    );
 
-    isUpdating(): boolean {
-        return !!this._billingAddress.statuses.isUpdating;
-    }
+    const getLoadError = createSelector(
+        (state: BillingAddressState) => state.errors.loadError,
+        error => () => error
+    );
 
-    isContinuingAsGuest(): boolean {
-        return !!this._billingAddress.statuses.isContinuingAsGuest;
-    }
+    const isUpdating = createSelector(
+        (state: BillingAddressState) => !!state.statuses.isUpdating,
+        status => () => status
+    );
 
-    isLoading(): boolean {
-        return !!this._billingAddress.statuses.isLoading;
-    }
+    const isContinuingAsGuest = createSelector(
+        (state: BillingAddressState) => !!state.statuses.isContinuingAsGuest,
+        status => () => status
+    );
+
+    const isLoading = createSelector(
+        (state: BillingAddressState) => !!state.statuses.isLoading,
+        status => () => status
+    );
+
+    return memoizeOne((
+        state: BillingAddressState = DEFAULT_STATE
+    ): BillingAddressSelector => {
+        return {
+            getBillingAddress: getBillingAddress(state),
+            getUpdateError: getUpdateError(state),
+            getContinueAsGuestError: getContinueAsGuestError(state),
+            getLoadError: getLoadError(state),
+            isUpdating: isUpdating(state),
+            isContinuingAsGuest: isContinuingAsGuest(state),
+            isLoading: isLoading(state),
+        };
+    });
 }

--- a/src/billing/billing-address-state.ts
+++ b/src/billing/billing-address-state.ts
@@ -17,3 +17,8 @@ export interface BillingAddressStatusesState {
     isUpdating?: boolean;
     isContinuingAsGuest?: boolean;
 }
+
+export const DEFAULT_STATE: BillingAddressState = {
+    errors: {},
+    statuses: {},
+};

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -1,7 +1,7 @@
 export * from './billing-address-actions';
 
 export { default as BillingAddress, BillingAddressRequestBody, BillingAddressUpdateRequestBody } from './billing-address';
-export { default as BillingAddressSelector } from './billing-address-selector';
+export { default as BillingAddressSelector, BillingAddressSelectorFactory, createBillingAddressSelectorFactory } from './billing-address-selector';
 export { default as BillingAddressActionCreator } from './billing-address-action-creator';
 export { default as BillingAddressState } from './billing-address-state';
 export { default as BillingAddressRequestSender } from './billing-address-request-sender';

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -1,4 +1,4 @@
-import { BillingAddressSelector } from '../billing';
+import { createBillingAddressSelectorFactory } from '../billing';
 import { CartSelector } from '../cart';
 import { CheckoutButtonSelector } from '../checkout-buttons';
 import { createFreezeProxies } from '../common/utility';
@@ -24,11 +24,12 @@ export type InternalCheckoutSelectorsFactory = (
 ) => InternalCheckoutSelectors;
 
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
+    const createBillingAddressSelector = createBillingAddressSelectorFactory();
     const createCouponSelector = createCouponSelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
 
     return (state, options = {}) => {
-        const billingAddress = new BillingAddressSelector(state.billingAddress);
+        const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = new CartSelector(state.cart);
         const checkoutButton = new CheckoutButtonSelector(state.checkoutButton);
         const config = new ConfigSelector(state.config);


### PR DESCRIPTION
## What?
* Refactor `BillingSelector` to return new getters only when there are changes to relevant data.
* Update `billingReducer` to transform state only when it is necessary.

## Why?
These changes allow us to keep track of changes more efficiently. Currently, in order to make sure we return the same object reference when there are no changes to the return value of a selector, we run a deep object comparison between the old and the new value when the selector is called every time. A better approach is to do a comparison when we write to the data store. This is because we write to store less frequently than we read from it. Also, this approach allows us to memoize the selectors, as we can easily detect whether or not there's a need to re-execute the selectors. This is especially important for selectors that derive new data from existing data, as don't want to re-run them unless their depended data has changed.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
