### PR TITLE
CHECKOUT-4272: Optimise customer / customer strategy selector and reducer

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -4,7 +4,7 @@ import { createCheckoutButtonSelectorFactory } from '../checkout-buttons';
 import { createFreezeProxies } from '../common/utility';
 import { createConfigSelectorFactory } from '../config';
 import { createCouponSelectorFactory, createGiftCertificateSelectorFactory } from '../coupon';
-import { createCustomerSelectorFactory, CustomerStrategySelector } from '../customer';
+import { createCustomerSelectorFactory, createCustomerStrategySelectorFactory } from '../customer';
 import { createFormSelectorFactory } from '../form';
 import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
@@ -31,6 +31,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createCountrySelector = createCountrySelectorFactory();
     const createCouponSelector = createCouponSelectorFactory();
     const createCustomerSelector = createCustomerSelectorFactory();
+    const createCustomerStrategySelector = createCustomerStrategySelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
@@ -44,7 +45,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const countries = createCountrySelector(state.countries);
         const coupons = createCouponSelector(state.coupons);
         const customer = createCustomerSelector(state.customer);
-        const customerStrategies = new CustomerStrategySelector(state.customerStrategies);
+        const customerStrategies = createCustomerStrategySelector(state.customerStrategies);
         const form = createFormSelector(state.config);
         const giftCertificates = createGiftCertificateSelector(state.giftCertificates);
         const instruments = new InstrumentSelector(state.instruments);

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -4,7 +4,7 @@ import { createCheckoutButtonSelectorFactory } from '../checkout-buttons';
 import { createFreezeProxies } from '../common/utility';
 import { createConfigSelectorFactory } from '../config';
 import { createCouponSelectorFactory, createGiftCertificateSelectorFactory } from '../coupon';
-import { CustomerSelector, CustomerStrategySelector } from '../customer';
+import { createCustomerSelectorFactory, CustomerStrategySelector } from '../customer';
 import { createFormSelectorFactory } from '../form';
 import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
@@ -30,6 +30,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createConfigSelector = createConfigSelectorFactory();
     const createCountrySelector = createCountrySelectorFactory();
     const createCouponSelector = createCouponSelectorFactory();
+    const createCustomerSelector = createCustomerSelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
@@ -42,7 +43,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const config = createConfigSelector(state.config);
         const countries = createCountrySelector(state.countries);
         const coupons = createCouponSelector(state.coupons);
-        const customer = new CustomerSelector(state.customer);
+        const customer = createCustomerSelector(state.customer);
         const customerStrategies = new CustomerStrategySelector(state.customerStrategies);
         const form = createFormSelector(state.config);
         const giftCertificates = createGiftCertificateSelector(state.giftCertificates);

--- a/src/customer/customer-reducer.ts
+++ b/src/customer/customer-reducer.ts
@@ -3,9 +3,7 @@ import { combineReducers } from '@bigcommerce/data-store';
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 
 import Customer from './customer';
-import CustomerState from './customer-state';
-
-const DEFAULT_STATE: CustomerState = {};
+import CustomerState, { DEFAULT_STATE } from './customer-state';
 
 export default function customerReducer(
     state: CustomerState = DEFAULT_STATE,

--- a/src/customer/customer-reducer.ts
+++ b/src/customer/customer-reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
+import { objectMerge } from '../common/utility';
 
 import Customer from './customer';
 import CustomerState, { DEFAULT_STATE } from './customer-state';
@@ -22,7 +23,7 @@ function dataReducer(
 ): Customer | undefined {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutSucceeded:
-        return action.payload ? { ...data, ...action.payload.customer } : data;
+        return objectMerge(data, action.payload && action.payload.customer);
 
     default:
         return data;

--- a/src/customer/customer-selector.spec.ts
+++ b/src/customer/customer-selector.spec.ts
@@ -1,26 +1,28 @@
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
-import CustomerSelector from './customer-selector';
+import CustomerSelector, { createCustomerSelectorFactory, CustomerSelectorFactory } from './customer-selector';
 import { getCustomer } from './customers.mock';
 
 describe('CustomerSelector', () => {
+    let createCustomerSelector: CustomerSelectorFactory;
     let selector: CustomerSelector;
     let state: CheckoutStoreState;
 
     beforeEach(() => {
+        createCustomerSelector = createCustomerSelectorFactory();
         state = getCheckoutStoreState();
     });
 
     describe('#getCustomer()', () => {
         it('returns current customer', () => {
-            selector = new CustomerSelector(state.customer);
+            selector = createCustomerSelector(state.customer);
 
             expect(selector.getCustomer()).toEqual(getCustomer());
         });
 
         it('returns undefined if customer is unavailable', () => {
-            selector = new CustomerSelector({});
+            selector = createCustomerSelector({});
 
             expect(selector.getCustomer()).toEqual(undefined);
         });

--- a/src/customer/customer-selector.ts
+++ b/src/customer/customer-selector.ts
@@ -1,15 +1,26 @@
-import { selector } from '../common/selector';
+import { createSelector } from '../common/selector';
+import { memoizeOne } from '../common/utility';
 
 import Customer from './customer';
-import CustomerState from './customer-state';
+import CustomerState, { DEFAULT_STATE } from './customer-state';
 
-@selector
-export default class CustomerSelector {
-    constructor(
-        private _customer: CustomerState
-    ) {}
+export default interface CustomerSelector {
+    getCustomer(): Customer | undefined;
+}
 
-    getCustomer(): Customer | undefined {
-        return this._customer.data;
-    }
+export type CustomerSelectorFactory = (state: CustomerState) => CustomerSelector;
+
+export function createCustomerSelectorFactory(): CustomerSelectorFactory {
+    const getCustomer = createSelector(
+        (state: CustomerState) => state.data,
+        customer => () => customer
+    );
+
+    return memoizeOne((
+        state: CustomerState = DEFAULT_STATE
+    ): CustomerSelector => {
+        return {
+            getCustomer: getCustomer(state),
+        };
+    });
 }

--- a/src/customer/customer-state.ts
+++ b/src/customer/customer-state.ts
@@ -3,3 +3,5 @@ import Customer from './customer';
 export default interface CustomerState {
     data?: Customer;
 }
+
+export const DEFAULT_STATE: CustomerState = {};

--- a/src/customer/customer-strategy-reducer.ts
+++ b/src/customer/customer-strategy-reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { clearErrorReducer } from '../common/error';
+import { objectMerge } from '../common/utility';
 
 import { CustomerStrategyAction, CustomerStrategyActionType } from './customer-strategy-actions';
 import CustomerStrategyState, { CustomerStrategyDataState, CustomerStrategyErrorsState, CustomerStrategyStatusesState, DEFAULT_STATE } from './customer-strategy-state';
@@ -24,20 +25,18 @@ function dataReducer(
 ): CustomerStrategyDataState {
     switch (action.type) {
     case CustomerStrategyActionType.InitializeSucceeded:
-        return {
-            ...data,
+        return objectMerge(data, {
             [action.meta && action.meta.methodId]: {
                 isInitialized: true,
             },
-        };
+        });
 
     case CustomerStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...data,
+        return objectMerge(data, {
             [action.meta && action.meta.methodId]: {
                 isInitialized: false,
             },
-        };
+        });
     }
 
     return data;
@@ -50,78 +49,68 @@ function errorsReducer(
     switch (action.type) {
     case CustomerStrategyActionType.InitializeRequested:
     case CustomerStrategyActionType.InitializeSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             initializeError: undefined,
             initializeMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.InitializeFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             initializeError: action.payload,
             initializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case CustomerStrategyActionType.DeinitializeRequested:
     case CustomerStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             deinitializeError: undefined,
             deinitializeMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.DeinitializeFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             deinitializeError: action.payload,
             deinitializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case CustomerStrategyActionType.SignInRequested:
     case CustomerStrategyActionType.SignInSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             signInError: undefined,
             signInMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.SignInFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             signInError: action.payload,
             signInMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case CustomerStrategyActionType.SignOutRequested:
     case CustomerStrategyActionType.SignOutSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             signOutError: undefined,
             signOutMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.SignOutFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             signOutError: action.payload,
             signOutMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case CustomerStrategyActionType.WidgetInteractionStarted:
     case CustomerStrategyActionType.WidgetInteractionFinished:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             widgetInteractionError: undefined,
             widgetInteractionMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.WidgetInteractionFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             widgetInteractionError: action.payload,
             widgetInteractionMethodId: action.meta.methodId,
-        };
+        });
 
     default:
         return errors;
@@ -134,79 +123,69 @@ function statusesReducer(
 ): CustomerStrategyStatusesState {
     switch (action.type) {
     case CustomerStrategyActionType.InitializeRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isInitializing: true,
             initializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case CustomerStrategyActionType.InitializeFailed:
     case CustomerStrategyActionType.InitializeSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isInitializing: false,
             initializeMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.DeinitializeRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isDeinitializing: true,
             deinitializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case CustomerStrategyActionType.DeinitializeFailed:
     case CustomerStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isDeinitializing: false,
             deinitializeMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.SignInRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isSigningIn: true,
             signInMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case CustomerStrategyActionType.SignInFailed:
     case CustomerStrategyActionType.SignInSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isSigningIn: false,
             signInMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.SignOutRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isSigningOut: true,
             signOutMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case CustomerStrategyActionType.SignOutFailed:
     case CustomerStrategyActionType.SignOutSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isSigningOut: false,
             signOutMethodId: undefined,
-        };
+        });
 
     case CustomerStrategyActionType.WidgetInteractionStarted:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isWidgetInteracting: true,
             widgetInteractionMethodId: action.meta.methodId,
-         };
+         });
 
     case CustomerStrategyActionType.WidgetInteractionFinished:
     case CustomerStrategyActionType.WidgetInteractionFailed:
-         return {
-            ...statuses,
+        return objectMerge(statuses, {
             isWidgetInteracting: false,
             widgetInteractionMethodId: undefined,
-         };
+         });
 
     default:
         return statuses;

--- a/src/customer/customer-strategy-selector.spec.ts
+++ b/src/customer/customer-strategy-selector.spec.ts
@@ -1,13 +1,15 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import CustomerStrategySelector from './customer-strategy-selector';
+import CustomerStrategySelector, { createCustomerStrategySelectorFactory, CustomerStrategySelectorFactory } from './customer-strategy-selector';
 import { getCustomerStrategyState } from './internal-customers.mock';
 
 describe('CustomerStrategySelector', () => {
+    let createCustomerStrategySelector: CustomerStrategySelectorFactory;
     let selector: CustomerStrategySelector;
     let state: any;
 
     beforeEach(() => {
+        createCustomerStrategySelector = createCustomerStrategySelectorFactory();
         state = {
             customerStrategy: getCustomerStrategyState(),
         };
@@ -17,7 +19,7 @@ describe('CustomerStrategySelector', () => {
         it('returns error if unable to sign in', () => {
             const signInError = getErrorResponse();
 
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 errors: { signInError },
             });
@@ -26,7 +28,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('does not returns error if able to sign in', () => {
-            selector = new CustomerStrategySelector(state.customerStrategy);
+            selector = createCustomerStrategySelector(state.customerStrategy);
 
             expect(selector.getSignInError()).toBeUndefined();
         });
@@ -36,7 +38,7 @@ describe('CustomerStrategySelector', () => {
         it('returns error if unable to sign out', () => {
             const signOutError = getErrorResponse();
 
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 errors: { signOutError },
             });
@@ -45,7 +47,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('does not returns error if able to sign out', () => {
-            selector = new CustomerStrategySelector(state.customerStrategy);
+            selector = createCustomerStrategySelector(state.customerStrategy);
 
             expect(selector.getSignOutError()).toBeUndefined();
         });
@@ -53,7 +55,7 @@ describe('CustomerStrategySelector', () => {
 
     describe('#getInitializeError()', () => {
         it('returns error if unable to initialize any method', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 errors: { initializeError: getErrorResponse(), initializeMethodId: 'foobar' },
             });
@@ -62,7 +64,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns error if unable to initialize specific method', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 errors: { initializeError: getErrorResponse(), initializeMethodId: 'foobar' },
             });
@@ -72,7 +74,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('does not return error if able to initialize', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 errors: {},
             });
@@ -83,7 +85,7 @@ describe('CustomerStrategySelector', () => {
 
     describe('#getWidgetInteractingError()', () => {
         it('returns error if unable to initialize any method', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 errors: { widgetInteractionError: getErrorResponse(), widgetInteractionMethodId: 'foobar' },
             });
@@ -92,7 +94,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns error if unable to initialize specific method', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 errors: { widgetInteractionError: getErrorResponse(), widgetInteractionMethodId: 'foobar' },
             });
@@ -102,7 +104,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('does not return error if able to initialize', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 errors: {},
             });
@@ -113,7 +115,7 @@ describe('CustomerStrategySelector', () => {
 
     describe('#isSigningIn()', () => {
         it('returns true if signing in', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 statuses: { isSigningIn: true },
             });
@@ -122,7 +124,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns false if not signing in', () => {
-            selector = new CustomerStrategySelector(state.customerStrategy);
+            selector = createCustomerStrategySelector(state.customerStrategy);
 
             expect(selector.isSigningIn()).toEqual(false);
         });
@@ -130,7 +132,7 @@ describe('CustomerStrategySelector', () => {
 
     describe('#isSigningOut()', () => {
         it('returns true if signing out', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 statuses: { isSigningOut: true },
             });
@@ -139,7 +141,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns false if not signing out', () => {
-            selector = new CustomerStrategySelector(state.customerStrategy);
+            selector = createCustomerStrategySelector(state.customerStrategy);
 
             expect(selector.isSigningOut()).toEqual(false);
         });
@@ -147,7 +149,7 @@ describe('CustomerStrategySelector', () => {
 
     describe('#isInitializing()', () => {
         it('returns true if initializing any method', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 statuses: { initializeMethodId: 'foobar', isInitializing: true },
             });
@@ -156,7 +158,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns true if initializing specific method', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 statuses: { initializeMethodId: 'foobar', isInitializing: true },
             });
@@ -166,7 +168,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns false if not initializing method', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 statuses: { initializeMethodId: undefined, isInitializing: false },
             });
@@ -177,7 +179,7 @@ describe('CustomerStrategySelector', () => {
 
     describe('#isInitialized()', () => {
         it('returns true if method is initialized', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 data: { foobar: { isInitialized: true } },
             });
@@ -186,7 +188,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns false if method is not initialized', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 data: { foobar: { isInitialized: false } },
             });
@@ -198,7 +200,7 @@ describe('CustomerStrategySelector', () => {
 
     describe('#isWidgetInteracting()', () => {
         it('returns true if any method is interacting with a widget', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 statuses: { widgetInteractionMethodId: 'foobar', isWidgetInteracting: true },
             });
@@ -207,7 +209,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns true if a specific method is interacting with a widget', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 statuses: { widgetInteractionMethodId: 'foobar', isWidgetInteracting: true },
             });
@@ -217,7 +219,7 @@ describe('CustomerStrategySelector', () => {
         });
 
         it('returns false if not interacting with a widget', () => {
-            selector = new CustomerStrategySelector({
+            selector = createCustomerStrategySelector({
                 ...state.customerStrategy,
                 statuses: { widgetInteractionMethodId: undefined, isWidgetInteracting: false },
             });

--- a/src/customer/customer-strategy-selector.ts
+++ b/src/customer/customer-strategy-selector.ts
@@ -1,77 +1,142 @@
-import CustomerStrategyState from './customer-strategy-state';
+import { createSelector } from '../common/selector';
+import { memoizeOne } from '../common/utility';
 
-export default class CustomerStrategySelector {
-    constructor(
-        private _customerStrategies: CustomerStrategyState
-    ) {}
+import CustomerStrategyState, { DEFAULT_STATE } from './customer-strategy-state';
 
-    getSignInError(methodId?: string): Error | undefined {
-        if (methodId && this._customerStrategies.errors.signInMethodId !== methodId) {
-            return;
+export default interface CustomerStrategySelector {
+    getSignInError(methodId?: string): Error | undefined;
+    getSignOutError(methodId?: string): Error | undefined;
+    getInitializeError(methodId?: string): Error | undefined;
+    getWidgetInteractionError(methodId?: string): Error | undefined;
+    isSigningIn(methodId?: string): boolean;
+    isSigningOut(methodId?: string): boolean;
+    isInitializing(methodId?: string): boolean;
+    isInitialized(methodId: string): boolean;
+    isWidgetInteracting(methodId?: string): boolean;
+}
+
+export type CustomerStrategySelectorFactory = (state: CustomerStrategyState) => CustomerStrategySelector;
+
+export function createCustomerStrategySelectorFactory(): CustomerStrategySelectorFactory {
+    const getSignInError = createSelector(
+        (state: CustomerStrategyState) => state.errors.signInMethodId,
+        (state: CustomerStrategyState) => state.errors.signInError,
+        (signInMethodId, signInError) => (methodId?: string) => {
+            if (methodId && signInMethodId !== methodId) {
+                return;
+            }
+
+            return signInError;
         }
+    );
 
-        return this._customerStrategies.errors.signInError;
-    }
+    const getSignOutError = createSelector(
+        (state: CustomerStrategyState) => state.errors.signOutMethodId,
+        (state: CustomerStrategyState) => state.errors.signOutError,
+        (signOutMethodId, signOutError) => (methodId?: string) => {
+            if (methodId && signOutMethodId !== methodId) {
+                return;
+            }
 
-    getSignOutError(methodId?: string): Error | undefined {
-        if (methodId && this._customerStrategies.errors.signOutMethodId !== methodId) {
-            return;
+            return signOutError;
         }
+    );
 
-        return this._customerStrategies.errors.signOutError;
-    }
+    const getInitializeError = createSelector(
+        (state: CustomerStrategyState) => state.errors.initializeMethodId,
+        (state: CustomerStrategyState) => state.errors.initializeError,
+        (initializeMethodId, initializeError) => (methodId?: string) => {
+            if (methodId && initializeMethodId !== methodId) {
+                return;
+            }
 
-    getInitializeError(methodId?: string): Error | undefined {
-        if (methodId && this._customerStrategies.errors.initializeMethodId !== methodId) {
-            return;
+            return initializeError;
         }
+    );
 
-        return this._customerStrategies.errors.initializeError;
-    }
+    const getWidgetInteractionError = createSelector(
+        (state: CustomerStrategyState) => state.errors.widgetInteractionMethodId,
+        (state: CustomerStrategyState) => state.errors.widgetInteractionError,
+        (widgetInteractionMethodId, widgetInteractionError) => (methodId?: string) => {
+            if (methodId && widgetInteractionMethodId !== methodId) {
+                return;
+            }
 
-    getWidgetInteractionError(methodId?: string): Error | undefined {
-        if (methodId && this._customerStrategies.errors.widgetInteractionMethodId !== methodId) {
-            return;
+            return widgetInteractionError;
         }
+    );
 
-        return this._customerStrategies.errors.widgetInteractionError;
-    }
+    const isSigningIn = createSelector(
+        (state: CustomerStrategyState) => state.statuses.signInMethodId,
+        (state: CustomerStrategyState) => state.statuses.isSigningIn,
+        (signInMethodId, isSigningIn) => (methodId?: string) => {
+            if (methodId && signInMethodId !== methodId) {
+                return false;
+            }
 
-    isSigningIn(methodId?: string): boolean {
-        if (methodId && this._customerStrategies.statuses.signInMethodId !== methodId) {
-            return false;
+            return !!isSigningIn;
         }
+    );
 
-        return !!this._customerStrategies.statuses.isSigningIn;
-    }
+    const isSigningOut = createSelector(
+        (state: CustomerStrategyState) => state.statuses.signOutMethodId,
+        (state: CustomerStrategyState) => state.statuses.isSigningOut,
+        (signOutMethodId, isSigningOut) => (methodId?: string) => {
+            if (methodId && signOutMethodId !== methodId) {
+                return false;
+            }
 
-    isSigningOut(methodId?: string): boolean {
-        if (methodId && this._customerStrategies.statuses.signOutMethodId !== methodId) {
-            return false;
+            return !!isSigningOut;
         }
+    );
 
-        return !!this._customerStrategies.statuses.isSigningOut;
-    }
+    const isInitializing = createSelector(
+        (state: CustomerStrategyState) => state.statuses.initializeMethodId,
+        (state: CustomerStrategyState) => state.statuses.isInitializing,
+        (initializeMethodId, isInitializing) => (methodId?: string) => {
+            if (methodId && initializeMethodId !== methodId) {
+                return false;
+            }
 
-    isInitializing(methodId?: string): boolean {
-        if (methodId && this._customerStrategies.statuses.initializeMethodId !== methodId) {
-            return false;
+            return !!isInitializing;
         }
+    );
 
-        return !!this._customerStrategies.statuses.isInitializing;
-    }
-
-    isInitialized(methodId: string): boolean {
-        return !!(
-            this._customerStrategies.data[methodId] &&
-            this._customerStrategies.data[methodId].isInitialized
-        );
-    }
-
-    isWidgetInteracting(methodId?: string): boolean {
-        if (methodId && this._customerStrategies.statuses.widgetInteractionMethodId !== methodId) {
-            return false;
+    const isInitialized = createSelector(
+        (state: CustomerStrategyState) => state.data,
+        data => (methodId: string) => {
+            return !!(
+                data[methodId] &&
+                data[methodId].isInitialized
+            );
         }
+    );
 
-        return !!this._customerStrategies.statuses.isWidgetInteracting;
-    }}
+    const isWidgetInteracting = createSelector(
+        (state: CustomerStrategyState) => state.statuses.widgetInteractionMethodId,
+        (state: CustomerStrategyState) => state.statuses.isWidgetInteracting,
+        (widgetInteractionMethodId, isWidgetInteracting) => (methodId?: string) => {
+            if (methodId && widgetInteractionMethodId !== methodId) {
+                return false;
+            }
+
+            return !!isWidgetInteracting;
+        }
+    );
+
+    return memoizeOne((
+        state: CustomerStrategyState = DEFAULT_STATE
+    ): CustomerStrategySelector => {
+        return {
+            getSignInError: getSignInError(state),
+            getSignOutError: getSignOutError(state),
+            getInitializeError: getInitializeError(state),
+            getWidgetInteractionError: getWidgetInteractionError(state),
+            isSigningIn: isSigningIn(state),
+            isSigningOut: isSigningOut(state),
+            isInitializing: isInitializing(state),
+            isInitialized: isInitialized(state),
+            isWidgetInteracting: isWidgetInteracting(state),
+        };
+    });
+}

--- a/src/customer/index.ts
+++ b/src/customer/index.ts
@@ -12,7 +12,7 @@ export { default as CustomerRequestSender } from './customer-request-sender';
 export { default as CustomerSelector, CustomerSelectorFactory, createCustomerSelectorFactory } from './customer-selector';
 export { default as CustomerState } from './customer-state';
 export { default as CustomerStrategyActionCreator } from './customer-strategy-action-creator';
-export { default as CustomerStrategySelector } from './customer-strategy-selector';
+export { default as CustomerStrategySelector, CustomerStrategySelectorFactory, createCustomerStrategySelectorFactory } from './customer-strategy-selector';
 export { default as CustomerStrategyState } from './customer-strategy-state';
 export { default as customerStrategyReducer } from './customer-strategy-reducer';
 export { default as GuestCredentials } from './guest-credentials';

--- a/src/customer/index.ts
+++ b/src/customer/index.ts
@@ -9,7 +9,7 @@ export { default as customerReducer } from './customer-reducer';
 export { default as CustomerActionCreator } from './customer-action-creator';
 export { default as CustomerCredentials } from './customer-credentials';
 export { default as CustomerRequestSender } from './customer-request-sender';
-export { default as CustomerSelector } from './customer-selector';
+export { default as CustomerSelector, CustomerSelectorFactory, createCustomerSelectorFactory } from './customer-selector';
 export { default as CustomerState } from './customer-state';
 export { default as CustomerStrategyActionCreator } from './customer-strategy-action-creator';
 export { default as CustomerStrategySelector } from './customer-strategy-selector';


### PR DESCRIPTION
## What?
* Refactor `CustomerSelector` and `CustomerStrategySelector` to return new getters only when there are changes to relevant data.
* Update `customerReducer` and `customerStrategyReducer` to transform state only when it is necessary.

## Why?
Please refer to my previous PRs. They are related to this one.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
