### PR TITLE
CHECKOUT-4272: Check to make sure there are no unused locals and parameters

### DIFF
--- a/src/checkout-buttons/checkout-button-strategy-action-creator.spec.ts
+++ b/src/checkout-buttons/checkout-button-strategy-action-creator.spec.ts
@@ -26,7 +26,7 @@ describe('CheckoutButtonStrategyActionCreator', () => {
     let store: CheckoutStore;
 
     class MockButtonStrategy implements CheckoutButtonStrategy {
-        initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        initialize(): Promise<void> {
             return Promise.resolve();
         }
 

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
@@ -60,7 +60,7 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
                         shape: 'rect',
                         ...pick(paypalOptions.style, 'layout', 'size', 'color', 'label', 'shape', 'tagline', 'fundingicons'),
                     },
-                    payment: (data, actions) => this._setupPayment(merchantId, actions, paypalOptions.onPaymentError),
+                    payment: (_, actions) => this._setupPayment(merchantId, actions, paypalOptions.onPaymentError),
                     onAuthorize: (data, actions) => this._tokenizePayment(data, actions, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
                 }, options.containerId);
             });
@@ -102,7 +102,7 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
         data: PaypalAuthorizeData,
         actions?: PaypalActions,
         shouldProcessPayment?: boolean,
-        onError?: (error: StandardError) => void
+        _onError?: (error: StandardError) => void // FIXME: This parameter seems to be unused
     ): Promise<void> {
         if (!this._paymentMethod) {
             throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -44,7 +44,6 @@ import { OfflinePaymentStrategy } from '../payment/strategies/offline';
 import {
     createShippingStrategyRegistry,
     ConsignmentActionCreator,
-    ConsignmentActionType,
     ConsignmentRequestSender,
     ShippingCountryActionCreator,
     ShippingCountryRequestSender,
@@ -53,16 +52,12 @@ import {
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 import { getShippingOptions } from '../shipping/shipping-options.mock';
 
-import Checkout from './checkout';
 import CheckoutActionCreator from './checkout-action-creator';
 import CheckoutRequestSender from './checkout-request-sender';
 import CheckoutService from './checkout-service';
 import CheckoutStore from './checkout-store';
-import CheckoutStoreErrorSelector from './checkout-store-error-selector';
-import CheckoutStoreSelector from './checkout-store-selector';
-import CheckoutStoreStatusSelector from './checkout-store-status-selector';
 import CheckoutValidator from './checkout-validator';
-import { getCheckout, getCheckoutState, getCheckoutStoreState, getCheckoutWithCoupons, getCheckoutWithGiftCertificates, getCheckoutWithPayments } from './checkouts.mock';
+import { getCheckout, getCheckoutStoreState, getCheckoutWithCoupons, getCheckoutWithPayments } from './checkouts.mock';
 import createCheckoutStore from './create-checkout-store';
 
 describe('CheckoutService', () => {

--- a/src/common/data-store/cachable-action-decorator.spec.ts
+++ b/src/common/data-store/cachable-action-decorator.spec.ts
@@ -12,13 +12,13 @@ describe('cachableActionDecorator()', () => {
         ) {}
 
         @cachableAction
-        loadMessage(name: string, options?: ActionOptions): Observable<Action> {
+        loadMessage(name: string, _options?: ActionOptions): Observable<Action> {
             return from(this._fetch(name))
                 .pipe(map(response => createAction('GET_MESSAGE', response)));
         }
 
         @cachableAction
-        loadUppercaseMessage(name: string, options?: ActionOptions): Observable<Action> {
+        loadUppercaseMessage(name: string, _options?: ActionOptions): Observable<Action> {
             return from(this._fetch(name))
                 .pipe(map(response => createAction('GET_UPPERCASE_MESSAGE', response.toUpperCase())));
         }

--- a/src/common/data-store/cachable-action-decorator.ts
+++ b/src/common/data-store/cachable-action-decorator.ts
@@ -2,7 +2,7 @@ import cacheAction from './cache-action';
 import isActionOptions from './is-action-options';
 
 export default function cachableActionDecorator<TMethod extends (...args: any[]) => any>(
-    target: object,
+    _: object,
     key: string,
     descriptor: TypedPropertyDescriptor<TMethod>
 ): TypedPropertyDescriptor<TMethod> {

--- a/src/common/data-store/cache-action.spec.ts
+++ b/src/common/data-store/cache-action.spec.ts
@@ -42,7 +42,7 @@ describe('cacheAction()', () => {
     it('returns thunk action that emits cached value', async () => {
         const getMessage = jest.fn(() => Promise.resolve(createAction('GET_MESSAGE', 'Hello world')));
         const subscriber = jest.fn();
-        const createCachedAction = cacheAction(() => store => defer(() => getMessage()));
+        const createCachedAction = cacheAction(() => _ => defer(() => getMessage()));
         const store = createDataStore(state => state);
 
         createCachedAction()(store).subscribe(subscriber);
@@ -58,7 +58,7 @@ describe('cacheAction()', () => {
     it('caches emitted values from thunk action based on parameters', async () => {
         const getMessage = jest.fn(name => Promise.resolve(createAction('GET_MESSAGE', `Hello ${name}`)));
         const subscriber = jest.fn();
-        const createCachedAction = cacheAction(name => store => defer(() => getMessage(name)));
+        const createCachedAction = cacheAction(name => _ => defer(() => getMessage(name)));
         const store = createDataStore(state => state);
 
         createCachedAction('Foo')(store).subscribe(subscriber);

--- a/src/common/utility/bind-decorator.ts
+++ b/src/common/utility/bind-decorator.ts
@@ -40,7 +40,7 @@ export function bindClassDecorator<T extends Constructor<object>>(target: T): T 
 /**
  * Decorates a method by binding it to the calling instance.
  */
-export function bindMethodDecorator<T extends Method>(target: object, key: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> {
+export function bindMethodDecorator<T extends Method>(_: object, key: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> {
     if (typeof descriptor.value !== 'function') {
         return descriptor;
     }

--- a/src/common/utility/cancellable-promise.ts
+++ b/src/common/utility/cancellable-promise.ts
@@ -3,7 +3,7 @@ export default class CancellablePromise<T> {
     cancel!: (reason?: any) => void;
 
     constructor(promise: Promise<T>) {
-        const cancellable = new Promise<T>((resolve, reject) => {
+        const cancellable = new Promise<T>((_, reject) => {
             this.cancel = reject;
         });
 

--- a/src/common/utility/clone-decorator.ts
+++ b/src/common/utility/clone-decorator.ts
@@ -31,7 +31,7 @@ export function cloneClassDecorator<T extends Constructor<object>>(target: T): T
     return decoratedTarget;
 }
 
-export function cloneMethodDecorator<T extends Method>(target: object, key: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> {
+export function cloneMethodDecorator<T extends Method>(_: object, key: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> {
     if (typeof descriptor.value !== 'function') {
         return descriptor;
     }

--- a/src/common/utility/omit-deep.spec.ts
+++ b/src/common/utility/omit-deep.spec.ts
@@ -19,6 +19,6 @@ describe('omitDeep()', () => {
             ],
         };
 
-        expect(omitDeep(object, (value, key) => key === '$$key')).toEqual(expected);
+        expect(omitDeep(object, (_, key) => key === '$$key')).toEqual(expected);
     });
 });

--- a/src/common/utility/omit-private.ts
+++ b/src/common/utility/omit-private.ts
@@ -2,5 +2,5 @@ import isPrivate from './is-private';
 import omitDeep from './omit-deep';
 
 export default function omitPrivate(object: any): any {
-    return omitDeep(object, (value: any, key: string) => isPrivate(key));
+    return omitDeep(object, (_: any, key: string) => isPrivate(key));
 }

--- a/src/customer/strategies/amazon/amazon-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon/amazon-pay-customer-strategy.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../payment/strategies/amazon-pay';
 import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { getRemoteTokenResponseBody } from '../../../remote-checkout/remote-checkout.mock';
+import CustomerStrategy from '../customer-strategy';
 
 import AmazonPayCustomerStrategy from './amazon-pay-customer-strategy';
 
@@ -32,7 +33,7 @@ describe('AmazonPayCustomerStrategy', () => {
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let remoteCheckoutRequestSender: RemoteCheckoutRequestSender;
     let scriptLoader: AmazonPayScriptLoader;
-    let strategy: AmazonPayCustomerStrategy;
+    let strategy: CustomerStrategy;
     let state: CheckoutStoreState;
     let store: CheckoutStore;
 
@@ -45,7 +46,7 @@ describe('AmazonPayCustomerStrategy', () => {
             const element = document.getElementById(container);
 
             if (element) {
-                element.addEventListener('authorize', event => {
+                element.addEventListener('authorize', _ => {
                     if (options.authorization) {
                         options.authorization();
                     }
@@ -87,7 +88,7 @@ describe('AmazonPayCustomerStrategy', () => {
         container.setAttribute('id', 'login');
         document.body.appendChild(container);
 
-        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((method, onReady) => {
+        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((_, onReady) => {
             hostWindow.OffAmazonPayments = { Button: MockLoginButton } as any;
             hostWindow.amazon = { Login: MockLogin };
 

--- a/src/customer/strategies/amazon/amazon-pay-customer-strategy.ts
+++ b/src/customer/strategies/amazon/amazon-pay-customer-strategy.ts
@@ -3,7 +3,6 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplem
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { AmazonPayLoginButton, AmazonPayScriptLoader, AmazonPayWindow } from '../../../payment/strategies/amazon-pay';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
-import CustomerCredentials from '../../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
@@ -57,13 +56,13 @@ export default class AmazonPayCustomerStrategy implements CustomerStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         this._paymentMethod = undefined;
 
         return Promise.resolve(this._store.getState());
     }
 
-    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    signIn(): Promise<InternalCheckoutSelectors> {
         throw new NotImplementedError(
             'In order to sign in via AmazonPay, the shopper must click on "Login with Amazon" button.'
         );

--- a/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
@@ -157,7 +157,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         });
 
         it('registers the error and success callbacks', async () => {
-            visaCheckoutSDK.on = jest.fn((type, callback) => callback());
+            visaCheckoutSDK.on = jest.fn((_, callback) => callback());
             await strategy.initialize(visaCheckoutOptions);
 
             expect(visaCheckoutSDK.on).toHaveBeenCalledWith('payment.success', expect.any(Function));

--- a/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
+++ b/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
@@ -4,7 +4,6 @@ import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { BraintreeVisaCheckoutPaymentProcessor, VisaCheckoutScriptLoader } from '../../../payment/strategies/braintree';
 import { VisaCheckoutPaymentSuccessPayload } from '../../../payment/strategies/braintree/visacheckout';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
-import CustomerCredentials from '../../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategyActionCreator from '../../customer-strategy-action-creator';
 import CustomerStrategy from '../customer-strategy';
@@ -73,7 +72,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
                         this._paymentInstrumentSelected(paymentSuccessPayload)
                             .catch(error => onError(error))
                     );
-                    visaCheckout.on('payment.error', (payment, error) => onError(error));
+                    visaCheckout.on('payment.error', (_, error) => onError(error));
 
                     return signInButton;
                 })
@@ -82,7 +81,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
             .then(() => this._store.getState());
     }
 
-    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    signIn(): Promise<InternalCheckoutSelectors> {
         throw new NotImplementedError(
             'In order to sign in via VisaCheckout, the shopper must click on "Visa Checkout" button.'
         );
@@ -94,7 +93,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
         );
     }
 
-    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         this._paymentMethod = undefined;
 
         return this._braintreeVisaCheckoutPaymentProcessor.deinitialize()

--- a/src/customer/strategies/chasepay/chasepay-customer-strategy.spec.ts
+++ b/src/customer/strategies/chasepay/chasepay-customer-strategy.spec.ts
@@ -175,7 +175,7 @@ describe('ChasePayCustomerStrategy', () => {
         });
 
         it('registers the start and complete callbacks', async () => {
-            JPMC.ChasePay.on = jest.fn((type, callback) => callback);
+            JPMC.ChasePay.on = jest.fn((_, callback) => callback);
 
             await strategy.initialize(chasePayOptions);
 

--- a/src/customer/strategies/chasepay/chasepay-customer-strategy.ts
+++ b/src/customer/strategies/chasepay/chasepay-customer-strategy.ts
@@ -6,7 +6,6 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplem
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { ChasePayScriptLoader, ChasePaySuccessPayload } from '../../../payment/strategies/chasepay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
-import CustomerCredentials from '../../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
@@ -94,11 +93,11 @@ export default class ChasePayCustomerStrategy implements CustomerStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    signIn(): Promise<InternalCheckoutSelectors> {
         throw new NotImplementedError(
             'In order to sign in via Chase Pay®, the shopper must click on "Chase Pay®" button.'
         );

--- a/src/customer/strategies/default/default-customer-strategy.ts
+++ b/src/customer/strategies/default/default-customer-strategy.ts
@@ -1,7 +1,7 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import CustomerActionCreator from '../../customer-action-creator';
 import CustomerCredentials from '../../customer-credentials';
-import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
+import { CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
 export default class DefaultCustomerStrategy implements CustomerStrategy {
@@ -22,11 +22,11 @@ export default class DefaultCustomerStrategy implements CustomerStrategy {
         );
     }
 
-    initialize(options?: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
@@ -15,6 +15,7 @@ import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { CustomerInitializeOptions } from '../../customer-request-options';
 import { getCustomerState } from '../../customers.mock';
+import CustomerStrategy from '../customer-strategy';
 
 import { getBraintreeCustomerInitializeOptions, Mode } from './googlepay-customer-mock';
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
@@ -28,7 +29,7 @@ describe('GooglePayCustomerStrategy', () => {
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
     let store: CheckoutStore;
-    let strategy: GooglePayCustomerStrategy;
+    let strategy: CustomerStrategy;
     let walletButton: HTMLAnchorElement;
 
     beforeEach(() => {
@@ -185,7 +186,6 @@ describe('GooglePayCustomerStrategy', () => {
     });
 
     describe('#signIn()', () => {
-
         it('throws error if trying to sign in programmatically', async () => {
             customerInitializeOptions = getBraintreeCustomerInitializeOptions();
 

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -5,7 +5,6 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplem
 import { bindDecorator as bind } from '../../../common/utility';
 import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
-import CustomerCredentials from '../../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
@@ -37,7 +36,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         if (this._walletButton && this._walletButton.parentNode) {
             this._walletButton.parentNode.removeChild(this._walletButton);
             this._walletButton = undefined;
@@ -47,7 +46,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             .then(() => this._store.getState());
     }
 
-    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    signIn(): Promise<InternalCheckoutSelectors> {
         throw new NotImplementedError(
             'In order to sign in via Google Pay, the shopper must click on "Google Pay" button.'
         );

--- a/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
@@ -13,6 +13,7 @@ import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { CustomerInitializeOptions } from '../../customer-request-options';
 import { getCustomerState } from '../../customers.mock';
+import CustomerStrategy from '../customer-strategy';
 
 import { getStripeCustomerInitializeOptions, Mode } from './googlepay-customer-mock';
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
@@ -26,7 +27,7 @@ describe('GooglePayCustomerStrategy', () => {
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
     let store: CheckoutStore;
-    let strategy: GooglePayCustomerStrategy;
+    let strategy: CustomerStrategy;
     let walletButton: HTMLAnchorElement;
 
     beforeEach(() => {

--- a/src/customer/strategies/masterpass/masterpass-customer-strategy.ts
+++ b/src/customer/strategies/masterpass/masterpass-customer-strategy.ts
@@ -8,7 +8,6 @@ import {
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { getCallbackUrl, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
-import CustomerCredentials from '../../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
@@ -67,7 +66,7 @@ export default class MasterpassCustomerStrategy implements CustomerStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         this._paymentMethod = undefined;
 
         if (this._signInButton && this._signInButton.parentNode) {
@@ -78,7 +77,7 @@ export default class MasterpassCustomerStrategy implements CustomerStrategy {
         return Promise.resolve(this._store.getState());
     }
 
-    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    signIn(): Promise<InternalCheckoutSelectors> {
         throw new NotImplementedError(
             'In order to sign in via Masterpass, the shopper must click on "Masterpass" button.'
         );

--- a/src/customer/strategies/square/square-customer-strategy.ts
+++ b/src/customer/strategies/square/square-customer-strategy.ts
@@ -1,8 +1,7 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { NotImplementedError } from '../../../common/error/errors';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
-import CustomerCredentials from '../../customer-credentials';
-import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
+import { CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
 export default class SquareCustomerStrategy implements CustomerStrategy {
@@ -12,7 +11,7 @@ export default class SquareCustomerStrategy implements CustomerStrategy {
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator
     ) {}
 
-    signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    signIn(): Promise<InternalCheckoutSelectors> {
         throw new NotImplementedError(
             'In order to sign in via Masterpass, the shopper must click on "Masterpass" button.'
         );
@@ -31,11 +30,11 @@ export default class SquareCustomerStrategy implements CustomerStrategy {
         );
     }
 
-    initialize(options?: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/src/embedded-checkout/resizable-iframe-creator.spec.ts
+++ b/src/embedded-checkout/resizable-iframe-creator.spec.ts
@@ -6,7 +6,7 @@ import { NotEmbeddableError } from './errors';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
 jest.mock('iframe-resizer', () => ({
-    iframeResizer: jest.fn((options: IFrameOptions, element: HTMLIFrameElement) => {
+    iframeResizer: jest.fn((_: IFrameOptions, element: HTMLIFrameElement) => {
         (element as IFrameComponent).iFrameResizer = {} as IFrameObject;
 
         return [element];

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -2,7 +2,7 @@ import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-
 import { concat, defer, empty, from, of, Observable, Observer } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 
-import { CheckoutValidator, InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
+import { CheckoutValidator, InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -354,9 +354,7 @@ export default function createPaymentStrategyRegistry(
             paymentMethodActionCreator,
             paymentActionCreator,
             orderActionCreator,
-            new StripeScriptLoader(scriptLoader),
-            paymentRequestSender,
-            paymentRequestTransformer
+            new StripeScriptLoader(scriptLoader)
         )
     );
 

--- a/src/payment/instrument/instrument-request-sender.spec.ts
+++ b/src/payment/instrument/instrument-request-sender.spec.ts
@@ -30,10 +30,10 @@ describe('InstrumentRequestSender', () => {
         requestSender = createRequestSender();
 
         client = {
-            getVaultAccessToken: jest.fn((payload, callback) => callback()),
-            loadInstruments: jest.fn((payload, callback) => callback()),
-            loadInstrumentsWithAddress: jest.fn((payload, callback) => callback()),
-            deleteShopperInstrument: jest.fn((payload, callback) => callback()),
+            getVaultAccessToken: jest.fn((_, callback) => callback()),
+            loadInstruments: jest.fn((_, callback) => callback()),
+            loadInstrumentsWithAddress: jest.fn((_, callback) => callback()),
+            deleteShopperInstrument: jest.fn((_, callback) => callback()),
         };
 
         jest.spyOn(requestSender, 'get').mockReturnValue(Promise.resolve());
@@ -78,7 +78,7 @@ describe('InstrumentRequestSender', () => {
 
     describe('#loadInstruments()', () => {
         it('returns instruments if request is successful', async () => {
-            client.loadInstruments = jest.fn((payload, callback) => callback(null,
+            client.loadInstruments = jest.fn((_, callback) => callback(null,
                 getPaymentResponse(getInternalInstrumentsResponseBody())
             ));
 
@@ -96,7 +96,7 @@ describe('InstrumentRequestSender', () => {
         });
 
         it('returns error response if request is unsuccessful', async () => {
-            client.loadInstruments = jest.fn((payload, callback) => callback(
+            client.loadInstruments = jest.fn((_, callback) => callback(
                 getPaymentResponse(getErrorInstrumentResponseBody(), {}, 400, 'Bad Request')
             ));
 
@@ -109,7 +109,7 @@ describe('InstrumentRequestSender', () => {
         });
 
         it('returns loads trusted instruments if shipping address is available', async () => {
-            client.loadInstrumentsWithAddress = jest.fn((payload, callback) => callback(null,
+            client.loadInstrumentsWithAddress = jest.fn((_, callback) => callback(null,
                 getPaymentResponse(getInternalInstrumentsResponseBody())
             ));
 
@@ -128,7 +128,7 @@ describe('InstrumentRequestSender', () => {
         });
 
         it('returns error response if request is unsuccessful when passing shipping address', async () => {
-            client.loadInstrumentsWithAddress = jest.fn((payload, callback) => callback(
+            client.loadInstrumentsWithAddress = jest.fn((_, callback) => callback(
                 getPaymentResponse(getErrorInstrumentResponseBody(), {}, 400, 'Bad Request')
             ));
 
@@ -143,7 +143,7 @@ describe('InstrumentRequestSender', () => {
 
     describe('#deleteInstrument()', () => {
         it('deletes an instrument if request is successful', async () => {
-            client.deleteShopperInstrument = jest.fn((payload, callback) => callback(null,
+            client.deleteShopperInstrument = jest.fn((_, callback) => callback(null,
                 getPaymentResponse(deleteInstrumentResponseBody())
             ));
 
@@ -158,7 +158,7 @@ describe('InstrumentRequestSender', () => {
         });
 
         it('returns error response if request is unsuccessful', async () => {
-            client.deleteShopperInstrument = jest.fn((payload, callback) => callback(
+            client.deleteShopperInstrument = jest.fn((_, callback) => callback(
                 getPaymentResponse(getErrorInstrumentResponseBody(), {}, 400, 'Bad Request')
             ));
 

--- a/src/payment/payment-request-sender.spec.ts
+++ b/src/payment/payment-request-sender.spec.ts
@@ -8,7 +8,7 @@ describe('PaymentRequestSender', () => {
     describe('#submitPayment()', () => {
         beforeEach(() => {
             bigpayClient = {
-                submitPayment: jest.fn((payload, callback) => callback(null, {
+                submitPayment: jest.fn((_, callback) => callback(null, {
                     data: getPaymentResponseBody(),
                     status: 200,
                     statusText: 'OK',
@@ -37,7 +37,7 @@ describe('PaymentRequestSender', () => {
         });
 
         it('returns error response if submission is unsuccessful', async () => {
-            bigpayClient.submitPayment = jest.fn((payload, callback) => callback({
+            bigpayClient.submitPayment = jest.fn((_, callback) => callback({
                 data: getErrorPaymentResponseBody(),
                 status: 400,
                 statusText: 'Bad Request',

--- a/src/payment/payment-strategy-action-creator.ts
+++ b/src/payment/payment-strategy-action-creator.ts
@@ -1,5 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { concat, defer, empty, from, of, Observable, Observer } from 'rxjs';
+import { concat, defer, empty, of, Observable, Observer } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
@@ -150,7 +150,7 @@ export default class PaymentStrategyActionCreator {
     }
 
     widgetInteraction(method: () => Promise<any>, options?: PaymentRequestOptions): ThunkAction<PaymentStrategyWidgetAction> {
-        return store => Observable.create((observer: Observer<PaymentStrategyWidgetAction>) => {
+        return () => Observable.create((observer: Observer<PaymentStrategyWidgetAction>) => {
             const methodId = options && options.methodId;
             const meta = { methodId };
 

--- a/src/payment/payment-strategy-registry.spec.ts
+++ b/src/payment/payment-strategy-registry.spec.ts
@@ -1,10 +1,8 @@
 import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../checkout';
 import { getConfigState } from '../config/configs.mock';
-import { OrderRequestBody } from '../order';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 
 import { getAdyenAmex, getAmazonPay, getBankDeposit, getBraintree, getBraintreePaypal, getCybersource } from './payment-methods.mock';
-import { PaymentInitializeOptions, PaymentRequestOptions } from './payment-request-options';
 import PaymentStrategyRegistry from './payment-strategy-registry';
 import PaymentStrategyType from './payment-strategy-type';
 import { PaymentStrategy } from './strategies';
@@ -18,19 +16,19 @@ describe('PaymentStrategyRegistry', () => {
             private _store: CheckoutStore
         ) {}
 
-        execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        execute(): Promise<InternalCheckoutSelectors> {
             return Promise.resolve(this._store.getState());
         }
 
-        finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        finalize(): Promise<InternalCheckoutSelectors> {
             return Promise.reject(new OrderFinalizationNotRequiredError());
         }
 
-        initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        initialize(): Promise<InternalCheckoutSelectors> {
             return Promise.resolve(this._store.getState());
         }
 
-        deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        deinitialize(): Promise<InternalCheckoutSelectors> {
             return Promise.resolve(this._store.getState());
         }
     }

--- a/src/payment/payments.mock.ts
+++ b/src/payment/payments.mock.ts
@@ -10,7 +10,7 @@ import { getConsignments } from '../shipping/consignments.mock';
 import { getFlatRateOption } from '../shipping/internal-shipping-options.mock';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 
-import Payment, { CreditCardInstrument, ThreeDSVaultedInstrument, VaultedInstrument } from './payment';
+import Payment, { CreditCardInstrument, VaultedInstrument } from './payment';
 import { getAuthorizenet, getPaymentMethodsMeta } from './payment-methods.mock';
 import PaymentRequestBody from './payment-request-body';
 import PaymentResponseBody from './payment-response-body';

--- a/src/payment/strategies/affirm/affirm-payment-strategy.ts
+++ b/src/payment/strategies/affirm/affirm-payment-strategy.ts
@@ -95,7 +95,7 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             });
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         if (this._affirm) {
             this._affirm = undefined;
         }
@@ -103,7 +103,7 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
         return Promise.resolve(this._store.getState());
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
@@ -42,7 +42,7 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         if (this._afterpaySdk) {
             this._afterpaySdk = undefined;
         }

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -150,14 +150,14 @@ describe('AmazonPayPaymentStrategy', () => {
         container.setAttribute('id', 'wallet');
         document.body.appendChild(container);
 
-        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((method, onReady) => {
+        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((_, onReady) => {
             hostWindow.OffAmazonPayments = {
                 Button: {} as AmazonPayLoginButtonConstructor,
                 Widgets: {
                     AddressBook: {} as AmazonPayAddressBookConstructor,
                     Wallet: MockWallet,
                 },
-                initConfirmationFlow: jest.fn((sellerId, referenceId, confirmationFlow) => {}),
+                initConfirmationFlow: jest.fn(() => {}),
             } as OffAmazonPayments;
 
             onReady();
@@ -531,7 +531,7 @@ describe('AmazonPayPaymentStrategy', () => {
 
         it('redirects to confirmation flow success when support 3ds', async () => {
             if (hostWindow.OffAmazonPayments) {
-                hostWindow.OffAmazonPayments.initConfirmationFlow = jest.fn((sellerId, referenceId, callback) => {
+                hostWindow.OffAmazonPayments.initConfirmationFlow = jest.fn((_sellerId, _referenceId, callback) => {
                     callback(amazonConfirmationFlow);
                 });
 
@@ -551,7 +551,7 @@ describe('AmazonPayPaymentStrategy', () => {
                         throw new StandardError('error');
                     });
 
-                hostWindow.OffAmazonPayments.initConfirmationFlow = jest.fn((sellerId, referenceId, callback) => {
+                hostWindow.OffAmazonPayments.initConfirmationFlow = jest.fn((_sellerId, _referenceId, callback) => {
                     callback(amazonConfirmationFlow).catch((error: StandardError) => {
                         expect(error).toBeInstanceOf(StandardError);
                     });

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -74,7 +74,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         this._walletOptions = undefined;
 
         return Promise.resolve(this._store.getState());
@@ -123,7 +123,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
             });
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
@@ -235,7 +235,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
     }
 
     private _processPaymentWith3ds(sellerId: string, referenceId: string, methodId: string, useStoreCredit: boolean, options: PaymentRequestOptions): Promise<never> {
-        return new Promise((resolve, reject) => {
+        return new Promise((_, reject) => {
             if (!this._window.OffAmazonPayments) {
                 return reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
             }

--- a/src/payment/strategies/amazon-pay/amazon-pay-script-loader.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-script-loader.spec.ts
@@ -3,7 +3,7 @@ import { merge } from 'lodash';
 
 import { getAmazonPay } from '../../payment-methods.mock';
 
-import AmazonPayLogin, { AmazonPayLoginOptions } from './amazon-pay-login';
+import AmazonPayLogin from './amazon-pay-login';
 import AmazonPayScriptLoader from './amazon-pay-script-loader';
 import AmazonPayWindow from './amazon-pay-window';
 
@@ -15,7 +15,7 @@ describe('AmazonPayScriptLoader', () => {
     let setUseCookieSpy: jest.Mock;
 
     const MockLogin: AmazonPayLogin = {
-        authorize(options: AmazonPayLoginOptions, redirectUrl: string): void {},
+        authorize(): void {},
 
         setClientId(clientId: string): void {
             setClientIdSpy(clientId);

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -62,11 +62,11 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
             .catch((error: Error) => this._handleError(error));
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return this._braintreePaymentProcessor.deinitialize()
             .then(() => this._store.getState());
     }

--- a/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -78,7 +78,7 @@ describe('BraintreePaymentProcessor', () => {
             braintreePaymentProcessor.initialize('clientToken', {
                 threeDSecure: {
                     ...getThreeDSecureOptionsMock(),
-                    addFrame: (error, iframe, cancel) => {
+                    addFrame: (_error, _iframe, cancel) => {
                         cancelVerifyCard = cancel;
                     },
                 },

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -17,6 +17,7 @@ import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentMethodActionType } from '../../payment-method-actions';
 import { getBraintreePaypal } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
 
 import BraintreePaymentProcessor from './braintree-payment-processor';
 import BraintreePaypalPaymentStrategy from './braintree-paypal-payment-strategy';
@@ -26,7 +27,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
     let paymentActionCreator: PaymentActionCreator;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
     let braintreePaymentProcessorMock: BraintreePaymentProcessor;
-    let braintreePaypalPaymentStrategy: BraintreePaypalPaymentStrategy;
+    let braintreePaypalPaymentStrategy: PaymentStrategy;
     let paymentMethodMock: PaymentMethod;
     let loadPaymentMethodAction: Observable<Action>;
     let store: CheckoutStore;

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -64,11 +64,11 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             .catch((error: Error) => this._handleError(error));
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    deinitialize(options: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return this._braintreePaymentProcessor.deinitialize()
             .then(() => this._store.getState());
     }

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -164,7 +164,7 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
         });
 
         it('registers the error and success callbacks', async () => {
-            visaCheckoutSDK.on = jest.fn((type, callback) => callback());
+            visaCheckoutSDK.on = jest.fn((_, callback) => callback());
             await strategy.initialize(visaCheckoutOptions);
 
             expect(visaCheckoutSDK.on).toHaveBeenCalledWith('payment.success', expect.any(Function));

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
@@ -76,7 +76,7 @@ export default class BraintreeVisaCheckoutPaymentStrategy implements PaymentStra
                             .then(() => onPaymentSelect())
                             .catch(error => onError(error))
                     );
-                    visaCheckout.on('payment.error', (payment, error) => onError(error));
+                    visaCheckout.on('payment.error', (_, error) => onError(error));
                 });
             })
             .then(() => this._store.getState());
@@ -102,11 +102,11 @@ export default class BraintreeVisaCheckoutPaymentStrategy implements PaymentStra
             .catch((error: Error) => this._handleError(error));
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return this._braintreeVisaCheckoutPaymentProcessor.deinitialize()
             .then(() => this._store.getState());
     }

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
@@ -185,7 +185,7 @@ describe('ChasePayPaymentStrategy', () => {
         });
 
         it('registers the start and complete callbacks', async () => {
-            JPMC.ChasePay.on = jest.fn((type, callback) => callback);
+            JPMC.ChasePay.on = jest.fn((_, callback) => callback);
 
             await strategy.initialize(chasePayOptions);
 
@@ -199,7 +199,7 @@ describe('ChasePayPaymentStrategy', () => {
 
             jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
 
-            JPMC.ChasePay.on = jest.fn((type, callback) => callback(payload));
+            JPMC.ChasePay.on = jest.fn((_, callback) => callback(payload));
 
             await strategy.initialize(chasePayOptions);
 
@@ -208,7 +208,7 @@ describe('ChasePayPaymentStrategy', () => {
         });
 
         it('registers the start and cancel callbacks', async () => {
-            JPMC.ChasePay.on = jest.fn((type, callback) => callback);
+            JPMC.ChasePay.on = jest.fn((_, callback) => callback);
 
             await strategy.initialize(chasePayOptions);
 

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
@@ -58,7 +58,7 @@ export default class ChasePayPaymentStrategy implements PaymentStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         if (this._walletButton) {
             this._walletButton.removeEventListener('click', this._handleWalletButtonClick);
         }
@@ -84,7 +84,7 @@ export default class ChasePayPaymentStrategy implements PaymentStrategy {
             );
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 

--- a/src/payment/strategies/converge/converge-payment-strategy.spec.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.spec.ts
@@ -59,7 +59,7 @@ describe('ConvergeaymentStrategy', () => {
         jest.spyOn(store, 'dispatch');
 
         jest.spyOn(formPoster, 'postForm')
-            .mockImplementation((url, data, callback = () => {}) => callback());
+            .mockImplementation((_url, _data, callback = () => {}) => callback());
 
         jest.spyOn(orderActionCreator, 'finalizeOrder')
             .mockReturnValue(finalizeOrderAction);

--- a/src/payment/strategies/converge/converge-payment-strategy.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.ts
@@ -7,7 +7,7 @@ import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentRequestOptions } from '../../payment-request-options';
 import * as paymentStatusTypes from '../../payment-status-types';
 import PaymentStrategy from '../payment-strategy';
 
@@ -57,11 +57,11 @@ export default class ConvergePaymentStrategy implements PaymentStrategy {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.ts
@@ -27,15 +27,15 @@ export default class CreditCardPaymentStrategy implements PaymentStrategy {
             );
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(_options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/cybersource/cardinal-client.ts
+++ b/src/payment/strategies/cybersource/cardinal-client.ts
@@ -106,7 +106,7 @@ export default class CardinalClient {
         return this._getClientSDK()
             .then(client => {
                 return new Promise<ThreeDSecureToken>((resolve, reject) => {
-                    client.on(CardinalEventType.Validated, (data: CardinalValidatedData, jwt: string) => {
+                    client.on(CardinalEventType.Validated, (_: CardinalValidatedData, jwt: string) => {
                         client.off(CardinalEventType.Validated);
                         if (!jwt) {
                             reject(new StandardError('User failed authentication or an error was encountered while processing the transaction.'));

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
@@ -10,7 +10,7 @@ import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '.
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import isCreditCardLike from '../../is-credit-card-like';
 import isVaultedInstrument from '../../is-vaulted-instrument';
-import { CreditCardInstrument, VaultedInstrument } from '../../payment';
+import { CreditCardInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
@@ -66,11 +66,11 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
             this._placeOrder(order, payment, options);
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
@@ -92,7 +92,7 @@ describe('GooglePayPaymentProcessor', () => {
             const googlePaySDK = getGooglePaySDKMock();
             clientMock = {
                 isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
-                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                loadPaymentData: jest.fn(() => Promise.resolve(googlePaymentDataMock)),
                 createButton: jest.fn(() => Promise.resolve(new HTMLElement())),
             };
             googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
@@ -173,7 +173,7 @@ describe('GooglePayPaymentProcessor', () => {
             const googlePaySDK = getGooglePaySDKMock();
             clientMock = {
                 isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
-                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                loadPaymentData: jest.fn(() => Promise.resolve(googlePaymentDataMock)),
                 createButton: jest.fn(() => Promise.resolve()),
             };
             googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
@@ -225,7 +225,7 @@ describe('GooglePayPaymentProcessor', () => {
             const googlePaySDK = getGooglePaySDKMock();
             clientMock = {
                 isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
-                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                loadPaymentData: jest.fn(() => Promise.resolve(googlePaymentDataMock)),
                 createButton: jest.fn(() => Promise.resolve(new HTMLElement())),
             };
             googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
@@ -302,7 +302,7 @@ describe('GooglePayPaymentProcessor', () => {
         it('displays wallet properly', async () => {
             clientMock = {
                 isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
-                loadPaymentData: jest.fn((a: any) => Promise.resolve(googlePaymentDataMock)),
+                loadPaymentData: jest.fn(() => Promise.resolve(googlePaymentDataMock)),
                 createButton: jest.fn(() => Promise.resolve()),
             };
             googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);
@@ -331,7 +331,7 @@ describe('GooglePayPaymentProcessor', () => {
             };
             clientMock = {
                 isReadyToPay: jest.fn(() => Promise.resolve(googlePayIsReadyToPayResponse)),
-                loadPaymentData: jest.fn((a: any) => Promise.reject(googlePayError)),
+                loadPaymentData: jest.fn(() => Promise.reject(googlePayError)),
                 createButton: jest.fn(() => Promise.resolve()),
             };
             googlePaySDK.payments.api.PaymentsClient = jest.fn(() => clientMock);

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -57,7 +57,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             });
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         if (this._walletButton) {
             this._walletButton.removeEventListener('click', this._handleWalletButtonClick);
         }
@@ -95,13 +95,13 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
                 return payment;
             })
-            .then(payment =>
+            .then(() =>
                 this._store.dispatch(this._orderActionCreator.submitOrder({ useStoreCredit: payload.useStoreCredit }, options))
                     .then(() => this._store.dispatch(this._paymentActionCreator.submitPayment(this._getPayment())))
             );
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 

--- a/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
@@ -75,9 +75,9 @@ describe('KlarnaPaymentStrategy', () => {
         );
 
         klarnaCredit = {
-            authorize: jest.fn((data, callback) => callback({ approved: true, authorization_token: 'bar' })),
+            authorize: jest.fn((_, callback) => callback({ approved: true, authorization_token: 'bar' })),
             init: jest.fn(() => {}),
-            load: jest.fn((options, callback) => callback({ show_form: true })),
+            load: jest.fn((_, callback) => callback({ show_form: true })),
         };
 
         paymentMethod = getKlarna();
@@ -235,7 +235,7 @@ describe('KlarnaPaymentStrategy', () => {
         describe('when klarna authorization is not approved', () => {
             beforeEach(() => {
                 klarnaCredit.authorize = jest.fn(
-                    (params, callback) => callback({ approved: false, show_form: true })
+                    (_, callback) => callback({ approved: false, show_form: true })
                 );
             });
 
@@ -255,7 +255,7 @@ describe('KlarnaPaymentStrategy', () => {
         describe('when klarna authorization fails', () => {
             beforeEach(() => {
                 klarnaCredit.authorize = jest.fn(
-                    (params, callback) => callback({ approved: false })
+                    (_, callback) => callback({ approved: false })
                 );
             });
 

--- a/src/payment/strategies/klarna/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.ts
@@ -57,7 +57,7 @@ export default class KlarnaPaymentStrategy implements PaymentStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         if (this._unsubscribe) {
             this._unsubscribe();
         }
@@ -87,7 +87,7 @@ export default class KlarnaPaymentStrategy implements PaymentStrategy {
             ));
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
@@ -99,7 +99,7 @@ export default class KlarnaPaymentStrategy implements PaymentStrategy {
         const { methodId, klarna: { container, onLoad } } = options;
 
         return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
-            .then(state => new Promise<KlarnaLoadResponse>((resolve, reject) => {
+            .then(state => new Promise<KlarnaLoadResponse>(resolve => {
                 const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
 
                 if (!paymentMethod) {

--- a/src/payment/strategies/legacy/legacy-payment-strategy.ts
+++ b/src/payment/strategies/legacy/legacy-payment-strategy.ts
@@ -1,7 +1,7 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
 export default class LegacyPaymentStrategy implements PaymentStrategy {
@@ -14,15 +14,15 @@ export default class LegacyPaymentStrategy implements PaymentStrategy {
         return this._store.dispatch(this._orderActionCreator.submitOrder(payload, options));
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.ts
@@ -52,7 +52,7 @@ export default class MasterpassPaymentStrategy implements PaymentStrategy {
             });
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         this._paymentMethod = undefined;
 
         if (this._walletButton) {
@@ -89,7 +89,7 @@ export default class MasterpassPaymentStrategy implements PaymentStrategy {
             .then(() => this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData })));
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 

--- a/src/payment/strategies/no-payment/no-payment-data-required-strategy.ts
+++ b/src/payment/strategies/no-payment/no-payment-data-required-strategy.ts
@@ -3,7 +3,7 @@ import { omit } from 'lodash';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
 export default class NoPaymentDataRequiredPaymentStrategy implements PaymentStrategy {
@@ -18,15 +18,15 @@ export default class NoPaymentDataRequiredPaymentStrategy implements PaymentStra
         );
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/offline/offline-payment-strategy.ts
+++ b/src/payment/strategies/offline/offline-payment-strategy.ts
@@ -1,7 +1,7 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
 export default class OfflinePaymentStrategy implements PaymentStrategy {
@@ -19,15 +19,15 @@ export default class OfflinePaymentStrategy implements PaymentStrategy {
         return this._store.dispatch(action);
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/offsite/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.ts
@@ -3,7 +3,7 @@ import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '.
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentRequestOptions } from '../../payment-request-options';
 import * as paymentStatusTypes from '../../payment-status-types';
 import PaymentStrategy from '../payment-strategy';
 
@@ -40,11 +40,11 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 

--- a/src/payment/strategies/paypal/paypal-pro-payment-strategy.ts
+++ b/src/payment/strategies/paypal/paypal-pro-payment-strategy.ts
@@ -3,7 +3,7 @@ import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentRequestOptions } from '../../payment-request-options';
 import * as paymentStatusTypes from '../../payment-status-types';
 import PaymentStrategy from '../payment-strategy';
 
@@ -37,15 +37,15 @@ export default class PaypalProPaymentStrategy implements PaymentStrategy {
             );
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 

--- a/src/payment/strategies/sage-pay/sage-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/sage-pay/sage-pay-payment-strategy.spec.ts
@@ -59,7 +59,7 @@ describe('SagePayPaymentStrategy', () => {
         jest.spyOn(store, 'dispatch');
 
         jest.spyOn(formPoster, 'postForm')
-            .mockImplementation((url, data, callback = () => {}) => callback());
+            .mockImplementation((_url, _data, callback = () => {}) => callback());
 
         jest.spyOn(orderActionCreator, 'finalizeOrder')
             .mockReturnValue(finalizeOrderAction);

--- a/src/payment/strategies/sage-pay/sage-pay-payment-strategy.ts
+++ b/src/payment/strategies/sage-pay/sage-pay-payment-strategy.ts
@@ -6,7 +6,7 @@ import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentRequestOptions } from '../../payment-request-options';
 import * as paymentStatusTypes from '../../payment-status-types';
 import PaymentStrategy from '../payment-strategy';
 
@@ -56,11 +56,11 @@ export default class SagePayPaymentStrategy implements PaymentStrategy {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -85,11 +85,11 @@ export default class SquarePaymentStrategy implements PaymentStrategy {
                 ));
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -94,9 +94,7 @@ describe('StripeV3PaymentStrategy', () => {
             paymentMethodActionCreator,
             paymentActionCreator,
             orderActionCreator,
-            stripeScriptLoader,
-            paymentRequestSender,
-            paymentRequestTransformer
+            stripeScriptLoader
         );
     });
 

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -18,8 +18,6 @@ import { HostedInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
-import PaymentRequestSender from '../../payment-request-sender';
-import PaymentRequestTransformer from '../../payment-request-transformer';
 import PaymentStrategy from '../payment-strategy';
 
 import {
@@ -42,9 +40,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
         private _orderActionCreator: OrderActionCreator,
-        private _stripeScriptLoader: StripeV3ScriptLoader,
-        private _paymentRequestSender: PaymentRequestSender,
-        private _paymentRequestTransformer: PaymentRequestTransformer
+        private _stripeScriptLoader: StripeV3ScriptLoader
     ) {}
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -137,11 +133,11 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
             });
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         if (this._cardElement) {
             this._cardElement.unmount();
         }

--- a/src/payment/strategies/stripev3/stripev3-script-loader.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-script-loader.spec.ts
@@ -2,7 +2,7 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { StandardError } from '../../../common/error/errors';
 
-import { StripeHostWindow, StripeV3JsOptions } from './stripev3';
+import { StripeHostWindow } from './stripev3';
 import StripeV3ScriptLoader from './stripev3-script-loader';
 import { getStripeV3JsMock } from './stripev3.mock';
 
@@ -22,9 +22,7 @@ describe('StripeV3PayScriptLoader', () => {
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {
-                mockWindow.Stripe = jest.fn(
-                    (publishableKey: string, options: StripeV3JsOptions) => stripeV3JsMock
-                );
+                mockWindow.Stripe = jest.fn(() => stripeV3JsMock);
 
                 return Promise.resolve();
             });

--- a/src/payment/strategies/zip/zip-payment-strategy.ts
+++ b/src/payment/strategies/zip/zip-payment-strategy.ts
@@ -16,7 +16,7 @@ import { PaymentMethodCancelledError, PaymentMethodDeclinedError, PaymentMethodI
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
 import { Zip, ZipModalEvent } from './zip';
@@ -36,7 +36,7 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
         private _requestSender: RequestSender
     ) { }
 
-    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return this._zipScriptLoader.load()
             .then(zip => {
                 this._zipClient = zip;
@@ -45,7 +45,7 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
             });
     }
 
-    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         this._paymentMethod = undefined;
         this._zipClient = undefined;
 
@@ -123,7 +123,7 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
             });
     }
 
-    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 

--- a/src/payment/strategies/zip/zip.mock.ts
+++ b/src/payment/strategies/zip/zip.mock.ts
@@ -57,7 +57,7 @@ export function getZipScriptMock(status: string): Zip {
         Checkout: {
             attachButton: jest.fn(),
             init: jest.fn(payload => {
-                new Promise((resolve, reject) => {
+                new Promise(resolve => {
                     payload.onCheckout(resolve);
                 })
                     .then(() => payload.onComplete(mockZipResponse));

--- a/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.spec.ts
@@ -89,7 +89,7 @@ describe('AmazonPayShippingStrategy', () => {
         container.setAttribute('id', 'addressBook');
         document.body.appendChild(container);
 
-        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((method, onReady) => {
+        jest.spyOn(scriptLoader, 'loadWidget').mockImplementation((_, onReady) => {
             hostWindow.OffAmazonPayments = { Widgets: { AddressBook: MockAddressBook } } as any;
 
             onReady();

--- a/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.ts
+++ b/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.ts
@@ -1,6 +1,6 @@
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 
-import { isInternalAddressEqual, mapFromInternalAddress, AddressRequestBody } from '../../../address';
+import { isInternalAddressEqual, mapFromInternalAddress } from '../../../address';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
@@ -55,13 +55,13 @@ export default class AmazonPayShippingStrategy implements ShippingStrategy {
             .then(() => this._store.getState());
     }
 
-    deinitialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         this._paymentMethod = undefined;
 
         return Promise.resolve(this._store.getState());
     }
 
-    updateAddress(address: AddressRequestBody, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
+    updateAddress(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 

--- a/src/shipping/strategies/default/default-shipping-strategy.ts
+++ b/src/shipping/strategies/default/default-shipping-strategy.ts
@@ -22,11 +22,11 @@ export default class DefaultShippingStrategy implements ShippingStrategy {
         );
     }
 
-    initialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
+    initialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
+    deinitialize(): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
         ],
         "module": "es6",
         "moduleResolution": "node",
+        "noUnusedParameters": true,
+        "noUnusedLocals": true,
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,


### PR DESCRIPTION
## What?
Check to make sure there are no unused locals and parameters.

## Why?
These rules can help us improve the maintainability of the code.

I think we used to check for unused variables using TSLint before, but we have [removed the rule](https://github.com/bigcommerce/tslint-config/pull/16) few months ago and forgot to enable its replacement.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
