### PR TITLE
feat(checkout): CHECKOUT-4465 Make state/province optional for certain countries based on requireState flag

### DIFF
--- a/src/form/form-selector.spec.ts
+++ b/src/form/form-selector.spec.ts
@@ -73,6 +73,16 @@ describe('FormSelector', () => {
             expect(province!.fieldType).not.toEqual('dropdown');
         });
 
+        it('make provinces required if requireState flag is on', () => {
+            const forms = formSelector.getShippingAddressFields(countries, 'AU');
+            const province = find(forms, { name: 'stateOrProvinceCode' });
+            expect(province!.required).toBe(true);
+            expect(province!.fieldType).toEqual('dropdown');
+            expect(province!.options!.items).toEqual([
+                { value: 'NSW', label: 'New South Wales' },
+            ]);
+        });
+
         it('makes postcode required for countries that require it', () => {
             const forms = formSelector.getShippingAddressFields(countries, 'AU');
             const postCode = find(forms, { name: 'postalCode' });
@@ -132,6 +142,17 @@ describe('FormSelector', () => {
             expect(province!.options!.items).toEqual([
                 { value: 'NSW', label: 'New South Wales' },
                 { value: 'VIC', label: 'Victoria' },
+            ]);
+        });
+
+        it('make provinces optional when requireState flag is off', () => {
+            const forms = formSelector.getShippingAddressFields(countries, 'US');
+            const province = find(forms, { name: 'stateOrProvinceCode' });
+            expect(province!.required).toBe(false);
+            expect(province!.fieldType).toEqual('dropdown');
+            expect(province!.options!.items).toEqual([
+                { value: 'CA', label: 'California' },
+                { value: 'TX', label: 'Texas' },
             ]);
         });
 

--- a/src/form/form-selector.ts
+++ b/src/form/form-selector.ts
@@ -73,12 +73,12 @@ export function createFormSelectorFactory(): FormSelectorFactory {
     }
 
     function processProvince(field: FormField, country?: Country): FormField {
-        const { subdivisions = [] } = country || {};
+        const { subdivisions = [], requiresState } = country || {};
 
         if (!subdivisions.length) {
             return {
                 ...field,
-                required: false,
+                required: requiresState == null ? false : requiresState,
             };
         }
 
@@ -91,7 +91,7 @@ export function createFormSelectorFactory(): FormSelectorFactory {
             ...field,
             name: 'stateOrProvinceCode',
             options: { items },
-            required: true,
+            required: requiresState == null ? true : requiresState,
             type: 'array',
             fieldType: 'dropdown',
             itemtype: 'string',

--- a/src/geography/countries.mock.ts
+++ b/src/geography/countries.mock.ts
@@ -34,6 +34,7 @@ export function getAustralia(): Country {
             { code: 'VIC', name: 'Victoria' },
         ],
         hasPostalCodes: true,
+        requiresState: true,
     };
 }
 
@@ -46,6 +47,7 @@ export function getUnitedStates(): Country {
             { code: 'CA', name: 'California' },
             { code: 'TX', name: 'Texas' },
         ],
+        requiresState: false,
     };
 }
 
@@ -55,5 +57,6 @@ export function getJapan(): Country {
         name: 'Japan',
         hasPostalCodes: false,
         subdivisions: [],
+        requiresState: false,
     };
 }

--- a/src/geography/country-reducer.spec.ts
+++ b/src/geography/country-reducer.spec.ts
@@ -33,7 +33,7 @@ describe('countryReducer()', () => {
         const action: LoadCountriesAction = {
             type: CountryActionType.LoadCountriesSucceeded,
             payload: [
-                { code: 'JP', name: 'Japan', hasPostalCodes: false, subdivisions: [] },
+                { code: 'JP', name: 'Japan', hasPostalCodes: false, subdivisions: [], requiresState: false },
             ],
         };
 

--- a/src/geography/country.ts
+++ b/src/geography/country.ts
@@ -3,6 +3,7 @@ export default interface Country {
     name: string;
     hasPostalCodes: boolean;
     subdivisions: Region[];
+    requiresState: boolean;
 }
 
 export interface Region {

--- a/src/shipping/shipping-countries.mock.ts
+++ b/src/shipping/shipping-countries.mock.ts
@@ -32,6 +32,7 @@ export function getAustralia(): Country {
             { code: 'NSW', name: 'New South Wales' },
         ],
         hasPostalCodes: true,
+        requiresState: true,
     };
 }
 
@@ -41,5 +42,6 @@ export function getJapan(): Country {
         name: 'Japan',
         hasPostalCodes: false,
         subdivisions: [],
+        requiresState: false,
     };
 }

--- a/src/shipping/shipping-country-reducer.spec.ts
+++ b/src/shipping/shipping-country-reducer.spec.ts
@@ -35,7 +35,7 @@ describe('shippingCountryReducer()', () => {
         const action: LoadShippingCountriesAction = {
             type: ShippingCountryActionType.LoadShippingCountriesSucceeded,
             payload: [
-                { code: 'JP', name: 'Japan', hasPostalCodes: false, subdivisions: [] },
+                { code: 'JP', name: 'Japan', hasPostalCodes: false, subdivisions: [], requiresState: false },
             ],
         };
 


### PR DESCRIPTION
## What?
The backend would now return list of countries along with a flag for each country that specifies if the state or province is required for that country. The functionality is currently guarded by an experiment, value for which is also part of the country response. 

Based on the experiment toggle and the value of the requireState flag the state/province field will be made required/optional in both the billing and shipping address.

## Why?
Certain countries don't need the state/province as a mandatory field to uniquely identify billing or shipping address. For these countries shopper should be allowed to save his/her billing and shipping address without selecting the state or province. 

## Testing / Proof
Unit test cases updated accordingly and pass. Values verified in DB and behaviour toggles with change in DB values.

DB State: 
![Screen Shot 2019-10-31 at 10 38 21 am](https://user-images.githubusercontent.com/55068632/67907029-a4e5cd00-fbca-11e9-8408-3f7c40d2231b.png)


Required: 
<img width="848" alt="Screen Shot 2019-10-31 at 10 29 18 am" src="https://user-images.githubusercontent.com/55068632/67906778-c6928480-fbc9-11e9-8131-24035d8e7466.png">

Optional 
<img width="846" alt="Screen Shot 2019-10-31 at 10 27 41 am" src="https://user-images.githubusercontent.com/55068632/67906783-cb573880-fbc9-11e9-8314-146a220b646e.png">


@bigcommerce/checkout @bigcommerce/payments
