### PR TITLE
fix(order): CHECKOUT-4393 Fix could not resubmit order after failed attempt

### DIFF
--- a/src/order/spam-protection/google-recaptcha.spec.ts
+++ b/src/order/spam-protection/google-recaptcha.spec.ts
@@ -73,6 +73,8 @@ describe('GoogleRecaptcha', () => {
 
             googleRecaptchaMock = getGoogleRecaptchaMock();
 
+            googleRecaptchaMock.render = jest.fn((_containerId, { callback }) => callback());
+
             jest.spyOn(googleRecaptchaScriptLoader, 'load')
                 .mockResolvedValue(googleRecaptchaMock);
         });
@@ -98,6 +100,8 @@ describe('GoogleRecaptcha', () => {
 
             await new Promise(resolve => process.nextTick(resolve));
 
+            expect(googleRecaptchaMock.getResponse).toHaveBeenCalled();
+            expect(googleRecaptchaMock.reset).toHaveBeenCalled();
             expect(googleRecaptchaMock.execute).toHaveBeenCalled();
         });
     });

--- a/src/order/spam-protection/google-recaptcha.ts
+++ b/src/order/spam-protection/google-recaptcha.ts
@@ -33,6 +33,7 @@ export default class GoogleRecaptcha {
                         event$.next({
                             token: recaptcha.getResponse(),
                         });
+                        recaptcha.reset();
                     },
                     'error-callback': () => {
                         event$.next({
@@ -83,8 +84,6 @@ export default class GoogleRecaptcha {
                     error: new SpamProtectionNotCompletedError(),
                 });
             }
-        })
-
-        .observe(container, { attributes: true, attributeFilter: ['style'] });
+        }).observe(container, { attributes: true, attributeFilter: ['style'] });
     }
 }


### PR DESCRIPTION
## What?
As per above.

## Why?
After we got the spam protection token from Google for the first failed attempt to place an order, the callback will not be called the second time, and this caused it to get stuck. After this fix, we will reset after we got the token, so that if the first attempt failed, callback will still be called for the second attempt, also Google does not allow to reuse the token

## Testing / Proof
Manual testing. Placed an order successfully after failing the a few attempt:
![Screen Shot 2019-09-06 at 11 39 58 am](https://user-images.githubusercontent.com/22089936/64394779-160d7600-d09b-11e9-9327-1f44160fa112.png)


@bigcommerce/checkout @bigcommerce/payments
