### PR TITLE
fix(shopper): CHECKOUT-4415 Add Customer Group to Customer object in payments payload

### DIFF
--- a/src/checkout/checkout-default-includes.ts
+++ b/src/checkout/checkout-default-includes.ts
@@ -2,6 +2,7 @@ const CHECKOUT_DEFAULT_INCLUDES = [
     'cart.lineItems.physicalItems.options',
     'cart.lineItems.digitalItems.options',
     'customer',
+    'customer.customerGroup',
     'payments',
     'promotions.banners',
 ];

--- a/src/checkout/checkout-request-sender.spec.ts
+++ b/src/checkout/checkout-request-sender.spec.ts
@@ -17,6 +17,7 @@ describe('CheckoutRequestSender', () => {
         'cart.lineItems.physicalItems.options',
         'cart.lineItems.digitalItems.options',
         'customer',
+        'customer.customerGroup',
         'payments',
         'promotions.banners',
     ].join(',');

--- a/src/coupon/coupon-request-sender.spec.ts
+++ b/src/coupon/coupon-request-sender.spec.ts
@@ -13,6 +13,7 @@ describe('Coupon Request Sender', () => {
         'cart.lineItems.physicalItems.options',
         'cart.lineItems.digitalItems.options',
         'customer',
+        'customer.customerGroup',
         'payments',
         'promotions.banners',
         'consignments.availableShippingOptions',

--- a/src/coupon/gift-certificate-request-sender.spec.ts
+++ b/src/coupon/gift-certificate-request-sender.spec.ts
@@ -14,6 +14,7 @@ describe('Gift Certificate Request Sender', () => {
         'cart.lineItems.physicalItems.options',
         'cart.lineItems.digitalItems.options',
         'customer',
+        'customer.customerGroup',
         'payments',
         'promotions.banners',
     ].join(',');

--- a/src/customer/customer.ts
+++ b/src/customer/customer.ts
@@ -9,9 +9,15 @@ export default interface Customer {
     fullName: string;
     isGuest: boolean;
     lastName: string;
+    customerGroup: CustomerGroup;
 }
 
 export interface CustomerAddress extends Address {
     id: number;
     type: string;
+}
+
+export interface CustomerGroup  {
+    id: number;
+    name: string;
 }

--- a/src/customer/customers.mock.ts
+++ b/src/customer/customers.mock.ts
@@ -12,6 +12,10 @@ export function getGuestCustomer(): Customer {
         isGuest: true,
         lastName: '',
         storeCredit: 0,
+        customerGroup: {
+            id: 0,
+            name: '',
+        },
     };
 }
 
@@ -31,6 +35,10 @@ export function getCustomer(): Customer {
             },
         ],
         isGuest: false,
+        customerGroup: {
+            id: 1,
+            name: 'vip',
+        },
     };
 }
 

--- a/src/customer/internal-customers.mock.ts
+++ b/src/customer/internal-customers.mock.ts
@@ -8,6 +8,7 @@ export function getGuestCustomer(): InternalCustomer {
     return {
         addresses: [],
         customerId: 0,
+        customerGroupName: '',
         email: 'test@bigcommerce.com',
         firstName: 'Test',
         lastName: 'Tester',
@@ -27,6 +28,7 @@ export function getCustomer(): InternalCustomer {
             },
         ],
         customerId: 4,
+        customerGroupName: 'vip',
         isGuest: false,
         email: 'test@bigcommerce.com',
         firstName: 'Foo',

--- a/src/customer/map-to-internal-customer.ts
+++ b/src/customer/map-to-internal-customer.ts
@@ -22,5 +22,6 @@ export default function mapToInternalCustomer(customer: Customer, billingAddress
         firstName,
         lastName,
         name: customer.fullName || [firstName, lastName].join(' '),
+        customerGroupName: customer.customerGroup.name,
     };
 }

--- a/src/store-credit/store-credit-request-sender.spec.ts
+++ b/src/store-credit/store-credit-request-sender.spec.ts
@@ -13,6 +13,7 @@ describe('StoreCredit Request Sender', () => {
         'cart.lineItems.physicalItems.options',
         'cart.lineItems.digitalItems.options',
         'customer',
+        'customer.customerGroup',
         'payments',
         'promotions.banners',
     ].join(',');


### PR DESCRIPTION
## What?
Fixing ticket CHECKOUT-4415: After CHECKOUT-4405 (API and checkoutSDK to support Customer Group) has been merged, Checkout SDK needs to be updated to retrieve the customer group as part of the customer information by requesting `customer.customerGroup`

e.g. https://my-dev-store-574230549.store.bcdev/api/storefront/checkout/08efed69-92fd-41c5-ba58-60a9aa0313e7?include=customer.customerGroup

## Why?
Mainly to fix the issue PAYMENTS-4691: CyberSource Field 90 (Customer Group) Does Not Get Passed on UCO

## Testing / Proof
Unit Testing
Screenshots

<img width="1074" alt="Screen Shot 2019-09-13 at 5 43 47 pm" src="https://user-images.githubusercontent.com/36555311/64845656-1afb9800-d64e-11e9-9668-11b3cad47eb2.png">

<img width="1202" alt="Screen Shot 2019-09-13 at 5 47 24 pm" src="https://user-images.githubusercontent.com/36555311/64845929-b55bdb80-d64e-11e9-8b93-80a61c7d2073.png">

ping @bigcommerce-labs/payments
ping @bigcommerce/checkout 
ping @bigcommerce/payments

