### PR TITLE
fix(payment): INT-2140 Unpatch mapToCardInstrument

### DIFF
--- a/src/payment/instrument/map-to-card-instrument.ts
+++ b/src/payment/instrument/map-to-card-instrument.ts
@@ -12,7 +12,7 @@ export function mapToCardInstrument(instrument: CardInternalInstrument): CardIns
         expiryYear: instrument.expiry_year,
         brand: instrument.brand,
         trustedShippingAddress: instrument.trusted_shipping_address,
-        method:  instrument.method === 'card' ? 'credit_card' : instrument.method, // This is a temporary change for the rollout of some changes in bigpay. It is meant to be removed when the changes in bigpay are fully rolled out
+        method:  instrument.method,
         type: 'card',
     };
 }


### PR DESCRIPTION
## What?
Unpatch method mapToCardInstrument to remove _instrument.method === 'card' ? 'credit_card' : instrument.method_ and just keep _instrument.method_

## Why?
This change is already agreed with @icatalina & @IamDavidovich to keep the code clean.

## Testing / Proof
No tests affected

@bigcommerce/checkout @bigcommerce/intersys-integrations 
