### PR TITLE
PAYMENTS-4616 Use paypal_account for sending paypal information to bigpay

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -4,7 +4,7 @@ export default interface Payment {
     paymentData?: PaymentInstrument & PaymentInstrumentMeta;
 }
 
-export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument | HostedInstrument | ThreeDSVaultedInstrument;
+export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument | HostedInstrument | ThreeDSVaultedInstrument | FormattedPayload<PaypalInstrument>;
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
@@ -26,6 +26,7 @@ export interface CreditCardInstrument {
 
 export interface NonceInstrument {
     nonce: string;
+    shouldSaveInstrument?: boolean;
     deviceSessionId?: string;
 }
 
@@ -68,4 +69,16 @@ export interface ThreeDSecureToken {
 
 export interface HostedInstrument {
     shouldSaveInstrument?: boolean;
+}
+
+export interface PaypalInstrument {
+    device_info: string | null;
+    paypal_account: {
+        token: string;
+        email: string | null;
+    };
+}
+
+export interface FormattedPayload<T> {
+    formattedPayload: T;
 }

--- a/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -184,6 +184,19 @@ describe('BraintreePaymentProcessor', () => {
         });
     });
 
+    describe('#getSessionId()', () => {
+        it('appends data to a processed payment', async () => {
+            braintreeSDKCreator.getDataCollector = jest.fn().mockResolvedValue({
+                deviceData: 'my_device_session_id',
+            });
+
+            const braintreePaymentProcessor = new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
+            const expected = await braintreePaymentProcessor.getSessionId();
+
+            expect(expected).toEqual('my_device_session_id');
+        });
+    });
+
     describe('#deinitialize()', () => {
         it('calls teardown in the braintree sdk creator', async () => {
             braintreeSDKCreator.teardown = jest.fn();

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -46,7 +46,7 @@ export interface BraintreeClient {
 }
 
 export interface BraintreeThreeDSecure extends BraintreeModule {
-    verifyCard(options: BraintreeThreeDSecureOptions): Promise<{ nonce: string }>;
+    verifyCard(options: BraintreeThreeDSecureOptions): Promise<BraintreeVerifyPayload>;
     cancelVerifyCard(): Promise<BraintreeVerifyPayload>;
 }
 


### PR DESCRIPTION
Note: https://github.com/bigcommerce/bigpay-client-js/pull/82 is required for this PR to work.

## What?
Send paypal payment information as `paypal_account`

## Why?
The API for bigpay will start requiring paypal information to be send
within the paypal_account key.

## Testing / Proof
- Unit / Functional / Manual

<img width="567" alt="image" src="https://user-images.githubusercontent.com/4542735/63907514-0ff61480-ca5f-11e9-865b-f5dd92238fe5.png">

@bigcommerce/checkout @bigcommerce/payments
