### PR TITLE
CHECKOUT-4509 Optional param to exclude shippings options

### DIFF
--- a/src/checkout/checkout-params.ts
+++ b/src/checkout/checkout-params.ts
@@ -5,5 +5,9 @@ export enum CheckoutIncludes {
 }
 
 export default interface CheckoutParams {
-    include?: CheckoutIncludes[];
+    include?: CheckoutIncludes[] | CheckoutIncludeParam;
 }
+
+export type CheckoutIncludeParam = {
+    [key in CheckoutIncludes]?: boolean;
+};

--- a/src/checkout/checkout-request-sender.ts
+++ b/src/checkout/checkout-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
+import { joinOrMergeIncludes, ContentType, RequestOptions } from '../common/http-request';
 
 import Checkout, { CheckoutRequestBody } from './checkout';
 import CHECKOUT_DEFAULT_INCLUDES from './checkout-default-includes';
@@ -12,16 +12,13 @@ export default class CheckoutRequestSender {
         private _requestSender: RequestSender
     ) {}
 
-    loadCheckout(id: string, { params, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
+    loadCheckout(id: string, { params: { include } = {}, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkout/${id}`;
         const headers = { Accept: ContentType.JsonV1 };
 
         return this._requestSender.get(url, {
             params: {
-                include: joinIncludes([
-                    ...CHECKOUT_DEFAULT_INCLUDES,
-                    ...(params && params.include || []),
-                ]),
+                include: joinOrMergeIncludes(CHECKOUT_DEFAULT_INCLUDES, include),
             },
             headers,
             timeout,
@@ -34,16 +31,13 @@ export default class CheckoutRequestSender {
         });
     }
 
-    updateCheckout(id: string, body: CheckoutRequestBody, { params, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
+    updateCheckout(id: string, body: CheckoutRequestBody, { params: { include } = {}, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkout/${id}`;
         const headers = { Accept: ContentType.JsonV1 };
 
         return this._requestSender.put(url, {
             params: {
-                include: joinIncludes([
-                    ...CHECKOUT_DEFAULT_INCLUDES,
-                    ...(params && params.include || []),
-                ]),
+                include: joinOrMergeIncludes(CHECKOUT_DEFAULT_INCLUDES, include),
             },
             body,
             headers,

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -703,7 +703,10 @@ export default class CheckoutService {
      * @param options - Options for updating the shipping address.
      * @returns A promise that resolves to the current state.
      */
-    updateShippingAddress(address: Partial<AddressRequestBody>, options?: ShippingRequestOptions): Promise<CheckoutSelectors> {
+    updateShippingAddress(
+        address: Partial<AddressRequestBody>,
+        options?: ShippingRequestOptions<CheckoutParams>
+    ): Promise<CheckoutSelectors> {
         const action = this._shippingStrategyActionCreator.updateAddress(address, options);
 
         return this._dispatch(action, { queueId: 'shippingStrategy' });

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -3,7 +3,7 @@ export * from './checkout-actions';
 export { default as Checkout, CheckoutPayment } from './checkout';
 export { default as CHECKOUT_DEFAULT_INCLUDES } from './checkout-default-includes';
 export { default as CheckoutActionCreator } from './checkout-action-creator';
-export { default as CheckoutParams, CheckoutIncludes } from './checkout-params';
+export { default as CheckoutParams, CheckoutIncludes, CheckoutIncludeParam } from './checkout-params';
 export { default as checkoutReducer } from './checkout-reducer';
 export { default as CheckoutRequestSender } from './checkout-request-sender';
 export { default as CheckoutSelector, CheckoutSelectorFactory, createCheckoutSelectorFactory } from './checkout-selector';

--- a/src/common/http-request/index.ts
+++ b/src/common/http-request/index.ts
@@ -4,3 +4,4 @@ export { default as InternalResponseBody } from './internal-response-body';
 export { default as ContentType } from './content-type';
 export { default as RequestOptions } from './request-options';
 export { default as joinIncludes } from './join-includes';
+export { default as joinOrMergeIncludes } from './join-or-merge-includes';

--- a/src/common/http-request/join-includes.ts
+++ b/src/common/http-request/join-includes.ts
@@ -1,5 +1,5 @@
 import { uniq } from 'lodash';
 
-export default function joinIncludes(includes: string[]): string {
+export default function joinIncludes<T>(includes: T[]): string {
     return uniq(includes).join(',');
 }

--- a/src/common/http-request/join-or-merge-includes.ts
+++ b/src/common/http-request/join-or-merge-includes.ts
@@ -1,0 +1,17 @@
+import joinIncludes from './join-includes';
+import mergeIncludes from './merge-includes';
+
+/**
+ * Joins or merges a base list of includes with a set of additional includes.
+ */
+export default function joinOrMergeIncludes<T extends string>(
+    baseIncludes: T[],
+    includeDictionaryOrList: { [key in T]?: boolean } | T[] = []
+): string {
+    return Array.isArray(includeDictionaryOrList) ?
+        joinIncludes([
+            ...baseIncludes,
+            ...includeDictionaryOrList,
+        ]) :
+        mergeIncludes(baseIncludes, includeDictionaryOrList);
+}

--- a/src/common/http-request/merge-includes.ts
+++ b/src/common/http-request/merge-includes.ts
@@ -1,0 +1,20 @@
+import { difference, filter, keys, pickBy } from 'lodash';
+
+import joinIncludes from './join-includes';
+
+/**
+ * Merges includes given a list of base includes and a dictionary
+ * of includes
+ */
+export default function mergeIncludes<T extends string>(
+    baseIncludes: T[],
+    includesDictionary?: { [key in T]?: boolean }
+): string {
+    const deletions = keys(pickBy(includesDictionary, on => !on));
+    const additions = keys(filter(includesDictionary));
+
+    return joinIncludes([
+            ...difference(baseIncludes, deletions),
+            ...additions,
+        ]);
+}

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -4,7 +4,7 @@ import { Observable, Observer } from 'rxjs';
 
 import { AddressRequestBody } from '../address';
 import { Cart } from '../cart';
-import { CheckoutIncludes, CheckoutRequestSender, InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
+import { CheckoutIncludes, CheckoutParams, CheckoutRequestSender, InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
 
@@ -150,7 +150,7 @@ export default class ConsignmentActionCreator {
 
     updateAddress(
         address: AddressRequestBody,
-        options?: RequestOptions
+        options?: RequestOptions<CheckoutParams>
     ): ThunkAction<CreateConsignmentsAction | UpdateConsignmentAction, InternalCheckoutSelectors> {
         return store => {
             const consignment = this._getConsignmentRequestBody(address, store);
@@ -166,7 +166,7 @@ export default class ConsignmentActionCreator {
 
     createConsignments(
         consignments: ConsignmentsRequestBody,
-        options?: RequestOptions
+        options?: RequestOptions<CheckoutParams>
     ): ThunkAction<CreateConsignmentsAction, InternalCheckoutSelectors> {
         return store => Observable.create((observer: Observer<CreateConsignmentsAction>) => {
             const checkout = store.getState().checkout.getCheckout();
@@ -190,7 +190,7 @@ export default class ConsignmentActionCreator {
 
     updateConsignment(
         consignment: ConsignmentUpdateRequestBody,
-        options?: RequestOptions
+        options?: RequestOptions<CheckoutParams>
     ): ThunkAction<UpdateConsignmentAction, InternalCheckoutSelectors> {
         return store => Observable.create((observer: Observer<UpdateConsignmentAction>) => {
             const checkout = store.getState().checkout.getCheckout();
@@ -267,7 +267,7 @@ export default class ConsignmentActionCreator {
 
     private _createOrUpdateConsignment(
         consignment: ConsignmentCreateRequestBody | ConsignmentUpdateRequestBody,
-        options?: RequestOptions
+        options?: RequestOptions<CheckoutParams>
     ): ThunkAction<UpdateConsignmentAction | CreateConsignmentsAction, InternalCheckoutSelectors> {
         return store => {
             const checkout = store.getState().checkout.getCheckout();

--- a/src/shipping/consignment-request-sender.spec.ts
+++ b/src/shipping/consignment-request-sender.spec.ts
@@ -19,13 +19,14 @@ describe('ConsignmentRequestSender', () => {
         lineItems: consignment.lineItems!,
     }];
     const options = { timeout: createTimeout() };
-    const include = [
-        'consignments.availableShippingOptions',
+    const shippingInclude = 'consignments.availableShippingOptions';
+    const baseInclude = [
         'cart.lineItems.physicalItems.options',
         'cart.lineItems.digitalItems.options',
         'customer',
         'promotions.banners',
     ].join(',');
+    const include = [ shippingInclude, baseInclude ].join(',');
 
     beforeEach(() => {
         jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve({ body: getCheckout() }));
@@ -64,6 +65,26 @@ describe('ConsignmentRequestSender', () => {
                 },
             });
         });
+
+        it('creates consignments without including shipping options', async () => {
+            await consignmentRequestSender.createConsignments(checkoutId, consignments, {
+                ...options,
+                params: { include: {
+                    'consignments.availableShippingOptions': false,
+                } },
+            });
+
+            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/foo/consignments', {
+                ...options,
+                body: consignments,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+                params: {
+                    include: baseInclude,
+                },
+            });
+        });
     });
 
     describe('#updateConsignment()', () => {
@@ -94,6 +115,26 @@ describe('ConsignmentRequestSender', () => {
                 },
                 params: {
                     include,
+                },
+            });
+        });
+
+        it('updates a consignment without requesting shipping options', async () => {
+            await consignmentRequestSender.updateConsignment(checkoutId, consignment, {
+                ...options,
+                params: { include: {
+                    'consignments.availableShippingOptions': false,
+                } },
+            });
+
+            expect(requestSender.put).toHaveBeenCalledWith(`/api/storefront/checkouts/foo/consignments/${id}`, {
+                ...options,
+                body,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                },
+                params: {
+                    include: baseInclude,
                 },
             });
         });

--- a/src/shipping/consignment-request-sender.ts
+++ b/src/shipping/consignment-request-sender.ts
@@ -1,44 +1,69 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { Checkout } from '../checkout';
-import { ContentType, RequestOptions } from '../common/http-request';
+import { Checkout, CheckoutParams } from '../checkout';
+import { joinIncludes, joinOrMergeIncludes, ContentType, RequestOptions } from '../common/http-request';
 
 import { ConsignmentsRequestBody, ConsignmentUpdateRequestBody } from './consignment';
 
-const DEFAULT_PARAMS = {
-    include: [
+const DEFAULT_INCLUDES = [
         'consignments.availableShippingOptions',
         'cart.lineItems.physicalItems.options',
         'cart.lineItems.digitalItems.options',
         'customer',
         'promotions.banners',
-    ].join(','),
-};
+    ];
 
 export default class ConsignmentRequestSender {
     constructor(
         private _requestSender: RequestSender
     ) {}
 
-    createConsignments(checkoutId: string, consignments: ConsignmentsRequestBody, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
+    createConsignments(
+        checkoutId: string,
+        consignments: ConsignmentsRequestBody,
+        { timeout, params: { include } = {} }: RequestOptions<CheckoutParams> = {}
+    ): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/consignments`;
         const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.post(url, { body: consignments, params: DEFAULT_PARAMS, headers, timeout });
+        return this._requestSender.post(url, {
+            body: consignments,
+            params: {
+                include: joinOrMergeIncludes(DEFAULT_INCLUDES, include),
+            },
+            headers,
+            timeout,
+        });
     }
 
-    updateConsignment(checkoutId: string, consignment: ConsignmentUpdateRequestBody, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
+    updateConsignment(
+        checkoutId: string,
+        consignment: ConsignmentUpdateRequestBody,
+        { timeout, params: { include } = {} }: RequestOptions<CheckoutParams> = {}
+    ): Promise<Response<Checkout>> {
         const { id, ...body } = consignment;
         const url = `/api/storefront/checkouts/${checkoutId}/consignments/${id}`;
         const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.put(url, { params: DEFAULT_PARAMS, body, headers, timeout });
+        return this._requestSender.put(url, {
+            body,
+            params: {
+                include: joinOrMergeIncludes(DEFAULT_INCLUDES, include),
+            },
+            headers,
+            timeout,
+        });
     }
 
-    deleteConsignment(checkoutId: string, consignmentId: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
+    deleteConsignment(
+        checkoutId: string,
+        consignmentId: string,
+        { timeout }: RequestOptions = {}
+    ): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/consignments/${consignmentId}`;
         const headers = { Accept: ContentType.JsonV1 };
+        const include = joinIncludes(DEFAULT_INCLUDES);
 
-        return this._requestSender.delete(url, { params: DEFAULT_PARAMS, headers, timeout });
+        return this._requestSender.delete(url, { params: { include }, headers, timeout });
     }
 }

--- a/src/shipping/shipping-request-options.ts
+++ b/src/shipping/shipping-request-options.ts
@@ -11,7 +11,7 @@ import { AmazonPayShippingInitializeOptions } from './strategies/amazon';
  * specific flow for setting the shipping address or option. Otherwise, these
  * options are not required.
  */
-export interface ShippingRequestOptions extends RequestOptions {
+export interface ShippingRequestOptions<T = {}> extends RequestOptions<T> {
     methodId?: string;
 }
 
@@ -25,7 +25,7 @@ export interface ShippingRequestOptions extends RequestOptions {
  * need to provide additional information in order to initialize the shipping
  * step of checkout.
  */
-export interface ShippingInitializeOptions extends ShippingRequestOptions {
+export interface ShippingInitializeOptions<T = {}> extends ShippingRequestOptions<T> {
     /**
      * The options that are required to initialize the shipping step of checkout
      * when using Amazon Pay.


### PR DESCRIPTION
## What?
Add param to optionally exclude shipping options

## Why?
At the moment we always include shipping options when shipping address is updated. Sometimes we want to update fields that we know won't affect shipping, so it's savy not to fetch shipping options in this scenario.

## Testing / Proof
unit

Coverage:
<img width="939" alt="Screen Shot 2019-10-25 at 6 17 00 pm" src="https://user-images.githubusercontent.com/1621894/67551036-aa1ec400-f753-11e9-89e7-e8a63203bd3a.png">


@bigcommerce/checkout @bigcommerce/payments
