### PR TITLE
CHECKOUT-4203: Add factory for creating hosted payment forms

### DIFF
--- a/src/common/error/error-response-body.ts
+++ b/src/common/error/error-response-body.ts
@@ -23,7 +23,12 @@ export interface InternalErrorResponseBody {
 
 export interface PaymentErrorResponseBody {
     status: string;
-    errors: Array<{ code: string; message?: string }>;
+    errors: PaymentErrorData[];
+}
+
+export interface PaymentErrorData {
+    code: string;
+    message?: string;
 }
 
 export default ErrorResponseBody;

--- a/src/common/error/index.ts
+++ b/src/common/error/index.ts
@@ -8,6 +8,7 @@ export { default as ErrorMessageTransformer } from './error-message-transformer'
 export {
     default as ErrorResponseBody,
     StorefrontErrorResponseBody,
+    PaymentErrorData,
     PaymentErrorResponseBody,
     InternalErrorResponseBody
 } from './error-response-body';

--- a/src/hosted-form/errors/index.ts
+++ b/src/hosted-form/errors/index.ts
@@ -1,0 +1,2 @@
+export { default as InvalidHostedFormConfigError } from './invalid-hosted-form-config-error';
+export { default as InvalidHostedFormError } from './invalid-hosted-form-error';

--- a/src/hosted-form/errors/invalid-hosted-form-config-error.ts
+++ b/src/hosted-form/errors/invalid-hosted-form-config-error.ts
@@ -1,0 +1,10 @@
+import { StandardError } from '../../common/error/errors';
+
+export default class InvalidHostedFormConfigError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to proceed due to invalid configuration provided for the hosted payment form.');
+
+        this.name = 'InvalidHostedFormConfigError';
+        this.type = 'invalid_hosted_form_config';
+    }
+}

--- a/src/hosted-form/errors/invalid-hosted-form-error.ts
+++ b/src/hosted-form/errors/invalid-hosted-form-error.ts
@@ -1,0 +1,10 @@
+import { StandardError } from '../../common/error/errors';
+
+export default class InvalidHostedFormError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to proceed due to an unknown error with the hosted payment form.');
+
+        this.name = 'InvalidHostedFormError';
+        this.type = 'invalid_hosted_form';
+    }
+}

--- a/src/hosted-form/hosted-field-events.ts
+++ b/src/hosted-form/hosted-field-events.ts
@@ -1,0 +1,36 @@
+import HostedFieldType from './hosted-field-type';
+import { HostedFieldStylesMap } from './hosted-form-options';
+import HostedFormOrderData from './hosted-form-order-data';
+
+export enum HostedFieldEventType {
+    AttachRequested = 'HOSTED_FIELD:ATTACH_REQUESTED',
+    SubmitRequested = 'HOSTED_FIELD:SUBMITTED_REQUESTED',
+}
+
+export interface HostedFieldEventMap {
+    [HostedFieldEventType.AttachRequested]: HostedFieldAttachEvent;
+    [HostedFieldEventType.SubmitRequested]: HostedFieldSubmitRequestEvent;
+}
+
+export type HostedFieldEvent = (
+    HostedFieldAttachEvent |
+    HostedFieldSubmitRequestEvent
+);
+
+export interface HostedFieldAttachEvent {
+    type: HostedFieldEventType.AttachRequested;
+    payload: {
+        accessibilityLabel?: string;
+        placeholder?: string;
+        styles?: HostedFieldStylesMap;
+        type: HostedFieldType;
+    };
+}
+
+export interface HostedFieldSubmitRequestEvent {
+    type: HostedFieldEventType.SubmitRequested;
+    payload: {
+        data: HostedFormOrderData;
+        fields: HostedFieldType[];
+    };
+}

--- a/src/hosted-form/hosted-field-type.ts
+++ b/src/hosted-form/hosted-field-type.ts
@@ -1,0 +1,8 @@
+enum HostedFieldType {
+    CardCode = 'cardCode',
+    CardExpiry = 'cardExpiry',
+    CardName = 'cardName',
+    CardNumber = 'cardNumber',
+}
+
+export default HostedFieldType;

--- a/src/hosted-form/hosted-field.spec.ts
+++ b/src/hosted-form/hosted-field.spec.ts
@@ -1,0 +1,173 @@
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+
+import { InvalidHostedFormConfigError, InvalidHostedFormError } from './errors';
+import HostedField from './hosted-field';
+import { HostedFieldEvent, HostedFieldEventType } from './hosted-field-events';
+import HostedFieldType from './hosted-field-type';
+import { getHostedFormOrderData } from './hosted-form-order-data.mock';
+import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
+
+describe('HostedField', () => {
+    let container: HTMLDivElement;
+    let field: HostedField;
+    let eventPoster: Pick<IframeEventPoster<HostedFieldEvent>, 'post' | 'setTarget'>;
+    let eventListener: Pick<IframeEventListener<HostedInputEventMap>, 'listen'>;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        eventPoster = { post: jest.fn(), setTarget: jest.fn() };
+        eventListener = { listen: jest.fn() };
+
+        container.id = 'field-container-id';
+        document.body.appendChild(container);
+
+        field = new HostedField(
+            'https://payment.bigcommerce.com',
+            'dc030783-6129-4ee3-8e06-6f4270df1527',
+            HostedFieldType.CardNumber,
+            'field-container-id',
+            'Enter your card number here',
+            'Card number',
+            { default: { color: 'rgb(0, 0, 0)' } },
+            eventPoster as IframeEventPoster<HostedFieldEvent>,
+            eventListener as IframeEventListener<HostedInputEventMap>
+        );
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('attaches iframe to container', () => {
+        field.attach();
+
+        expect(document.querySelector('#field-container-id iframe'))
+            .toBeDefined();
+    });
+
+    it('sets target for event poster', async () => {
+        process.nextTick(() => {
+            // tslint:disable-next-line:no-non-null-assertion
+            document.querySelector('#field-container-id iframe')!
+                .dispatchEvent(new Event('load'));
+        });
+
+        await field.attach();
+
+        expect(eventPoster.setTarget)
+            .toHaveBeenCalled();
+    });
+
+    it('notifies if able to attach', async () => {
+        jest.spyOn(eventPoster, 'post')
+            .mockResolvedValue({ type: HostedInputEventType.AttachSucceeded });
+
+        process.nextTick(() => {
+            // tslint:disable-next-line:no-non-null-assertion
+            document.querySelector('#field-container-id iframe')!
+                .dispatchEvent(new Event('load'));
+        });
+
+        await field.attach();
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedFieldEventType.AttachRequested,
+                payload: {
+                    accessibilityLabel: 'Card number',
+                    placeholder: 'Enter your card number here',
+                    styles: { default: { color: 'rgb(0, 0, 0)' } },
+                    type: HostedFieldType.CardNumber,
+                },
+            }, {
+                successType: HostedInputEventType.AttachSucceeded,
+                errorType: HostedInputEventType.AttachFailed,
+            });
+    });
+
+    it('throws error if unable to attach', async () => {
+        jest.spyOn(eventPoster, 'post')
+            .mockRejectedValue({
+                type: HostedInputEventType.AttachFailed,
+                payload: {
+                    error: { message: 'Invalid form', redirectUrl: 'https://store.foobar.com/checkout' },
+                },
+            });
+
+        process.nextTick(() => {
+            // tslint:disable-next-line:no-non-null-assertion
+            document.querySelector('#field-container-id iframe')!
+                .dispatchEvent(new Event('load'));
+        });
+
+        try {
+            await field.attach();
+        } catch (error) {
+            expect(error)
+                .toBeInstanceOf(InvalidHostedFormError);
+        }
+    });
+
+    it('throws error if container is invalid', async () => {
+        container.remove();
+
+        try {
+            await field.attach();
+        } catch (error) {
+            expect(error)
+                .toBeInstanceOf(InvalidHostedFormConfigError);
+        }
+    });
+
+    it('sends request to submit payment data', async () => {
+        jest.spyOn(eventPoster, 'post')
+            .mockResolvedValue({ type: HostedInputEventType.SubmitSucceeded });
+
+        const fields = [HostedFieldType.CardExpiry, HostedFieldType.CardNumber];
+        const data = getHostedFormOrderData();
+
+        await field.submit(fields, data);
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedFieldEventType.SubmitRequested,
+                payload: { fields, data },
+            }, {
+                successType: HostedInputEventType.SubmitSucceeded,
+                errorType: HostedInputEventType.SubmitFailed,
+            });
+    });
+
+    it('throws error if unable to submit payment', async () => {
+        jest.spyOn(eventPoster, 'post')
+            .mockRejectedValue({
+                type: HostedInputEventType.SubmitFailed,
+                payload: { error: { code: 'hosted_form_error', message: 'Invalid form' } },
+            });
+
+        const fields = [HostedFieldType.CardExpiry, HostedFieldType.CardNumber];
+        const data = getHostedFormOrderData();
+
+        try {
+            await field.submit(fields, data);
+        } catch (error) {
+            expect(error).toBeInstanceOf(InvalidHostedFormError);
+        }
+    });
+
+    it('forwards error if submission fails because of runtime error', async () => {
+        const rejection = new Error('Runtime error');
+
+        jest.spyOn(eventPoster, 'post')
+            .mockRejectedValue(rejection);
+
+        const fields = [HostedFieldType.CardExpiry, HostedFieldType.CardNumber];
+        const data = getHostedFormOrderData();
+
+        try {
+            await field.submit(fields, data);
+        } catch (error) {
+            expect(error).toEqual(rejection);
+        }
+    });
+});

--- a/src/hosted-form/hosted-field.ts
+++ b/src/hosted-form/hosted-field.ts
@@ -1,0 +1,121 @@
+import { fromEvent } from 'rxjs';
+import { catchError, switchMap, take } from 'rxjs/operators';
+
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+
+import { InvalidHostedFormConfigError, InvalidHostedFormError } from './errors';
+import { HostedFieldEvent, HostedFieldEventType } from './hosted-field-events';
+import HostedFieldType from './hosted-field-type';
+import { HostedFieldStylesMap } from './hosted-form-options';
+import HostedFormOrderData from './hosted-form-order-data';
+import { HostedInputAttachErrorEvent, HostedInputEventMap, HostedInputEventType, HostedInputSubmitErrorEvent } from './iframe-content';
+
+export default class HostedField {
+    private _iframe: HTMLIFrameElement;
+
+    constructor(
+        host: string,
+        formId: string,
+        private _type: HostedFieldType,
+        private _containerId: string,
+        private _placeholder: string,
+        private _accessibilityLabel: string,
+        private _styles: HostedFieldStylesMap,
+        private _eventPoster: IframeEventPoster<HostedFieldEvent>,
+        private _eventListener: IframeEventListener<HostedInputEventMap>
+    ) {
+        this._iframe = document.createElement('iframe');
+
+        this._iframe.src = `${host}/pay/hosted_forms/${formId}/field`;
+        this._iframe.style.border = 'none';
+        this._iframe.style.height = '100%';
+        this._iframe.style.width = '100%';
+    }
+
+    getType(): HostedFieldType {
+        return this._type;
+    }
+
+    attach(): Promise<void> {
+        const container = document.getElementById(this._containerId);
+
+        if (!container) {
+            throw new InvalidHostedFormConfigError('Unable to proceed because the provided container ID is not valid.');
+        }
+
+        container.appendChild(this._iframe);
+        this._eventListener.listen();
+
+        return fromEvent(this._iframe, 'load')
+            .pipe(
+                switchMap(async ({ target }) => {
+                    const contentWindow = target && (target as HTMLIFrameElement).contentWindow;
+
+                    if (!contentWindow) {
+                        throw new Error('The content window of the iframe cannot be accessed.');
+                    }
+
+                    this._eventPoster.setTarget(contentWindow);
+
+                    await this._eventPoster.post({
+                        type: HostedFieldEventType.AttachRequested,
+                        payload: {
+                            accessibilityLabel: this._accessibilityLabel,
+                            placeholder: this._placeholder,
+                            styles: this._styles,
+                            type: this._type,
+                        },
+                    }, {
+                        successType: HostedInputEventType.AttachSucceeded,
+                        errorType: HostedInputEventType.AttachFailed,
+                    });
+                }),
+                catchError(error => {
+                    if (this._isAttachErrorEvent(error)) {
+                        throw new InvalidHostedFormError(error.payload.error.message);
+                    }
+
+                    throw error;
+                }),
+                take(1)
+            ).toPromise();
+    }
+
+    detach(): void {
+        if (!this._iframe.parentElement) {
+            return;
+        }
+
+        this._iframe.parentElement.removeChild(this._iframe);
+        this._eventListener.stopListen();
+    }
+
+    async submit(
+        fields: HostedFieldType[],
+        data: HostedFormOrderData
+    ): Promise<void> {
+        try {
+            await this._eventPoster.post({
+                type: HostedFieldEventType.SubmitRequested,
+                payload: { fields, data },
+            }, {
+                successType: HostedInputEventType.SubmitSucceeded,
+                errorType: HostedInputEventType.SubmitFailed,
+            });
+        } catch (event) {
+            if (this._isSubmitErrorEvent(event) && event.payload.error.code === 'hosted_form_error') {
+                throw new InvalidHostedFormError(event.payload.error.message);
+            }
+
+            throw event;
+        }
+    }
+
+    private _isSubmitErrorEvent(event: any): event is HostedInputSubmitErrorEvent {
+        return event.type === HostedInputEventType.SubmitFailed;
+    }
+
+    private _isAttachErrorEvent(event: any): event is HostedInputAttachErrorEvent {
+        return event.type === HostedInputEventType.AttachFailed;
+    }
+}

--- a/src/hosted-form/hosted-form-factory.spec.ts
+++ b/src/hosted-form/hosted-form-factory.spec.ts
@@ -1,0 +1,29 @@
+import { createCheckoutStore, ReadableCheckoutStore } from '../checkout';
+
+import HostedFieldType from './hosted-field-type';
+import HostedForm from './hosted-form';
+import HostedFormFactory from './hosted-form-factory';
+
+describe('HostedFormFactory', () => {
+    let factory: HostedFormFactory;
+    let store: ReadableCheckoutStore;
+
+    beforeEach(() => {
+        store = createCheckoutStore();
+        factory = new HostedFormFactory(store);
+    });
+
+    it('creates hosted form', () => {
+        const result = factory.create('https://store.foobar.com', 'dc030783-6129-4ee3-8e06-6f4270df1527', {
+            fields: {
+                [HostedFieldType.CardCode]: { containerId: 'card-code' },
+                [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                [HostedFieldType.CardName]: { containerId: 'card-name' },
+                [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+            },
+        });
+
+        expect(result)
+            .toBeInstanceOf(HostedForm);
+    });
+});

--- a/src/hosted-form/hosted-form-factory.ts
+++ b/src/hosted-form/hosted-form-factory.ts
@@ -1,0 +1,48 @@
+import { pick } from 'lodash';
+
+import { ReadableCheckoutStore } from '../checkout';
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+
+import HostedField from './hosted-field';
+import HostedForm from './hosted-form';
+import HostedFormOptions from './hosted-form-options';
+import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
+
+export default class HostedFormFactory {
+    constructor(
+        private _store: ReadableCheckoutStore
+    ) {}
+
+    create(host: string, formId: string, options: HostedFormOptions): HostedForm {
+        const fieldTypes = Object.keys(options.fields) as Array<keyof HostedFormOptions['fields']>;
+        const fields = fieldTypes.reduce<HostedField[]>((result, type) => {
+            const fieldOption = options.fields[type];
+
+            if (!fieldOption) {
+                return result;
+            }
+
+            return [
+                ...result,
+                new HostedField(
+                    host,
+                    formId,
+                    type,
+                    fieldOption.containerId,
+                    fieldOption.placeholder || '',
+                    fieldOption.accessibilityLabel || '',
+                    options.styles || {},
+                    new IframeEventPoster(host),
+                    new IframeEventListener(host)
+                ),
+            ];
+        }, []);
+
+        return new HostedForm(
+            fields,
+            new IframeEventListener(host),
+            new HostedFormOrderDataTransformer(this._store),
+            pick(options, 'onBlur', 'onFocus', 'onCardTypeChange', 'onValidateError')
+        );
+    }
+}

--- a/src/hosted-form/hosted-form-options.ts
+++ b/src/hosted-form/hosted-form-options.ts
@@ -1,0 +1,37 @@
+import HostedFieldType from './hosted-field-type';
+import { HostedInputBlurEvent, HostedInputCardTypeChangeEvent, HostedInputFocusEvent, HostedInputStyles, HostedInputValidateErrorEvent } from './iframe-content';
+
+export default interface HostedFormOptions {
+    fields: HostedFieldOptionsMap;
+    styles?: HostedFieldStylesMap;
+    onBlur?(data: HostedFieldBlurEventData): void;
+    onCardTypeChange?(data: HostedFieldCardTypeChangeEventData): void;
+    onFocus?(data: HostedFieldFocusEventData): void;
+    onValidateError?(data: HostedFieldValidateErrorEventData): void;
+}
+
+export type HostedFieldBlurEventData = HostedInputBlurEvent['payload'];
+export type HostedFieldCardTypeChangeEventData = HostedInputCardTypeChangeEvent['payload'];
+export type HostedFieldFocusEventData = HostedInputFocusEvent['payload'];
+export type HostedFieldValidateErrorEventData = HostedInputValidateErrorEvent['payload'];
+
+export interface HostedFieldOptionsMap {
+    [HostedFieldType.CardCode]?: HostedFieldOptions;
+    [HostedFieldType.CardExpiry]: HostedFieldOptions;
+    [HostedFieldType.CardName]: HostedFieldOptions;
+    [HostedFieldType.CardNumber]: HostedFieldOptions;
+}
+
+export interface HostedFieldOptions {
+    accessibilityLabel?: string;
+    containerId: string;
+    placeholder?: string;
+}
+
+export interface HostedFieldStylesMap {
+    default?: HostedFieldStyles;
+    error?: HostedFieldStyles;
+    focus?: HostedFieldStyles;
+}
+
+export type HostedFieldStyles = HostedInputStyles;

--- a/src/hosted-form/hosted-form-order-data-transformer.spec.ts
+++ b/src/hosted-form/hosted-form-order-data-transformer.spec.ts
@@ -1,0 +1,36 @@
+import { createCheckoutStore, ReadableCheckoutStore } from '../checkout';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+
+import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
+
+describe('HostedFormOrderDataTransformer', () => {
+    let store: ReadableCheckoutStore;
+    let transformer: HostedFormOrderDataTransformer;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        transformer = new HostedFormOrderDataTransformer(store);
+    });
+
+    it('transforms payload', () => {
+        jest.spyOn(store.getState().payment, 'getPaymentToken')
+            .mockReturnValue('JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c');
+
+        const result = transformer.transform({
+            methodId: 'authorizenet',
+            paymentData: { shouldSaveInstrument: true },
+        });
+
+        expect(Object.keys(result))
+            .toEqual(expect.arrayContaining([
+                'authToken',
+                'checkout',
+                'config',
+                'order',
+                'orderMeta',
+                'payment',
+                'paymentMethod',
+                'paymentMethodMeta',
+            ]));
+    });
+});

--- a/src/hosted-form/hosted-form-order-data-transformer.ts
+++ b/src/hosted-form/hosted-form-order-data-transformer.ts
@@ -1,0 +1,41 @@
+import { omit } from 'lodash';
+
+import { ReadableCheckoutStore } from '../checkout';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { OrderPaymentRequestBody } from '../order';
+import { HostedCreditCardInstrument } from '../payment';
+
+import HostedFormOrderData from './hosted-form-order-data';
+
+export default class HostedFormOrderDataTransformer {
+    constructor(
+        private _store: ReadableCheckoutStore
+    ) {}
+
+    transform(payload: OrderPaymentRequestBody): HostedFormOrderData {
+        const state = this._store.getState();
+        const authToken = state.payment.getPaymentToken();
+        const checkout = state.checkout.getCheckout();
+        const config = state.config.getConfig();
+        const order = state.order.getOrder();
+        const orderMeta = state.order.getOrderMeta();
+        const payment = omit(payload.paymentData, 'ccExpiry', 'ccName', 'ccNumber', 'ccCvv') as HostedCreditCardInstrument;
+        const paymentMethod = state.paymentMethods.getPaymentMethod(payload.methodId, payload.gatewayId);
+        const paymentMethodMeta = state.paymentMethods.getPaymentMethodsMeta();
+
+        if (!authToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentToken);
+        }
+
+        return {
+            authToken,
+            checkout,
+            config,
+            order,
+            orderMeta,
+            payment,
+            paymentMethod,
+            paymentMethodMeta,
+        };
+    }
+}

--- a/src/hosted-form/hosted-form-order-data.mock.ts
+++ b/src/hosted-form/hosted-form-order-data.mock.ts
@@ -1,0 +1,19 @@
+import { getCheckoutWithGiftCertificates } from '../checkout/checkouts.mock';
+import { getConfig } from '../config/configs.mock';
+import { getOrder, getOrderMeta } from '../order/orders.mock';
+import { getPaymentMethod, getPaymentMethodsMeta } from '../payment/payment-methods.mock';
+
+import HostedFormOrderData from './hosted-form-order-data';
+
+export function getHostedFormOrderData(): HostedFormOrderData {
+    return {
+        authToken: 'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        checkout: getCheckoutWithGiftCertificates(),
+        config: getConfig(),
+        order: getOrder(),
+        orderMeta: getOrderMeta(),
+        payment: {},
+        paymentMethod: getPaymentMethod(),
+        paymentMethodMeta: getPaymentMethodsMeta(),
+    };
+}

--- a/src/hosted-form/hosted-form-order-data.ts
+++ b/src/hosted-form/hosted-form-order-data.ts
@@ -1,0 +1,15 @@
+import { Checkout } from '../checkout';
+import { Config } from '../config';
+import { Order, OrderMeta } from '../order';
+import { HostedCreditCardInstrument, HostedVaultedInstrument, PaymentInstrumentMeta, PaymentMethod, PaymentMethodMeta } from '../payment';
+
+export default interface HostedFormOrderData {
+    authToken: string;
+    checkout?: Checkout;
+    config?: Config;
+    order?: Order;
+    orderMeta?: OrderMeta;
+    payment?: (HostedCreditCardInstrument | HostedVaultedInstrument) & PaymentInstrumentMeta;
+    paymentMethod?: PaymentMethod;
+    paymentMethodMeta?: PaymentMethodMeta;
+}

--- a/src/hosted-form/hosted-form.spec.ts
+++ b/src/hosted-form/hosted-form.spec.ts
@@ -1,0 +1,152 @@
+import { IframeEventListener } from '../common/iframe';
+
+import HostedField from './hosted-field';
+import HostedFieldType from './hosted-field-type';
+import HostedForm from './hosted-form';
+import HostedFormOptions from './hosted-form-options';
+import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
+import { getHostedFormOrderData } from './hosted-form-order-data.mock';
+import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
+
+describe('HostedForm', () => {
+    let callbacks: Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onValidateError'>;
+    let eventListener: IframeEventListener<HostedInputEventMap>;
+    let fields: HostedField[];
+    let form: HostedForm;
+    let payloadTransformer: Pick<HostedFormOrderDataTransformer, 'transform'>;
+
+    const fieldPrototype: Partial<HostedField> = {
+        attach: jest.fn(),
+        detach: jest.fn(),
+        getType: jest.fn(),
+        submit: jest.fn(),
+    };
+
+    beforeEach(() => {
+        callbacks = {
+            onBlur: jest.fn(),
+            onFocus: jest.fn(),
+            onCardTypeChange: jest.fn(),
+            onValidateError: jest.fn(),
+        };
+
+        fields = [
+            Object.create(fieldPrototype) as HostedField,
+            Object.create(fieldPrototype) as HostedField,
+            Object.create(fieldPrototype) as HostedField,
+            Object.create(fieldPrototype) as HostedField,
+        ];
+
+        jest.spyOn(fields[0], 'getType')
+            .mockReturnValue(HostedFieldType.CardCode);
+        jest.spyOn(fields[1], 'getType')
+            .mockReturnValue(HostedFieldType.CardExpiry);
+        jest.spyOn(fields[2], 'getType')
+            .mockReturnValue(HostedFieldType.CardName);
+        jest.spyOn(fields[3], 'getType')
+            .mockReturnValue(HostedFieldType.CardNumber);
+
+        eventListener = new IframeEventListener('https://store.foobar.com');
+        payloadTransformer = { transform: jest.fn() };
+
+        form = new HostedForm(
+            fields,
+            eventListener,
+            payloadTransformer as HostedFormOrderDataTransformer,
+            callbacks
+        );
+    });
+
+    it('attaches all fields to document', async () => {
+        fields.forEach(field =>
+            jest.spyOn(field, 'attach')
+                .mockResolvedValue(undefined)
+        );
+
+        await form.attach();
+
+        expect(fields[0].attach).toHaveBeenCalled();
+        expect(fields[1].attach).toHaveBeenCalled();
+        expect(fields[2].attach).toHaveBeenCalled();
+        expect(fields[3].attach).toHaveBeenCalled();
+    });
+
+    it('detaches all fields from document', async () => {
+        fields.forEach(field =>
+            jest.spyOn(field, 'detach')
+                .mockReturnValue(undefined)
+        );
+
+        await form.detach();
+
+        expect(fields[0].detach).toHaveBeenCalled();
+        expect(fields[1].detach).toHaveBeenCalled();
+        expect(fields[2].detach).toHaveBeenCalled();
+        expect(fields[3].detach).toHaveBeenCalled();
+    });
+
+    it('submits payment by passing order data to number field', async () => {
+        // tslint:disable-next-line:no-non-null-assertion
+        const field = fields.find(field => field.getType() === HostedFieldType.CardNumber)!;
+        const data = getHostedFormOrderData();
+        const payload = {
+            methodId: 'authorizenet',
+            paymentData: { shouldSaveInstrument: true },
+        };
+
+        jest.spyOn(field, 'submit')
+            .mockResolvedValue(undefined);
+
+        jest.spyOn(payloadTransformer, 'transform')
+            .mockReturnValue(data);
+
+        await form.submit(payload);
+
+        expect(payloadTransformer.transform)
+            .toHaveBeenCalledWith(payload);
+        expect(field.submit)
+            .toHaveBeenCalledWith(fields.map(field => field.getType()), data);
+    });
+
+    it('notifies when card type changes', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.CardTypeChanged,
+            payload: { cardType: 'visa' },
+        });
+
+        expect(callbacks.onCardTypeChange)
+            .toHaveBeenCalledWith({ cardType: 'visa' });
+    });
+
+    it('notifies when validation fails', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.ValidateFailed,
+            payload: { errors: [{ fieldType: HostedFieldType.CardCode, message: 'Missing required data' }] },
+        });
+
+        expect(callbacks.onValidateError)
+            .toHaveBeenCalledWith({
+                errors: [{ fieldType: HostedFieldType.CardCode, message: 'Missing required data' }],
+            });
+    });
+
+    it('notifies when input receives focus event', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.Focused,
+            payload: { fieldType: HostedFieldType.CardCode },
+        });
+
+        expect(callbacks.onFocus)
+            .toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
+    });
+
+    it('notifies when input receives blur event', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.Blurred,
+            payload: { fieldType: HostedFieldType.CardCode },
+        });
+
+        expect(callbacks.onBlur)
+            .toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
+    });
+});

--- a/src/hosted-form/hosted-form.ts
+++ b/src/hosted-form/hosted-form.ts
@@ -1,0 +1,66 @@
+import { noop, without } from 'lodash';
+
+import { IframeEventListener } from '../common/iframe';
+import { OrderPaymentRequestBody } from '../order';
+
+import { InvalidHostedFormConfigError } from './errors';
+import HostedField from './hosted-field';
+import HostedFieldType from './hosted-field-type';
+import HostedFormOptions from './hosted-form-options';
+import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
+import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
+
+type HostedFormEventCallbacks = Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onValidateError'>;
+
+export default class HostedForm {
+    constructor(
+        private _fields: HostedField[],
+        private _eventListener: IframeEventListener<HostedInputEventMap>,
+        private _payloadTransformer: HostedFormOrderDataTransformer,
+        eventCallbacks: HostedFormEventCallbacks
+    ) {
+        const { onBlur = noop, onCardTypeChange = noop, onFocus = noop, onValidateError: onValidateError = noop } = eventCallbacks;
+
+        this._eventListener.addListener(HostedInputEventType.Blurred, ({ payload }) => onBlur(payload));
+        this._eventListener.addListener(HostedInputEventType.CardTypeChanged, ({ payload }) => onCardTypeChange(payload));
+        this._eventListener.addListener(HostedInputEventType.Focused, ({ payload }) => onFocus(payload));
+        this._eventListener.addListener(HostedInputEventType.ValidateFailed, ({ payload }) => onValidateError(payload));
+    }
+
+    async attach(): Promise<void> {
+        this._eventListener.listen();
+
+        const numberField = this._getNumberField();
+        const otherFields = without(this._fields, numberField);
+
+        await numberField.attach();
+        await Promise.all(otherFields.map(field => field.attach()));
+    }
+
+    detach(): void {
+        this._eventListener.stopListen();
+
+        this._fields.forEach(field => {
+            field.detach();
+        });
+    }
+
+    async submit(payload: OrderPaymentRequestBody): Promise<void> {
+        return await this._getNumberField().submit(
+            this._fields.map(field => field.getType()),
+            this._payloadTransformer.transform(payload)
+        );
+    }
+
+    private _getNumberField(): HostedField {
+        const numberField = this._fields.find(field =>
+            field.getType() === HostedFieldType.CardNumber
+        );
+
+        if (!numberField) {
+            throw new InvalidHostedFormConfigError('Unable to proceed because the credit card number field is not defined.');
+        }
+
+        return numberField;
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-input-events.ts
+++ b/src/hosted-form/iframe-content/hosted-input-events.ts
@@ -1,0 +1,101 @@
+import { PaymentErrorData } from '../../common/error';
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInputInitializeErrorData from './hosted-input-initialize-error-data';
+import HostedInputValidateErrorData from './hosted-input-validate-error-data';
+
+// Event types
+export enum HostedInputEventType {
+    AttachSucceeded = 'HOSTED_INPUT:ATTACH_SUCCEEDED',
+    AttachFailed = 'HOSTED_INPUT:ATTACH_FAILED',
+    Blurred = 'HOSTED_INPUT:BLURRED',
+    Changed = 'HOSTED_INPUT:CHANGED',
+    CardTypeChanged = 'HOSTED_INPUT:CARD_TYPE_CHANGED',
+    Focused = 'HOSTED_INPUT:FOCUSED',
+    SubmitSucceeded = 'HOSTED_INPUT:SUBMIT_SUCCEEDED',
+    SubmitFailed = 'HOSTED_INPUT:SUBMIT_FAILED',
+    ValidateFailed = 'HOSTED_INPUT:VALIDATE_FAILED',
+}
+
+// Event mapping
+export interface HostedInputEventMap {
+    [HostedInputEventType.AttachSucceeded]: HostedInputAttachSuccessEvent;
+    [HostedInputEventType.AttachFailed]: HostedInputAttachErrorEvent;
+    [HostedInputEventType.Blurred]: HostedInputBlurEvent;
+    [HostedInputEventType.Changed]: HostedInputChangeEvent;
+    [HostedInputEventType.CardTypeChanged]: HostedInputCardTypeChangeEvent;
+    [HostedInputEventType.Focused]: HostedInputFocusEvent;
+    [HostedInputEventType.SubmitSucceeded]: HostedInputSubmitSuccessEvent;
+    [HostedInputEventType.SubmitFailed]: HostedInputSubmitErrorEvent;
+    [HostedInputEventType.ValidateFailed]: HostedInputValidateErrorEvent;
+}
+
+// Events
+export type HostedInputEvent = (
+    HostedInputAttachSuccessEvent |
+    HostedInputAttachErrorEvent |
+    HostedInputBlurEvent |
+    HostedInputChangeEvent |
+    HostedInputCardTypeChangeEvent |
+    HostedInputFocusEvent |
+    HostedInputSubmitSuccessEvent |
+    HostedInputSubmitErrorEvent |
+    HostedInputValidateErrorEvent
+);
+
+export interface HostedInputAttachSuccessEvent {
+    type: HostedInputEventType.AttachSucceeded;
+}
+
+export interface HostedInputAttachErrorEvent {
+    type: HostedInputEventType.AttachFailed;
+    payload: {
+        error: HostedInputInitializeErrorData;
+    };
+}
+
+export interface HostedInputBlurEvent {
+    type: HostedInputEventType.Blurred;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputChangeEvent {
+    type: HostedInputEventType.Changed;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputCardTypeChangeEvent {
+    type: HostedInputEventType.CardTypeChanged;
+    payload: {
+        cardType?: string;
+    };
+}
+
+export interface HostedInputFocusEvent {
+    type: HostedInputEventType.Focused;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputSubmitSuccessEvent {
+    type: HostedInputEventType.SubmitSucceeded;
+}
+
+export interface HostedInputSubmitErrorEvent {
+    type: HostedInputEventType.SubmitFailed;
+    payload: {
+        error: PaymentErrorData;
+    };
+}
+
+export interface HostedInputValidateErrorEvent {
+    type: HostedInputEventType.ValidateFailed;
+    payload: {
+        errors: HostedInputValidateErrorData[];
+    };
+}

--- a/src/hosted-form/iframe-content/hosted-input-initialize-error-data.ts
+++ b/src/hosted-form/iframe-content/hosted-input-initialize-error-data.ts
@@ -1,0 +1,4 @@
+export default interface HostedInputInitializeErrorData {
+    message: string;
+    redirectUrl: string;
+}

--- a/src/hosted-form/iframe-content/hosted-input-styles.ts
+++ b/src/hosted-form/iframe-content/hosted-input-styles.ts
@@ -1,0 +1,15 @@
+type HostedInputStyles = Partial<Pick<
+    CSSStyleDeclaration,
+    'color' |
+    'fontFamily' |
+    'fontSize' |
+    'fontWeight'
+>>;
+
+export default HostedInputStyles;
+
+export interface HostedInputStylesMap {
+    default?: HostedInputStyles;
+    error?: HostedInputStyles;
+    focus?: HostedInputStyles;
+}

--- a/src/hosted-form/iframe-content/hosted-input-validate-error-data.ts
+++ b/src/hosted-form/iframe-content/hosted-input-validate-error-data.ts
@@ -1,0 +1,4 @@
+export default interface HostedInputValidateErrorData {
+    fieldType: string;
+    message: string;
+}

--- a/src/hosted-form/iframe-content/hosted-input-values.ts
+++ b/src/hosted-form/iframe-content/hosted-input-values.ts
@@ -1,0 +1,8 @@
+import HostedFieldType from '../hosted-field-type';
+
+export default interface HostedInputValues {
+    [HostedFieldType.CardCode]?: string;
+    [HostedFieldType.CardExpiry]: string;
+    [HostedFieldType.CardName]: string;
+    [HostedFieldType.CardNumber]: string;
+}

--- a/src/hosted-form/iframe-content/index.ts
+++ b/src/hosted-form/iframe-content/index.ts
@@ -1,0 +1,7 @@
+import HostedInputStyles from './hosted-input-styles';
+import HostedInputValues from './hosted-input-values';
+
+export type HostedInputStyles = HostedInputStyles;
+export type HostedInputValues = HostedInputValues;
+
+export * from './hosted-input-events';

--- a/src/hosted-form/index.ts
+++ b/src/hosted-form/index.ts
@@ -1,0 +1,10 @@
+import HostedFormOptions from './hosted-form-options';
+import HostedFormOrderData from './hosted-form-order-data';
+
+export type HostedFormOptions = HostedFormOptions;
+export type HostedFormOrderData = HostedFormOrderData;
+
+export { default as HostedFieldType } from './hosted-field-type';
+export { default as HostedForm } from './hosted-form';
+export { default as HostedFormFactory } from './hosted-form-factory';
+export { default as HostedFormOrderDataTransformer } from './hosted-form-order-data-transformer';

--- a/src/order/index.ts
+++ b/src/order/index.ts
@@ -1,7 +1,7 @@
 export * from './internal-order-responses';
 export * from './order-actions';
 
-export { default as Order, GatewayOrderPayment } from './order';
+export { default as Order, GatewayOrderPayment, OrderMeta } from './order';
 export { default as InternalOrder, InternalIncompleteOrder, InternalOrderPayment } from './internal-order';
 export { default as InternalOrderRequestBody } from './internal-order-request-body';
 

--- a/src/order/internal-orders.mock.ts
+++ b/src/order/internal-orders.mock.ts
@@ -244,7 +244,7 @@ export function getCompleteOrderResponseBody(): InternalOrderResponseBody {
 
 export function getSubmitOrderResponseHeaders(): { token: string } {
     return {
-        token: 'JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1MDcxODcxMzMsIm5iZiI6MTUwNzE4MzUzMywiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoiMTUwNDA5ODgyMSIsImp0aSI6IjNkOTA4ZDE5LTY4OTMtNGQzYi1iMWEwLWJjNWYzMjRhM2ZiZCIsImlhdCI6MTUwNzE4MzUzMywiZGF0YSI6eyJzdG9yZV9pZCI6IjE1MDQwOTg4MjEiLCJvcmRlcl9pZCI6IjExOSIsImFtb3VudCI6MjAwMDAsImN1cnJlbmN5IjoiVVNEIn19.FSfZpI98l3_p5rbQdlHNeCfKR5Dwwk8_fvPZvtb64-Q',
+        token: 'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
     };
 }
 

--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -4,6 +4,8 @@ import { Coupon } from '../coupon';
 import { Currency } from '../currency';
 import { Tax } from '../tax';
 
+import { OrderMetaState } from './order-state';
+
 export default interface Order {
     baseAmount: number;
     billingAddress: BillingAddress;
@@ -32,6 +34,8 @@ export default interface Order {
 }
 
 export type OrderPayments = Array<GatewayOrderPayment | GiftCertificateOrderPayment>;
+
+export type OrderMeta = OrderMetaState;
 
 export interface OrderPayment {
     providerId: string;

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -10,9 +10,12 @@ export { default as PaymentActionCreator } from './payment-action-creator';
 export {
     default as Payment,
     CreditCardInstrument,
+    HostedCreditCardInstrument,
     HostedInstrument,
+    HostedVaultedInstrument,
     VaultedInstrument,
     PaymentInstrument,
+    PaymentInstrumentMeta,
     NonceInstrument,
     ThreeDSecure,
     ThreeDSecureToken
@@ -26,8 +29,11 @@ export { default as PaymentMethodRequestSender } from './payment-method-request-
 export { default as PaymentMethodSelector, PaymentMethodSelectorFactory, createPaymentMethodSelectorFactory } from './payment-method-selector';
 export { default as PaymentMethodState } from './payment-method-state';
 export { default as paymentReducer } from './payment-reducer';
+export { default as PaymentRequestBody } from './payment-request-body';
 export { default as PaymentRequestSender } from './payment-request-sender';
+export { default as PaymentRequestTransformer } from './payment-request-transformer';
 export { default as PaymentResponse } from './payment-response';
+export { default as PaymentResponseBody } from './payment-response-body';
 export { default as PaymentSelector, PaymentSelectorFactory, createPaymentSelectorFactory } from './payment-selector';
 export { default as PaymentState } from './payment-state';
 export { default as PaymentStrategyActionCreator } from './payment-strategy-action-creator';

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -1,10 +1,21 @@
+import { Omit } from '../common/types';
+
 export default interface Payment {
     methodId: string;
     gatewayId?: string;
     paymentData?: PaymentInstrument & PaymentInstrumentMeta;
 }
 
-export type PaymentInstrument = CreditCardInstrument | NonceInstrument | VaultedInstrument | CryptogramInstrument | HostedInstrument | ThreeDSVaultedInstrument | FormattedPayload<PaypalInstrument>;
+export type PaymentInstrument = (
+    CreditCardInstrument |
+    CryptogramInstrument |
+    FormattedPayload<PaypalInstrument> |
+    HostedCreditCardInstrument |
+    HostedInstrument |
+    NonceInstrument |
+    ThreeDSVaultedInstrument |
+    VaultedInstrument
+);
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
@@ -23,6 +34,10 @@ export interface CreditCardInstrument {
     extraData?: any;
     threeDSecure?: ThreeDSecure | ThreeDSecureToken;
 }
+
+export type HostedCreditCardInstrument = Omit<CreditCardInstrument, 'ccExpiry' | 'ccName' | 'ccNumber' | 'ccCvv'>;
+
+export type HostedVaultedInstrument = Omit<VaultedInstrument, 'ccNumber' | 'ccCvv'>;
 
 export interface NonceInstrument {
     nonce: string;

--- a/src/payment/payments.mock.ts
+++ b/src/payment/payments.mock.ts
@@ -43,7 +43,7 @@ export function getVaultedInstrument(): VaultedInstrument {
 
 export function getPaymentRequestBody(): PaymentRequestBody {
     return {
-        authToken: 'JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1MDcxODcxMzMsIm5iZiI6MTUwNzE4MzUzMywiaXNzIjoicGF5bWVudHMuYmlnY29tbWVyY2UuY29tIiwic3ViIjoiMTUwNDA5ODgyMSIsImp0aSI6IjNkOTA4ZDE5LTY4OTMtNGQzYi1iMWEwLWJjNWYzMjRhM2ZiZCIsImlhdCI6MTUwNzE4MzUzMywiZGF0YSI6eyJzdG9yZV9pZCI6IjE1MDQwOTg4MjEiLCJvcmRlcl9pZCI6IjExOSIsImFtb3VudCI6MjAwMDAsImN1cnJlbmN5IjoiVVNEIn19.FSfZpI98l3_p5rbQdlHNeCfKR5Dwwk8_fvPZvtb64-Q',
+        authToken: 'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
         billingAddress: mapToInternalAddress(getBillingAddress()),
         cart: mapToInternalCart(getCheckoutWithGiftCertificates()),
         customer: mapToInternalCustomer(getCustomer(), getBillingAddress()),


### PR DESCRIPTION
## What?
Add `HostedFormFactory` for creating hosted payment forms. It returns an instance of `HostedForm`, which you can use to collect and submit payment details within a set of cross-origin iframes.

## Why?
This is a part of the work required for the hosted payment form project. Please note that the code required for the iframes will come in the next PR.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
