### PR TITLE
feat(payment): INT-1990 Resolve browser info for Adyen v2

### DIFF
--- a/src/common/browser-info/browser-info.ts
+++ b/src/common/browser-info/browser-info.ts
@@ -1,0 +1,8 @@
+export default interface BrowserInfo {
+    color_depth: number;
+    java_enabled: boolean;
+    language: string;
+    screen_height: number;
+    screen_width: number;
+    time_zone_offset: string;
+}

--- a/src/common/browser-info/get-browser-info.spec.ts
+++ b/src/common/browser-info/get-browser-info.spec.ts
@@ -1,0 +1,15 @@
+import getBrowserInfo from './get-browser-info';
+
+describe('getBrowserInfo()', () => {
+    it('retrieves browser info', () => {
+        expect(getBrowserInfo())
+            .toEqual(expect.objectContaining({
+                color_depth: expect.any(Number),
+                java_enabled: expect.any(Boolean),
+                language: expect.any(String),
+                screen_height: expect.any(Number),
+                screen_width: expect.any(Number),
+                time_zone_offset: expect.any(String),
+            }));
+    });
+});

--- a/src/common/browser-info/get-browser-info.ts
+++ b/src/common/browser-info/get-browser-info.ts
@@ -1,0 +1,12 @@
+import BrowserInfo from './browser-info';
+
+export default function getBrowserInfo(): BrowserInfo {
+    return {
+        color_depth: screen.colorDepth || 24,
+        java_enabled: typeof navigator.javaEnabled === 'function' ? navigator.javaEnabled() : false,
+        language: navigator.language || (navigator as any).userLanguage,
+        screen_height: screen.height,
+        screen_width: screen.width,
+        time_zone_offset: new Date().getTimezoneOffset().toString(),
+    };
+}

--- a/src/common/browser-info/index.ts
+++ b/src/common/browser-info/index.ts
@@ -1,0 +1,2 @@
+export { default as BrowserInfo } from './browser-info';
+export { default as getBrowserInfo } from './get-browser-info';

--- a/src/payment/is-vaulted-instrument.ts
+++ b/src/payment/is-vaulted-instrument.ts
@@ -1,4 +1,4 @@
-import { HostedVaultedInstrument, PaymentInstrument, VaultedInstrument } from './payment';
+import { FormattedPayload, FormattedVaultedInstrument, HostedVaultedInstrument, PaymentInstrument, VaultedInstrument } from './payment';
 
 export default function isVaultedInstrument(instrument: PaymentInstrument): instrument is VaultedInstrument {
     return Boolean((instrument as VaultedInstrument).instrumentId);
@@ -10,4 +10,15 @@ export function isHostedVaultedInstrument(instrument: PaymentInstrument): instru
         !instrument.hasOwnProperty('ccNumber') &&
         !instrument.hasOwnProperty('ccCvv')
     );
+}
+
+export function isFormattedVaultedInstrument(instrument: PaymentInstrument): instrument is FormattedPayload<FormattedVaultedInstrument> {
+    const formattedInstrument = (instrument as FormattedPayload<FormattedVaultedInstrument>).formattedPayload;
+
+    if (!formattedInstrument) {
+        return false;
+    }
+
+    return typeof formattedInstrument.bigpay_token === 'string' ||
+        Boolean(formattedInstrument.bigpay_token && formattedInstrument.bigpay_token.token);
 }

--- a/src/payment/payment-request-transformer.ts
+++ b/src/payment/payment-request-transformer.ts
@@ -10,7 +10,7 @@ import { CardExpiryFormatter, CardNumberFormatter, HostedInputValues } from '../
 import { mapToInternalOrder } from '../order';
 import { mapToInternalShippingOption } from '../shipping';
 
-import isVaultedInstrument from './is-vaulted-instrument';
+import isVaultedInstrument, { isFormattedVaultedInstrument } from './is-vaulted-instrument';
 import Payment, { CreditCardInstrument, HostedCreditCardInstrument, HostedVaultedInstrument, VaultedInstrument } from './payment';
 import PaymentMethod from './payment-method';
 import PaymentRequestBody from './payment-request-body';
@@ -35,7 +35,8 @@ export default class PaymentRequestTransformer {
         const orderMeta = checkoutState.order.getOrderMeta();
         const internalCustomer = customer && billingAddress && mapToInternalCustomer(customer, billingAddress);
 
-        const authToken = instrumentMeta && payment.paymentData && isVaultedInstrument(payment.paymentData) ?
+        const authToken = instrumentMeta && payment.paymentData &&
+            (isVaultedInstrument(payment.paymentData) || isFormattedVaultedInstrument(payment.paymentData)) ?
             `${checkoutState.payment.getPaymentToken()}, ${instrumentMeta.vaultAccessToken}` :
             checkoutState.payment.getPaymentToken();
 

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -1,3 +1,4 @@
+import { BrowserInfo } from '../common/browser-info';
 import { Omit } from '../common/types';
 
 export default interface Payment {
@@ -9,7 +10,7 @@ export default interface Payment {
 export type PaymentInstrument = (
     CreditCardInstrument |
     CryptogramInstrument |
-    FormattedPayload<PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument> |
+    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument> |
     HostedCreditCardInstrument |
     HostedInstrument |
     NonceInstrument |
@@ -38,6 +39,8 @@ export interface CreditCardInstrument {
 export type HostedCreditCardInstrument = Omit<CreditCardInstrument, 'ccExpiry' | 'ccName' | 'ccNumber' | 'ccCvv'>;
 
 export type HostedVaultedInstrument = Omit<VaultedInstrument, 'ccNumber' | 'ccCvv'>;
+
+export type AdyenV2Instrument = AdyenV2Token | AdyenV2Card;
 
 export interface NonceInstrument {
     nonce: string;
@@ -95,12 +98,29 @@ export interface PaypalInstrument {
     };
 }
 
+interface AdyenV2Token extends FormattedVaultedInstrument {
+    browser_info: BrowserInfo;
+    credit_card_token?: void;
+}
+
+interface AdyenV2Card {
+    browser_info: BrowserInfo;
+    credit_card_token: {
+        token: string;
+    };
+    bigpay_token?: void;
+}
+
 export interface FormattedHostedInstrument {
     vault_payment_instrument: boolean | null;
 }
 
 export interface FormattedVaultedInstrument {
-    bigpay_token: string | null;
+    bigpay_token: {
+        credit_card_number_confirmation?: string;
+        verification_value?: string;
+        token: string;
+    } | string | null;
 }
 
 export interface FormattedPayload<T> {


### PR DESCRIPTION
## What?
BrowserInfo values are now sent from frontEnd to backEnd, this variable send this info: 
```
{
      userAgent,
      acceptHeader,
      language,
      colorDepth,
      screenHeight,
      screenWidth,
      timeZoneOffset,
      javaEnabled
}
```

## Why?
Adyen V2 needs browserInfo values direct from the browser to the backend to handle 3DS validations

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/66786050-b2017d00-eea4-11e9-89b7-d5f9f4be1cdf.png)
![image](https://user-images.githubusercontent.com/35146660/66785666-87fb8b00-eea3-11e9-89a5-270cde00e835.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
