### PR TITLE
CHECKOUT-4272: Optimise checkout button selector and reducer

### DIFF
--- a/src/checkout-buttons/checkout-button-reducer.ts
+++ b/src/checkout-buttons/checkout-button-reducer.ts
@@ -1,13 +1,7 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
 import { CheckoutButtonAction, CheckoutButtonActionType } from './checkout-button-actions';
-import CheckoutButtonState, { CheckoutButtonDataState, CheckoutButtonErrorsState, CheckoutButtonStatusesState } from './checkout-button-state';
-
-const DEFAULT_STATE: CheckoutButtonState = {
-    data: {},
-    errors: {},
-    statuses: {},
-};
+import CheckoutButtonState, { CheckoutButtonDataState, CheckoutButtonErrorsState, CheckoutButtonStatusesState, DEFAULT_STATE } from './checkout-button-state';
 
 const DEFAULT_DATA_STATE: CheckoutButtonDataState = { initializedContainers: {} };
 const DEFAULT_ERROR_STATE: CheckoutButtonErrorsState = {};

--- a/src/checkout-buttons/checkout-button-reducer.ts
+++ b/src/checkout-buttons/checkout-button-reducer.ts
@@ -1,5 +1,7 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
+import { objectMerge, objectSet } from '../common/utility';
+
 import { CheckoutButtonAction, CheckoutButtonActionType } from './checkout-button-actions';
 import CheckoutButtonState, { CheckoutButtonDataState, CheckoutButtonErrorsState, CheckoutButtonStatusesState, DEFAULT_STATE } from './checkout-button-state';
 
@@ -40,19 +42,14 @@ function dataReducer(
             return data;
         }
 
-        return {
-            ...data,
+        return objectMerge(data, {
             initializedContainers: {
-                ...data.initializedContainers,
                 [action.meta.containerId]: true,
             },
-        };
+        });
 
     case CheckoutButtonActionType.DeinitializeButtonSucceeded:
-        return {
-            ...data,
-            initializedContainers: {},
-        };
+        return objectSet(data, 'initializedContainers', {});
     }
 
     return data;
@@ -65,29 +62,17 @@ function errorsReducer(
     switch (action.type) {
     case CheckoutButtonActionType.InitializeButtonRequested:
     case CheckoutButtonActionType.InitializeButtonSucceeded:
-        return {
-            ...errors,
-            initializeError: undefined,
-        };
+        return objectSet(errors, 'initializeError', undefined);
 
     case CheckoutButtonActionType.InitializeButtonFailed:
-        return {
-            ...errors,
-            initializeError: action.payload,
-        };
+        return objectSet(errors, 'initializeError', action.payload);
 
     case CheckoutButtonActionType.DeinitializeButtonRequested:
     case CheckoutButtonActionType.DeinitializeButtonSucceeded:
-        return {
-            ...errors,
-            deinitializeError: undefined,
-        };
+        return objectSet(errors, 'deinitializeError', undefined);
 
     case CheckoutButtonActionType.DeinitializeButtonFailed:
-        return {
-            ...errors,
-            deinitializeError: action.payload,
-        };
+        return objectSet(errors, 'deinitializeError', action.payload);
 
     default:
         return errors;
@@ -100,30 +85,18 @@ function statusesReducer(
 ): CheckoutButtonStatusesState {
     switch (action.type) {
     case CheckoutButtonActionType.InitializeButtonRequested:
-        return {
-            ...statuses,
-            isInitializing: true,
-        };
+        return objectSet(statuses, 'isInitializing', true);
 
     case CheckoutButtonActionType.InitializeButtonFailed:
     case CheckoutButtonActionType.InitializeButtonSucceeded:
-        return {
-            ...statuses,
-            isInitializing: false,
-        };
+        return objectSet(statuses, 'isInitializing', false);
 
     case CheckoutButtonActionType.DeinitializeButtonRequested:
-        return {
-            ...statuses,
-            isDeinitializing: true,
-        };
+        return objectSet(statuses, 'isDeinitializing', true);
 
     case CheckoutButtonActionType.DeinitializeButtonFailed:
     case CheckoutButtonActionType.DeinitializeButtonSucceeded:
-        return {
-            ...statuses,
-            isDeinitializing: false,
-        };
+        return objectSet(statuses, 'isDeinitializing', false);
 
     default:
         return statuses;

--- a/src/checkout-buttons/checkout-button-selector.spec.ts
+++ b/src/checkout-buttons/checkout-button-selector.spec.ts
@@ -1,13 +1,15 @@
-import CheckoutButtonSelector from './checkout-button-selector';
+import { createCheckoutButtonSelectorFactory, CheckoutButtonSelectorFactory } from './checkout-button-selector';
 import CheckoutButtonState from './checkout-button-state';
 import { getCheckoutButtonState } from './checkout-buttons.mock';
 import { CheckoutButtonMethodType } from './strategies';
 
 describe('CheckoutButtonSelector', () => {
     let state: CheckoutButtonState;
+    let createCheckoutButtonSelector: CheckoutButtonSelectorFactory;
 
     describe('#isInitializing()', () => {
         beforeEach(() => {
+            createCheckoutButtonSelector = createCheckoutButtonSelectorFactory();
             state = {
                 ...getCheckoutButtonState(),
                 statuses: {
@@ -19,19 +21,19 @@ describe('CheckoutButtonSelector', () => {
         });
 
         it('returns true if initializing checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.isInitializing(CheckoutButtonMethodType.BRAINTREE_PAYPAL)).toEqual(true);
         });
 
         it('returns true if initializing any checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.isInitializing()).toEqual(true);
         });
 
         it('returns false if not initializing checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.isInitializing(CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT)).toEqual(false);
         });
@@ -39,7 +41,7 @@ describe('CheckoutButtonSelector', () => {
         it('returns false if not initializing any checkout button', () => {
             state = getCheckoutButtonState();
 
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.isInitializing()).toEqual(false);
         });
@@ -47,7 +49,7 @@ describe('CheckoutButtonSelector', () => {
 
     describe('#isInitialized()', () => {
         it('returns true if method is initialized', () => {
-            const selector = new CheckoutButtonSelector({
+            const selector = createCheckoutButtonSelector({
                 ...state,
                 data: {
                     [CheckoutButtonMethodType.BRAINTREE_PAYPAL]: {
@@ -60,7 +62,7 @@ describe('CheckoutButtonSelector', () => {
         });
 
         it('returns false if method is not initialized', () => {
-            const selector = new CheckoutButtonSelector({
+            const selector = createCheckoutButtonSelector({
                 ...state,
                 data: {
                     [CheckoutButtonMethodType.BRAINTREE_PAYPAL]: {
@@ -87,19 +89,19 @@ describe('CheckoutButtonSelector', () => {
         });
 
         it('returns true if deinitializing checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.isDeinitializing(CheckoutButtonMethodType.BRAINTREE_PAYPAL)).toEqual(true);
         });
 
         it('returns true if deinitializing any checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.isDeinitializing()).toEqual(true);
         });
 
         it('returns false if not deinitializing checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.isDeinitializing(CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT)).toEqual(false);
         });
@@ -107,7 +109,7 @@ describe('CheckoutButtonSelector', () => {
         it('returns false if not deinitializing any checkout button', () => {
             state = getCheckoutButtonState();
 
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.isDeinitializing()).toEqual(false);
         });
@@ -130,19 +132,19 @@ describe('CheckoutButtonSelector', () => {
         });
 
         it('returns error if unable to initialize checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.getInitializeError(CheckoutButtonMethodType.BRAINTREE_PAYPAL)).toEqual(expectedError);
         });
 
         it('returns error if unable to initialize any checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.getInitializeError()).toEqual(expectedError);
         });
 
         it('returns undefined if able to initialize checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.getInitializeError(CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT)).toBeUndefined();
         });
@@ -150,7 +152,7 @@ describe('CheckoutButtonSelector', () => {
         it('returns undefined if there are no issues initializing any checkout button', () => {
             state = getCheckoutButtonState();
 
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.getInitializeError()).toBeUndefined();
         });
@@ -173,19 +175,19 @@ describe('CheckoutButtonSelector', () => {
         });
 
         it('returns error if unable to deinitialize checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.getDeinitializeError(CheckoutButtonMethodType.BRAINTREE_PAYPAL)).toEqual(expectedError);
         });
 
         it('returns error if unable to deinitialize any checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.getDeinitializeError()).toEqual(expectedError);
         });
 
         it('returns undefined if able to deinitialize checkout button', () => {
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.getDeinitializeError(CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT)).toBeUndefined();
         });
@@ -193,7 +195,7 @@ describe('CheckoutButtonSelector', () => {
         it('returns undefined if there are no issues deinitializing any checkout button', () => {
             state = getCheckoutButtonState();
 
-            const selector = new CheckoutButtonSelector(state);
+            const selector = createCheckoutButtonSelector(state);
 
             expect(selector.getDeinitializeError()).toBeUndefined();
         });

--- a/src/checkout-buttons/checkout-button-selector.ts
+++ b/src/checkout-buttons/checkout-button-selector.ts
@@ -1,67 +1,103 @@
 import { find, some, values } from 'lodash';
 
-import { selector } from '../common/selector';
+import { createSelector } from '../common/selector';
+import { memoize, memoizeOne } from '../common/utility';
 
-import CheckoutButtonState from './checkout-button-state';
+import CheckoutButtonState, { DEFAULT_STATE } from './checkout-button-state';
 import { CheckoutButtonMethodType } from './strategies';
 
-@selector
-export default class CheckoutButtonSelector {
-    constructor(
-        private _checkoutButton: CheckoutButtonState
-    ) {}
+export default interface CheckoutButtonSelector {
+    getState(): CheckoutButtonState;
+    isInitializing(methodId?: CheckoutButtonMethodType): boolean;
+    isInitialized(methodId: CheckoutButtonMethodType, containerId?: string): boolean;
+    isDeinitializing(methodId?: CheckoutButtonMethodType): boolean;
+    getInitializeError(methodId?: CheckoutButtonMethodType): Error | undefined;
+    getDeinitializeError(methodId?: CheckoutButtonMethodType): Error | undefined;
+}
 
-    getState(): CheckoutButtonState {
-        return this._checkoutButton;
-    }
+export type CheckoutButtonSelectorFactory = (state: CheckoutButtonState) => CheckoutButtonSelector;
 
-    isInitializing(methodId?: CheckoutButtonMethodType): boolean {
-        if (methodId) {
-            const method = this._checkoutButton.statuses[methodId];
+export function createCheckoutButtonSelectorFactory(): CheckoutButtonSelectorFactory {
+    const getState = createSelector(
+        (state: CheckoutButtonState) => state,
+        state => () => state
+    );
 
-            return (method && method.isInitializing) === true;
-        }
+    const isInitializing = createSelector(
+        (state: CheckoutButtonState) => state.statuses,
+        statuses => memoize((methodId?: CheckoutButtonMethodType) => {
+            if (methodId) {
+                const method = statuses[methodId];
 
-        return some(this._checkoutButton.statuses, { isInitializing: true });
-    }
+                return (method && method.isInitializing) === true;
+            }
 
-    isInitialized(methodId: CheckoutButtonMethodType, containerId?: string): boolean {
-        const method = this._checkoutButton.data[methodId];
+            return some(statuses, { isInitializing: true });
+        })
+    );
 
-        if (!method) {
-            return false;
-        }
+    const isInitialized = createSelector(
+        (state: CheckoutButtonState) => state.data,
+        data => memoize((methodId: CheckoutButtonMethodType, containerId?: string) => {
+            const method = data[methodId];
 
-        if (!containerId) {
-            return some(method.initializedContainers, isInitialized => isInitialized === true);
-        }
+            if (!method) {
+                return false;
+            }
 
-        return method.initializedContainers[containerId] === true;
-    }
+            if (!containerId) {
+                return some(method.initializedContainers, isInitialized => isInitialized === true);
+            }
 
-    isDeinitializing(methodId?: CheckoutButtonMethodType): boolean {
-        if (methodId) {
-            const method = this._checkoutButton.statuses[methodId];
+            return method.initializedContainers[containerId] === true;
+        })
+    );
 
-            return (method && method.isDeinitializing) === true;
-        }
+    const isDeinitializing = createSelector(
+        (state: CheckoutButtonState) => state.statuses,
+        statuses => memoize((methodId?: CheckoutButtonMethodType) => {
+            if (methodId) {
+                const method = statuses[methodId];
 
-        return some(this._checkoutButton.statuses, { isDeinitializing: true });
-    }
+                return (method && method.isDeinitializing) === true;
+            }
 
-    getInitializeError(methodId?: CheckoutButtonMethodType): Error | undefined {
-        const method = methodId ?
-            this._checkoutButton.errors[methodId] :
-            find(values(this._checkoutButton.errors), method => !!(method && method.initializeError));
+            return some(statuses, { isDeinitializing: true });
+        })
+    );
 
-        return method && method.initializeError;
-    }
+    const getInitializeError = createSelector(
+        (state: CheckoutButtonState) => state.errors,
+        errors => memoize((methodId?: CheckoutButtonMethodType) => {
+            const method = methodId ?
+                errors[methodId] :
+                find(values(errors), method => !!(method && method.initializeError));
 
-    getDeinitializeError(methodId?: CheckoutButtonMethodType): Error | undefined {
-        const method = methodId ?
-            this._checkoutButton.errors[methodId] :
-            find(values(this._checkoutButton.errors), method => !!(method && method.deinitializeError));
+            return method && method.initializeError;
+        })
+    );
 
-        return method && method.deinitializeError;
-    }
+    const getDeinitializeError = createSelector(
+        (state: CheckoutButtonState) => state.errors,
+        errors => memoize((methodId?: CheckoutButtonMethodType) => {
+            const method = methodId ?
+                errors[methodId] :
+                find(values(errors), method => !!(method && method.deinitializeError));
+
+            return method && method.deinitializeError;
+        })
+    );
+
+    return memoizeOne((
+        state: CheckoutButtonState = DEFAULT_STATE
+    ): CheckoutButtonSelector => {
+        return {
+            getState: getState(state),
+            isInitializing: isInitializing(state),
+            isInitialized: isInitialized(state),
+            isDeinitializing: isDeinitializing(state),
+            getInitializeError: getInitializeError(state),
+            getDeinitializeError: getDeinitializeError(state),
+        };
+    });
 }

--- a/src/checkout-buttons/checkout-button-state.ts
+++ b/src/checkout-buttons/checkout-button-state.ts
@@ -27,3 +27,9 @@ export interface CheckoutButtonStatusesState {
     isInitializing?: boolean;
     isDeinitializing?: boolean;
 }
+
+export const DEFAULT_STATE: CheckoutButtonState = {
+    data: {},
+    errors: {},
+    statuses: {},
+};

--- a/src/checkout-buttons/index.ts
+++ b/src/checkout-buttons/index.ts
@@ -1,6 +1,6 @@
 export { default as createCheckoutButtonInitializer } from './create-checkout-button-initializer';
 export { default as checkoutButtonReducer } from './checkout-button-reducer';
-export { default as CheckoutButtonSelector } from './checkout-button-selector';
+export { default as CheckoutButtonSelector, CheckoutButtonSelectorFactory, createCheckoutButtonSelectorFactory } from './checkout-button-selector';
 export { default as CheckoutButtonState } from './checkout-button-state';
 
 export { CheckoutButtonOptions, CheckoutButtonInitializeOptions } from './checkout-button-options';

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -1,6 +1,6 @@
 import { createBillingAddressSelectorFactory } from '../billing';
 import { createCartSelectorFactory } from '../cart/cart-selector';
-import { CheckoutButtonSelector } from '../checkout-buttons';
+import { createCheckoutButtonSelectorFactory } from '../checkout-buttons';
 import { createFreezeProxies } from '../common/utility';
 import { ConfigSelector } from '../config';
 import { createCouponSelectorFactory, createGiftCertificateSelectorFactory } from '../coupon';
@@ -26,6 +26,7 @@ export type InternalCheckoutSelectorsFactory = (
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
     const createBillingAddressSelector = createBillingAddressSelectorFactory();
     const createCartSelector = createCartSelectorFactory();
+    const createCheckoutButtonSelector = createCheckoutButtonSelectorFactory();
     const createCouponSelector = createCouponSelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createOrderSelector = createOrderSelectorFactory();
@@ -33,7 +34,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     return (state, options = {}) => {
         const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = createCartSelector(state.cart);
-        const checkoutButton = new CheckoutButtonSelector(state.checkoutButton);
+        const checkoutButton = createCheckoutButtonSelector(state.checkoutButton);
         const config = new ConfigSelector(state.config);
         const countries = new CountrySelector(state.countries);
         const coupons = createCouponSelector(state.coupons);


### PR DESCRIPTION
## What?
* Refactor `CheckoutButtonSelector` to return new getters only when there are changes to relevant data.
* Update `checkoutButtonReducer` to transform state only when it is necessary.

## Why?
These changes allow us to keep track of changes more efficiently. Currently, in order to make sure we return the same object reference when there are no changes to the return value of a selector, we run a deep object comparison between the old and the new value when the selector is called every time. A better approach is to do a comparison when we write to the data store. This is because we write to store less frequently than we read from it. Also, this approach allows us to memoize the selectors, as we can easily detect whether or not there's a need to re-execute the selectors. This is especially important for selectors that derive new data from existing data, as don't want to re-run them unless their depended data has changed.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
