### PR TITLE
feat(payment): INT-1901 Use modal to handle 3DS

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -371,7 +371,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             formPoster
-            )
+        )
     );
 
     registry.register(PaymentStrategyType.STRIPEV3, () =>

--- a/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
@@ -1,6 +1,6 @@
 import Omit from '../../../common/types/omit';
 
-import { CreditCardComponentOptions, ThreeDS2ComponentOptions } from './adyenv2';
+import { AdyenCreditCardComponentOptions, AdyenThreeDS2Options } from './adyenv2';
 
 /**
  * A set of options that are required to initialize the AdyenV2 payment method.
@@ -21,12 +21,12 @@ export default interface AdyenV2PaymentInitializeOptions {
     threeDS2ContainerId: string;
 
     /**
-     * Optional. Overwriting the default options
+     * ThreeDS2Options
      */
-    options?: Omit<CreditCardComponentOptions, 'onChange'>;
+    threeDS2Options: AdyenThreeDS2Options;
 
     /**
-     * Optional. Contains all three ds 2 options
+     * Optional. Overwriting the default options
      */
-    threeDS2Options?: ThreeDS2ComponentOptions;
+    options?: Omit<AdyenCreditCardComponentOptions, 'onChange'>;
 }

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -31,7 +31,6 @@ export default class AdyenV2ScriptLoader {
         .catch(() => {
             throw new PaymentMethodClientUnavailableError();
         });
-
     }
 
     private _loadStylesheet(src: string): Promise<Event> {

--- a/src/payment/strategies/adyenv2/adyenv2.mock.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.mock.ts
@@ -1,5 +1,9 @@
+
+import { RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
 import { OrderRequestBody } from '../../../order';
 import { PaymentInitializeOptions } from '../../payment-request-options';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
 
 import {
     AdyenCardState,
@@ -38,7 +42,11 @@ export function getAdyenInitializeOptions(): PaymentInitializeOptions {
                 styles: {},
                 placeholders: {},
             },
-            threeDS2Options: { threeDS2ChallengeWidgetSize: '01' },
+            threeDS2Options: {
+                widgetSize: '1',
+                onComplete: jest.fn(),
+                onLoad: jest.fn(),
+            },
         },
     };
 }
@@ -86,7 +94,7 @@ export function getValidChallengeResponse(): any {
     };
 }
 
-export function getChallengeShopperErrorResponse(): ThreeDSRequiredErrorResponse {
+function getChallengeShopperErrorResponse(): ThreeDSRequiredErrorResponse {
     return {
         errors: [
             { code: 'three_d_secure_required' },
@@ -98,6 +106,13 @@ export function getChallengeShopperErrorResponse(): ThreeDSRequiredErrorResponse
         },
         status: 'error',
     };
+}
+
+export function getChallengeShopperError(): RequestError {
+    return new RequestError(getResponse({
+        ...getErrorPaymentResponseBody(),
+        ...getChallengeShopperErrorResponse(),
+    }));
 }
 
 export function getIdentifyShopperErrorResponse(): ThreeDSRequiredErrorResponse {
@@ -113,8 +128,14 @@ export function getIdentifyShopperErrorResponse(): ThreeDSRequiredErrorResponse 
         status: 'error',
     };
 }
+export function getIdentifyShopperError(): RequestError {
+    return new RequestError(getResponse({
+        ...getErrorPaymentResponseBody(),
+        ...getIdentifyShopperErrorResponse(),
+    }));
+}
 
-export function getRedirectShopperErrorResponse(): ThreeDSRequiredErrorResponse {
+function getRedirectShopperErrorResponse(): ThreeDSRequiredErrorResponse {
     return {
         errors: [
             { code: 'three_d_secure_required' },
@@ -128,4 +149,11 @@ export function getRedirectShopperErrorResponse(): ThreeDSRequiredErrorResponse 
         },
         status: 'error',
     };
+}
+
+export function getRedirectShopperError(): RequestError {
+    return new RequestError(getResponse({
+        ...getErrorPaymentResponseBody(),
+        ...getRedirectShopperErrorResponse(),
+    }));
 }

--- a/src/payment/strategies/adyenv2/adyenv2.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.ts
@@ -162,6 +162,24 @@ export interface InputDetail {
     value?: string;
 }
 
+export interface AdyenThreeDS2Options {
+    /**
+     * Specify Three3DS2Challenge Widget Size
+     */
+    widgetSize?: string;
+
+    /**
+     * A callback that gets called when adyen component is mounted
+     */
+    onLoad(cancel: () => void): void;
+
+    /**
+     * A callback that gets called when adyen component verification
+     * is completed
+     */
+    onComplete(): void;
+}
+
 export enum ThreeDS2ComponentType {
     ThreeDS2DeviceFingerprint = 'threeDS2DeviceFingerprint',
     ThreeDS2Challenge = 'threeDS2Challenge',
@@ -452,15 +470,11 @@ export interface AdyenComponent {
 }
 
 export interface AdyenCheckout {
-    create(type: string, componentOptions?: CreditCardComponentOptions |
+    create(type: string, componentOptions?: AdyenCreditCardComponentOptions |
         ThreeDS2DeviceFingerprintComponentOptions | ThreeDS2ChallengeComponentOptions): AdyenComponent;
 }
 
-export interface ThreeDS2ComponentOptions {
-    threeDS2ChallengeWidgetSize?: string;
-}
-
-export interface CreditCardComponentOptions {
+export interface AdyenCreditCardComponentOptions {
     /**
      * Set an object containing the details array for type: scheme from
      * the /paymentMethods response.


### PR DESCRIPTION
## What?
3DS 2.0 should show in a modal and you should not be able to do anything else. As well the loading icon keeps showing see screenshot.

## Why?
AdyenV2 Feedback

## Testing / Proof
![image](https://user-images.githubusercontent.com/8570490/66013189-e2eab680-e48f-11e9-80bf-0f2004a2372f.png)

![NewAdyen3DSModal](https://user-images.githubusercontent.com/8570490/66013106-8ab3b480-e48f-11e9-9426-7fa5a4df2a7f.gif)

## Sibling PR
[UCO](https://github.com/bigcommerce/checkout-js/pull/120)

@bigcommerce/checkout @bigcommerce/payments
