### PR TITLE
CHECKOUT-4272: Optimise checkout external selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -940,13 +940,15 @@
       }
     },
     "@bigcommerce/data-store": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/data-store/-/data-store-0.2.7.tgz",
-      "integrity": "sha512-RheDlIA7+qldHLd/GRtbOCwBr4RykZ6AZMhOAXf419qK261t6VhWU3c/Ax7N1hPNpXX3D/bHL+4WWGk/9MflwQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/data-store/-/data-store-1.0.0.tgz",
+      "integrity": "sha512-Hpx06GOCk97IPTfBQD1mmtX5fDIl/GFk/qFeU8+WtHZAuBOay6unSKvINMLTxEgQfDxJrt2YRlu35Xda17Ho4g==",
       "requires": {
         "@types/lodash": "^4.14.92",
+        "@types/shallowequal": "^1.1.1",
         "lodash": "^4.17.4",
         "rxjs": "^6.3.3",
+        "shallowequal": "^1.1.0",
         "tslib": "^1.8.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
     "@bigcommerce/bigpay-client": "^4.2.0",
-    "@bigcommerce/data-store": "^0.2.7",
+    "@bigcommerce/data-store": "^1.0.0",
     "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/request-sender": "^0.3.0",
     "@bigcommerce/script-loader": "^0.1.6",

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -262,7 +262,7 @@ describe('CheckoutService', () => {
         it('returns state', () => {
             expect(checkoutService.getState()).toEqual(expect.objectContaining({
                 data: expect.any(Object),
-                errors: expect.any(CheckoutStoreErrorSelector),
+                errors: expect.any(Object),
                 statuses: expect.any(Object),
             }));
         });

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -263,7 +263,7 @@ describe('CheckoutService', () => {
             expect(checkoutService.getState()).toEqual(expect.objectContaining({
                 data: expect.any(Object),
                 errors: expect.any(CheckoutStoreErrorSelector),
-                statuses: expect.any(CheckoutStoreStatusSelector),
+                statuses: expect.any(Object),
             }));
         });
 

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -261,7 +261,7 @@ describe('CheckoutService', () => {
     describe('#getState()', () => {
         it('returns state', () => {
             expect(checkoutService.getState()).toEqual(expect.objectContaining({
-                data: expect.any(CheckoutStoreSelector),
+                data: expect.any(Object),
                 errors: expect.any(CheckoutStoreErrorSelector),
                 statuses: expect.any(CheckoutStoreStatusSelector),
             }));
@@ -294,7 +294,8 @@ describe('CheckoutService', () => {
 
             await checkoutService.loadCheckout();
 
-            expect(filter).toHaveBeenCalledWith(checkoutService.getState());
+            expect(Object.keys((filter as jest.Mock).mock.calls[0][0]))
+                .toEqual(Object.keys(checkoutService.getState()));
         });
 
         it('calls subscriber on state change', async () => {

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -23,7 +23,7 @@ import CheckoutActionCreator from './checkout-action-creator';
 import CheckoutParams from './checkout-params';
 import CheckoutSelectors from './checkout-selectors';
 import CheckoutStore from './checkout-store';
-import createCheckoutSelectors from './create-checkout-selectors';
+import createCheckoutSelectors, { createCheckoutSelectorsFactory, CheckoutSelectorsFactory } from './create-checkout-selectors';
 import createCheckoutServiceErrorTransformer from './create-checkout-service-error-transformer';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
@@ -38,6 +38,7 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
 export default class CheckoutService {
     private _storeProjection: DataStoreProjection<InternalCheckoutSelectors, CheckoutSelectors>;
     private _errorTransformer: ErrorMessageTransformer;
+    private _selectorsFactory: CheckoutSelectorsFactory;
 
     /**
      * @internal
@@ -62,6 +63,7 @@ export default class CheckoutService {
         private _spamProtectionActionCreator: SpamProtectionActionCreator
     ) {
         this._errorTransformer = createCheckoutServiceErrorTransformer();
+        this._selectorsFactory = createCheckoutSelectorsFactory();
         this._storeProjection = new DataStoreProjection(this._store, createCheckoutSelectors);
     }
 

--- a/src/checkout/checkout-store-error-selector.spec.ts
+++ b/src/checkout/checkout-store-error-selector.spec.ts
@@ -2,31 +2,35 @@ import { Response } from '@bigcommerce/request-sender';
 
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import CheckoutStoreErrorSelector from './checkout-store-error-selector';
+import { createCheckoutStoreErrorSelectorFactory, CheckoutStoreErrorSelectorFactory } from './checkout-store-error-selector';
 import { getCheckoutStoreStateWithOrder } from './checkouts.mock';
 import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 describe('CheckoutStoreErrorSelector', () => {
+    let createCheckoutStoreErrorSelector: CheckoutStoreErrorSelectorFactory;
     let errorResponse: Response;
-    let errors: CheckoutStoreErrorSelector;
     let selectors: InternalCheckoutSelectors;
 
     beforeEach(() => {
+        createCheckoutStoreErrorSelector = createCheckoutStoreErrorSelectorFactory();
         selectors = createInternalCheckoutSelectors(getCheckoutStoreStateWithOrder());
-        errors = new CheckoutStoreErrorSelector(selectors);
 
         errorResponse = getErrorResponse();
     });
 
     describe('#getError()', () => {
         it('returns no error if there are no errors', () => {
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getError()).toEqual(undefined);
         });
 
         it('returns the first error that it encounters', () => {
             jest.spyOn(selectors.checkout, 'getLoadError').mockReturnValue(undefined);
             jest.spyOn(selectors.paymentStrategies, 'getExecuteError').mockReturnValue(errorResponse);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getError()).toEqual(errorResponse);
 
@@ -39,12 +43,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading checkout', () => {
             jest.spyOn(selectors.checkout, 'getLoadError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadCheckoutError()).toEqual(errorResponse);
             expect(selectors.checkout.getLoadError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when loading checkout', () => {
             jest.spyOn(selectors.checkout, 'getLoadError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadCheckoutError()).toEqual(undefined);
             expect(selectors.checkout.getLoadError).toHaveBeenCalled();
@@ -55,12 +63,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading checkout', () => {
             jest.spyOn(selectors.checkout, 'getUpdateError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getUpdateCheckoutError()).toEqual(errorResponse);
             expect(selectors.checkout.getUpdateError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when loading checkout', () => {
             jest.spyOn(selectors.checkout, 'getUpdateError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getUpdateCheckoutError()).toEqual(undefined);
             expect(selectors.checkout.getUpdateError).toHaveBeenCalled();
@@ -71,12 +83,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when submitting order', () => {
             jest.spyOn(selectors.paymentStrategies, 'getExecuteError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getSubmitOrderError()).toEqual(errorResponse);
             expect(selectors.paymentStrategies.getExecuteError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when submitting order', () => {
             jest.spyOn(selectors.paymentStrategies, 'getExecuteError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getSubmitOrderError()).toEqual(undefined);
             expect(selectors.paymentStrategies.getExecuteError).toHaveBeenCalled();
@@ -87,12 +103,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when finalizing order', () => {
             jest.spyOn(selectors.paymentStrategies, 'getFinalizeError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getFinalizeOrderError()).toEqual(errorResponse);
             expect(selectors.paymentStrategies.getFinalizeError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when finalizing order', () => {
             jest.spyOn(selectors.paymentStrategies, 'getFinalizeError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getFinalizeOrderError()).toEqual(undefined);
             expect(selectors.paymentStrategies.getFinalizeError).toHaveBeenCalled();
@@ -103,12 +123,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading order', () => {
             jest.spyOn(selectors.order, 'getLoadError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadOrderError()).toEqual(errorResponse);
             expect(selectors.order.getLoadError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when loading order', () => {
             jest.spyOn(selectors.order, 'getLoadError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadOrderError()).toEqual(undefined);
             expect(selectors.order.getLoadError).toHaveBeenCalled();
@@ -119,12 +143,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading cart', () => {
             jest.spyOn(selectors.cart, 'getLoadError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadCartError()).toEqual(errorResponse);
             expect(selectors.cart.getLoadError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when loading cart', () => {
             jest.spyOn(selectors.cart, 'getLoadError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadCartError()).toEqual(undefined);
             expect(selectors.cart.getLoadError).toHaveBeenCalled();
@@ -135,12 +163,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading billing countries', () => {
             jest.spyOn(selectors.countries, 'getLoadError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadBillingCountriesError()).toEqual(errorResponse);
             expect(selectors.countries.getLoadError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when loading billing countries', () => {
             jest.spyOn(selectors.countries, 'getLoadError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadBillingCountriesError()).toEqual(undefined);
             expect(selectors.countries.getLoadError).toHaveBeenCalled();
@@ -151,12 +183,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading shipping countries', () => {
             jest.spyOn(selectors.shippingCountries, 'getLoadError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadShippingCountriesError()).toEqual(errorResponse);
             expect(selectors.shippingCountries.getLoadError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when loading shipping countries', () => {
             jest.spyOn(selectors.shippingCountries, 'getLoadError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadShippingCountriesError()).toEqual(undefined);
             expect(selectors.shippingCountries.getLoadError).toHaveBeenCalled();
@@ -167,12 +203,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading payment methods', () => {
             jest.spyOn(selectors.paymentMethods, 'getLoadError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadPaymentMethodsError()).toEqual(errorResponse);
             expect(selectors.paymentMethods.getLoadError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when loading payment methods', () => {
             jest.spyOn(selectors.paymentMethods, 'getLoadError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadPaymentMethodsError()).toEqual(undefined);
             expect(selectors.paymentMethods.getLoadError).toHaveBeenCalled();
@@ -183,12 +223,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading payment method', () => {
             jest.spyOn(selectors.paymentMethods, 'getLoadMethodError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadPaymentMethodError('braintree')).toEqual(errorResponse);
             expect(selectors.paymentMethods.getLoadMethodError).toHaveBeenCalledWith('braintree');
         });
 
         it('returns undefined if there is no error when loading payment method', () => {
             jest.spyOn(selectors.paymentMethods, 'getLoadMethodError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadPaymentMethodError('braintree')).toEqual(undefined);
             expect(selectors.paymentMethods.getLoadMethodError).toHaveBeenCalledWith('braintree');
@@ -199,12 +243,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if unable to initialize payment', () => {
             jest.spyOn(selectors.paymentStrategies, 'getInitializeError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getInitializePaymentError('braintree')).toEqual(errorResponse);
             expect(selectors.paymentStrategies.getInitializeError).toHaveBeenCalledWith('braintree');
         });
 
         it('returns undefined if able to initialize payment', () => {
             jest.spyOn(selectors.paymentStrategies, 'getInitializeError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getInitializePaymentError('braintree')).toEqual(undefined);
             expect(selectors.paymentStrategies.getInitializeError).toHaveBeenCalledWith('braintree');
@@ -215,12 +263,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when signing in', () => {
             jest.spyOn(selectors.customerStrategies, 'getSignInError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getSignInError()).toEqual(errorResponse);
             expect(selectors.customerStrategies.getSignInError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when signing in', () => {
             jest.spyOn(selectors.customerStrategies, 'getSignInError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getSignInError()).toEqual(undefined);
             expect(selectors.customerStrategies.getSignInError).toHaveBeenCalled();
@@ -231,12 +283,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when signing out', () => {
             jest.spyOn(selectors.customerStrategies, 'getSignOutError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getSignOutError()).toEqual(errorResponse);
             expect(selectors.customerStrategies.getSignOutError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is no error when signing out', () => {
             jest.spyOn(selectors.customerStrategies, 'getSignOutError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getSignOutError()).toEqual(undefined);
             expect(selectors.customerStrategies.getSignOutError).toHaveBeenCalled();
@@ -247,12 +303,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if unable to initialize customer', () => {
             jest.spyOn(selectors.customerStrategies, 'getInitializeError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getInitializeCustomerError()).toEqual(errorResponse);
             expect(selectors.customerStrategies.getInitializeError).toHaveBeenCalled();
         });
 
         it('returns undefined if able to initialize customer', () => {
             jest.spyOn(selectors.customerStrategies, 'getInitializeError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getInitializeCustomerError()).toEqual(undefined);
             expect(selectors.customerStrategies.getInitializeError).toHaveBeenCalled();
@@ -263,12 +323,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading the shipping options', () => {
             jest.spyOn(selectors.consignments, 'getLoadShippingOptionsError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadShippingOptionsError()).toEqual(errorResponse);
             expect(selectors.consignments.getLoadShippingOptionsError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when loading the shipping options', () => {
             jest.spyOn(selectors.consignments, 'getLoadShippingOptionsError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadShippingOptionsError()).toEqual(undefined);
             expect(selectors.consignments.getLoadShippingOptionsError).toHaveBeenCalled();
@@ -279,12 +343,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when selecting the shipping options', () => {
             jest.spyOn(selectors.shippingStrategies, 'getSelectOptionError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getSelectShippingOptionError()).toEqual(errorResponse);
             expect(selectors.shippingStrategies.getSelectOptionError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when selecting the shipping options', () => {
             jest.spyOn(selectors.shippingStrategies, 'getSelectOptionError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getSelectShippingOptionError()).toEqual(undefined);
             expect(selectors.shippingStrategies.getSelectOptionError).toHaveBeenCalled();
@@ -295,12 +363,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when updating the billing address', () => {
             jest.spyOn(selectors.billingAddress, 'getUpdateError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getUpdateBillingAddressError()).toEqual(errorResponse);
             expect(selectors.billingAddress.getUpdateError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when updating the billing address', () => {
             jest.spyOn(selectors.billingAddress, 'getUpdateError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getUpdateBillingAddressError()).toEqual(undefined);
             expect(selectors.billingAddress.getUpdateError).toHaveBeenCalled();
@@ -311,12 +383,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error', () => {
             jest.spyOn(selectors.billingAddress, 'getContinueAsGuestError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getContinueAsGuestError()).toEqual(errorResponse);
             expect(selectors.billingAddress.getContinueAsGuestError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO errors', () => {
             jest.spyOn(selectors.billingAddress, 'getContinueAsGuestError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getContinueAsGuestError()).toEqual(undefined);
             expect(selectors.billingAddress.getContinueAsGuestError).toHaveBeenCalled();
@@ -327,12 +403,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when updating consignments', () => {
             jest.spyOn(selectors.consignments, 'getUpdateError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getUpdateConsignmentError('foo')).toEqual(errorResponse);
             expect(selectors.consignments.getUpdateError).toHaveBeenCalledWith('foo');
         });
 
         it('returns undefined if there is NO error when updating consignments', () => {
             jest.spyOn(selectors.consignments, 'getUpdateError');
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getUpdateConsignmentError('foo')).toEqual(undefined);
             expect(selectors.consignments.getUpdateError).toHaveBeenCalledWith('foo');
@@ -343,12 +423,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when deleting consignments', () => {
             jest.spyOn(selectors.consignments, 'getDeleteError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getDeleteConsignmentError('foo')).toEqual(errorResponse);
             expect(selectors.consignments.getDeleteError).toHaveBeenCalledWith('foo');
         });
 
         it('returns undefined if there is NO error when deleting consignments', () => {
             jest.spyOn(selectors.consignments, 'getDeleteError');
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getDeleteConsignmentError('foo')).toEqual(undefined);
             expect(selectors.consignments.getDeleteError).toHaveBeenCalledWith('foo');
@@ -359,12 +443,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when creating consignments', () => {
             jest.spyOn(selectors.consignments, 'getCreateError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getCreateConsignmentsError()).toEqual(errorResponse);
             expect(selectors.consignments.getCreateError).toHaveBeenCalledWith();
         });
 
         it('returns undefined if there is NO error when creating consignments', () => {
             jest.spyOn(selectors.consignments, 'getCreateError');
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getCreateConsignmentsError()).toEqual(undefined);
             expect(selectors.consignments.getCreateError).toHaveBeenCalledWith();
@@ -375,12 +463,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when updating the shipping address', () => {
             jest.spyOn(selectors.shippingStrategies, 'getUpdateAddressError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getUpdateShippingAddressError()).toEqual(errorResponse);
             expect(selectors.shippingStrategies.getUpdateAddressError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when updating the shipping address', () => {
             jest.spyOn(selectors.shippingStrategies, 'getUpdateAddressError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getUpdateShippingAddressError()).toEqual(undefined);
             expect(selectors.shippingStrategies.getUpdateAddressError).toHaveBeenCalled();
@@ -391,12 +483,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if unable to initialize shipping', () => {
             jest.spyOn(selectors.shippingStrategies, 'getInitializeError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getInitializeShippingError('foobar')).toEqual(errorResponse);
             expect(selectors.shippingStrategies.getInitializeError).toHaveBeenCalledWith('foobar');
         });
 
         it('returns undefined if able to initialize shipping', () => {
             jest.spyOn(selectors.shippingStrategies, 'getInitializeError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getInitializeShippingError('foobar')).toEqual(undefined);
             expect(selectors.shippingStrategies.getInitializeError).toHaveBeenCalledWith('foobar');
@@ -407,12 +503,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when updating the a coupon', () => {
             jest.spyOn(selectors.coupons, 'getApplyError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getApplyCouponError()).toEqual(errorResponse);
             expect(selectors.coupons.getApplyError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when updating the a coupon', () => {
             jest.spyOn(selectors.coupons, 'getApplyError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getApplyCouponError()).toEqual(undefined);
             expect(selectors.coupons.getApplyError).toHaveBeenCalled();
@@ -423,12 +523,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when updating the a coupon', () => {
             jest.spyOn(selectors.coupons, 'getRemoveError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getRemoveCouponError()).toEqual(errorResponse);
             expect(selectors.coupons.getRemoveError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when updating the a coupon', () => {
             jest.spyOn(selectors.coupons, 'getRemoveError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getRemoveCouponError()).toEqual(undefined);
             expect(selectors.coupons.getRemoveError).toHaveBeenCalled();
@@ -439,12 +543,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when applying gift certificate', () => {
             jest.spyOn(selectors.giftCertificates, 'getApplyError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getApplyGiftCertificateError()).toEqual(errorResponse);
             expect(selectors.giftCertificates.getApplyError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when applying gift certificate', () => {
             jest.spyOn(selectors.giftCertificates, 'getApplyError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getApplyGiftCertificateError()).toEqual(undefined);
             expect(selectors.giftCertificates.getApplyError).toHaveBeenCalled();
@@ -455,12 +563,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when removing gift certificate', () => {
             jest.spyOn(selectors.giftCertificates, 'getRemoveError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getRemoveGiftCertificateError()).toEqual(errorResponse);
             expect(selectors.giftCertificates.getRemoveError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when removing gift certificate', () => {
             jest.spyOn(selectors.giftCertificates, 'getRemoveError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getRemoveGiftCertificateError()).toEqual(undefined);
             expect(selectors.giftCertificates.getRemoveError).toHaveBeenCalled();
@@ -471,12 +583,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading instruments', () => {
             jest.spyOn(selectors.instruments, 'getLoadError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadInstrumentsError()).toEqual(errorResponse);
             expect(selectors.instruments.getLoadError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when loading instruments', () => {
             jest.spyOn(selectors.instruments, 'getLoadError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadInstrumentsError()).toEqual(undefined);
             expect(selectors.instruments.getLoadError).toHaveBeenCalled();
@@ -487,12 +603,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when deleting instruments', () => {
             jest.spyOn(selectors.instruments, 'getDeleteError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getDeleteInstrumentError('123')).toEqual(errorResponse);
             expect(selectors.instruments.getDeleteError).toHaveBeenCalledWith('123');
         });
 
         it('returns undefined if there is NO error when deleting instruments', () => {
             jest.spyOn(selectors.instruments, 'getDeleteError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getDeleteInstrumentError('123')).toEqual(undefined);
             expect(selectors.instruments.getDeleteError).toHaveBeenCalledWith('123');
@@ -503,12 +623,16 @@ describe('CheckoutStoreErrorSelector', () => {
         it('returns error if there is an error when loading config', () => {
             jest.spyOn(selectors.config, 'getLoadError').mockReturnValue(errorResponse);
 
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
             expect(errors.getLoadConfigError()).toEqual(errorResponse);
             expect(selectors.config.getLoadError).toHaveBeenCalled();
         });
 
         it('returns undefined if there is NO error when loading config', () => {
             jest.spyOn(selectors.config, 'getLoadError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
 
             expect(errors.getLoadConfigError()).toEqual(undefined);
             expect(selectors.config.getLoadError).toHaveBeenCalled();

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -1,17 +1,8 @@
-import { BillingAddressSelector } from '../billing';
-import { CartSelector } from '../cart';
 import { RequestError } from '../common/error/errors';
-import { selector } from '../common/selector';
-import { ConfigSelector } from '../config';
-import { CouponSelector, GiftCertificateSelector } from '../coupon';
-import { CustomerStrategySelector } from '../customer';
-import { CountrySelector } from '../geography';
-import { OrderSelector } from '../order';
-import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
-import { InstrumentSelector } from '../payment/instrument';
-import { ConsignmentSelector, ShippingCountrySelector, ShippingStrategySelector } from '../shipping';
+import { createSelector, createShallowEqualSelector } from '../common/selector';
+import { Omit } from '../common/types';
+import { memoizeOne } from '../common/utility';
 
-import CheckoutSelector from './checkout-selector';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 /**
@@ -22,164 +13,71 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
  * not executed successfully. For example, if you are unable to submit an order,
  * you can use this object to retrieve the reason for the failure.
  */
-@selector
-export default class CheckoutStoreErrorSelector {
-    private _billingAddress: BillingAddressSelector;
-    private _cart: CartSelector;
-    private _checkout: CheckoutSelector;
-    private _config: ConfigSelector;
-    private _consignments: ConsignmentSelector;
-    private _countries: CountrySelector;
-    private _coupons: CouponSelector;
-    private _customerStrategies: CustomerStrategySelector;
-    private _giftCertificates: GiftCertificateSelector;
-    private _instruments: InstrumentSelector;
-    private _order: OrderSelector;
-    private _paymentMethods: PaymentMethodSelector;
-    private _paymentStrategies: PaymentStrategySelector;
-    private _shippingCountries: ShippingCountrySelector;
-    private _shippingStrategies: ShippingStrategySelector;
-
-    /**
-     * @internal
-     */
-    constructor(selectors: InternalCheckoutSelectors) {
-        this._billingAddress = selectors.billingAddress;
-        this._cart = selectors.cart;
-        this._checkout = selectors.checkout;
-        this._config = selectors.config;
-        this._consignments = selectors.consignments;
-        this._countries = selectors.countries;
-        this._coupons = selectors.coupons;
-        this._customerStrategies = selectors.customerStrategies;
-        this._giftCertificates = selectors.giftCertificates;
-        this._instruments = selectors.instruments;
-        this._order = selectors.order;
-        this._paymentMethods = selectors.paymentMethods;
-        this._paymentStrategies = selectors.paymentStrategies;
-        this._shippingCountries = selectors.shippingCountries;
-        this._shippingStrategies = selectors.shippingStrategies;
-    }
-
-    /**
-     * Gets the error of any checkout action that has failed.
-     *
-     * @returns The error object if unable to perform any checkout action,
-     * otherwise undefined.
-     */
-    getError(): Error | undefined {
-        // tslint:disable-next-line:cyclomatic-complexity
-        return this.getLoadCheckoutError() ||
-            this.getSubmitOrderError() ||
-            this.getFinalizeOrderError() ||
-            this.getLoadOrderError() ||
-            this.getLoadCartError() ||
-            this.getLoadBillingCountriesError() ||
-            this.getLoadShippingCountriesError() ||
-            this.getLoadPaymentMethodsError() ||
-            this.getLoadPaymentMethodError() ||
-            this.getInitializePaymentError() ||
-            this.getLoadShippingOptionsError() ||
-            this.getSelectShippingOptionError() ||
-            this.getSignInError() ||
-            this.getSignOutError() ||
-            this.getInitializeCustomerError() ||
-            this.getUpdateShippingAddressError() ||
-            this.getUpdateBillingAddressError() ||
-            this.getContinueAsGuestError() ||
-            this.getUpdateConsignmentError() ||
-            this.getCreateConsignmentsError() ||
-            this.getDeleteConsignmentError() ||
-            this.getInitializeShippingError() ||
-            this.getApplyCouponError() ||
-            this.getRemoveCouponError() ||
-            this.getApplyGiftCertificateError() ||
-            this.getRemoveGiftCertificateError() ||
-            this.getLoadInstrumentsError() ||
-            this.getDeleteInstrumentError() ||
-            this.getLoadConfigError();
-    }
+export default interface CheckoutStoreErrorSelector {
+    getError(): Error | undefined;
 
     /**
      * Returns an error if unable to load the current checkout.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadCheckoutError(): Error | undefined {
-        return this._checkout.getLoadError();
-    }
+    getLoadCheckoutError(): Error | undefined;
 
     /**
      * Returns an error if unable to update the current checkout.
      *
      * @returns The error object if unable to update, otherwise undefined.
      */
-    getUpdateCheckoutError(): Error | undefined {
-        return this._checkout.getUpdateError();
-    }
+    getUpdateCheckoutError(): Error | undefined;
 
     /**
      * Returns an error if unable to submit the current order.
      *
      * @returns The error object if unable to submit, otherwise undefined.
      */
-    getSubmitOrderError(): Error | undefined {
-        return this._paymentStrategies.getExecuteError();
-    }
+    getSubmitOrderError(): Error | undefined;
 
     /**
      * Returns an error if unable to finalize the current order.
      *
      * @returns The error object if unable to finalize, otherwise undefined.
      */
-    getFinalizeOrderError(): Error | undefined {
-        return this._paymentStrategies.getFinalizeError();
-    }
+    getFinalizeOrderError(): Error | undefined;
 
     /**
      * Returns an error if unable to load the current order.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadOrderError(): Error | undefined {
-        return this._order.getLoadError();
-    }
+    getLoadOrderError(): Error | undefined;
 
     /**
      * Returns an error if unable to load the current cart.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadCartError(): Error | undefined {
-        return this._cart.getLoadError();
-    }
+    getLoadCartError(): Error | undefined;
 
     /**
      * Returns an error if unable to load billing countries.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadBillingCountriesError(): Error | undefined {
-        return this._countries.getLoadError();
-    }
+    getLoadBillingCountriesError(): Error | undefined;
 
     /**
      * Returns an error if unable to load shipping countries.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadShippingCountriesError(): Error | undefined {
-        return this._shippingCountries.getLoadError();
-    }
+    getLoadShippingCountriesError(): Error | undefined;
 
     /**
      * Returns an error if unable to load payment methods.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadPaymentMethodsError(): Error | undefined {
-        return this._paymentMethods.getLoadError();
-    }
+    getLoadPaymentMethodsError(): Error | undefined;
 
     /**
      * Returns an error if unable to load a specific payment method.
@@ -187,9 +85,7 @@ export default class CheckoutStoreErrorSelector {
      * @param methodId - The identifier of the payment method to load.
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadPaymentMethodError(methodId?: string): Error | undefined {
-        return this._paymentMethods.getLoadMethodError(methodId);
-    }
+    getLoadPaymentMethodError(methodId?: string): Error | undefined;
 
     /**
      * Returns an error if unable to initialize a specific payment method.
@@ -197,27 +93,21 @@ export default class CheckoutStoreErrorSelector {
      * @param methodId - The identifier of the payment method to initialize.
      * @returns The error object if unable to initialize, otherwise undefined.
      */
-    getInitializePaymentError(methodId?: string): Error | undefined {
-        return this._paymentStrategies.getInitializeError(methodId);
-    }
+    getInitializePaymentError(methodId?: string): Error | undefined;
 
     /**
      * Returns an error if unable to sign in.
      *
      * @returns The error object if unable to sign in, otherwise undefined.
      */
-    getSignInError(): Error | undefined {
-        return this._customerStrategies.getSignInError();
-    }
+    getSignInError(): Error | undefined;
 
     /**
      * Returns an error if unable to sign out.
      *
      * @returns The error object if unable to sign out, otherwise undefined.
      */
-    getSignOutError(): Error | undefined {
-        return this._customerStrategies.getSignOutError();
-    }
+    getSignOutError(): Error | undefined;
 
     /**
      * Returns an error if unable to initialize the customer step of a checkout
@@ -226,18 +116,14 @@ export default class CheckoutStoreErrorSelector {
      * @param methodId - The identifer of the initialization method to execute.
      * @returns The error object if unable to initialize, otherwise undefined.
      */
-    getInitializeCustomerError(methodId?: string): Error | undefined {
-        return this._customerStrategies.getInitializeError(methodId);
-    }
+    getInitializeCustomerError(methodId?: string): Error | undefined;
 
     /**
      * Returns an error if unable to load shipping options.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadShippingOptionsError(): Error | undefined {
-        return this._consignments.getLoadShippingOptionsError();
-    }
+    getLoadShippingOptionsError(): Error | undefined;
 
     /**
      * Returns an error if unable to select a shipping option.
@@ -248,37 +134,28 @@ export default class CheckoutStoreErrorSelector {
      * @param consignmentId - The identifier of the consignment to be checked.
      * @returns The error object if unable to select, otherwise undefined.
      */
-    getSelectShippingOptionError(consignmentId?: string): Error | undefined {
-        return this._shippingStrategies.getSelectOptionError() ||
-            this._consignments.getUpdateShippingOptionError(consignmentId);
-    }
+    getSelectShippingOptionError(consignmentId?: string): Error | undefined;
 
     /**
      * Returns an error if unable to continue as guest.
      *
      * @returns The error object if unable to continue, otherwise undefined.
      */
-    getContinueAsGuestError(): Error | undefined {
-        return this._billingAddress.getContinueAsGuestError();
-    }
+    getContinueAsGuestError(): Error | undefined;
 
     /**
      * Returns an error if unable to update billing address.
      *
      * @returns The error object if unable to update, otherwise undefined.
      */
-    getUpdateBillingAddressError(): Error | undefined {
-        return this._billingAddress.getUpdateError();
-    }
+    getUpdateBillingAddressError(): Error | undefined;
 
     /**
      * Returns an error if unable to update shipping address.
      *
      * @returns The error object if unable to update, otherwise undefined.
      */
-    getUpdateShippingAddressError(): Error | undefined {
-        return this._shippingStrategies.getUpdateAddressError();
-    }
+    getUpdateShippingAddressError(): Error | undefined;
 
     /**
      * Returns an error if unable to delete a consignment.
@@ -289,9 +166,7 @@ export default class CheckoutStoreErrorSelector {
      * @param consignmentId - The identifier of the consignment to be checked.
      * @returns The error object if unable to delete, otherwise undefined.
      */
-    getDeleteConsignmentError(consignmentId?: string): Error | undefined {
-        return this._consignments.getDeleteError(consignmentId);
-    }
+    getDeleteConsignmentError(consignmentId?: string): Error | undefined;
 
     /**
      * Returns an error if unable to update a consignment.
@@ -302,18 +177,14 @@ export default class CheckoutStoreErrorSelector {
      * @param consignmentId - The identifier of the consignment to be checked.
      * @returns The error object if unable to update, otherwise undefined.
      */
-    getUpdateConsignmentError(consignmentId?: string): Error | undefined {
-        return this._consignments.getUpdateError(consignmentId);
-    }
+    getUpdateConsignmentError(consignmentId?: string): Error | undefined;
 
     /**
      * Returns an error if unable to create consignments.
      *
      * @returns The error object if unable to create, otherwise undefined.
      */
-    getCreateConsignmentsError(): Error | undefined {
-        return this._consignments.getCreateError();
-    }
+    getCreateConsignmentsError(): Error | undefined;
 
     /**
      * Returns an error if unable to initialize the shipping step of a checkout
@@ -322,54 +193,42 @@ export default class CheckoutStoreErrorSelector {
      * @param methodId - The identifer of the initialization method to execute.
      * @returns The error object if unable to initialize, otherwise undefined.
      */
-    getInitializeShippingError(methodId?: string): Error | undefined {
-        return this._shippingStrategies.getInitializeError(methodId);
-    }
+    getInitializeShippingError(methodId?: string): Error | undefined;
 
     /**
      * Returns an error if unable to apply a coupon code.
      *
      * @returns The error object if unable to apply, otherwise undefined.
      */
-    getApplyCouponError(): RequestError | undefined {
-        return this._coupons.getApplyError();
-    }
+    getApplyCouponError(): RequestError | undefined;
 
     /**
      * Returns an error if unable to remove a coupon code.
      *
      * @returns The error object if unable to remove, otherwise undefined.
      */
-    getRemoveCouponError(): RequestError | undefined {
-        return this._coupons.getRemoveError();
-    }
+    getRemoveCouponError(): RequestError | undefined;
 
     /**
      * Returns an error if unable to apply a gift certificate.
      *
      * @returns The error object if unable to apply, otherwise undefined.
      */
-    getApplyGiftCertificateError(): RequestError | undefined {
-        return this._giftCertificates.getApplyError();
-    }
+    getApplyGiftCertificateError(): RequestError | undefined;
 
     /**
      * Returns an error if unable to remove a gift certificate.
      *
      * @returns The error object if unable to remove, otherwise undefined.
      */
-    getRemoveGiftCertificateError(): RequestError | undefined {
-        return this._giftCertificates.getRemoveError();
-    }
+    getRemoveGiftCertificateError(): RequestError | undefined;
 
     /**
      * Returns an error if unable to load payment instruments.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadInstrumentsError(): Error | undefined {
-        return this._instruments.getLoadError();
-    }
+    getLoadInstrumentsError(): Error | undefined;
 
     /**
      * Returns an error if unable to delete a payment instrument.
@@ -377,16 +236,82 @@ export default class CheckoutStoreErrorSelector {
      * @param instrumentId - The identifier of the payment instrument to delete.
      * @returns The error object if unable to delete, otherwise undefined.
      */
-    getDeleteInstrumentError(instrumentId?: string): Error | undefined {
-        return this._instruments.getDeleteError(instrumentId);
-    }
+    getDeleteInstrumentError(instrumentId?: string): Error | undefined;
 
     /**
      * Returns an error if unable to load the checkout configuration of a store.
      *
      * @returns The error object if unable to load, otherwise undefined.
      */
-    getLoadConfigError(): Error | undefined {
-        return this._config.getLoadError();
-    }
+    getLoadConfigError(): Error | undefined;
+}
+
+export type CheckoutStoreErrorSelectorFactory = (state: InternalCheckoutSelectors) => CheckoutStoreErrorSelector;
+
+export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSelectorFactory {
+    const getError = createShallowEqualSelector(
+        (selector: Omit<CheckoutStoreErrorSelector, 'getError'>) => selector,
+        selector => () => {
+            for (const key of Object.keys(selector) as Array<keyof Omit<CheckoutStoreErrorSelector, 'getError'>>) {
+                const error = selector[key]();
+
+                if (error) {
+                    return error;
+                }
+            }
+        }
+    );
+
+    const getSelectShippingOptionError = createSelector(
+        ({ shippingStrategies }: InternalCheckoutSelectors) => shippingStrategies.getSelectOptionError,
+        ({ consignments }: InternalCheckoutSelectors) => consignments.getUpdateShippingOptionError,
+        (getSelectOptionError, getUpdateShippingOptionError) => (consignmentId?: string) => {
+            return (
+                getSelectOptionError() ||
+                getUpdateShippingOptionError(consignmentId)
+            );
+        }
+    );
+
+    return memoizeOne((
+        state: InternalCheckoutSelectors
+    ): CheckoutStoreErrorSelector => {
+        const selector = {
+            getLoadCheckoutError: state.checkout.getLoadError,
+            getUpdateCheckoutError: state.checkout.getUpdateError,
+            getSubmitOrderError: state.paymentStrategies.getExecuteError,
+            getFinalizeOrderError: state.paymentStrategies.getFinalizeError,
+            getLoadOrderError: state.order.getLoadError,
+            getLoadCartError: state.cart.getLoadError,
+            getLoadBillingCountriesError: state.countries.getLoadError,
+            getLoadShippingCountriesError: state.shippingCountries.getLoadError,
+            getLoadPaymentMethodsError: state.paymentMethods.getLoadError,
+            getLoadPaymentMethodError: state.paymentMethods.getLoadMethodError,
+            getInitializePaymentError: state.paymentStrategies.getInitializeError,
+            getSignInError: state.customerStrategies.getSignInError,
+            getSignOutError: state.customerStrategies.getSignOutError,
+            getInitializeCustomerError: state.customerStrategies.getInitializeError,
+            getLoadShippingOptionsError: state.consignments.getLoadShippingOptionsError,
+            getSelectShippingOptionError: getSelectShippingOptionError(state),
+            getContinueAsGuestError: state.billingAddress.getContinueAsGuestError,
+            getUpdateBillingAddressError: state.billingAddress.getUpdateError,
+            getUpdateShippingAddressError: state.shippingStrategies.getUpdateAddressError,
+            getDeleteConsignmentError: state.consignments.getDeleteError,
+            getUpdateConsignmentError: state.consignments.getUpdateError,
+            getCreateConsignmentsError: state.consignments.getCreateError,
+            getInitializeShippingError: state.shippingStrategies.getInitializeError,
+            getApplyCouponError: state.coupons.getApplyError,
+            getRemoveCouponError: state.coupons.getRemoveError,
+            getApplyGiftCertificateError: state.giftCertificates.getApplyError,
+            getRemoveGiftCertificateError: state.giftCertificates.getRemoveError,
+            getLoadInstrumentsError: state.instruments.getLoadError,
+            getDeleteInstrumentError: state.instruments.getDeleteError,
+            getLoadConfigError: state.config.getLoadError,
+        };
+
+        return {
+            getError: getError(selector),
+            ...selector,
+        };
+    });
 }

--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -6,21 +6,23 @@ import { getUnitedStates } from '../geography/countries.mock';
 import { getAustralia } from '../shipping/shipping-countries.mock';
 import { getShippingOptions } from '../shipping/shipping-options.mock';
 
-import CheckoutStoreSelector from './checkout-store-selector';
+import CheckoutStoreSelector, { createCheckoutStoreSelectorFactory, CheckoutStoreSelectorFactory } from './checkout-store-selector';
 import CheckoutStoreState from './checkout-store-state';
 import { getCheckoutStoreStateWithOrder } from './checkouts.mock';
 import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 describe('CheckoutStoreSelector', () => {
+    let createCheckoutStoreSelector: CheckoutStoreSelectorFactory;
     let state: CheckoutStoreState;
     let internalSelectors: InternalCheckoutSelectors;
     let selector: CheckoutStoreSelector;
 
     beforeEach(() => {
+        createCheckoutStoreSelector = createCheckoutStoreSelectorFactory();
         state = getCheckoutStoreStateWithOrder();
         internalSelectors = createInternalCheckoutSelectors(state);
-        selector = new CheckoutStoreSelector(internalSelectors);
+        selector = createCheckoutStoreSelector(internalSelectors);
     });
 
     it('returns checkout data', () => {
@@ -77,7 +79,11 @@ describe('CheckoutStoreSelector', () => {
         });
 
         it('returns geo-ip dummy shipping address', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
             jest.spyOn(internalSelectors.shippingAddress, 'getShippingAddress').mockReturnValue(undefined);
+
+            selector = createCheckoutStoreSelector(internalSelectors);
 
             expect(selector.getShippingAddress()).toEqual({
                 address1: '',
@@ -97,8 +103,12 @@ describe('CheckoutStoreSelector', () => {
         });
 
         it('returns undefined if shippingAddress & geoIp are not present', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
             jest.spyOn(internalSelectors.shippingAddress, 'getShippingAddress').mockReturnValue(undefined);
             jest.spyOn(internalSelectors.config, 'getContextConfig').mockReturnValue(undefined);
+
+            selector = createCheckoutStoreSelector(internalSelectors);
 
             expect(selector.getShippingAddress()).toBeUndefined();
         });

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -1,27 +1,19 @@
 import { Address } from '../address';
-import { BillingAddress, BillingAddressSelector } from '../billing';
-import { Cart, CartSelector } from '../cart';
-import { selector } from '../common/selector';
-import { clone } from '../common/utility';
-import { ConfigSelector } from '../config';
+import { BillingAddress } from '../billing';
+import { Cart } from '../cart';
+import { createSelector } from '../common/selector';
+import { cloneResult as clone, memoizeOne } from '../common/utility';
 import { StoreConfig } from '../config/config';
-import { Coupon, CouponSelector, GiftCertificate, GiftCertificateSelector } from '../coupon';
-import { Customer, CustomerSelector } from '../customer';
-import { FormField, FormSelector } from '../form';
-import { Country, CountrySelector } from '../geography';
-import { Order, OrderSelector } from '../order';
-import { PaymentMethod, PaymentMethodSelector, PaymentSelector } from '../payment';
-import { Instrument, InstrumentSelector } from '../payment/instrument';
-import {
-    Consignment,
-    ConsignmentSelector,
-    ShippingAddressSelector,
-    ShippingCountrySelector,
-    ShippingOption,
-} from '../shipping';
+import { Coupon, GiftCertificate } from '../coupon';
+import { Customer } from '../customer';
+import { FormField } from '../form';
+import { Country } from '../geography';
+import { Order } from '../order';
+import { PaymentMethod } from '../payment';
+import { Instrument } from '../payment/instrument';
+import { Consignment, ShippingOption } from '../shipping';
 
 import Checkout from './checkout';
-import CheckoutSelector from './checkout-selector';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 /**
@@ -30,74 +22,27 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
  * This object has a set of methods that allow you to get a specific piece of
  * checkout information, such as shipping and billing details.
  */
-@selector
-@clone
-export default class CheckoutStoreSelector {
-    private _billingAddress: BillingAddressSelector;
-    private _cart: CartSelector;
-    private _checkout: CheckoutSelector;
-    private _config: ConfigSelector;
-    private _consignments: ConsignmentSelector;
-    private _countries: CountrySelector;
-    private _coupons: CouponSelector;
-    private _customer: CustomerSelector;
-    private _form: FormSelector;
-    private _giftCertificates: GiftCertificateSelector;
-    private _instruments: InstrumentSelector;
-    private _order: OrderSelector;
-    private _payment: PaymentSelector;
-    private _paymentMethods: PaymentMethodSelector;
-    private _shippingAddress: ShippingAddressSelector;
-    private _shippingCountries: ShippingCountrySelector;
-
-    /**
-     * @internal
-     */
-    constructor(selectors: InternalCheckoutSelectors) {
-        this._billingAddress = selectors.billingAddress;
-        this._cart = selectors.cart;
-        this._checkout = selectors.checkout;
-        this._config = selectors.config;
-        this._consignments = selectors.consignments;
-        this._countries = selectors.countries;
-        this._coupons = selectors.coupons;
-        this._customer = selectors.customer;
-        this._form = selectors.form;
-        this._giftCertificates = selectors.giftCertificates;
-        this._instruments = selectors.instruments;
-        this._order = selectors.order;
-        this._payment = selectors.payment;
-        this._paymentMethods = selectors.paymentMethods;
-        this._shippingAddress = selectors.shippingAddress;
-        this._shippingCountries = selectors.shippingCountries;
-    }
-
+export default interface CheckoutStoreSelector {
     /**
      * Gets the current checkout.
      *
      * @returns The current checkout if it is loaded, otherwise undefined.
      */
-    getCheckout(): Checkout | undefined {
-        return this._checkout.getCheckout();
-    }
+    getCheckout(): Checkout | undefined;
 
     /**
      * Gets the current order.
      *
      * @returns The current order if it is loaded, otherwise undefined.
      */
-    getOrder(): Order | undefined {
-        return this._order.getOrder();
-    }
+    getOrder(): Order | undefined;
 
     /**
      * Gets the checkout configuration of a store.
      *
      * @returns The configuration object if it is loaded, otherwise undefined.
      */
-    getConfig(): StoreConfig | undefined {
-        return this._config.getStoreConfig();
-    }
+    getConfig(): StoreConfig | undefined;
 
     /**
      * Gets the shipping address of the current checkout.
@@ -108,34 +53,7 @@ export default class CheckoutStoreSelector {
      * @returns The shipping address object if it is loaded, otherwise
      * undefined.
      */
-    getShippingAddress(): Address | undefined {
-        const shippingAddress = this._shippingAddress.getShippingAddress();
-        const context = this._config.getContextConfig();
-
-        if (!shippingAddress) {
-            if (!context || !context.geoCountryCode) {
-                return;
-            }
-
-            return {
-                firstName: '',
-                lastName: '',
-                company: '',
-                address1: '',
-                address2: '',
-                city: '',
-                stateOrProvince: '',
-                stateOrProvinceCode: '',
-                postalCode: '',
-                country: '',
-                phone: '',
-                customFields: [],
-                countryCode: context.geoCountryCode,
-            };
-        }
-
-        return shippingAddress;
-    }
+    getShippingAddress(): Address | undefined;
 
     /**
      * Gets a list of shipping options available for the shipping address.
@@ -145,15 +63,7 @@ export default class CheckoutStoreSelector {
      *
      * @returns The list of shipping options if any, otherwise undefined.
      */
-    getShippingOptions(): ShippingOption[] | undefined {
-        const consignments = this._consignments.getConsignments();
-
-        if (consignments && consignments.length) {
-            return consignments[0].availableShippingOptions;
-        }
-
-        return;
-    }
+    getShippingOptions(): ShippingOption[] | undefined;
 
     /**
      * Gets a list of consignments.
@@ -163,9 +73,7 @@ export default class CheckoutStoreSelector {
      *
      * @returns The list of consignments if any, otherwise undefined.
      */
-    getConsignments(): Consignment[] | undefined {
-        return this._consignments.getConsignments();
-    }
+    getConsignments(): Consignment[] | undefined;
 
     /**
      * Gets the selected shipping option for the current checkout.
@@ -173,51 +81,35 @@ export default class CheckoutStoreSelector {
      * @returns The shipping option object if there is a selected option,
      * otherwise undefined.
      */
-    getSelectedShippingOption(): ShippingOption | undefined {
-        const consignments = this._consignments.getConsignments();
-
-        if (!consignments || !consignments.length) {
-            return;
-        }
-
-        return consignments[0].selectedShippingOption;
-    }
+    getSelectedShippingOption(): ShippingOption | undefined;
 
     /**
      * Gets a list of countries available for shipping.
      *
      * @returns The list of countries if it is loaded, otherwise undefined.
      */
-    getShippingCountries(): Country[] | undefined {
-        return this._shippingCountries.getShippingCountries();
-    }
+    getShippingCountries(): Country[] | undefined;
 
     /**
      * Gets the billing address of an order.
      *
      * @returns The billing address object if it is loaded, otherwise undefined.
      */
-    getBillingAddress(): BillingAddress | undefined {
-        return this._billingAddress.getBillingAddress();
-    }
+    getBillingAddress(): BillingAddress | undefined;
 
     /**
      * Gets a list of countries available for billing.
      *
      * @returns The list of countries if it is loaded, otherwise undefined.
      */
-    getBillingCountries(): Country[] | undefined {
-        return this._countries.getCountries();
-    }
+    getBillingCountries(): Country[] | undefined;
 
     /**
      * Gets a list of payment methods available for checkout.
      *
      * @returns The list of payment methods if it is loaded, otherwise undefined.
      */
-    getPaymentMethods(): PaymentMethod[] | undefined {
-        return this._paymentMethods.getPaymentMethods();
-    }
+    getPaymentMethods(): PaymentMethod[] | undefined;
 
     /**
      * Gets a payment method by an id.
@@ -232,9 +124,7 @@ export default class CheckoutStoreSelector {
      * @returns The payment method object if loaded and available, otherwise,
      * undefined.
      */
-    getPaymentMethod(methodId: string, gatewayId?: string): PaymentMethod | undefined {
-        return this._paymentMethods.getPaymentMethod(methodId, gatewayId);
-    }
+    getPaymentMethod(methodId: string, gatewayId?: string): PaymentMethod | undefined;
 
     /**
      * Gets the payment method that is selected for checkout.
@@ -242,38 +132,28 @@ export default class CheckoutStoreSelector {
      * @returns The payment method object if there is a selected method;
      * undefined if otherwise.
      */
-    getSelectedPaymentMethod(): PaymentMethod | undefined {
-        const payment = this._payment.getPaymentId();
-
-        return payment && this._paymentMethods.getPaymentMethod(payment.providerId, payment.gatewayId);
-    }
+    getSelectedPaymentMethod(): PaymentMethod | undefined;
 
     /**
      * Gets the current cart.
      *
      * @returns The current cart object if it is loaded, otherwise undefined.
      */
-    getCart(): Cart | undefined {
-        return this._cart.getCart();
-    }
+    getCart(): Cart | undefined;
 
     /**
      * Gets a list of coupons that are applied to the current checkout.
      *
      * @returns The list of applied coupons if there is any, otherwise undefined.
      */
-    getCoupons(): Coupon[] | undefined {
-        return this._coupons.getCoupons();
-    }
+    getCoupons(): Coupon[] | undefined;
 
     /**
      * Gets a list of gift certificates that are applied to the current checkout.
      *
      * @returns The list of applied gift certificates if there is any, otherwise undefined.
      */
-    getGiftCertificates(): GiftCertificate[] | undefined {
-        return this._giftCertificates.getGiftCertificates();
-    }
+    getGiftCertificates(): GiftCertificate[] | undefined;
 
     /**
      * Gets the current customer.
@@ -281,9 +161,7 @@ export default class CheckoutStoreSelector {
      * @returns The current customer object if it is loaded, otherwise
      * undefined.
      */
-    getCustomer(): Customer | undefined {
-        return this._customer.getCustomer();
-    }
+    getCustomer(): Customer | undefined;
 
     /**
      * Checks if payment data is required or not.
@@ -303,9 +181,7 @@ export default class CheckoutStoreSelector {
      * with store credit applied; otherwise, check without store credit.
      * @returns True if payment data is required, otherwise false.
      */
-    isPaymentDataRequired(useStoreCredit?: boolean): boolean {
-        return this._payment.isPaymentDataRequired(useStoreCredit);
-    }
+    isPaymentDataRequired(useStoreCredit?: boolean): boolean;
 
     /**
      * Checks if payment data is submitted or not.
@@ -318,18 +194,14 @@ export default class CheckoutStoreSelector {
      * payment method.
      * @returns True if payment data is submitted, otherwise false.
      */
-    isPaymentDataSubmitted(methodId: string, gatewayId?: string): boolean {
-        return this._payment.isPaymentDataSubmitted(this.getPaymentMethod(methodId, gatewayId));
-    }
+    isPaymentDataSubmitted(methodId: string, gatewayId?: string): boolean;
 
     /**
      * Gets a list of payment instruments associated with the current customer.
      *
      * @returns The list of payment instruments if it is loaded, otherwise undefined.
      */
-    getInstruments(): Instrument[] | undefined {
-        return this._instruments.getInstruments();
-    }
+    getInstruments(): Instrument[] | undefined;
 
     /**
      * Gets a set of form fields that should be presented to customers in order
@@ -339,9 +211,7 @@ export default class CheckoutStoreSelector {
      * @returns The set of billing address form fields if it is loaded,
      * otherwise undefined.
      */
-    getBillingAddressFields(countryCode: string): FormField[] {
-        return this._form.getBillingAddressFields(this.getBillingCountries(), countryCode);
-    }
+    getBillingAddressFields(countryCode: string): FormField[];
 
     /**
      * Gets a set of form fields that should be presented to customers in order
@@ -351,7 +221,204 @@ export default class CheckoutStoreSelector {
      * @returns The set of shipping address form fields if it is loaded,
      * otherwise undefined.
      */
-    getShippingAddressFields(countryCode: string): FormField[] {
-        return this._form.getShippingAddressFields(this.getShippingCountries(), countryCode);
-    }
+    getShippingAddressFields(countryCode: string): FormField[];
+}
+
+export type CheckoutStoreSelectorFactory = (state: InternalCheckoutSelectors) => CheckoutStoreSelector;
+
+export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFactory {
+    const getCheckout = createSelector(
+        ({ checkout }: InternalCheckoutSelectors) => checkout.getCheckout,
+        getCheckout => clone(getCheckout)
+    );
+
+    const getOrder = createSelector(
+        ({ order }: InternalCheckoutSelectors) => order.getOrder,
+        getOrder => clone(getOrder)
+    );
+
+    const getConfig = createSelector(
+        ({ config }: InternalCheckoutSelectors) => config.getStoreConfig,
+        getStoreConfig => clone(getStoreConfig)
+    );
+
+    const getShippingAddress = createSelector(
+        ({ shippingAddress }: InternalCheckoutSelectors) => shippingAddress.getShippingAddress,
+        ({ config }: InternalCheckoutSelectors) => config.getContextConfig,
+        (getShippingAddress, getContextConfig) => clone(() => {
+            const shippingAddress = getShippingAddress();
+            const context = getContextConfig();
+
+            if (!shippingAddress) {
+                if (!context || !context.geoCountryCode) {
+                    return;
+                }
+
+                return {
+                    firstName: '',
+                    lastName: '',
+                    company: '',
+                    address1: '',
+                    address2: '',
+                    city: '',
+                    stateOrProvince: '',
+                    stateOrProvinceCode: '',
+                    postalCode: '',
+                    country: '',
+                    phone: '',
+                    customFields: [],
+                    countryCode: context.geoCountryCode,
+                };
+            }
+
+            return shippingAddress;
+        })
+    );
+
+    const getShippingOptions = createSelector(
+        ({ consignments }: InternalCheckoutSelectors) => consignments.getConsignments,
+        getConsignments => clone(() => {
+            const consignments = getConsignments();
+
+            if (consignments && consignments.length) {
+                return consignments[0].availableShippingOptions;
+            }
+        })
+    );
+
+    const getConsignments = createSelector(
+        ({ consignments }: InternalCheckoutSelectors) => consignments.getConsignments,
+        getConsignments => clone(getConsignments)
+    );
+
+    const getSelectedShippingOption = createSelector(
+        ({ consignments }: InternalCheckoutSelectors) => consignments.getConsignments,
+        getConsignments => clone(() => {
+            const consignments = getConsignments();
+
+            if (!consignments || !consignments.length) {
+                return;
+            }
+
+            return consignments[0].selectedShippingOption;
+        })
+    );
+
+    const getShippingCountries = createSelector(
+        ({ shippingCountries }: InternalCheckoutSelectors) => shippingCountries.getShippingCountries,
+        getShippingCountries => clone(getShippingCountries)
+    );
+
+    const getBillingAddress = createSelector(
+        ({ billingAddress }: InternalCheckoutSelectors) => billingAddress.getBillingAddress,
+        getBillingAddress => clone(getBillingAddress)
+    );
+
+    const getBillingCountries = createSelector(
+        ({ countries }: InternalCheckoutSelectors) => countries.getCountries,
+        getCountries => clone(getCountries)
+    );
+
+    const getPaymentMethods = createSelector(
+        ({ paymentMethods }: InternalCheckoutSelectors) => paymentMethods.getPaymentMethods,
+        getPaymentMethods => clone(getPaymentMethods)
+    );
+
+    const getPaymentMethod = createSelector(
+        ({ paymentMethods }: InternalCheckoutSelectors) => paymentMethods.getPaymentMethod,
+        getPaymentMethod => clone(getPaymentMethod)
+    );
+
+    const getSelectedPaymentMethod = createSelector(
+        ({ payment }: InternalCheckoutSelectors) => payment.getPaymentId,
+        ({ paymentMethods }: InternalCheckoutSelectors) => paymentMethods.getPaymentMethod,
+        (getPaymentId, getPaymentMethod) => clone(() => {
+            const payment = getPaymentId();
+
+            return payment && getPaymentMethod(payment.providerId, payment.gatewayId);
+        })
+    );
+
+    const getCart = createSelector(
+        ({ cart }: InternalCheckoutSelectors) => cart.getCart,
+        getCart => clone(getCart)
+    );
+
+    const getCoupons = createSelector(
+        ({ coupons }: InternalCheckoutSelectors) => coupons.getCoupons,
+        getCoupons => clone(getCoupons)
+    );
+
+    const getGiftCertificates = createSelector(
+        ({ giftCertificates }: InternalCheckoutSelectors) => giftCertificates.getGiftCertificates,
+        getGiftCertificates => clone(getGiftCertificates)
+    );
+
+    const getCustomer = createSelector(
+        ({ customer }: InternalCheckoutSelectors) => customer.getCustomer,
+        getCustomer => clone(getCustomer)
+    );
+
+    const isPaymentDataRequired = createSelector(
+        ({ payment }: InternalCheckoutSelectors) => payment.isPaymentDataRequired,
+        isPaymentDataRequired => clone(isPaymentDataRequired)
+    );
+
+    const isPaymentDataSubmitted = createSelector(
+        ({ payment }: InternalCheckoutSelectors) => payment.isPaymentDataSubmitted,
+        ({ paymentMethods }: InternalCheckoutSelectors) => paymentMethods.getPaymentMethod,
+        (isPaymentDataSubmitted, getPaymentMethod) => clone((methodId: string, gatewayId?: string) => {
+            return isPaymentDataSubmitted(getPaymentMethod(methodId, gatewayId));
+        })
+    );
+
+    const getInstruments = createSelector(
+        ({ instruments }: InternalCheckoutSelectors) => instruments.getInstruments,
+        getInstruments => clone(getInstruments)
+    );
+
+    const getBillingAddressFields = createSelector(
+        ({ form }: InternalCheckoutSelectors) => form.getBillingAddressFields,
+        ({ countries }: InternalCheckoutSelectors) => countries.getCountries,
+        (getBillingAddressFields, getCountries) => clone((countryCode: string) => {
+            return getBillingAddressFields(getCountries(), countryCode);
+        })
+    );
+
+    const getShippingAddressFields = createSelector(
+        ({ form }: InternalCheckoutSelectors) => form.getShippingAddressFields,
+        ({ shippingCountries }: InternalCheckoutSelectors) => shippingCountries.getShippingCountries,
+        (getShippingAddressFields, getShippingCountries) => clone((countryCode: string) => {
+            return getShippingAddressFields(getShippingCountries(), countryCode);
+        })
+    );
+
+    return memoizeOne((
+        state: InternalCheckoutSelectors
+    ): CheckoutStoreSelector => {
+        return {
+            getCheckout: getCheckout(state),
+            getOrder: getOrder(state),
+            getConfig: getConfig(state),
+            getShippingAddress: getShippingAddress(state),
+            getShippingOptions: getShippingOptions(state),
+            getConsignments: getConsignments(state),
+            getSelectedShippingOption: getSelectedShippingOption(state),
+            getShippingCountries: getShippingCountries(state),
+            getBillingAddress: getBillingAddress(state),
+            getBillingCountries: getBillingCountries(state),
+            getPaymentMethods: getPaymentMethods(state),
+            getPaymentMethod: getPaymentMethod(state),
+            getSelectedPaymentMethod: getSelectedPaymentMethod(state),
+            getCart: getCart(state),
+            getCoupons: getCoupons(state),
+            getGiftCertificates: getGiftCertificates(state),
+            getCustomer: getCustomer(state),
+            isPaymentDataRequired: isPaymentDataRequired(state),
+            isPaymentDataSubmitted: isPaymentDataSubmitted(state),
+            getInstruments: getInstruments(state),
+            getBillingAddressFields: getBillingAddressFields(state),
+            getShippingAddressFields: getShippingAddressFields(state),
+        };
+    });
 }

--- a/src/checkout/checkout-store-status-selector.spec.ts
+++ b/src/checkout/checkout-store-status-selector.spec.ts
@@ -1,20 +1,22 @@
-import CheckoutStoreStatusSelector from './checkout-store-status-selector';
+import { createCheckoutStoreStatusSelectorFactory, CheckoutStoreStatusSelectorFactory } from './checkout-store-status-selector';
 import { getCheckoutStoreState } from './checkouts.mock';
 import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 describe('CheckoutStoreStatusSelector', () => {
+    let createCheckoutStoreStatusSelector: CheckoutStoreStatusSelectorFactory;
     let selectors: InternalCheckoutSelectors;
-    let statuses: CheckoutStoreStatusSelector;
 
     beforeEach(() => {
+        createCheckoutStoreStatusSelector = createCheckoutStoreStatusSelectorFactory();
         selectors = createInternalCheckoutSelectors(getCheckoutStoreState());
-        statuses = new CheckoutStoreStatusSelector(selectors);
     });
 
     describe('#isLoadingCheckout()', () => {
         it('returns true if loading checkout', () => {
             jest.spyOn(selectors.checkout, 'isLoading').mockReturnValue(true);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingCheckout()).toEqual(true);
             expect(selectors.checkout.isLoading).toHaveBeenCalled();
@@ -22,6 +24,8 @@ describe('CheckoutStoreStatusSelector', () => {
 
         it('returns false if loading checkout', () => {
             jest.spyOn(selectors.checkout, 'isLoading').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingCheckout()).toEqual(false);
             expect(selectors.checkout.isLoading).toHaveBeenCalled();
@@ -32,12 +36,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading checkout', () => {
             jest.spyOn(selectors.checkout, 'isUpdating').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isUpdatingCheckout()).toEqual(true);
             expect(selectors.checkout.isUpdating).toHaveBeenCalled();
         });
 
         it('returns false if loading checkout', () => {
             jest.spyOn(selectors.checkout, 'isUpdating').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isUpdatingCheckout()).toEqual(false);
             expect(selectors.checkout.isUpdating).toHaveBeenCalled();
@@ -48,12 +56,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if submitting order', () => {
             jest.spyOn(selectors.paymentStrategies, 'isExecuting').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isSubmittingOrder()).toEqual(true);
             expect(selectors.paymentStrategies.isExecuting).toHaveBeenCalled();
         });
 
         it('returns false if submitting order', () => {
             jest.spyOn(selectors.paymentStrategies, 'isExecuting').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isSubmittingOrder()).toEqual(false);
             expect(selectors.paymentStrategies.isExecuting).toHaveBeenCalled();
@@ -64,12 +76,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if finalizing order', () => {
             jest.spyOn(selectors.paymentStrategies, 'isFinalizing').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isFinalizingOrder()).toEqual(true);
             expect(selectors.paymentStrategies.isFinalizing).toHaveBeenCalled();
         });
 
         it('returns false if finalizing order', () => {
             jest.spyOn(selectors.paymentStrategies, 'isFinalizing').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isFinalizingOrder()).toEqual(false);
             expect(selectors.paymentStrategies.isFinalizing).toHaveBeenCalled();
@@ -80,12 +96,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading order', () => {
             jest.spyOn(selectors.order, 'isLoading').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingOrder()).toEqual(true);
             expect(selectors.order.isLoading).toHaveBeenCalled();
         });
 
         it('returns false if loading order', () => {
             jest.spyOn(selectors.order, 'isLoading').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingOrder()).toEqual(false);
             expect(selectors.order.isLoading).toHaveBeenCalled();
@@ -96,12 +116,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading cart', () => {
             jest.spyOn(selectors.cart, 'isLoading').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingCart()).toEqual(true);
             expect(selectors.cart.isLoading).toHaveBeenCalled();
         });
 
         it('returns false if loading cart', () => {
             jest.spyOn(selectors.cart, 'isLoading').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingCart()).toEqual(false);
             expect(selectors.cart.isLoading).toHaveBeenCalled();
@@ -112,12 +136,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading countries', () => {
             jest.spyOn(selectors.countries, 'isLoading').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingBillingCountries()).toEqual(true);
             expect(selectors.countries.isLoading).toHaveBeenCalled();
         });
 
         it('returns false if loading countries', () => {
             jest.spyOn(selectors.countries, 'isLoading').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingBillingCountries()).toEqual(false);
             expect(selectors.countries.isLoading).toHaveBeenCalled();
@@ -128,12 +156,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading shipping countries', () => {
             jest.spyOn(selectors.shippingCountries, 'isLoading').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingShippingCountries()).toEqual(true);
             expect(selectors.shippingCountries.isLoading).toHaveBeenCalled();
         });
 
         it('returns false if loading shipping countries', () => {
             jest.spyOn(selectors.shippingCountries, 'isLoading').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingShippingCountries()).toEqual(false);
             expect(selectors.shippingCountries.isLoading).toHaveBeenCalled();
@@ -144,12 +176,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading payment methods', () => {
             jest.spyOn(selectors.paymentMethods, 'isLoading').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingPaymentMethods()).toEqual(true);
             expect(selectors.paymentMethods.isLoading).toHaveBeenCalled();
         });
 
         it('returns false if loading payment methods', () => {
             jest.spyOn(selectors.paymentMethods, 'isLoading').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingPaymentMethods()).toEqual(false);
             expect(selectors.paymentMethods.isLoading).toHaveBeenCalled();
@@ -160,12 +196,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading payment method', () => {
             jest.spyOn(selectors.paymentMethods, 'isLoadingMethod').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingPaymentMethod('braintree')).toEqual(true);
             expect(selectors.paymentMethods.isLoadingMethod).toHaveBeenCalledWith('braintree');
         });
 
         it('returns false if loading payment methods', () => {
             jest.spyOn(selectors.paymentMethods, 'isLoadingMethod').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingPaymentMethod('braintree')).toEqual(false);
             expect(selectors.paymentMethods.isLoadingMethod).toHaveBeenCalledWith('braintree');
@@ -180,11 +220,15 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if initializing payment', () => {
             jest.spyOn(selectors.paymentStrategies, 'isInitializing').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isInitializingPayment('foobar')).toEqual(true);
             expect(selectors.paymentStrategies.isInitializing).toHaveBeenCalledWith('foobar');
         });
 
         it('returns false if not initializing payment', () => {
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isInitializingPayment('foobar')).toEqual(false);
             expect(selectors.paymentStrategies.isInitializing).toHaveBeenCalledWith('foobar');
         });
@@ -194,12 +238,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if signing in', () => {
             jest.spyOn(selectors.customerStrategies, 'isSigningIn').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isSigningIn()).toEqual(true);
             expect(selectors.customerStrategies.isSigningIn).toHaveBeenCalled();
         });
 
         it('returns false if signing in', () => {
             jest.spyOn(selectors.customerStrategies, 'isSigningIn').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isSigningIn()).toEqual(false);
             expect(selectors.customerStrategies.isSigningIn).toHaveBeenCalled();
@@ -214,11 +262,15 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if signing out', () => {
             jest.spyOn(selectors.customerStrategies, 'isSigningOut').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isSigningOut()).toEqual(true);
             expect(selectors.customerStrategies.isSigningOut).toHaveBeenCalled();
         });
 
         it('returns false if signing out', () => {
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isSigningOut()).toEqual(false);
             expect(selectors.customerStrategies.isSigningOut).toHaveBeenCalled();
         });
@@ -228,12 +280,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if initializing', () => {
             jest.spyOn(selectors.customerStrategies, 'isInitializing').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isInitializingCustomer('foobar')).toEqual(true);
             expect(selectors.customerStrategies.isInitializing).toHaveBeenCalledWith('foobar');
         });
 
         it('returns false if not initializing', () => {
             jest.spyOn(selectors.customerStrategies, 'isInitializing').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isInitializingCustomer('foobar')).toEqual(false);
             expect(selectors.customerStrategies.isInitializing).toHaveBeenCalledWith('foobar');
@@ -244,12 +300,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading shipping options', () => {
             jest.spyOn(selectors.consignments, 'isLoadingShippingOptions').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingShippingOptions()).toEqual(true);
             expect(selectors.consignments.isLoadingShippingOptions).toHaveBeenCalled();
         });
 
         it('returns false if not loading shipping options', () => {
             jest.spyOn(selectors.consignments, 'isLoadingShippingOptions').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingShippingOptions()).toEqual(false);
             expect(selectors.consignments.isLoadingShippingOptions).toHaveBeenCalled();
@@ -260,12 +320,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if selecting shipping options', () => {
             jest.spyOn(selectors.shippingStrategies, 'isSelectingOption').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isSelectingShippingOption()).toEqual(true);
             expect(selectors.shippingStrategies.isSelectingOption).toHaveBeenCalled();
         });
 
         it('returns false if not selecting shipping options', () => {
             jest.spyOn(selectors.shippingStrategies, 'isSelectingOption').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isSelectingShippingOption()).toEqual(false);
             expect(selectors.shippingStrategies.isSelectingOption).toHaveBeenCalled();
@@ -276,12 +340,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if updating billing address', () => {
             jest.spyOn(selectors.billingAddress, 'isUpdating').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isUpdatingBillingAddress()).toEqual(true);
             expect(selectors.billingAddress.isUpdating).toHaveBeenCalled();
         });
 
         it('returns false if not updating billing address', () => {
             jest.spyOn(selectors.billingAddress, 'isUpdating').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isUpdatingBillingAddress()).toEqual(false);
             expect(selectors.billingAddress.isUpdating).toHaveBeenCalled();
@@ -292,12 +360,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if continuing as guest', () => {
             jest.spyOn(selectors.billingAddress, 'isContinuingAsGuest').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isContinuingAsGuest()).toEqual(true);
             expect(selectors.billingAddress.isContinuingAsGuest).toHaveBeenCalled();
         });
 
         it('returns false if not continuing as guest', () => {
             jest.spyOn(selectors.billingAddress, 'isContinuingAsGuest').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isContinuingAsGuest()).toEqual(false);
             expect(selectors.billingAddress.isContinuingAsGuest).toHaveBeenCalled();
@@ -308,12 +380,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if updating shipping address', () => {
             jest.spyOn(selectors.shippingStrategies, 'isUpdatingAddress').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isUpdatingShippingAddress()).toEqual(true);
             expect(selectors.shippingStrategies.isUpdatingAddress).toHaveBeenCalled();
         });
 
         it('returns false if not updating shipping address', () => {
             jest.spyOn(selectors.shippingStrategies, 'isUpdatingAddress').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isUpdatingShippingAddress()).toEqual(false);
             expect(selectors.shippingStrategies.isUpdatingAddress).toHaveBeenCalled();
@@ -324,12 +400,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if updating shipping address', () => {
             jest.spyOn(selectors.consignments, 'isUpdating').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isUpdatingConsignment()).toEqual(true);
             expect(selectors.consignments.isUpdating).toHaveBeenCalled();
         });
 
         it('returns false if not updating shipping address', () => {
             jest.spyOn(selectors.consignments, 'isUpdating').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isUpdatingConsignment()).toEqual(false);
             expect(selectors.consignments.isUpdating).toHaveBeenCalled();
@@ -340,12 +420,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if deleting consignment', () => {
             jest.spyOn(selectors.consignments, 'isDeleting').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isDeletingConsignment()).toEqual(true);
             expect(selectors.consignments.isDeleting).toHaveBeenCalled();
         });
 
         it('returns false if not deleting consignment', () => {
             jest.spyOn(selectors.consignments, 'isDeleting').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isDeletingConsignment()).toEqual(false);
             expect(selectors.consignments.isDeleting).toHaveBeenCalled();
@@ -356,12 +440,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if updating shipping address', () => {
             jest.spyOn(selectors.consignments, 'isCreating').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isCreatingConsignments()).toEqual(true);
             expect(selectors.consignments.isCreating).toHaveBeenCalled();
         });
 
         it('returns false if not updating shipping address', () => {
             jest.spyOn(selectors.consignments, 'isCreating').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isCreatingConsignments()).toEqual(false);
             expect(selectors.consignments.isCreating).toHaveBeenCalled();
@@ -372,12 +460,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if initializing shipping', () => {
             jest.spyOn(selectors.shippingStrategies, 'isInitializing').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isInitializingShipping('foobar')).toEqual(true);
             expect(selectors.shippingStrategies.isInitializing).toHaveBeenCalledWith('foobar');
         });
 
         it('returns false if not initializing shipping', () => {
             jest.spyOn(selectors.shippingStrategies, 'isInitializing').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isInitializingShipping('foobar')).toEqual(false);
             expect(selectors.shippingStrategies.isInitializing).toHaveBeenCalledWith('foobar');
@@ -388,12 +480,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if applying a coupon', () => {
             jest.spyOn(selectors.coupons, 'isApplying').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isApplyingCoupon()).toEqual(true);
             expect(selectors.coupons.isApplying).toHaveBeenCalled();
         });
 
         it('returns false if not applying a coupon', () => {
             jest.spyOn(selectors.coupons, 'isApplying').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isApplyingCoupon()).toEqual(false);
             expect(selectors.coupons.isApplying).toHaveBeenCalled();
@@ -404,12 +500,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if removing a coupon', () => {
             jest.spyOn(selectors.coupons, 'isRemoving').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isRemovingCoupon()).toEqual(true);
             expect(selectors.coupons.isRemoving).toHaveBeenCalled();
         });
 
         it('returns false if not removing a coupon', () => {
             jest.spyOn(selectors.coupons, 'isRemoving').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isRemovingCoupon()).toEqual(false);
             expect(selectors.coupons.isRemoving).toHaveBeenCalled();
@@ -420,12 +520,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if applying a gift certificate', () => {
             jest.spyOn(selectors.giftCertificates, 'isApplying').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isApplyingGiftCertificate()).toEqual(true);
             expect(selectors.giftCertificates.isApplying).toHaveBeenCalled();
         });
 
         it('returns false if not applying a gift certificate', () => {
             jest.spyOn(selectors.giftCertificates, 'isApplying').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isApplyingGiftCertificate()).toEqual(false);
             expect(selectors.giftCertificates.isApplying).toHaveBeenCalled();
@@ -436,12 +540,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if removing a gift certificate', () => {
             jest.spyOn(selectors.giftCertificates, 'isRemoving').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isRemovingGiftCertificate()).toEqual(true);
             expect(selectors.giftCertificates.isRemoving).toHaveBeenCalled();
         });
 
         it('returns false if not removing a gift certificate', () => {
             jest.spyOn(selectors.giftCertificates, 'isRemoving').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isRemovingGiftCertificate()).toEqual(false);
             expect(selectors.giftCertificates.isRemoving).toHaveBeenCalled();
@@ -452,12 +560,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading instruments', () => {
             jest.spyOn(selectors.instruments, 'isLoading').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingInstruments()).toEqual(true);
             expect(selectors.instruments.isLoading).toHaveBeenCalled();
         });
 
         it('returns false if not loading instruments', () => {
             jest.spyOn(selectors.instruments, 'isLoading').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingInstruments()).toEqual(false);
             expect(selectors.instruments.isLoading).toHaveBeenCalled();
@@ -468,12 +580,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if deleting instrument', () => {
             jest.spyOn(selectors.instruments, 'isDeleting').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isDeletingInstrument('123')).toEqual(true);
             expect(selectors.instruments.isDeleting).toHaveBeenCalledWith('123');
         });
 
         it('returns false if not deleting instrument', () => {
             jest.spyOn(selectors.instruments, 'isDeleting').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isDeletingInstrument('123')).toEqual(false);
             expect(selectors.instruments.isDeleting).toHaveBeenCalledWith('123');
@@ -484,12 +600,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if loading config', () => {
             jest.spyOn(selectors.config, 'isLoading').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isLoadingConfig()).toEqual(true);
             expect(selectors.config.isLoading).toHaveBeenCalledWith();
         });
 
         it('returns false if not loading config', () => {
             jest.spyOn(selectors.config, 'isLoading').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isLoadingConfig()).toEqual(false);
             expect(selectors.config.isLoading).toHaveBeenCalled();
@@ -500,12 +620,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if widget is interacting', () => {
             jest.spyOn(selectors.paymentStrategies, 'isWidgetInteracting').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isPaymentStepPending()).toEqual(true);
             expect(selectors.paymentStrategies.isWidgetInteracting).toHaveBeenCalled();
         });
 
         it('returns false if widget is not interacting', () => {
             jest.spyOn(selectors.paymentStrategies, 'isWidgetInteracting').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isPaymentStepPending()).toEqual(false);
             expect(selectors.paymentStrategies.isWidgetInteracting).toHaveBeenCalled();
@@ -514,12 +638,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if strategy is initializing', () => {
             jest.spyOn(selectors.paymentStrategies, 'isInitializing').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isPaymentStepPending()).toEqual(true);
             expect(selectors.paymentStrategies.isInitializing).toHaveBeenCalled();
         });
 
         it('returns false if strategy is not initializing', () => {
             jest.spyOn(selectors.paymentStrategies, 'isInitializing').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isPaymentStepPending()).toEqual(false);
             expect(selectors.paymentStrategies.isInitializing).toHaveBeenCalled();
@@ -528,12 +656,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if strategy is executing', () => {
             jest.spyOn(selectors.paymentStrategies, 'isExecuting').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isPaymentStepPending()).toEqual(true);
             expect(selectors.paymentStrategies.isExecuting).toHaveBeenCalled();
         });
 
         it('returns false if strategy is not executing', () => {
             jest.spyOn(selectors.paymentStrategies, 'isExecuting').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isPaymentStepPending()).toEqual(false);
             expect(selectors.paymentStrategies.isExecuting).toHaveBeenCalled();
@@ -542,12 +674,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if strategy is finalizing', () => {
             jest.spyOn(selectors.paymentStrategies, 'isFinalizing').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isPaymentStepPending()).toEqual(true);
             expect(selectors.paymentStrategies.isFinalizing).toHaveBeenCalled();
         });
 
         it('returns false if strategy is not finalizing', () => {
             jest.spyOn(selectors.paymentStrategies, 'isFinalizing').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isPaymentStepPending()).toEqual(false);
             expect(selectors.paymentStrategies.isFinalizing).toHaveBeenCalled();
@@ -558,12 +694,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if widget is interacting', () => {
             jest.spyOn(selectors.customerStrategies, 'isWidgetInteracting').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isCustomerStepPending()).toEqual(true);
             expect(selectors.customerStrategies.isWidgetInteracting).toHaveBeenCalled();
         });
 
         it('returns false if widget is not interacting', () => {
             jest.spyOn(selectors.customerStrategies, 'isWidgetInteracting').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isCustomerStepPending()).toEqual(false);
             expect(selectors.customerStrategies.isWidgetInteracting).toHaveBeenCalled();
@@ -572,12 +712,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if strategy is initializing', () => {
             jest.spyOn(selectors.customerStrategies, 'isInitializing').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isCustomerStepPending()).toEqual(true);
             expect(selectors.customerStrategies.isInitializing).toHaveBeenCalled();
         });
 
         it('returns false if strategy is not initializing', () => {
             jest.spyOn(selectors.customerStrategies, 'isInitializing').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isCustomerStepPending()).toEqual(false);
             expect(selectors.customerStrategies.isInitializing).toHaveBeenCalled();
@@ -586,12 +730,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if strategy is executing', () => {
             jest.spyOn(selectors.customerStrategies, 'isSigningIn').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isCustomerStepPending()).toEqual(true);
             expect(selectors.customerStrategies.isSigningIn).toHaveBeenCalled();
         });
 
         it('returns false if strategy is not executing', () => {
             jest.spyOn(selectors.customerStrategies, 'isSigningIn').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isCustomerStepPending()).toEqual(false);
             expect(selectors.customerStrategies.isSigningIn).toHaveBeenCalled();
@@ -600,12 +748,16 @@ describe('CheckoutStoreStatusSelector', () => {
         it('returns true if strategy is finalizing', () => {
             jest.spyOn(selectors.customerStrategies, 'isSigningOut').mockReturnValue(true);
 
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
             expect(statuses.isCustomerStepPending()).toEqual(true);
             expect(selectors.customerStrategies.isSigningOut).toHaveBeenCalled();
         });
 
         it('returns false if strategy is not finalizing', () => {
             jest.spyOn(selectors.customerStrategies, 'isSigningOut').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
 
             expect(statuses.isCustomerStepPending()).toEqual(false);
             expect(selectors.customerStrategies.isSigningOut).toHaveBeenCalled();

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -1,16 +1,7 @@
-import { BillingAddressSelector } from '../billing';
-import { CartSelector } from '../cart';
-import { selector } from '../common/selector';
-import { ConfigSelector } from '../config';
-import { CouponSelector, GiftCertificateSelector } from '../coupon';
-import { CustomerStrategySelector } from '../customer';
-import { CountrySelector } from '../geography';
-import { OrderSelector } from '../order';
-import { PaymentMethodSelector, PaymentStrategySelector } from '../payment';
-import { InstrumentSelector } from '../payment/instrument';
-import { ConsignmentSelector, ShippingCountrySelector, ShippingStrategySelector } from '../shipping';
+import { createSelector, createShallowEqualSelector } from '../common/selector';
+import { Omit } from '../common/types';
+import { memoizeOne } from '../common/utility';
 
-import CheckoutSelector from './checkout-selector';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
 
 /**
@@ -21,165 +12,76 @@ import InternalCheckoutSelectors from './internal-checkout-selectors';
  * progress. For example, you can check whether a customer is submitting an
  * order and waiting for the request to complete.
  */
-@selector
-export default class CheckoutStoreStatusSelector {
-    private _billingAddress: BillingAddressSelector;
-    private _cart: CartSelector;
-    private _checkout: CheckoutSelector;
-    private _config: ConfigSelector;
-    private _consignments: ConsignmentSelector;
-    private _countries: CountrySelector;
-    private _coupons: CouponSelector;
-    private _customerStrategies: CustomerStrategySelector;
-    private _giftCertificates: GiftCertificateSelector;
-    private _instruments: InstrumentSelector;
-    private _order: OrderSelector;
-    private _paymentMethods: PaymentMethodSelector;
-    private _paymentStrategies: PaymentStrategySelector;
-    private _shippingCountries: ShippingCountrySelector;
-    private _shippingStrategies: ShippingStrategySelector;
-
-    /**
-     * @internal
-     */
-    constructor(selectors: InternalCheckoutSelectors) {
-        this._billingAddress = selectors.billingAddress;
-        this._cart = selectors.cart;
-        this._checkout = selectors.checkout;
-        this._config = selectors.config;
-        this._consignments = selectors.consignments;
-        this._countries = selectors.countries;
-        this._coupons = selectors.coupons;
-        this._customerStrategies = selectors.customerStrategies;
-        this._giftCertificates = selectors.giftCertificates;
-        this._instruments = selectors.instruments;
-        this._order = selectors.order;
-        this._paymentMethods = selectors.paymentMethods;
-        this._paymentStrategies = selectors.paymentStrategies;
-        this._shippingCountries = selectors.shippingCountries;
-        this._shippingStrategies = selectors.shippingStrategies;
-    }
-
+export default interface CheckoutStoreStatusSelector {
     /**
      * Checks whether any checkout action is pending.
      *
      * @returns True if there is a pending action, otherwise false.
      */
-    isPending(): boolean {
-        // tslint:disable-next-line:cyclomatic-complexity
-        return this.isLoadingCheckout() ||
-            this.isSubmittingOrder() ||
-            this.isFinalizingOrder() ||
-            this.isLoadingOrder() ||
-            this.isLoadingCart() ||
-            this.isLoadingBillingCountries() ||
-            this.isLoadingShippingCountries() ||
-            this.isLoadingPaymentMethods() ||
-            this.isLoadingPaymentMethod() ||
-            this.isInitializingPayment() ||
-            this.isLoadingShippingOptions() ||
-            this.isSelectingShippingOption() ||
-            this.isSigningIn() ||
-            this.isSigningOut() ||
-            this.isInitializingCustomer() ||
-            this.isUpdatingBillingAddress() ||
-            this.isContinuingAsGuest() ||
-            this.isUpdatingShippingAddress() ||
-            this.isUpdatingConsignment() ||
-            this.isCreatingConsignments() ||
-            this.isDeletingConsignment() ||
-            this.isInitializingShipping() ||
-            this.isApplyingCoupon() ||
-            this.isRemovingCoupon() ||
-            this.isApplyingGiftCertificate() ||
-            this.isRemovingGiftCertificate() ||
-            this.isLoadingInstruments() ||
-            this.isDeletingInstrument() ||
-            this.isLoadingConfig() ||
-            this.isCustomerStepPending() ||
-            this.isPaymentStepPending();
-    }
+    isPending(): boolean;
 
     /**
      * Checks whether the current checkout is loading.
      *
      * @returns True if the current checkout is loading, otherwise false.
      */
-    isLoadingCheckout(): boolean {
-        return this._checkout.isLoading();
-    }
+    isLoadingCheckout(): boolean;
 
     /**
      * Checks whether the current checkout is being updated.
      *
      * @returns True if the current checkout is being updated, otherwise false.
      */
-    isUpdatingCheckout(): boolean {
-        return this._checkout.isUpdating();
-    }
+    isUpdatingCheckout(): boolean;
 
     /**
      * Checks whether the current order is submitting.
      *
      * @returns True if the current order is submitting, otherwise false.
      */
-    isSubmittingOrder(): boolean {
-        return this._paymentStrategies.isExecuting();
-    }
+    isSubmittingOrder(): boolean;
 
     /**
      * Checks whether the current order is finalizing.
      *
      * @returns True if the current order is finalizing, otherwise false.
      */
-    isFinalizingOrder(): boolean {
-        return this._paymentStrategies.isFinalizing();
-    }
+    isFinalizingOrder(): boolean;
 
     /**
      * Checks whether the current order is loading.
      *
      * @returns True if the current order is loading, otherwise false.
      */
-    isLoadingOrder(): boolean {
-        return this._order.isLoading();
-    }
+    isLoadingOrder(): boolean;
 
     /**
      * Checks whether the current cart is loading.
      *
      * @returns True if the current cart is loading, otherwise false.
      */
-    isLoadingCart(): boolean {
-        return this._cart.isLoading();
-    }
+    isLoadingCart(): boolean;
 
     /**
      * Checks whether billing countries are loading.
      *
      * @returns True if billing countries are loading, otherwise false.
      */
-    isLoadingBillingCountries(): boolean {
-        return this._countries.isLoading();
-    }
+    isLoadingBillingCountries(): boolean;
 
     /**
      * Checks whether shipping countries are loading.
      *
      * @returns True if shipping countries are loading, otherwise false.
      */
-    isLoadingShippingCountries(): boolean {
-        return this._shippingCountries.isLoading();
-    }
+    isLoadingShippingCountries(): boolean;
 
     /**
      * Checks whether payment methods are loading.
      *
      * @returns True if payment methods are loading, otherwise false.
      */
-    isLoadingPaymentMethods(): boolean {
-        return this._paymentMethods.isLoading();
-    }
+    isLoadingPaymentMethods(): boolean;
 
     /**
      * Checks whether a specific or any payment method is loading.
@@ -190,9 +92,7 @@ export default class CheckoutStoreStatusSelector {
      * @param methodId - The identifier of the payment method to check.
      * @returns True if the payment method is loading, otherwise false.
      */
-    isLoadingPaymentMethod(methodId?: string): boolean {
-        return this._paymentMethods.isLoadingMethod(methodId);
-    }
+    isLoadingPaymentMethod(methodId?: string): boolean;
 
     /**
      * Checks whether a specific or any payment method is initializing.
@@ -203,9 +103,7 @@ export default class CheckoutStoreStatusSelector {
      * @param methodId - The identifier of the payment method to check.
      * @returns True if the payment method is initializing, otherwise false.
      */
-    isInitializingPayment(methodId?: string): boolean {
-        return this._paymentStrategies.isInitializing(methodId);
-    }
+    isInitializingPayment(methodId?: string): boolean;
 
     /**
      * Checks whether the current customer is signing in.
@@ -217,9 +115,7 @@ export default class CheckoutStoreStatusSelector {
      * current customer.
      * @returns True if the customer is signing in, otherwise false.
      */
-    isSigningIn(methodId?: string): boolean {
-        return this._customerStrategies.isSigningIn(methodId);
-    }
+    isSigningIn(methodId?: string): boolean;
 
     /**
      * Checks whether the current customer is signing out.
@@ -231,9 +127,7 @@ export default class CheckoutStoreStatusSelector {
      * current customer.
      * @returns True if the customer is signing out, otherwise false.
      */
-    isSigningOut(methodId?: string): boolean {
-        return this._customerStrategies.isSigningOut(methodId);
-    }
+    isSigningOut(methodId?: string): boolean;
 
     /**
      * Checks whether the customer step is initializing.
@@ -245,18 +139,14 @@ export default class CheckoutStoreStatusSelector {
      * customer step of checkout.
      * @returns True if the customer step is initializing, otherwise false.
      */
-    isInitializingCustomer(methodId?: string): boolean {
-        return this._customerStrategies.isInitializing(methodId);
-    }
+    isInitializingCustomer(methodId?: string): boolean;
 
     /**
      * Checks whether shipping options are loading.
      *
      * @returns True if shipping options are loading, otherwise false.
      */
-    isLoadingShippingOptions(): boolean {
-        return this._consignments.isLoadingShippingOptions();
-    }
+    isLoadingShippingOptions(): boolean;
 
     /**
      * Checks whether a shipping option is being selected.
@@ -268,37 +158,28 @@ export default class CheckoutStoreStatusSelector {
      * @param consignmentId - The identifier of the consignment to be checked.
      * @returns True if selecting a shipping option, otherwise false.
      */
-    isSelectingShippingOption(consignmentId?: string): boolean {
-        return this._shippingStrategies.isSelectingOption() ||
-            this._consignments.isUpdatingShippingOption(consignmentId);
-    }
+    isSelectingShippingOption(consignmentId?: string): boolean;
 
     /**
      * Checks whether the billing address is being updated.
      *
      * @returns True if updating their billing address, otherwise false.
      */
-    isUpdatingBillingAddress(): boolean {
-        return this._billingAddress.isUpdating();
-    }
+    isUpdatingBillingAddress(): boolean;
 
     /**
      * Checks whether the shopper is continuing out as a guest.
      *
      * @returns True if continuing as guest, otherwise false.
      */
-    isContinuingAsGuest(): boolean {
-        return this._billingAddress.isContinuingAsGuest();
-    }
+    isContinuingAsGuest(): boolean;
 
     /**
      * Checks the shipping address is being updated.
      *
      * @returns True if updating their shipping address, otherwise false.
      */
-    isUpdatingShippingAddress(): boolean {
-        return this._shippingStrategies.isUpdatingAddress();
-    }
+    isUpdatingShippingAddress(): boolean;
 
     /**
      * Checks whether a given/any consignment is being updated.
@@ -309,9 +190,7 @@ export default class CheckoutStoreStatusSelector {
      * @param consignmentId - The identifier of the consignment to be checked.
      * @returns True if updating consignment(s), otherwise false.
      */
-    isUpdatingConsignment(consignmentId?: string): boolean {
-        return this._consignments.isUpdating(consignmentId);
-    }
+    isUpdatingConsignment(consignmentId?: string): boolean;
 
     /**
      * Checks whether a given/any consignment is being deleted.
@@ -322,9 +201,7 @@ export default class CheckoutStoreStatusSelector {
      * @param consignmentId - The identifier of the consignment to be checked.
      * @returns True if deleting consignment(s), otherwise false.
      */
-    isDeletingConsignment(consignmentId?: string): boolean {
-        return this._consignments.isDeleting(consignmentId);
-    }
+    isDeletingConsignment(consignmentId?: string): boolean;
 
     /**
      * Checks whether a given/any consignment is being updated.
@@ -334,9 +211,7 @@ export default class CheckoutStoreStatusSelector {
      *
      * @returns True if creating consignments, otherwise false.
      */
-    isCreatingConsignments(): boolean {
-        return this._consignments.isCreating();
-    }
+    isCreatingConsignments(): boolean;
 
     /**
      * Checks whether the shipping step of a checkout process is initializing.
@@ -348,72 +223,56 @@ export default class CheckoutStoreStatusSelector {
      * @param methodId - The identifer of the initialization method to check.
      * @returns True if the shipping step is initializing, otherwise false.
      */
-    isInitializingShipping(methodId?: string) {
-        return this._shippingStrategies.isInitializing(methodId);
-    }
+    isInitializingShipping(methodId?: string): boolean;
 
     /**
      * Checks whether the current customer is applying a coupon code.
      *
      * @returns True if applying a coupon code, otherwise false.
      */
-    isApplyingCoupon(): boolean {
-        return this._coupons.isApplying();
-    }
+    isApplyingCoupon(): boolean;
 
     /**
      * Checks whether the current customer is removing a coupon code.
      *
      * @returns True if removing a coupon code, otherwise false.
      */
-    isRemovingCoupon(): boolean {
-        return this._coupons.isRemoving();
-    }
+    isRemovingCoupon(): boolean;
 
     /**
      * Checks whether the current customer is applying a gift certificate.
      *
      * @returns True if applying a gift certificate, otherwise false.
      */
-    isApplyingGiftCertificate(): boolean {
-        return this._giftCertificates.isApplying();
-    }
+    isApplyingGiftCertificate(): boolean;
 
     /**
      * Checks whether the current customer is removing a gift certificate.
      *
      * @returns True if removing a gift certificate, otherwise false.
      */
-    isRemovingGiftCertificate(): boolean {
-        return this._giftCertificates.isRemoving();
-    }
+    isRemovingGiftCertificate(): boolean;
 
     /**
      * Checks whether the current customer's payment instruments are loading.
      *
      * @returns True if payment instruments are loading, otherwise false.
      */
-    isLoadingInstruments(): boolean {
-        return this._instruments.isLoading();
-    }
+    isLoadingInstruments(): boolean;
 
     /**
      * Checks whether the current customer is deleting a payment instrument.
      *
      * @returns True if deleting a payment instrument, otherwise false.
      */
-    isDeletingInstrument(instrumentId?: string): boolean {
-        return this._instruments.isDeleting(instrumentId);
-    }
+    isDeletingInstrument(instrumentId?: string): boolean;
 
     /**
      * Checks whether the checkout configuration of a store is loading.
      *
      * @returns True if the configuration is loading, otherwise false.
      */
-    isLoadingConfig(): boolean {
-        return this._config.isLoading();
-    }
+    isLoadingConfig(): boolean;
 
     /**
      * Checks whether the customer step of a checkout is in a pending state.
@@ -424,12 +283,7 @@ export default class CheckoutStoreStatusSelector {
      *
      * @returns True if the customer step is pending, otherwise false.
      */
-    isCustomerStepPending(): boolean {
-        return this._customerStrategies.isInitializing() ||
-            this._customerStrategies.isSigningIn() ||
-            this._customerStrategies.isSigningOut() ||
-            this._customerStrategies.isWidgetInteracting();
-    }
+    isCustomerStepPending(): boolean;
 
     /**
      * Checks whether the payment step of a checkout is in a pending state.
@@ -440,10 +294,102 @@ export default class CheckoutStoreStatusSelector {
      *
      * @returns True if the payment step is pending, otherwise false.
      */
-    isPaymentStepPending(): boolean {
-        return this._paymentStrategies.isInitializing() ||
-            this._paymentStrategies.isExecuting() ||
-            this._paymentStrategies.isFinalizing() ||
-            this._paymentStrategies.isWidgetInteracting();
-    }
+    isPaymentStepPending(): boolean;
+}
+
+export type CheckoutStoreStatusSelectorFactory = (state: InternalCheckoutSelectors) => CheckoutStoreStatusSelector;
+
+export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusSelectorFactory {
+    const isPending = createShallowEqualSelector(
+        (selector: Omit<CheckoutStoreStatusSelector, 'isPending'>) => selector,
+        selector => () => {
+            return (Object.keys(selector) as Array<keyof Omit<CheckoutStoreStatusSelector, 'isPending'>>)
+                .some(key => selector[key]());
+        }
+    );
+
+    const isSelectingShippingOption = createSelector(
+        ({ shippingStrategies }: InternalCheckoutSelectors) => shippingStrategies.isSelectingOption,
+        ({ consignments }: InternalCheckoutSelectors) => consignments.isUpdatingShippingOption,
+        (isSelectingOption, isUpdatingShippingOption) => (consignmentId?: string) => {
+            return (
+                isSelectingOption() ||
+                isUpdatingShippingOption(consignmentId)
+            );
+        }
+    );
+
+    const isCustomerStepPending = createSelector(
+        ({ customerStrategies }: InternalCheckoutSelectors) => customerStrategies.isInitializing,
+        ({ customerStrategies }: InternalCheckoutSelectors) => customerStrategies.isSigningIn,
+        ({ customerStrategies }: InternalCheckoutSelectors) => customerStrategies.isSigningOut,
+        ({ customerStrategies }: InternalCheckoutSelectors) => customerStrategies.isWidgetInteracting,
+        (isInitializing, isSigningIn, isSigningOut, isWidgetInteracting) => (methodId?: string) => {
+            return (
+                isInitializing(methodId) ||
+                isSigningIn(methodId) ||
+                isSigningOut(methodId) ||
+                isWidgetInteracting(methodId)
+            );
+        }
+    );
+
+    const isPaymentStepPending = createSelector(
+        ({ paymentStrategies }: InternalCheckoutSelectors) => paymentStrategies.isInitializing,
+        ({ paymentStrategies }: InternalCheckoutSelectors) => paymentStrategies.isExecuting,
+        ({ paymentStrategies }: InternalCheckoutSelectors) => paymentStrategies.isFinalizing,
+        ({ paymentStrategies }: InternalCheckoutSelectors) => paymentStrategies.isWidgetInteracting,
+        (isInitializing, isExecuting, isFinalizing, isWidgetInteracting) => (methodId?: string) => {
+            return (
+                isInitializing(methodId) ||
+                isExecuting(methodId) ||
+                isFinalizing(methodId) ||
+                isWidgetInteracting(methodId)
+            );
+        }
+    );
+
+    return memoizeOne((
+        state: InternalCheckoutSelectors
+    ): CheckoutStoreStatusSelector => {
+        const selector = {
+            isLoadingCheckout: state.checkout.isLoading,
+            isUpdatingCheckout: state.checkout.isUpdating,
+            isSubmittingOrder: state.paymentStrategies.isExecuting,
+            isFinalizingOrder: state.paymentStrategies.isFinalizing,
+            isLoadingOrder: state.order.isLoading,
+            isLoadingCart: state.cart.isLoading,
+            isLoadingBillingCountries: state.countries.isLoading,
+            isLoadingShippingCountries: state.shippingCountries.isLoading,
+            isLoadingPaymentMethods: state.paymentMethods.isLoading,
+            isLoadingPaymentMethod: state.paymentMethods.isLoadingMethod,
+            isInitializingPayment: state.paymentStrategies.isInitializing,
+            isSigningIn: state.customerStrategies.isSigningIn,
+            isSigningOut: state.customerStrategies.isSigningOut,
+            isInitializingCustomer: state.customerStrategies.isInitializing,
+            isLoadingShippingOptions: state.consignments.isLoadingShippingOptions,
+            isSelectingShippingOption: isSelectingShippingOption(state),
+            isUpdatingBillingAddress: state.billingAddress.isUpdating,
+            isContinuingAsGuest: state.billingAddress.isContinuingAsGuest,
+            isUpdatingShippingAddress: state.shippingStrategies.isUpdatingAddress,
+            isUpdatingConsignment: state.consignments.isUpdating,
+            isDeletingConsignment: state.consignments.isDeleting,
+            isCreatingConsignments: state.consignments.isCreating,
+            isInitializingShipping: state.shippingStrategies.isInitializing,
+            isApplyingCoupon: state.coupons.isApplying,
+            isRemovingCoupon: state.coupons.isRemoving,
+            isApplyingGiftCertificate: state.giftCertificates.isApplying,
+            isRemovingGiftCertificate: state.giftCertificates.isRemoving,
+            isLoadingInstruments: state.instruments.isLoading,
+            isDeletingInstrument: state.instruments.isDeleting,
+            isLoadingConfig: state.config.isLoading,
+            isCustomerStepPending: isCustomerStepPending(state),
+            isPaymentStepPending: isPaymentStepPending(state),
+        };
+
+        return {
+            isPending: isPending(selector),
+            ...selector,
+        };
+    });
 }

--- a/src/checkout/create-checkout-selectors.ts
+++ b/src/checkout/create-checkout-selectors.ts
@@ -1,17 +1,18 @@
 import {
     createCheckoutStoreSelectorFactory,
+    createCheckoutStoreStatusSelectorFactory,
     CheckoutSelectors,
     CheckoutStoreErrorSelector,
-    CheckoutStoreStatusSelector,
     InternalCheckoutSelectors,
 } from '../checkout';
 
 export default function createCheckoutSelectors(selectors: InternalCheckoutSelectors): CheckoutSelectors {
     const createCheckoutStoreSelector = createCheckoutStoreSelectorFactory();
+    const createCheckoutStoreStatusSelector = createCheckoutStoreStatusSelectorFactory();
 
     const data = createCheckoutStoreSelector(selectors);
     const errors = new CheckoutStoreErrorSelector(selectors);
-    const statuses = new CheckoutStoreStatusSelector(selectors);
+    const statuses = createCheckoutStoreStatusSelector(selectors);
 
     return {
         data,

--- a/src/checkout/create-checkout-selectors.ts
+++ b/src/checkout/create-checkout-selectors.ts
@@ -1,17 +1,18 @@
 import {
+    createCheckoutStoreErrorSelectorFactory,
     createCheckoutStoreSelectorFactory,
     createCheckoutStoreStatusSelectorFactory,
     CheckoutSelectors,
-    CheckoutStoreErrorSelector,
     InternalCheckoutSelectors,
 } from '../checkout';
 
 export default function createCheckoutSelectors(selectors: InternalCheckoutSelectors): CheckoutSelectors {
     const createCheckoutStoreSelector = createCheckoutStoreSelectorFactory();
+    const createCheckoutStoreErrorSelector = createCheckoutStoreErrorSelectorFactory();
     const createCheckoutStoreStatusSelector = createCheckoutStoreStatusSelectorFactory();
 
     const data = createCheckoutStoreSelector(selectors);
-    const errors = new CheckoutStoreErrorSelector(selectors);
+    const errors = createCheckoutStoreErrorSelector(selectors);
     const statuses = createCheckoutStoreStatusSelector(selectors);
 
     return {

--- a/src/checkout/create-checkout-selectors.ts
+++ b/src/checkout/create-checkout-selectors.ts
@@ -6,18 +6,26 @@ import {
     InternalCheckoutSelectors,
 } from '../checkout';
 
-export default function createCheckoutSelectors(selectors: InternalCheckoutSelectors): CheckoutSelectors {
+export type CheckoutSelectorsFactory = (selectors: InternalCheckoutSelectors) => CheckoutSelectors;
+
+export function createCheckoutSelectorsFactory(): CheckoutSelectorsFactory {
     const createCheckoutStoreSelector = createCheckoutStoreSelectorFactory();
     const createCheckoutStoreErrorSelector = createCheckoutStoreErrorSelectorFactory();
     const createCheckoutStoreStatusSelector = createCheckoutStoreStatusSelectorFactory();
 
-    const data = createCheckoutStoreSelector(selectors);
-    const errors = createCheckoutStoreErrorSelector(selectors);
-    const statuses = createCheckoutStoreStatusSelector(selectors);
+    return (selectors: InternalCheckoutSelectors) => {
+        const data = createCheckoutStoreSelector(selectors);
+        const errors = createCheckoutStoreErrorSelector(selectors);
+        const statuses = createCheckoutStoreStatusSelector(selectors);
 
-    return {
-        data,
-        errors,
-        statuses,
+        return {
+            data,
+            errors,
+            statuses,
+        };
     };
+}
+
+export default function createCheckoutSelectors(selectors: InternalCheckoutSelectors): CheckoutSelectors {
+    return createCheckoutSelectorsFactory()(selectors);
 }

--- a/src/checkout/create-checkout-selectors.ts
+++ b/src/checkout/create-checkout-selectors.ts
@@ -1,13 +1,15 @@
 import {
+    createCheckoutStoreSelectorFactory,
     CheckoutSelectors,
     CheckoutStoreErrorSelector,
-    CheckoutStoreSelector,
     CheckoutStoreStatusSelector,
     InternalCheckoutSelectors,
 } from '../checkout';
 
 export default function createCheckoutSelectors(selectors: InternalCheckoutSelectors): CheckoutSelectors {
-    const data = new CheckoutStoreSelector(selectors);
+    const createCheckoutStoreSelector = createCheckoutStoreSelectorFactory();
+
+    const data = createCheckoutStoreSelector(selectors);
     const errors = new CheckoutStoreErrorSelector(selectors);
     const statuses = new CheckoutStoreStatusSelector(selectors);
 

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -13,7 +13,7 @@ export { default as CheckoutState } from './checkout-state';
 export { default as CheckoutStoreErrorSelector } from './checkout-store-error-selector';
 export { default as CheckoutStoreSelector, CheckoutStoreSelectorFactory, createCheckoutStoreSelectorFactory } from './checkout-store-selector';
 export { default as CheckoutStoreState } from './checkout-store-state';
-export { default as CheckoutStoreStatusSelector } from './checkout-store-status-selector';
+export { default as CheckoutStoreStatusSelector, CheckoutStoreStatusSelectorFactory, createCheckoutStoreStatusSelectorFactory } from './checkout-store-status-selector';
 export { default as CheckoutStore, CheckoutStoreOptions, ReadableCheckoutStore } from './checkout-store';
 export { default as CheckoutValidator } from './checkout-validator';
 export { default as InternalCheckoutSelectors } from './internal-checkout-selectors';

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -11,7 +11,7 @@ export { default as CheckoutSelectors } from './checkout-selectors';
 export { default as CheckoutService } from './checkout-service';
 export { default as CheckoutState } from './checkout-state';
 export { default as CheckoutStoreErrorSelector } from './checkout-store-error-selector';
-export { default as CheckoutStoreSelector } from './checkout-store-selector';
+export { default as CheckoutStoreSelector, CheckoutStoreSelectorFactory, createCheckoutStoreSelectorFactory } from './checkout-store-selector';
 export { default as CheckoutStoreState } from './checkout-store-state';
 export { default as CheckoutStoreStatusSelector } from './checkout-store-status-selector';
 export { default as CheckoutStore, CheckoutStoreOptions, ReadableCheckoutStore } from './checkout-store';

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -10,7 +10,7 @@ export { default as CheckoutSelector, CheckoutSelectorFactory, createCheckoutSel
 export { default as CheckoutSelectors } from './checkout-selectors';
 export { default as CheckoutService } from './checkout-service';
 export { default as CheckoutState } from './checkout-state';
-export { default as CheckoutStoreErrorSelector } from './checkout-store-error-selector';
+export { default as CheckoutStoreErrorSelector, createCheckoutStoreErrorSelectorFactory } from './checkout-store-error-selector';
 export { default as CheckoutStoreSelector, CheckoutStoreSelectorFactory, createCheckoutStoreSelectorFactory } from './checkout-store-selector';
 export { default as CheckoutStoreState } from './checkout-store-state';
 export { default as CheckoutStoreStatusSelector, CheckoutStoreStatusSelectorFactory, createCheckoutStoreStatusSelectorFactory } from './checkout-store-status-selector';

--- a/src/common/utility/clone-result.ts
+++ b/src/common/utility/clone-result.ts
@@ -1,0 +1,24 @@
+import { cloneDeep, memoize } from 'lodash';
+
+const memoizedCloneDeep = memoize(cloneDeep);
+
+// Use WeakMap as the MapCache, this allows for better garbage collection
+// There's a deprecated `clear` method in the lodash implementation
+// of MapCache, hence the `any`
+memoizedCloneDeep.cache = new WeakMap() as any;
+
+/**
+ * Clone the return value of a function. If the result is the same as previous
+ * calls, return the previous clone instead of cloning it again.
+ */
+export default function cloneResult<T extends Func>(fn: T): T {
+    return ((...args: any[]) => {
+        const result = fn(...args);
+
+        return result && typeof result === 'object'
+            ? memoizedCloneDeep(result)
+            : result;
+    }) as T;
+}
+
+export type Func = (...args: any[]) => any;

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -2,6 +2,7 @@ export { default as AmountTransformer } from './amount-transformer';
 export { default as arrayReplace } from './array-replace';
 export { default as bindDecorator } from './bind-decorator';
 export { default as clone } from './clone-decorator';
+export { default as cloneResult } from './clone-result';
 export { default as createFreezeProxy, createFreezeProxies } from './create-freeze-proxy';
 export { default as CacheKeyResolver } from './cache-key-resolver';
 export { default as CancellablePromise } from './cancellable-promise';


### PR DESCRIPTION
## What?
Refactor `CheckoutSelectors` to return new getters only when there are changes to relevant data.

## Why?
Please refer to my previous PRs. They are related to this one.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
