### PR TITLE
CHECKOUT-4272: Optimise coupon / gift certificate selector and reducer

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -3,7 +3,7 @@ import { CartSelector } from '../cart';
 import { CheckoutButtonSelector } from '../checkout-buttons';
 import { createFreezeProxies } from '../common/utility';
 import { ConfigSelector } from '../config';
-import { CouponSelector, GiftCertificateSelector } from '../coupon';
+import { createCouponSelectorFactory, GiftCertificateSelector } from '../coupon';
 import { CustomerSelector, CustomerStrategySelector } from '../customer';
 import { FormSelector } from '../form';
 import { CountrySelector } from '../geography';
@@ -24,13 +24,15 @@ export type InternalCheckoutSelectorsFactory = (
 ) => InternalCheckoutSelectors;
 
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
+    const createCouponSelector = createCouponSelectorFactory();
+
     return (state, options = {}) => {
         const billingAddress = new BillingAddressSelector(state.billingAddress);
         const cart = new CartSelector(state.cart);
         const checkoutButton = new CheckoutButtonSelector(state.checkoutButton);
         const config = new ConfigSelector(state.config);
         const countries = new CountrySelector(state.countries);
-        const coupons = new CouponSelector(state.coupons);
+        const coupons = createCouponSelector(state.coupons);
         const customer = new CustomerSelector(state.customer);
         const customerStrategies = new CustomerStrategySelector(state.customerStrategies);
         const form = new FormSelector(state.config);

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -3,7 +3,7 @@ import { CartSelector } from '../cart';
 import { CheckoutButtonSelector } from '../checkout-buttons';
 import { createFreezeProxies } from '../common/utility';
 import { ConfigSelector } from '../config';
-import { createCouponSelectorFactory, GiftCertificateSelector } from '../coupon';
+import { createCouponSelectorFactory, createGiftCertificateSelectorFactory } from '../coupon';
 import { CustomerSelector, CustomerStrategySelector } from '../customer';
 import { FormSelector } from '../form';
 import { CountrySelector } from '../geography';
@@ -25,6 +25,7 @@ export type InternalCheckoutSelectorsFactory = (
 
 export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelectorsFactory {
     const createCouponSelector = createCouponSelectorFactory();
+    const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
 
     return (state, options = {}) => {
         const billingAddress = new BillingAddressSelector(state.billingAddress);
@@ -36,7 +37,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const customer = new CustomerSelector(state.customer);
         const customerStrategies = new CustomerStrategySelector(state.customerStrategies);
         const form = new FormSelector(state.config);
-        const giftCertificates = new GiftCertificateSelector(state.giftCertificates);
+        const giftCertificates = createGiftCertificateSelector(state.giftCertificates);
         const instruments = new InstrumentSelector(state.instruments);
         const paymentMethods = new PaymentMethodSelector(state.paymentMethods);
         const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);

--- a/src/coupon/coupon-reducer.ts
+++ b/src/coupon/coupon-reducer.ts
@@ -2,16 +2,12 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
+import { arrayReplace, objectSet } from '../common/utility';
 import { OrderAction, OrderActionType } from '../order';
 
 import Coupon from './coupon';
 import { CouponAction, CouponActionType } from './coupon-actions';
-import CouponState, { CouponErrorsState, CouponStatusesState } from './coupon-state';
-
-const DEFAULT_STATE: CouponState = {
-    errors: {},
-    statuses: {},
-};
+import CouponState, { CouponErrorsState, CouponStatusesState, DEFAULT_STATE } from './coupon-state';
 
 export default function couponReducer(
     state: CouponState = DEFAULT_STATE,
@@ -35,7 +31,7 @@ function dataReducer(
     case CouponActionType.ApplyCouponSucceeded:
     case CouponActionType.RemoveCouponSucceeded:
     case OrderActionType.LoadOrderSucceeded:
-        return action.payload ? action.payload.coupons : data;
+        return arrayReplace(data, action.payload && action.payload.coupons);
 
     default:
         return data;
@@ -49,17 +45,17 @@ function errorsReducer(
     switch (action.type) {
     case CouponActionType.ApplyCouponRequested:
     case CouponActionType.ApplyCouponSucceeded:
-        return { ...errors, applyCouponError: undefined };
+        return objectSet(errors, 'applyCouponError', undefined);
 
     case CouponActionType.ApplyCouponFailed:
-        return { ...errors, applyCouponError: action.payload };
+        return objectSet(errors, 'applyCouponError', action.payload);
 
     case CouponActionType.RemoveCouponRequested:
     case CouponActionType.RemoveCouponSucceeded:
-        return { ...errors, removeCouponError: undefined };
+        return objectSet(errors, 'removeCouponError', undefined);
 
     case CouponActionType.RemoveCouponFailed:
-        return { ...errors, removeCouponError: action.payload };
+        return objectSet(errors, 'removeCouponError', action.payload);
 
     default:
         return errors;
@@ -72,18 +68,18 @@ function statusesReducer(
 ): CouponStatusesState {
     switch (action.type) {
     case CouponActionType.ApplyCouponRequested:
-        return { ...statuses, isApplyingCoupon: true };
+        return objectSet(statuses, 'isApplyingCoupon', true);
 
     case CouponActionType.ApplyCouponSucceeded:
     case CouponActionType.ApplyCouponFailed:
-        return { ...statuses, isApplyingCoupon: false };
+        return objectSet(statuses, 'isApplyingCoupon', false);
 
     case CouponActionType.RemoveCouponRequested:
-        return { ...statuses, isRemovingCoupon: true };
+        return objectSet(statuses, 'isRemovingCoupon', true);
 
     case CouponActionType.RemoveCouponSucceeded:
     case CouponActionType.RemoveCouponFailed:
-        return { ...statuses, isRemovingCoupon: false };
+        return objectSet(statuses, 'isRemovingCoupon', false);
 
     default:
         return statuses;

--- a/src/coupon/coupon-selector.spec.ts
+++ b/src/coupon/coupon-selector.spec.ts
@@ -1,13 +1,15 @@
 import { RequestError } from '../common/error/errors';
 
-import CouponSelector from './coupon-selector';
+import CouponSelector, { createCouponSelectorFactory, CouponSelectorFactory } from './coupon-selector';
 import CouponState from './coupon-state';
 
 describe('CouponSelector', () => {
     let couponSelector: CouponSelector;
+    let createCouponSelector: CouponSelectorFactory;
     let state: CouponState;
 
     beforeEach(() => {
+        createCouponSelector = createCouponSelectorFactory();
         state = {
             errors: {},
             statuses: {},
@@ -18,7 +20,7 @@ describe('CouponSelector', () => {
         it('returns error if unable to apply', () => {
             const applyCouponError = new RequestError();
 
-            couponSelector = new CouponSelector({
+            couponSelector = createCouponSelector({
                 ...state,
                 errors: { applyCouponError },
             });
@@ -27,7 +29,7 @@ describe('CouponSelector', () => {
         });
 
         it('does not returns error if able to apply', () => {
-            couponSelector = new CouponSelector(state);
+            couponSelector = createCouponSelector(state);
 
             expect(couponSelector.getApplyError()).toBeUndefined();
         });
@@ -35,7 +37,7 @@ describe('CouponSelector', () => {
 
     describe('#isApplying()', () => {
         it('returns true if applying a coupon', () => {
-            couponSelector = new CouponSelector({
+            couponSelector = createCouponSelector({
                 ...state,
                 statuses: { isApplyingCoupon: true },
             });
@@ -44,7 +46,7 @@ describe('CouponSelector', () => {
         });
 
         it('returns false if not applying a coupon', () => {
-            couponSelector = new CouponSelector(state);
+            couponSelector = createCouponSelector(state);
 
             expect(couponSelector.isApplying()).toEqual(false);
         });
@@ -54,7 +56,7 @@ describe('CouponSelector', () => {
         it('returns error if unable to remove', () => {
             const removeCouponError = new RequestError();
 
-            couponSelector = new CouponSelector({
+            couponSelector = createCouponSelector({
                 ...state,
                 errors: { removeCouponError },
             });
@@ -63,7 +65,7 @@ describe('CouponSelector', () => {
         });
 
         it('does not returns error if able to remove', () => {
-            couponSelector = new CouponSelector(state);
+            couponSelector = createCouponSelector(state);
 
             expect(couponSelector.getRemoveError()).toBeUndefined();
         });
@@ -71,7 +73,7 @@ describe('CouponSelector', () => {
 
     describe('#isRemoving()', () => {
         it('returns true if removing a coupon', () => {
-            couponSelector = new CouponSelector({
+            couponSelector = createCouponSelector({
                 ...state,
                 statuses: { isRemovingCoupon: true },
             });
@@ -80,7 +82,7 @@ describe('CouponSelector', () => {
         });
 
         it('returns false if not removing a coupon', () => {
-            couponSelector = new CouponSelector(state);
+            couponSelector = createCouponSelector(state);
 
             expect(couponSelector.isRemoving()).toEqual(false);
         });

--- a/src/coupon/coupon-state.ts
+++ b/src/coupon/coupon-state.ts
@@ -18,3 +18,8 @@ export interface CouponStatusesState {
     isApplyingCoupon?: boolean;
     isRemovingCoupon?: boolean;
 }
+
+export const DEFAULT_STATE: CouponState = {
+    errors: {},
+    statuses: {},
+};

--- a/src/coupon/gift-certificate-reducer.ts
+++ b/src/coupon/gift-certificate-reducer.ts
@@ -2,6 +2,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
+import { arrayReplace, objectSet } from '../common/utility';
 import { ConsignmentAction, ConsignmentActionType } from '../shipping/consignment-actions';
 
 import { CouponAction, CouponActionType } from './coupon-actions';
@@ -36,7 +37,7 @@ function dataReducer(
     case CouponActionType.RemoveCouponSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
-        return action.payload ? action.payload.giftCertificates : data;
+        return arrayReplace(data, action.payload && action.payload.giftCertificates);
 
     default:
         return data;
@@ -50,17 +51,17 @@ function errorsReducer(
     switch (action.type) {
     case GiftCertificateActionType.ApplyGiftCertificateRequested:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
-        return { ...errors, applyGiftCertificateError: undefined };
+        return objectSet(errors, 'applyGiftCertificateError', undefined);
 
     case GiftCertificateActionType.ApplyGiftCertificateFailed:
-        return { ...errors, applyGiftCertificateError: action.payload };
+        return objectSet(errors, 'applyGiftCertificateError', action.payload);
 
     case GiftCertificateActionType.RemoveGiftCertificateRequested:
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
-        return { ...errors, removeGiftCertificateError: undefined };
+        return objectSet(errors, 'removeGiftCertificateError', undefined);
 
     case GiftCertificateActionType.RemoveGiftCertificateFailed:
-        return { ...errors, removeGiftCertificateError: action.payload };
+        return objectSet(errors, 'removeGiftCertificateError', action.payload);
 
     default:
         return errors;
@@ -73,18 +74,18 @@ function statusesReducer(
 ): GiftCertificateStatusesState {
     switch (action.type) {
     case GiftCertificateActionType.ApplyGiftCertificateRequested:
-        return { ...statuses, isApplyingGiftCertificate: true };
+        return objectSet(statuses, 'isApplyingGiftCertificate', true);
 
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateFailed:
-        return { ...statuses, isApplyingGiftCertificate: false };
+        return objectSet(statuses, 'isApplyingGiftCertificate', false);
 
     case GiftCertificateActionType.RemoveGiftCertificateRequested:
-        return { ...statuses, isRemovingGiftCertificate: true };
+        return objectSet(statuses, 'isRemovingGiftCertificate', true);
 
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
     case GiftCertificateActionType.RemoveGiftCertificateFailed:
-        return { ...statuses, isRemovingGiftCertificate: false };
+        return objectSet(statuses, 'isRemovingGiftCertificate', false);
 
     default:
         return statuses;

--- a/src/coupon/gift-certificate-reducer.ts
+++ b/src/coupon/gift-certificate-reducer.ts
@@ -7,12 +7,7 @@ import { ConsignmentAction, ConsignmentActionType } from '../shipping/consignmen
 import { CouponAction, CouponActionType } from './coupon-actions';
 import GiftCertificate from './gift-certificate';
 import { GiftCertificateAction, GiftCertificateActionType } from './gift-certificate-actions';
-import GiftCertificateState, { GiftCertificateErrorsState, GiftCertificateStatusesState } from './gift-certificate-state';
-
-const DEFAULT_STATE: GiftCertificateState = {
-    errors: {},
-    statuses: {},
-};
+import GiftCertificateState, { DEFAULT_STATE, GiftCertificateErrorsState, GiftCertificateStatusesState } from './gift-certificate-state';
 
 export default function giftCertificateReducer(
     state: GiftCertificateState = DEFAULT_STATE,

--- a/src/coupon/gift-certificate-selector.spec.ts
+++ b/src/coupon/gift-certificate-selector.spec.ts
@@ -1,15 +1,17 @@
 import { createRequestErrorFactory } from '../common/error';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import GiftCertificateSelector from './gift-certificate-selector';
+import GiftCertificateSelector, { createGiftCertificateSelectorFactory, GiftCertificateSelectorFactory } from './gift-certificate-selector';
 import GiftCertificateState from './gift-certificate-state';
 
 describe('GiftCertificateSelector', () => {
+    let createGiftCertificateSelector: GiftCertificateSelectorFactory;
     let giftCertificateSelector: GiftCertificateSelector;
     let state: { giftCertificates: GiftCertificateState };
     const errorFactory = createRequestErrorFactory();
 
     beforeEach(() => {
+        createGiftCertificateSelector = createGiftCertificateSelectorFactory();
         state = {
             giftCertificates: {
                 errors: {},
@@ -22,7 +24,7 @@ describe('GiftCertificateSelector', () => {
         it('returns error if unable to apply', () => {
             const applyGiftCertificateError = errorFactory.createError(getErrorResponse());
 
-            giftCertificateSelector = new GiftCertificateSelector({
+            giftCertificateSelector = createGiftCertificateSelector({
                 ...state.giftCertificates,
                  errors: { applyGiftCertificateError } ,
             });
@@ -31,7 +33,7 @@ describe('GiftCertificateSelector', () => {
         });
 
         it('does not returns error if able to apply', () => {
-            giftCertificateSelector = new GiftCertificateSelector(state.giftCertificates);
+            giftCertificateSelector = createGiftCertificateSelector(state.giftCertificates);
 
             expect(giftCertificateSelector.getApplyError()).toBeUndefined();
         });
@@ -39,7 +41,7 @@ describe('GiftCertificateSelector', () => {
 
     describe('#isApplying()', () => {
         it('returns true if applying a gift certificate', () => {
-            giftCertificateSelector = new GiftCertificateSelector({
+            giftCertificateSelector = createGiftCertificateSelector({
                 ...state.giftCertificates,
                 statuses: { isApplyingGiftCertificate: true },
             });
@@ -48,7 +50,7 @@ describe('GiftCertificateSelector', () => {
         });
 
         it('returns false if not applying a gift certificate', () => {
-            giftCertificateSelector = new GiftCertificateSelector(state.giftCertificates);
+            giftCertificateSelector = createGiftCertificateSelector(state.giftCertificates);
 
             expect(giftCertificateSelector.isApplying()).toEqual(false);
         });
@@ -58,7 +60,7 @@ describe('GiftCertificateSelector', () => {
         it('returns error if unable to remove', () => {
             const removeGiftCertificateError = errorFactory.createError(getErrorResponse());
 
-            giftCertificateSelector = new GiftCertificateSelector({
+            giftCertificateSelector = createGiftCertificateSelector({
                 ...state.giftCertificates,
                 errors: { removeGiftCertificateError },
             });
@@ -67,7 +69,7 @@ describe('GiftCertificateSelector', () => {
         });
 
         it('does not returns error if able to remove', () => {
-            giftCertificateSelector = new GiftCertificateSelector(state.giftCertificates);
+            giftCertificateSelector = createGiftCertificateSelector(state.giftCertificates);
 
             expect(giftCertificateSelector.getRemoveError()).toBeUndefined();
         });
@@ -75,7 +77,7 @@ describe('GiftCertificateSelector', () => {
 
     describe('#isRemoving()', () => {
         it('returns true if removing a gift certificate', () => {
-            giftCertificateSelector = new GiftCertificateSelector({
+            giftCertificateSelector = createGiftCertificateSelector({
                 ...state.giftCertificates,
                 statuses: { isRemovingGiftCertificate: true },
             });
@@ -84,7 +86,7 @@ describe('GiftCertificateSelector', () => {
         });
 
         it('returns false if not removing a gift certificate', () => {
-            giftCertificateSelector = new GiftCertificateSelector(state.giftCertificates);
+            giftCertificateSelector = createGiftCertificateSelector(state.giftCertificates);
 
             expect(giftCertificateSelector.isRemoving()).toEqual(false);
         });

--- a/src/coupon/gift-certificate-state.ts
+++ b/src/coupon/gift-certificate-state.ts
@@ -18,3 +18,8 @@ export interface GiftCertificateStatusesState {
     isApplyingGiftCertificate?: boolean;
     isRemovingGiftCertificate?: boolean;
 }
+
+export const DEFAULT_STATE: GiftCertificateState = {
+    errors: {},
+    statuses: {},
+};

--- a/src/coupon/index.ts
+++ b/src/coupon/index.ts
@@ -14,7 +14,7 @@ export { default as GiftCertificateState } from './gift-certificate-state';
 export { default as InternalGiftCertificate } from './internal-gift-certificate';
 export { default as GiftCertificateActionCreator } from './gift-certificate-action-creator';
 export { default as GiftCertificateRequestSender } from './gift-certificate-request-sender';
-export { default as GiftCertificateSelector } from './gift-certificate-selector';
+export { default as GiftCertificateSelector, GiftCertificateSelectorFactory, createGiftCertificateSelectorFactory } from './gift-certificate-selector';
 export { default as giftCertificateReducer } from './gift-certificate-reducer';
 
 export { default as mapToInternalCoupon } from './map-to-internal-coupon';

--- a/src/coupon/index.ts
+++ b/src/coupon/index.ts
@@ -6,7 +6,7 @@ export { default as CouponState } from './coupon-state';
 export { default as InternalCoupon } from './internal-coupon';
 export { default as CouponActionCreator } from './coupon-action-creator';
 export { default as CouponRequestSender } from './coupon-request-sender';
-export { default as CouponSelector } from './coupon-selector';
+export { default as CouponSelector, CouponSelectorFactory, createCouponSelectorFactory } from './coupon-selector';
 export { default as couponReducer } from './coupon-reducer';
 
 export { default as GiftCertificate } from './gift-certificate';


### PR DESCRIPTION
## What?
* Refactor `CouponSelector` and `GiftCertificateSelector` to return new getters only when there are changes to relevant data.
* Update `couponReducer` and `giftCertificateSelector` to transform state only when it is necessary.

## Why?
These changes allow us to keep track of changes more efficiently. Currently, in order to make sure we return the same object reference when there are no changes to the return value of a selector, we run a deep object comparison between the old and the new value when the selector is called every time. A better approach is to do a comparison when we write to the data store. This is because we write to store less frequently than we read from it. Also, this approach allows us to memoize the selectors, as we can easily detect whether or not there's a need to re-execute the selectors. This is especially important for selectors that derive new data from existing data, as don't want to re-run them unless their depended data has changed.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
