### PR TITLE
PAYMENTS-4616 Add braintree.paypal as a supported instrument

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -9,6 +9,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'braintree',
         method: 'card',
     },
+    braintreepaypal: {
+        provider: 'braintree',
+        method: 'paypal',
+    },
     authorizenet: {
         provider: 'authorizenet',
         method: 'card',


### PR DESCRIPTION
## What?
- As per title

## Why?
- In order to read instruments from braintree.paypal, we need the instrument type to be whitelisted

## Testing / Proof
### Manual:
- [x] `getInstruments` returns braintree paypal instruments after this change

@bigcommerce/checkout @bigcommerce/payments
