### PR TITLE
INT-1759 Using same order reference ID when an error occurs

### DIFF
--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -14,6 +14,7 @@ export default interface Order {
     customerId: number;
     customerMessage: string;
     discountAmount: number;
+    handlingCostTotal: number;
     hasDigitalItems: boolean;
     isComplete: boolean;
     isDownloadable: boolean;
@@ -22,13 +23,12 @@ export default interface Order {
     orderAmount: number;
     orderAmountAsInteger: number;
     orderId: number;
+    payments?: OrderPayments;
     shippingCostTotal: number;
     shippingCostBeforeDiscount: number;
-    handlingCostTotal: number;
+    status: string;
     taxes: Tax[];
     taxTotal: number;
-    payments?: OrderPayments;
-    status: string;
 }
 
 export type OrderPayments = Array<GatewayOrderPayment | GiftCertificateOrderPayment>;

--- a/src/order/orders.mock.ts
+++ b/src/order/orders.mock.ts
@@ -22,9 +22,9 @@ export function getOrder(): Order {
         customerCanBeCreated: true,
         customerId: 0,
         discountAmount: 10,
+        handlingCostTotal: 8,
         hasDigitalItems: false,
         isComplete: true,
-        status: 'ORDER_STATUS_AWAITING_FULFILLMENT',
         isDownloadable: false,
         isTaxIncluded: false,
         lineItems: {
@@ -37,16 +37,6 @@ export function getOrder(): Order {
             ],
             customItems: [],
         },
-         taxes: [
-            {
-                name: 'Tax',
-                amount: 3,
-            },
-        ],
-        taxTotal: 3,
-        shippingCostTotal: 15,
-        shippingCostBeforeDiscount: 20,
-        handlingCostTotal: 8,
         orderAmount: 190,
         orderAmountAsInteger: 19000,
         orderId: 295,
@@ -54,6 +44,16 @@ export function getOrder(): Order {
             getGatewayOrderPayment(),
             getGiftCertificateOrderPayment(),
         ],
+        shippingCostTotal: 15,
+        shippingCostBeforeDiscount: 20,
+        status: 'ORDER_STATUS_AWAITING_FULFILLMENT',
+        taxes: [
+            {
+                name: 'Tax',
+                amount: 3,
+            },
+        ],
+        taxTotal: 3,
     };
 }
 

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -76,6 +76,7 @@ describe('AmazonPayPaymentStrategy', () => {
             walletSpy(options);
 
             options.onReady(orderReference);
+            options.onPaymentSelect(orderReference);
         }
 
         bind(id: string) {
@@ -469,26 +470,10 @@ describe('AmazonPayPaymentStrategy', () => {
     });
 
     describe('When 3ds is enabled', () => {
+        const amazon3ds = getAmazonPay();
+        const payload = getOrderRequestBody();
         const paymentMethodsState = {
-            data: [{
-                id: 'amazon',
-                logoUrl: '',
-                method: 'widget',
-                supportedCards: [],
-                config: {
-                    displayName: 'AmazonPay',
-                    is3dsEnabled: true,
-                    merchantId: '0c173620-beb6-4421-99ef-03dc71a60685',
-                    testMode: false,
-                },
-                type: 'PAYMENT_TYPE_API',
-                initializationData: {
-                    clientId: '087eccf4-7f68-4384-b0a9-5f2fd6b0d344',
-                    region: 'US',
-                    redirectUrl: '/remote-checkout/amazon/redirect',
-                    tokenPrefix: 'ABCD|',
-                },
-            }],
+            data: [amazon3ds],
             meta: {
                 geoCountryCode: 'AU',
                 deviceSessionId: 'a37230e9a8e4ea2d7765e2f3e19f7b1d',
@@ -497,11 +482,11 @@ describe('AmazonPayPaymentStrategy', () => {
             errors: {},
             statuses: {},
         };
-        const payload = getOrderRequestBody();
         let options: PaymentInitializeOptions;
         let store3ds: CheckoutStore;
         let strategy3ds: AmazonPayPaymentStrategy;
         let amazonConfirmationFlow: AmazonPayConfirmationFlow;
+        amazon3ds.config.is3dsEnabled = true;
 
         beforeEach(async () => {
             options = { methodId: paymentMethod.id };
@@ -522,13 +507,36 @@ describe('AmazonPayPaymentStrategy', () => {
                 error: jest.fn(),
             };
 
-            jest.spyOn(store3ds, 'dispatch').mockReturnValue(Promise.resolve());
-            jest.spyOn(store3ds.getState().remoteCheckout, 'getCheckout')
-                    .mockReturnValue({ referenceId: 'referenceId' });
             await strategy3ds.initialize({ methodId: paymentMethod.id, amazon: { container: 'wallet' } });
         });
 
         it('redirects to confirmation flow success when support 3ds', async () => {
+
+            const remoteCheckout = {
+                referenceId: 'referenceId',
+                shipping: {},
+            };
+
+            jest.spyOn(store3ds, 'getState');
+
+            jest.spyOn(store3ds.getState().remoteCheckout, 'getCheckout')
+                .mockReturnValue(remoteCheckout);
+
+            if (hostWindow.OffAmazonPayments) {
+                hostWindow.OffAmazonPayments.initConfirmationFlow = jest.fn((_sellerId, _referenceId, callback) => {
+                    callback(amazonConfirmationFlow);
+                });
+
+                strategy3ds.execute(payload, options);
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(hostWindow.OffAmazonPayments.initConfirmationFlow).toHaveBeenCalled();
+            }
+
+        });
+
+        it('redirects to confirmation flow success when support 3ds and extract OrderReferenceId from InitializationData', async () => {
             if (hostWindow.OffAmazonPayments) {
                 hostWindow.OffAmazonPayments.initConfirmationFlow = jest.fn((_sellerId, _referenceId, callback) => {
                     callback(amazonConfirmationFlow);

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -34,6 +34,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
     private _paymentMethod?: PaymentMethod;
     private _walletOptions?: AmazonPayPaymentInitializeOptions;
     private _window: AmazonPayWindow;
+    private _isPaymentMethodSelected: boolean;
 
     constructor(
         private _store: CheckoutStore,
@@ -43,6 +44,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
         private _scriptLoader: AmazonPayScriptLoader
     ) {
         this._window = window;
+        this._isPaymentMethodSelected = false;
     }
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -92,6 +94,10 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to proceed because "payload.payment.methodId" argument is not provided.');
         }
 
+        if (!this._isPaymentMethodSelected) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
         const { payment: { paymentData, ...paymentPayload }, useStoreCredit = false } = payload;
 
         if (options && this._paymentMethod && this._paymentMethod.config.is3dsEnabled) {
@@ -138,10 +144,14 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
         return amazon ? amazon.referenceId : undefined;
     }
 
+    private _getOrderReferenceIdFromInitializationData(): string | undefined {
+        return this._paymentMethod ? this._paymentMethod.initializationData.orderReferenceId : undefined;
+    }
+
     private _createWallet(options: AmazonPayPaymentInitializeOptions): Promise<AmazonPayWallet> {
         return new Promise((resolve, reject) => {
             const { container, onError = noop, onPaymentSelect = noop, onReady = noop } = options;
-            const referenceId = this._getOrderReferenceId();
+            const referenceId = this._getOrderReferenceId() || this._getOrderReferenceIdFromInitializationData();
             const merchantId = this._getMerchantId();
 
             if (!document.getElementById(container)) {
@@ -167,7 +177,10 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                 },
                 onPaymentSelect: orderReference => {
                     this._synchronizeBillingAddress()
-                        .then(() => onPaymentSelect(orderReference))
+                        .then(() => {
+                            this._isPaymentMethodSelected = true;
+                            onPaymentSelect(orderReference);
+                        })
                         .catch(onError);
                 },
                 onReady: orderReference => {
@@ -176,7 +189,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                 },
             };
 
-            if (!walletOptions.amazonOrderReferenceId) {
+            if (!this._getOrderReferenceId()) {
                 walletOptions.onReady = orderReference => {
                     this._updateOrderReference(orderReference)
                         .then(() => {


### PR DESCRIPTION
[INT-1759](https://jira.bigcommerce.com/browse/INT-1759)
## What?
We started retrieving the orderReferenceId from order to use the same value when InvalidPaymentMethod or MFA-Abandoned occurs we do not want to generate another orderReferenceId in this cases

## Why?
We do not want to hit the amazon endpoint for generating another orderReferenceId because we already have one

## Siblings PR
[INT-1744 BCAPP](https://github.com/bigcommerce/bigcommerce/pull/31095)

## Testing / Proof
![Screen Shot 2019-08-26 at 12 45 39 PM](https://user-images.githubusercontent.com/39630835/63710754-88f73100-c7ff-11e9-98d5-bb00a7747268.png)
![Screen Shot 2019-08-26 at 12 47 01 PM](https://user-images.githubusercontent.com/39630835/63710797-a2987880-c7ff-11e9-9a32-5cf575ab8283.png)




@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations