### PR TITLE
CHECKOUT-4272: Optimise cart selector and reducer

### DIFF
--- a/src/cart/cart-reducer.ts
+++ b/src/cart/cart-reducer.ts
@@ -3,6 +3,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 import { BillingAddressAction, BillingAddressActionType } from '../billing/billing-address-actions';
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
+import { objectMerge, objectSet } from '../common/utility';
 import { CouponAction, CouponActionType } from '../coupon/coupon-actions';
 import { GiftCertificateAction, GiftCertificateActionType } from '../coupon/gift-certificate-actions';
 import { ConsignmentAction, ConsignmentActionType } from '../shipping/consignment-actions';
@@ -38,7 +39,7 @@ function dataReducer(
     case CouponActionType.RemoveCouponSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
-        return action.payload ? { ...data, ...action.payload.cart } : data;
+        return objectMerge(data, action.payload && action.payload.cart);
 
     default:
         return data;
@@ -51,11 +52,11 @@ function statusesReducer(
 ): CartStatusesState {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
-        return { ...statuses, isLoading: true };
+        return objectSet(statuses, 'isLoading', true);
 
     case CheckoutActionType.LoadCheckoutFailed:
     case CheckoutActionType.LoadCheckoutSucceeded:
-        return { ...statuses, isLoading: false };
+        return objectSet(statuses, 'isLoading', false);
 
     default:
         return statuses;
@@ -69,10 +70,10 @@ function errorsReducer(
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
     case CheckoutActionType.LoadCheckoutSucceeded:
-        return { ...errors, loadError: undefined };
+        return objectSet(errors, 'loadError', undefined);
 
     case CheckoutActionType.LoadCheckoutFailed:
-        return { ...errors, loadError: action.payload };
+        return objectSet(errors, 'loadError', action.payload);
 
     default:
         return errors;

--- a/src/cart/cart-reducer.ts
+++ b/src/cart/cart-reducer.ts
@@ -8,12 +8,7 @@ import { GiftCertificateAction, GiftCertificateActionType } from '../coupon/gift
 import { ConsignmentAction, ConsignmentActionType } from '../shipping/consignment-actions';
 
 import Cart from './cart';
-import CartState, { CartErrorsState, CartStatusesState } from './cart-state';
-
-const DEFAULT_STATE: CartState = {
-    errors: {},
-    statuses: {},
-};
+import CartState, { CartErrorsState, CartStatusesState, DEFAULT_STATE } from './cart-state';
 
 export default function cartReducer(
     state: CartState = DEFAULT_STATE,

--- a/src/cart/cart-selector.spec.ts
+++ b/src/cart/cart-selector.spec.ts
@@ -1,19 +1,21 @@
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
-import CartSelector from './cart-selector';
+import CartSelector, { createCartSelectorFactory, CartSelectorFactory } from './cart-selector';
 
 describe('CartSelector', () => {
     let cartSelector: CartSelector;
+    let createCartSelector: CartSelectorFactory;
     let state: CheckoutStoreState;
 
     beforeEach(() => {
+        createCartSelector = createCartSelectorFactory();
         state = getCheckoutStoreState();
     });
 
     describe('#getCart()', () => {
         it('returns the current cart', () => {
-            cartSelector = new CartSelector(state.cart);
+            cartSelector = createCartSelector(state.cart);
 
             expect(cartSelector.getCart()).toEqual(state.cart.data);
         });
@@ -23,7 +25,7 @@ describe('CartSelector', () => {
         it('returns error if unable to load', () => {
             const loadError = new Error();
 
-            cartSelector = new CartSelector({
+            cartSelector = createCartSelector({
                 ...state.cart,
                 errors: { loadError },
             });
@@ -32,7 +34,7 @@ describe('CartSelector', () => {
         });
 
         it('does not returns error if able to load', () => {
-            cartSelector = new CartSelector(state.cart);
+            cartSelector = createCartSelector(state.cart);
 
             expect(cartSelector.getLoadError()).toBeUndefined();
         });
@@ -40,7 +42,7 @@ describe('CartSelector', () => {
 
     describe('#isLoading()', () => {
         it('returns true if loading cart', () => {
-            cartSelector = new CartSelector({
+            cartSelector = createCartSelector({
                 ...state.cart,
                 statuses: { isLoading: true },
             });
@@ -49,7 +51,7 @@ describe('CartSelector', () => {
         });
 
         it('returns false if not loading cart', () => {
-            cartSelector = new CartSelector(state.cart);
+            cartSelector = createCartSelector(state.cart);
 
             expect(cartSelector.isLoading()).toEqual(false);
         });

--- a/src/cart/cart-selector.ts
+++ b/src/cart/cart-selector.ts
@@ -1,23 +1,40 @@
-import { selector } from '../common/selector';
+import { createSelector } from '../common/selector';
+import { memoizeOne } from '../common/utility';
 
 import Cart from './cart';
-import CartState from './cart-state';
+import CartState, { DEFAULT_STATE } from './cart-state';
 
-@selector
-export default class CartSelector {
-    constructor(
-        private _cart: CartState
-    ) {}
+export default interface CartSelector {
+    getCart(): Cart | undefined;
+    getLoadError(): Error | undefined;
+    isLoading(): boolean;
+}
 
-    getCart(): Cart | undefined {
-        return this._cart.data;
-    }
+export type CartSelectorFactory = (state: CartState) => CartSelector;
 
-    getLoadError(): Error | undefined {
-        return this._cart.errors.loadError;
-    }
+export function createCartSelectorFactory() {
+    const getCart = createSelector(
+        (state: CartState) => state.data,
+        cart => () => cart
+    );
 
-    isLoading(): boolean {
-        return !!this._cart.statuses.isLoading;
-    }
+    const getLoadError = createSelector(
+        (state: CartState) => state.errors.loadError,
+        error => () => error
+    );
+
+    const isLoading = createSelector(
+        (state: CartState) => !!state.statuses.isLoading,
+        status => () => status
+    );
+
+    return memoizeOne((
+        state: CartState = DEFAULT_STATE
+    ): CartSelector => {
+        return {
+            getCart: getCart(state),
+            getLoadError: getLoadError(state),
+            isLoading: isLoading(state),
+        };
+    });
 }

--- a/src/cart/cart-state.ts
+++ b/src/cart/cart-state.ts
@@ -13,3 +13,8 @@ export interface CartErrorsState {
 export interface CartStatusesState {
     isLoading?: boolean;
 }
+
+export const DEFAULT_STATE: CartState = {
+    errors: {},
+    statuses: {},
+};

--- a/src/cart/index.ts
+++ b/src/cart/index.ts
@@ -7,7 +7,7 @@ export { default as LineItemMap } from './line-item-map';
 export { default as CartComparator } from './cart-comparator';
 export { default as cartReducer } from './cart-reducer';
 export { default as CartRequestSender } from './cart-request-sender';
-export { default as CartSelector } from './cart-selector';
+export { default as CartSelector, CartSelectorFactory, createCartSelectorFactory } from './cart-selector';
 export { default as CartState } from './cart-state';
 
 export { default as map } from './map-to-internal-cart';

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -1,5 +1,5 @@
 import { createBillingAddressSelectorFactory } from '../billing';
-import { CartSelector } from '../cart';
+import { createCartSelectorFactory } from '../cart/cart-selector';
 import { CheckoutButtonSelector } from '../checkout-buttons';
 import { createFreezeProxies } from '../common/utility';
 import { ConfigSelector } from '../config';
@@ -25,13 +25,14 @@ export type InternalCheckoutSelectorsFactory = (
 
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
     const createBillingAddressSelector = createBillingAddressSelectorFactory();
+    const createCartSelector = createCartSelectorFactory();
     const createCouponSelector = createCouponSelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createOrderSelector = createOrderSelectorFactory();
 
     return (state, options = {}) => {
         const billingAddress = createBillingAddressSelector(state.billingAddress);
-        const cart = new CartSelector(state.cart);
+        const cart = createCartSelector(state.cart);
         const checkoutButton = new CheckoutButtonSelector(state.checkoutButton);
         const config = new ConfigSelector(state.config);
         const countries = new CountrySelector(state.countries);

--- a/src/shipping/consignment-selector.spec.ts
+++ b/src/shipping/consignment-selector.spec.ts
@@ -1,6 +1,6 @@
 import { merge } from 'lodash';
 
-import { CartSelector } from '../cart';
+import { createCartSelectorFactory, CartSelector } from '../cart';
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
@@ -32,7 +32,7 @@ describe('ConsignmentSelector', () => {
 
     beforeEach(() => {
         state = getCheckoutStoreState();
-        cartSelector = new CartSelector(state.cart);
+        cartSelector = createCartSelectorFactory()(state.cart);
     });
 
     describe('#getConsignmentByAddress()', () => {


### PR DESCRIPTION
## What?
* Refactor `CartSelector` to return new getters only when there are changes to relevant data.
* Update `cartReducer` to transform state only when it is necessary.

## Why?
These changes allow us to keep track of changes more efficiently. Currently, in order to make sure we return the same object reference when there are no changes to the return value of a selector, we run a deep object comparison between the old and the new value when the selector is called every time. A better approach is to do a comparison when we write to the data store. This is because we write to store less frequently than we read from it. Also, this approach allows us to memoize the selectors, as we can easily detect whether or not there's a need to re-execute the selectors. This is especially important for selectors that derive new data from existing data, as don't want to re-run them unless their depended data has changed.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
