### PR TITLE
CHECKOUT-4367: Stop throwing generic `StandardError` type

### DIFF
--- a/src/billing/billing-address-action-creator.ts
+++ b/src/billing/billing-address-action-creator.ts
@@ -3,13 +3,14 @@ import { Response } from '@bigcommerce/request-sender';
 import { Observable, Observer } from 'rxjs';
 
 import { Checkout, InternalCheckoutSelectors } from '../checkout';
-import { MissingDataError, MissingDataErrorType, StandardError } from '../common/error/errors';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 import { GuestCredentials } from '../customer';
 
 import { BillingAddressRequestSender } from '.';
 import { BillingAddressUpdateRequestBody } from './billing-address';
 import { BillingAddressActionType, ContinueAsGuestAction, UpdateBillingAddressAction } from './billing-address-actions';
+import { UnableToContinueAsGuestError } from './errors';
 
 export default class BillingAddressActionCreator {
     constructor(
@@ -31,7 +32,7 @@ export default class BillingAddressActionCreator {
             const customer = state.customer.getCustomer();
 
             if (customer && !customer.isGuest) {
-                throw new StandardError('Cannot continue as guest: customer is logged in.');
+                throw new UnableToContinueAsGuestError();
             }
 
             const billingAddress = state.billingAddress.getBillingAddress();

--- a/src/billing/errors/index.ts
+++ b/src/billing/errors/index.ts
@@ -1,0 +1,1 @@
+export { default as UnableToContinueAsGuestError } from './unable-to-continue-as-guest-error';

--- a/src/billing/errors/unable-to-continue-as-guest-error.ts
+++ b/src/billing/errors/unable-to-continue-as-guest-error.ts
@@ -1,0 +1,14 @@
+import { StandardError } from '../../common/error/errors';
+
+/**
+ * This error should be thrown when a shopper tries to sign in as a guest but
+ * they are already signed in as a registered customer.
+ */
+export default class UnableToContinueAsGuestError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to continue as a guest because the customer is already signed in.');
+
+        this.name = 'UnableToContinueAsGuestError';
+        this.type = 'unable_to_continue_as_guest';
+    }
+}

--- a/src/checkout/checkout-action-creator.ts
+++ b/src/checkout/checkout-action-creator.ts
@@ -3,7 +3,7 @@ import { concat, defer, merge, of, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 import { throwErrorAction } from '../common/error';
-import { MissingDataError, MissingDataErrorType, StandardError } from '../common/error/errors';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 import { ConfigActionCreator } from '../config';
 
@@ -40,7 +40,7 @@ export default class CheckoutActionCreator {
                 const context = state.config.getContextConfig();
 
                 if (!context || !context.checkoutId) {
-                    throw new StandardError('Unable to load checkout: no cart is available');
+                    throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
                 }
 
                 return this._checkoutRequestSender.loadCheckout(context.checkoutId, options)

--- a/src/checkout/errors/checkout-not-available-error.ts
+++ b/src/checkout/errors/checkout-not-available-error.ts
@@ -3,6 +3,11 @@ import { Response } from '@bigcommerce/request-sender';
 import { InternalErrorResponseBody } from '../../common/error';
 import { RequestError } from '../../common/error/errors';
 
+/**
+ * Throw this error when we are unable to retrieve a checkout object from the
+ * server using the provided ID. It could be because the shopper does not have
+ * permission to view the object, or the ID itself is invalid.
+ */
 export default class CheckoutNotAvailableError extends RequestError {
     constructor(response: Response<InternalErrorResponseBody>) {
         super(response, { message: response.body.title });

--- a/src/common/error/errors/invalid-argument-error.ts
+++ b/src/common/error/errors/invalid-argument-error.ts
@@ -1,5 +1,10 @@
 import StandardError from './standard-error';
 
+/**
+ * This error should be thrown when a method is unable to proceed because the
+ * caller has not provided all the arguments according to their requirements,
+ * i.e.: if an argument is missing or it is not the expected data type.
+ */
 export default class InvalidArgumentError extends StandardError {
     constructor(message?: string) {
         super(message || 'Invalid arguments have been provided.');

--- a/src/common/error/errors/missing-data-error.ts
+++ b/src/common/error/errors/missing-data-error.ts
@@ -11,10 +11,16 @@ export enum MissingDataErrorType {
     MissingOrderId,
     MissingPayment,
     MissingPaymentMethod,
+    MissingPaymentToken,
     MissingShippingAddress,
     MissingSpamProtectionToken,
 }
 
+/**
+ * Throw this error when data that is expected to exist is missing. Usually it
+ * is due to the fact that certain data has not been retrieved from or saved to
+ * the server yet. And such data is required to perform certain actions.
+ */
 export default class MissingDataError extends StandardError {
     constructor(
         public subtype: MissingDataErrorType
@@ -52,6 +58,9 @@ function getErrorMessage(type: MissingDataErrorType): string {
 
     case MissingDataErrorType.MissingPayment:
         return 'Unable to proceed because payment data is unavailable.';
+
+    case MissingDataErrorType.MissingPaymentToken:
+        return 'Unable to proceed because the token required to submit a payment is missing.';
 
     case MissingDataErrorType.MissingPaymentMethod:
         return 'Unable to proceed because payment method data is unavailable or not properly configured.';

--- a/src/common/error/errors/not-implemented-error.ts
+++ b/src/common/error/errors/not-implemented-error.ts
@@ -1,5 +1,9 @@
 import StandardError from './standard-error';
 
+/**
+ * Throw this error if we try to call a method that is only a stub and has not
+ * been fully implemented.
+ */
 export default class NotImplementedError extends StandardError {
     constructor(message?: string) {
         super(message || 'Not implemented.');

--- a/src/common/error/errors/not-initialized-error.ts
+++ b/src/common/error/errors/not-initialized-error.ts
@@ -8,6 +8,11 @@ export enum NotInitializedErrorType {
     SpamProtectionNotInitialized,
 }
 
+/**
+ * Throw this error if a method requires a certain initialization call to be
+ * made first. Some objects can be constructed but they cannot be used until a
+ * separate initialization call is made.
+ */
 export default class NotInitializedError extends StandardError {
     constructor(
         public subtype: NotInitializedErrorType

--- a/src/common/error/errors/request-error.ts
+++ b/src/common/error/errors/request-error.ts
@@ -8,6 +8,10 @@ const DEFAULT_RESPONSE = {
     status: 0,
 };
 
+/**
+ * Throw this error if we are unable to make a request to the server. It wraps
+ * any server response into a JS error object.
+ */
 export default class RequestError<TBody = any> extends StandardError {
     body: TBody | {};
     headers: { [key: string]: any };

--- a/src/common/error/errors/standard-error.spec.ts
+++ b/src/common/error/errors/standard-error.spec.ts
@@ -1,12 +1,10 @@
 import StandardError from './standard-error';
 
 describe('StandardError', () => {
-    it('omits error constructor in stack trace', () => {
-        try {
-            throw new StandardError();
-        } catch (error) {
-            expect(error.stack).not.toContain('StandardError');
-        }
+    it('returns error name', () => {
+        const error = new StandardError();
+
+        expect(error.name).toEqual('StandardError');
     });
 
     it('sets error message if provided', () => {

--- a/src/common/error/errors/standard-error.spec.ts
+++ b/src/common/error/errors/standard-error.spec.ts
@@ -1,15 +1,17 @@
 import StandardError from './standard-error';
 
 describe('StandardError', () => {
+    class TestError extends StandardError {}
+
     it('returns error name', () => {
-        const error = new StandardError();
+        const error = new TestError();
 
         expect(error.name).toEqual('StandardError');
     });
 
     it('sets error message if provided', () => {
         const message = 'Hello world';
-        const error = new StandardError(message);
+        const error = new TestError(message);
 
         expect(error.message).toEqual(message);
     });

--- a/src/common/error/errors/standard-error.ts
+++ b/src/common/error/errors/standard-error.ts
@@ -3,6 +3,7 @@ import { setPrototypeOf } from '../../utility';
 import CustomError from './custom-error';
 
 export default class StandardError extends Error implements CustomError {
+    name = 'StandardError';
     type = 'standard';
 
     constructor(message?: string) {

--- a/src/common/error/errors/standard-error.ts
+++ b/src/common/error/errors/standard-error.ts
@@ -2,7 +2,11 @@ import { setPrototypeOf } from '../../utility';
 
 import CustomError from './custom-error';
 
-export default class StandardError extends Error implements CustomError {
+/**
+ * This error type should not be constructed directly. It is a base class for
+ * all custom errors thrown in this library.
+ */
+export default abstract class StandardError extends Error implements CustomError {
     name = 'StandardError';
     type = 'standard';
 

--- a/src/common/error/errors/timeout-error.ts
+++ b/src/common/error/errors/timeout-error.ts
@@ -2,6 +2,10 @@ import { Response } from '@bigcommerce/request-sender';
 
 import RequestError from './request-error';
 
+/**
+ * Throw this error if a request fails to complete within its required timeframe
+ * because of a network issue.
+ */
 export default class TimeoutError extends RequestError<{}> {
     constructor(response?: Response) {
         super(response, {

--- a/src/common/error/errors/unrecoverable-error.ts
+++ b/src/common/error/errors/unrecoverable-error.ts
@@ -2,6 +2,10 @@ import { Response } from '@bigcommerce/request-sender';
 
 import RequestError from './request-error';
 
+/**
+ * Throw this error if there is an unexpected error and it is not possible to
+ * recover from unless the shopper creates a new checkout session.
+ */
 export default class UnrecoverableError extends RequestError {
     constructor(response: Response, message?: string) {
         super(response, {

--- a/src/common/error/errors/unsupported-browser-error.ts
+++ b/src/common/error/errors/unsupported-browser-error.ts
@@ -1,5 +1,9 @@
 import StandardError from './standard-error';
 
+/**
+ * Throw this error if the shopper is using a browser version that is not
+ * supported by us or any third party provider we use.
+ */
 export default class UnsupportedBrowserError extends StandardError {
     constructor(message?: string) {
         super(message || 'Unsupported browser error');

--- a/src/embedded-checkout/errors/invalid-login-token-error.ts
+++ b/src/embedded-checkout/errors/invalid-login-token-error.ts
@@ -3,6 +3,10 @@ import { Response } from '@bigcommerce/request-sender';
 import { InternalErrorResponseBody } from '../../common/error';
 import { RequestError } from '../../common/error/errors';
 
+/**
+ * Throw this error we are not able to sign in a shopper because the provided
+ * login token is invalid.
+ */
 export default class InvalidLoginTokenError extends RequestError {
     constructor(response: Response<InternalErrorResponseBody>) {
         super(response, { message: response.body.title });

--- a/src/embedded-checkout/errors/not-embeddable-error.ts
+++ b/src/embedded-checkout/errors/not-embeddable-error.ts
@@ -6,6 +6,12 @@ export enum NotEmbeddableErrorType {
     UnknownError = 'unknown_error',
 }
 
+/**
+ * Throw this error if we are not able to embed the checkout form as an iframe.
+ * This can be due to the fact that the provided container ID is invalid, or the
+ * checkout form fails to load inside the iframe. It can also be due to an
+ * unknown reason.
+ */
 export default class NotEmbeddableError extends StandardError {
     constructor(
         message?: string,

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
@@ -1,5 +1,4 @@
 import { CartChangedError } from '../../cart/errors';
-import { StandardError } from '../../common/error/errors';
 import { EmbeddedCheckoutEvent, EmbeddedCheckoutEventType } from '../embedded-checkout-events';
 import IframeEventListener from '../iframe-event-listener';
 import IframeEventPoster from '../iframe-event-poster';
@@ -72,7 +71,7 @@ describe('EmbeddedCheckoutMessenger', () => {
     });
 
     it('posts `frame_error` event to parent window without target origin', () => {
-        const error = new StandardError();
+        const error = new Error();
 
         messenger.postFrameError(error);
 
@@ -80,7 +79,6 @@ describe('EmbeddedCheckoutMessenger', () => {
             type: EmbeddedCheckoutEventType.FrameError,
             payload: {
                 message: error.message,
-                type: error.type,
             },
         });
     });

--- a/src/order/errors/order-finalization-not-required-error.ts
+++ b/src/order/errors/order-finalization-not-required-error.ts
@@ -1,5 +1,9 @@
 import { StandardError } from '../../common/error/errors';
 
+/**
+ * Throw this error if we are trying to make an order finalization request for a
+ * payment method that does not require such procedure.
+ */
 export default class OrderFinalizationNotRequiredError extends StandardError {
     constructor() {
         super('The current order does not need to be finalized at this stage.');

--- a/src/order/spam-protection/errors/spam-protection-failed-error.ts
+++ b/src/order/spam-protection/errors/spam-protection-failed-error.ts
@@ -1,5 +1,9 @@
 import { StandardError } from '../../../common/error/errors';
 
+/**
+ * Throw this error if we fail to complete the required spam protection
+ * verification due to an unknown reason.
+ */
 export default class SpamProtectionFailedError extends StandardError {
     constructor() {
         super('We were not able to complete our spam protection verification. Please try again.');

--- a/src/order/spam-protection/errors/spam-protection-not-completed-error.ts
+++ b/src/order/spam-protection/errors/spam-protection-not-completed-error.ts
@@ -1,5 +1,9 @@
 import { StandardError } from '../../../common/error/errors';
 
+/**
+ * Throw this error if the shopper chooses not to complete the spam protection
+ * challenge (i.e.: they close the reCaptcha window).
+ */
 export default class SpamProtectionNotCompletedError extends StandardError {
     constructor() {
         super('You haven\'t complete our spam protection verification. Please try again.');

--- a/src/payment/errors/index.ts
+++ b/src/payment/errors/index.ts
@@ -1,4 +1,6 @@
 export { default as PaymentArgumentInvalidError } from './payment-argument-invalid-error';
 export { default as PaymentMethodCancelledError } from './payment-method-cancelled-error';
+export { default as PaymentMethodFailedError } from './payment-method-failed-error';
+export { default as PaymentMethodClientUnavailableError } from './payment-method-client-unavailable-error';
 export { default as PaymentMethodDeclinedError } from './payment-method-declined-error';
 export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';

--- a/src/payment/errors/payment-argument-invalid-error.ts
+++ b/src/payment/errors/payment-argument-invalid-error.ts
@@ -1,5 +1,10 @@
 import { InvalidArgumentError } from '../../common/error/errors';
 
+/**
+ * This error should be thrown when we are unable to submit a payment because
+ * the caller has not provided all the required fields, i.e.: if an argument is
+ * missing or it is not the expected data type.
+ */
 export default class PaymentArgumentInvalidError extends InvalidArgumentError {
     constructor(invalidFields?: string[]) {
         let message = 'Unable to submit payment for the order because the payload is invalid.';

--- a/src/payment/errors/payment-method-cancelled-error.ts
+++ b/src/payment/errors/payment-method-cancelled-error.ts
@@ -1,5 +1,10 @@
 import { StandardError } from '../../common/error/errors';
 
+/**
+ * This error should be thrown when the payment flow is cancelled. It could be
+ * due to a deliberate user interaction, i.e.: the user clicks on a cancel
+ * button which dismisses the payment modal.
+ */
 export default class PaymentMethodCancelledError extends StandardError {
     constructor(message?: string) {
         super(message || 'Payment process was cancelled.');

--- a/src/payment/errors/payment-method-client-unavailable-error.ts
+++ b/src/payment/errors/payment-method-client-unavailable-error.ts
@@ -1,0 +1,14 @@
+import { StandardError } from '../../common/error/errors';
+
+/**
+ * This error should be thrown when the client library of a payment method fails
+ * to load, or for some reason, it is inaccessible.
+ */
+export default class PaymentMethodClientUnavailableError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to proceed because the client library of a payment method is not loaded or ready to be used.');
+
+        this.name = 'PaymentMethodClientUnavailableError';
+        this.type = 'payment_method_client_unavailable';
+    }
+}

--- a/src/payment/errors/payment-method-declined-error.ts
+++ b/src/payment/errors/payment-method-declined-error.ts
@@ -1,5 +1,10 @@
 import { StandardError } from '../../common/error/errors';
 
+/**
+ * Throw this error if a payment method explicitly returns a declined error and
+ * the shopper has to choose a different payment method if they wish to continue
+ * their checkout process.
+ */
 export default class PaymentMethodDeclinedError extends StandardError {
     constructor(message?: string) {
         super(message || 'The selected payment method was declined. Please select another payment method.');

--- a/src/payment/errors/payment-method-failed-error.ts
+++ b/src/payment/errors/payment-method-failed-error.ts
@@ -1,0 +1,15 @@
+import { StandardError } from '../../common/error/errors';
+
+/**
+ * This error should be thrown when a payment method experiences some kind of
+ * failure (i.e.: its client library returns a rejected promise). And there is
+ * no other error type that is more specific than this one.
+ */
+export default class PaymentMethodFailedError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to proceed because the client library of a payment method has thrown an unexpected error.');
+
+        this.name = 'PaymentMethodFailedError';
+        this.type = 'payment_method_client_invalid';
+    }
+}

--- a/src/payment/errors/payment-method-invalid-error.ts
+++ b/src/payment/errors/payment-method-invalid-error.ts
@@ -2,6 +2,11 @@ import { Response } from '@bigcommerce/request-sender';
 
 import { RequestError } from '../../common/error/errors';
 
+/**
+ * Throw this error if we are unable to successfully submit a server request
+ * using a payment method because the method has invalid configuration or is in
+ * an invalid state.
+ */
 export default class PaymentMethodInvalidError extends RequestError {
     constructor(response?: Response) {
         super(response, { message: 'There is a problem processing your payment. Please try again later.' });

--- a/src/payment/payment-request-transformer.spec.ts
+++ b/src/payment/payment-request-transformer.spec.ts
@@ -1,7 +1,7 @@
 import { getBillingAddress } from '../billing/billing-addresses.mock';
 import { createInternalCheckoutSelectors, CheckoutStoreState, InternalCheckoutSelectors } from '../checkout';
 import { getCheckoutStoreStateWithOrder, getCheckoutWithGiftCertificates } from '../checkout/checkouts.mock';
-import { StandardError } from '../common/error/errors';
+import { MissingDataError } from '../common/error/errors';
 import { getConfig } from '../config/configs.mock';
 import { getCustomer } from '../customer/customers.mock';
 import { getOrder, getOrderMeta } from '../order/orders.mock';
@@ -68,7 +68,7 @@ describe('PaymentRequestTransformer', () => {
         jest.spyOn(selectors.payment, 'getPaymentToken')
             .mockReturnValue(undefined);
 
-        expect(() => paymentRequestTransformer.transform(payment, selectors)).toThrow(StandardError);
+        expect(() => paymentRequestTransformer.transform(payment, selectors)).toThrow(MissingDataError);
     });
 
     it('returns paymentMethod as undefined when state does not have paymentMethods', () => {

--- a/src/payment/payment-request-transformer.ts
+++ b/src/payment/payment-request-transformer.ts
@@ -2,8 +2,8 @@ import { pick } from 'lodash';
 
 import { mapToInternalAddress } from '../address';
 import { mapToInternalCart } from '../cart';
-import InternalCheckoutSelectors from '../checkout/internal-checkout-selectors';
-import { StandardError } from '../common/error/errors';
+import { InternalCheckoutSelectors } from '../checkout';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { mapToInternalCustomer } from '../customer';
 import { mapToInternalOrder } from '../order';
 import { mapToInternalShippingOption } from '../shipping';
@@ -36,7 +36,7 @@ export default class PaymentRequestTransformer {
             checkoutState.payment.getPaymentToken();
 
         if (!authToken) {
-            throw new StandardError();
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentToken);
         }
 
         return {

--- a/src/payment/strategies/affirm/affirm-script-loader.ts
+++ b/src/payment/strategies/affirm/affirm-script-loader.ts
@@ -1,4 +1,4 @@
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { Affirm, AffirmHostWindow, AffirmScripts } from './affirm';
 import loadAffirmJS from './affirmJs';
@@ -12,8 +12,9 @@ export default class AffirmScriptLoader {
         const scriptURI = this._getScriptURI(testMode);
 
         loadAffirmJS(apikey, scriptURI);
+
         if (!this._window.affirm) {
-            throw new StandardError();
+            throw new PaymentMethodClientUnavailableError();
         }
 
         return Promise.resolve(this._window.affirm);

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -21,7 +21,6 @@ import {
     NotInitializedError,
     RequestError
 } from '../../../common/error/errors';
-import StandardError from '../../../common/error/errors/standard-error';
 import { getErrorResponse } from '../../../common/http-request/responses.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import {
@@ -548,19 +547,19 @@ describe('AmazonPayPaymentStrategy', () => {
             if (hostWindow.OffAmazonPayments) {
                 jest.spyOn(remoteCheckoutActionCreator, 'initializePayment')
                     .mockImplementation(() => {
-                        throw new StandardError('error');
+                        throw new Error('error');
                     });
 
                 hostWindow.OffAmazonPayments.initConfirmationFlow = jest.fn((_sellerId, _referenceId, callback) => {
-                    callback(amazonConfirmationFlow).catch((error: StandardError) => {
-                        expect(error).toBeInstanceOf(StandardError);
+                    callback(amazonConfirmationFlow).catch((error: Error) => {
+                        expect(error).toBeInstanceOf(Error);
                     });
                 });
 
                 try {
                     await strategy3ds.execute(payload, options);
                 } catch (error) {
-                    expect(error).toBeInstanceOf(StandardError);
+                    expect(error).toBeInstanceOf(Error);
                 }
             }
         });

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -1,8 +1,8 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { MissingDataError, MissingDataErrorType, StandardError } from '../../../common/error/errors';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentArgumentInvalidError } from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodFailedError } from '../../errors';
 import isCreditCardLike from '../../is-credit-card-like';
 import isVaultedInstrument from '../../is-vaulted-instrument';
 import Payment, { PaymentInstrument } from '../../payment';
@@ -73,7 +73,7 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
 
     private _handleError(error: Error): never {
         if (error.name === 'BraintreeError') {
-            throw new StandardError(error.message);
+            throw new PaymentMethodFailedError(error.message);
         }
 
         throw error;

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -1,8 +1,8 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../../common/error/errors';
+import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodCancelledError, PaymentMethodFailedError } from '../../errors';
 import Payment from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
@@ -82,7 +82,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             throw new PaymentMethodCancelledError(error.message);
         }
 
-        throw new StandardError(error.message);
+        throw new PaymentMethodFailedError(error.message);
     }
 
     private _preparePaymentData(payment: OrderPaymentRequestBody, useStoreCredit?: boolean): Promise<Payment> {

--- a/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 import { GooglePayCreator } from '../googlepay';
 
 import {
@@ -24,7 +24,7 @@ export default class BraintreeScriptLoader {
             .loadScript('//js.braintreegateway.com/web/3.37.0/js/client.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.client) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.braintree.client;
@@ -36,7 +36,7 @@ export default class BraintreeScriptLoader {
             .loadScript('//js.braintreegateway.com/web/3.37.0/js/three-d-secure.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.threeDSecure) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.braintree.threeDSecure;
@@ -48,7 +48,7 @@ export default class BraintreeScriptLoader {
             .loadScript('//js.braintreegateway.com/web/3.37.0/js/data-collector.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.dataCollector) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.braintree.dataCollector;
@@ -60,7 +60,7 @@ export default class BraintreeScriptLoader {
             .loadScript('//js.braintreegateway.com/web/3.37.0/js/paypal.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.paypal) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.braintree.paypal;
@@ -72,7 +72,7 @@ export default class BraintreeScriptLoader {
             .loadScript('//js.braintreegateway.com/web/3.37.0/js/paypal-checkout.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.paypalCheckout) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.braintree.paypalCheckout;
@@ -84,7 +84,7 @@ export default class BraintreeScriptLoader {
             .loadScript('//js.braintreegateway.com/web/3.37.0/js/visa-checkout.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.visaCheckout) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.braintree.visaCheckout;
@@ -96,7 +96,7 @@ export default class BraintreeScriptLoader {
             .loadScript('//js.braintreegateway.com/web/3.37.0/js/google-payment.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.googlePayment) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.braintree.googlePayment;

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
@@ -1,7 +1,8 @@
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { InvalidArgumentError, MissingDataError, MissingDataErrorType, StandardError } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentMethodFailedError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
@@ -135,7 +136,7 @@ export default class BraintreeVisaCheckoutPaymentStrategy implements PaymentStra
 
     private _handleError(error: Error): never {
         if (error.name === 'BraintreeError') {
-            throw new StandardError(error.message);
+            throw new PaymentMethodFailedError(error.message);
         }
 
         throw error;

--- a/src/payment/strategies/braintree/visacheckout-script-loader.ts
+++ b/src/payment/strategies/braintree/visacheckout-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { VisaCheckoutHostWindow, VisaCheckoutSDK } from './visacheckout';
 
@@ -15,7 +15,7 @@ export default class VisaCheckoutScriptLoader {
             .loadScript(`//${testMode ? 'sandbox-' : ''}assets.secure.checkout.visa.com/checkout-widget/resources/js/integration/v1/sdk.js`)
             .then(() => {
                 if (!this._window.V) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.V;

--- a/src/payment/strategies/cardinal/cardinal-script-loader.spec.ts
+++ b/src/payment/strategies/cardinal/cardinal-script-loader.spec.ts
@@ -1,6 +1,6 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { getCardinalScriptMock } from './cardinal.mock';
 import { CardinalScriptLoader, CardinalWindow } from './index';
@@ -47,13 +47,13 @@ describe('CardinalScriptLoader', () => {
 
     it('throws error to inform that order finalization is not required', async () => {
         scriptLoader.loadScript = jest.fn(() => {
-            throw new StandardError();
+            throw new PaymentMethodClientUnavailableError();
         });
 
         try {
             await cardinalScriptLoader.load('provider');
         } catch (error) {
-            expect(error).toBeInstanceOf(StandardError);
+            expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
         }
     });
 });

--- a/src/payment/strategies/cardinal/cardinal-script-loader.ts
+++ b/src/payment/strategies/cardinal/cardinal-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { CardinalSDK, CardinalWindow } from './cardinal';
 
@@ -20,7 +20,7 @@ export default class CardinalScriptLoader {
             .loadScript(url + '?v=' + provider)
             .then(() => {
                 if (!this._window.Cardinal) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.Cardinal;

--- a/src/payment/strategies/cardinal/cardinal-three-d-secure-flow.spec.ts
+++ b/src/payment/strategies/cardinal/cardinal-three-d-secure-flow.spec.ts
@@ -12,7 +12,7 @@ import {
     CheckoutValidator,
 } from '../../../checkout';
 import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
-import { InvalidArgumentError, MissingDataError, RequestError, StandardError } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
 import {
     OrderActionCreator,
@@ -175,12 +175,12 @@ describe('CardinalThreeDSecureFlow', () => {
 
         it('does not complete the purchase if there was an error', async () => {
             jest.spyOn(paymentActionCreator, 'submitPayment')
-                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, new StandardError('Custom Error'))));
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, new Error('Custom Error'))));
 
             try {
                 await cardinalFlow.start(payment);
             } catch (error) {
-                expect(error).toBeInstanceOf(StandardError);
+                expect(error).toBeInstanceOf(Error);
                 expect(error.message).toBe('Custom Error');
             }
         });

--- a/src/payment/strategies/chasepay/chasepay-script-loader.ts
+++ b/src/payment/strategies/chasepay/chasepay-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 import { ChasePayHostWindow, JPMC } from '../chasepay/chasepay';
 
 export default class ChasePayScriptLoader {
@@ -14,7 +14,7 @@ export default class ChasePayScriptLoader {
             .loadScript(`//pwc${testMode ? 'psb' : ''}.chase.com/pwc/checkout/js/v20170521/list.action?type=raw&applId=PWC&channelId=CWC&version=1`)
             .then(() => {
                 if (!this._window.JPMC) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.JPMC;

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
@@ -10,7 +10,6 @@ import {
     MissingDataErrorType,
     NotInitializedError,
     NotInitializedErrorType,
-    StandardError
 } from '../../../common/error/errors';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
@@ -148,8 +147,7 @@ describe('GooglePayPaymentProcessor', () => {
             try {
                 await processor.initialize('googlepay');
             } catch (error) {
-                expect(error).toBeInstanceOf(Error);
-                expect(error).toEqual(new StandardError(new MissingDataError(MissingDataErrorType.MissingPaymentMethod).message));
+                expect(error).toBeInstanceOf(MissingDataError);
             }
         });
     });

--- a/src/payment/strategies/googlepay/googlepay-script-loader.ts
+++ b/src/payment/strategies/googlepay/googlepay-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { GooglePayHostWindow, GooglePaySDK } from './googlepay';
 
@@ -15,7 +15,7 @@ export default class GooglePayScriptLoader {
             .loadScript('https://pay.google.com/gp/p/js/pay.js')
             .then(() => {
                 if (!this._window.google) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.google;

--- a/src/payment/strategies/masterpass/masterpass-script-loader.ts
+++ b/src/payment/strategies/masterpass/masterpass-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { Masterpass, MasterpassHostWindow } from './masterpass';
 
@@ -15,7 +15,7 @@ export default class MasterpassScriptLoader {
             .loadScript(`//${testMode ? 'sandbox.' : ''}masterpass.com/integration/merchant.js`)
             .then(() => {
                 if (!this._window.masterpass) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.masterpass;

--- a/src/payment/strategies/paypal/paypal-script-loader.ts
+++ b/src/payment/strategies/paypal/paypal-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { PaypalHostWindow, PaypalSDK } from './paypal-sdk';
 
@@ -18,7 +18,7 @@ export default class PaypalScriptLoader {
             .loadScript('//www.paypalobjects.com/api/checkout.min.js')
             .then(() => {
                 if (!this._window.paypal) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.paypal;

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -9,7 +9,6 @@ import {
     MissingDataErrorType,
     NotInitializedError,
     NotInitializedErrorType,
-    StandardError,
     TimeoutError,
     UnsupportedBrowserError,
 } from '../../../common/error/errors';
@@ -202,7 +201,7 @@ export default class SquarePaymentStrategy implements PaymentStrategy {
 
     private _handleCardNonceResponse(errors?: NonceGenerationError[], nonce?: string): void {
         if (!this._deferredRequestNonce) {
-            throw new StandardError();
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
         if (nonce && !errors) {

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -16,8 +16,7 @@ import {
     InvalidArgumentError,
     MissingDataError,
     NotInitializedError,
-    RequestError,
-    StandardError
+    RequestError
 } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
 import { getCustomer } from '../../../customer/customers.mock';
@@ -41,7 +40,7 @@ import {
     PaymentRequestSender
 } from '../../../payment';
 import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
-import { PaymentArgumentInvalidError } from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodFailedError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
@@ -277,7 +276,7 @@ describe('StripeV3PaymentStrategy', () => {
 
             expect(response).rejects.toThrowError(stripeError.error.message);
 
-            return expect(response).rejects.toThrow(StandardError);
+            return expect(response).rejects.toThrow(PaymentMethodFailedError);
         });
 
         it('throws an error when handle card payment to stripe', async () => {
@@ -306,7 +305,7 @@ describe('StripeV3PaymentStrategy', () => {
 
             expect(response).rejects.toThrowError(stripeError.error.message);
 
-            return expect(response).rejects.toThrow(StandardError);
+            return expect(response).rejects.toThrow(PaymentMethodFailedError);
         });
 
         it('throws an error when ClientToken is undefined', async () => {
@@ -619,7 +618,7 @@ describe('StripeV3PaymentStrategy', () => {
                 expect(orderActionCreator.submitOrder).toHaveBeenCalled();
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledTimes(1);
                 expect(stripeV3JsMock.handleCardPayment).toHaveBeenCalled();
-                expect(error).toEqual(new StandardError(stripeError.error && stripeError.error.message));
+                expect(error.message).toEqual(stripeError.error && stripeError.error.message);
             }
         });
     });

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -9,13 +9,12 @@ import {
     MissingDataErrorType,
     NotInitializedError,
     NotInitializedErrorType,
-    RequestError,
-    StandardError
+    RequestError
 } from '../../../common/error/errors';
 import { Customer } from '../../../customer';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentArgumentInvalidError } from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodFailedError } from '../../errors';
 import isVaultedInstrument from '../../is-vaulted-instrument';
 import { HostedInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
@@ -96,7 +95,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                             return this._getStripeJs().handleCardPayment(error.body.three_ds_result.token)
                                 .then(stripeResponse => {
                                     if (stripeResponse.error || !stripeResponse.paymentIntent.id) {
-                                        throw new StandardError(stripeResponse.error && stripeResponse.error.message);
+                                        throw new PaymentMethodFailedError(stripeResponse.error && stripeResponse.error.message);
                                     }
 
                                     const paymentPayload = {
@@ -123,7 +122,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                         return this._getStripeJs().createPaymentMethod('card', this._cardElement, this._mapStripePaymentMethodOptions())
                             .then(stripePaymentMethod => {
                                 if (stripePaymentMethod.error || !stripePaymentMethod.paymentMethod.id) {
-                                    throw new StandardError(stripePaymentMethod.error && stripePaymentMethod.error.message);
+                                    throw new PaymentMethodFailedError(stripePaymentMethod.error && stripePaymentMethod.error.message);
                                 }
 
                                 if (!paymentIntent) {
@@ -139,7 +138,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                             })
                             .then(stripeResponse => {
                                 if (stripeResponse.error || !stripeResponse.paymentIntent.id) {
-                                    throw new StandardError(stripeResponse.error && stripeResponse.error.message);
+                                    throw new PaymentMethodFailedError(stripeResponse.error && stripeResponse.error.message);
                                 }
 
                                 const paymentPayload = {

--- a/src/payment/strategies/stripev3/stripev3-script-loader.ts
+++ b/src/payment/strategies/stripev3/stripev3-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { StripeHostWindow, StripeV3Client } from './stripev3';
 
@@ -15,7 +15,7 @@ export default class StripeV3ScriptLoader {
             .loadScript('https://js.stripe.com/v3/')
             .then(() => {
                 if (!this._window.Stripe) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.Stripe(publishableKey, {

--- a/src/payment/strategies/zip/zip-script-loader.ts
+++ b/src/payment/strategies/zip/zip-script-loader.ts
@@ -1,6 +1,6 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { StandardError } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 import { Zip, ZipHostWindow } from '../zip/zip';
 
 export default class ZipScriptLoader {
@@ -14,7 +14,7 @@ export default class ZipScriptLoader {
             .loadScript(`//static.zipmoney.com.au/checkout/checkout-v1.min.js`)
             .then(() => {
                 if (!this._window.Zip) {
-                    throw new StandardError();
+                    throw new PaymentMethodClientUnavailableError();
                 }
 
                 return this._window.Zip;

--- a/src/remote-checkout/errors/remote-checkout-synchronization-error.ts
+++ b/src/remote-checkout/errors/remote-checkout-synchronization-error.ts
@@ -1,5 +1,9 @@
 import { StandardError } from '../../common/error/errors';
 
+/**
+ * Throw this error if we are unable to synchronize the checkout details of a
+ * shopper with a hosted / remote checkout provider (i.e.: Amazon).
+ */
 export default class RemoteCheckoutSynchronizationError extends StandardError {
     constructor(
         public error?: Error


### PR DESCRIPTION
## What?
Stop throwing generic `StandardError` type.

## Why?
* It's supposed to be a base class, intended for other custom error types to inherit from. But it has been used directly. It is not preferred because it's quite generic which doesn't give you more information than a regular `Error` type. This change makes it `abstract` so it's not possible to construct it directly.
* In order to do so, I've replaced all the usage of `StandardError` with more specific error types.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
