### PR TITLE
CHECKOUT-4272: Optimise payment / payment strategy selector and reducer

### DIFF
--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -8,7 +8,7 @@ import { createCustomerSelectorFactory, createCustomerStrategySelectorFactory } 
 import { createFormSelectorFactory } from '../form';
 import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
-import { createPaymentMethodSelectorFactory, PaymentSelector, PaymentStrategySelector } from '../payment';
+import { createPaymentMethodSelectorFactory, createPaymentSelectorFactory, PaymentStrategySelector } from '../payment';
 import { createInstrumentSelectorFactory } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, createShippingStrategySelectorFactory } from '../shipping';
@@ -41,6 +41,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createShippingStrategySelector = createShippingStrategySelectorFactory();
     const createConsignmentSelector = createConsignmentSelectorFactory();
     const createOrderSelector = createOrderSelectorFactory();
+    const createPaymentSelector = createPaymentSelectorFactory();
 
     return (state, options = {}) => {
         const billingAddress = createBillingAddressSelector(state.billingAddress);
@@ -65,7 +66,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const consignments = createConsignmentSelector(state.consignments, cart);
         const checkout = new CheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, customer, giftCertificates);
         const order = createOrderSelector(state.order, billingAddress, coupons);
-        const payment = new PaymentSelector(checkout, order);
+        const payment = createPaymentSelector(checkout, order);
 
         const selectors = {
             billingAddress,

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -8,7 +8,7 @@ import { createCustomerSelectorFactory, createCustomerStrategySelectorFactory } 
 import { createFormSelectorFactory } from '../form';
 import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
-import { createPaymentMethodSelectorFactory, createPaymentSelectorFactory, PaymentStrategySelector } from '../payment';
+import { createPaymentMethodSelectorFactory, createPaymentSelectorFactory, createPaymentStrategySelectorFactory } from '../payment';
 import { createInstrumentSelectorFactory } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, createShippingStrategySelectorFactory } from '../shipping';
@@ -36,6 +36,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createInstrumentSelector = createInstrumentSelectorFactory();
     const createFormSelector = createFormSelectorFactory();
     const createPaymentMethodSelector = createPaymentMethodSelectorFactory();
+    const createPaymentStrategySelector = createPaymentStrategySelectorFactory();
     const createShippingAddressSelector = createShippingAddressSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
     const createShippingStrategySelector = createShippingStrategySelectorFactory();
@@ -56,7 +57,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const giftCertificates = createGiftCertificateSelector(state.giftCertificates);
         const instruments = createInstrumentSelector(state.instruments);
         const paymentMethods = createPaymentMethodSelector(state.paymentMethods);
-        const paymentStrategies = new PaymentStrategySelector(state.paymentStrategies);
+        const paymentStrategies = createPaymentStrategySelector(state.paymentStrategies);
         const shippingAddress = createShippingAddressSelector(state.consignments);
         const remoteCheckout = new RemoteCheckoutSelector(state.remoteCheckout);
         const shippingCountries = createShippingCountrySelector(state.shippingCountries);

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -32,5 +32,5 @@ export { default as PaymentState } from './payment-state';
 export { default as PaymentStrategyActionCreator } from './payment-strategy-action-creator';
 export { default as paymentStrategyReducer } from './payment-strategy-reducer';
 export { default as PaymentStrategyRegistry } from './payment-strategy-registry';
-export { default as PaymentStrategySelector } from './payment-strategy-selector';
+export { default as PaymentStrategySelector, PaymentStrategySelectorFactory, createPaymentStrategySelectorFactory } from './payment-strategy-selector';
 export { default as PaymentStrategyState } from './payment-strategy-state';

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -27,7 +27,7 @@ export { default as PaymentMethodSelector, PaymentMethodSelectorFactory, createP
 export { default as PaymentMethodState } from './payment-method-state';
 export { default as paymentReducer } from './payment-reducer';
 export { default as PaymentRequestSender } from './payment-request-sender';
-export { default as PaymentSelector } from './payment-selector';
+export { default as PaymentSelector, PaymentSelectorFactory, createPaymentSelectorFactory } from './payment-selector';
 export { default as PaymentState } from './payment-state';
 export { default as PaymentStrategyActionCreator } from './payment-strategy-action-creator';
 export { default as paymentStrategyReducer } from './payment-strategy-reducer';

--- a/src/payment/payment-selector.spec.ts
+++ b/src/payment/payment-selector.spec.ts
@@ -5,22 +5,24 @@ import { getCheckoutStoreStateWithOrder, getCheckoutWithPayments } from '../chec
 import { getCompleteOrder as getInternalCompleteOrder } from '../order/internal-orders.mock';
 
 import { getPaymentMethod } from './payment-methods.mock';
-import PaymentSelector from './payment-selector';
+import PaymentSelector, { createPaymentSelectorFactory, PaymentSelectorFactory } from './payment-selector';
 import { ACKNOWLEDGE, FINALIZE } from './payment-status-types';
 
 describe('PaymentSelector', () => {
+    let createPaymentSelector: PaymentSelectorFactory;
     let state: CheckoutStoreState;
     let selectors: InternalCheckoutSelectors;
     let paymentSelector: PaymentSelector;
 
     beforeEach(() => {
+        createPaymentSelector = createPaymentSelectorFactory();
         state = getCheckoutStoreStateWithOrder();
         selectors = createInternalCheckoutSelectors(state);
     });
 
     describe('#getPaymentId()', () => {
         it('returns payment ID from order if order has been created', () => {
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             const payment = paymentSelector.getPaymentId();
 
@@ -36,7 +38,7 @@ describe('PaymentSelector', () => {
                     meta: { payment: getInternalCompleteOrder().payment },
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             const payment = paymentSelector.getPaymentId();
 
@@ -55,7 +57,7 @@ describe('PaymentSelector', () => {
                     data: undefined,
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             const payment = paymentSelector.getPaymentId();
 
@@ -65,7 +67,7 @@ describe('PaymentSelector', () => {
 
     describe('#getPaymentStatus()', () => {
         it('returns payment status from order if order has been created', () => {
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.getPaymentStatus()).toEqual(FINALIZE);
         });
@@ -79,7 +81,7 @@ describe('PaymentSelector', () => {
                     meta: { payment: getInternalCompleteOrder().payment },
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.getPaymentStatus()).toEqual(FINALIZE);
         });
@@ -97,7 +99,7 @@ describe('PaymentSelector', () => {
                     meta: undefined,
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.getPaymentStatus()).toEqual(ACKNOWLEDGE);
         });
@@ -118,13 +120,13 @@ describe('PaymentSelector', () => {
                     },
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.getPaymentRedirectUrl()).toEqual('/checkout.php');
         });
 
         it('returns undefined if unavailable', () => {
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.getPaymentRedirectUrl()).toEqual(undefined);
         });
@@ -132,7 +134,7 @@ describe('PaymentSelector', () => {
 
     describe('#getPaymentToken()', () => {
         it('returns payment token if available', () => {
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.getPaymentToken()).toEqual(state.order.meta && state.order.meta.token);
         });
@@ -146,7 +148,7 @@ describe('PaymentSelector', () => {
                     meta: undefined,
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.getPaymentToken()).toEqual(undefined);
         });
@@ -154,7 +156,7 @@ describe('PaymentSelector', () => {
 
     describe('#isPaymentDataRequired()', () => {
         it('returns true if payment is required', () => {
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.isPaymentDataRequired()).toEqual(true);
         });
@@ -167,7 +169,7 @@ describe('PaymentSelector', () => {
                     },
                 },
             }));
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.isPaymentDataRequired(true)).toEqual(false);
         });
@@ -180,7 +182,7 @@ describe('PaymentSelector', () => {
                     },
                 },
             }));
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.isPaymentDataRequired(false)).toEqual(true);
         });
@@ -192,7 +194,7 @@ describe('PaymentSelector', () => {
                 ...getPaymentMethod(),
                 nonce: '8903d867-6f7b-475c-8ab2-0b47ec6e000d',
             };
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.isPaymentDataSubmitted(paymentMethod)).toEqual(true);
         });
@@ -205,7 +207,7 @@ describe('PaymentSelector', () => {
                     data: getCheckoutWithPayments(),
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.isPaymentDataSubmitted(getPaymentMethod())).toEqual(true);
         });
@@ -224,7 +226,7 @@ describe('PaymentSelector', () => {
                     data: checkout,
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.isPaymentDataSubmitted(getPaymentMethod())).toEqual(true);
         });
@@ -238,7 +240,7 @@ describe('PaymentSelector', () => {
                     meta: undefined,
                 },
             });
-            paymentSelector = new PaymentSelector(selectors.checkout, selectors.order);
+            paymentSelector = createPaymentSelector(selectors.checkout, selectors.order);
 
             expect(paymentSelector.isPaymentDataSubmitted(getPaymentMethod())).toEqual(false);
         });

--- a/src/payment/payment-strategy-reducer.ts
+++ b/src/payment/payment-strategy-reducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { clearErrorReducer } from '../common/error';
+import { objectMerge } from '../common/utility';
 
 import { PaymentStrategyAction, PaymentStrategyActionType } from './payment-strategy-actions';
 import PaymentStrategyState, { DEFAULT_STATE, PaymentStrategyDataState, PaymentStrategyErrorsState, PaymentStrategyStatusesState } from './payment-strategy-state';
@@ -24,20 +25,18 @@ function dataReducer(
 ): PaymentStrategyDataState {
     switch (action.type) {
     case PaymentStrategyActionType.InitializeSucceeded:
-        return {
-            ...data,
+        return objectMerge(data, {
             [action.meta && action.meta.methodId]: {
                 isInitialized: true,
             },
-        };
+        });
 
     case PaymentStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...data,
+        return objectMerge(data, {
             [action.meta && action.meta.methodId]: {
                 isInitialized: false,
             },
-        };
+        });
     }
 
     return data;
@@ -50,78 +49,68 @@ function errorsReducer(
     switch (action.type) {
     case PaymentStrategyActionType.InitializeRequested:
     case PaymentStrategyActionType.InitializeSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             initializeError: undefined,
             initializeMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.InitializeFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             initializeError: action.payload,
             initializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case PaymentStrategyActionType.DeinitializeRequested:
     case PaymentStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             deinitializeError: undefined,
             deinitializeMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.DeinitializeFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             deinitializeError: action.payload,
             deinitializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case PaymentStrategyActionType.ExecuteRequested:
     case PaymentStrategyActionType.ExecuteSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             executeError: undefined,
             executeMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.ExecuteFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             executeError: action.payload,
             executeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case PaymentStrategyActionType.FinalizeRequested:
     case PaymentStrategyActionType.FinalizeSucceeded:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             finalizeError: undefined,
             finalizeMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.FinalizeFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             finalizeError: action.payload,
             finalizeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case PaymentStrategyActionType.WidgetInteractionStarted:
     case PaymentStrategyActionType.WidgetInteractionFinished:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             widgetInteractionError: undefined,
             widgetInteractionMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.WidgetInteractionFailed:
-        return {
-            ...errors,
+        return objectMerge(errors, {
             widgetInteractionError: action.payload,
             widgetInteractionMethodId: action.meta.methodId,
-        };
+        });
 
     default:
         return errors;
@@ -134,79 +123,69 @@ function statusesReducer(
 ): PaymentStrategyStatusesState {
     switch (action.type) {
     case PaymentStrategyActionType.InitializeRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isInitializing: true,
             initializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case PaymentStrategyActionType.InitializeFailed:
     case PaymentStrategyActionType.InitializeSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isInitializing: false,
             initializeMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.DeinitializeRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isDeinitializing: true,
             deinitializeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case PaymentStrategyActionType.DeinitializeFailed:
     case PaymentStrategyActionType.DeinitializeSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isDeinitializing: false,
             deinitializeMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.ExecuteRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isExecuting: true,
             executeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case PaymentStrategyActionType.ExecuteFailed:
     case PaymentStrategyActionType.ExecuteSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isExecuting: false,
             executeMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.FinalizeRequested:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isFinalizing: true,
             finalizeMethodId: action.meta && action.meta.methodId,
-        };
+        });
 
     case PaymentStrategyActionType.FinalizeFailed:
     case PaymentStrategyActionType.FinalizeSucceeded:
-        return {
-            ...statuses,
+        return objectMerge(statuses, {
             isFinalizing: false,
             finalizeMethodId: undefined,
-        };
+        });
 
     case PaymentStrategyActionType.WidgetInteractionStarted:
-    return {
-        ...statuses,
-        isWidgetInteracting: true,
-        widgetInteractionMethodId: action.meta.methodId,
-     };
+        return objectMerge(statuses, {
+            isWidgetInteracting: true,
+            widgetInteractionMethodId: action.meta.methodId,
+        });
 
     case PaymentStrategyActionType.WidgetInteractionFinished:
     case PaymentStrategyActionType.WidgetInteractionFailed:
-     return {
-        ...statuses,
-        isWidgetInteracting: false,
-        widgetInteractionMethodId: undefined,
-     };
+        return objectMerge(statuses, {
+            isWidgetInteracting: false,
+            widgetInteractionMethodId: undefined,
+        });
 
     default:
         return statuses;

--- a/src/payment/payment-strategy-selector.spec.ts
+++ b/src/payment/payment-strategy-selector.spec.ts
@@ -1,13 +1,15 @@
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import PaymentStrategySelector from './payment-strategy-selector';
+import PaymentStrategySelector, { createPaymentStrategySelectorFactory, PaymentStrategySelectorFactory } from './payment-strategy-selector';
 import { DEFAULT_STATE } from './payment-strategy-state';
 
 describe('PaymentStrategySelector', () => {
+    let createPaymentStrategySelector: PaymentStrategySelectorFactory;
     let selector: PaymentStrategySelector;
     let state: any;
 
     beforeEach(() => {
+        createPaymentStrategySelector = createPaymentStrategySelectorFactory();
         state = {
             paymentStrategy: DEFAULT_STATE,
         };
@@ -17,7 +19,7 @@ describe('PaymentStrategySelector', () => {
         it('returns error if unable to execute', () => {
             const executeError = getErrorResponse();
 
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 errors: { executeError },
             });
@@ -26,7 +28,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('does not returns error if able to execute', () => {
-            selector = new PaymentStrategySelector(state.paymentStrategy);
+            selector = createPaymentStrategySelector(state.paymentStrategy);
 
             expect(selector.getExecuteError()).toBeUndefined();
         });
@@ -36,7 +38,7 @@ describe('PaymentStrategySelector', () => {
         it('returns error if unable to finalize', () => {
             const finalizeError = getErrorResponse();
 
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 errors: { finalizeError },
             });
@@ -45,7 +47,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('does not returns error if able to finalize', () => {
-            selector = new PaymentStrategySelector(state.paymentStrategy);
+            selector = createPaymentStrategySelector(state.paymentStrategy);
 
             expect(selector.getFinalizeError()).toBeUndefined();
         });
@@ -53,7 +55,7 @@ describe('PaymentStrategySelector', () => {
 
     describe('#getInitializeError()', () => {
         it('returns error if unable to initialize any method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 errors: { initializeError: getErrorResponse(), initializeMethodId: 'foobar' },
             });
@@ -62,7 +64,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('returns error if unable to initialize specific method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 errors: { initializeError: getErrorResponse(), initializeMethodId: 'foobar' },
             });
@@ -72,7 +74,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('does not return error if able to initialize', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 errors: {},
             });
@@ -83,7 +85,7 @@ describe('PaymentStrategySelector', () => {
 
     describe('#getWidgetInteractingError()', () => {
         it('returns error if widget interaction failed', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 errors: { widgetInteractionError: getErrorResponse(), widgetInteractionMethodId: 'foobar' },
             });
@@ -92,7 +94,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('returns error if unable to initialize specific method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 errors: { initializeError: getErrorResponse(), initializeMethodId: 'foobar' },
             });
@@ -102,7 +104,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('does not return error if able to initialize', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 errors: {},
             });
@@ -113,7 +115,7 @@ describe('PaymentStrategySelector', () => {
 
     describe('#isExecuting()', () => {
         it('returns true if updating address', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 statuses: { isExecuting: true },
             });
@@ -122,7 +124,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('returns false if not updating address', () => {
-            selector = new PaymentStrategySelector(state.paymentStrategy);
+            selector = createPaymentStrategySelector(state.paymentStrategy);
 
             expect(selector.isExecuting()).toEqual(false);
         });
@@ -130,7 +132,7 @@ describe('PaymentStrategySelector', () => {
 
     describe('#isFinalizing()', () => {
         it('returns true if selecting option', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 statuses: { isFinalizing: true },
             });
@@ -139,7 +141,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('returns false if not selecting option', () => {
-            selector = new PaymentStrategySelector(state.paymentStrategy);
+            selector = createPaymentStrategySelector(state.paymentStrategy);
 
             expect(selector.isFinalizing()).toEqual(false);
         });
@@ -147,7 +149,7 @@ describe('PaymentStrategySelector', () => {
 
     describe('#isInitializing()', () => {
         it('returns true if initializing any method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 statuses: { initializeMethodId: 'foobar', isInitializing: true },
             });
@@ -156,7 +158,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('returns true if initializing specific method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 statuses: { initializeMethodId: 'foobar', isInitializing: true },
             });
@@ -166,7 +168,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('returns false if not initializing method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 statuses: { initializeMethodId: undefined, isInitializing: false },
             });
@@ -177,7 +179,7 @@ describe('PaymentStrategySelector', () => {
 
     describe('#isWidgetInteracting()', () => {
         it('returns true if widget interacting in any method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 statuses: { initializeMethodId: 'foobar', isWidgetInteracting: true },
             });
@@ -186,7 +188,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('returns true if widget interacting for a specific method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 statuses: { widgetInteractionMethodId: 'foobar', isWidgetInteracting: true },
             });
@@ -196,7 +198,7 @@ describe('PaymentStrategySelector', () => {
         });
 
         it('returns false if widget not interacting for a specific method', () => {
-            selector = new PaymentStrategySelector({
+            selector = createPaymentStrategySelector({
                 ...state.paymentStrategy,
                 statuses: { widgetInteractionMethodId: undefined, isWidgetInteracting: false },
             });

--- a/src/payment/payment-strategy-selector.ts
+++ b/src/payment/payment-strategy-selector.ts
@@ -1,81 +1,142 @@
-import { selector } from '../common/selector';
+import { createSelector } from '../common/selector';
+import { memoizeOne } from '../common/utility';
 
 import PaymentStrategyState, { DEFAULT_STATE } from './payment-strategy-state';
 
-@selector
-export default class PaymentStrategySelector {
-    constructor(
-        private _paymentStrategies: PaymentStrategyState = DEFAULT_STATE
-    ) {}
+export default interface PaymentStrategySelector {
+    getInitializeError(methodId?: string): Error | undefined;
+    getExecuteError(methodId?: string): Error | undefined;
+    getFinalizeError(methodId?: string): Error | undefined;
+    getWidgetInteractingError(methodId?: string): Error | undefined;
+    isInitializing(methodId?: string): boolean;
+    isInitialized(methodId: string): boolean;
+    isExecuting(methodId?: string): boolean;
+    isFinalizing(methodId?: string): boolean;
+    isWidgetInteracting(methodId?: string): boolean;
+}
 
-    getInitializeError(methodId?: string): Error | undefined {
-        if (methodId && this._paymentStrategies.errors.initializeMethodId !== methodId) {
-            return;
+export type PaymentStrategySelectorFactory = (state: PaymentStrategyState) => PaymentStrategySelector;
+
+export function createPaymentStrategySelectorFactory(): PaymentStrategySelectorFactory {
+    const getInitializeError = createSelector(
+        (state: PaymentStrategyState) => state.errors.initializeMethodId,
+        (state: PaymentStrategyState) => state.errors.initializeError,
+        (initializeMethodId, initializeError) => (methodId?: string) => {
+            if (methodId && initializeMethodId !== methodId) {
+                return;
+            }
+
+            return initializeError;
         }
+    );
 
-        return this._paymentStrategies.errors.initializeError;
-    }
+    const getExecuteError = createSelector(
+        (state: PaymentStrategyState) => state.errors.executeMethodId,
+        (state: PaymentStrategyState) => state.errors.executeError,
+        (executeMethodId, executeError) => (methodId?: string) => {
+            if (methodId && executeMethodId !== methodId) {
+                return;
+            }
 
-    getExecuteError(methodId?: string): Error | undefined {
-        if (methodId && this._paymentStrategies.errors.executeMethodId !== methodId) {
-            return;
+            return executeError;
         }
+    );
 
-        return this._paymentStrategies.errors.executeError;
-    }
+    const getFinalizeError = createSelector(
+        (state: PaymentStrategyState) => state.errors.finalizeMethodId,
+        (state: PaymentStrategyState) => state.errors.finalizeError,
+        (finalizeMethodId, finalizeError) => (methodId?: string) => {
+            if (methodId && finalizeMethodId !== methodId) {
+                return;
+            }
 
-    getFinalizeError(methodId?: string): Error | undefined {
-        if (methodId && this._paymentStrategies.errors.finalizeMethodId !== methodId) {
-            return;
+            return finalizeError;
         }
+    );
 
-        return this._paymentStrategies.errors.finalizeError;
-    }
+    const getWidgetInteractingError = createSelector(
+        (state: PaymentStrategyState) => state.errors.widgetInteractionMethodId,
+        (state: PaymentStrategyState) => state.errors.widgetInteractionError,
+        (widgetInteractionMethodId, widgetInteractionError) => (methodId?: string) => {
+            if (methodId && widgetInteractionMethodId !== methodId) {
+                return;
+            }
 
-    getWidgetInteractingError(methodId?: string): Error | undefined {
-        if (methodId && this._paymentStrategies.errors.widgetInteractionMethodId !== methodId) {
-            return;
+            return widgetInteractionError;
         }
+    );
 
-        return this._paymentStrategies.errors.widgetInteractionError;
-    }
+    const isInitializing = createSelector(
+        (state: PaymentStrategyState) => state.statuses.initializeMethodId,
+        (state: PaymentStrategyState) => state.statuses.isInitializing,
+        (initializeMethodId, isInitializing) => (methodId?: string) => {
+            if (methodId && initializeMethodId !== methodId) {
+                return false;
+            }
 
-    isInitializing(methodId?: string): boolean {
-        if (methodId && this._paymentStrategies.statuses.initializeMethodId !== methodId) {
-            return false;
+            return !!isInitializing;
         }
+    );
 
-        return !!this._paymentStrategies.statuses.isInitializing;
-    }
-
-    isInitialized(methodId: string): boolean {
-        return !!(
-            this._paymentStrategies.data[methodId] &&
-            this._paymentStrategies.data[methodId].isInitialized
-        );
-    }
-
-    isExecuting(methodId?: string): boolean {
-        if (methodId && this._paymentStrategies.statuses.executeMethodId !== methodId) {
-            return false;
+    const isInitialized = createSelector(
+        (state: PaymentStrategyState) => state.data,
+        data => (methodId: string) => {
+            return !!(
+                data[methodId] &&
+                data[methodId].isInitialized
+            );
         }
+    );
 
-        return !!this._paymentStrategies.statuses.isExecuting;
-    }
+    const isExecuting = createSelector(
+        (state: PaymentStrategyState) => state.statuses.executeMethodId,
+        (state: PaymentStrategyState) => state.statuses.isExecuting,
+        (executeMethodId, isExecuting) => (methodId?: string) => {
+            if (methodId && executeMethodId !== methodId) {
+                return false;
+            }
 
-    isFinalizing(methodId?: string): boolean {
-        if (methodId && this._paymentStrategies.statuses.finalizeMethodId !== methodId) {
-            return false;
+            return !!isExecuting;
         }
+    );
 
-        return !!this._paymentStrategies.statuses.isFinalizing;
-    }
+    const isFinalizing = createSelector(
+        (state: PaymentStrategyState) => state.statuses.finalizeMethodId,
+        (state: PaymentStrategyState) => state.statuses.isFinalizing,
+        (finalizeMethodId, isFinalizing) => (methodId?: string) => {
+            if (methodId && finalizeMethodId !== methodId) {
+                return false;
+            }
 
-    isWidgetInteracting(methodId?: string): boolean {
-        if (methodId && this._paymentStrategies.statuses.widgetInteractionMethodId !== methodId) {
-            return false;
+            return !!isFinalizing;
         }
+    );
 
-        return !!this._paymentStrategies.statuses.isWidgetInteracting;
-    }
+    const isWidgetInteracting = createSelector(
+        (state: PaymentStrategyState) => state.statuses.widgetInteractionMethodId,
+        (state: PaymentStrategyState) => state.statuses.isWidgetInteracting,
+        (widgetInteractionMethodId, isWidgetInteracting) => (methodId?: string) => {
+            if (methodId && widgetInteractionMethodId !== methodId) {
+                return false;
+            }
+
+            return !!isWidgetInteracting;
+        }
+    );
+
+    return memoizeOne((
+        state: PaymentStrategyState = DEFAULT_STATE
+    ): PaymentStrategySelector => {
+        return {
+            getInitializeError: getInitializeError(state),
+            getExecuteError: getExecuteError(state),
+            getFinalizeError: getFinalizeError(state),
+            getWidgetInteractingError: getWidgetInteractingError(state),
+            isInitializing: isInitializing(state),
+            isInitialized: isInitialized(state),
+            isExecuting: isExecuting(state),
+            isFinalizing: isFinalizing(state),
+            isWidgetInteracting: isWidgetInteracting(state),
+        };
+    });
 }


### PR DESCRIPTION
## What?
* Refactor `PaymentSelector` and `PaymentStrategySelector` to return new getters only when there are changes to relevant data.
* Update `paymentStrategyReducer` to transform state only when it is necessary.

## Why?
Please refer to my previous PRs. They are related to this one.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
