### PR TITLE
feat(checkout): CHECKOUT-4294 Require province based on country

### DIFF
--- a/src/form/form-selector.ts
+++ b/src/form/form-selector.ts
@@ -92,7 +92,7 @@ export function createFormSelectorFactory(): FormSelectorFactory {
             ...field,
             name: 'stateOrProvinceCode',
             options: { items },
-            required: true,
+            required: requireProvince(country),
             type: 'array',
             fieldType: 'dropdown',
             itemtype: 'string',
@@ -107,6 +107,18 @@ export function createFormSelectorFactory(): FormSelectorFactory {
         }
 
         return { ...field, required: Boolean(hasPostalCodes) };
+    }
+
+    function requireProvince(country?: Country): boolean {
+        const countriesRequiringProvince = [
+            'US',
+            'CA',
+            'AU',
+            'MX',
+            'MY',
+        ];
+
+        return country ? countriesRequiringProvince.indexOf(country.code) !== -1 : false;
     }
 
     return memoizeOne((


### PR DESCRIPTION
## What?
Requiring province/state based on specific countries, rather than requiring them just because a list of states was returned in association with a country.

## Why?
Some countries that return states  in checkout do not actually require states in address. For example, Germany and Switzerland both display states when selected, but this is not a requirement for addressing packages in those countries. More often, the building number, street, and postal code are sufficient.

I used this site as a reference for address requirements: https://www.bitboost.com/ref/international-address-formats.html#Formats

The list of countries requiring state/province can be updated over time if any country's postal requirements change.

## Testing / Proof
I forked checkout and checkout SDK, and referenced my SDK branch within checkout.
Within my BC VM I was able to verify that state/province is required in the shipping address form based on whether the ISO2 value of the country selected matches any of the countries in the `countriesRequiringProvince` array.

More importantly, I get the same set of shipping quotes for states like Germany and Switzerland when I exclude the state. I have FedEx, USPS, and UPS enabled with all options selected, sending from an origin in Austin, Texas, USA.

Germany, no state selected:
![image](https://user-images.githubusercontent.com/16565458/63120882-d9050680-bf68-11e9-904e-f3a5dc087e5b.png)

Germany, state selected:
![image](https://user-images.githubusercontent.com/16565458/63123390-744caa80-bf6e-11e9-9d1a-80d3f92f3a08.png)


@bigcommerce/checkout @bigcommerce/payments
