### PR TITLE
fix(order): CHECKOUT-4450 Handle recaptcha challenge not finish loading on slow connection

### DIFF
--- a/src/checkout/checkout-store-status-selector.spec.ts
+++ b/src/checkout/checkout-store-status-selector.spec.ts
@@ -70,6 +70,24 @@ describe('CheckoutStoreStatusSelector', () => {
             expect(statuses.isSubmittingOrder()).toEqual(false);
             expect(selectors.paymentStrategies.isExecuting).toHaveBeenCalled();
         });
+
+        it('returns true if executing spam protection', () => {
+            jest.spyOn(selectors.order, 'isSpamProtectionExecuting').mockReturnValue(true);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
+            expect(statuses.isSubmittingOrder()).toEqual(true);
+            expect(selectors.order.isSpamProtectionExecuting).toHaveBeenCalled();
+        });
+
+        it('returns false if executing spam protection', () => {
+            jest.spyOn(selectors.order, 'isSpamProtectionExecuting').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
+            expect(statuses.isSubmittingOrder()).toEqual(false);
+            expect(selectors.order.isSpamProtectionExecuting).toHaveBeenCalled();
+        });
     });
 
     describe('#isFinalizingOrder()', () => {

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -357,13 +357,24 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
         }
     );
 
+    const isSubmittingOrder = createSelector(
+        ({ paymentStrategies }: InternalCheckoutSelectors) => paymentStrategies.isExecuting,
+        ({ order }: InternalCheckoutSelectors) => order.isSpamProtectionExecuting,
+        (isExecuting, isSpamProtectionExecuting) => (methodId?: string) => {
+            return (
+                isExecuting(methodId) ||
+                isSpamProtectionExecuting()
+            );
+        }
+    );
+
     return memoizeOne((
         state: InternalCheckoutSelectors
     ): CheckoutStoreStatusSelector => {
         const selector = {
             isLoadingCheckout: state.checkout.isLoading,
             isUpdatingCheckout: state.checkout.isUpdating,
-            isSubmittingOrder: state.paymentStrategies.isExecuting,
+            isSubmittingOrder: isSubmittingOrder(state),
             isFinalizingOrder: state.paymentStrategies.isFinalizing,
             isLoadingOrder: state.order.isLoading,
             isLoadingCart: state.cart.isLoading,

--- a/src/order/order-reducer.spec.ts
+++ b/src/order/order-reducer.spec.ts
@@ -109,6 +109,36 @@ describe('orderReducer()', () => {
         }));
     });
 
+    it('returns new status while executing spam protection', () => {
+        const action: SpamProtectionAction = {
+            type: SpamProtectionActionType.ExecuteRequested,
+        };
+
+        expect(orderReducer(initialState, action)).toEqual(expect.objectContaining({
+            statuses: { isSpamProtectionExecuting: true },
+        }));
+    });
+
+    it('returns new status if spam protection completed', () => {
+        const action: SpamProtectionAction = {
+            type: SpamProtectionActionType.Completed,
+        };
+
+        expect(orderReducer(initialState, action)).toEqual(expect.objectContaining({
+            statuses: { isSpamProtectionExecuting: false },
+        }));
+    });
+
+    it('returns new status if submitting spam protection failed', () => {
+        const action: SpamProtectionAction = {
+            type: SpamProtectionActionType.SubmitFailed,
+        };
+
+        expect(orderReducer(initialState, action)).toEqual(expect.objectContaining({
+            statuses: { isSpamProtectionExecuting: false },
+        }));
+    });
+
     describe('loadOrderPayments', () => {
         it('returns new status while fetching order', () => {
             const action: LoadOrderPaymentsAction = {

--- a/src/order/order-reducer.ts
+++ b/src/order/order-reducer.ts
@@ -80,7 +80,7 @@ function errorsReducer(
 
 function statusesReducer(
     statuses: OrderStatusesState = DEFAULT_STATE.statuses,
-    action: OrderAction
+    action: OrderAction | SpamProtectionAction
 ): OrderStatusesState {
     switch (action.type) {
     case OrderActionType.LoadOrderRequested:
@@ -92,6 +92,13 @@ function statusesReducer(
     case OrderActionType.LoadOrderPaymentsSucceeded:
     case OrderActionType.LoadOrderPaymentsFailed:
         return objectSet(statuses, 'isLoading', false);
+
+    case SpamProtectionActionType.ExecuteRequested:
+        return objectSet(statuses, 'isSpamProtectionExecuting', true);
+
+    case SpamProtectionActionType.Completed:
+    case SpamProtectionActionType.SubmitFailed:
+        return objectSet(statuses, 'isSpamProtectionExecuting', false);
 
     default:
         return statuses;

--- a/src/order/order-selector.spec.ts
+++ b/src/order/order-selector.spec.ts
@@ -73,4 +73,21 @@ describe('OrderSelector', () => {
             expect(orderSelector.isLoading()).toEqual(false);
         });
     });
+
+    describe('#isSpamProtectionExecuting()', () => {
+        it('returns true if executing spam protection', () => {
+            orderSelector = createOrderSelector({
+                ...state.order,
+                statuses: { isSpamProtectionExecuting: true },
+            }, selectors.billingAddress, selectors.coupons);
+
+            expect(orderSelector.isSpamProtectionExecuting()).toEqual(true);
+        });
+
+        it('returns false if not executing spam protection', () => {
+            orderSelector = createOrderSelector(state.order, selectors.billingAddress, selectors.coupons);
+
+            expect(orderSelector.isSpamProtectionExecuting()).toEqual(false);
+        });
+    });
 });

--- a/src/order/order-selector.ts
+++ b/src/order/order-selector.ts
@@ -12,6 +12,7 @@ export default interface OrderSelector {
     getOrderMeta(): OrderMetaState | undefined;
     getLoadError(): Error | undefined;
     isLoading(): boolean;
+    isSpamProtectionExecuting(): boolean;
 }
 
 export type OrderSelectorFactory = (
@@ -58,6 +59,11 @@ export function createOrderSelectorFactory(): OrderSelectorFactory {
         status => () => status
     );
 
+    const isSpamProtectionExecuting = createSelector(
+        (state: OrderState) => !!state.statuses.isSpamProtectionExecuting,
+        status => () => status
+    );
+
     return memoizeOne((
         state: OrderState = DEFAULT_STATE,
         billingAddress: BillingAddressSelector,
@@ -68,6 +74,7 @@ export function createOrderSelectorFactory(): OrderSelectorFactory {
             getOrderMeta: getOrderMeta(state),
             getLoadError: getLoadError(state),
             isLoading: isLoading(state),
+            isSpamProtectionExecuting: isSpamProtectionExecuting(state),
         };
     });
 }

--- a/src/order/order-state.ts
+++ b/src/order/order-state.ts
@@ -28,6 +28,7 @@ export interface OrderErrorsState {
 
 export interface OrderStatusesState {
     isLoading?: boolean;
+    isSpamProtectionExecuting?: boolean;
     isSubmitting?: boolean;
     isFinalizing?: boolean;
 }

--- a/src/order/spam-protection/errors/index.ts
+++ b/src/order/spam-protection/errors/index.ts
@@ -1,2 +1,3 @@
 export { default as SpamProtectionFailedError } from './spam-protection-failed-error';
 export { default as SpamProtectionNotCompletedError } from './spam-protection-not-completed-error';
+export { default as SpamProtectionNotLoadedError } from './spam-protection-not-loaded-error';

--- a/src/order/spam-protection/errors/spam-protection-not-loaded-error.spec.ts
+++ b/src/order/spam-protection/errors/spam-protection-not-loaded-error.spec.ts
@@ -1,0 +1,9 @@
+import SpamProtectionNotLoadedError from './spam-protection-not-loaded-error';
+
+describe('SpamProtectionNotLoadedError', () => {
+    it('returns error name', () => {
+        const error = new SpamProtectionNotLoadedError();
+
+        expect(error.name).toEqual('SpamProtectionNotLoadedError');
+    });
+});

--- a/src/order/spam-protection/errors/spam-protection-not-loaded-error.ts
+++ b/src/order/spam-protection/errors/spam-protection-not-loaded-error.ts
@@ -1,0 +1,14 @@
+import { StandardError } from '../../../common/error/errors';
+
+/**
+ * Throw this error if spam protection is not loaded when trying to
+ * complete the required spam protection verification.
+ */
+export default class SpamProtectionNotLoadedError extends StandardError {
+    constructor() {
+        super('Spam protection is not loaded. Please try again.');
+
+        this.name = 'SpamProtectionNotLoadedError';
+        this.type = 'spam_protection_failed';
+    }
+}


### PR DESCRIPTION
## What?
As per above.

## Why?
Previously, when the shopper is on slow connection, the recaptcha challenge window might not finish loading when the shopper place an order. This will cause the checkout-sdk to throw an error and the UI will stop working, but there is no indication to the shopper on that is happening.

With this fix, we will handle this situtation gracefully. We will retry multiple times within a 7 second timeframe when the user place an order. If after 7 seconds the recaptcha challenge window has yet to finish loading, we will throw an error, but not block the UI. Shopper can then retry by trying to place order again.

## Testing / Proof
Added unit tests and manual testing.

Place an order on slow 3g connection:
<img width="2506" alt="Screen Shot 2019-10-04 at 10 39 48 am" src="https://user-images.githubusercontent.com/22089936/66173420-7c35ea80-e693-11e9-99c5-ad206626aa77.png">


@bigcommerce/checkout @bigcommerce/payments
