### PR TITLE
PAYMENTS-4616 Allow vaulting and paying with BraintreePaypal accounts

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -72,6 +72,7 @@ export interface HostedInstrument {
 }
 
 export interface PaypalInstrument {
+    vault_payment_instrument: boolean | null;
     device_info: string | null;
     paypal_account: {
         token: string;

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -4,7 +4,7 @@ export default interface Payment {
     paymentData?: PaymentInstrument & PaymentInstrumentMeta;
 }
 
-export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument | HostedInstrument | ThreeDSVaultedInstrument;
+export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument | HostedInstrument | ThreeDSVaultedInstrument | FormattedPayload<PaypalInstrument>;
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
@@ -26,6 +26,7 @@ export interface CreditCardInstrument {
 
 export interface NonceInstrument {
     nonce: string;
+    shouldSaveInstrument?: boolean;
     deviceSessionId?: string;
 }
 
@@ -68,4 +69,16 @@ export interface ThreeDSecureToken {
 
 export interface HostedInstrument {
     shouldSaveInstrument?: boolean;
+}
+
+export interface PaypalInstrument {
+    device_info: string | null;
+    paypal_account: {
+        token: string;
+        email: string | null;
+    };
+}
+
+export interface FormattedPayload<T> {
+    formattedPayload: T;
 }

--- a/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -237,6 +237,27 @@ describe('BraintreePaymentProcessor', () => {
                 });
         });
 
+        it('shows Paypal modal for vaulting', async () => {
+            const processor = new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
+
+            await processor.paypal({
+                amount: 200,
+                locale: 'en',
+                currency: 'USD',
+                shouldSaveInstrument: true,
+            });
+
+            expect(paypal.tokenize)
+                .toHaveBeenCalledWith({
+                    amount: 200,
+                    currency: 'USD',
+                    enableShippingAddress: true,
+                    flow: 'vault',
+                    locale: 'en',
+                    useraction: 'commit',
+                });
+        });
+
         it('toggles overlay', async () => {
             const processor = new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
 

--- a/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -220,7 +220,11 @@ describe('BraintreePaymentProcessor', () => {
         it('shows Paypal modal for tokenization', async () => {
             const processor = new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
 
-            await processor.paypal(200, 'en', 'USD', false);
+            await processor.paypal({
+                amount: 200,
+                locale: 'en',
+                currency: 'USD',
+            });
 
             expect(paypal.tokenize)
                 .toHaveBeenCalledWith({
@@ -229,7 +233,6 @@ describe('BraintreePaymentProcessor', () => {
                     enableShippingAddress: true,
                     flow: 'checkout',
                     locale: 'en',
-                    offerCredit: false,
                     useraction: 'commit',
                 });
         });
@@ -237,8 +240,11 @@ describe('BraintreePaymentProcessor', () => {
         it('toggles overlay', async () => {
             const processor = new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
 
-            await processor.paypal(200, 'en', 'USD', false);
-
+            await processor.paypal({
+                amount: 200,
+                locale: 'en',
+                currency: 'USD',
+            });
             expect(overlay.show)
                 .toHaveBeenCalled();
 
@@ -253,7 +259,11 @@ describe('BraintreePaymentProcessor', () => {
             const processor = new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
 
             try {
-                await processor.paypal(200, 'en', 'USD', false);
+                await processor.paypal({
+                    amount: 200,
+                    locale: 'en',
+                    currency: 'USD',
+                });
             } catch (error) {
                 expect(overlay.remove)
                     .toHaveBeenCalled();
@@ -263,7 +273,11 @@ describe('BraintreePaymentProcessor', () => {
         it('focus PayPal window when overlay is clicked', async () => {
             const processor = new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
 
-            await processor.paypal(200, 'en', 'USD', false);
+            await processor.paypal({
+                amount: 200,
+                locale: 'en',
+                currency: 'USD',
+            });
 
             const { onClick } = (overlay.show as jest.Mock).mock.calls[0][0];
 

--- a/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -176,6 +176,19 @@ describe('BraintreePaymentProcessor', () => {
         });
     });
 
+    describe('#getSessionId()', () => {
+        it('appends data to a processed payment', async () => {
+            braintreeSDKCreator.getDataCollector = jest.fn().mockResolvedValue({
+                deviceData: 'my_device_session_id',
+            });
+
+            const braintreePaymentProcessor = new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
+            const expected = await braintreePaymentProcessor.getSessionId();
+
+            expect(expected).toEqual('my_device_session_id');
+        });
+    });
+
     describe('#deinitialize()', () => {
         it('calls teardown in the braintree sdk creator', async () => {
             braintreeSDKCreator.teardown = jest.fn();

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -15,6 +15,7 @@ export interface PaypalConfig {
     currency: string;
     locale: string;
     offerCredit?: boolean;
+    shouldSaveInstrument?: boolean;
 }
 
 export default class BraintreePaymentProcessor {
@@ -45,7 +46,7 @@ export default class BraintreePaymentProcessor {
             }));
     }
 
-    paypal(config: PaypalConfig): Promise<BraintreeTokenizePayload> {
+    paypal({ shouldSaveInstrument, ...config }: PaypalConfig): Promise<BraintreeTokenizePayload> {
         return this._braintreeSDKCreator.getPaypal()
             .then(paypal => {
                 this._overlay.show({
@@ -54,7 +55,7 @@ export default class BraintreePaymentProcessor {
 
                 return paypal.tokenize({
                     enableShippingAddress: true,
-                    flow: 'checkout',
+                    flow: shouldSaveInstrument ? 'vault' : 'checkout',
                     useraction: 'commit',
                     ...config,
                 });

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -10,6 +10,13 @@ import { BraintreePaypal, BraintreeRequestData, BraintreeTokenizePayload, Braint
 import { BraintreePaymentInitializeOptions, BraintreeThreeDSecureOptions } from './braintree-payment-options';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 
+export interface PaypalConfig {
+    amount: number;
+    currency: string;
+    locale: string;
+    offerCredit?: boolean;
+}
+
 export default class BraintreePaymentProcessor {
     private _threeDSecureOptions?: BraintreeThreeDSecureOptions;
 
@@ -38,7 +45,7 @@ export default class BraintreePaymentProcessor {
             }));
     }
 
-    paypal(amount: number, storeLanguage: string, currency: string, offerCredit: boolean): Promise<BraintreeTokenizePayload> {
+    paypal(config: PaypalConfig): Promise<BraintreeTokenizePayload> {
         return this._braintreeSDKCreator.getPaypal()
             .then(paypal => {
                 this._overlay.show({
@@ -46,13 +53,10 @@ export default class BraintreePaymentProcessor {
                 });
 
                 return paypal.tokenize({
-                    amount,
-                    currency,
                     enableShippingAddress: true,
                     flow: 'checkout',
-                    locale: storeLanguage,
-                    offerCredit,
                     useraction: 'commit',
+                    ...config,
                 });
             })
             .then(response => {

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -162,7 +162,13 @@ describe('BraintreePaypalPaymentStrategy', () => {
             await braintreePaypalPaymentStrategy.initialize(options);
             await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
 
-            expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith(190, 'en_US', 'USD', false);
+            expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith({
+                amount: 190,
+                locale: 'en_US',
+                currency: 'USD',
+                offerCredit: false,
+            });
+
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
             expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
         });
@@ -178,12 +184,22 @@ describe('BraintreePaypalPaymentStrategy', () => {
             await braintreePaypalPaymentStrategy.execute({ ...orderRequestBody, useStoreCredit: true }, options);
 
             expect(checkout.getOutstandingBalance).toHaveBeenCalledWith(true);
-            expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith(150, 'en_US', 'USD', false);
+            expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith({
+                amount: 150,
+                locale: 'en_US',
+                currency: 'USD',
+                offerCredit: false,
+            });
 
             await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
 
             expect(checkout.getOutstandingBalance).toHaveBeenCalledWith(false);
-            expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith(190, 'en_US', 'USD', false);
+            expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith({
+                amount: 190,
+                locale: 'en_US',
+                currency: 'USD',
+                offerCredit: false,
+            });
         });
 
         it('does not call paypal if a nonce is present', async () => {
@@ -274,7 +290,12 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 await braintreePaypalPaymentStrategy.initialize(options);
                 await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
 
-                expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith(190, 'en_US', 'USD', true);
+                expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith({
+                    amount: 190,
+                    locale: 'en_US',
+                    currency: 'USD',
+                    offerCredit: true,
+                });
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
                 expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
             });

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -150,6 +150,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 ...orderRequestBody.payment,
                 paymentData: {
                     formattedPayload: {
+                        vault_payment_instrument: null,
                         device_info: 'my_session_id',
                         paypal_account: {
                             token: 'my_tokenized_card',
@@ -166,6 +167,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 amount: 190,
                 locale: 'en_US',
                 currency: 'USD',
+                shouldSaveInstrument: false,
                 offerCredit: false,
             });
 
@@ -188,6 +190,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 amount: 150,
                 locale: 'en_US',
                 currency: 'USD',
+                shouldSaveInstrument: false,
                 offerCredit: false,
             });
 
@@ -198,6 +201,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 amount: 190,
                 locale: 'en_US',
                 currency: 'USD',
+                shouldSaveInstrument: false,
                 offerCredit: false,
             });
         });
@@ -208,6 +212,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             const expected = expect.objectContaining({
                 paymentData: {
                     formattedPayload: {
+                        vault_payment_instrument: null,
                         device_info: null,
                         paypal_account: {
                             token: 'some-nonce',
@@ -321,6 +326,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                     ...orderRequestBody.payment,
                     paymentData: {
                         formattedPayload: {
+                            vault_payment_instrument: null,
                             device_info: 'my_session_id',
                             paypal_account: {
                                 token: 'my_tokenized_card',
@@ -337,10 +343,85 @@ describe('BraintreePaypalPaymentStrategy', () => {
                     amount: 190,
                     locale: 'en_US',
                     currency: 'USD',
+                    shouldSaveInstrument: false,
                     offerCredit: true,
                 });
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
                 expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+            });
+        });
+
+        describe('when vaulting is selected', () => {
+            beforeEach(() => {
+                orderRequestBody = {
+                    payment: {
+                        methodId: 'braintreepaypal',
+                        paymentData: {
+                            shouldSaveInstrument: true,
+                        },
+                    },
+                };
+            });
+
+            it('initializes paypal in vault mode', async () => {
+                paymentMethodMock.config.isVaultingEnabled = true;
+
+                const expected = {
+                    ...orderRequestBody.payment,
+                    paymentData: {
+                        formattedPayload: {
+                            vault_payment_instrument: true,
+                            device_info: 'my_session_id',
+                            paypal_account: {
+                                token: 'my_tokenized_card',
+                                email: 'random@email.com',
+                            },
+                        },
+                    },
+                };
+
+                await braintreePaypalPaymentStrategy.initialize(options);
+                await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
+
+                expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith(expect.objectContaining({
+                    shouldSaveInstrument: true,
+                }));
+
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
+                expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+            });
+
+            it('sends vault_payment_instrument set to true', async () => {
+                paymentMethodMock.config.isVaultingEnabled = true;
+
+                const expected = {
+                    ...orderRequestBody.payment,
+                    paymentData: {
+                        formattedPayload: expect.objectContaining({
+                            vault_payment_instrument: true,
+                        }),
+                    },
+                };
+
+                await braintreePaypalPaymentStrategy.initialize(options);
+                await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
+
+                expect(braintreePaymentProcessorMock.paypal).toHaveBeenCalledWith(expect.objectContaining({
+                    shouldSaveInstrument: true,
+                }));
+
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
+                expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+            });
+
+            it('throws if vaulting is enabled and trying to save an instrument', async () => {
+                await braintreePaypalPaymentStrategy.initialize(options);
+
+                try {
+                    await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(InvalidArgumentError);
+                }
             });
         });
     });

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -110,7 +110,12 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
         }
 
         return Promise.all([
-            this._braintreePaymentProcessor.paypal(grandTotal, storeLanguage, currency.code, this._credit),
+            this._braintreePaymentProcessor.paypal({
+                amount: grandTotal,
+                locale: storeLanguage,
+                currency: currency.code,
+                offerCredit: this._credit,
+            }),
             this._braintreePaymentProcessor.getSessionId(),
         ]).then(([
             { nonce, details },

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -41,7 +41,7 @@ export interface BraintreeClient {
 }
 
 export interface BraintreeThreeDSecure extends BraintreeModule {
-    verifyCard(options: BraintreeThreeDSecureOptions): Promise<{ nonce: string }>;
+    verifyCard(options: BraintreeThreeDSecureOptions): Promise<BraintreeVerifyPayload>;
     cancelVerifyCard(): Promise<BraintreeVerifyPayload>;
 }
 


### PR DESCRIPTION
## What?
- Use an object to configure `BraintreePaypal`
- Support for paying with `BraintreePaypal` vaulted accounts
- Support for vaulting `BraintreePaypal` accounts
- Bump `@bigcommerce/bigpay-client` to support `formattedPayload`

## Why?
- Paypal Vaulting Support

## Testing / Proof
- Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
