### PR TITLE
PAYMENTS-4759 Add support to get and filter instruments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,9 +1183,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-4.5.0.tgz",
-      "integrity": "sha512-UZy7iRVK4TpLdpvtY7T60DXr+P64cMQ8UAfZezae67OjBQrW0ksVJhrH6opJB2zq6jBbSvgnfRKUHFliJYvH0A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.0.0.tgz",
+      "integrity": "sha512-xM9AJJPCXGHRVAtfCWBTTNHiWC2tn8pVSvpecuDyAU+VcqA0W9xxpUedlJzioAPQly3qbMQvl8CpKX0fSuiHWw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.2.1",
         "deep-assign": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@bigcommerce/bigpay-client": "^4.5.0",
+    "@bigcommerce/bigpay-client": "^5.0.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -203,7 +203,7 @@ export default interface CheckoutStoreSelector {
      *
      * @returns The list of payment instruments if it is loaded, otherwise undefined.
      */
-    getInstruments(): Instrument[] | undefined;
+    getInstruments(paymentMethod?: PaymentMethod): Instrument[] | undefined;
 
     /**
      * Gets a set of form fields that should be presented to customers in order

--- a/src/payment/errors/index.ts
+++ b/src/payment/errors/index.ts
@@ -4,3 +4,4 @@ export { default as PaymentMethodFailedError } from './payment-method-failed-err
 export { default as PaymentMethodClientUnavailableError } from './payment-method-client-unavailable-error';
 export { default as PaymentMethodDeclinedError } from './payment-method-declined-error';
 export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';
+export { default as PaymentInstrumentNotValidError } from './payment-instrument-not-valid-error';

--- a/src/payment/errors/payment-instrument-not-valid-error.spec.ts
+++ b/src/payment/errors/payment-instrument-not-valid-error.spec.ts
@@ -1,0 +1,9 @@
+import PaymentInstrumentNotValidError from './payment-instrument-not-valid-error';
+
+describe('PaymentMethodCancelledError', () => {
+    it('returns error name', () => {
+        const error = new PaymentInstrumentNotValidError();
+
+        expect(error.name).toEqual('PaymentInstrumentNotValidError');
+    });
+});

--- a/src/payment/errors/payment-instrument-not-valid-error.ts
+++ b/src/payment/errors/payment-instrument-not-valid-error.ts
@@ -1,0 +1,13 @@
+import { InvalidArgumentError } from '../../common/error/errors';
+
+/**
+ * This error should be thrown when the selected instrument is not in the list
+ * of valid instruments or the type doesn't match the expected type.
+ */
+export default class PaymentInstrumentNotValidError extends InvalidArgumentError {
+    constructor(message?: string) {
+        super(message || 'The selected instrument is either missing or not a valid type.');
+
+        this.name = 'PaymentInstrumentNotValidError';
+    }
+}

--- a/src/payment/instrument/instrument-reducer.spec.ts
+++ b/src/payment/instrument/instrument-reducer.spec.ts
@@ -1,3 +1,5 @@
+import { reject } from 'lodash';
+
 import { createRequestErrorFactory } from '../../common/error';
 import { getErrorResponse } from '../../common/http-request/responses.mock';
 
@@ -90,7 +92,7 @@ describe('instrumentReducer()', () => {
 
         expect(instrumentReducer(initialState, action)).toEqual({
             ...initialState,
-            data: [initialInstruments[1]],
+            data: reject(initialInstruments, initialInstruments[0]),
             meta: action.meta,
             errors: { deleteError: undefined },
             statuses: {

--- a/src/payment/instrument/instrument-response-body.ts
+++ b/src/payment/instrument/instrument-response-body.ts
@@ -5,16 +5,27 @@ export interface InstrumentError {
     message: string;
 }
 
-export interface InternalInstrument {
+export type InternalInstrument = CardInternalInstrument | AccountInternalInstrument;
+
+export interface BaseInternalInstrument {
     bigpay_token: string;
     default_instrument: boolean;
     provider: string;
-    iin: string;
-    last_4: string;
+    trusted_shipping_address: boolean;
+}
+
+export interface CardInternalInstrument extends BaseInternalInstrument {
+    brand: string;
     expiry_month: string;
     expiry_year: string;
-    brand: string;
-    trusted_shipping_address: boolean;
+    iin: string;
+    last_4: string;
+    method_type: 'card';
+}
+
+export interface AccountInternalInstrument extends BaseInternalInstrument {
+    external_id: string;
+    method_type: 'paypal';
 }
 
 export interface InstrumentsResponseBody {

--- a/src/payment/instrument/instrument-response-transformer.spec.ts
+++ b/src/payment/instrument/instrument-response-transformer.spec.ts
@@ -15,18 +15,14 @@ describe('InstrumentResponseTransformer', () => {
             const response = getPaymentResponse(getInternalInstrumentsResponseBody());
             const result = instrumentResponseTransformer.transformResponse(response);
 
-            expect(result).toEqual(
-                expect.objectContaining({ body: getLoadInstrumentsResponseBody() })
-            );
+            expect(result.body).toEqual(getLoadInstrumentsResponseBody());
         });
 
         it('transforms an empty loadInstruments response', () => {
             const response = getPaymentResponse({ vaulted_instruments: [] });
             const result = instrumentResponseTransformer.transformResponse(response);
 
-            expect(result).toEqual(expect.objectContaining({
-                body: { vaultedInstruments: [] },
-            }));
+            expect(result.body).toEqual({ vaultedInstruments: [] });
         });
     });
 
@@ -35,9 +31,7 @@ describe('InstrumentResponseTransformer', () => {
             const response = getResponse(getVaultAccessTokenResponseBody());
             const result = instrumentResponseTransformer.transformVaultAccessResponse(response);
 
-            expect(result).toEqual(
-                expect.objectContaining({ body: getVaultAccessToken() })
-            );
+            expect(result.body).toEqual(getVaultAccessToken());
         });
     });
 
@@ -46,9 +40,7 @@ describe('InstrumentResponseTransformer', () => {
             const response = getPaymentResponse(getErrorInstrumentResponseBody());
             const result = instrumentResponseTransformer.transformErrorResponse(response);
 
-            expect(result).toEqual(
-                expect.objectContaining({ body: getErrorInstrumentResponseBody() })
-            );
+            expect(result.body).toEqual(getErrorInstrumentResponseBody());
         });
     });
 });

--- a/src/payment/instrument/instrument-response-transformer.ts
+++ b/src/payment/instrument/instrument-response-transformer.ts
@@ -4,6 +4,8 @@ import PaymentResponse from '../payment-response';
 
 import Instrument, { VaultAccessToken } from './instrument';
 import { InstrumentsResponseBody, InstrumentErrorResponseBody, InternalInstrument, InternalInstrumentsResponseBody, InternalInstrumentErrorResponseBody, InternalVaultAccessTokenResponseBody } from './instrument-response-body';
+import { mapToAccountInstrument } from './map-to-account-instrument';
+import { mapToCardInstrument } from './map-to-card-instrument';
 
 export default class InstrumentResponseTransformer {
     transformResponse(
@@ -38,17 +40,15 @@ export default class InstrumentResponseTransformer {
     }
 
     private _transformVaultedInstruments(vaultedInstruments: InternalInstrument[] = []): Instrument[] {
-        return vaultedInstruments.map(instrument => ({
-            bigpayToken: instrument.bigpay_token,
-            defaultInstrument: instrument.default_instrument,
-            provider: instrument.provider,
-            iin: instrument.iin,
-            last4: instrument.last_4,
-            expiryMonth: instrument.expiry_month,
-            expiryYear: instrument.expiry_year,
-            brand: instrument.brand,
-            trustedShippingAddress: instrument.trusted_shipping_address,
-        }));
+        return vaultedInstruments
+            .map(instrument => {
+                switch (instrument.method_type) {
+                    case 'paypal':
+                        return mapToAccountInstrument(instrument);
+                    default:
+                        return mapToCardInstrument(instrument);
+                }
+            });
     }
 
     private _transformResponse<T>(response: PaymentResponse<T>): Response<T> {

--- a/src/payment/instrument/instrument-selector.spec.ts
+++ b/src/payment/instrument/instrument-selector.spec.ts
@@ -1,5 +1,8 @@
+import { filter, set } from 'lodash';
+
 import { CheckoutStoreState } from '../../checkout';
 import { getCheckoutStoreState } from '../../checkout/checkouts.mock';
+import { getBraintree } from '../payment-methods.mock';
 
 import InstrumentSelector, { createInstrumentSelectorFactory, InstrumentSelectorFactory } from './instrument-selector';
 import { getInstrumentsMeta } from './instrument.mock';
@@ -15,10 +18,36 @@ describe('InstrumentSelector', () => {
     });
 
     describe('#loadInstruments()', () => {
-        it('returns a list of instruments', () => {
+        it('returns only card instruments if no method is passed', () => {
             instrumentSelector = createInstrumentSelector(state.instruments);
 
-            expect(instrumentSelector.getInstruments()).toEqual(state.instruments.data);
+            expect(instrumentSelector.getInstruments())
+                .toEqual(filter(state.instruments.data, { method: 'card' }));
+        });
+
+        it('returns only card instruments if no method is passed', () => {
+            set(state, 'instruments.data[0].provider', 'invalid');
+            set(state, 'instruments.data[0].method', 'card');
+
+            instrumentSelector = createInstrumentSelector(state.instruments);
+            const result = instrumentSelector.getInstruments();
+
+            expect(result).toContainEqual(expect.objectContaining({ provider: 'authorizenet', method: 'card' }));
+            expect(result).not.toContainEqual(expect.objectContaining({ provider: 'invalid' }));
+        });
+
+        it('returns the instruments for a particular method', () => {
+            instrumentSelector = createInstrumentSelector(state.instruments);
+
+            expect(instrumentSelector.getInstruments(getBraintree()))
+                .toEqual([ expect.objectContaining({ provider: 'braintree', method: 'card' }) ]);
+        });
+
+        it('returns an empty array if the method is not supported', () => {
+            instrumentSelector = createInstrumentSelector(state.instruments);
+
+            expect(instrumentSelector.getInstruments({ ...getBraintree(), id: 'nonexistent' }))
+                .toEqual([]);
         });
 
         it('returns an empty array if there are no instruments', () => {

--- a/src/payment/instrument/instrument.mock.ts
+++ b/src/payment/instrument/instrument.mock.ts
@@ -25,6 +25,8 @@ export function getInstruments(): Instrument[] {
             brand: 'test',
             trustedShippingAddress: true,
             defaultInstrument: true,
+            method: 'card',
+            type: 'card',
         },
         {
             bigpayToken: '111',
@@ -36,6 +38,17 @@ export function getInstruments(): Instrument[] {
             brand: 'test',
             trustedShippingAddress: false,
             defaultInstrument: false,
+            method: 'card',
+            type: 'card',
+        },
+        {
+            bigpayToken: '31415',
+            provider: 'braintree',
+            trustedShippingAddress: false,
+            defaultInstrument: false,
+            method: 'paypal',
+            externalId: 'test@external-id.com',
+            type: 'account',
         },
     ];
 }
@@ -95,6 +108,7 @@ export function getInternalInstrumentsResponseBody(): InternalInstrumentsRespons
                 brand: 'test',
                 trusted_shipping_address: true,
                 default_instrument: true,
+                method_type: 'card',
             },
             {
                 bigpay_token: '111',
@@ -106,6 +120,15 @@ export function getInternalInstrumentsResponseBody(): InternalInstrumentsRespons
                 brand: 'test',
                 trusted_shipping_address: false,
                 default_instrument: false,
+                method_type: 'card',
+            },
+            {
+                bigpay_token: '31415',
+                provider: 'braintree',
+                trusted_shipping_address: false,
+                default_instrument: false,
+                method_type: 'paypal',
+                external_id: 'test@external-id.com',
             },
         ],
     };

--- a/src/payment/instrument/instrument.ts
+++ b/src/payment/instrument/instrument.ts
@@ -1,13 +1,30 @@
-export default interface Instrument {
+type Instrument = CardInstrument | AccountInstrument;
+
+export default Instrument;
+
+interface BaseInstrument {
     bigpayToken: string;
     defaultInstrument: boolean;
     provider: string;
-    iin: string;
-    last4: string;
+    trustedShippingAddress: boolean;
+    method: string;
+    type: string;
+}
+
+export interface CardInstrument extends BaseInstrument {
+    brand: string;
     expiryMonth: string;
     expiryYear: string;
-    brand: string;
-    trustedShippingAddress: boolean;
+    iin: string;
+    last4: string;
+    method: 'card';
+    type: 'card';
+}
+
+export interface AccountInstrument extends BaseInstrument {
+    externalId: string;
+    method: 'paypal';
+    type: 'account';
 }
 
 export interface VaultAccessToken {

--- a/src/payment/instrument/map-to-account-instrument.spec.ts
+++ b/src/payment/instrument/map-to-account-instrument.spec.ts
@@ -1,0 +1,24 @@
+import { mapToAccountInstrument } from './map-to-account-instrument';
+
+describe('mapToAccountInstrument', () => {
+    it('returns a AccountInstrument from a AccountInternalInstrument', () => {
+        const result = mapToAccountInstrument({
+            bigpay_token: 'my-bigpay-token',
+            trusted_shipping_address: true,
+            provider: 'braintree',
+            method_type: 'paypal',
+            default_instrument: false,
+            external_id: 'test@external-id.com',
+        });
+
+        expect(result).toEqual({
+            bigpayToken: 'my-bigpay-token',
+            trustedShippingAddress: true,
+            provider: 'braintree',
+            method: 'paypal',
+            defaultInstrument: false,
+            externalId: 'test@external-id.com',
+            type: 'account',
+        });
+    });
+});

--- a/src/payment/instrument/map-to-account-instrument.ts
+++ b/src/payment/instrument/map-to-account-instrument.ts
@@ -1,0 +1,14 @@
+import { AccountInstrument } from './instrument';
+import { AccountInternalInstrument } from './instrument-response-body';
+
+export function mapToAccountInstrument(instrument: AccountInternalInstrument): AccountInstrument {
+    return {
+        bigpayToken: instrument.bigpay_token,
+        defaultInstrument: instrument.default_instrument,
+        provider: instrument.provider,
+        externalId: instrument.external_id,
+        trustedShippingAddress: instrument.trusted_shipping_address,
+        method: instrument.method_type,
+        type: 'account',
+    };
+}

--- a/src/payment/instrument/map-to-card-instrument.spec.ts
+++ b/src/payment/instrument/map-to-card-instrument.spec.ts
@@ -1,0 +1,32 @@
+import { mapToCardInstrument } from './map-to-card-instrument';
+
+describe('mapToCardInstrument', () => {
+    it('returns a CardInstrument from a CardInternalInstrument', () => {
+        const result = mapToCardInstrument({
+            bigpay_token: 'my-bigpay-token',
+            trusted_shipping_address: true,
+            provider: 'braintree',
+            method_type: 'card',
+            last_4: '4111',
+            iin: '4242',
+            expiry_year: '2020',
+            expiry_month: '12',
+            default_instrument: false,
+            brand: 'VISA',
+        });
+
+        expect(result).toEqual({
+            bigpayToken: 'my-bigpay-token',
+            brand: 'VISA',
+            trustedShippingAddress: true,
+            provider: 'braintree',
+            method: 'card',
+            last4: '4111',
+            iin: '4242',
+            expiryYear: '2020',
+            expiryMonth: '12',
+            defaultInstrument: false,
+            type: 'card',
+        });
+    });
+});

--- a/src/payment/instrument/map-to-card-instrument.ts
+++ b/src/payment/instrument/map-to-card-instrument.ts
@@ -1,0 +1,18 @@
+import { CardInstrument } from './instrument';
+import { CardInternalInstrument } from './instrument-response-body';
+
+export function mapToCardInstrument(instrument: CardInternalInstrument): CardInstrument {
+    return {
+        bigpayToken: instrument.bigpay_token,
+        defaultInstrument: instrument.default_instrument,
+        provider: instrument.provider,
+        iin: instrument.iin,
+        last4: instrument.last_4,
+        expiryMonth: instrument.expiry_month,
+        expiryYear: instrument.expiry_year,
+        brand: instrument.brand,
+        trustedShippingAddress: instrument.trusted_shipping_address,
+        method: instrument.method_type,
+        type: 'card',
+    };
+}

--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -1,0 +1,42 @@
+import Instrument from './instrument';
+
+interface SupportedInstruments {
+    [key: string]: Pick<Instrument, 'method' | 'provider'>;
+}
+
+const supportedInstruments: SupportedInstruments = {
+    braintree: {
+        provider: 'braintree',
+        method: 'card',
+    },
+    authorizenet: {
+        provider: 'authorizenet',
+        method: 'card',
+    },
+    stripe: {
+        provider: 'stripe',
+        method: 'card',
+    },
+    stripev3: {
+        provider: 'stripev3',
+        method: 'card',
+    },
+    cybersource: {
+        provider: 'cybersource',
+        method: 'card',
+    },
+    converge: {
+        provider: 'converge',
+        method: 'card',
+    },
+    bluesnapv2: {
+        provider: 'bluesnapv2',
+        method: 'card',
+    },
+    paymetric: {
+        provider: 'paymetric',
+        method: 'card',
+    },
+};
+
+export default supportedInstruments;


### PR DESCRIPTION
## What?
- Add support for account instruments
- Add support to filter instruments based on payment method type

## Why?
- We want to support account-type instruments required for paypal vaulting
- We would like to future proof the SDK so new instruments added to the API don't break old copies of the Checkout SDK.
- **From now onwards:** In order to instrument types that are not of type `card` you need to provide the `paymentMethod` to `getAllInstruments`

## Testing / Proof
- Unit / Functional

@bigcommerce/checkout @bigcommerce/payments
