### PR TITLE
feat(checkout): INT-1778 Create a method to get browser info

### DIFF
--- a/src/common/browser-info/browser-info.ts
+++ b/src/common/browser-info/browser-info.ts
@@ -4,5 +4,6 @@ export default interface BrowserInfo {
     language: string;
     screen_height: number;
     screen_width: number;
+    time_zone?: string;
     time_zone_offset: string;
 }

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -10,7 +10,7 @@ export default interface Payment {
 export type PaymentInstrument = (
     CreditCardInstrument |
     CryptogramInstrument |
-    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument> |
+    FormattedPayload<AdyenV2Instrument | FormattedBrowserInfo | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument> |
     HostedCreditCardInstrument |
     HostedInstrument |
     NonceInstrument |
@@ -109,6 +109,10 @@ interface AdyenV2Card {
         token: string;
     };
     bigpay_token?: void;
+}
+
+export interface FormattedBrowserInfo {
+    browser_info: BrowserInfo | null;
 }
 
 export interface FormattedHostedInstrument {

--- a/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
@@ -102,7 +102,21 @@ describe('OffsitePaymentStrategy', () => {
     it('initializes offsite payment flow', async () => {
         await strategy.execute(payload, options);
 
-        expect(paymentActionCreator.initializeOffsitePayment).toHaveBeenCalledWith(options.methodId, options.gatewayId, null, null);
+        expect(paymentActionCreator.initializeOffsitePayment).toHaveBeenCalledWith(
+            options.methodId,
+            options.gatewayId,
+            null,
+            null,
+            expect.objectContaining({
+                color_depth: expect.any(Number),
+                java_enabled: expect.any(Boolean),
+                language: expect.any(String),
+                screen_height: expect.any(Number),
+                screen_width: expect.any(Number),
+                time_zone: expect.any(String),
+                time_zone_offset: expect.any(String),
+            })
+        );
         expect(store.dispatch).toHaveBeenCalledWith(initializeOffsitePaymentAction);
     });
 

--- a/src/payment/strategies/offsite/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.ts
@@ -1,4 +1,5 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { getBrowserInfo } from '../../../common/browser-info';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
@@ -32,8 +33,12 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
                     payment.methodId,
                     payment.gatewayId,
                     instrumentId,
-                    shouldSaveInstrument))
-            );
+                    shouldSaveInstrument,
+                    {
+                        ...getBrowserInfo(),
+                        time_zone: new Date().toLocaleTimeString('en-us', {timeZoneName: 'short'}).split(' ')[2],
+                    }
+                )));
     }
 
     finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {


### PR DESCRIPTION
## What?
Create a method to get browser info and add it to the offsite payment flow.

## Why?
Barclaycard requires browser info for 3DS2, but it can be reused/extended for other providers

## Testing / Proof
Pending

@bigcommerce/checkout @bigcommerce/payments
