### PR TITLE
CHECKOUT-4321: Fix getters not returning previous cloned objects that are nested inside another even when they are unchanged.

### DIFF
--- a/src/common/utility/clone-result.spec.ts
+++ b/src/common/utility/clone-result.spec.ts
@@ -1,0 +1,47 @@
+import cloneResult from './clone-result';
+
+describe('cloneResult()', () => {
+    it('clones output of function', () => {
+        const data = { message: 'foo' };
+        const fn = () => data;
+        const clonedFn = cloneResult(fn);
+
+        expect(clonedFn())
+            .toEqual(fn());
+
+        expect(clonedFn())
+            .not.toBe(fn());
+    });
+
+    it('only clones again if output is different to previous call', () => {
+        let data = { message: 'foo' };
+        const fn = () => data;
+        const clonedFn = cloneResult(fn);
+        const resultA = clonedFn();
+
+        expect(resultA)
+            .toBe(clonedFn());
+
+        data = { message: 'bar' };
+
+        expect(resultA)
+            .not.toBe(clonedFn());
+    });
+
+    it('does not clone nested object again if it is already cloned', () => {
+        let data = { message: 'foo', child: { id: 1 } };
+        const fn = () => data;
+        const clonedFn = cloneResult(fn);
+        const resultA = clonedFn();
+
+        data = { ...data, message: 'bar' };
+
+        const resultB = clonedFn();
+
+        expect(resultA.child)
+            .toBe(resultB.child);
+
+        expect(resultA.child)
+            .not.toBe(fn().child);
+    });
+});

--- a/src/common/utility/clone-result.ts
+++ b/src/common/utility/clone-result.ts
@@ -1,24 +1,48 @@
-import { cloneDeep, memoize } from 'lodash';
+import { memoize } from 'lodash';
 
-const memoizedCloneDeep = memoize(cloneDeep);
+import isPlainObject from './is-plain-object';
+
+const cloneDeep = memoize(<T>(input: T): T => {
+    if (Array.isArray(input)) {
+        return input.map((value: T[keyof T]) => (
+            cloneDeepSafe(value)
+        )) as any;
+    }
+
+    if (isPlainObject(input)) {
+        return (Object.keys(input) as Array<keyof T>)
+            .reduce((result, key) => ({
+                ...result,
+                [key]: cloneDeepSafe(input[key]),
+            }), {}) as T;
+    }
+
+    return input;
+});
 
 // Use WeakMap as the MapCache, this allows for better garbage collection
 // There's a deprecated `clear` method in the lodash implementation
 // of MapCache, hence the `any`
-memoizedCloneDeep.cache = new WeakMap() as any;
+cloneDeep.cache = new WeakMap() as any;
+
+/**
+ * This is a wrapper function for `cloneDeep`. We need it because `cloneDeep` is
+ * a memoized function using an instance of `WeakMap` as its cache. Without this
+ * wrapper, the memoized function will throw an error if it is called with a
+ * non-object argument.
+ */
+const cloneDeepSafe = <T>(input: T): T => {
+    return typeof input === 'object' && input !== null ?
+        cloneDeep(input) :
+        input;
+};
 
 /**
  * Clone the return value of a function. If the result is the same as previous
  * calls, return the previous clone instead of cloning it again.
  */
 export default function cloneResult<T extends Func>(fn: T): T {
-    return ((...args: any[]) => {
-        const result = fn(...args);
-
-        return result && typeof result === 'object'
-            ? memoizedCloneDeep(result)
-            : result;
-    }) as T;
+    return ((...args: any[]) => cloneDeepSafe(fn(...args))) as T;
 }
 
 export type Func = (...args: any[]) => any;


### PR DESCRIPTION
## What?
Fix the problem where getters are not returning previous cloned objects even when they are unchanged. This problem affects objects that are nested inside another. For example.: `Checkout` object has several child objects, such as `payments`, `consignments`, `billingAddress` etc... 

The intention is for the references to these sub-objects to remain unchanged unless the value of their properties changes. In other words, if `consignments` collection changes because the shopper has selected a different shipping option, the reference to `billingAddress` should remain the same; only `consignments` and the top-level `checkout` object should have a different reference (a new reference because all objects are immutable). 

The change detection mechanism all works fine internally after the the changes introduced by the recent PRs. But for objects that are returned externally, we clone them recursively before returning them to the caller. The intention is to prevent external user from mutating the state that is used internally. Currently, we simply re-clone the entire object whenever there's a change to the return value of a getter. What we should do instead is to also check if the sub-resources of such object have changed, and only clone them if they are different. This can be done by recursively traversing the returned object and apply a memoized `clone` function on all non-primitive values, instead of just using a memoized `cloneDeep`.

## Why?
This issue can cause subscribers with filters applied to trigger more times than they should, if the conditions of the filters depend on the state of sub-resources. This isn't a problem before because the subscribers do a deep comparison when testing if the condition of a filter is matched. Now, the subscribers do a strict & shallow comparison instead; so they depend on getting the right object reference in order to work properly.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
