### PR TITLE
CHECKOUT-4272: Fix immutable array replacer as it returns original array instead of merged array

### DIFF
--- a/src/common/utility/array-replace.spec.ts
+++ b/src/common/utility/array-replace.spec.ts
@@ -67,4 +67,90 @@ describe('arrayReplace()', () => {
         expect(result[1])
             .toBe(newArray[1]);
     });
+
+    it('handles nested collections of objects', () => {
+        const currentArray = [
+            {
+                id: '5d49eb3897a7d',
+                shippingCost: 0,
+                handlingCost: 0,
+                couponDiscounts: [],
+                discounts: [],
+                lineItemIds: [
+                    '5193c8b5-752a-4369-aeb4-53f881871aa2',
+                    '0aa305d8-3549-4a96-94e7-8c2ee0f3c23b',
+                ],
+                shippingAddress: {
+                    firstName: 'Good',
+                    lastName: 'Shopper',
+                    email: '',
+                    company: 'BigShopper',
+                    address1: '685 Market St',
+                    address2: '',
+                    city: 'San Francisco',
+                    stateOrProvince: 'California',
+                    stateOrProvinceCode: 'CA',
+                    country: 'United States',
+                    countryCode: 'US',
+                    postalCode: '94105',
+                    phone: '5677891234',
+                    customFields: [],
+                },
+                availableShippingOptions: [],
+            },
+        ];
+
+        const newArray = [
+            {
+                id: '5d49eb3897a7d',
+                shippingCost: 0,
+                handlingCost: 0,
+                couponDiscounts: [],
+                discounts: [],
+                lineItemIds: [
+                    '5193c8b5-752a-4369-aeb4-53f881871aa2',
+                    '0aa305d8-3549-4a96-94e7-8c2ee0f3c23b',
+                ],
+                shippingAddress: {
+                    firstName: 'Good',
+                    lastName: 'Shopper',
+                    email: '',
+                    company: 'BigShopper',
+                    address1: '685 Market St',
+                    address2: '',
+                    city: 'San Francisco',
+                    stateOrProvince: 'California',
+                    stateOrProvinceCode: 'CA',
+                    country: 'United States',
+                    countryCode: 'US',
+                    postalCode: '94105',
+                    phone: '5677891234',
+                    customFields: [],
+                },
+                availableShippingOptions: [
+                    {
+                        id: '4dcbf24f457dd67d5f89bcf374e0bc9b',
+                        type: 'freeshipping',
+                        description: 'Free Shipping',
+                        imageUrl: '',
+                        cost: 0,
+                        transitTime: '',
+                        isRecommended: true,
+                        additionalDescription: '',
+                    },
+                ],
+            },
+        ];
+
+        const result = arrayReplace(currentArray, newArray);
+
+        expect(result)
+            .toEqual(newArray);
+        expect(result[0].shippingAddress)
+            .toBe(currentArray[0].shippingAddress);
+        expect(result[0].lineItemIds)
+            .toBe(currentArray[0].lineItemIds);
+        expect(result[0].availableShippingOptions)
+            .toBe(newArray[0].availableShippingOptions);
+    });
 });


### PR DESCRIPTION
## What?
Keep two counters - one for counting the number of new items, another one for counting the number of original items. Return the new array if all items in the mapped array are new items from the new array. Return the original array if all items in the mapped array are original items from the original array. Otherwise, return the mapped array, which could contain either merged item, new item or original item.

## Why?
The current condition before this change would return the original array if both the original and new array contains the same set of entities but differ in some of their properties. This is because it cannot distinguish between what is new versus what is merged. Basically, to achieve what's described above, we need to be sure that the items in the mapped array exactly match the original or the new.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
