### PR TITLE
CHECKOUT-4272: Optimise order selector and reducer

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -7,7 +7,7 @@ import { createCouponSelectorFactory, createGiftCertificateSelectorFactory } fro
 import { CustomerSelector, CustomerStrategySelector } from '../customer';
 import { FormSelector } from '../form';
 import { CountrySelector } from '../geography';
-import { OrderSelector } from '../order';
+import { createOrderSelectorFactory } from '../order';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
@@ -27,6 +27,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createBillingAddressSelector = createBillingAddressSelectorFactory();
     const createCouponSelector = createCouponSelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
+    const createOrderSelector = createOrderSelectorFactory();
 
     return (state, options = {}) => {
         const billingAddress = createBillingAddressSelector(state.billingAddress);
@@ -50,7 +51,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         // Compose selectors
         const consignments = new ConsignmentSelector(state.consignments, cart);
         const checkout = new CheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, customer, giftCertificates);
-        const order = new OrderSelector(state.order, billingAddress, coupons);
+        const order = createOrderSelector(state.order, billingAddress, coupons);
         const payment = new PaymentSelector(checkout, order);
 
         const selectors = {

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -9,7 +9,7 @@ export { default as OrderActionCreator } from './order-action-creator';
 export { default as orderReducer } from './order-reducer';
 export { default as OrderRequestBody, OrderPaymentRequestBody } from './order-request-body';
 export { default as OrderRequestSender } from './order-request-sender';
-export { default as OrderSelector } from './order-selector';
+export { default as OrderSelector, OrderSelectorFactory, createOrderSelectorFactory } from './order-selector';
 export { default as OrderState } from './order-state';
 
 export { default as mapToInternalOrder } from './map-to-internal-order';

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -2,6 +2,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 import { omit } from 'lodash';
 
 import { clearErrorReducer } from '../common/error';
+import { objectMerge, objectSet } from '../common/utility';
 
 import { OrderAction, OrderActionType } from './order-actions';
 import OrderState, { DEFAULT_STATE, OrderDataState, OrderErrorsState, OrderMetaState, OrderStatusesState } from './order-state';
@@ -28,9 +29,7 @@ function dataReducer(
     switch (action.type) {
     case OrderActionType.LoadOrderSucceeded:
     case OrderActionType.LoadOrderPaymentsSucceeded:
-        return action.payload
-            ? omit({ ...data, ...action.payload }, ['billingAddress', 'coupons'])
-            : data;
+        return objectMerge(data, omit(action.payload, ['billingAddress', 'coupons'])) as OrderDataState;
 
     default:
         return data;
@@ -44,18 +43,16 @@ function metaReducer(
     switch (action.type) {
     case OrderActionType.FinalizeOrderSucceeded:
     case OrderActionType.SubmitOrderSucceeded:
-        return action.payload ? {
-            ...meta,
+        return objectMerge(meta, {
             ...action.meta,
-            callbackUrl: action.payload.order.callbackUrl,
-            orderToken: action.payload.order.token,
-            payment: action.payload.order && action.payload.order.payment,
-        } : meta;
+            callbackUrl: action.payload && action.payload.order.callbackUrl,
+            orderToken: action.payload && action.payload.order.token,
+            payment: action.payload && action.payload.order && action.payload.order.payment,
+        });
+
     case SpamProtectionActionType.Completed:
-        return action.payload ? {
-            ...meta,
-            spamProtectionToken: action.payload,
-        } : meta;
+        return objectSet(meta, 'spamProtectionToken', action.payload);
+
     default:
         return meta;
     }
@@ -70,11 +67,11 @@ function errorsReducer(
     case OrderActionType.LoadOrderSucceeded:
     case OrderActionType.LoadOrderPaymentsSucceeded:
     case OrderActionType.LoadOrderPaymentsRequested:
-        return { ...errors, loadError: undefined };
+        return objectSet(errors, 'loadError', undefined);
 
     case OrderActionType.LoadOrderFailed:
     case OrderActionType.LoadOrderPaymentsFailed:
-        return { ...errors, loadError: action.payload };
+        return objectSet(errors, 'loadError', action.payload);
 
     default:
         return errors;
@@ -88,13 +85,13 @@ function statusesReducer(
     switch (action.type) {
     case OrderActionType.LoadOrderRequested:
     case OrderActionType.LoadOrderPaymentsRequested:
-        return { ...statuses, isLoading: true };
+        return objectSet(statuses, 'isLoading', true);
 
     case OrderActionType.LoadOrderSucceeded:
     case OrderActionType.LoadOrderFailed:
     case OrderActionType.LoadOrderPaymentsSucceeded:
     case OrderActionType.LoadOrderPaymentsFailed:
-        return { ...statuses, isLoading: false };
+        return objectSet(statuses, 'isLoading', false);
 
     default:
         return statuses;

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -4,14 +4,8 @@ import { omit } from 'lodash';
 import { clearErrorReducer } from '../common/error';
 
 import { OrderAction, OrderActionType } from './order-actions';
-import OrderState, { OrderDataState, OrderErrorsState, OrderMetaState, OrderStatusesState } from './order-state';
+import OrderState, { DEFAULT_STATE, OrderDataState, OrderErrorsState, OrderMetaState, OrderStatusesState } from './order-state';
 import { SpamProtectionAction, SpamProtectionActionType } from './spam-protection';
-
-const DEFAULT_STATE: OrderState = {
-    errors: {},
-    meta: {},
-    statuses: {},
-};
 
 export default function orderReducer(
     state: OrderState = DEFAULT_STATE,

--- a/src/order/order-selector.spec.ts
+++ b/src/order/order-selector.spec.ts
@@ -3,22 +3,24 @@ import { getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import OrderSelector from './order-selector';
+import OrderSelector, { createOrderSelectorFactory, OrderSelectorFactory } from './order-selector';
 import { getOrder } from './orders.mock';
 
 describe('OrderSelector', () => {
+    let createOrderSelector: OrderSelectorFactory;
     let orderSelector: OrderSelector;
     let state: CheckoutStoreState;
     let selectors: InternalCheckoutSelectors;
 
     beforeEach(() => {
+        createOrderSelector = createOrderSelectorFactory();
         state = getCheckoutStoreStateWithOrder();
         selectors = createInternalCheckoutSelectors(state);
     });
 
     describe('#getOrder()', () => {
         it('returns the current order', () => {
-            orderSelector = new OrderSelector(state.order, selectors.billingAddress, selectors.coupons);
+            orderSelector = createOrderSelector(state.order, selectors.billingAddress, selectors.coupons);
 
             expect(orderSelector.getOrder()).toEqual({
                 ...getOrder(),
@@ -30,7 +32,7 @@ describe('OrderSelector', () => {
 
     describe('#getOrderMeta()', () => {
         it('returns order meta', () => {
-            orderSelector = new OrderSelector(state.order, selectors.billingAddress, selectors.coupons);
+            orderSelector = createOrderSelector(state.order, selectors.billingAddress, selectors.coupons);
 
             expect(orderSelector.getOrderMeta()).toEqual(state.order.meta);
         });
@@ -40,7 +42,7 @@ describe('OrderSelector', () => {
         it('returns error if unable to load', () => {
             const loadError = new RequestError(getErrorResponse());
 
-            orderSelector = new OrderSelector({
+            orderSelector = createOrderSelector({
                 ...state.order,
                 errors: { loadError },
             }, selectors.billingAddress, selectors.coupons);
@@ -49,7 +51,7 @@ describe('OrderSelector', () => {
         });
 
         it('does not returns error if able to load', () => {
-            orderSelector = new OrderSelector(state.order, selectors.billingAddress, selectors.coupons);
+            orderSelector = createOrderSelector(state.order, selectors.billingAddress, selectors.coupons);
 
             expect(orderSelector.getLoadError()).toBeUndefined();
         });
@@ -57,7 +59,7 @@ describe('OrderSelector', () => {
 
     describe('#isLoading()', () => {
         it('returns true if loading order', () => {
-            orderSelector = new OrderSelector({
+            orderSelector = createOrderSelector({
                 ...state.order,
                 statuses: { isLoading: true },
             }, selectors.billingAddress, selectors.coupons);
@@ -66,7 +68,7 @@ describe('OrderSelector', () => {
         });
 
         it('returns false if not loading order', () => {
-            orderSelector = new OrderSelector(state.order, selectors.billingAddress, selectors.coupons);
+            orderSelector = createOrderSelector(state.order, selectors.billingAddress, selectors.coupons);
 
             expect(orderSelector.isLoading()).toEqual(false);
         });

--- a/src/order/order-state.ts
+++ b/src/order/order-state.ts
@@ -31,3 +31,9 @@ export interface OrderStatusesState {
     isSubmitting?: boolean;
     isFinalizing?: boolean;
 }
+
+export const DEFAULT_STATE: OrderState = {
+    errors: {},
+    meta: {},
+    statuses: {},
+};

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -220,7 +220,7 @@ describe('AfterpayPaymentStrategy', () => {
                         }],
                     },
                 },
-                order: null,
+                order: {},
             }));
 
             strategy = new AfterpayPaymentStrategy(


### PR DESCRIPTION
## What?
* Refactor `OrderSelector` to return new getters only when there are changes to relevant data.
* Update `orderReducer` to transform state only when it is necessary.

## Why?
These changes allow us to keep track of changes more efficiently. Currently, in order to make sure we return the same object reference when there are no changes to the return value of a selector, we run a deep object comparison between the old and the new value when the selector is called every time. A better approach is to do a comparison when we write to the data store. This is because we write to store less frequently than we read from it. Also, this approach allows us to memoize the selectors, as we can easily detect whether or not there's a need to re-execute the selectors. This is especially important for selectors that derive new data from existing data, as don't want to re-run them unless their depended data has changed.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
