### PR TITLE
CHECKOUT-4203: Allow synthetic default imports

### DIFF
--- a/src/common/selector/create-shallow-equal-selector.ts
+++ b/src/common/selector/create-shallow-equal-selector.ts
@@ -1,5 +1,5 @@
 import { createSelectorCreator, defaultMemoize } from 'reselect';
-import * as shallowEqual from 'shallowequal';
+import shallowEqual from 'shallowequal';
 
 import withMemoizedCombiner from './with-memoized-combiner';
 

--- a/src/common/utility/cache-key-resolver.ts
+++ b/src/common/utility/cache-key-resolver.ts
@@ -1,5 +1,5 @@
 import { noop } from 'lodash';
-import * as shallowEqual from 'shallowequal';
+import shallowEqual from 'shallowequal';
 
 import { isRootCacheKeyMap, isTerminalCacheKeyMap, ChildCacheKeyMap, IntermediateCacheKeyMap, RootCacheKeyMap, TerminalCacheKeyMap } from './cache-key-maps';
 

--- a/src/embedded-checkout/embed-checkout.spec.ts
+++ b/src/embedded-checkout/embed-checkout.spec.ts
@@ -11,15 +11,13 @@ import LoadingIndicator from './loading-indicator';
 import ResizableIframeCreator from './resizable-iframe-creator';
 
 jest.mock('./embedded-checkout', () => {
-    return {
-        default: jest.fn(() => {
-            const instance: Partial<EmbeddedCheckout> = {
-                attach: jest.fn(() => Promise.resolve(instance)),
-            };
+    return jest.fn(() => {
+        const instance: Partial<EmbeddedCheckout> = {
+            attach: jest.fn(() => Promise.resolve(instance)),
+        };
 
-            return instance;
-        }),
-    };
+        return instance;
+    });
 });
 
 describe('embedCheckout()', () => {

--- a/src/locale/language-service.ts
+++ b/src/locale/language-service.ts
@@ -1,5 +1,5 @@
 import { isObject, union } from 'lodash';
-import * as MessageFormat from 'messageformat';
+import MessageFormat from 'messageformat';
 
 import { Logger } from '../common/log';
 import { bindDecorator as bind } from '../common/utility';

--- a/tsconfig-jest.json
+++ b/tsconfig-jest.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
         "declaration": false,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
         "importHelpers": true,


### PR DESCRIPTION
## What?
Allow synthetic default imports.

## Why?
So it is easier import CommonJS packages that don't have a default export, as I'll soon need to import and use `card-validator` and `credit-card-type` packages. They both don't have a default export.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
