### PR TITLE
CHECKOUT-4272: Optimise country / shipping country selector and reducer

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -11,7 +11,7 @@ import { createOrderSelectorFactory } from '../order';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
-import { ConsignmentSelector, ShippingAddressSelector, ShippingCountrySelector, ShippingStrategySelector } from '../shipping';
+import { createShippingCountrySelectorFactory, ConsignmentSelector, ShippingAddressSelector, ShippingStrategySelector } from '../shipping';
 
 import CheckoutSelector from './checkout-selector';
 import { CheckoutStoreOptions } from './checkout-store';
@@ -32,6 +32,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createCouponSelector = createCouponSelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
+    const createShippingCountrySelector = createShippingCountrySelectorFactory();
     const createOrderSelector = createOrderSelectorFactory();
 
     return (state, options = {}) => {
@@ -50,7 +51,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
         const shippingAddress = new ShippingAddressSelector(state.consignments);
         const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);
-        const shippingCountries = new ShippingCountrySelector(state.shippingCountries);
+        const shippingCountries = createShippingCountrySelector(state.shippingCountries);
         const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);
 
         // Compose selectors

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -6,7 +6,7 @@ import { createConfigSelectorFactory } from '../config';
 import { createCouponSelectorFactory, createGiftCertificateSelectorFactory } from '../coupon';
 import { CustomerSelector, CustomerStrategySelector } from '../customer';
 import { createFormSelectorFactory } from '../form';
-import { CountrySelector } from '../geography';
+import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
@@ -28,6 +28,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createCartSelector = createCartSelectorFactory();
     const createCheckoutButtonSelector = createCheckoutButtonSelectorFactory();
     const createConfigSelector = createConfigSelectorFactory();
+    const createCountrySelector = createCountrySelectorFactory();
     const createCouponSelector = createCouponSelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
@@ -38,7 +39,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const cart = createCartSelector(state.cart);
         const checkoutButton = createCheckoutButtonSelector(state.checkoutButton);
         const config = createConfigSelector(state.config);
-        const countries = new CountrySelector(state.countries);
+        const countries = createCountrySelector(state.countries);
         const coupons = createCouponSelector(state.coupons);
         const customer = new CustomerSelector(state.customer);
         const customerStrategies = new CustomerStrategySelector(state.customerStrategies);

--- a/src/geography/country-reducer.ts
+++ b/src/geography/country-reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { clearErrorReducer } from '../common/error';
+import { arrayReplace, objectSet } from '../common/utility';
 
 import Country from './country';
 import { CountryActionType, LoadCountriesAction } from './country-actions';
@@ -25,7 +26,7 @@ function dataReducer(
 ): Country[] | undefined {
     switch (action.type) {
     case CountryActionType.LoadCountriesSucceeded:
-        return action.payload || [];
+        return arrayReplace(data, action.payload);
 
     default:
         return data;
@@ -39,10 +40,10 @@ function errorsReducer(
     switch (action.type) {
     case CountryActionType.LoadCountriesRequested:
     case CountryActionType.LoadCountriesSucceeded:
-        return { ...errors, loadError: undefined };
+        return objectSet(errors, 'loadError', undefined);
 
     case CountryActionType.LoadCountriesFailed:
-        return { ...errors, loadError: action.payload };
+        return objectSet(errors, 'loadError', action.payload);
 
     default:
         return errors;
@@ -55,11 +56,11 @@ function statusesReducer(
 ): CountryStatusesState {
     switch (action.type) {
     case CountryActionType.LoadCountriesRequested:
-        return { ...statuses, isLoading: true };
+        return objectSet(statuses, 'isLoading', true);
 
     case CountryActionType.LoadCountriesSucceeded:
     case CountryActionType.LoadCountriesFailed:
-        return { ...statuses, isLoading: false };
+        return objectSet(statuses, 'isLoading', false);
 
     default:
         return statuses;

--- a/src/geography/country-reducer.ts
+++ b/src/geography/country-reducer.ts
@@ -4,12 +4,7 @@ import { clearErrorReducer } from '../common/error';
 
 import Country from './country';
 import { CountryActionType, LoadCountriesAction } from './country-actions';
-import CountryState, { CountryErrorsState, CountryStatusesState } from './country-state';
-
-const DEFAULT_STATE: CountryState = {
-    errors: {},
-    statuses: {},
-};
+import CountryState, { CountryErrorsState, CountryStatusesState, DEFAULT_STATE } from './country-state';
 
 export default function countryReducer(
     state: CountryState = DEFAULT_STATE,

--- a/src/geography/country-selector.spec.ts
+++ b/src/geography/country-selector.spec.ts
@@ -1,25 +1,27 @@
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
-import CountrySelector from './country-selector';
+import CountrySelector, { createCountrySelectorFactory, CountrySelectorFactory } from './country-selector';
 
 describe('CountrySelector', () => {
     let countrySelector: CountrySelector;
+    let createCountrySelector: CountrySelectorFactory;
     let state: CheckoutStoreState;
 
     beforeEach(() => {
+        createCountrySelector = createCountrySelectorFactory();
         state = getCheckoutStoreState();
     });
 
     describe('#getCountries()', () => {
         it('returns a list of countries', () => {
-            countrySelector = new CountrySelector(state.countries);
+            countrySelector = createCountrySelector(state.countries);
 
             expect(countrySelector.getCountries()).toEqual(state.countries.data);
         });
 
         it('returns an empty array if there are no countries', () => {
-            countrySelector = new CountrySelector({
+            countrySelector = createCountrySelector({
                 ...state.countries,
                 data: [],
             });
@@ -32,7 +34,7 @@ describe('CountrySelector', () => {
         it('returns error if unable to load', () => {
             const loadError = new Error();
 
-            countrySelector = new CountrySelector({
+            countrySelector = createCountrySelector({
                 ...state.countries,
                 errors: { loadError },
             });
@@ -41,7 +43,7 @@ describe('CountrySelector', () => {
         });
 
         it('does not returns error if able to load', () => {
-            countrySelector = new CountrySelector(state.countries);
+            countrySelector = createCountrySelector(state.countries);
 
             expect(countrySelector.getLoadError()).toBeUndefined();
         });
@@ -49,7 +51,7 @@ describe('CountrySelector', () => {
 
     describe('#isLoading()', () => {
         it('returns true if loading countries', () => {
-            countrySelector = new CountrySelector({
+            countrySelector = createCountrySelector({
                 ...state.countries,
                 statuses: { isLoading: true },
             });
@@ -58,7 +60,7 @@ describe('CountrySelector', () => {
         });
 
         it('returns false if not loading countries', () => {
-            countrySelector = new CountrySelector(state.countries);
+            countrySelector = createCountrySelector(state.countries);
 
             expect(countrySelector.isLoading()).toEqual(false);
         });

--- a/src/geography/country-state.ts
+++ b/src/geography/country-state.ts
@@ -13,3 +13,8 @@ export interface CountryErrorsState {
 export interface CountryStatusesState {
     isLoading?: boolean;
 }
+
+export const DEFAULT_STATE: CountryState = {
+    errors: {},
+    statuses: {},
+};

--- a/src/geography/index.ts
+++ b/src/geography/index.ts
@@ -3,6 +3,6 @@ export * from './country-responses';
 export { default as CountryActionCreator } from './country-action-creator';
 export { default as CountryRequestSender } from './country-request-sender';
 export { default as Country } from './country';
-export { default as CountrySelector } from './country-selector';
+export { default as CountrySelector, CountrySelectorFactory, createCountrySelectorFactory } from './country-selector';
 export { default as CountryState } from './country-state';
 export { default as countryReducer } from './country-reducer';

--- a/src/shipping/index.ts
+++ b/src/shipping/index.ts
@@ -14,7 +14,7 @@ export { default as ShippingAddressSelector } from './shipping-address-selector'
 
 export { default as ShippingCountryActionCreator } from './shipping-country-action-creator';
 export { default as ShippingCountryRequestSender } from './shipping-country-request-sender';
-export { default as ShippingCountrySelector } from './shipping-country-selector';
+export { default as ShippingCountrySelector, ShippingCountrySelectorFactory, createShippingCountrySelectorFactory } from './shipping-country-selector';
 export { default as ShippingCountryState } from './shipping-country-state';
 export { default as shippingCountryReducer } from './shipping-country-reducer';
 

--- a/src/shipping/shipping-country-reducer.ts
+++ b/src/shipping/shipping-country-reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { clearErrorReducer } from '../common/error';
+import { arrayReplace, objectSet } from '../common/utility';
 import { Country } from '../geography';
 
 import { LoadShippingCountriesAction, ShippingCountryActionType } from './shipping-country-actions';
@@ -25,7 +26,7 @@ function dataReducer(
 ): Country[] | undefined {
     switch (action.type) {
     case ShippingCountryActionType.LoadShippingCountriesSucceeded:
-        return action.payload || [];
+        return arrayReplace(data, action.payload);
 
     default:
         return data;
@@ -39,10 +40,10 @@ function errorsReducer(
     switch (action.type) {
     case ShippingCountryActionType.LoadShippingCountriesRequested:
     case ShippingCountryActionType.LoadShippingCountriesSucceeded:
-        return { ...errors, loadError: undefined };
+        return objectSet(errors, 'loadError', undefined);
 
     case ShippingCountryActionType.LoadShippingCountriesFailed:
-        return { ...errors, loadError: action.payload };
+        return objectSet(errors, 'loadError', action.payload);
 
     default:
         return errors;
@@ -55,11 +56,11 @@ function statusesReducer(
 ): ShippingCountryStatusesState {
     switch (action.type) {
     case ShippingCountryActionType.LoadShippingCountriesRequested:
-        return { ...statuses, isLoading: true };
+        return objectSet(statuses, 'isLoading', true);
 
     case ShippingCountryActionType.LoadShippingCountriesSucceeded:
     case ShippingCountryActionType.LoadShippingCountriesFailed:
-        return { ...statuses, isLoading: false };
+        return objectSet(statuses, 'isLoading', false);
 
     default:
         return statuses;

--- a/src/shipping/shipping-country-reducer.ts
+++ b/src/shipping/shipping-country-reducer.ts
@@ -4,12 +4,7 @@ import { clearErrorReducer } from '../common/error';
 import { Country } from '../geography';
 
 import { LoadShippingCountriesAction, ShippingCountryActionType } from './shipping-country-actions';
-import ShippingCountryState, { ShippingCountryErrorsState, ShippingCountryStatusesState } from './shipping-country-state';
-
-const DEFAULT_STATE: ShippingCountryState = {
-    errors: {},
-    statuses: {},
-};
+import ShippingCountryState, { DEFAULT_STATE, ShippingCountryErrorsState, ShippingCountryStatusesState } from './shipping-country-state';
 
 export default function shippingCountryReducer(
     state: ShippingCountryState = DEFAULT_STATE,

--- a/src/shipping/shipping-country-selector.spec.ts
+++ b/src/shipping/shipping-country-selector.spec.ts
@@ -1,25 +1,27 @@
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
-import ShippingCountrySelector from './shipping-country-selector';
+import ShippingCountrySelector, { createShippingCountrySelectorFactory, ShippingCountrySelectorFactory } from './shipping-country-selector';
 
 describe('ShippingCountrySelector', () => {
+    let createShippingCountrySelector: ShippingCountrySelectorFactory;
     let shippingCountrySelector: ShippingCountrySelector;
     let state: CheckoutStoreState;
 
     beforeEach(() => {
+        createShippingCountrySelector = createShippingCountrySelectorFactory();
         state = getCheckoutStoreState();
     });
 
     describe('#getShippingCountries()', () => {
         it('returns a list of countries', () => {
-            shippingCountrySelector = new ShippingCountrySelector(state.shippingCountries);
+            shippingCountrySelector = createShippingCountrySelector(state.shippingCountries);
 
             expect(shippingCountrySelector.getShippingCountries()).toEqual(state.shippingCountries.data);
         });
 
         it('returns an empty array if there are no countries', () => {
-            shippingCountrySelector = new ShippingCountrySelector({
+            shippingCountrySelector = createShippingCountrySelector({
                 ...state.shippingCountries,
                 data: [],
             });
@@ -32,7 +34,7 @@ describe('ShippingCountrySelector', () => {
         it('returns error if unable to load', () => {
             const loadError = new Error();
 
-            shippingCountrySelector = new ShippingCountrySelector({
+            shippingCountrySelector = createShippingCountrySelector({
                 ...state.shippingCountries,
                 errors: { loadError },
             });
@@ -41,7 +43,7 @@ describe('ShippingCountrySelector', () => {
         });
 
         it('does not returns error if able to load', () => {
-            shippingCountrySelector = new ShippingCountrySelector(state.shippingCountries);
+            shippingCountrySelector = createShippingCountrySelector(state.shippingCountries);
 
             expect(shippingCountrySelector.getLoadError()).toBeUndefined();
         });
@@ -49,7 +51,7 @@ describe('ShippingCountrySelector', () => {
 
     describe('#isLoading()', () => {
         it('returns true if loading countries', () => {
-            shippingCountrySelector = new ShippingCountrySelector({
+            shippingCountrySelector = createShippingCountrySelector({
                 ...state.shippingCountries,
                 statuses: { isLoading: true },
             });
@@ -58,7 +60,7 @@ describe('ShippingCountrySelector', () => {
         });
 
         it('returns false if not loading countries', () => {
-            shippingCountrySelector = new ShippingCountrySelector(state.shippingCountries);
+            shippingCountrySelector = createShippingCountrySelector(state.shippingCountries);
 
             expect(shippingCountrySelector.isLoading()).toEqual(false);
         });

--- a/src/shipping/shipping-country-state.ts
+++ b/src/shipping/shipping-country-state.ts
@@ -13,3 +13,8 @@ export interface ShippingCountryErrorsState {
 export interface ShippingCountryStatusesState {
     isLoading?: boolean;
 }
+
+export const DEFAULT_STATE: ShippingCountryState = {
+    errors: {},
+    statuses: {},
+};


### PR DESCRIPTION
## What?
* Refactor `CountrySelector` and `ShippingCountrySelector` to return new getters only when there are changes to relevant data.
* Update `countryReducer` and `shippingCountryReducer` to transform state only when it is necessary.

## Why?
Please refer to my previous PRs. They are related to this one.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
