### PR TITLE
INT-1743 [Feedback - Post-Launch] PaymentMethodNotAllowed – The constraint on ORO are not handled

### DIFF
--- a/src/payment/errors/payment-method-not-allowed-error.spec.ts
+++ b/src/payment/errors/payment-method-not-allowed-error.spec.ts
@@ -1,0 +1,9 @@
+import PaymentMethodNotAllowedError from './payment-method-not-allowed-error';
+
+describe('PaymentMethodNotAllowedError', () => {
+    it('returns error name', () => {
+        const error = new PaymentMethodNotAllowedError();
+
+        expect(error.name).toEqual('PaymentMethodNotAllowedError');
+    });
+});

--- a/src/payment/errors/payment-method-not-allowed-error.ts
+++ b/src/payment/errors/payment-method-not-allowed-error.ts
@@ -1,0 +1,12 @@
+import { Response } from '@bigcommerce/request-sender';
+
+import { RequestError } from '../../common/error/errors';
+
+export default class PaymentMethodNotAllowedError extends RequestError {
+    constructor(response?: Response) {
+        super(response, { message: 'The selected payment method is not allowed for this transaction. Please choose another payment method.' });
+
+        this.name = 'PaymentMethodNotAllowedError';
+        this.type = 'payment_method_not_allowed';
+    }
+}

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -38,6 +38,7 @@ import {
 } from '../../../remote-checkout';
 import { getRemoteCheckoutState, getRemoteCheckoutStateData } from '../../../remote-checkout/remote-checkout.mock';
 import { getConsignmentsState } from '../../../shipping/consignments.mock';
+import PaymentMethodNotAllowedError from '../../errors/payment-method-not-allowed-error';
 import PaymentMethod from '../../payment-method';
 import { getAmazonPay, getPaymentMethodsState } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
@@ -76,6 +77,7 @@ describe('AmazonPayPaymentStrategy', () => {
             walletSpy(options);
 
             options.onReady(orderReference);
+            options.onPaymentSelect(orderReference);
         }
 
         bind(id: string) {
@@ -468,7 +470,26 @@ describe('AmazonPayPaymentStrategy', () => {
         }
     });
 
-    describe('When 3ds is enabled', () => {
+    describe('#initialize', () => {
+        it('throws PaymentMethodNotAllowedError', () => {
+            const remoteCheckout = {
+                referenceId: 'referenceId',
+                billing: {
+                    address: {},
+                    paymentMethodNotAllowed: true,
+                },
+            };
+
+            jest.spyOn(store, 'getState');
+            jest.spyOn(store.getState().remoteCheckout, 'getCheckout')
+                .mockReturnValue(remoteCheckout);
+
+            expect(strategy.initialize({ methodId: paymentMethod.id, amazon: { container: 'wallet' } }))
+                .resolves.toThrow(PaymentMethodNotAllowedError);
+        });
+    });
+
+    describe('#execute', () => {
         const paymentMethodsState = {
             data: [{
                 id: 'amazon',
@@ -528,7 +549,7 @@ describe('AmazonPayPaymentStrategy', () => {
             await strategy3ds.initialize({ methodId: paymentMethod.id, amazon: { container: 'wallet' } });
         });
 
-        it('redirects to confirmation flow success when support 3ds', async () => {
+        it('redirects to confirmation flow success when 3ds is enabled and supported', async () => {
             if (hostWindow.OffAmazonPayments) {
                 hostWindow.OffAmazonPayments.initConfirmationFlow = jest.fn((_sellerId, _referenceId, callback) => {
                     callback(amazonConfirmationFlow);
@@ -543,7 +564,7 @@ describe('AmazonPayPaymentStrategy', () => {
 
         });
 
-        it('redirects to confirmation flow  error when initializePayment fails', async () => {
+        it('redirects to confirmation flow  error when 3ds is enabled and initializePayment fails', async () => {
             if (hostWindow.OffAmazonPayments) {
                 jest.spyOn(remoteCheckoutActionCreator, 'initializePayment')
                     .mockImplementation(() => {
@@ -564,7 +585,7 @@ describe('AmazonPayPaymentStrategy', () => {
             }
         });
 
-        it('returns NotInitializedError when referenceId is undefined', async () => {
+        it('returns NotInitializedError when 3ds is enabled and referenceId is undefined', async () => {
             jest.spyOn(store3ds.getState().remoteCheckout, 'getCheckout')
                 .mockReturnValue({ referenceId: undefined });
             try {
@@ -574,7 +595,7 @@ describe('AmazonPayPaymentStrategy', () => {
             }
         });
 
-        it('returns NotInitializedError when payload.payment is undefined', async () => {
+        it('returns NotInitializedError when 3ds is enabled and payload.payment is undefined', async () => {
             payload.payment = undefined;
             try {
                 await strategy3ds.execute(payload, options);

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -19,6 +19,7 @@ import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
 import { RemoteCheckoutSynchronizationError } from '../../../remote-checkout/errors';
+import PaymentMethodNotAllowedError from '../../errors/payment-method-not-allowed-error';
 import PaymentMethod from '../../payment-method';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
@@ -211,6 +212,10 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                 const remoteAddress = amazon && amazon.billing && amazon.billing.address;
                 const billingAddress = state.billingAddress.getBillingAddress();
                 const internalBillingAddress = billingAddress && mapToInternalAddress(billingAddress);
+
+                if (amazon && amazon.billing && amazon.billing.paymentMethodNotAllowed) {
+                    throw new PaymentMethodNotAllowedError();
+                }
 
                 if (remoteAddress === false) {
                     throw new RemoteCheckoutSynchronizationError();

--- a/src/remote-checkout/methods/amazon-pay-remote-checkout.ts
+++ b/src/remote-checkout/methods/amazon-pay-remote-checkout.ts
@@ -4,6 +4,7 @@ export default interface AmazonPayRemoteCheckout {
     referenceId?: string;
     billing?: {
         address?: InternalAddress | false;
+        paymentMethodNotAllowed?: boolean;
     };
     shipping?: {
         address?: InternalAddress | false;


### PR DESCRIPTION
[INT-1743](https://jira.bigcommerce.com/browse/INT-1743)
## What?
We are handling the PaymentMethodNotAllowed error

## Why?
we want to be able to handle this error inside bigcommerce page

## Testing / Proof
![PaymentMethodNotAllowed](https://user-images.githubusercontent.com/39630835/64213036-14606a00-ce71-11e9-9186-1051509e08df.gif)


## Siblings PRs
[INT-1743 BCAPP](https://github.com/bigcommerce/bigcommerce/pull/31545)

@bigcommerce/checkout @bigcommerce/payments
