### PR TITLE
CHECKOUT-4499: Upgrade `rxjs` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9661,9 +9661,9 @@
       }
     },
     "rxjs": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lodash": "^4.17.15",
     "messageformat": "2.1.0",
     "reselect": "^4.0.0",
-    "rxjs": "^6.3.3",
+    "rxjs": "^6.5.3",
     "shallowequal": "^1.1.0",
     "tslib": "^1.10.0"
   },

--- a/src/common/data-store/cache-action.spec.ts
+++ b/src/common/data-store/cache-action.spec.ts
@@ -1,4 +1,4 @@
-import { createAction, createDataStore } from '@bigcommerce/data-store';
+import { createAction, createDataStore, Action } from '@bigcommerce/data-store';
 import { defer } from 'rxjs';
 
 import cacheAction from './cache-action';
@@ -7,7 +7,7 @@ describe('cacheAction()', () => {
     it('returns observable action that emits cached value', async () => {
         const getMessage = jest.fn(() => Promise.resolve(createAction('GET_MESSAGE', 'Hello world')));
         const subscriber = jest.fn();
-        const createCachedAction = cacheAction(() => defer(() => getMessage()));
+        const createCachedAction = cacheAction(() => defer(() => getMessage() as Promise<Action>));
 
         createCachedAction().subscribe(subscriber);
         createCachedAction().subscribe(subscriber);
@@ -22,7 +22,7 @@ describe('cacheAction()', () => {
     it('caches emitted values from observable action based on parameters', async () => {
         const getMessage = jest.fn(name => Promise.resolve(createAction('GET_MESSAGE', `Hello ${name}`)));
         const subscriber = jest.fn();
-        const createCachedAction = cacheAction(name => defer(() => getMessage(name)));
+        const createCachedAction = cacheAction(name => defer(() => getMessage(name) as Promise<Action>));
 
         createCachedAction('Foo').subscribe(subscriber);
         createCachedAction('Foo').subscribe(subscriber);
@@ -42,7 +42,7 @@ describe('cacheAction()', () => {
     it('returns thunk action that emits cached value', async () => {
         const getMessage = jest.fn(() => Promise.resolve(createAction('GET_MESSAGE', 'Hello world')));
         const subscriber = jest.fn();
-        const createCachedAction = cacheAction(() => _ => defer(() => getMessage()));
+        const createCachedAction = cacheAction(() => _ => defer(() => getMessage() as Promise<Action>));
         const store = createDataStore(state => state);
 
         createCachedAction()(store).subscribe(subscriber);
@@ -58,7 +58,7 @@ describe('cacheAction()', () => {
     it('caches emitted values from thunk action based on parameters', async () => {
         const getMessage = jest.fn(name => Promise.resolve(createAction('GET_MESSAGE', `Hello ${name}`)));
         const subscriber = jest.fn();
-        const createCachedAction = cacheAction(name => _ => defer(() => getMessage(name)));
+        const createCachedAction = cacheAction(name => _ => defer(() => getMessage(name) as Promise<Action>));
         const store = createDataStore(state => state);
 
         createCachedAction('Foo')(store).subscribe(subscriber);

--- a/src/embedded-checkout/embedded-checkout.spec.ts
+++ b/src/embedded-checkout/embedded-checkout.spec.ts
@@ -299,7 +299,7 @@ describe('EmbeddedCheckout', () => {
     it('does not retry renew cookie allowance if already retried recently', async () => {
         (storage.getItem as jest.Mock).mockRestore();
         storage.setItem(IS_COOKIE_ALLOWED_KEY, true);
-        storage.setItem(LAST_ALLOW_COOKIE_ATTEMPT_KEY, Date.now() - ALLOW_COOKIE_ATTEMPT_INTERVAL);
+        storage.setItem(LAST_ALLOW_COOKIE_ATTEMPT_KEY, Date.now() - ALLOW_COOKIE_ATTEMPT_INTERVAL - 1000); // Add 1 second buffer time
 
         jest.spyOn(iframeCreator, 'createFrame')
             .mockRejectedValue(new NotEmbeddableError('Empty cart', NotEmbeddableErrorType.MissingContent));


### PR DESCRIPTION
## What?
Upgrade `rxjs` version

## Why?
Dependabot is unable to [upgrade](https://github.com/bigcommerce/checkout-sdk-js/pull/586) due to incompatibility.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
