### PR TITLE
fix(common): PAYMENTS-4802 Fix ArrayReplace default comparison

### DIFF
--- a/src/common/utility/array-replace.spec.ts
+++ b/src/common/utility/array-replace.spec.ts
@@ -68,6 +68,15 @@ describe('arrayReplace()', () => {
             .toBe(newArray[1]);
     });
 
+    it('does not assume objects are equal if `id` is undefined', () => {
+        const currentArray = [{ id: undefined, altId: 'a', oldKey: 'oldA' }];
+        const newArray = [{ id: undefined, altId: 'c' }];
+
+        const result = arrayReplace(currentArray, newArray);
+
+        expect(result).toBe(newArray);
+    });
+
     it('handles nested collections of objects', () => {
         const currentArray = [
             {

--- a/src/common/utility/array-replace.ts
+++ b/src/common/utility/array-replace.ts
@@ -12,7 +12,7 @@ export default function arrayReplace<T>(currentArray: T[] | undefined, newArray:
 export default function arrayReplace<T>(currentArray: T[], newArray?: T[], options?: ArrayReplaceOptions): undefined;
 export default function arrayReplace<T>(currentArray?: T[], newArray?: T[], options?: ArrayReplaceOptions): T[] | undefined;
 export default function arrayReplace<T>(currentArray?: T[], newArray?: T[], options?: ArrayReplaceOptions): T[] | undefined {
-    const { matchObject = (a: any, b: any) => a.id === b.id } = options || {};
+    const { matchObject = (a: any, b: any) => a.id !== undefined && a.id === b.id } = options || {};
 
     // Return the new array if the current array does not exist
     if (!currentArray) {


### PR DESCRIPTION
## What?
- Make sure the default matcher takes into account objects without id

## Why?
- When objects in an array don't contain an `id` key, the default matcher
will think they are the same object causing incorrect merges.

## Testing / Proof
- Unit

@bigcommerce/checkout @bigcommerce/payments
