### PR TITLE
feat(checkout): INT-1916 Make barclaycard compatible with offsite strategy

### DIFF
--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -69,7 +69,7 @@ export default class PaymentStrategyRegistry extends Registry<PaymentStrategy, P
 
         const { clientSidePaymentProviders } = config.paymentSettings;
 
-        if (!clientSidePaymentProviders || paymentMethod.gateway === 'adyen') {
+        if (!clientSidePaymentProviders || paymentMethod.gateway === 'adyen' || paymentMethod.gateway === 'barclaycard') {
             return false;
         }
 

--- a/src/payment/strategies/offsite/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.ts
@@ -55,6 +55,6 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
             return false;
         }
 
-        return payment.gatewayId === 'adyen' || payment.methodId === 'ccavenuemars';
+        return payment.gatewayId === 'adyen' || payment.gatewayId === 'barclaycard' || payment.methodId === 'ccavenuemars';
     }
 }


### PR DESCRIPTION
## What?
Add barclaycard to offsite strategy and payment strategy registry validations.

## Why?
To make barclaycard compatible with the offsite-payment-strategy.
## SIbling PRs
https://github.com/bigcommerce/checkout-js/pull/143

## Testing / Proof
<img width="327" alt="Screen Shot 2019-10-18 at 3 10 02 PM" src="https://user-images.githubusercontent.com/35502707/67124972-63602580-f1b9-11e9-8e65-9b68a952acad.png">


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
