### PR TITLE
CHECKOUT-4462: Handle scenario where there is no cart ID in session versus unable to store session ID in cookies due to browser setting

### DIFF
--- a/src/embedded-checkout/embedded-checkout.ts
+++ b/src/embedded-checkout/embedded-checkout.ts
@@ -15,8 +15,9 @@ import IframeEventPoster from './iframe-event-poster';
 import LoadingIndicator from './loading-indicator';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
-const CAN_RETRY_ALLOW_COOKIE = 'canRetryAllowCookie';
-const IS_COOKIE_ALLOWED_KEY = 'isCookieAllowed';
+export const ALLOW_COOKIE_ATTEMPT_INTERVAL = 10 * 60 * 1000;
+export const IS_COOKIE_ALLOWED_KEY = 'isCookieAllowed';
+export const LAST_ALLOW_COOKIE_ATTEMPT_KEY = 'lastAllowCookieAttempt';
 
 @bind
 export default class EmbeddedCheckout {
@@ -143,16 +144,18 @@ export default class EmbeddedCheckout {
      */
     private _allowCookie(): Promise<void> {
         if (this._storage.getItem(IS_COOKIE_ALLOWED_KEY)) {
-            // It could be possible that the flag is set to true but the browser
-            // has already removed the permission to store cookie. In that case,
-            // we should try to redirect the user again.
-            this._storage.setItem(CAN_RETRY_ALLOW_COOKIE, true);
-
             return Promise.resolve();
         }
 
-        this._storage.removeItem(CAN_RETRY_ALLOW_COOKIE);
         this._storage.setItem(IS_COOKIE_ALLOWED_KEY, true);
+
+        // It could be possible that the flag is set to true but the browser has
+        // already removed the permission to store third-party cookies. In that
+        // case, we should try to redirect the user again. But we only want to
+        // do it once within a fixed interval. This is to avoid getting into a
+        // redirect loop if the shopper actually doesn't have a valid card
+        // session.
+        this._storage.setItem(LAST_ALLOW_COOKIE_ATTEMPT_KEY, Date.now());
 
         const { origin } = parseUrl(this._options.url);
         const redirectUrl = `${origin}/embedded-checkout/allow-cookie?returnUrl=${encodeURIComponent(this._location.href)}`;
@@ -164,8 +167,9 @@ export default class EmbeddedCheckout {
     }
 
     private _retryAllowCookie(error: EmbeddedCheckoutError): Promise<void> {
+        const lastAttempt = Number(this._storage.getItem(LAST_ALLOW_COOKIE_ATTEMPT_KEY));
         const canRetry = (
-            this._storage.getItem(CAN_RETRY_ALLOW_COOKIE) &&
+            (!lastAttempt || Date.now() - lastAttempt > ALLOW_COOKIE_ATTEMPT_INTERVAL) &&
             error instanceof NotEmbeddableError &&
             error.subtype === NotEmbeddableErrorType.MissingContent
         );
@@ -174,7 +178,7 @@ export default class EmbeddedCheckout {
             return Promise.reject();
         }
 
-        this._storage.removeItem(CAN_RETRY_ALLOW_COOKIE);
+        this._storage.removeItem(LAST_ALLOW_COOKIE_ATTEMPT_KEY);
         this._storage.removeItem(IS_COOKIE_ALLOWED_KEY);
 
         return this._allowCookie();

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
@@ -125,6 +125,22 @@ describe('EmbeddedCheckoutMessenger', () => {
         });
     });
 
+    it('does not invoke message callback if it does not match with type of event', () => {
+        const handler = jest.fn();
+
+        messenger = new IframeEmbeddedCheckoutMessenger(
+            messageListener,
+            messagePoster,
+            untargetedMessagePoster,
+            { [EmbeddedCheckoutEventType.FrameLoaded]: handler }
+        );
+
+        messenger.postFrameError(new Error('Unexpected error'));
+
+        expect(handler)
+            .not.toHaveBeenCalled();
+    });
+
     it('has methods that can be destructed', () => {
         const { postComplete } = messenger;
 

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.ts
@@ -110,7 +110,11 @@ export default class IframeEmbeddedCheckoutMessenger implements EmbeddedCheckout
     private _notifyMessageHandlers(message: EmbeddedCheckoutEvent): void {
         Object.keys(this._messageHandlers)
             .forEach(key => {
-                const handler = this._messageHandlers[key as keyof EmbeddedCheckoutEventMap];
+                if (message.type !== key) {
+                    return;
+                }
+
+                const handler = this._messageHandlers[key];
 
                 if (handler) {
                     (handler as (event: EmbeddedCheckoutEvent) => void).call(null, message);


### PR DESCRIPTION
## What?
Only redirect to `/embedded-checkout/allow-cookie` (which is a workaround for setting third-party cookies) if sufficient time has passed since the last redirect.

## Why?
You could receive an error from the iframe of Embedded Checkout if there's no cart ID associated with your session. You could also receive the same type of error if your browser is unable to store your session ID in cookies. For the first scenario, you could end up in a redirect loop, because you will never be able to load EC if there's no cart. Unfortunately, there's no way to differentiate between the two. So to work around this problem, we should first check to see if we have recently redirected before doing the redirect. If we have and still can't load EC page, then we know the problem is due to the fact that you don't have an active cart.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
