### PR TITLE
CHECKOUT-4388: Mark index file of Embedded Checkout as file with side effect

### DIFF
--- a/src/common/iframe/iframe-resizer.ts
+++ b/src/common/iframe/iframe-resizer.ts
@@ -28,3 +28,13 @@ export function iframeResizer(options: IFrameOptions, target: string | HTMLEleme
 
     return originalIframeResizer(options, target);
 }
+
+// We also need to wrap the original `iframeResizer.contentWindow` because
+// similarly the package sets up event listeners as soon as the package gets
+// imported. Another reason is that if it is imported at the top level using a
+// regular import statement, it will be stripped out by Webpack as it is
+// considered as "unused", unless we explicitly mark it as a package that
+// produces side effects.
+export function setupContentWindowForIframeResizer(): void {
+    require('iframe-resizer/js/iframeResizer.contentWindow');
+}

--- a/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/create-embedded-checkout-messenger.ts
@@ -1,3 +1,4 @@
+import { setupContentWindowForIframeResizer } from '../../common/iframe';
 import { EmbeddedCheckoutEvent, EmbeddedCheckoutEventType } from '../embedded-checkout-events';
 import IframeEventListener from '../iframe-event-listener';
 import IframeEventPoster from '../iframe-event-poster';
@@ -35,6 +36,8 @@ import NoopEmbeddedCheckoutMessenger from './noop-embedded-checkout-messenger';
  * @returns - An instance of `EmbeddedCheckoutMessenger`
  */
 export default function createEmbeddedCheckoutMessenger(options: EmbeddedCheckoutMessengerOptions): EmbeddedCheckoutMessenger {
+    setupContentWindowForIframeResizer();
+
     const parentWindow = options.parentWindow || window.parent;
 
     // Return a No-op messenger if it is not called inside an iframe

--- a/src/embedded-checkout/iframe-content/index.ts
+++ b/src/embedded-checkout/iframe-content/index.ts
@@ -1,3 +1,1 @@
-import 'iframe-resizer/js/iframeResizer.contentWindow';
-
 export { default as createEmbeddedCheckoutMessenger } from './create-embedded-checkout-messenger';


### PR DESCRIPTION
## What?
Mark the index file of Embedded Checkout as a file with side effects.

## Why?
* Otherwise, `iframeResizer.contentWindow`, which is used in the index file, gets stripped out.
* It appears the file has been stripped out since the beginning. But the problem doesn't affect anything because the file is also exported in the index file of `iframeResizer` package. When the package gets imported, it also imports `iframeResizer.contentWindow`, which performs some side effect calls (i.e.: setting up event listeners). But since the change introduced by #679, we no longer require `iframeResizer` inside the iframe, which means `iframeResizer.contentWindow` from `iframeResizer` also doesn't get required and executed.
* The workaround for this problem is simply to require `iframeResizer.contentWindow` in `createEmbeddedCheckoutMessenger`, which is always called inside the iframe. That way, Webpack won't strip out the package because it will not consider it unused; and we will only set up the event listeners (the side effects of `iframeResizer.contentWindow`) when Embedded Checkout is active.

## Testing / Proof
Manual
<img width="970" alt="Screen Shot 2019-09-04 at 4 18 40 pm" src="https://user-images.githubusercontent.com/667603/64230272-b34b9b80-cf2f-11e9-8803-db5abc2cadaa.png">

@bigcommerce/checkout @bigcommerce/payments
