### PR TITLE
feat(payments): INT-1997 Integrate BlueSnap V2 strategy

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -12,6 +12,7 @@ import { AdyenV2PaymentStrategy } from './strategies/adyenv2';
 import { AffirmPaymentStrategy } from './strategies/affirm';
 import { AfterpayPaymentStrategy } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy } from './strategies/amazon-pay';
+import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy } from './strategies/braintree';
 import { ChasepayPaymentStrategy } from './strategies/chasepay';
 import { ConvergePaymentStrategy } from './strategies/converge';
@@ -69,6 +70,11 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate braintree', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.BRAINTREE);
         expect(paymentStrategy).toBeInstanceOf(BraintreeCreditCardPaymentStrategy);
+    });
+
+    it('can instantiate bluesnapv2', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.BLUESNAPV2);
+        expect(paymentStrategy).toBeInstanceOf(BlueSnapV2PaymentStrategy);
     });
 
     it('can instantiate braintreepaypal', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -23,6 +23,7 @@ import { AdyenV2PaymentStrategy, AdyenV2ScriptLoader } from './strategies/adyenv
 import { AffirmPaymentStrategy, AffirmScriptLoader } from './strategies/affirm';
 import { AfterpayPaymentStrategy, AfterpayScriptLoader } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy, AmazonPayScriptLoader } from './strategies/amazon-pay';
+import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVisaCheckoutPaymentStrategy, VisaCheckoutScriptLoader } from './strategies/braintree';
 import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow } from './strategies/cardinal';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
@@ -110,6 +111,14 @@ export default function createPaymentStrategyRegistry(
             billingAddressActionCreator,
             remoteCheckoutActionCreator,
             new AmazonPayScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register(PaymentStrategyType.BLUESNAPV2, () =>
+        new BlueSnapV2PaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator
         )
     );
 

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -1,14 +1,17 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { noop } from 'lodash';
 import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
 import { createCheckoutStore, CheckoutStore, CheckoutValidator } from '../checkout';
 import { getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
 import { getResponse } from '../common/http-request/responses.mock';
+import { CancellablePromise } from '../common/utility';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../order';
 import { getOrder } from '../order/orders.mock';
 
 import createPaymentClient from './create-payment-client';
+import { PaymentMethodCancelledError } from './errors';
 import PaymentActionCreator from './payment-action-creator';
 import { PaymentActionType } from './payment-actions';
 import PaymentRequestSender from './payment-request-sender';
@@ -132,6 +135,41 @@ describe('PaymentActionCreator', () => {
 
             expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
+                {
+                    type: PaymentActionType.InitializeOffsitePaymentRequested,
+                },
+                {
+                    type: PaymentActionType.InitializeOffsitePaymentFailed,
+                    payload: error,
+                    error: true,
+                },
+            ]);
+        });
+
+        it('dispatches error actions to data store if payment cancelled', async () => {
+            const error = new PaymentMethodCancelledError();
+
+            jest.spyOn(paymentRequestSender, 'initializeOffsitePayment')
+                .mockResolvedValue(new Promise(noop));
+
+            const cancelPayment = new CancellablePromise<undefined>(new Promise(noop));
+            const errorHandler = jest.fn(action => of(action));
+            const payment = getPayment();
+
+            const actions = from(paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId, undefined, undefined, undefined, cancelPayment.promise)(store))
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
+                .toPromise();
+
+            cancelPayment.cancel(error);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(errorHandler).toHaveBeenCalled();
+
+            return expect(actions).resolves.toEqual([
                 {
                     type: PaymentActionType.InitializeOffsitePaymentRequested,
                 },

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -40,7 +40,8 @@ export default class PaymentActionCreator {
         gatewayId?: string,
         instrumentId?: string,
         shouldSaveInstrument?: boolean,
-        target?: string
+        target?: string,
+        promise?: Promise<undefined>
     ): ThunkAction<InitializeOffsitePaymentAction, InternalCheckoutSelectors> {
         return store => {
             let paymentData: FormattedPayload<FormattedHostedInstrument | FormattedVaultedInstrument> | undefined;
@@ -55,7 +56,7 @@ export default class PaymentActionCreator {
 
             return concat(
                 of(createAction(PaymentActionType.InitializeOffsitePaymentRequested)),
-                this._paymentRequestSender.initializeOffsitePayment(payload, target)
+                Promise.race([this._paymentRequestSender.initializeOffsitePayment(payload, target), promise].filter(Boolean))
                     .then(() => createAction(PaymentActionType.InitializeOffsitePaymentSucceeded))
             ).pipe(
                 catchError(error => throwErrorAction(PaymentActionType.InitializeOffsitePaymentFailed, error))

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -39,7 +39,8 @@ export default class PaymentActionCreator {
         methodId: string,
         gatewayId?: string,
         instrumentId?: string,
-        shouldSaveInstrument?: boolean
+        shouldSaveInstrument?: boolean,
+        target?: string
     ): ThunkAction<InitializeOffsitePaymentAction, InternalCheckoutSelectors> {
         return store => {
             let paymentData: FormattedPayload<FormattedHostedInstrument | FormattedVaultedInstrument> | undefined;
@@ -54,7 +55,7 @@ export default class PaymentActionCreator {
 
             return concat(
                 of(createAction(PaymentActionType.InitializeOffsitePaymentRequested)),
-                this._paymentRequestSender.initializeOffsitePayment(payload)
+                this._paymentRequestSender.initializeOffsitePayment(payload, target)
                     .then(() => createAction(PaymentActionType.InitializeOffsitePaymentSucceeded))
             ).pipe(
                 catchError(error => throwErrorAction(PaymentActionType.InitializeOffsitePaymentFailed, error))

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -126,6 +126,21 @@ export function getAuthorizenet(): PaymentMethod {
     };
 }
 
+export function getBlueSnapV2(): PaymentMethod {
+    return {
+        id: 'cc',
+        gateway: 'bluesnapv2',
+        logoUrl: '',
+        method: 'multi-option',
+        supportedCards: [],
+        config: {
+            displayName: 'Credit Card',
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_HOSTED',
+    };
+}
+
 export function getCybersource(): PaymentMethod {
     return {
         id: 'cybersource',
@@ -435,6 +450,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getAfterpay(),
         getAmazonPay(),
         getAuthorizenet(),
+        getBlueSnapV2(),
         getBraintree(),
         getBraintreePaypal(),
         getBraintreePaypalCredit(),

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -2,6 +2,7 @@ import { RequestOptions } from '../common/http-request';
 
 import { AdyenV2PaymentInitializeOptions } from './strategies/adyenv2';
 import { AmazonPayPaymentInitializeOptions } from './strategies/amazon-pay';
+import { BlueSnapV2PaymentInitializeOptions } from './strategies/bluesnapv2';
 import { BraintreePaymentInitializeOptions, BraintreeVisaCheckoutPaymentInitializeOptions } from './strategies/braintree';
 import { ChasePayInitializeOptions } from './strategies/chasepay';
 import { CreditCardPaymentInitializeOptions } from './strategies/credit-card';
@@ -54,6 +55,12 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * method. They can be omitted unless you need to support AmazonPay.
      */
     amazon?: AmazonPayPaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the BlueSnapV2 payment method.
+     * They can be omitted unless you need to support BlueSnapV2.
+     */
+    bluesnapv2?: BlueSnapV2PaymentInitializeOptions;
 
     /**
      * The options that are required to initialize the Braintree payment method.

--- a/src/payment/payment-request-sender.spec.ts
+++ b/src/payment/payment-request-sender.spec.ts
@@ -71,7 +71,15 @@ describe('PaymentRequestSender', () => {
 
             paymentRequestSender.initializeOffsitePayment(payload);
 
-            expect(bigpayClient.initializeOffsitePayment).toHaveBeenCalledWith(payload);
+            expect(bigpayClient.initializeOffsitePayment).toHaveBeenCalledWith(payload, null, undefined);
+        });
+
+        it('submits payment data to BigPay with custom target', () => {
+            const payload = getPaymentRequestBody();
+
+            paymentRequestSender.initializeOffsitePayment(payload, 'iframename');
+
+            expect(bigpayClient.initializeOffsitePayment).toHaveBeenCalledWith(payload, null, 'iframename');
         });
     });
 });

--- a/src/payment/payment-request-sender.ts
+++ b/src/payment/payment-request-sender.ts
@@ -26,9 +26,9 @@ export default class PaymentRequestSender {
         });
     }
 
-    initializeOffsitePayment(payload: PaymentRequestBody): Promise<void> {
+    initializeOffsitePayment(payload: PaymentRequestBody, target?: string): Promise<void> {
         return new Promise(() => {
-            this._client.initializeOffsitePayment(payload);
+            this._client.initializeOffsitePayment(payload, null, target);
         });
     }
 

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -3,6 +3,7 @@ enum PaymentStrategyType {
     AFFIRM = 'affirm',
     AFTERPAY = 'afterpay',
     AMAZON = 'amazon',
+    BLUESNAPV2 = 'bluesnapv2',
     CREDIT_CARD = 'creditcard',
     CYBERSOURCE = 'cybersource',
     KLARNA = 'klarna',

--- a/src/payment/strategies/bluesnapv2/bluesnapv2-payment-options.ts
+++ b/src/payment/strategies/bluesnapv2/bluesnapv2-payment-options.ts
@@ -1,0 +1,27 @@
+import { BlueSnapV2StyleProps } from './bluesnapv2';
+
+/**
+ * A set of options that are required to initialize the BlueSnap V2 payment
+ * method.
+ *
+ * The payment step is done through a web page via an iframe provided by the
+ * strategy.
+ */
+export interface BlueSnapV2PaymentInitializeOptions {
+    /**
+     * A set of CSS properties to apply to the iframe.
+     */
+    style?: BlueSnapV2StyleProps;
+
+    /**
+     * A callback that gets called when the iframe is ready to be added to the
+     * current page. It is responsible for determining where the iframe should
+     * be inserted in the DOM.
+     *
+     * @param iframe - The iframe element containing the payment web page
+     * provided by the strategy.
+     * @param cancel - A function, when called, will cancel the payment
+     * process and remove the iframe.
+     */
+    onLoad(iframe: HTMLIFrameElement, cancel: () => void): void;
+}

--- a/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.spec.ts
@@ -1,0 +1,200 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction } from '@bigcommerce/data-store';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { merge, noop } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getIncompleteOrder, getOrderRequestBody, getSubmittedOrder } from '../../../order/internal-orders.mock';
+import { getOrder } from '../../../order/orders.mock';
+import { PaymentMethodCancelledError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { InitializeOffsitePaymentAction, PaymentActionType } from '../../payment-actions';
+import { getBlueSnapV2 } from '../../payment-methods.mock';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+import * as paymentStatusTypes from '../../payment-status-types';
+import { getPaymentRequestBody } from '../../payments.mock';
+
+import BlueSnapV2PaymentStrategy from './bluesnapv2-payment-strategy';
+
+describe('BlueSnapV2PaymentStrategy', () => {
+    let finalizeOrderAction: Observable<FinalizeOrderAction>;
+    let initializeOffsitePaymentAction: Observable<InitializeOffsitePaymentAction>;
+    let orderActionCreator: OrderActionCreator;
+    let paymentRequestTransformer: PaymentRequestTransformer;
+    let paymentRequestSender: PaymentRequestSender;
+    let paymentActionCreator: PaymentActionCreator;
+    let initializeOptions: PaymentInitializeOptions;
+    let options: PaymentRequestOptions;
+    let payload: OrderRequestBody;
+    let store: CheckoutStore;
+    let strategy: BlueSnapV2PaymentStrategy;
+    let submitOrderAction: Observable<SubmitOrderAction>;
+    let cancelPayment: () => void;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        orderActionCreator = new OrderActionCreator(
+            new OrderRequestSender(createRequestSender()),
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+        );
+        paymentRequestTransformer = new PaymentRequestTransformer();
+        paymentRequestSender = new PaymentRequestSender(createPaymentClient());
+        paymentActionCreator = new PaymentActionCreator(
+            paymentRequestSender,
+            orderActionCreator,
+            paymentRequestTransformer
+        );
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        initializeOffsitePaymentAction = of(createAction(PaymentActionType.InitializeOffsitePaymentRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+
+        initializeOptions = {
+            methodId: 'foobar',
+            bluesnapv2: {
+                onLoad: (_iframe: HTMLIFrameElement, cancel: () => void) => {
+                    cancelPayment = cancel;
+                },
+            },
+        };
+        payload = merge(getOrderRequestBody(), {
+            payment: {
+                methodId: 'foobar',
+                paymentData: null,
+            },
+        });
+        options = { methodId: 'foobar' };
+
+        jest.spyOn(store, 'dispatch');
+
+        jest.spyOn(orderActionCreator, 'finalizeOrder')
+            .mockReturnValue(finalizeOrderAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'initializeOffsitePayment')
+            .mockReturnValue(initializeOffsitePaymentAction);
+
+        strategy = new BlueSnapV2PaymentStrategy(store, orderActionCreator, paymentActionCreator);
+    });
+
+    it('submits order with payment data', async () => {
+        await strategy.initialize(initializeOptions);
+        await strategy.execute(payload, options);
+
+        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(payload, options);
+        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    });
+
+    it('initializes offsite payment flow', async () => {
+        await strategy.initialize(initializeOptions);
+        await strategy.execute(payload, options);
+
+        expect(paymentActionCreator.initializeOffsitePayment)
+            .toHaveBeenCalledWith(
+                options.methodId,
+                options.gatewayId,
+                undefined,
+                false,
+                'bluesnapv2_hosted_payment_page',
+                expect.any(Promise)
+            );
+        expect(store.dispatch).toHaveBeenCalledWith(initializeOffsitePaymentAction);
+    });
+
+    it('returns cancel error if the user cancels flow', async () => {
+        jest.spyOn(paymentActionCreator, 'initializeOffsitePayment')
+            .mockRestore();
+
+        jest.spyOn(paymentRequestTransformer, 'transform')
+            .mockReturnValue({ ...getPaymentRequestBody(), paymentMethod: getBlueSnapV2() });
+
+        jest.spyOn(paymentRequestSender, 'initializeOffsitePayment')
+            .mockReturnValue(new Promise(noop));
+
+        await strategy.initialize(initializeOptions);
+        const promise = strategy.execute(payload, options);
+
+        await new Promise(resolve => process.nextTick(resolve));
+        cancelPayment();
+
+        return expect(promise).rejects.toThrow(PaymentMethodCancelledError);
+    });
+
+    it('finalizes order if order is created and payment is acknowledged', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(getOrder());
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.ACKNOWLEDGE);
+
+        await strategy.finalize(options);
+
+        expect(orderActionCreator.finalizeOrder).toHaveBeenCalledWith(getOrder().orderId, options);
+        expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('finalizes order if order is created and payment is finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(getOrder());
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.FINALIZE);
+
+        await strategy.finalize(options);
+
+        expect(orderActionCreator.finalizeOrder).toHaveBeenCalledWith(getOrder().orderId, options);
+        expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not created', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(getIncompleteOrder());
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not finalized or acknowledged', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(merge({}, getSubmittedOrder(), {
+                payment: {
+                    status: paymentStatusTypes.INITIALIZE,
+                },
+            }));
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('throws error if unable to finalize due to missing data', () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        return expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+    });
+
+    it('returns checkout state', async () => {
+        await strategy.initialize(initializeOptions);
+
+        return expect(strategy.execute(payload, options)).resolves.toEqual(store.getState());
+    });
+});

--- a/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.ts
+++ b/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.ts
@@ -1,0 +1,97 @@
+import { noop } from 'lodash';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { CancellablePromise } from '../../../common/utility';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import * as paymentStatusTypes from '../../payment-status-types';
+import PaymentStrategy from '../payment-strategy';
+
+import { BlueSnapV2StyleProps } from './bluesnapv2';
+import { BlueSnapV2PaymentInitializeOptions } from './bluesnapv2-payment-options';
+
+const IFRAME_NAME = 'bluesnapv2_hosted_payment_page';
+
+export default class BlueSnapV2PaymentStrategy implements PaymentStrategy {
+
+    private _initializeOptions?: BlueSnapV2PaymentInitializeOptions;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator
+    ) {}
+
+    async execute(orderRequest: OrderRequestBody, options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { payment } = orderRequest;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        if (!this._initializeOptions) {
+            throw new NotInitializedError(
+                NotInitializedErrorType.PaymentNotInitialized
+            );
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(orderRequest, options));
+
+        const { onLoad, style } = this._initializeOptions;
+        const frame = this._createIframe(IFRAME_NAME, style);
+        const promise = new CancellablePromise<undefined>(new Promise(noop));
+
+        onLoad(frame, () => promise.cancel(new PaymentMethodCancelledError()));
+
+        return this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment(
+            payment.methodId,
+            payment.gatewayId,
+            undefined,
+            false,
+            frame.name,
+            promise.promise
+        ));
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const order = state.order.getOrder();
+        const status = state.payment.getPaymentStatus();
+
+        if (order && (status === paymentStatusTypes.ACKNOWLEDGE || status === paymentStatusTypes.FINALIZE)) {
+            return this._store.dispatch(this._orderActionCreator.finalizeOrder(order.orderId, options));
+        }
+
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        this._initializeOptions = options && options.bluesnapv2;
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _createIframe(name: string, style?: BlueSnapV2StyleProps): HTMLIFrameElement {
+        const iframe = document.createElement('iframe');
+
+        iframe.name = name;
+
+        if (style) {
+            const { border, height, width } = style;
+
+            iframe.style.border = border as string;
+            iframe.style.height = height as string;
+            iframe.style.width = width as string;
+        }
+
+        return iframe;
+    }
+}

--- a/src/payment/strategies/bluesnapv2/bluesnapv2.ts
+++ b/src/payment/strategies/bluesnapv2/bluesnapv2.ts
@@ -1,0 +1,5 @@
+export interface BlueSnapV2StyleProps {
+    border?: string;
+    height?: string;
+    width?: string;
+}

--- a/src/payment/strategies/bluesnapv2/index.ts
+++ b/src/payment/strategies/bluesnapv2/index.ts
@@ -1,0 +1,2 @@
+export { BlueSnapV2PaymentInitializeOptions } from './bluesnapv2-payment-options';
+export { default as BlueSnapV2PaymentStrategy } from './bluesnapv2-payment-strategy';


### PR DESCRIPTION
## What? [INT-1997](https://jira.bigcommerce.com/browse/INT-1997)
Create the BlueSnap V2 payment strategy and make it available in checkout.

## Why?
A new payment strategy is required to support BlueSnap V2.

## Sibling PRs
[4] [bigcommerce/checkout-js](https://github.com/bigcommerce/checkout-js/pull/155) depends on:
[3] THIS PR depends on:
[2] [bigcommerce/bigpay-client-js](https://github.com/bigcommerce/bigpay-client-js/pull/88) depends on:
[1] [bigcommerce/form-poster-js](https://github.com/bigcommerce/form-poster-js/pull/9)

## Testing / Proof
You can watch the video [here](https://drive.google.com/open?id=1unL57CIRZ-KRZK6SvJc-ZNH3Grxgpm0w)

![image](https://user-images.githubusercontent.com/4843328/68165534-50718300-ff25-11e9-86c7-493c9b114cef.png)
![image](https://user-images.githubusercontent.com/4843328/68165693-b1995680-ff25-11e9-913d-78cdb44cb088.png)
![image](https://user-images.githubusercontent.com/4843328/68166190-35077780-ff27-11e9-9b75-75a41a9fbc9e.png)
![image](https://user-images.githubusercontent.com/4843328/68165910-57e55c00-ff26-11e9-9d89-5f053334f7f0.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations
