### PR TITLE
CHECKOUT-4203: Add text input element responsible for accepting user input inside iframe

### DIFF
--- a/src/hosted-form/hosted-field.ts
+++ b/src/hosted-form/hosted-field.ts
@@ -29,6 +29,7 @@ export default class HostedField {
         this._iframe.src = `${host}/pay/hosted_forms/${formId}/field`;
         this._iframe.style.border = 'none';
         this._iframe.style.height = '100%';
+        this._iframe.style.overflow = 'hidden';
         this._iframe.style.width = '100%';
     }
 

--- a/src/hosted-form/iframe-content/hosted-input-aggregator.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-aggregator.spec.ts
@@ -1,0 +1,79 @@
+import { includes } from 'lodash';
+
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import HostedInputWindow from './hosted-input-window';
+
+describe('HostedInputAggregator', () => {
+    let aggregator: HostedInputAggregator;
+    let frames: HostedInputWindow[];
+    let parentWindow: Pick<Window, 'frames'>;
+
+    beforeEach(() => {
+        parentWindow = Object.create(window);
+        aggregator = new HostedInputAggregator(parentWindow as Window);
+        frames = [
+            Object.create(window),
+            Object.create(window),
+            Object.create(window),
+            Object.create(window),
+        ];
+
+        const codeInput = {
+            getType: jest.fn(() => HostedFieldType.CardCode),
+            getValue: jest.fn(() => '123'),
+        } as Pick<HostedInput, 'getType' | 'getValue'>;
+
+        const expiryInput = {
+            getType: jest.fn(() => HostedFieldType.CardExpiry),
+            getValue: jest.fn(() => '10 / 20'),
+        } as Pick<HostedInput, 'getType' | 'getValue'>;
+
+        const nameInput = {
+            getType: jest.fn(() => HostedFieldType.CardName),
+            getValue: jest.fn(() => 'Good Shopper'),
+        } as Pick<HostedInput, 'getType' | 'getValue'>;
+
+        const numberInput = {
+            getType: jest.fn(() => HostedFieldType.CardNumber),
+            getValue: jest.fn(() => '4111 1111 1111 1111'),
+        } as Pick<HostedInput, 'getType' | 'getValue'>;
+
+        frames[0].hostedInput = codeInput as HostedInput;
+        frames[1].hostedInput = expiryInput as HostedInput;
+        frames[2].hostedInput = nameInput as HostedInput;
+        frames[3].hostedInput = numberInput as HostedInput;
+
+        (parentWindow as any).frames = frames;
+    });
+
+    it('gathers all adjacent hosted inputs', () => {
+        expect(aggregator.getInputs())
+            .toEqual(frames.map(frame => frame.hostedInput));
+    });
+
+    it('gathers all adjacent hosted inputs that satisfy filter', () => {
+        expect(aggregator.getInputs(field => includes([HostedFieldType.CardCode, HostedFieldType.CardExpiry], field.getType())))
+            .toEqual([frames[0].hostedInput, frames[1].hostedInput]);
+    });
+
+    it('gathers all values of adjacent hosted inputs', () => {
+        expect(aggregator.getInputValues())
+            .toEqual({
+                [HostedFieldType.CardCode]: '123',
+                [HostedFieldType.CardExpiry]: '10 / 20',
+                [HostedFieldType.CardName]: 'Good Shopper',
+                [HostedFieldType.CardNumber]: '4111 1111 1111 1111',
+            });
+    });
+
+    it('gathers all values of adjacent hosted inputs that satisfy filter', () => {
+        expect(aggregator.getInputValues(field => includes([HostedFieldType.CardCode, HostedFieldType.CardExpiry], field.getType())))
+            .toEqual({
+                [HostedFieldType.CardCode]: '123',
+                [HostedFieldType.CardExpiry]: '10 / 20',
+            });
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-input-aggregator.ts
+++ b/src/hosted-form/iframe-content/hosted-input-aggregator.ts
@@ -1,0 +1,32 @@
+import HostedInput from './hosted-input';
+import HostedInputValues from './hosted-input-values';
+import HostedInputWindow from './hosted-input-window';
+
+export default class HostedInputAggregator {
+    constructor(
+        private _parentWindow: Window
+    ) {}
+
+    getInputs(filter?: (field: HostedInput) => boolean): HostedInput[] {
+        return Array.prototype.slice.call(this._parentWindow.frames)
+            .reduce((result: Window[], frame: Window) => {
+                const input = (frame as HostedInputWindow).hostedInput;
+
+                if (!input || (filter && !filter(input))) {
+                    return result;
+                }
+
+                return [...result, input];
+            }, []);
+    }
+
+    getInputValues(filter?: (field: HostedInput) => boolean): HostedInputValues {
+        return this.getInputs(filter)
+            .reduce((result, input) => {
+                return {
+                    ...result,
+                    [input.getType()]: input.getValue(),
+                };
+            }, {} as HostedInputValues);
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
@@ -1,0 +1,95 @@
+import HostedInputValidator from './hosted-input-validator';
+import HostedInputValues from './hosted-input-values';
+
+describe('HostedInputValidator', () => {
+    let validData: HostedInputValues;
+    let validator: HostedInputValidator;
+
+    beforeEach(() => {
+        validData = {
+            cardCode: '123',
+            cardExpiry: '10 / 25',
+            cardName: 'BC',
+            cardNumber: '4111 1111 1111 1111',
+        };
+
+        validator = new HostedInputValidator();
+    });
+
+    it('does not throw error if data is valid', async () => {
+        expect(await validator.validate(validData))
+            .toEqual([]);
+    });
+
+    it('returns error if card number is missing', async () => {
+        expect(await validator.validate({ ...validData, cardNumber: '' }))
+            .toEqual([
+                { fieldType: 'cardNumber', message: 'Credit card number is required' },
+                { fieldType: 'cardNumber', message: 'Credit card number must be valid' },
+            ]);
+    });
+
+    it('returns error if card number is invalid', async () => {
+        expect(await validator.validate({ ...validData, cardNumber: '9999 9999 9999 9999' }))
+            .toEqual([
+                { fieldType: 'cardNumber', message: 'Credit card number must be valid' },
+            ]);
+    });
+
+    it('returns error if card name is missing', async () => {
+        expect(await validator.validate({ ...validData, cardName: '' }))
+            .toEqual([
+                { fieldType: 'cardName', message: 'Full name is required' },
+            ]);
+    });
+
+    it('returns error if expiry date is missing', async () => {
+        expect(await validator.validate({ ...validData, cardExpiry: '' }))
+            .toEqual([
+                { fieldType: 'cardExpiry', message: 'Expiration date is required' },
+                { fieldType: 'cardExpiry', message: 'Expiration date must be a valid future date in MM / YY format' },
+            ]);
+    });
+
+    it('returns error if expiry date is invalid', async () => {
+        expect(await validator.validate({ ...validData, cardExpiry: '2030 / 12' }))
+            .toEqual([
+                { fieldType: 'cardExpiry', message: 'Expiration date must be a valid future date in MM / YY format' },
+            ]);
+    });
+
+    it('returns error if expiry date is in past', async () => {
+        expect(await validator.validate({ ...validData, cardExpiry: '12 / 10' }))
+            .toEqual([
+                { fieldType: 'cardExpiry', message: 'Expiration date must be a valid future date in MM / YY format' },
+            ]);
+    });
+
+    it('returns error if card code is missing when required', async () => {
+        expect(await validator.validate({ ...validData, cardCode: '' }, { isCardCodeRequired: true }))
+            .toEqual([
+                { fieldType: 'cardCode', message: 'CVV is required' },
+                { fieldType: 'cardCode', message: 'CVV must be valid' },
+            ]);
+    });
+
+    it('returns error if card code is invalid when required', async () => {
+        expect(await validator.validate({ ...validData, cardCode: '99999' }, { isCardCodeRequired: true }))
+            .toEqual([
+                { fieldType: 'cardCode', message: 'CVV must be valid' },
+            ]);
+    });
+
+    it('returns error if card code is invalid for given card number', async () => {
+        // Card code for American Express should have 4 digts
+        expect(await validator.validate({ ...validData, cardCode: '123', cardNumber: '378282246310005' }, { isCardCodeRequired: true }))
+            .toEqual([
+                { fieldType: 'cardCode', message: 'CVV must be valid' },
+            ]);
+    });
+
+    it('does not return error if card code is not required', async () => {
+        expect(await validator.validate({ ...validData, cardCode: '' }))
+            .toEqual([]);
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-input-validator.ts
+++ b/src/hosted-form/iframe-content/hosted-input-validator.ts
@@ -1,0 +1,77 @@
+import { cvv, expirationDate, number } from 'card-validator';
+import { pick } from 'lodash';
+import { object, string, StringSchema, ValidationError } from 'yup';
+
+import HostedInputValidateErrorData from './hosted-input-validate-error-data';
+import HostedInputValues from './hosted-input-values';
+
+interface HostedInputValidateOptions {
+    isCardCodeRequired?: boolean;
+}
+
+export default class HostedInputValidator {
+    async validate(values: HostedInputValues, options?: HostedInputValidateOptions): Promise<HostedInputValidateErrorData[]> {
+        const schemas: { [key in keyof HostedInputValues]: StringSchema } = {
+            cardExpiry: this._getCardExpirySchema(),
+            cardName: this._getCardNameSchema(),
+            cardNumber: this._getCardNumberSchema(),
+        };
+
+        if (options && options.isCardCodeRequired) {
+            schemas.cardCode = this._getCardCodeSchema();
+        }
+
+        try {
+            await object(pick(schemas, Object.keys(values)))
+                .validate(values, { abortEarly: false });
+
+            return [];
+        } catch (error) {
+            if (error.name !== 'ValidationError') {
+                throw error;
+            }
+
+            return (error as ValidationError).inner.map(innerError => ({
+                fieldType: innerError.path,
+                message: innerError.errors.join(' '),
+            }));
+        }
+    }
+
+    private _getCardCodeSchema(): StringSchema {
+        return string()
+            .required('CVV is required')
+            .test({
+                message: 'CVV must be valid',
+                test(value) {
+                    const { card } = number((this.parent as HostedInputValues).cardNumber);
+
+                    return cvv(value, card && card.code ? card.code.size : undefined).isValid;
+                },
+            });
+    }
+
+    private _getCardExpirySchema(): StringSchema {
+        return string()
+            .required('Expiration date is required')
+            .test({
+                message: 'Expiration date must be a valid future date in MM / YY format',
+                test: value => expirationDate(value).isValid,
+            });
+    }
+
+    private _getCardNameSchema(): StringSchema {
+        return string()
+            .max(200)
+            .required('Full name is required');
+    }
+
+    private _getCardNumberSchema(): StringSchema {
+        return string()
+            .required('Credit card number is required')
+            .test({
+                message: 'Credit card number must be valid',
+                test: value => number(value).isValid,
+            });
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-input-window.ts
+++ b/src/hosted-form/iframe-content/hosted-input-window.ts
@@ -1,0 +1,5 @@
+import HostedInput from './hosted-input';
+
+export default interface HostedInputWindow extends Window {
+    hostedInput: HostedInput;
+}

--- a/src/hosted-form/iframe-content/hosted-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input.spec.ts
@@ -1,0 +1,208 @@
+import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
+import { InvalidHostedFormConfigError } from '../errors';
+import { HostedFieldEventMap } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+describe('HostedInput', () => {
+    let container: HTMLDivElement;
+    let eventListener: Pick<IframeEventListener<HostedFieldEventMap>, 'addListener' | 'listen' | 'stopListen'>;
+    let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'setTarget' | 'post'>;
+    let input: HostedInput;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
+    let inputValidator: Pick<HostedInputValidator, 'validate'>;
+    let styles: HostedInputStylesMap;
+
+    beforeEach(() => {
+        eventListener = {
+            addListener: jest.fn(),
+            listen: jest.fn(),
+            stopListen: jest.fn(),
+        };
+        eventPoster = {
+            post: jest.fn(),
+            setTarget: jest.fn(),
+        };
+        inputAggregator = { getInputValues: jest.fn() };
+        inputValidator = { validate: jest.fn() };
+        styles = {
+            default: {
+                color: 'rgb(255, 255, 255)',
+                fontSize: '15px',
+            },
+        };
+
+        input = new HostedInput(
+            HostedFieldType.CardName,
+            'input-container',
+            'Full name',
+            'Cardholder name',
+            'cc-name',
+            styles,
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator
+        );
+
+        container = document.createElement('div');
+        container.id = 'input-container';
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('returns input type', () => {
+        expect(input.getType())
+            .toEqual(HostedFieldType.CardName);
+    });
+
+    it('sets and returns input value', () => {
+        input.setValue('abc');
+
+        expect(input.getValue())
+            .toEqual('abc');
+    });
+
+    it('attaches input to container', () => {
+        input.attach();
+
+        expect(container.querySelector('input'))
+            .toBeDefined();
+    });
+
+    it('configures input with expected attributes', () => {
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        expect(element.id)
+            .toEqual('card-name');
+        expect(element.placeholder)
+            .toEqual('Full name');
+        expect(element.autocomplete)
+            .toEqual('cc-name');
+        expect(element.getAttribute('aria-label'))
+            .toEqual('Cardholder name');
+    });
+
+    it('sets target for event poster', () => {
+        input.attach();
+
+        expect(eventPoster.setTarget)
+            .toHaveBeenCalled();
+    });
+
+    it('starts listening to events', () => {
+        input.attach();
+
+        expect(eventListener.listen)
+            .toHaveBeenCalled();
+    });
+
+    it('applies default styles to input', () => {
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        expect(element.style.color)
+            .toEqual('rgb(255, 255, 255)');
+        expect(element.style.fontSize)
+            .toEqual('15px');
+    });
+
+    it('notifies when input is attached', () => {
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({ type: HostedInputEventType.AttachSucceeded });
+    });
+
+    it('throws error if container cannot be found', () => {
+        container.remove();
+
+        expect(() => input.attach())
+            .toThrowError(InvalidHostedFormConfigError);
+    });
+
+    it('notifies input change', () => {
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '123';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedInputEventType.Changed,
+                payload: {
+                    fieldType: HostedFieldType.CardName,
+                },
+            });
+    });
+
+    it('notifies when input is in focus', () => {
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.dispatchEvent(new Event('focus', { bubbles: true }));
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedInputEventType.Focused,
+                payload: {
+                    fieldType: HostedFieldType.CardName,
+                },
+            });
+    });
+
+    it('notifies when input loses focus', () => {
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.dispatchEvent(new Event('blur', { bubbles: true }));
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedInputEventType.Blurred,
+                payload: {
+                    fieldType: HostedFieldType.CardName,
+                },
+            });
+    });
+
+    it('cleans up when it detaches', () => {
+        jest.spyOn(eventListener, 'stopListen');
+
+        input.attach();
+        input.detach();
+
+        expect(eventListener.stopListen)
+            .toHaveBeenCalled();
+        expect(container.querySelector('input'))
+            .toBeFalsy();
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-input.ts
+++ b/src/hosted-form/iframe-content/hosted-input.ts
@@ -1,0 +1,206 @@
+import { kebabCase } from 'lodash';
+
+import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
+import { InvalidHostedFormConfigError } from '../errors';
+import { HostedFieldEventMap, HostedFieldEventType, HostedFieldSubmitRequestEvent } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputStyles, { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+import HostedInputWindow from './hosted-input-window';
+
+export default class HostedInput {
+    protected _input: HTMLInputElement;
+    protected _previousValue?: string;
+    private _isSubmitted: boolean = false;
+    private _isTouched: boolean = false;
+
+    /**
+     * @internal
+     */
+    constructor(
+        protected _type: HostedFieldType,
+        protected _containerId: string,
+        protected _placeholder: string,
+        protected _accessibilityLabel: string,
+        protected _autocomplete: string,
+        protected _styles: HostedInputStylesMap,
+        protected _eventListener: IframeEventListener<HostedFieldEventMap>,
+        protected _eventPoster: IframeEventPoster<HostedInputEvent>,
+        protected _inputAggregator: HostedInputAggregator,
+        protected _inputValidator: HostedInputValidator
+    ) {
+        this._input = document.createElement('input');
+
+        this._input.addEventListener('input', this._handleInput);
+        this._input.addEventListener('blur', this._handleBlur);
+        this._input.addEventListener('focus', this._handleFocus);
+        this._eventListener.addListener(HostedFieldEventType.SubmitRequested, this._handleSubmit);
+
+        this._configureInput();
+    }
+
+    getType(): HostedFieldType {
+        return this._type;
+    }
+
+    getValue(): string {
+        return this._input.value;
+    }
+
+    setValue(value: string): void {
+        this._processChange(value);
+    }
+
+    isTouched(): boolean {
+        return this._isTouched;
+    }
+
+    attach(): void {
+        const container = document.getElementById(this._containerId);
+
+        if (!container) {
+            throw new InvalidHostedFormConfigError('Unable to proceed because the provided container ID is not valid.');
+        }
+
+        container.appendChild(this._input);
+
+        this._eventPoster.setTarget(window.parent);
+        this._eventListener.listen();
+
+        // Assign itself to the global so it can be accessed by its sibling frames
+        (window as unknown as HostedInputWindow).hostedInput = this;
+
+        this._eventPoster.post({ type: HostedInputEventType.AttachSucceeded });
+    }
+
+    detach(): void {
+        if (this._input.parentElement) {
+            this._input.parentElement.removeChild(this._input);
+        }
+
+        this._eventListener.stopListen();
+    }
+
+    protected _formatChange(value: string): void {
+        this._input.value = value;
+    }
+
+    protected _notifyChange(_value: string): void {
+        this._eventPoster.post({
+            type: HostedInputEventType.Changed,
+            payload: {
+                fieldType: this._type,
+            },
+        });
+    }
+
+    private _configureInput(): void {
+        this._input.style.backgroundColor = 'transparent';
+        this._input.style.border = '0';
+        this._input.style.display = 'block';
+        this._input.style.height = '100%';
+        this._input.style.margin = '0';
+        this._input.style.outline = 'none';
+        this._input.style.padding = '0';
+        this._input.style.width = '100%';
+        this._input.id = kebabCase(this._type);
+        this._input.placeholder = this._placeholder;
+        this._input.autocomplete = this._autocomplete;
+
+        this._input.setAttribute('aria-label', this._accessibilityLabel);
+
+        this._applyStyles(this._styles.default);
+    }
+
+    private _applyStyles(styles: HostedInputStyles = {}): void {
+        const allowedStyles: { [key in keyof Required<HostedInputStyles>]: HostedInputStyles[key] } = {
+            color: styles.color,
+            fontFamily: styles.fontFamily,
+            fontSize: styles.fontSize,
+            fontWeight: styles.fontWeight,
+        };
+        const styleKeys = Object.keys(allowedStyles) as Array<keyof HostedInputStyles>;
+
+        styleKeys.forEach(key => {
+            if (!allowedStyles[key]) {
+                return;
+            }
+
+            this._input.style[key] = allowedStyles[key] || '';
+        });
+    }
+
+    private async _validateChange(value: string): Promise<void> {
+        if (!this._isSubmitted) {
+            return;
+        }
+
+        const values = {
+            ...this._inputAggregator.getInputValues(field => field.isTouched()),
+            [this._type]: value,
+        };
+        const errors = await this._inputValidator.validate(values, { isCardCodeRequired: HostedFieldType.CardCode in values });
+
+        if (!errors.length) {
+            this._applyStyles(this._styles.default);
+
+            return;
+        }
+
+        this._applyStyles(this._styles.error);
+
+        this._eventPoster.post({
+            type: HostedInputEventType.ValidateFailed,
+            payload: { errors },
+        });
+    }
+
+    private _processChange(value: string): void {
+        if (value === this._previousValue) {
+            return;
+        }
+
+        this._isTouched = true;
+
+        this._validateChange(value);
+        this._formatChange(value);
+        this._notifyChange(value);
+
+        this._previousValue = value;
+    }
+
+    private _handleInput: (event: Event) => void = event => {
+        const input = event.target as HTMLInputElement;
+
+        this._processChange(input.value);
+    };
+
+    private _handleBlur: (event: Event) => void = () => {
+        this._applyStyles(this._styles.default);
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Blurred,
+            payload: {
+                fieldType: this._type,
+            },
+        });
+    };
+
+    private _handleFocus: (event: Event) => void = () => {
+        this._applyStyles(this._styles.focus);
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Focused,
+            payload: {
+                fieldType: this._type,
+            },
+        });
+    };
+
+    private _handleSubmit: (event: HostedFieldSubmitRequestEvent) => void = () => {
+        this._isSubmitted = true;
+    };
+}


### PR DESCRIPTION
## What?
Add `HostedInput` class, which is responsible for accepting user inputs inside an iframe.

## Why?
It is intended to be loaded and initialised inside a hosted field iframe. It also acts as a base class for specialised fields, such as card number and expiry field.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
