### PR TITLE
feat(payment): INT-2062 Support iDEAL payment provider through Adyen V2 gateway

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
@@ -1,12 +1,12 @@
 import { Omit } from '../../../common/types';
 
-import { AdyenCreditCardComponentOptions, AdyenThreeDS2Options } from './adyenv2';
+import { AdyenAdditionalActionOptions, AdyenCreditCardComponentOptions, AdyenIdealComponentOptions, AdyenThreeDS2Options } from './adyenv2';
 
 /**
  * A set of options that are required to initialize the AdyenV2 payment method.
  *
  * Once AdyenV2 payment is initialized, credit card form fields, provided by the
- * payment provider as iFrames, will be inserted into the current page. These
+ * payment provider as IFrames, will be inserted into the current page. These
  * options provide a location and styling for each of the form fields.
  */
 export default interface AdyenV2PaymentInitializeOptions {
@@ -16,7 +16,8 @@ export default interface AdyenV2PaymentInitializeOptions {
     containerId: string;
 
     /**
-     * The location to insert the Adyen 3DS V2 component.
+     * @deprecated The location to insert the Adyen 3DS V2 component.
+     * Use additionalActionOptions instead as this property will be removed in the future
      */
     threeDS2ContainerId: string;
 
@@ -26,12 +27,18 @@ export default interface AdyenV2PaymentInitializeOptions {
     cardVerificationContainerId?: string;
 
     /**
-     * ThreeDS2Options
+     * @deprecated
+     * Use additionalActionOptions instead as this property will be removed in the future
      */
     threeDS2Options: AdyenThreeDS2Options;
 
     /**
+     * A set of options that are required to initialize additional payment actions.
+     */
+    additionalActionOptions: AdyenAdditionalActionOptions;
+
+    /**
      * Optional. Overwriting the default options
      */
-    options?: Omit<AdyenCreditCardComponentOptions, 'onChange'>;
+    options?: Omit<AdyenCreditCardComponentOptions, 'onChange'> | AdyenIdealComponentOptions;
 }

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -22,8 +22,8 @@ describe('AdyenV2ScriptLoader', () => {
     describe('#load()', () => {
         const adyenClient = getAdyenCheckout();
         const configuration = getAdyenConfiguration();
-        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.3.0/adyen.js';
-        const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.3.0/adyen.css';
+        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.5.0/adyen.js';
+        const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.5.0/adyen.css';
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -13,8 +13,8 @@ export default class AdyenV2ScriptLoader {
 
     load(configuration: AdyenConfiguration): Promise<AdyenCheckout> {
         return Promise.all([
-            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.3.0/adyen.css`),
-            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.3.0/adyen.js`),
+            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.5.0/adyen.css`),
+            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.5.0/adyen.js`),
         ])
         .then(() => {
             if (!this._window.AdyenCheckout) {


### PR DESCRIPTION
[INT-2062](https://jira.bigcommerce.com/browse/INT-2062)

## What?
Support iDEAL APM through AdyenV2 gateway

## Why?
As a merchant I want to be able to support online back transfers using iDEAL as APM if store country is Netherlands and selected currency for the order is Euro.

## Testing / Proof
Unit Testing

## Dependencies
[BigPay](https://github.com/bigcommerce/bigpay/pull/2169)

@bigcommerce/checkout @bigcommerce/payments

![Ideal 1 0 2020-01-13 14_37_34](https://user-images.githubusercontent.com/8570490/72290515-05ee4000-3613-11ea-975c-f3acd71d9ffe.gif)

