### PR TITLE
CHECKOUT-4455: Upgrade `script-loader` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,11 +1251,12 @@
       }
     },
     "@bigcommerce/script-loader": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-0.1.6.tgz",
-      "integrity": "sha512-32KdV5V+V58llBxRvHmBJlSjgidrGGQeRg0BBfWAm0zdoIgKNdA5Q42Xxn4p4m+iPHlU7EsF/mf8BIDMctGtcQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/script-loader/-/script-loader-2.0.0.tgz",
+      "integrity": "sha512-85/LHtiEPgKoezE6X/CxQ3p4wxarSil6tF063vUNpNVaL52oiHK53YZ3Km3ZuwMHfwxzviXqLWcfoDiOcUlKvA==",
       "requires": {
-        "tslib": "^1.8.0"
+        "@bigcommerce/request-sender": "^0.3.0",
+        "tslib": "^1.10.0"
       }
     },
     "@bigcommerce/tslint-config": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/memoize": "^1.0.0",
     "@bigcommerce/request-sender": "^0.3.0",
-    "@bigcommerce/script-loader": "^0.1.6",
+    "@bigcommerce/script-loader": "^2.0.0",
     "@types/iframe-resizer": "^3.5.6",
     "@types/lodash": "^4.14.139",
     "@types/reselect": "^2.2.0",

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -1,6 +1,6 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
 import { RequestSender } from '@bigcommerce/request-sender';
-import { getScriptLoader } from '@bigcommerce/script-loader';
+import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
@@ -92,7 +92,7 @@ export default function createPaymentStrategyRegistry(
             store,
             paymentActionCreator,
             orderActionCreator,
-            new AdyenV2ScriptLoader(scriptLoader),
+            new AdyenV2ScriptLoader(scriptLoader, getStylesheetLoader()),
             formPoster,
             locale
         )

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
-import { createScriptLoader } from '@bigcommerce/script-loader';
+import { createScriptLoader, createStylesheetLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -77,6 +77,7 @@ describe('AdyenV2PaymentStrategy', () => {
 
     beforeEach(() => {
         const scriptLoader = createScriptLoader();
+        const stylesheetLoader = createStylesheetLoader();
         const requestSender = createRequestSender();
         orderRequestSender = new OrderRequestSender(requestSender);
         orderActionCreator = new OrderActionCreator(
@@ -91,7 +92,7 @@ describe('AdyenV2PaymentStrategy', () => {
             new PaymentRequestTransformer()
         );
 
-        adyenV2ScriptLoader = new AdyenV2ScriptLoader(scriptLoader);
+        adyenV2ScriptLoader = new AdyenV2ScriptLoader(scriptLoader, stylesheetLoader);
 
         formPoster = createFormPoster();
         store = createCheckoutStore(getCheckoutStoreState());

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -1,4 +1,4 @@
-import { ScriptLoader } from '@bigcommerce/script-loader';
+import { ScriptLoader, StylesheetLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
@@ -9,16 +9,15 @@ import {
 } from './adyenv2';
 
 export default class AdyenV2ScriptLoader {
-    private _stylesheets: { [key: string]: Promise<Event> } = {};
-
     constructor(
         private _scriptLoader: ScriptLoader,
+        private _stylesheetLoader: StylesheetLoader,
         private _window: AdyenHostWindow = window
     ) {}
 
     load(configuration: AdyenConfiguration): Promise<AdyenCheckout> {
         return Promise.all([
-            this._loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css`),
+            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css`),
             this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.0.0/adyen.js`),
         ])
         .then(() => {
@@ -31,28 +30,5 @@ export default class AdyenV2ScriptLoader {
         .catch(() => {
             throw new PaymentMethodClientUnavailableError();
         });
-    }
-
-    private _loadStylesheet(src: string): Promise<Event> {
-        if (!this._stylesheets[src]) {
-            this._stylesheets[src] = new Promise((resolve, reject) => {
-                const stylesheet = document.createElement('link');
-
-                stylesheet.onload = event => {
-                    resolve(event);
-                };
-                stylesheet.onerror = event => {
-                    delete this._stylesheets[src];
-                    reject(event);
-                };
-                stylesheet.type = 'text/css';
-                stylesheet.rel = 'stylesheet';
-                stylesheet.href = src;
-
-                document.head.appendChild(stylesheet);
-            });
-        }
-
-        return this._stylesheets[src];
     }
 }

--- a/src/payment/strategies/amazon-pay/amazon-pay-script-loader.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-script-loader.ts
@@ -13,7 +13,7 @@ export default class AmazonPayScriptLoader {
         this._window = window;
     }
 
-    loadWidget(method: PaymentMethod, onPaymentReady?: () => void): Promise<Event> {
+    loadWidget(method: PaymentMethod, onPaymentReady?: () => void): Promise<void> {
         const {
             config: { merchantId, testMode },
             initializationData: { region = 'us' } = {},


### PR DESCRIPTION
## What?
Upgrade `script-loader` version.

## Why?
The newer version can load stylesheets, so we can remove the `loadStylesheet` method in `AdyenV2ScriptLoader`.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
