### PR TITLE
fix(checkout): CHECKOUT-3365 Update cart and checkout state when shipping options are loaded

### DIFF
--- a/src/cart/cart-reducer.spec.ts
+++ b/src/cart/cart-reducer.spec.ts
@@ -103,6 +103,17 @@ describe('cartReducer()', () => {
         }));
     });
 
+    it('returns new data when shipping options are loaded', () => {
+        const action = {
+            type: ConsignmentActionType.LoadShippingOptionsSucceeded,
+            payload: getCheckout(),
+        };
+
+        expect(cartReducer(initialState, action)).toEqual(expect.objectContaining({
+            data: getCart(),
+        }));
+    });
+
     it('returns new data when coupon gets applied', () => {
         const action = {
             type: CouponActionType.ApplyCouponSucceeded,

--- a/src/cart/cart-reducer.ts
+++ b/src/cart/cart-reducer.ts
@@ -34,6 +34,7 @@ function dataReducer(
     case ConsignmentActionType.DeleteConsignmentSucceeded:
     case ConsignmentActionType.UpdateConsignmentSucceeded:
     case ConsignmentActionType.UpdateShippingOptionSucceeded:
+    case ConsignmentActionType.LoadShippingOptionsSucceeded:
     case CouponActionType.ApplyCouponSucceeded:
     case CouponActionType.RemoveCouponSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:

--- a/src/checkout/checkout-reducer.spec.ts
+++ b/src/checkout/checkout-reducer.spec.ts
@@ -77,6 +77,15 @@ describe('checkoutReducer', () => {
         }));
     });
 
+    it('returns new state when Load Shipping options succeeded', () => {
+        const action = createAction(ConsignmentActionType.LoadShippingOptionsSucceeded, getCheckout());
+        const output = checkoutReducer(initialState, action);
+
+        expect(output).toEqual(expect.objectContaining({
+            data: omit(action.payload, ['billingAddress', 'cart', 'customer', 'consignments', 'coupons', 'giftCertificates']),
+        }));
+    });
+
     it('returns new state when consignment gets deleted', () => {
         const action = createAction(ConsignmentActionType.DeleteConsignmentSucceeded, getCheckout(), { id: '123' });
         const output = checkoutReducer(initialState, action);

--- a/src/checkout/checkout-reducer.ts
+++ b/src/checkout/checkout-reducer.ts
@@ -41,6 +41,7 @@ function dataReducer(
     case ConsignmentActionType.UpdateConsignmentSucceeded:
     case ConsignmentActionType.DeleteConsignmentSucceeded:
     case ConsignmentActionType.UpdateShippingOptionSucceeded:
+    case ConsignmentActionType.LoadShippingOptionsSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
         return objectMerge(data, omit(action.payload, [


### PR DESCRIPTION
## What?
Update the Cart summary on the checkout page if the user's cart is updated on a different tab or window. 

Existing Behavior: 
User changes quantity in a different tab (cart page)
User is prompted with an error on checkout page but quantity and price is not updated.
User selects the shipping address and the update to the cart summary is reflected.

New Behavior: 
User Changes quantity in a different tab(cart page)
User is prompted with an error on checkout page and the quantity is updated keeping the previous shipping address.
If user updates the shipping address the cart summary is changed accordingly else remains the same.

## Why?
The error message provides a feedback to the shopper that the cart has been updated. However the updated summary is displayed only after he/she confirms the shipping address. 
This change will provide a more updated version of the cart summary and would only change if the user changes his shipping address.

## Testing / Proof
The cart summary is updated as soon as the error is displayed.

<img width="1680" alt="Screen Shot 2019-10-11 at 10 12 02 am" src="https://user-images.githubusercontent.com/55068632/66613499-726f3280-ec11-11e9-8c92-ae4f657cd0a7.png">


@bigcommerce/checkout @bigcommerce/payments
