### PR TITLE
fix(payment): PAYMENTS-4704 Send shipping address when checking out …

### DIFF
--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -6,7 +6,7 @@ import { OrderPaymentRequestBody } from '../../../order';
 import { PaymentMethodCancelledError } from '../../errors';
 import { CreditCardInstrument, NonceInstrument } from '../../payment';
 
-import { BraintreePaypal, BraintreeRequestData, BraintreeTokenizePayload, BraintreeVerifyPayload } from './braintree';
+import { BraintreeAddress, BraintreePaypal, BraintreeRequestData, BraintreeTokenizePayload, BraintreeVerifyPayload } from './braintree';
 import { BraintreePaymentInitializeOptions, BraintreeThreeDSecureOptions } from './braintree-payment-options';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 
@@ -15,6 +15,7 @@ export interface PaypalConfig {
     currency: string;
     locale: string;
     offerCredit?: boolean;
+    shippingAddressOverride?: BraintreeAddress;
     shouldSaveInstrument?: boolean;
 }
 

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -8,6 +8,7 @@ import { InvalidArgumentError, MissingDataError, StandardError } from '../../../
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import { PaymentMethodCancelledError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
@@ -20,6 +21,7 @@ import PaymentStrategy from '../payment-strategy';
 
 import BraintreePaymentProcessor from './braintree-payment-processor';
 import BraintreePaypalPaymentStrategy from './braintree-paypal-payment-strategy';
+import mapToBraintreeAddress from './map-to-braintree-address';
 
 describe('BraintreePaypalPaymentStrategy', () => {
     let orderActionCreator: OrderActionCreator;
@@ -125,6 +127,8 @@ describe('BraintreePaypalPaymentStrategy', () => {
         let orderRequestBody: OrderRequestBody;
         let options: PaymentInitializeOptions;
 
+        const shippingAddress = mapToBraintreeAddress(getShippingAddress());
+
         beforeEach(() => {
             orderRequestBody = getOrderRequestBody();
             options = { methodId: getBraintreePaypal().id };
@@ -169,6 +173,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 currency: 'USD',
                 shouldSaveInstrument: false,
                 offerCredit: false,
+                shippingAddressOverride: shippingAddress,
             });
 
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
@@ -192,6 +197,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 currency: 'USD',
                 shouldSaveInstrument: false,
                 offerCredit: false,
+                shippingAddressOverride: shippingAddress,
             });
 
             await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
@@ -203,6 +209,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 currency: 'USD',
                 shouldSaveInstrument: false,
                 offerCredit: false,
+                shippingAddressOverride: shippingAddress,
             });
         });
 
@@ -345,6 +352,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                     currency: 'USD',
                     shouldSaveInstrument: false,
                     offerCredit: true,
+                    shippingAddressOverride: shippingAddress,
                 });
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
                 expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -14,6 +14,7 @@ import PaymentStrategy from '../payment-strategy';
 import { BraintreeError } from './braintree';
 import BraintreePaymentProcessor from './braintree-payment-processor';
 import isBraintreeError from './is-braintree-error';
+import mapToBraintreeAddress from './map-to-braintree-address';
 
 export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     private _paymentMethod?: PaymentMethod;
@@ -123,12 +124,17 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Vaulting is disabled but shouldSaveInstrument is set to true');
         }
 
+        const shippingAddress = state.shippingAddress.getShippingAddress();
+
+        const braintreeAddress = shippingAddress ? mapToBraintreeAddress(shippingAddress) : undefined;
+
         return Promise.all([
             this._braintreePaymentProcessor.paypal({
                 amount: grandTotal,
                 locale: storeLanguage,
                 currency: currency.code,
                 offerCredit: this._credit,
+                shippingAddressOverride: braintreeAddress,
                 shouldSaveInstrument: paymentData.shouldSaveInstrument || false,
             }),
             this._braintreePaymentProcessor.getSessionId(),

--- a/src/payment/strategies/braintree/braintree.mock.ts
+++ b/src/payment/strategies/braintree/braintree.mock.ts
@@ -1,7 +1,7 @@
 import { OrderPaymentRequestBody } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 
-import { BraintreeClient, BraintreeDataCollector, BraintreeModule, BraintreeModuleCreator, BraintreePaypalCheckout, BraintreeRequestData, BraintreeThreeDSecure, BraintreeTokenizePayload, BraintreeTokenizeResponse, BraintreeVerifyPayload, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
+import { BraintreeAddress, BraintreeClient, BraintreeDataCollector, BraintreeModule, BraintreeModuleCreator, BraintreePaypalCheckout, BraintreeRequestData, BraintreeThreeDSecure, BraintreeTokenizePayload, BraintreeTokenizeResponse, BraintreeVerifyPayload, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
 import { BraintreeThreeDSecureOptions } from './braintree-payment-options';
 
 export function getClientMock(): BraintreeClient {
@@ -147,6 +147,21 @@ export function getBraintreePaymentData(): OrderPaymentRequestBody {
     return {
         ...getOrderRequestBody().payment,
         methodId: 'braintree',
+    };
+}
+
+export function getBraintreeAddress(): BraintreeAddress {
+    return {
+        line1: '12345 Testing Way',
+        line2: '',
+        city: 'Some City',
+        state: 'CA',
+        countryCode: 'US',
+        postalCode: '95555',
+        phone: '555-555-5555',
+        recipientName: 'Test Tester',
+        firstName: 'Test',
+        lastName: 'Tester',
     };
 }
 

--- a/src/payment/strategies/braintree/map-to-braintree-address.spec.ts
+++ b/src/payment/strategies/braintree/map-to-braintree-address.spec.ts
@@ -1,0 +1,12 @@
+
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
+
+import { getBraintreeAddress } from './braintree.mock';
+import mapToBraintreeAddress from './map-to-braintree-address';
+
+describe('mapToBraintreeAddress()', () => {
+    it('maps shipping address to braintree address', () => {
+        expect(mapToBraintreeAddress(getShippingAddress()))
+            .toEqual(getBraintreeAddress());
+    });
+});

--- a/src/payment/strategies/braintree/map-to-braintree-address.ts
+++ b/src/payment/strategies/braintree/map-to-braintree-address.ts
@@ -1,0 +1,18 @@
+import { Address } from '../../../address';
+
+import { BraintreeAddress } from './braintree';
+
+export default function mapToBraintreeAddress(address: Address): BraintreeAddress {
+    return {
+        firstName: address.firstName,
+        lastName: address.lastName,
+        recipientName: `${address.firstName} ${address.lastName}`,
+        line1: address.address1,
+        line2: address.address2,
+        city: address.city,
+        state: address.stateOrProvinceCode,
+        postalCode: address.postalCode,
+        countryCode: address.countryCode,
+        phone: address.phone,
+    };
+}


### PR DESCRIPTION
…using Braintree PayPal

## What?
When using the Braintree Checkout module, when selecting PayPal on the checkout page, BC does not submit the Shipping Address to PayPal, so [PayPal] ends up showing them their default shipping address.

## Why?
This causes some confusion and can also cause issues if the addresses differ, in chargebacks and disputes.

## Testing / Proof
Unit Tests
Screenshots
**Before**

<img width="1252" alt="Screen Shot 2019-10-28 at 12 04 36 pm" src="https://user-images.githubusercontent.com/36555311/67645199-542c6500-f97b-11e9-8e09-d32ea03cb727.png">

**After**

<img width="1266" alt="Screen Shot 2019-10-28 at 11 28 42 am" src="https://user-images.githubusercontent.com/36555311/67645084-b2a51380-f97a-11e9-813b-b7982449362d.png">


@bigcommerce/checkout @bigcommerce/payments
ping @bigcommerce-labs/payments