### PR TITLE
CHECKOUT-4272: Only set up event listeners for iframe resizer when it is in use

### DIFF
--- a/src/common/iframe/iframe-resizer.spec.ts
+++ b/src/common/iframe/iframe-resizer.spec.ts
@@ -1,0 +1,38 @@
+jest.mock('iframe-resizer', () => {
+    window.addEventListener('resize', () => {});
+
+    return {
+        iframeResizer: jest.fn(),
+    };
+});
+
+describe('iframeResizer()', () => {
+    const options = { scrolling: false };
+    const iframe = document.createElement('iframe');
+
+    it('does not set up resizer listener until it is used', () => {
+        jest.spyOn(window, 'addEventListener');
+
+        const { iframeResizer } = require('./iframe-resizer');
+
+        expect(window.addEventListener)
+            .not.toHaveBeenCalledWith('resize', expect.any(Function));
+
+        iframeResizer(options, iframe);
+
+        expect(window.addEventListener)
+            .toHaveBeenCalledWith('resize', expect.any(Function));
+
+        (window.addEventListener as jest.Mock).mockReset();
+    });
+
+    it('passes parameter to original iframe resizer', () => {
+        const { iframeResizer: originalIframeResizer } = require('iframe-resizer');
+        const { iframeResizer } = require('./iframe-resizer');
+
+        iframeResizer(options, iframe);
+
+        expect(originalIframeResizer)
+            .toHaveBeenCalledWith(options, iframe);
+    });
+});

--- a/src/common/iframe/iframe-resizer.ts
+++ b/src/common/iframe/iframe-resizer.ts
@@ -1,0 +1,30 @@
+import { IFrameComponent, IFrameOptions } from 'iframe-resizer';
+
+export {
+    HeightCalculationMethod,
+    IFrameComponent,
+    IFrameMessageData,
+    IFrameObject,
+    IFrameOptions,
+    IFramePage,
+    IFramePageOptions,
+    IFrameResizedData,
+    IFrameScrollData,
+    PageInfo,
+    WidthCalculationMethod,
+} from 'iframe-resizer';
+
+// The reason why we are wrapping the original `iframeResizer` function imported
+// from the package is because the package sets up event listeners (window
+// resize etc...) as soon as the package is imported. Therefore, to defer the
+// side effect from happening until the function is actually being used, we are
+// importing the package inside this function. To minimise the chance of
+// importing the original package inadvertently, we are also re-exporting all of
+// its public interfaces. The re-exports do not cause any side effect because
+// they are plain TypeScript interfaces; meaning they are only used for type
+// checks rather than for code output.
+export function iframeResizer(options: IFrameOptions, target: string | HTMLElement): IFrameComponent[] {
+    const { iframeResizer: originalIframeResizer } = require('iframe-resizer');
+
+    return originalIframeResizer(options, target);
+}

--- a/src/common/iframe/index.ts
+++ b/src/common/iframe/index.ts
@@ -1,0 +1,1 @@
+export * from './iframe-resizer';

--- a/src/embedded-checkout/embedded-checkout.spec.ts
+++ b/src/embedded-checkout/embedded-checkout.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
-import { iframeResizer, IFrameComponent } from 'iframe-resizer';
 
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { iframeResizer, IFrameComponent } from '../common/iframe';
 import { BrowserStorage } from '../common/storage';
 
 import EmbeddedCheckout from './embedded-checkout';

--- a/src/embedded-checkout/embedded-checkout.ts
+++ b/src/embedded-checkout/embedded-checkout.ts
@@ -1,6 +1,6 @@
 import { RequestSender } from '@bigcommerce/request-sender';
-import { IFrameComponent } from 'iframe-resizer';
 
+import { IFrameComponent } from '../common/iframe';
 import { BrowserStorage } from '../common/storage';
 import { parseUrl } from '../common/url';
 import { bindDecorator as bind } from '../common/utility';

--- a/src/embedded-checkout/resizable-iframe-creator.spec.ts
+++ b/src/embedded-checkout/resizable-iframe-creator.spec.ts
@@ -1,11 +1,12 @@
 import { EventEmitter } from 'events';
-import { iframeResizer, IFrameComponent, IFrameObject, IFrameOptions } from 'iframe-resizer';
+
+import { iframeResizer, IFrameComponent, IFrameObject, IFrameOptions } from '../common/iframe';
 
 import { EmbeddedCheckoutEventType } from './embedded-checkout-events';
 import { NotEmbeddableError } from './errors';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
-jest.mock('iframe-resizer', () => ({
+jest.mock('../common/iframe', () => ({
     iframeResizer: jest.fn((_: IFrameOptions, element: HTMLIFrameElement) => {
         (element as IFrameComponent).iFrameResizer = {} as IFrameObject;
 

--- a/src/embedded-checkout/resizable-iframe-creator.ts
+++ b/src/embedded-checkout/resizable-iframe-creator.ts
@@ -1,5 +1,4 @@
-import { iframeResizer, IFrameComponent } from 'iframe-resizer';
-
+import { iframeResizer, IFrameComponent } from '../common/iframe';
 import { parseUrl } from '../common/url';
 
 import { EmbeddedCheckoutEventType } from './embedded-checkout-events';


### PR DESCRIPTION
## What?
Only set up event listeners for the iframe resizer when it is in use.

## Why?
Otherwise, the event listeners (window resize etc...) will take up CPU resources and affect performance.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
