### PR TITLE
fix(payment): PAYMENTS-4759 Make Instrument types backward compatible

### DIFF
--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -3,6 +3,7 @@ import { find, reject } from 'lodash';
 import { FormField } from '../form';
 import { getFormFields } from '../form/form.mock';
 import { getUnitedStates } from '../geography/countries.mock';
+import { getBraintree } from '../payment/payment-methods.mock';
 import { getAustralia } from '../shipping/shipping-countries.mock';
 import { getShippingOptions } from '../shipping/shipping-options.mock';
 
@@ -116,6 +117,12 @@ describe('CheckoutStoreSelector', () => {
 
     it('returns instruments', () => {
         expect(selector.getInstruments()).toEqual(internalSelectors.instruments.getInstruments());
+    });
+
+    it('returns instruments for a particular payment method', () => {
+        const paymentMethodMock = getBraintree();
+
+        expect(selector.getInstruments(paymentMethodMock)).toEqual(internalSelectors.instruments.getInstrumentsByPaymentMethod(paymentMethodMock));
     });
 
     it('returns flag indicating if payment is submitted', () => {

--- a/src/payment/instrument/index.ts
+++ b/src/payment/instrument/index.ts
@@ -1,4 +1,4 @@
-export { default as Instrument } from './instrument';
+export { default as PaymentInstrument, AccountInstrument, CardInstrument } from './instrument';
 export { default as InstrumentActionCreator } from './instrument-action-creator';
 export { default as InstrumentRequestSender } from './instrument-request-sender';
 export { default as InstrumentSelector, InstrumentSelectorFactory, createInstrumentSelectorFactory } from './instrument-selector';

--- a/src/payment/instrument/instrument-reducer.ts
+++ b/src/payment/instrument/instrument-reducer.ts
@@ -3,7 +3,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 import { clearErrorReducer } from '../../common/error';
 import { arrayReplace, objectMerge, objectSet } from '../../common/utility';
 
-import Instrument from './instrument';
+import PaymentInstrument from './instrument';
 import { InstrumentAction, InstrumentActionType } from './instrument-actions';
 import InstrumentState, { DEFAULT_STATE, InstrumentErrorState, InstrumentMeta, InstrumentStatusState } from './instrument-state';
 
@@ -22,9 +22,9 @@ export default function instrumentReducer(
 }
 
 function dataReducer(
-    data: Instrument[] = DEFAULT_STATE.data,
+    data: PaymentInstrument[] = DEFAULT_STATE.data,
     action: InstrumentAction
-): Instrument[] {
+): PaymentInstrument[] {
     switch (action.type) {
     case InstrumentActionType.LoadInstrumentsSucceeded:
         return arrayReplace(data, action.payload && action.payload.vaultedInstruments || []);

--- a/src/payment/instrument/instrument-response-body.ts
+++ b/src/payment/instrument/instrument-response-body.ts
@@ -1,4 +1,4 @@
-import Instrument from './instrument';
+import PaymentInstrument from './instrument';
 
 export interface InstrumentError {
     code: number;
@@ -29,7 +29,7 @@ export interface AccountInternalInstrument extends BaseInternalInstrument {
 }
 
 export interface InstrumentsResponseBody {
-    vaultedInstruments: Instrument[];
+    vaultedInstruments: PaymentInstrument[];
 }
 
 export interface InstrumentErrorResponseBody {

--- a/src/payment/instrument/instrument-response-transformer.ts
+++ b/src/payment/instrument/instrument-response-transformer.ts
@@ -2,7 +2,7 @@ import { Response } from '@bigcommerce/request-sender';
 
 import PaymentResponse from '../payment-response';
 
-import Instrument, { VaultAccessToken } from './instrument';
+import PaymentInstrument, { VaultAccessToken } from './instrument';
 import { InstrumentsResponseBody, InstrumentErrorResponseBody, InternalInstrument, InternalInstrumentsResponseBody, InternalInstrumentErrorResponseBody, InternalVaultAccessTokenResponseBody } from './instrument-response-body';
 import { mapToAccountInstrument } from './map-to-account-instrument';
 import { mapToCardInstrument } from './map-to-card-instrument';
@@ -39,7 +39,7 @@ export default class InstrumentResponseTransformer {
         };
     }
 
-    private _transformVaultedInstruments(vaultedInstruments: InternalInstrument[] = []): Instrument[] {
+    private _transformVaultedInstruments(vaultedInstruments: InternalInstrument[] = []): PaymentInstrument[] {
         return vaultedInstruments
             .map(instrument => {
                 switch (instrument.method_type) {

--- a/src/payment/instrument/instrument-state.ts
+++ b/src/payment/instrument/instrument-state.ts
@@ -1,7 +1,7 @@
-import Instrument, { VaultAccessToken } from './instrument';
+import PaymentInstrument, { VaultAccessToken } from './instrument';
 
 export default interface InstrumentState {
-    data?: Instrument[];
+    data?: PaymentInstrument[];
     meta?: InstrumentMeta;
     errors: InstrumentErrorState;
     statuses: InstrumentStatusState;

--- a/src/payment/instrument/instrument.mock.ts
+++ b/src/payment/instrument/instrument.mock.ts
@@ -1,4 +1,4 @@
-import Instrument, { InstrumentRequestContext, VaultAccessToken } from './instrument';
+import PaymentInstrument, { CardInstrument, InstrumentRequestContext, VaultAccessToken } from './instrument';
 import { InstrumentsResponseBody, InstrumentErrorResponseBody, InternalInstrumentsResponseBody, InternalVaultAccessTokenResponseBody } from './instrument-response-body';
 import InstrumentState, { InstrumentMeta } from './instrument-state';
 
@@ -13,7 +13,7 @@ export function getVaultAccessToken(): VaultAccessToken {
     };
 }
 
-export function getInstruments(): Instrument[] {
+export function getInstruments(): PaymentInstrument[] {
     return [
         {
             bigpayToken: '123',
@@ -51,6 +51,22 @@ export function getInstruments(): Instrument[] {
             type: 'account',
         },
     ];
+}
+
+export function getCardInstrument(): CardInstrument {
+    return {
+        bigpayToken: '123',
+        provider: 'braintree',
+        iin: '11111111',
+        last4: '4321',
+        expiryMonth: '02',
+        expiryYear: '2020',
+        brand: 'test',
+        trustedShippingAddress: true,
+        defaultInstrument: true,
+        method: 'card',
+        type: 'card',
+    };
 }
 
 export function getInstrumentsState(): InstrumentState {

--- a/src/payment/instrument/instrument.ts
+++ b/src/payment/instrument/instrument.ts
@@ -1,6 +1,6 @@
-type Instrument = CardInstrument | AccountInstrument;
+type PaymentInstrument = CardInstrument | AccountInstrument;
 
-export default Instrument;
+export default PaymentInstrument;
 
 interface BaseInstrument {
     bigpayToken: string;

--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -1,7 +1,7 @@
-import Instrument from './instrument';
+import PaymentInstrument from './instrument';
 
 interface SupportedInstruments {
-    [key: string]: Pick<Instrument, 'method' | 'provider'>;
+    [key: string]: Pick<PaymentInstrument, 'method' | 'provider'>;
 }
 
 const supportedInstruments: SupportedInstruments = {

--- a/src/payment/strategies/cardinal/cardinal-three-d-secure-flow.ts
+++ b/src/payment/strategies/cardinal/cardinal-three-d-secure-flow.ts
@@ -102,12 +102,12 @@ export default class CardinalThreeDSecureFlow {
             return payment.ccNumber;
         }
 
-        const instruments = this._store.getState().instruments.getInstruments(this._paymentMethod);
+        const instruments = this._store.getState().instruments.getInstruments();
         const { instrumentId: bigpayToken } = payment;
 
         const entry = find(instruments, { bigpayToken });
 
-        if (!entry || entry.type !== 'card') {
+        if (!entry) {
             throw new PaymentInstrumentNotValidError();
         }
 


### PR DESCRIPTION
## What?
Make sure new instrument types stay backward compatible.

## Why?
My previous commits in https://github.com/bigcommerce/checkout-sdk-js/pull/730 broke backward compatibility, this PR aims to fix that.

We overloaded the `getInstruments` method so it is backward compatible. It returns `CardInstrument` when you don't specify a payment method and all types (PaymentInstrument) if you ask for a specific instrument type.

## Testing / Proof
- Unit / Functional / Manual

I've checked in `checkout-js` master and both `npm run build` & `npm run test` run without problems using this version of the checkout.

The only changed required is adjusting the `Instrument` mock.

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/4542735/67489016-8c525000-f6bc-11e9-830e-52a8d45a1e93.png">

<img width="774" alt="image" src="https://user-images.githubusercontent.com/4542735/67489090-adb33c00-f6bc-11e9-9d24-8619e40b67b0.png">

@bigcommerce/checkout @bigcommerce/payments
