### PR TITLE
CHECKOUT-4272: Optimise shipping / shipping strategy selector and reducer

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -11,7 +11,7 @@ import { createOrderSelectorFactory } from '../order';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
-import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, ShippingStrategySelector } from '../shipping';
+import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, createShippingStrategySelectorFactory } from '../shipping';
 
 import CheckoutSelector from './checkout-selector';
 import { CheckoutStoreOptions } from './checkout-store';
@@ -36,6 +36,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createFormSelector = createFormSelectorFactory();
     const createShippingAddressSelector = createShippingAddressSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
+    const createShippingStrategySelector = createShippingStrategySelectorFactory();
     const createConsignmentSelector = createConsignmentSelectorFactory();
     const createOrderSelector = createOrderSelectorFactory();
 
@@ -56,7 +57,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const shippingAddress = createShippingAddressSelector(state.consignments);
         const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);
         const shippingCountries = createShippingCountrySelector(state.shippingCountries);
-        const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);
+        const shippingStrategies = createShippingStrategySelector(state.shippingStrategies);
 
         // Compose selectors
         const consignments = createConsignmentSelector(state.consignments, cart);

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -11,7 +11,7 @@ import { createOrderSelectorFactory } from '../order';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
-import { createConsignmentSelectorFactory, createShippingCountrySelectorFactory, ShippingAddressSelector, ShippingStrategySelector } from '../shipping';
+import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, ShippingStrategySelector } from '../shipping';
 
 import CheckoutSelector from './checkout-selector';
 import { CheckoutStoreOptions } from './checkout-store';
@@ -34,6 +34,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createCustomerStrategySelector = createCustomerStrategySelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
+    const createShippingAddressSelector = createShippingAddressSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
     const createConsignmentSelector = createConsignmentSelectorFactory();
     const createOrderSelector = createOrderSelectorFactory();
@@ -52,7 +53,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const instruments = new InstrumentSelector(state.instruments);
         const paymentMethods = new PaymentMethodSelector(state.paymentMethods);
         const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
-        const shippingAddress = new ShippingAddressSelector(state.consignments);
+        const shippingAddress = createShippingAddressSelector(state.consignments);
         const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);
         const shippingCountries = createShippingCountrySelector(state.shippingCountries);
         const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -11,7 +11,7 @@ import { createOrderSelectorFactory } from '../order';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
-import { createShippingCountrySelectorFactory, ConsignmentSelector, ShippingAddressSelector, ShippingStrategySelector } from '../shipping';
+import { createConsignmentSelectorFactory, createShippingCountrySelectorFactory, ShippingAddressSelector, ShippingStrategySelector } from '../shipping';
 
 import CheckoutSelector from './checkout-selector';
 import { CheckoutStoreOptions } from './checkout-store';
@@ -35,6 +35,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
+    const createConsignmentSelector = createConsignmentSelectorFactory();
     const createOrderSelector = createOrderSelectorFactory();
 
     return (state, options = {}) => {
@@ -57,7 +58,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const shippingStrategies = new ShippingStrategySelector(state.shippingStrategies);
 
         // Compose selectors
-        const consignments = new ConsignmentSelector(state.consignments, cart);
+        const consignments = createConsignmentSelector(state.consignments, cart);
         const checkout = new CheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, customer, giftCertificates);
         const order = createOrderSelector(state.order, billingAddress, coupons);
         const payment = new PaymentSelector(checkout, order);

--- a/src/shipping/consignment-reducer.ts
+++ b/src/shipping/consignment-reducer.ts
@@ -7,20 +7,7 @@ import { CustomerAction, CustomerActionType } from '../customer';
 
 import Consignment from './consignment';
 import { ConsignmentAction, ConsignmentActionType } from './consignment-actions';
-import ConsignmentState, { ConsignmentErrorsState, ConsignmentStatusesState } from './consignment-state';
-
-const DEFAULT_STATE: ConsignmentState = {
-    errors: {
-        updateShippingOptionError: {},
-        updateError: {},
-        deleteError: {},
-    },
-    statuses: {
-        isUpdating: {},
-        isUpdatingShippingOption: {},
-        isDeleting: {},
-    },
-};
+import ConsignmentState, { ConsignmentErrorsState, ConsignmentStatusesState, DEFAULT_STATE } from './consignment-state';
 
 export default function consignmentReducer(
     state: ConsignmentState = DEFAULT_STATE,

--- a/src/shipping/consignment-reducer.ts
+++ b/src/shipping/consignment-reducer.ts
@@ -2,6 +2,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
+import { arrayReplace, objectMerge, objectSet } from '../common/utility';
 import { CouponAction, CouponActionType } from '../coupon';
 import { CustomerAction, CustomerActionType } from '../customer';
 
@@ -35,10 +36,10 @@ function dataReducer(
     case ConsignmentActionType.UpdateShippingOptionSucceeded:
     case CouponActionType.ApplyCouponSucceeded:
     case CouponActionType.RemoveCouponSucceeded:
-        return action.payload ? action.payload.consignments : data;
+        return arrayReplace(data, action.payload && action.payload.consignments);
 
     case CustomerActionType.SignOutCustomerSucceeded:
-        return [];
+        return arrayReplace(data, []);
 
     default:
         return data;
@@ -54,42 +55,38 @@ function errorsReducer(
     case CheckoutActionType.LoadCheckoutSucceeded:
     case ConsignmentActionType.LoadShippingOptionsSucceeded:
     case ConsignmentActionType.LoadShippingOptionsRequested:
-        return { ...errors, loadError: undefined };
+        return objectSet(errors, 'loadError', undefined);
 
     case CheckoutActionType.LoadCheckoutFailed:
     case ConsignmentActionType.LoadShippingOptionsFailed:
-        return { ...errors, loadError: action.payload };
+        return objectSet(errors, 'loadError', action.payload);
 
     case ConsignmentActionType.CreateConsignmentsRequested:
     case ConsignmentActionType.CreateConsignmentsSucceeded:
-        return { ...errors, createError: undefined };
+        return objectSet(errors, 'createError', undefined);
 
     case ConsignmentActionType.CreateConsignmentsFailed:
-        return { ...errors, createError: action.payload };
+        return objectSet(errors, 'createError', action.payload);
 
     case ConsignmentActionType.UpdateConsignmentSucceeded:
     case ConsignmentActionType.UpdateConsignmentRequested:
         if (action.meta) {
-            errors = {
-                ...errors,
+            return objectMerge(errors, {
                 updateError: {
-                    ...errors.updateError,
                     [action.meta.id]: undefined,
                 },
-            };
+            });
         }
 
         return errors;
 
     case ConsignmentActionType.UpdateConsignmentFailed:
         if (action.meta) {
-            errors = {
-                ...errors,
+            return objectMerge(errors, {
                 updateError: {
-                    ...errors.updateError,
                     [action.meta.id]: action.payload,
                 },
-            };
+            });
         }
 
         return errors;
@@ -97,26 +94,22 @@ function errorsReducer(
     case ConsignmentActionType.DeleteConsignmentSucceeded:
     case ConsignmentActionType.DeleteConsignmentRequested:
         if (action.meta) {
-            errors = {
-                ...errors,
+            return objectMerge(errors, {
                 deleteError: {
-                    ...errors.deleteError,
                     [action.meta.id]: undefined,
                 },
-            };
+            });
         }
 
         return errors;
 
     case ConsignmentActionType.DeleteConsignmentFailed:
         if (action.meta) {
-            errors = {
-                ...errors,
+            return objectMerge(errors, {
                 deleteError: {
-                    ...errors.deleteError,
                     [action.meta.id]: action.payload,
                 },
-            };
+            });
         }
 
         return errors;
@@ -124,26 +117,22 @@ function errorsReducer(
     case ConsignmentActionType.UpdateShippingOptionRequested:
     case ConsignmentActionType.UpdateShippingOptionSucceeded:
         if (action.meta) {
-            errors = {
-                ...errors,
+            return objectMerge(errors, {
                 updateShippingOptionError: {
-                    ...errors.updateShippingOptionError,
                     [action.meta.id]: undefined,
                 },
-            };
+            });
         }
 
         return errors;
 
     case ConsignmentActionType.UpdateShippingOptionFailed:
         if (action.meta) {
-            errors = {
-                ...errors,
+            return objectMerge(errors, {
                 updateShippingOptionError: {
-                    ...errors.updateShippingOptionError,
                     [action.meta.id]: action.payload,
                 },
-            };
+            });
         }
 
         return errors;
@@ -159,35 +148,33 @@ function statusesReducer(
 ): ConsignmentStatusesState {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
-        return { ...statuses, isLoading: true };
+        return objectSet(statuses, 'isLoading', true);
 
     case ConsignmentActionType.LoadShippingOptionsRequested:
-        return { ...statuses, isLoadingShippingOptions: true };
+        return objectSet(statuses, 'isLoadingShippingOptions', true);
 
     case CheckoutActionType.LoadCheckoutSucceeded:
     case CheckoutActionType.LoadCheckoutFailed:
-        return { ...statuses, isLoading: false };
+        return objectSet(statuses, 'isLoading', false);
 
     case ConsignmentActionType.LoadShippingOptionsSucceeded:
     case ConsignmentActionType.LoadShippingOptionsFailed:
-        return { ...statuses, isLoadingShippingOptions: false };
+        return objectSet(statuses, 'isLoadingShippingOptions', false);
 
     case ConsignmentActionType.CreateConsignmentsRequested:
-        return { ...statuses, isCreating: true };
+        return objectSet(statuses, 'isCreating', true);
 
     case ConsignmentActionType.CreateConsignmentsSucceeded:
     case ConsignmentActionType.CreateConsignmentsFailed:
-        return { ...statuses, isCreating: false };
+        return objectSet(statuses, 'isCreating', false);
 
     case ConsignmentActionType.UpdateConsignmentRequested:
         if (action.meta) {
-            statuses = {
-                ...statuses,
+            return objectMerge(statuses, {
                 isUpdating: {
-                    ...statuses.isUpdating,
                     [action.meta.id]: true,
                 },
-            };
+            });
         }
 
         return statuses;
@@ -195,26 +182,22 @@ function statusesReducer(
     case ConsignmentActionType.UpdateConsignmentSucceeded:
     case ConsignmentActionType.UpdateConsignmentFailed:
         if (action.meta) {
-            statuses = {
-                ...statuses,
+            return objectMerge(statuses, {
                 isUpdating: {
-                    ...statuses.isUpdating,
                     [action.meta.id]: false,
                 },
-            };
+            });
         }
 
         return statuses;
 
     case ConsignmentActionType.DeleteConsignmentRequested:
         if (action.meta) {
-            statuses = {
-                ...statuses,
+            return objectMerge(statuses, {
                 isDeleting: {
-                    ...statuses.isDeleting,
                     [action.meta.id]: true,
                 },
-            };
+            });
         }
 
         return statuses;
@@ -222,26 +205,22 @@ function statusesReducer(
     case ConsignmentActionType.DeleteConsignmentSucceeded:
     case ConsignmentActionType.DeleteConsignmentFailed:
         if (action.meta) {
-            statuses = {
-                ...statuses,
+            return objectMerge(statuses, {
                 isDeleting: {
-                    ...statuses.isDeleting,
                     [action.meta.id]: false,
                 },
-            };
+            });
         }
 
         return statuses;
 
     case ConsignmentActionType.UpdateShippingOptionRequested:
         if (action.meta) {
-            statuses = {
-                ...statuses,
+            return objectMerge(statuses, {
                 isUpdatingShippingOption: {
-                    ...statuses.isUpdatingShippingOption,
                     [action.meta.id]: true,
                 },
-            };
+            });
         }
 
         return statuses;
@@ -249,13 +228,11 @@ function statusesReducer(
     case ConsignmentActionType.UpdateShippingOptionSucceeded:
     case ConsignmentActionType.UpdateShippingOptionFailed:
         if (action.meta) {
-            statuses = {
-                ...statuses,
+            return objectMerge(statuses, {
                 isUpdatingShippingOption: {
-                    ...statuses.isUpdatingShippingOption,
                     [action.meta.id]: false,
                 },
-            };
+            });
         }
 
         return statuses;

--- a/src/shipping/consignment-selector.spec.ts
+++ b/src/shipping/consignment-selector.spec.ts
@@ -4,7 +4,7 @@ import { createCartSelectorFactory, CartSelector } from '../cart';
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
-import ConsignmentSelector from './consignment-selector';
+import ConsignmentSelector, { createConsignmentSelectorFactory, ConsignmentSelectorFactory } from './consignment-selector';
 import ConsignmentState from './consignment-state';
 import { getConsignment, getConsignmentsState } from './consignments.mock';
 import { getShippingAddress } from './shipping-addresses.mock';
@@ -29,15 +29,17 @@ describe('ConsignmentSelector', () => {
     let selector: ConsignmentSelector;
     let state: CheckoutStoreState;
     let cartSelector: CartSelector;
+    let createConsignmentSelector: ConsignmentSelectorFactory;
 
     beforeEach(() => {
+        createConsignmentSelector = createConsignmentSelectorFactory();
         state = getCheckoutStoreState();
         cartSelector = createCartSelectorFactory()(state.cart);
     });
 
     describe('#getConsignmentByAddress()', () => {
         it('returns first matched consignment when address matches', () => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = createConsignmentSelector(state.consignments, cartSelector);
 
             expect(selector.getConsignmentByAddress(existingAddress))
                 // tslint:disable-next-line:no-non-null-assertion
@@ -45,7 +47,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns undefined if no address matches a consignment', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.getConsignmentByAddress(nonexistentAddress))
                 .toEqual(undefined);
@@ -54,7 +56,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getConsignmentById()', () => {
         it('returns consignment that matches id', () => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = createConsignmentSelector(state.consignments, cartSelector);
 
             expect(selector.getConsignmentById('55c96cda6f04c'))
                 // tslint:disable-next-line:no-non-null-assertion
@@ -62,7 +64,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns undefined if no id matches a consignment', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.getConsignmentById('none'))
                 .toEqual(undefined);
@@ -71,13 +73,13 @@ describe('ConsignmentSelector', () => {
 
     describe('#getConsignments()', () => {
         it('returns consignments', () => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = createConsignmentSelector(state.consignments, cartSelector);
 
             expect(selector.getConsignments()).toEqual(getConsignmentsState().data);
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.getConsignments()).toEqual(undefined);
         });
@@ -85,13 +87,13 @@ describe('ConsignmentSelector', () => {
 
     describe('#getShippingOption()', () => {
         it('returns selected shipping option for default consignment', () => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
+            selector = createConsignmentSelector(state.consignments, cartSelector);
 
             expect(selector.getShippingOption()).toEqual(getConsignment().selectedShippingOption);
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.getConsignments()).toEqual(undefined);
         });
@@ -101,7 +103,7 @@ describe('ConsignmentSelector', () => {
         it('returns load error', () => {
             const loadError = new Error();
 
-            selector = new ConsignmentSelector(merge({}, emptyState, {
+            selector = createConsignmentSelector(merge({}, emptyState, {
                 errors: { loadError },
             }), cartSelector);
 
@@ -109,7 +111,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.getLoadError()).toEqual(undefined);
         });
@@ -119,7 +121,7 @@ describe('ConsignmentSelector', () => {
         it('returns create error', () => {
             const createError = new Error();
 
-            selector = new ConsignmentSelector(merge({}, emptyState, {
+            selector = createConsignmentSelector(merge({}, emptyState, {
                 errors: { createError },
             }), cartSelector);
 
@@ -127,7 +129,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.getCreateError()).toEqual(undefined);
         });
@@ -137,7 +139,7 @@ describe('ConsignmentSelector', () => {
         it('returns shipping options load error', () => {
             const loadShippingOptionsError = new Error();
 
-            selector = new ConsignmentSelector(merge({}, emptyState, {
+            selector = createConsignmentSelector(merge({}, emptyState, {
                 errors: { loadShippingOptionsError },
             }), cartSelector);
 
@@ -145,7 +147,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns undefined if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.getLoadShippingOptionsError()).toEqual(undefined);
         });
@@ -153,7 +155,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getUpdateShippingOptionError()', () => {
         it('returns undefined if none errored', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = createConsignmentSelector(merge({}, emptyState), cartSelector);
             expect(selector.getUpdateShippingOptionError()).toEqual(undefined);
         });
 
@@ -161,7 +163,7 @@ describe('ConsignmentSelector', () => {
             const error = new Error();
 
             beforeEach(() => {
-                selector = new ConsignmentSelector(merge({}, emptyState, {
+                selector = createConsignmentSelector(merge({}, emptyState, {
                     errors: {
                         updateShippingOptionError: {
                             foo: error,
@@ -186,7 +188,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getUpdateError()', () => {
         it('returns undefined if none errored', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = createConsignmentSelector(merge({}, emptyState), cartSelector);
             expect(selector.getUpdateError()).toEqual(undefined);
         });
 
@@ -194,7 +196,7 @@ describe('ConsignmentSelector', () => {
             const error = new Error();
 
             beforeEach(() => {
-                selector = new ConsignmentSelector(merge({}, emptyState, {
+                selector = createConsignmentSelector(merge({}, emptyState, {
                     errors: {
                         updateError: {
                             foo: error,
@@ -219,7 +221,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#getDeleteError()', () => {
         it('returns undefined if none errored', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = createConsignmentSelector(merge({}, emptyState), cartSelector);
             expect(selector.getDeleteError()).toEqual(undefined);
         });
 
@@ -227,7 +229,7 @@ describe('ConsignmentSelector', () => {
             const error = new Error();
 
             beforeEach(() => {
-                selector = new ConsignmentSelector(merge({}, emptyState, {
+                selector = createConsignmentSelector(merge({}, emptyState, {
                     errors: {
                         deleteError: {
                             foo: error,
@@ -255,7 +257,7 @@ describe('ConsignmentSelector', () => {
         const createError = new Error();
 
         beforeEach(() => {
-            selector = new ConsignmentSelector(merge(state.consignments, {
+            selector = createConsignmentSelector(merge(state.consignments, {
                 errors: {
                     updateError: {
                         '55c96cda6f04c': updateError,
@@ -275,11 +277,9 @@ describe('ConsignmentSelector', () => {
     });
 
     describe('#getUnassignedItems()', () => {
-        beforeEach(() => {
-            selector = new ConsignmentSelector(state.consignments, cartSelector);
-        });
-
         it('returns unassigned items', () => {
+            selector = createConsignmentSelector(state.consignments, cartSelector);
+
             expect(selector.getUnassignedItems()).toEqual([
                 // tslint:disable-next-line:no-non-null-assertion
                 state.cart.data!.lineItems.physicalItems[0],
@@ -297,6 +297,9 @@ describe('ConsignmentSelector', () => {
                     }],
                 },
             });
+
+            selector = createConsignmentSelector(state.consignments, cartSelector);
+
             expect(selector.getUnassignedItems()).toEqual([]);
         });
 
@@ -305,18 +308,24 @@ describe('ConsignmentSelector', () => {
                 ...state.cart,
                 lineItems: { physicalItems: null },
             });
+
+            selector = createConsignmentSelector(state.consignments, cartSelector);
+
             expect(selector.getUnassignedItems()).toEqual([]);
         });
 
         it('returns empty array if there is no cart', () => {
             jest.spyOn(cartSelector, 'getCart').mockReturnValue(null);
+
+            selector = createConsignmentSelector(state.consignments, cartSelector);
+
             expect(selector.getUnassignedItems()).toEqual([]);
         });
     });
 
     describe('#isLoading()', () => {
         it('returns true if loading', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState, {
+            selector = createConsignmentSelector(merge({}, emptyState, {
                 statuses: { isLoading: true },
             }), cartSelector);
 
@@ -324,7 +333,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns false if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.isLoading()).toEqual(false);
         });
@@ -332,7 +341,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#isLoadingShippingOptions()', () => {
         it('returns true if loading', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState, {
+            selector = createConsignmentSelector(merge({}, emptyState, {
                 statuses: { isLoadingShippingOptions: true },
             }), cartSelector);
 
@@ -340,7 +349,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns false if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.isLoadingShippingOptions()).toEqual(false);
         });
@@ -348,7 +357,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#isCreating()', () => {
         it('returns true if creating', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState, {
+            selector = createConsignmentSelector(merge({}, emptyState, {
                 statuses: { isCreating: true },
             }), cartSelector);
 
@@ -356,7 +365,7 @@ describe('ConsignmentSelector', () => {
         });
 
         it('returns false if unavailable', () => {
-            selector = new ConsignmentSelector(emptyState, cartSelector);
+            selector = createConsignmentSelector(emptyState, cartSelector);
 
             expect(selector.isCreating()).toEqual(false);
         });
@@ -364,13 +373,13 @@ describe('ConsignmentSelector', () => {
 
     describe('#isUpdating()', () => {
         it('returns false if none is updating', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = createConsignmentSelector(merge({}, emptyState), cartSelector);
             expect(selector.isUpdating()).toEqual(false);
         });
 
         describe('when only one consignment is being updated', () => {
             beforeEach(() => {
-                selector = new ConsignmentSelector(merge({}, emptyState, {
+                selector = createConsignmentSelector(merge({}, emptyState, {
                     statuses: {
                         isUpdating: {
                             foo: true,
@@ -396,13 +405,13 @@ describe('ConsignmentSelector', () => {
 
     describe('#isDeleting()', () => {
         it('returns false if none is deleting', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = createConsignmentSelector(merge({}, emptyState), cartSelector);
             expect(selector.isDeleting()).toEqual(false);
         });
 
         describe('when only one consignment is being deleted', () => {
             beforeEach(() => {
-                selector = new ConsignmentSelector(merge({}, emptyState, {
+                selector = createConsignmentSelector(merge({}, emptyState, {
                     statuses: {
                         isDeleting: {
                             foo: true,
@@ -428,7 +437,7 @@ describe('ConsignmentSelector', () => {
 
     describe('#isAssigningItems()', () => {
         beforeEach(() => {
-            selector = new ConsignmentSelector(merge(state.consignments, {
+            selector = createConsignmentSelector(merge(state.consignments, {
                 statuses: {
                     isUpdating: {
                         '55c96cda6f04c': true,
@@ -449,13 +458,13 @@ describe('ConsignmentSelector', () => {
 
     describe('#isUpdatingShippingOption()', () => {
         it('returns false if none is updating', () => {
-            selector = new ConsignmentSelector(merge({}, emptyState), cartSelector);
+            selector = createConsignmentSelector(merge({}, emptyState), cartSelector);
             expect(selector.isUpdatingShippingOption()).toEqual(false);
         });
 
         describe('when only one consignment is being updated', () => {
             beforeEach(() => {
-                selector = new ConsignmentSelector(merge({}, emptyState, {
+                selector = createConsignmentSelector(merge({}, emptyState, {
                     statuses: {
                         isUpdatingShippingOption: {
                             foo: true,

--- a/src/shipping/consignment-selector.ts
+++ b/src/shipping/consignment-selector.ts
@@ -2,151 +2,246 @@ import { find } from 'lodash';
 
 import { isAddressEqual, AddressRequestBody } from '../address';
 import { CartSelector, PhysicalItem } from '../cart';
-import { selector } from '../common/selector';
+import { createSelector } from '../common/selector';
+import { memoizeOne } from '../common/utility';
 
 import Consignment from './consignment';
-import ConsignmentState from './consignment-state';
+import ConsignmentState, { DEFAULT_STATE } from './consignment-state';
 import ShippingOption from './shipping-option';
 
-@selector
-export default class ConsignmentSelector {
-    constructor(
-        private _consignments: ConsignmentState,
-        private _cart: CartSelector
-    ) {}
+export default interface ConsignmentSelector {
+    getConsignments(): Consignment[] | undefined;
+    getConsignmentById(id: string): Consignment | undefined;
+    getConsignmentByAddress(address: AddressRequestBody): Consignment | undefined;
+    getShippingOption(): ShippingOption | undefined;
+    getLoadError(): Error | undefined;
+    getCreateError(): Error | undefined;
+    getLoadShippingOptionsError(): Error | undefined;
+    getUnassignedItems(): PhysicalItem[];
+    getUpdateError(consignmentId?: string): Error | undefined;
+    getDeleteError(consignmentId?: string): Error | undefined;
+    getItemAssignmentError(address: AddressRequestBody): Error | undefined;
+    getUpdateShippingOptionError(consignmentId?: string): Error | undefined;
+    isLoading(): boolean;
+    isLoadingShippingOptions(): boolean;
+    isCreating(): boolean;
+    isUpdating(consignmentId?: string): boolean;
+    isDeleting(consignmentId?: string): boolean;
+    isAssigningItems(address: AddressRequestBody): boolean;
+    isUpdatingShippingOption(consignmentId?: string): boolean;
+}
 
-    getConsignments(): Consignment[] | undefined {
-        return this._consignments.data;
-    }
+export type ConsignmentSelectorFactory = (
+    state: ConsignmentState,
+    cart: CartSelector
+) => ConsignmentSelector;
 
-    getConsignmentById(id: string): Consignment | undefined {
-        const consignments = this._consignments.data;
+interface ConsignmentSelectorDependencies {
+    cart: CartSelector;
+}
 
-        if (!consignments || !consignments.length) {
-            return;
+export function createConsignmentSelectorFactory(): ConsignmentSelectorFactory {
+    const getConsignments = createSelector(
+        (state: ConsignmentState) => state.data,
+        consignments => () => consignments
+    );
+
+    const getConsignmentById = createSelector(
+        (state: ConsignmentState) => state.data,
+        consignments => (id: string) => {
+            if (!consignments || !consignments.length) {
+                return;
+            }
+
+            return find(consignments, { id });
         }
+    );
 
-        return find(consignments, { id });
-    }
+    const getConsignmentByAddress = createSelector(
+        (state: ConsignmentState) => state.data,
+        consignments => (address: AddressRequestBody) => {
+            if (!consignments || !consignments.length) {
+                return;
+            }
 
-    getConsignmentByAddress(address: AddressRequestBody): Consignment | undefined {
-        const consignments = this._consignments.data;
-
-        if (!consignments || !consignments.length) {
-            return;
+            return find(consignments, consignment =>
+                isAddressEqual(consignment.shippingAddress, address)
+            );
         }
+    );
 
-        return find(consignments, consignment =>
-            isAddressEqual(consignment.shippingAddress, address)
-        );
-    }
-
-    getShippingOption(): ShippingOption | undefined {
-        const consignments = this._consignments.data;
-
-        if (consignments && consignments.length) {
-            return consignments[0].selectedShippingOption;
+    const getShippingOption = createSelector(
+        (state: ConsignmentState) => state.data,
+        consignments => () => {
+            if (consignments && consignments.length) {
+                return consignments[0].selectedShippingOption;
+            }
         }
-    }
+    );
 
-    getLoadError(): Error | undefined {
-        return this._consignments.errors.loadError;
-    }
+    const getLoadError = createSelector(
+        (state: ConsignmentState) => state.errors.loadError,
+        error => () => error
+    );
 
-    getCreateError(): Error | undefined {
-        return this._consignments.errors.createError;
-    }
+    const getCreateError = createSelector(
+        (state: ConsignmentState) => state.errors.createError,
+        error => () => error
+    );
 
-    getLoadShippingOptionsError(): Error | undefined {
-        return this._consignments.errors.loadShippingOptionsError;
-    }
+    const getLoadShippingOptionsError = createSelector(
+        (state: ConsignmentState) => state.errors.loadShippingOptionsError,
+        error => () => error
+    );
 
-    getUnassignedItems(): PhysicalItem[] {
-        const cart = this._cart.getCart();
+    const getUnassignedItems = createSelector(
+        getConsignments,
+        (_: ConsignmentState, { cart }: ConsignmentSelectorDependencies) => cart.getCart,
+        (getConsignments, getCart) => () => {
+            const cart = getCart();
 
-        if (!cart) {
-            return [];
+            if (!cart) {
+                return [];
+            }
+
+            const assignedLineItemIds = (getConsignments() || []).reduce(
+                (itemIds, consignment) => itemIds.concat(consignment.lineItemIds),
+                [] as string[]
+            );
+
+            return (cart.lineItems.physicalItems || []).filter(
+                item => assignedLineItemIds.indexOf(item.id as string) < 0
+            );
         }
+    );
 
-        const assignedLineItemIds = (this.getConsignments() || []).reduce(
-            (itemIds, consignment) => itemIds.concat(consignment.lineItemIds),
-            [] as string[]
-        );
+    const getUpdateError = createSelector(
+        (state: ConsignmentState) => state.errors.updateError,
+        updateError => (consignmentId?: string) => {
+            if (consignmentId) {
+                return updateError[consignmentId];
+            }
 
-        return (cart.lineItems.physicalItems || []).filter(
-            item => assignedLineItemIds.indexOf(item.id as string) < 0
-        );
-    }
-
-    getUpdateError(consignmentId?: string): Error | undefined {
-        if (consignmentId) {
-            return this._consignments.errors.updateError[consignmentId];
+            return find(updateError);
         }
+    );
 
-        return find(this._consignments.errors.updateError);
-    }
+    const getDeleteError = createSelector(
+        (state: ConsignmentState) => state.errors.deleteError,
+        deleteError => (consignmentId?: string) => {
+            if (consignmentId) {
+                return deleteError[consignmentId];
+            }
 
-    getDeleteError(consignmentId?: string): Error | undefined {
-        if (consignmentId) {
-            return this._consignments.errors.deleteError[consignmentId];
+            return find(deleteError);
         }
+    );
 
-        return find(this._consignments.errors.deleteError);
-    }
+    const getItemAssignmentError = createSelector(
+        getConsignmentByAddress,
+        getUpdateError,
+        getCreateError,
+        (getConsignmentByAddress, getUpdateError, getCreateError) => (address: AddressRequestBody) => {
+            const consignment = getConsignmentByAddress(address);
 
-    getItemAssignmentError(address: AddressRequestBody): Error | undefined {
-        const consignment = this.getConsignmentByAddress(address);
-
-        return consignment ? this.getUpdateError(consignment.id) : this.getCreateError();
-    }
-
-    getUpdateShippingOptionError(consignmentId?: string): Error | undefined {
-        if (consignmentId) {
-            return this._consignments.errors.updateShippingOptionError[consignmentId];
+            return consignment ? getUpdateError(consignment.id) : getCreateError();
         }
+    );
 
-        return find(this._consignments.errors.updateShippingOptionError);
-    }
+    const getUpdateShippingOptionError = createSelector(
+        (state: ConsignmentState) => state.errors.updateShippingOptionError,
+        updateShippingOptionError => (consignmentId?: string) => {
+            if (consignmentId) {
+                return updateShippingOptionError[consignmentId];
+            }
 
-    isLoading(): boolean {
-        return this._consignments.statuses.isLoading === true;
-    }
-
-    isLoadingShippingOptions(): boolean {
-        return this._consignments.statuses.isLoadingShippingOptions === true;
-    }
-
-    isCreating(): boolean {
-        return this._consignments.statuses.isCreating === true;
-    }
-
-    isUpdating(consignmentId?: string): boolean {
-        if (consignmentId) {
-            return this._consignments.statuses.isUpdating[consignmentId] === true;
+            return find(updateShippingOptionError);
         }
+    );
 
-        return find(this._consignments.statuses.isUpdating) === true;
-    }
+    const isLoading = createSelector(
+        (state: ConsignmentState) => state.statuses.isLoading,
+        isLoading => () => isLoading === true
+    );
 
-    isDeleting(consignmentId?: string): boolean {
-        if (consignmentId) {
-            return this._consignments.statuses.isDeleting[consignmentId] === true;
+    const isLoadingShippingOptions = createSelector(
+        (state: ConsignmentState) => state.statuses.isLoadingShippingOptions,
+        isLoadingShippingOptions => () => isLoadingShippingOptions === true
+    );
+
+    const isCreating = createSelector(
+        (state: ConsignmentState) => state.statuses.isCreating,
+        isCreating => () => isCreating === true
+    );
+
+    const isUpdating = createSelector(
+        (state: ConsignmentState) => state.statuses.isUpdating,
+        isUpdating => (consignmentId?: string) => {
+            if (consignmentId) {
+                return isUpdating[consignmentId] === true;
+            }
+
+            return find(isUpdating) === true;
         }
+    );
 
-        return find(this._consignments.statuses.isDeleting) === true;
-    }
+    const isDeleting = createSelector(
+        (state: ConsignmentState) => state.statuses.isDeleting,
+        isDeleting => (consignmentId?: string) => {
+            if (consignmentId) {
+                return isDeleting[consignmentId] === true;
+            }
 
-    isAssigningItems(address: AddressRequestBody): boolean {
-        const consignment = this.getConsignmentByAddress(address);
-
-        return consignment ? this.isUpdating(consignment.id) : this.isCreating();
-    }
-
-    isUpdatingShippingOption(consignmentId?: string): boolean {
-        if (consignmentId) {
-            return this._consignments.statuses.isUpdatingShippingOption[consignmentId] === true;
+            return find(isDeleting) === true;
         }
+    );
 
-        return find(this._consignments.statuses.isUpdatingShippingOption) === true;
-    }
+    const isAssigningItems = createSelector(
+        getConsignmentByAddress,
+        isUpdating,
+        isCreating,
+        (getConsignmentByAddress, isUpdating, isCreating) => (address: AddressRequestBody) => {
+            const consignment = getConsignmentByAddress(address);
+
+            return consignment ? isUpdating(consignment.id) : isCreating();
+        }
+    );
+
+    const isUpdatingShippingOption = createSelector(
+        (state: ConsignmentState) => state.statuses.isUpdatingShippingOption,
+        isUpdatingShippingOption => (consignmentId?: string) => {
+            if (consignmentId) {
+                return isUpdatingShippingOption[consignmentId] === true;
+            }
+
+            return find(isUpdatingShippingOption) === true;
+        }
+    );
+
+    return memoizeOne((
+        state: ConsignmentState = DEFAULT_STATE,
+        cart: CartSelector
+    ): ConsignmentSelector => {
+        return {
+            getConsignments: getConsignments(state),
+            getConsignmentById: getConsignmentById(state),
+            getConsignmentByAddress: getConsignmentByAddress(state),
+            getShippingOption: getShippingOption(state),
+            getLoadError: getLoadError(state),
+            getCreateError: getCreateError(state),
+            getLoadShippingOptionsError: getLoadShippingOptionsError(state),
+            getUnassignedItems: getUnassignedItems(state, { cart }),
+            getUpdateError: getUpdateError(state),
+            getDeleteError: getDeleteError(state),
+            getItemAssignmentError: getItemAssignmentError(state),
+            getUpdateShippingOptionError: getUpdateShippingOptionError(state),
+            isLoading: isLoading(state),
+            isLoadingShippingOptions: isLoadingShippingOptions(state),
+            isCreating: isCreating(state),
+            isUpdating: isUpdating(state),
+            isDeleting: isDeleting(state),
+            isAssigningItems: isAssigningItems(state),
+            isUpdatingShippingOption: isUpdatingShippingOption(state),
+        };
+    });
 }

--- a/src/shipping/consignment-state.ts
+++ b/src/shipping/consignment-state.ts
@@ -23,3 +23,16 @@ export interface ConsignmentStatusesState {
     isDeleting: { [key: string]: boolean };
     isUpdatingShippingOption: { [key: string]: boolean };
 }
+
+export const DEFAULT_STATE: ConsignmentState = {
+    errors: {
+        updateShippingOptionError: {},
+        updateError: {},
+        deleteError: {},
+    },
+    statuses: {
+        isUpdating: {},
+        isUpdatingShippingOption: {},
+        isDeleting: {},
+    },
+};

--- a/src/shipping/index.ts
+++ b/src/shipping/index.ts
@@ -4,7 +4,7 @@ export * from './shipping-request-options';
 export { default as createShippingStrategyRegistry } from './create-shipping-strategy-registry';
 
 export { default as Consignment, ConsignmentsRequestBody, ConsignmentRequestBody } from './consignment';
-export { default as ConsignmentSelector } from './consignment-selector';
+export { default as ConsignmentSelector, ConsignmentSelectorFactory, createConsignmentSelectorFactory } from './consignment-selector';
 export { default as ConsignmentState } from './consignment-state';
 export { default as consignmentReducer } from './consignment-reducer';
 export { default as ConsignmentActionCreator } from './consignment-action-creator';

--- a/src/shipping/index.ts
+++ b/src/shipping/index.ts
@@ -10,7 +10,7 @@ export { default as consignmentReducer } from './consignment-reducer';
 export { default as ConsignmentActionCreator } from './consignment-action-creator';
 export { default as ConsignmentRequestSender } from './consignment-request-sender';
 
-export { default as ShippingAddressSelector } from './shipping-address-selector';
+export { default as ShippingAddressSelector, ShippingAddressSelectorFactory, createShippingAddressSelectorFactory } from './shipping-address-selector';
 
 export { default as ShippingCountryActionCreator } from './shipping-country-action-creator';
 export { default as ShippingCountryRequestSender } from './shipping-country-request-sender';

--- a/src/shipping/index.ts
+++ b/src/shipping/index.ts
@@ -22,7 +22,7 @@ export { default as ShippingOption } from './shipping-option';
 export { default as InternalShippingOption, InternalShippingOptionList } from './internal-shipping-option';
 
 export { default as ShippingStrategyActionCreator } from './shipping-strategy-action-creator';
-export { default as ShippingStrategySelector } from './shipping-strategy-selector';
+export { default as ShippingStrategySelector, ShippingStrategySelectorFactory, createShippingStrategySelectorFactory } from './shipping-strategy-selector';
 export { default as ShippingStrategyState } from './shipping-strategy-state';
 export { default as shippingStrategyReducer } from './shipping-strategy-reducer';
 

--- a/src/shipping/shipping-address-selector.spec.ts
+++ b/src/shipping/shipping-address-selector.spec.ts
@@ -1,18 +1,20 @@
 import ConsignmentState from './consignment-state';
 import { getConsignment, getConsignmentsState } from './consignments.mock';
-import ShippingAddressSelector from './shipping-address-selector';
+import ShippingAddressSelector, { createShippingAddressSelectorFactory, ShippingAddressSelectorFactory } from './shipping-address-selector';
 
 describe('ShippingAddressSelector', () => {
+    let createShippingAddressSelector: ShippingAddressSelectorFactory;
     let shippingAddressSelector: ShippingAddressSelector;
     let consignmentState: ConsignmentState;
 
     describe('#getShippingAddress()', () => {
         beforeEach(() => {
+            createShippingAddressSelector = createShippingAddressSelectorFactory();
             consignmentState = getConsignmentsState();
         });
 
         it('returns the current shipping address', () => {
-            shippingAddressSelector = new ShippingAddressSelector(consignmentState);
+            shippingAddressSelector = createShippingAddressSelector(consignmentState);
 
             expect(shippingAddressSelector.getShippingAddress())
                 .toEqual(getConsignment().shippingAddress);
@@ -27,7 +29,7 @@ describe('ShippingAddressSelector', () => {
             });
 
             it('returns undefined', () => {
-                shippingAddressSelector = new ShippingAddressSelector(consignmentState);
+                shippingAddressSelector = createShippingAddressSelector(consignmentState);
 
                 expect(shippingAddressSelector.getShippingAddress()).toBeUndefined();
             });

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -1,21 +1,32 @@
 import { Address } from '../address';
-import { selector } from '../common/selector';
+import { createSelector } from '../common/selector';
+import { memoizeOne } from '../common/utility';
 
-import ConsignmentState from './consignment-state';
+import ConsignmentState, { DEFAULT_STATE } from './consignment-state';
 
-@selector
-export default class ShippingAddressSelector {
-    constructor(
-        private _consignments: ConsignmentState
-    ) {}
+export default interface ShippingAddressSelector {
+    getShippingAddress(): Address | undefined;
+}
 
-    getShippingAddress(): Address | undefined {
-        const consignments = this._consignments.data;
+export type ShippingAddressSelectorFactory = (state: ConsignmentState) => ShippingAddressSelector;
 
-        if (!consignments || !consignments[0]) {
-            return;
+export function createShippingAddressSelectorFactory(): ShippingAddressSelectorFactory {
+    const getShippingAddress = createSelector(
+        (state: ConsignmentState) => state.data,
+        consignments => () => {
+            if (!consignments || !consignments[0]) {
+                return;
+            }
+
+            return consignments[0].shippingAddress;
         }
+    );
 
-        return consignments[0].shippingAddress;
-    }
+    return memoizeOne((
+        state: ConsignmentState = DEFAULT_STATE
+    ): ShippingAddressSelector => {
+        return {
+            getShippingAddress: getShippingAddress(state),
+        };
+    });
 }

--- a/src/shipping/shipping-strategy-reducer.ts
+++ b/src/shipping/shipping-strategy-reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { clearErrorReducer } from '../common/error';
+import { objectMerge } from '../common/utility';
 
 import { ShippingStrategyAction, ShippingStrategyActionType } from './shipping-strategy-actions';
 import ShippingStrategyState, { DEFAULT_STATE, ShippingStrategyDataState, ShippingStrategyErrorsState, ShippingStrategyStatusesState } from './shipping-strategy-state';
@@ -24,20 +25,18 @@ function dataReducer(
 ): ShippingStrategyDataState {
     switch (action.type) {
     case ShippingStrategyActionType.InitializeSucceeded:
-        return {
-            ...data,
+        return objectMerge(data, {
             [action.meta && action.meta.methodId]: {
                 isInitialized: true,
             },
-        };
+        });
 
     case ShippingStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...data,
+        return objectMerge(data, {
             [action.meta && action.meta.methodId]: {
                 isInitialized: false,
             },
-        };
+        });
     }
 
     return data;
@@ -50,63 +49,55 @@ function errorsReducer(
     switch (action.type) {
     case ShippingStrategyActionType.InitializeRequested:
     case ShippingStrategyActionType.InitializeSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             initializeError: undefined,
             initializeMethodId: undefined,
-        };
+        });
 
     case ShippingStrategyActionType.InitializeFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             initializeError: action.payload,
             initializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case ShippingStrategyActionType.DeinitializeRequested:
     case ShippingStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             deinitializeError: undefined,
             deinitializeMethodId: undefined,
-        };
+        });
 
     case ShippingStrategyActionType.DeinitializeFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             deinitializeError: action.payload,
             deinitializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case ShippingStrategyActionType.UpdateAddressRequested:
     case ShippingStrategyActionType.UpdateAddressSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             updateAddressError: undefined,
             updateAddressMethodId: undefined,
-        };
+        });
 
     case ShippingStrategyActionType.UpdateAddressFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             updateAddressError: action.payload,
             updateAddressMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case ShippingStrategyActionType.SelectOptionRequested:
     case ShippingStrategyActionType.SelectOptionSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             selectOptionError: undefined,
             selectOptionMethodId: undefined,
-        };
+        });
 
     case ShippingStrategyActionType.SelectOptionFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             selectOptionError: action.payload,
             selectOptionMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     default:
         return errors;
@@ -119,64 +110,56 @@ function statusesReducer(
 ): ShippingStrategyStatusesState {
     switch (action.type) {
     case ShippingStrategyActionType.InitializeRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isInitializing: true,
             initializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case ShippingStrategyActionType.InitializeFailed:
     case ShippingStrategyActionType.InitializeSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isInitializing: false,
             initializeMethodId: undefined,
-        };
+        });
 
     case ShippingStrategyActionType.DeinitializeRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isDeinitializing: true,
             deinitializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case ShippingStrategyActionType.DeinitializeFailed:
     case ShippingStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isDeinitializing: false,
             deinitializeMethodId: undefined,
-        };
+        });
 
     case ShippingStrategyActionType.UpdateAddressRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isUpdatingAddress: true,
             updateAddressMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case ShippingStrategyActionType.UpdateAddressFailed:
     case ShippingStrategyActionType.UpdateAddressSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isUpdatingAddress: false,
             updateAddressMethodId: undefined,
-        };
+        });
 
     case ShippingStrategyActionType.SelectOptionRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isSelectingOption: true,
             selectOptionMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case ShippingStrategyActionType.SelectOptionFailed:
     case ShippingStrategyActionType.SelectOptionSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isSelectingOption: false,
             selectOptionMethodId: undefined,
-        };
+        });
 
     default:
         return statuses;

--- a/src/shipping/shipping-strategy-selector.spec.ts
+++ b/src/shipping/shipping-strategy-selector.spec.ts
@@ -1,13 +1,15 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import ShippingStrategySelector from './shipping-strategy-selector';
+import ShippingStrategySelector, { createShippingStrategySelectorFactory, ShippingStrategySelectorFactory } from './shipping-strategy-selector';
 import { DEFAULT_STATE } from './shipping-strategy-state';
 
 describe('ShippingStrategySelector', () => {
+    let createShippingStrategySelector: ShippingStrategySelectorFactory;
     let selector: ShippingStrategySelector;
     let state: any;
 
     beforeEach(() => {
+        createShippingStrategySelector = createShippingStrategySelectorFactory();
         state = {
             shippingStrategy: DEFAULT_STATE,
         };
@@ -17,7 +19,7 @@ describe('ShippingStrategySelector', () => {
         it('returns error if unable to update address', () => {
             const updateAddressError = getErrorResponse();
 
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 errors: { updateAddressError },
             });
@@ -26,7 +28,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('does not returns error if able to update address', () => {
-            selector = new ShippingStrategySelector(state.shippingStrategy);
+            selector = createShippingStrategySelector(state.shippingStrategy);
 
             expect(selector.getUpdateAddressError()).toBeUndefined();
         });
@@ -36,7 +38,7 @@ describe('ShippingStrategySelector', () => {
         it('returns error if unable to select option', () => {
             const selectOptionError = getErrorResponse();
 
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 errors: { selectOptionError },
             });
@@ -45,7 +47,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('does not returns error if able to select option', () => {
-            selector = new ShippingStrategySelector(state.shippingStrategy);
+            selector = createShippingStrategySelector(state.shippingStrategy);
 
             expect(selector.getSelectOptionError()).toBeUndefined();
         });
@@ -53,7 +55,7 @@ describe('ShippingStrategySelector', () => {
 
     describe('#getInitializeError()', () => {
         it('returns error if unable to initialize any method', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 errors: { initializeError: getErrorResponse(), initializeMethodId: 'foobar' },
             });
@@ -62,7 +64,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('returns error if unable to initialize specific method', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 errors: { initializeError: getErrorResponse(), initializeMethodId: 'foobar' },
             });
@@ -72,7 +74,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('does not return error if able to initialize', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 errors: {},
             });
@@ -83,7 +85,7 @@ describe('ShippingStrategySelector', () => {
 
     describe('#isUpdatingAddress()', () => {
         it('returns true if updating address', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 statuses: { isUpdatingAddress: true },
             });
@@ -92,7 +94,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('returns false if not updating address', () => {
-            selector = new ShippingStrategySelector(state.shippingStrategy);
+            selector = createShippingStrategySelector(state.shippingStrategy);
 
             expect(selector.isUpdatingAddress()).toEqual(false);
         });
@@ -100,7 +102,7 @@ describe('ShippingStrategySelector', () => {
 
     describe('#isSelectingOption()', () => {
         it('returns true if selecting option', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 statuses: { isSelectingOption: true },
             });
@@ -109,7 +111,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('returns false if not selecting option', () => {
-            selector = new ShippingStrategySelector(state.shippingStrategy);
+            selector = createShippingStrategySelector(state.shippingStrategy);
 
             expect(selector.isSelectingOption()).toEqual(false);
         });
@@ -117,7 +119,7 @@ describe('ShippingStrategySelector', () => {
 
     describe('#isInitializing()', () => {
         it('returns true if initializing any method', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 statuses: { initializeMethodId: 'foobar', isInitializing: true },
             });
@@ -126,7 +128,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('returns true if initializing specific method', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 statuses: { initializeMethodId: 'foobar', isInitializing: true },
             });
@@ -136,7 +138,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('returns false if not initializing method', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 statuses: { initializeMethodId: undefined, isInitializing: false },
             });
@@ -147,7 +149,7 @@ describe('ShippingStrategySelector', () => {
 
     describe('#isInitialized()', () => {
         it('returns true if method is initialized', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 data: { foobar: { isInitialized: true } },
             });
@@ -156,7 +158,7 @@ describe('ShippingStrategySelector', () => {
         });
 
         it('returns false if method is not initialized', () => {
-            selector = new ShippingStrategySelector({
+            selector = createShippingStrategySelector({
                 ...state.shippingStrategy,
                 data: { foobar: { isInitialized: false } },
             });


### PR DESCRIPTION
## What?
* Refactor `ShippingSelector` and `ShippingStrategySelector` to return new getters only when there are changes to relevant data.
* Update `shippingReducer` and `shippingStrategyReducer` to transform state only when it is necessary.

## Why?
Please refer to my previous PRs. They are related to this one.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
