### PR TITLE
#681 Use Lodash find

### DIFF
--- a/src/order/map-to-internal-order.ts
+++ b/src/order/map-to-internal-order.ts
@@ -153,7 +153,7 @@ function mapToInternalSocialData(lineItem: LineItem): InternalSocialDataList {
     const codes = ['fb', 'tw', 'gp'];
 
     return codes.reduce((socialData, code) => {
-        const item = lineItem.socialMedia && lineItem.socialMedia.find(item => item.code === code);
+        const item = lineItem.socialMedia && find(lineItem.socialMedia, item => item.code === code);
 
         if (!item) {
             return socialData;

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -1,4 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
+import { find } from 'lodash';
 import { Observable, Observer } from 'rxjs';
 
 import { AddressRequestBody } from '../address';
@@ -332,7 +333,7 @@ export default class ConsignmentActionCreator {
         }
 
         return this._hydrateLineItems(consignment.lineItemIds, cart).map(existingItem => {
-            const sharedItem = lineItems.find(lineItem => lineItem.itemId === existingItem.itemId);
+            const sharedItem = find(lineItems, lineItem => lineItem.itemId === existingItem.itemId);
 
             return {
                 ...existingItem,
@@ -361,7 +362,7 @@ export default class ConsignmentActionCreator {
 
     private _hydrateLineItems(lineItemIds: string[], cart: Cart): ConsignmentLineItem[] {
         return lineItemIds.map(itemId => {
-            const item = cart.lineItems.physicalItems.find(lineItem => lineItem.id === itemId );
+            const item = find(cart.lineItems.physicalItems, lineItem => lineItem.id === itemId);
 
             return {
                 itemId,


### PR DESCRIPTION
## What?
Use lodash `find` instead of `Array.protoype.find`

## Why?
To avoid need of polyfills. https://github.com/bigcommerce/checkout-sdk-js/issues/681

## Testing / Proof
unit

@bigcommerce/checkout 
