### PR TITLE
INT-1811 Cannot place order with CyberSource 3DS

### DIFF
--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
@@ -214,7 +214,7 @@ describe('CyberSourcePaymentStrategy', () => {
                 requestError = new RequestError(getResponse({
                     ...getErrorPaymentResponseBody(),
                     errors: [
-                        { code: 'enrolled_card' },
+                        { code: 'three_d_secure_required' },
                     ],
                     three_ds_result: {
                         acs_url: 'https://acs/url',

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
@@ -98,7 +98,7 @@ export default class CyberSourcePaymentStrategy implements PaymentStrategy {
 
                 return this._placeOrder(order, payment, options)
                     .catch(error => {
-                        if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'enrolled_card' })) {
+                        if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
                             return Promise.reject(error);
                         }
 


### PR DESCRIPTION
[INT-1811](https://jira.bigcommerce.com/browse/INT-1811)

## What?
Fix enrolled card Issue on Cybersource

## Why?
The issue was introduced in a PR for PayPal Pro since Cybersource and PayPal Pro will be using the same component for Cardinal.

## Testing / Proof
![cybersource3ds](https://user-images.githubusercontent.com/51794862/62903721-4e829400-bd29-11e9-91d6-0af0e5e0519d.gif)

## Siblings PR
[INT-1620](https://github.com/bigcommerce/bigpay/pull/1724)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce-labs/intersys-integrations
