### PR TITLE
CHECKOUT-4427: Fix IE11 issues for Embedded Checkout

### DIFF
--- a/src/common/url/parse-url.ts
+++ b/src/common/url/parse-url.ts
@@ -12,13 +12,19 @@ export default function parseUrl(url: string): Url {
 
     anchor.href = url;
 
+    // IE11 returns 80 or 443 for the port number depending on the URL scheme,
+    // even if the port number is not specified in the URL.
+    const port = anchor.port && url.indexOf(`${anchor.hostname}:${anchor.port}`) !== -1 ?
+        anchor.port :
+        '';
+
     return {
         hash: anchor.hash,
         hostname: anchor.hostname,
         href: anchor.href,
-        origin: anchor.origin,
+        origin: `${anchor.protocol}//${anchor.hostname}${port ? ':' + port : ''}`,
         pathname: anchor.pathname,
-        port: anchor.port,
+        port,
         protocol: anchor.protocol,
         search: anchor.search,
     };

--- a/src/embedded-checkout/loading-indicator.ts
+++ b/src/embedded-checkout/loading-indicator.ts
@@ -105,12 +105,14 @@ export default class LoadingIndicator {
         document.head.appendChild(style);
 
         if (style.sheet instanceof CSSStyleSheet) {
+            // We need to provide the 2nd parameter for IE11, even though it is
+            // 0 by default for all other browsers.
             style.sheet.insertRule(`
                 @keyframes ${ROTATION_ANIMATION} {
                     0% { transform: translateY(-50%) rotate(0deg); }
                     100% { transform: translateY(-50%) rotate(360deg); }
                 }
-            `);
+            `, 0);
         }
     }
 }


### PR DESCRIPTION
## What?
* Get the origin of URL by constructing it manually. IE11 doesn't support `HTMLHyperlinkElementUtils#origin` according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/origin). So we can't use it to get the origin of URL. Also, we can't get it by creating `URL` instance because IE11 doesn't support it as well.
* Provide an index position when inserting CSS rule. According to the [doc](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule), the index parameter is not optional for IE11.

## Why?
Otherwise, Embedded Checkout won't load in IE11.

## Testing / Proof
Manual
<img width="1269" alt="Screen Shot 2019-09-16 at 11 03 47 am" src="https://user-images.githubusercontent.com/667603/64930223-11eb1080-d872-11e9-8539-7a46c67ba6a2.png">

@bigcommerce/checkout @bigcommerce/payments
