### PR TITLE
fix(shipping): SHIPPING-1384 Extend shipping option interface

### DIFF
--- a/src/shipping/shipping-option.ts
+++ b/src/shipping/shipping-option.ts
@@ -1,4 +1,5 @@
 export default interface ShippingOption {
+    additionalDescription: string;
     description: string;
     id: string;
     isRecommended: boolean;

--- a/src/shipping/shipping-options.mock.ts
+++ b/src/shipping/shipping-options.mock.ts
@@ -2,6 +2,7 @@ import { ShippingOption } from '../shipping';
 
 export function getShippingOption(): ShippingOption {
     return {
+        additionalDescription: 'Flat rate additional description',
         description: 'Flat Rate',
         id: '0:61d4bb52f746477e1d4fb411221318c3',
         imageUrl: '',


### PR DESCRIPTION
## What?
Extend ShippingOption interface

## Why?
Add `additionalDescription` to shipping-option interface, so we can use the field in checkout-js to be displayed to customers.

## Testing / Proof
- Unit / Functional / Manual

@bigcommerce/checkout @bigcommerce/payments @davidchin 
