### PR TITLE
CHECKOUT-4272: Optimise payment method selector and reducer

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -8,7 +8,7 @@ import { createCustomerSelectorFactory, createCustomerStrategySelectorFactory } 
 import { createFormSelectorFactory } from '../form';
 import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
-import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
+import { createPaymentMethodSelectorFactory, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { createInstrumentSelectorFactory } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, createShippingStrategySelectorFactory } from '../shipping';
@@ -35,6 +35,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createGiftCertificateSelector = createGiftCertificateSelectorFactory();
     const createInstrumentSelector = createInstrumentSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
+    const createPaymentMethodSelector = createPaymentMethodSelectorFactory();
     const createShippingAddressSelector = createShippingAddressSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
     const createShippingStrategySelector = createShippingStrategySelectorFactory();
@@ -53,7 +54,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const form = createFormSelector(state.config);
         const giftCertificates = createGiftCertificateSelector(state.giftCertificates);
         const instruments = createInstrumentSelector(state.instruments);
-        const paymentMethods = new PaymentMethodSelector(state.paymentMethods);
+        const paymentMethods = createPaymentMethodSelector(state.paymentMethods);
         const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
         const shippingAddress = createShippingAddressSelector(state.consignments);
         const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -23,7 +23,7 @@ export { default as PaymentMethodConfig } from './payment-method-config';
 export { default as PaymentMethodActionCreator } from './payment-method-action-creator';
 export { default as paymentMethodReducer } from './payment-method-reducer';
 export { default as PaymentMethodRequestSender } from './payment-method-request-sender';
-export { default as PaymentMethodSelector } from './payment-method-selector';
+export { default as PaymentMethodSelector, PaymentMethodSelectorFactory, createPaymentMethodSelectorFactory } from './payment-method-selector';
 export { default as PaymentMethodState } from './payment-method-state';
 export { default as paymentReducer } from './payment-reducer';
 export { default as PaymentRequestSender } from './payment-request-sender';

--- a/src/payment/payment-method-reducer.ts
+++ b/src/payment/payment-method-reducer.ts
@@ -6,12 +6,7 @@ import { mergeOrPush } from '../common/utility';
 import PaymentMethod from './payment-method';
 import { PaymentMethodAction, PaymentMethodActionType } from './payment-method-actions';
 import PaymentMethodMeta from './payment-method-meta';
-import PaymentMethodState, { PaymentMethodErrorsState, PaymentMethodStatusesState } from './payment-method-state';
-
-const DEFAULT_STATE: PaymentMethodState = {
-    errors: {},
-    statuses: {},
-};
+import PaymentMethodState, { DEFAULT_STATE, PaymentMethodErrorsState, PaymentMethodStatusesState } from './payment-method-state';
 
 export default function paymentMethodReducer(
     state: PaymentMethodState = DEFAULT_STATE,

--- a/src/payment/payment-method-selector.spec.ts
+++ b/src/payment/payment-method-selector.spec.ts
@@ -3,26 +3,28 @@ import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import PaymentMethodSelector from './payment-method-selector';
+import PaymentMethodSelector, { createPaymentMethodSelectorFactory, PaymentMethodSelectorFactory } from './payment-method-selector';
 import { getAdyenAmex, getBraintree } from './payment-methods.mock';
 
 describe('PaymentMethodSelector', () => {
+    let createPaymentMethodSelector: PaymentMethodSelectorFactory;
     let paymentMethodSelector: PaymentMethodSelector;
     let state: CheckoutStoreState;
 
     beforeEach(() => {
+        createPaymentMethodSelector = createPaymentMethodSelectorFactory();
         state = getCheckoutStoreState();
     });
 
     describe('#getPaymentMethods()', () => {
         it('returns a list of payment methods', () => {
-            paymentMethodSelector = new PaymentMethodSelector(state.paymentMethods);
+            paymentMethodSelector = createPaymentMethodSelector(state.paymentMethods);
 
             expect(paymentMethodSelector.getPaymentMethods()).toEqual(state.paymentMethods.data);
         });
 
         it('returns an empty array if there are no payment methods', () => {
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 data: [],
             });
@@ -33,25 +35,25 @@ describe('PaymentMethodSelector', () => {
 
     describe('#getPaymentMethod()', () => {
         it('returns payment method if found', () => {
-            paymentMethodSelector = new PaymentMethodSelector(state.paymentMethods);
+            paymentMethodSelector = createPaymentMethodSelector(state.paymentMethods);
 
             expect(paymentMethodSelector.getPaymentMethod('braintree')).toEqual(getBraintree());
         });
 
         it('returns multi-option payment method if found', () => {
-            paymentMethodSelector = new PaymentMethodSelector(state.paymentMethods);
+            paymentMethodSelector = createPaymentMethodSelector(state.paymentMethods);
 
             expect(paymentMethodSelector.getPaymentMethod('amex', 'adyen')).toEqual(getAdyenAmex());
         });
 
         it('returns nothing if payment method is not found', () => {
-            paymentMethodSelector = new PaymentMethodSelector(state.paymentMethods);
+            paymentMethodSelector = createPaymentMethodSelector(state.paymentMethods);
 
             expect(paymentMethodSelector.getPaymentMethod('xyz')).toBeUndefined();
         });
 
         it('returns nothing if multi-option payment method is not found', () => {
-            paymentMethodSelector = new PaymentMethodSelector(state.paymentMethods);
+            paymentMethodSelector = createPaymentMethodSelector(state.paymentMethods);
 
             expect(paymentMethodSelector.getPaymentMethod('amex')).toEqual(getAdyenAmex());
         });
@@ -61,7 +63,7 @@ describe('PaymentMethodSelector', () => {
         it('returns error if unable to load', () => {
             const loadError = new RequestError(getErrorResponse());
 
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 errors: { loadError },
             });
@@ -70,7 +72,7 @@ describe('PaymentMethodSelector', () => {
         });
 
         it('does not returns error if able to load', () => {
-            paymentMethodSelector = new PaymentMethodSelector(state.paymentMethods);
+            paymentMethodSelector = createPaymentMethodSelector(state.paymentMethods);
 
             expect(paymentMethodSelector.getLoadError()).toBeUndefined();
         });
@@ -80,7 +82,7 @@ describe('PaymentMethodSelector', () => {
         it('returns error if unable to load', () => {
             const loadMethodError = new RequestError(getErrorResponse());
 
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 errors: { loadMethodError, loadMethodId: 'braintree' },
             });
@@ -89,7 +91,7 @@ describe('PaymentMethodSelector', () => {
         });
 
         it('does not returns error if able to load', () => {
-            paymentMethodSelector = new PaymentMethodSelector(state.paymentMethods);
+            paymentMethodSelector = createPaymentMethodSelector(state.paymentMethods);
 
             expect(paymentMethodSelector.getLoadMethodError('braintree')).toBeUndefined();
         });
@@ -97,7 +99,7 @@ describe('PaymentMethodSelector', () => {
         it('does not returns error if unable to load irrelevant method', () => {
             const loadMethodError = new RequestError(getErrorResponse());
 
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 errors: { loadMethodError, loadMethodId: 'authorizenet' },
             });
@@ -108,7 +110,7 @@ describe('PaymentMethodSelector', () => {
         it('returns any error if method id is not passed', () => {
             const loadMethodError = new RequestError(getErrorResponse());
 
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 errors: { loadMethodError, loadMethodId: 'braintree' },
             });
@@ -119,7 +121,7 @@ describe('PaymentMethodSelector', () => {
 
     describe('#isLoading()', () => {
         it('returns true if loading payment methods', () => {
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 statuses: { isLoading: true },
             });
@@ -128,7 +130,7 @@ describe('PaymentMethodSelector', () => {
         });
 
         it('returns false if not loading payment methods', () => {
-            paymentMethodSelector = new PaymentMethodSelector(state.paymentMethods);
+            paymentMethodSelector = createPaymentMethodSelector(state.paymentMethods);
 
             expect(paymentMethodSelector.isLoading()).toEqual(false);
         });
@@ -136,7 +138,7 @@ describe('PaymentMethodSelector', () => {
 
     describe('#isLoadingMethod()', () => {
         it('returns true if loading payment method', () => {
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 statuses: { isLoadingMethod: true, loadMethodId: 'braintree' },
             });
@@ -145,7 +147,7 @@ describe('PaymentMethodSelector', () => {
         });
 
         it('returns false if not loading payment method', () => {
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 statuses: { isLoadingMethod: false, loadMethodId: undefined },
             });
@@ -154,7 +156,7 @@ describe('PaymentMethodSelector', () => {
         });
 
         it('returns false if not loading specific payment method', () => {
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 statuses: { isLoadingMethod: true, loadMethodId: 'authorizenet' },
             });
@@ -163,7 +165,7 @@ describe('PaymentMethodSelector', () => {
         });
 
         it('returns any loading status if method id is not passed', () => {
-            paymentMethodSelector = new PaymentMethodSelector({
+            paymentMethodSelector = createPaymentMethodSelector({
                 ...state.paymentMethods,
                 statuses: { isLoadingMethod: true, loadMethodId: 'braintree' },
             });

--- a/src/payment/payment-method-state.ts
+++ b/src/payment/payment-method-state.ts
@@ -19,3 +19,8 @@ export interface PaymentMethodStatusesState {
     isLoading?: boolean;
     isLoadingMethod?: boolean;
 }
+
+export const DEFAULT_STATE: PaymentMethodState = {
+    errors: {},
+    statuses: {},
+};


### PR DESCRIPTION
## What?
* Refactor `PaymentMethodSelector` to return new getters only when there are changes to relevant data.
* Update `paymentMethodReducer` to transform state only when it is necessary.

## Why?
Please refer to my previous PRs. They are related to this one.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
