### PR TITLE
fix(payment): INT-1782 Add payment method tracking for Affirm & Zip

### DIFF
--- a/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
+++ b/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
@@ -162,7 +162,7 @@ describe('AffirmPaymentStrategy', () => {
 
             expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
 
-            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith({ useStoreCredit: false }, options);
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(payload, options);
             expect(affirm.checkout).toHaveBeenCalled();
             expect(affirm.checkout.open).toHaveBeenCalled();
             expect(affirm.ui.error.on).toHaveBeenCalled();

--- a/src/payment/strategies/affirm/affirm-payment-strategy.ts
+++ b/src/payment/strategies/affirm/affirm-payment-strategy.ts
@@ -48,7 +48,6 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const methodId = payload.payment && payload.payment.methodId;
-        const { useStoreCredit } = payload;
         const { _affirm } = this;
 
         if (!_affirm) {
@@ -69,7 +68,7 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             },
         };
 
-        return this._store.dispatch(this._orderActionCreator.submitOrder({ useStoreCredit }, requestOptions))
+        return this._store.dispatch(this._orderActionCreator.submitOrder(payload, requestOptions))
             .then<AffirmSuccessResponse>(() => {
                 _affirm.checkout(this._getCheckoutInformation());
 

--- a/src/payment/strategies/zip/zip-payment-strategy.spec.ts
+++ b/src/payment/strategies/zip/zip-payment-strategy.spec.ts
@@ -144,7 +144,6 @@ describe('ZipPaymentStrategy', () => {
         });
 
         it('executes the strategy successfully and submits the payment', async () => {
-            const { payment, ...order } = orderRequestBody;
             const expectedPayment = {
                 methodId: 'zip',
                 paymentData: {
@@ -158,7 +157,7 @@ describe('ZipPaymentStrategy', () => {
             await strategy.execute(orderRequestBody, zipOptions);
 
             expect(remoteCheckoutActionCreator.initializePayment).toHaveBeenCalledWith(expectedPayment.methodId, { useStoreCredit: false });
-            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(order, zipOptions);
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(orderRequestBody, zipOptions);
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
             expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
             expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);

--- a/src/payment/strategies/zip/zip-payment-strategy.ts
+++ b/src/payment/strategies/zip/zip-payment-strategy.ts
@@ -53,7 +53,7 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
     }
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        const { payment, ...order } = payload;
+        const { payment } = payload;
         const { _zipClient: zipClient } = this;
         const useStoreCredit = !!payload.useStoreCredit;
 
@@ -65,7 +65,7 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
+        return this._store.dispatch(this._orderActionCreator.submitOrder(payload, options))
             .then(() => this._store.dispatch(
                 this._remoteCheckoutActionCreator.initializePayment(payment.methodId, { useStoreCredit })
             ))


### PR DESCRIPTION
## What? [INT-1782](https://jira.bigcommerce.com/browse/INT-1782)

- Add payment method tracking for Affirm & Zip.

## Why?

When an order is created and his payment was not finished (incomplete orders) we need to keep track which payment method was used.

## Sibling PRs

https://github.com/bigcommerce/bigcommerce/pull/31194

## Testing / Proof

https://drive.google.com/open?id=1JRdHRaEWkIxE8LajF874d9jlTjvNgujs

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
