### PR TITLE
fix(checkout): CHECKOUT-4513 Add extendedComparisonPrice from API

### DIFF
--- a/src/cart/line-item.ts
+++ b/src/cart/line-item.ts
@@ -60,6 +60,7 @@ export interface LineItem {
     comparisonPrice: number;
     extendedListPrice: number;
     extendedSalePrice: number;
+    extendedComparisonPrice: number;
     socialMedia?: LineItemSocialData[];
     options?: LineItemOption[];
     addedByPromotion: boolean;

--- a/src/cart/line-items.mock.ts
+++ b/src/cart/line-items.mock.ts
@@ -20,6 +20,7 @@ export function getPhysicalItem(): PhysicalItem {
         comparisonPrice: 200,
         extendedListPrice: 200,
         extendedSalePrice: 200,
+        extendedComparisonPrice: 200,
         isShippingRequired: true,
         addedByPromotion: false,
         options: [
@@ -58,6 +59,7 @@ export function getDigitalItem(): DigitalItem {
         downloadSize: '',
         extendedListPrice: 200,
         extendedSalePrice: 200,
+        extendedComparisonPrice: 200,
         addedByPromotion: false,
         options: [
             {


### PR DESCRIPTION
## What?
Add type to SDK

## Why?
Expose extendedComparisonPrice to checkout and fix the inc/ex tax strike-through issue.

## Testing / Proof
price inc tax, show ex tax (no discount):
Before:
<img width="389" alt="Screen Shot 2019-11-20 at 9 49 55 am" src="https://user-images.githubusercontent.com/12888727/69193835-cdcf0180-0b7b-11ea-8a35-1c59fb2165f7.png">

After:
<img width="378" alt="Screen Shot 2019-11-20 at 9 39 11 am" src="https://user-images.githubusercontent.com/12888727/69193868-e3442b80-0b7b-11ea-9f0d-76a6f7cd8178.png">

price ex tax, show in tax (no discount):
Before:
<img width="391" alt="Screen Shot 2019-11-20 at 9 49 16 am" src="https://user-images.githubusercontent.com/12888727/69193888-f0611a80-0b7b-11ea-90ac-ad9c8931d834.png">

After:
<img width="380" alt="Screen Shot 2019-11-20 at 9 41 25 am" src="https://user-images.githubusercontent.com/12888727/69193907-fd7e0980-0b7b-11ea-8252-1cbed43d25b0.png">

@bigcommerce/checkout @bigcommerce/payments
