### PR TITLE
INT-1956 Disable or enable checkout button depending if a payment method is selected or not

### DIFF
--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-initialize-options.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-initialize-options.ts
@@ -1,4 +1,5 @@
 import { StandardError } from '../../../common/error/errors';
+import PaymentMethod from '../../payment-method';
 
 import AmazonPayOrderReference from './amazon-pay-order-reference';
 import AmazonPayWidgetError from './amazon-pay-widget-error';
@@ -15,6 +16,14 @@ export default interface AmazonPayPaymentInitializeOptions {
      * The ID of a container which the payment widget should insert into.
      */
     container: string;
+
+    /**
+     * A method used to disable/enable the checkout button
+     *
+     * @param {PaymentMethod} method
+     * @param {boolean} disabled
+     */
+    disableSubmit?(method: PaymentMethod, disabled: boolean): void;
 
     /**
      * A callback that gets called if unable to initialize the widget or select

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -150,7 +150,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
 
     private _createWallet(options: AmazonPayPaymentInitializeOptions): Promise<AmazonPayWallet> {
         return new Promise((resolve, reject) => {
-            const { container, onError = noop, onPaymentSelect = noop, onReady = noop } = options;
+            const { container, onError = noop, onPaymentSelect = noop, onReady = noop, disableSubmit = noop } = options;
             const referenceId = this._getOrderReferenceId() || this._getOrderReferenceIdFromInitializationData();
             const merchantId = this._getMerchantId();
 
@@ -180,8 +180,12 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                         .then(() => {
                             this._isPaymentMethodSelected = true;
                             onPaymentSelect(orderReference);
+                            disableSubmit(this._paymentMethod, false);
                         })
-                        .catch(onError);
+                        .catch(error => {
+                            onError(error);
+                            disableSubmit(this._paymentMethod, true);
+                        });
                 },
                 onReady: orderReference => {
                     resolve();


### PR DESCRIPTION
[INT-1956](https://jira.bigcommerce.com/browse/INT-1956)
## What?
Adding the ability to disable or enable the checkout button if a payment method is selected or not

## Why?
Because we want to prevent the user to click the checkout button if a payment method is not selected

## Testing / Proof
![INT-1956](https://user-images.githubusercontent.com/39630835/65467005-f52c7b00-de25-11e9-84f3-a75704937185.gif)

## Siblings PRs
[INT-1956 SDK](https://github.com/bigcommerce/checkout-sdk-js/pull/712)


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
