### PR TITLE
CHECKOUT-4415: Check if `customerGroup` is defined before accessing it

### DIFF
--- a/src/customer/customer.ts
+++ b/src/customer/customer.ts
@@ -9,7 +9,7 @@ export default interface Customer {
     fullName: string;
     isGuest: boolean;
     lastName: string;
-    customerGroup: CustomerGroup;
+    customerGroup?: CustomerGroup;
 }
 
 export interface CustomerAddress extends Address {

--- a/src/customer/map-to-internal-customer.ts
+++ b/src/customer/map-to-internal-customer.ts
@@ -22,6 +22,6 @@ export default function mapToInternalCustomer(customer: Customer, billingAddress
         firstName,
         lastName,
         name: customer.fullName || [firstName, lastName].join(' '),
-        customerGroupName: customer.customerGroup.name,
+        customerGroupName: customer.customerGroup && customer.customerGroup.name,
     };
 }


### PR DESCRIPTION
## What?
Check if `customerGroup` is defined before accessing it.

## Why?
It can be undefined (i.e.: a guest shopper always doesn't belong to a group; also a returning shopper may not belong to a group).

## Testing / Proof
Manual

@bigcommerce/checkout @bigcommerce/payments
