### PR TITLE
CHECKOUT-4272: Optimise instrument selector and reducer

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -9,7 +9,7 @@ import { createFormSelectorFactory } from '../form';
 import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
-import { InstrumentSelector } from '../payment/instrument';
+import { createInstrumentSelectorFactory } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, createShippingStrategySelectorFactory } from '../shipping';
 
@@ -33,6 +33,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createCustomerSelector = createCustomerSelectorFactory();
     const createCustomerStrategySelector = createCustomerStrategySelectorFactory();
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
+    const createInstrumentSelector = createInstrumentSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
     const createShippingAddressSelector = createShippingAddressSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
@@ -51,7 +52,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const customerStrategies = createCustomerStrategySelector(state.customerStrategies);
         const form = createFormSelector(state.config);
         const giftCertificates = createGiftCertificateSelector(state.giftCertificates);
-        const instruments = new InstrumentSelector(state.instruments);
+        const instruments = createInstrumentSelector(state.instruments);
         const paymentMethods = new PaymentMethodSelector(state.paymentMethods);
         const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
         const shippingAddress = createShippingAddressSelector(state.consignments);

--- a/src/payment/instrument/index.ts
+++ b/src/payment/instrument/index.ts
@@ -1,6 +1,6 @@
 export { default as Instrument } from './instrument';
 export { default as InstrumentActionCreator } from './instrument-action-creator';
 export { default as InstrumentRequestSender } from './instrument-request-sender';
-export { default as InstrumentSelector } from './instrument-selector';
+export { default as InstrumentSelector, InstrumentSelectorFactory, createInstrumentSelectorFactory } from './instrument-selector';
 export { default as InstrumentState } from './instrument-state';
 export { default as instrumentReducer } from './instrument-reducer';

--- a/src/payment/instrument/instrument-actions.ts
+++ b/src/payment/instrument/instrument-actions.ts
@@ -1,5 +1,6 @@
 import { Action } from '@bigcommerce/data-store';
 
+import { VaultAccessToken } from './instrument';
 import { InstrumentsResponseBody } from './instrument-response-body';
 
 export enum InstrumentActionType {
@@ -30,7 +31,7 @@ export interface LoadInstrumentsRequestedAction extends Action {
     type: InstrumentActionType.LoadInstrumentsRequested;
 }
 
-export interface LoadInstrumentsSucceededAction extends Action<InstrumentsResponseBody> {
+export interface LoadInstrumentsSucceededAction extends Action<InstrumentsResponseBody, VaultAccessToken> {
     type: InstrumentActionType.LoadInstrumentsSucceeded;
 }
 
@@ -42,7 +43,7 @@ export interface DeleteInstrumentRequestedAction extends Action {
     type: InstrumentActionType.DeleteInstrumentRequested;
 }
 
-export interface DeleteInstrumentSucceededAction extends Action<InstrumentsResponseBody> {
+export interface DeleteInstrumentSucceededAction extends Action<InstrumentsResponseBody, VaultAccessToken & { instrumentId: string }> {
     type: InstrumentActionType.DeleteInstrumentSucceeded;
 }
 

--- a/src/payment/instrument/instrument-reducer.ts
+++ b/src/payment/instrument/instrument-reducer.ts
@@ -4,13 +4,7 @@ import { clearErrorReducer } from '../../common/error';
 
 import Instrument from './instrument';
 import { InstrumentAction, InstrumentActionType } from './instrument-actions';
-import InstrumentState, { InstrumentErrorState, InstrumentMeta, InstrumentStatusState } from './instrument-state';
-
-const DEFAULT_STATE = {
-    data: [],
-    errors: {},
-    statuses: {},
-};
+import InstrumentState, { DEFAULT_STATE, InstrumentErrorState, InstrumentMeta, InstrumentStatusState } from './instrument-state';
 
 export default function instrumentReducer(
     state: InstrumentState = DEFAULT_STATE,

--- a/src/payment/instrument/instrument-selector.spec.ts
+++ b/src/payment/instrument/instrument-selector.spec.ts
@@ -1,26 +1,28 @@
 import { CheckoutStoreState } from '../../checkout';
 import { getCheckoutStoreState } from '../../checkout/checkouts.mock';
 
-import InstrumentSelector from './instrument-selector';
+import InstrumentSelector, { createInstrumentSelectorFactory, InstrumentSelectorFactory } from './instrument-selector';
 import { getInstrumentsMeta } from './instrument.mock';
 
 describe('InstrumentSelector', () => {
+    let createInstrumentSelector: InstrumentSelectorFactory;
     let instrumentSelector: InstrumentSelector;
     let state: CheckoutStoreState;
 
     beforeEach(() => {
+        createInstrumentSelector = createInstrumentSelectorFactory();
         state = getCheckoutStoreState();
     });
 
     describe('#loadInstruments()', () => {
         it('returns a list of instruments', () => {
-            instrumentSelector = new InstrumentSelector(state.instruments);
+            instrumentSelector = createInstrumentSelector(state.instruments);
 
             expect(instrumentSelector.getInstruments()).toEqual(state.instruments.data);
         });
 
         it('returns an empty array if there are no instruments', () => {
-            instrumentSelector = new InstrumentSelector({ data: [], errors: {}, statuses: {} });
+            instrumentSelector = createInstrumentSelector({ data: [], errors: {}, statuses: {} });
 
             expect(instrumentSelector.getInstruments()).toEqual([]);
         });
@@ -28,21 +30,21 @@ describe('InstrumentSelector', () => {
 
     describe('#getInstrumentsMeta()', () => {
         it('returns instrument meta', () => {
-            instrumentSelector = new InstrumentSelector(state.instruments);
+            instrumentSelector = createInstrumentSelector(state.instruments);
 
             expect(instrumentSelector.getInstrumentsMeta()).toEqual(getInstrumentsMeta());
         });
 
         it('returns same instrument meta unless state changes', () => {
-            instrumentSelector = new InstrumentSelector(state.instruments);
+            instrumentSelector = createInstrumentSelector(state.instruments);
 
             const meta = instrumentSelector.getInstrumentsMeta();
 
-            instrumentSelector = new InstrumentSelector(state.instruments);
+            instrumentSelector = createInstrumentSelector(state.instruments);
 
             expect(instrumentSelector.getInstrumentsMeta()).toBe(meta);
 
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 meta: {
                     vaultAccessToken: '321efg',
@@ -58,7 +60,7 @@ describe('InstrumentSelector', () => {
         it('returns error if unable to load', () => {
             const loadError = new Error();
 
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 errors: { loadError },
             });
@@ -67,7 +69,7 @@ describe('InstrumentSelector', () => {
         });
 
         it('does not return error if able to load', () => {
-            instrumentSelector = new InstrumentSelector(state.instruments);
+            instrumentSelector = createInstrumentSelector(state.instruments);
 
             expect(instrumentSelector.getLoadError()).toBeUndefined();
         });
@@ -79,7 +81,7 @@ describe('InstrumentSelector', () => {
         it('returns error if unable to delete', () => {
             const deleteError = new Error();
 
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 errors: { deleteError, failedInstrument: mockInstrumentId },
             });
@@ -88,7 +90,7 @@ describe('InstrumentSelector', () => {
         });
 
         it('does not return error if able to delete', () => {
-            instrumentSelector = new InstrumentSelector(state.instruments);
+            instrumentSelector = createInstrumentSelector(state.instruments);
 
             expect(instrumentSelector.getDeleteError(mockInstrumentId)).toBeUndefined();
         });
@@ -96,7 +98,7 @@ describe('InstrumentSelector', () => {
         it('does not return error if unable to delete irrelevant instrument', () => {
             const deleteError = new Error();
 
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 errors: { deleteError, failedInstrument: mockInstrumentId },
             });
@@ -107,7 +109,7 @@ describe('InstrumentSelector', () => {
         it('returns any error if instrument id is not passed', () => {
             const deleteError = new Error();
 
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 errors: { deleteError, failedInstrument: mockInstrumentId },
             });
@@ -118,7 +120,7 @@ describe('InstrumentSelector', () => {
 
     describe('#isLoading()', () => {
         it('returns true if loading instruments', () => {
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 statuses: { isLoading: true },
             });
@@ -127,7 +129,7 @@ describe('InstrumentSelector', () => {
         });
 
         it('returns false if not loading instruments', () => {
-            instrumentSelector = new InstrumentSelector(state.instruments);
+            instrumentSelector = createInstrumentSelector(state.instruments);
 
             expect(instrumentSelector.isLoading()).toEqual(false);
         });
@@ -137,7 +139,7 @@ describe('InstrumentSelector', () => {
         const mockInstrumentId = '123';
 
         it('returns true if deleting an instrument', () => {
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 statuses: { isDeleting: true, deletingInstrument: mockInstrumentId },
             });
@@ -146,7 +148,7 @@ describe('InstrumentSelector', () => {
         });
 
         it('returns false if not deleting an instrument', () => {
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 statuses: { isDeleting: false, deletingInstrument: undefined },
             });
@@ -155,7 +157,7 @@ describe('InstrumentSelector', () => {
         });
 
         it('returns false if not deleting specific instrument', () => {
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 statuses: { isDeleting: true, deletingInstrument: '321' },
             });
@@ -164,7 +166,7 @@ describe('InstrumentSelector', () => {
         });
 
         it('returns any deleting status if instrument id is not passed', () => {
-            instrumentSelector = new InstrumentSelector({
+            instrumentSelector = createInstrumentSelector({
                 ...state.instruments,
                 statuses: { isDeleting: true, deletingInstrument: mockInstrumentId },
             });

--- a/src/payment/instrument/instrument-state.ts
+++ b/src/payment/instrument/instrument-state.ts
@@ -22,3 +22,9 @@ export interface InstrumentStatusState {
 }
 
 export type InstrumentMeta = VaultAccessToken;
+
+export const DEFAULT_STATE = {
+    data: [],
+    errors: {},
+    statuses: {},
+};


### PR DESCRIPTION
## What?
* Refactor `InstrumentSelector` to return new getters only when there are changes to relevant data.
* Update `instrumentReducer` to transform state only when it is necessary.

## Why?
Please refer to my previous PRs. They are related to this one.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
