### PR TITLE
CHECKOUT-4272: Add function for creating internal checkout selectors factory

### DIFF
--- a/src/checkout/create-checkout-store.ts
+++ b/src/checkout/create-checkout-store.ts
@@ -6,13 +6,14 @@ import CheckoutStore, { CheckoutStoreOptions } from './checkout-store';
 import CheckoutStoreState from './checkout-store-state';
 import createActionTransformer from './create-action-transformer';
 import createCheckoutStoreReducer from './create-checkout-store-reducer';
-import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
+import { createInternalCheckoutSelectorsFactory } from './create-internal-checkout-selectors';
 
 export default function createCheckoutStore(
     initialState: Partial<CheckoutStoreState> = {},
     options?: CheckoutStoreOptions
 ): CheckoutStore {
     const actionTransformer = createActionTransformer(createRequestErrorFactory());
+    const createInternalCheckoutSelectors = createInternalCheckoutSelectorsFactory();
     const stateTransformer = (state: CheckoutStoreState) => createInternalCheckoutSelectors(state);
 
     return createDataStore(

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -18,54 +18,68 @@ import { CheckoutStoreOptions } from './checkout-store';
 import CheckoutStoreState from './checkout-store-state';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
-export default function createInternalCheckoutSelectors(state: CheckoutStoreState, options: CheckoutStoreOptions = {}): InternalCheckoutSelectors {
-    const billingAddress = new BillingAddressSelector(state.billingAddress);
-    const cart = new CartSelector(state.cart);
-    const checkoutButton = new CheckoutButtonSelector(state.checkoutButton);
-    const config = new ConfigSelector(state.config);
-    const countries = new CountrySelector(state.countries);
-    const coupons = new CouponSelector(state.coupons);
-    const customer = new CustomerSelector(state.customer);
-    const customerStrategies = new CustomerStrategySelector(state.customerStrategies);
-    const form = new FormSelector(state.config);
-    const giftCertificates = new GiftCertificateSelector(state.giftCertificates);
-    const instruments = new InstrumentSelector(state.instruments);
-    const paymentMethods = new PaymentMethodSelector(state.paymentMethods);
-    const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
-    const shippingAddress = new ShippingAddressSelector(state.consignments);
-    const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);
-    const shippingCountries = new ShippingCountrySelector(state.shippingCountries);
-    const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);
+export type InternalCheckoutSelectorsFactory = (
+    state: CheckoutStoreState,
+    options?: CheckoutStoreOptions
+) => InternalCheckoutSelectors;
 
-    // Compose selectors
-    const consignments = new ConsignmentSelector(state.consignments, cart);
-    const checkout = new CheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, customer, giftCertificates);
-    const order = new OrderSelector(state.order, billingAddress, coupons);
-    const payment = new PaymentSelector(checkout, order);
+export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
+    return (state, options = {}) => {
+        const billingAddress = new BillingAddressSelector(state.billingAddress);
+        const cart = new CartSelector(state.cart);
+        const checkoutButton = new CheckoutButtonSelector(state.checkoutButton);
+        const config = new ConfigSelector(state.config);
+        const countries = new CountrySelector(state.countries);
+        const coupons = new CouponSelector(state.coupons);
+        const customer = new CustomerSelector(state.customer);
+        const customerStrategies = new CustomerStrategySelector(state.customerStrategies);
+        const form = new FormSelector(state.config);
+        const giftCertificates = new GiftCertificateSelector(state.giftCertificates);
+        const instruments = new InstrumentSelector(state.instruments);
+        const paymentMethods = new PaymentMethodSelector(state.paymentMethods);
+        const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
+        const shippingAddress = new ShippingAddressSelector(state.consignments);
+        const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);
+        const shippingCountries = new ShippingCountrySelector(state.shippingCountries);
+        const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);
 
-    const selectors = {
-        billingAddress,
-        cart,
-        checkout,
-        checkoutButton,
-        config,
-        consignments,
-        countries,
-        coupons,
-        customer,
-        customerStrategies,
-        form,
-        giftCertificates,
-        instruments,
-        order,
-        payment,
-        paymentMethods,
-        paymentStrategies,
-        remoteCheckout,
-        shippingAddress,
-        shippingCountries,
-        shippingStrategies,
+        // Compose selectors
+        const consignments = new ConsignmentSelector(state.consignments, cart);
+        const checkout = new CheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, customer, giftCertificates);
+        const order = new OrderSelector(state.order, billingAddress, coupons);
+        const payment = new PaymentSelector(checkout, order);
+
+        const selectors = {
+            billingAddress,
+            cart,
+            checkout,
+            checkoutButton,
+            config,
+            consignments,
+            countries,
+            coupons,
+            customer,
+            customerStrategies,
+            form,
+            giftCertificates,
+            instruments,
+            order,
+            payment,
+            paymentMethods,
+            paymentStrategies,
+            remoteCheckout,
+            shippingAddress,
+            shippingCountries,
+            shippingStrategies,
+        };
+
+        return options.shouldWarnMutation ? createFreezeProxies(selectors) : selectors;
     };
+}
 
-    return options.shouldWarnMutation ? createFreezeProxies(selectors) : selectors;
+export default function createInternalCheckoutSelectors(
+    state: CheckoutStoreState,
+    options?: CheckoutStoreOptions
+): InternalCheckoutSelectors {
+    return createInternalCheckoutSelectorsFactory()(state, options);
 }

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -22,4 +22,4 @@ export { default as createActionTransformer } from './create-action-transformer'
 export { default as createCheckoutService } from './create-checkout-service';
 export { default as createCheckoutStore } from './create-checkout-store';
 export { default as createCheckoutSelectors } from './create-checkout-selectors';
-export { default as createInternalCheckoutSelectors } from './create-internal-checkout-selectors';
+export { default as createInternalCheckoutSelectors, createInternalCheckoutSelectorsFactory } from './create-internal-checkout-selectors';


### PR DESCRIPTION
## What?
Add a function for creating internal checkout selectors factory.

## Why?
We need this because we want to create a new set of memoized selectors per `store` instance. Without this, if memoized selectors are defined at the top level, they will be shared across instances, which could cause unexpected results.

## Testing / Proof
Travis

@bigcommerce/checkout @bigcommerce/payments
