### PR TITLE
feat(payments): PAYPAL-7 Pass in merchant ID on PayPal button script for PayPal Express Checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,9 +1251,9 @@
       }
     },
     "@bigcommerce/script-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.0.0.tgz",
-      "integrity": "sha512-85/LHtiEPgKoezE6X/CxQ3p4wxarSil6tF063vUNpNVaL52oiHK53YZ3Km3ZuwMHfwxzviXqLWcfoDiOcUlKvA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.1.0.tgz",
+      "integrity": "sha512-8gDZLB9MBcXw9UsicgL5sQu8pBlEGLG/Hq7ks7CdDxiHile/ySvLUwvBQWcrDBbh9VfzGtKMjNUbfqeVdo+PJg==",
       "requires": {
         "@bigcommerce/request-sender": "^0.3.0",
         "tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/memoize": "^1.0.0",
     "@bigcommerce/request-sender": "^0.3.0",
-    "@bigcommerce/script-loader": "^2.0.0",
+    "@bigcommerce/script-loader": "^2.1.0",
     "@types/iframe-resizer": "^3.5.6",
     "@types/lodash": "^4.14.139",
     "@types/reselect": "^2.2.0",

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -8,7 +8,7 @@ import { from } from 'rxjs';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { MissingDataError } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getPaypalExpress } from '../../../payment/payment-methods.mock';
 import { PaypalActions, PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../../payment/strategies/paypal';
@@ -108,7 +108,7 @@ describe('PaypalButtonStrategy', () => {
         );
     });
 
-    it('throws error if required data is not loaded', async () => {
+    it('throws error if paypal options is not loaded', async () => {
         try {
             store = createCheckoutStore();
             strategy = new PaypalButtonStrategy(
@@ -117,6 +117,32 @@ describe('PaypalButtonStrategy', () => {
                 paypalScriptLoader,
                 formPoster
             );
+
+            options = {
+                containerId: 'checkout-button',
+                methodId: CheckoutButtonMethodType.PAYPALEXPRESS,
+            };
+
+            await strategy.initialize(options);
+        } catch (error) {
+            expect(error).toBeInstanceOf(InvalidArgumentError);
+        }
+    });
+
+    it('throws error if payment method is not loaded', async () => {
+        try {
+            store = createCheckoutStore();
+            strategy = new PaypalButtonStrategy(
+                store,
+                checkoutActionCreator,
+                paypalScriptLoader,
+                formPoster
+            );
+
+            options = {
+                containerId: 'checkout-button',
+                paypal: paypalOptions,
+            } as CheckoutButtonInitializeOptions;
 
             await strategy.initialize(options);
         } catch (error) {

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
@@ -29,7 +29,11 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
             throw new InvalidArgumentError();
         }
 
-        return this._paypalScriptLoader.loadPaypal()
+        if (!paymentMethod) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return this._paypalScriptLoader.loadPaypal(paymentMethod.config.merchantId)
             .then(paypal => {
                 if (!paymentMethod || !paymentMethod.config.merchantId) {
                     throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);

--- a/src/payment/strategies/paypal/paypal-script-loader.spec.ts
+++ b/src/payment/strategies/paypal/paypal-script-loader.spec.ts
@@ -16,7 +16,7 @@ describe('PaypalScriptLoader', () => {
         paypalLoader = new PaypalScriptLoader(loader);
     });
 
-    it('loads PayPal script', async () => {
+    it('loads PayPal script without Merchant Id', async () => {
         jest.spyOn(loader, 'loadScript')
             .mockImplementation(() => {
                 (window as PaypalHostWindow).paypal = paypal;
@@ -27,6 +27,20 @@ describe('PaypalScriptLoader', () => {
         const output = await paypalLoader.loadPaypal();
 
         expect(loader.loadScript).toHaveBeenCalledWith('//www.paypalobjects.com/api/checkout.min.js');
+        expect(output).toEqual(paypal);
+    });
+
+    it('loads PayPal script with Merchant Id', async () => {
+        jest.spyOn(loader, 'loadScript')
+            .mockImplementation(() => {
+                (window as PaypalHostWindow).paypal = paypal;
+
+                return Promise.resolve();
+            });
+
+        const output = await paypalLoader.loadPaypal('ABC');
+
+        expect(loader.loadScript).toHaveBeenCalledWith('//www.paypalobjects.com/api/checkout.min.js', {async: true, attributes: { 'data-merchant-id': 'ABC'}});
         expect(output).toEqual(paypal);
     });
 

--- a/src/payment/strategies/paypal/paypal-script-loader.ts
+++ b/src/payment/strategies/paypal/paypal-script-loader.ts
@@ -13,7 +13,7 @@ export default class PaypalScriptLoader {
         this._window = window;
     }
 
-    loadPaypal = async (merchantId: string = ''): Promise<PaypalSDK> => {
+    async loadPaypal(merchantId: string = ''): Promise<PaypalSDK> {
         const scriptSrc = '//www.paypalobjects.com/api/checkout.min.js';
         const options: LoadScriptOptions = { async: true, attributes: { 'data-merchant-id': merchantId } };
 
@@ -26,5 +26,5 @@ export default class PaypalScriptLoader {
         }
 
         return this._window.paypal;
-    };
+    }
 }

--- a/src/payment/strategies/paypal/paypal-script-loader.ts
+++ b/src/payment/strategies/paypal/paypal-script-loader.ts
@@ -6,6 +6,7 @@ import { PaypalHostWindow, PaypalSDK } from './paypal-sdk';
 
 export default class PaypalScriptLoader {
     private _window: PaypalHostWindow;
+    private _scripts: { [key: string]: Promise<Event> } = {};
 
     constructor(
         private _scriptLoader: ScriptLoader
@@ -13,15 +14,52 @@ export default class PaypalScriptLoader {
         this._window = window;
     }
 
-    loadPaypal(): Promise<PaypalSDK> {
-        return this._scriptLoader
-            .loadScript('//www.paypalobjects.com/api/checkout.min.js')
-            .then(() => {
-                if (!this._window.paypal) {
-                    throw new PaymentMethodClientUnavailableError();
-                }
+    loadPaypal(merchantId: string = ''): Promise<PaypalSDK> {
+        if (merchantId.length > 0) {
+            return this.loadScriptWithAttribute('//www.paypalobjects.com/api/checkout.min.js', 'data-merchant-id', merchantId)
+                .then(() => {
+                    if (!this._window.paypal) {
+                        throw new PaymentMethodClientUnavailableError();
+                    }
 
-                return this._window.paypal;
-            });
+                    return this._window.paypal;
+                });
+        } else {
+            return this._scriptLoader
+                .loadScript('//www.paypalobjects.com/api/checkout.min.js')
+                .then(() => {
+                    if (!this._window.paypal) {
+                        throw new PaymentMethodClientUnavailableError();
+                    }
+
+                    return this._window.paypal;
+                });
+        }
     }
+
+    loadScriptWithAttribute(src: string, attribute: string, value: string): Promise<Event> {
+        if (!this._scripts[src]) {
+            this._scripts[src] = new Promise((resolve, reject) => {
+                const script = document.createElement('script') as LegacyHTMLScriptElement;
+
+                script.setAttribute(attribute, value);
+                script.onload = event => resolve(event);
+                script.onreadystatechange = event => resolve(event);
+                script.onerror = event => {
+                    delete this._scripts[src];
+                    reject(event);
+                };
+                script.async = true;
+                script.src = src;
+
+                document.body.appendChild(script);
+            });
+        }
+
+        return this._scripts[src];
+    }
+}
+
+interface LegacyHTMLScriptElement extends HTMLScriptElement {
+    onreadystatechange(this: HTMLElement, event: Event): any;
 }

--- a/src/payment/strategies/paypal/paypal-script-loader.ts
+++ b/src/payment/strategies/paypal/paypal-script-loader.ts
@@ -1,4 +1,4 @@
-import { ScriptLoader } from '@bigcommerce/script-loader';
+import { LoadScriptOptions, ScriptLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
@@ -6,7 +6,6 @@ import { PaypalHostWindow, PaypalSDK } from './paypal-sdk';
 
 export default class PaypalScriptLoader {
     private _window: PaypalHostWindow;
-    private _scripts: { [key: string]: Promise<Event> } = {};
 
     constructor(
         private _scriptLoader: ScriptLoader
@@ -14,52 +13,18 @@ export default class PaypalScriptLoader {
         this._window = window;
     }
 
-    loadPaypal(merchantId: string = ''): Promise<PaypalSDK> {
-        if (merchantId.length > 0) {
-            return this.loadScriptWithAttribute('//www.paypalobjects.com/api/checkout.min.js', 'data-merchant-id', merchantId)
-                .then(() => {
-                    if (!this._window.paypal) {
-                        throw new PaymentMethodClientUnavailableError();
-                    }
+    loadPaypal = async (merchantId: string = ''): Promise<PaypalSDK> => {
+        const scriptSrc = '//www.paypalobjects.com/api/checkout.min.js';
+        const options: LoadScriptOptions = { async: true, attributes: { 'data-merchant-id': merchantId } };
 
-                    return this._window.paypal;
-                });
-        } else {
-            return this._scriptLoader
-                .loadScript('//www.paypalobjects.com/api/checkout.min.js')
-                .then(() => {
-                    if (!this._window.paypal) {
-                        throw new PaymentMethodClientUnavailableError();
-                    }
+        merchantId
+            ? await this._scriptLoader.loadScript(scriptSrc, options)
+            : await this._scriptLoader.loadScript(scriptSrc);
 
-                    return this._window.paypal;
-                });
-        }
-    }
-
-    loadScriptWithAttribute(src: string, attribute: string, value: string): Promise<Event> {
-        if (!this._scripts[src]) {
-            this._scripts[src] = new Promise((resolve, reject) => {
-                const script = document.createElement('script') as LegacyHTMLScriptElement;
-
-                script.setAttribute(attribute, value);
-                script.onload = event => resolve(event);
-                script.onreadystatechange = event => resolve(event);
-                script.onerror = event => {
-                    delete this._scripts[src];
-                    reject(event);
-                };
-                script.async = true;
-                script.src = src;
-
-                document.body.appendChild(script);
-            });
+        if (!this._window.paypal) {
+            throw new PaymentMethodClientUnavailableError();
         }
 
-        return this._scripts[src];
-    }
-}
-
-interface LegacyHTMLScriptElement extends HTMLScriptElement {
-    onreadystatechange(this: HTMLElement, event: Event): any;
+        return this._window.paypal;
+    };
 }


### PR DESCRIPTION
# What
Add merchant ID on PayPal button script for PayPal Express Checkout

**Note**: we are going refactor this solution later: move some part of implemented here JS logic to https://github.com/bigcommerce/script-loader-js library but we need to make sure first that merchant ID is received on PayPal side.

## Why?
The PayPal Shopping feature should know which merchants to target for PayPal Store Cash
## Testing / Proof
<img width="1590" alt="Screen Shot 2019-10-02 at 14 40 24" src="https://user-images.githubusercontent.com/54856617/66041660-090d6680-e523-11e9-8066-9ffdeca0b1fc.png">
<img width="606" alt="Screen Shot 2019-10-02 at 14 41 09" src="https://user-images.githubusercontent.com/54856617/66041664-0b6fc080-e523-11e9-8970-63a90f117c11.png">

[Video with STR](https://drive.google.com/file/d/1Tm6pURoteWNBYMh2J8_2j8x9VB3V7T7-/view?usp=sharing)