### PR TITLE
640 Add shippingAddress initial param for Braintree PayPal

### DIFF
--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
@@ -1,3 +1,4 @@
+import { Address } from '../../../address';
 import { StandardError } from '../../../common/error/errors';
 import { BraintreeError } from '../../../payment/strategies/braintree';
 import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
@@ -18,6 +19,12 @@ export interface BraintreePaypalButtonInitializeOptions {
      * Whether or not to show a credit button.
      */
     allowCredit?: boolean;
+
+    /**
+     * Address to be used for shipping.
+     * If not provided, it will use the first saved address from the active customer.
+     */
+    shippingAddress?: Address | null;
 
     /**
      * A callback that gets called if unable to authorize and tokenize payment.


### PR DESCRIPTION
## What?
Allow to pass a shipping address when initialising Braintree PayPal.
For backwards compatibility, if none is provided, we would still pick the first customer address.

## Why?
https://github.com/bigcommerce/checkout-sdk-js/issues/640
Give more control to the SDK client and allow them to decide what value should be passed. 

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
