### PR TITLE
CHECKOUT-4203: Add card number and expiry inputs and export initialiser

### DIFF
--- a/src/bundles/hosted-form.ts
+++ b/src/bundles/hosted-form.ts
@@ -1,0 +1,1 @@
+export { initializeHostedInput, notifyInitializeError } from '../hosted-form/iframe-content';

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -89,6 +89,7 @@ export interface CheckoutSettings {
     isAnalyticsEnabled: boolean;
     isCardVaultingEnabled: boolean;
     isCouponCodeCollapsed: boolean;
+    isHostedPaymentFormEnabled: boolean;
     isPaymentRequestEnabled: boolean;
     isPaymentRequestCanMakePaymentEnabled: boolean;
     isSpamProtectionEnabled: boolean;
@@ -110,6 +111,7 @@ export interface ContextConfig {
     geoCountryCode: string;
     flashMessages: any[];
     payment: {
+        formId?: string;
         token?: string;
     };
 }

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -9,7 +9,9 @@ export function getConfig(): Config {
             checkoutId: '6a6071cc-82ba-45aa-adb0-ebec42d6ff6f',
             flashMessages: [],
             geoCountryCode: 'AU',
-            payment: {},
+            payment: {
+                formId: 'dc030783-6129-4ee3-8e06-6f4270df1527',
+            },
         },
         customization: {
             languageData: [],
@@ -26,6 +28,7 @@ export function getConfig(): Config {
                 googleRecaptchaSitekey: 'sitekey',
                 isAnalyticsEnabled: false,
                 isCardVaultingEnabled: true,
+                isHostedPaymentFormEnabled: false,
                 isPaymentRequestEnabled: false,
                 isPaymentRequestCanMakePaymentEnabled: false,
                 isCouponCodeCollapsed: true,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 export * from './config-actions';
 
-export { default as Config, StoreConfig } from './config';
+export { default as Config, StoreConfig, StoreProfile } from './config';
 export { default as ConfigActionCreator } from './config-action-creator';
 export { default as ConfigSelector, ConfigSelectorFactory, createConfigSelectorFactory } from './config-selector';
 export { default as configReducer } from './config-reducer';

--- a/src/hosted-form/iframe-content/hosted-autocomplete-fieldset.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-autocomplete-fieldset.spec.ts
@@ -1,0 +1,102 @@
+import HostedFieldType from '../hosted-field-type';
+
+import HostedAutocompleteFieldset from './hosted-autocomplete-fieldset';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+
+describe('HostedAutocompleteFieldset', () => {
+    let container: HTMLElement;
+    let fieldset: HostedAutocompleteFieldset;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputs'>;
+
+    beforeEach(() => {
+        inputAggregator = { getInputs: jest.fn() };
+        fieldset = new HostedAutocompleteFieldset(
+            'input-container',
+            [HostedFieldType.CardExpiry, HostedFieldType.CardName],
+            inputAggregator as HostedInputAggregator
+        );
+
+        container = document.createElement('div');
+        container.id = 'input-container';
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('attaches autocomplete inputs to container', () => {
+        fieldset.attach();
+
+        expect(container.querySelector('#autocomplete-card-expiry'))
+            .toBeTruthy();
+        expect(container.querySelector('#autocomplete-card-name'))
+            .toBeTruthy();
+    });
+
+    it('hides autocomplete input from user', () => {
+        fieldset.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const input = container.querySelector<HTMLInputElement>('#autocomplete-card-expiry')!;
+
+        expect(input.style.opacity)
+            .toEqual('0');
+        expect(input.style.position)
+            .toEqual('absolute');
+        expect(input.tabIndex)
+            .toEqual(-1);
+    });
+
+    it('configures autocomplete property based on field type', () => {
+        fieldset.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const expiryInput = container.querySelector<HTMLInputElement>('#autocomplete-card-expiry')!;
+        // tslint:disable-next-line:no-non-null-assertion
+        const nameInput = container.querySelector<HTMLInputElement>('#autocomplete-card-name')!;
+
+        expect(expiryInput.autocomplete)
+            .toEqual('cc-exp');
+        expect(nameInput.autocomplete)
+            .toEqual('cc-name');
+    });
+
+    it('updates corresponding hosted inputs when autocomplete inputs receive update', () => {
+        const hostedExpiryInput: Pick<HostedInput, 'getType' | 'setValue'> = {
+            getType: jest.fn(() => HostedFieldType.CardExpiry),
+            setValue: jest.fn(),
+        };
+        const hostedNameInput: Pick<HostedInput, 'getType' | 'setValue'> = {
+            getType: jest.fn(() => HostedFieldType.CardName),
+            setValue: jest.fn(),
+        };
+
+        jest.spyOn(inputAggregator, 'getInputs')
+            .mockReturnValue([hostedExpiryInput, hostedNameInput]);
+
+        fieldset.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const input = container.querySelector<HTMLInputElement>('#autocomplete-card-expiry')!;
+
+        input.value = '10 / 20';
+        input.dispatchEvent(new Event('change'));
+
+        expect(hostedExpiryInput.setValue)
+            .toHaveBeenCalledWith('10 / 20');
+        expect(hostedNameInput.setValue)
+            .not.toHaveBeenCalledWith('10 / 20');
+    });
+
+    it('removes autocomplete inputs when fieldset detaches', () => {
+        fieldset.attach();
+        fieldset.detach();
+
+        expect(container.querySelector('#autocomplete-card-expiry'))
+            .toBeFalsy();
+        expect(container.querySelector('#autocomplete-card-name'))
+            .toBeFalsy();
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-autocomplete-fieldset.ts
+++ b/src/hosted-form/iframe-content/hosted-autocomplete-fieldset.ts
@@ -1,0 +1,75 @@
+import { kebabCase } from 'lodash';
+
+import { InvalidHostedFormConfigError } from '../errors';
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import mapToAutocompleteType from './map-to-autocomplete-type';
+
+export default class HostedAutocompleteFieldset {
+    private _inputs: HTMLInputElement[];
+
+    constructor(
+        private _containerId: string,
+        private _fieldTypes: HostedFieldType[],
+        private _inputAggregator: HostedInputAggregator
+    ) {
+        this._inputs = this._fieldTypes.map(type => this._createInput(type));
+    }
+
+    attach(): void {
+        const container = document.getElementById(this._containerId);
+
+        if (!container) {
+            throw new InvalidHostedFormConfigError('Unable to proceed because the provided container ID is not valid.');
+        }
+
+        this._inputs.forEach(input => container.appendChild(input));
+    }
+
+    detach(): void {
+        this._inputs.forEach(input => {
+            if (!input.parentElement) {
+                return;
+            }
+
+            input.parentElement.removeChild(input);
+        });
+    }
+
+    private _createInput(type: HostedFieldType): HTMLInputElement {
+        const input = document.createElement('input');
+
+        input.autocomplete = mapToAutocompleteType(type);
+        input.id = this._getAutocompleteElementId(type);
+        input.tabIndex = -1;
+        input.style.position = 'absolute';
+        input.style.opacity = '0';
+        input.style.zIndex = '-1';
+
+        input.addEventListener('change', this._handleChange);
+
+        return input;
+    }
+
+    private _handleChange: (event: Event) => void = event => {
+        const targetInput = event.target as HTMLInputElement;
+
+        if (!targetInput) {
+            throw new Error('Unable to get a reference to the target of the change event.');
+        }
+
+        const targetHostedInput = this._inputAggregator.getInputs()
+            .find(input => this._getAutocompleteElementId(input.getType()) === targetInput.id);
+
+        if (!targetHostedInput) {
+            return;
+        }
+
+        targetHostedInput.setValue(targetInput.value);
+    };
+
+    private _getAutocompleteElementId(type: HostedFieldType): string {
+        return `autocomplete-${kebabCase(type)}`;
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-card-expiry-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-card-expiry-input.spec.ts
@@ -1,0 +1,81 @@
+import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import CardExpiryFormatter from './card-expiry-formatter';
+import HostedCardExpiryInput from './hosted-card-expiry-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent } from './hosted-input-events';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+describe('HostedCardExpiryInput', () => {
+    let container: HTMLDivElement;
+    let eventListener: Pick<IframeEventListener<HostedFieldEventMap>, 'addListener' | 'listen' | 'stopListen'>;
+    let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'post' | 'setTarget'>;
+    let expiryFormatter: Pick<CardExpiryFormatter, 'format'>;
+    let input: HostedCardExpiryInput;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
+    let inputValidator: Pick<HostedInputValidator, 'validate'>;
+    let styles: HostedInputStylesMap;
+
+    beforeEach(() => {
+        eventListener = {
+            addListener: jest.fn(),
+            listen: jest.fn(),
+            stopListen: jest.fn(),
+        };
+        eventPoster = {
+            post: jest.fn(),
+            setTarget: jest.fn(),
+        };
+        expiryFormatter = { format: jest.fn() };
+        inputAggregator = { getInputValues: jest.fn() };
+        inputValidator = { validate: jest.fn() };
+        styles = { default: { color: 'rgb(255, 255, 255)' } };
+
+        input = new HostedCardExpiryInput(
+            'input-container',
+            'Expiration',
+            'Card expiration',
+            'cc-expiry',
+            styles,
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            expiryFormatter as CardExpiryFormatter
+        );
+
+        container = document.createElement('div');
+        container.id = 'input-container';
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('returns input type', () => {
+        expect(input.getType())
+            .toEqual(HostedFieldType.CardExpiry);
+    });
+
+    it('formats input on change', () => {
+        jest.spyOn(expiryFormatter, 'format')
+            .mockReturnValue('10 / 20');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '1020';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(expiryFormatter.format)
+            .toHaveBeenCalledWith('1020');
+        expect(element.value)
+            .toEqual('10 / 20');
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-card-expiry-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-expiry-input.ts
@@ -1,0 +1,45 @@
+import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import CardExpiryFormatter from './card-expiry-formatter';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent } from './hosted-input-events';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+export default class HostedCardExpiryInput extends HostedInput {
+    /**
+     * @internal
+     */
+    constructor(
+        containerId: string,
+        placeholder: string,
+        accessibilityLabel: string,
+        autocomplete: string,
+        styles: HostedInputStylesMap,
+        eventListener: IframeEventListener<HostedFieldEventMap>,
+        eventPoster: IframeEventPoster<HostedInputEvent>,
+        inputAggregator: HostedInputAggregator,
+        inputValidator: HostedInputValidator,
+        private _formatter: CardExpiryFormatter
+    ) {
+        super(
+            HostedFieldType.CardExpiry,
+            containerId,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            eventListener,
+            eventPoster,
+            inputAggregator,
+            inputValidator
+        );
+    }
+
+    protected _formatValue(value: string): void {
+        this._input.value = this._formatter.format(value);
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
@@ -1,0 +1,126 @@
+import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import CardNumberFormatter from './card-number-formatter';
+import HostedAutocompleteFieldset from './hosted-autocomplete-fieldset';
+import HostedCardNumberInput from './hosted-card-number-input';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+describe('HostedCardNumberInput', () => {
+    let autocompleteFieldset: HostedAutocompleteFieldset;
+    let container: HTMLDivElement;
+    let eventListener: Pick<IframeEventListener<HostedFieldEventMap>, 'addListener' | 'listen' | 'stopListen'>;
+    let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'setTarget' | 'post'>;
+    let input: HostedInput;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
+    let inputValidator: Pick<HostedInputValidator, 'validate'>;
+    let numberFormatter: Pick<CardNumberFormatter, 'format'>;
+    let paymentHandler: Pick<HostedInputPaymentHandler, 'handle'>;
+    let styles: HostedInputStylesMap;
+
+    beforeEach(() => {
+        autocompleteFieldset = new HostedAutocompleteFieldset(
+            'input-container',
+            [HostedFieldType.CardCode, HostedFieldType.CardExpiry, HostedFieldType.CardName],
+            new HostedInputAggregator(window.parent)
+        );
+        eventListener = {
+            addListener: jest.fn(),
+            listen: jest.fn(),
+            stopListen: jest.fn(),
+        };
+        eventPoster = {
+            post: jest.fn(),
+            setTarget: jest.fn(),
+        };
+        inputAggregator = { getInputValues: jest.fn() };
+        inputValidator = { validate: jest.fn() };
+        numberFormatter = { format: jest.fn() };
+        paymentHandler = { handle: jest.fn() };
+        styles = { default: { color: 'rgb(255, 255, 255)' } };
+
+        input = new HostedCardNumberInput(
+            'input-container',
+            'Full name',
+            'Cardholder name',
+            'cc-name',
+            styles,
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            autocompleteFieldset,
+            numberFormatter as CardNumberFormatter,
+            paymentHandler as HostedInputPaymentHandler
+        );
+
+        container = document.createElement('div');
+        container.id = 'input-container';
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        container.remove();
+    });
+
+    it('returns input type', () => {
+        expect(input.getType())
+            .toEqual(HostedFieldType.CardNumber);
+    });
+
+    it('notifies input change', () => {
+        jest.spyOn(numberFormatter, 'format')
+            .mockReturnValue('4111');
+
+        jest.spyOn(eventPoster, 'post');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '4111';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedInputEventType.CardTypeChanged,
+                payload: {
+                    cardType: 'visa',
+                },
+            });
+    });
+
+    it('formats input on change', () => {
+        jest.spyOn(numberFormatter, 'format')
+            .mockReturnValue('4111 1111 1111 1111');
+
+        input.attach();
+
+        // tslint:disable-next-line:no-non-null-assertion
+        const element = container.querySelector('input')!;
+
+        element.value = '4111111111111111';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(numberFormatter.format)
+            .toHaveBeenCalledWith('4111111111111111');
+        expect(element.value)
+            .toEqual('4111 1111 1111 1111');
+    });
+
+    it('attaches autocomplete fieldset', () => {
+        jest.spyOn(autocompleteFieldset, 'attach');
+
+        input.attach();
+
+        expect(autocompleteFieldset.attach)
+            .toHaveBeenCalled();
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-card-number-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.ts
@@ -1,0 +1,85 @@
+import { number } from 'card-validator';
+import { get } from 'lodash';
+
+import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
+import { HostedFieldEventMap, HostedFieldEventType } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import CardNumberFormatter from './card-number-formatter';
+import HostedAutocompleteFieldset from './hosted-autocomplete-fieldset';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+
+export default class HostedCardNumberInput extends HostedInput {
+    /**
+     * @internal
+     */
+    constructor(
+        containerId: string,
+        placeholder: string,
+        accessibilityLabel: string,
+        autocomplete: string,
+        styles: HostedInputStylesMap,
+        eventListener: IframeEventListener<HostedFieldEventMap>,
+        eventPoster: IframeEventPoster<HostedInputEvent>,
+        inputAggregator: HostedInputAggregator,
+        inputValidator: HostedInputValidator,
+        private _autocompleteFieldset: HostedAutocompleteFieldset,
+        private _formatter: CardNumberFormatter,
+        private _paymentHandler: HostedInputPaymentHandler
+    ) {
+        super(
+            HostedFieldType.CardNumber,
+            containerId,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            eventListener,
+            eventPoster,
+            inputAggregator,
+            inputValidator
+        );
+
+        this._eventListener.addListener(HostedFieldEventType.SubmitRequested, this._paymentHandler.handle);
+    }
+
+    attach(): void {
+        super.attach();
+
+        this._autocompleteFieldset.attach();
+    }
+
+    protected _notifyChange(value: string): void {
+        const cardInfo = number(value).card;
+        const prevCardInfo = this._previousValue && number(this._previousValue).card;
+
+        if (get(prevCardInfo, 'type') === get(cardInfo, 'type')) {
+            return;
+        }
+
+        this._eventPoster.post({
+            type: HostedInputEventType.CardTypeChanged,
+            payload: {
+                cardType: cardInfo ? cardInfo.type : undefined,
+            },
+        });
+    }
+
+    protected _formatValue(value: string): void {
+        const selectionEnd = this._input.selectionEnd;
+        const formattedValue = this._formatter.format(value);
+
+        if (selectionEnd === value.length && value.length < formattedValue.length) {
+            this._input.setSelectionRange(formattedValue.length, formattedValue.length);
+        } else {
+            this._input.setSelectionRange(selectionEnd || 0, selectionEnd || 0);
+        }
+
+        this._input.value = formattedValue;
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-input-factory.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.spec.ts
@@ -1,0 +1,32 @@
+import HostedFieldType from '../hosted-field-type';
+
+import HostedCardExpiryInput from './hosted-card-expiry-input';
+import HostedCardNumberInput from './hosted-card-number-input';
+import HostedInput from './hosted-input';
+import HostedInputFactory from './hosted-input-factory';
+
+describe('HostedInputFactory', () => {
+    let factory: HostedInputFactory;
+
+    beforeEach(() => {
+        factory = new HostedInputFactory('https://store.foobar.com');
+    });
+
+    it('creates card number field', () => {
+        expect(factory.create('input-container', HostedFieldType.CardNumber))
+            .toBeInstanceOf(HostedCardNumberInput);
+    });
+
+    it('creates card expiry field', () => {
+        expect(factory.create('input-container', HostedFieldType.CardExpiry))
+            .toBeInstanceOf(HostedCardExpiryInput);
+    });
+
+    it('creates regular input field for other field types', () => {
+        expect(factory.create('input-container', HostedFieldType.CardCode))
+            .toBeInstanceOf(HostedInput);
+
+        expect(factory.create('input-container', HostedFieldType.CardName))
+            .toBeInstanceOf(HostedInput);
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-input-factory.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.ts
@@ -1,0 +1,121 @@
+import { createClient as createBigpayClient } from '@bigcommerce/bigpay-client';
+
+import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
+import { PaymentRequestSender, PaymentRequestTransformer } from '../../payment';
+import HostedFieldType from '../hosted-field-type';
+
+import CardExpiryFormatter from './card-expiry-formatter';
+import CardNumberFormatter from './card-number-formatter';
+import HostedAutocompleteFieldset from './hosted-autocomplete-fieldset';
+import HostedCardExpiryInput from './hosted-card-expiry-input';
+import HostedCardNumberInput from './hosted-card-number-input';
+import HostedInput from './hosted-input';
+import HostedInputAggregator from './hosted-input-aggregator';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import { HostedInputStylesMap } from './hosted-input-styles';
+import HostedInputValidator from './hosted-input-validator';
+import mapToAccessibilityLabel from './map-to-accessibility-label';
+import mapToAutocompleteType from './map-to-autocomplete-type';
+
+export default class HostedInputFactory {
+    constructor(
+        private _parentOrigin: string
+    ) {}
+
+    create(
+        containerId: string,
+        type: HostedFieldType,
+        styles: HostedInputStylesMap = {},
+        placeholder: string = '',
+        accessibilityLabel: string = mapToAccessibilityLabel(type)
+    ): HostedInput {
+        const autocomplete = mapToAutocompleteType(type);
+
+        if (type === HostedFieldType.CardNumber) {
+            return this._createNumberInput(containerId, styles, placeholder, accessibilityLabel, autocomplete);
+        }
+
+        if (type === HostedFieldType.CardExpiry) {
+            return this._createExpiryInput(containerId, styles, placeholder, accessibilityLabel, autocomplete);
+        }
+
+        return this._createInput(type, containerId, styles, placeholder, accessibilityLabel, autocomplete);
+    }
+
+    private _createExpiryInput(
+        containerId:
+        string,
+        styles: HostedInputStylesMap,
+        placeholder: string,
+        accessibilityLabel: string = '',
+        autocomplete: string = ''
+    ): HostedCardExpiryInput {
+        return new HostedCardExpiryInput(
+            containerId,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            new IframeEventListener(this._parentOrigin),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator(),
+            new CardExpiryFormatter()
+        );
+    }
+
+    private _createNumberInput(
+        containerId: string,
+        styles: HostedInputStylesMap,
+        placeholder: string,
+        accessibilityLabel: string = '',
+        autocomplete: string = ''
+    ): HostedCardNumberInput {
+        return new HostedCardNumberInput(
+            containerId,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            new IframeEventListener(this._parentOrigin),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator(),
+            new HostedAutocompleteFieldset(
+                containerId,
+                [HostedFieldType.CardCode, HostedFieldType.CardExpiry, HostedFieldType.CardName],
+                new HostedInputAggregator(window.parent)
+            ),
+            new CardNumberFormatter(),
+            new HostedInputPaymentHandler(
+                new HostedInputAggregator(window.parent),
+                new HostedInputValidator(),
+                new IframeEventPoster(this._parentOrigin, window.parent),
+                new PaymentRequestSender(createBigpayClient()),
+                new PaymentRequestTransformer()
+            )
+        );
+    }
+
+    private _createInput(
+        type: HostedFieldType,
+        containerId: string,
+        styles: HostedInputStylesMap,
+        placeholder: string,
+        accessibilityLabel: string = '',
+        autocomplete: string = ''
+    ): HostedInput {
+        return new HostedInput(
+            type,
+            containerId,
+            placeholder,
+            accessibilityLabel,
+            autocomplete,
+            styles,
+            new IframeEventListener(this._parentOrigin),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator()
+        );
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-input-initializer.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-initializer.spec.ts
@@ -1,0 +1,80 @@
+import { IframeEventListener } from '../../common/iframe';
+import { HostedFieldEventMap, HostedFieldEventType } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+
+import HostedInput from './hosted-input';
+import HostedInputFactory from './hosted-input-factory';
+import HostedInputInitializer from './hosted-input-initializer';
+
+describe('HostedInputInitializer', () => {
+    let eventListener: IframeEventListener<HostedFieldEventMap>;
+    let factory: Pick<HostedInputFactory, 'create'>;
+    let initializer: HostedInputInitializer;
+    let input: Pick<HostedInput, 'attach'>;
+
+    beforeEach(() => {
+        factory = { create: jest.fn() };
+        eventListener = new IframeEventListener('https://store.foobar.com');
+        input = { attach: jest.fn() };
+
+        initializer = new HostedInputInitializer(
+            factory as HostedInputFactory,
+            eventListener
+        );
+
+        jest.spyOn(input, 'attach')
+            .mockImplementation();
+
+        jest.spyOn(factory, 'create')
+            .mockReturnValue(input);
+    });
+
+    it('creates new hosted input', async () => {
+        process.nextTick(() => {
+            eventListener.trigger({
+                type: HostedFieldEventType.AttachRequested,
+                payload: {
+                    type: HostedFieldType.CardNumber,
+                    placeholder: 'Card name',
+                    styles: { default: { color: 'rgb(0, 0, 0)' } },
+                },
+            });
+        });
+
+        await initializer.initialize('input-container');
+
+        expect(factory.create)
+            .toHaveBeenCalledWith(
+                'input-container',
+                HostedFieldType.CardNumber,
+                { default: { color: 'rgb(0, 0, 0)' } },
+                'Card name'
+            );
+    });
+
+    it('attaches input to container', async () => {
+        process.nextTick(() => {
+            eventListener.trigger({
+                type: HostedFieldEventType.AttachRequested,
+                payload: { type: HostedFieldType.CardNumber },
+            });
+        });
+
+        await initializer.initialize('input-container');
+
+        expect(input.attach)
+            .toHaveBeenCalled();
+    });
+
+    it('returns newly created input', async () => {
+        process.nextTick(() => {
+            eventListener.trigger({
+                type: HostedFieldEventType.AttachRequested,
+                payload: { type: HostedFieldType.CardNumber },
+            });
+        });
+
+        expect(await initializer.initialize('input-container'))
+            .toEqual(input);
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-input-initializer.ts
+++ b/src/hosted-form/iframe-content/hosted-input-initializer.ts
@@ -1,0 +1,60 @@
+import { fromEvent } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+
+import { IframeEventListener } from '../../common/iframe';
+import { HostedFieldAttachEvent, HostedFieldEventMap, HostedFieldEventType } from '../hosted-field-events';
+
+import HostedInput from './hosted-input';
+import HostedInputFactory from './hosted-input-factory';
+
+interface EventTargetLike<TEvent> {
+    addListener(eventName: string, handler: (event: TEvent) => void): void;
+    removeListener(eventName: string, handler: (event: TEvent) => void): void;
+}
+
+export default class HostedInputInitializer {
+    constructor(
+        private _factory: HostedInputFactory,
+        private _eventListener: IframeEventListener<HostedFieldEventMap>
+    ) {}
+
+    initialize(containerId: string): Promise<HostedInput> {
+        this._resetPageStyles(containerId);
+        this._eventListener.listen();
+
+        return fromEvent<HostedFieldAttachEvent>(
+            this._eventListener as EventTargetLike<HostedFieldAttachEvent>,
+            HostedFieldEventType.AttachRequested
+        )
+            .pipe(
+                map(({ payload }) => {
+                    const { placeholder = '', styles = {}, type } = payload;
+                    const field = this._factory.create(containerId, type, styles, placeholder);
+
+                    field.attach();
+
+                    return field;
+                }),
+                take(1)
+            )
+            .toPromise();
+    }
+
+    private _resetPageStyles(containerId: string) {
+        const html = document.querySelector('html');
+        const body = document.querySelector('body');
+        const container = document.getElementById(containerId);
+
+        [html, body, container]
+            .forEach(node => {
+                if (!node) {
+                    return;
+                }
+
+                node.style.height = '100%';
+                node.style.width = '100%';
+                node.style.padding = '0';
+                node.style.margin = '0';
+            });
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-input-options.ts
+++ b/src/hosted-form/iframe-content/hosted-input-options.ts
@@ -1,0 +1,5 @@
+export default interface HostedInputOptions {
+    containerId: string;
+    origin: string;
+    parentOrigin: string;
+}

--- a/src/hosted-form/iframe-content/hosted-input-payment-handler.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-payment-handler.spec.ts
@@ -1,0 +1,147 @@
+import { getResponse } from '../../common/http-request/responses.mock';
+import { IframeEventPoster } from '../../common/iframe';
+import { PaymentRequestSender, PaymentRequestTransformer } from '../../payment';
+import { getErrorPaymentResponseBody, getPaymentRequestBody, getPaymentResponseBody } from '../../payment/payments.mock';
+import { HostedFieldEventType } from '../hosted-field-events';
+import HostedFieldType from '../hosted-field-type';
+import HostedFormOrderData from '../hosted-form-order-data';
+import { getHostedFormOrderData } from '../hosted-form-order-data.mock';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputPaymentHandler from './hosted-input-payment-handler';
+import HostedInputValidator from './hosted-input-validator';
+import HostedInputValues from './hosted-input-values';
+
+describe('HostedInputPaymentHandler', () => {
+    let data: HostedFormOrderData;
+    let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'post'>;
+    let fields: HostedFieldType[];
+    let handler: HostedInputPaymentHandler;
+    let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
+    let inputValidator: Pick<HostedInputValidator, 'validate'>;
+    let requestSender: Pick<PaymentRequestSender, 'submitPayment'>;
+    let requestTransformer: Pick<PaymentRequestTransformer, 'transformWithHostedFormData'>;
+    let values: HostedInputValues;
+
+    beforeEach(() => {
+        inputAggregator = { getInputValues: jest.fn() };
+        inputValidator = { validate: jest.fn(() => []) };
+        eventPoster = { post: jest.fn() };
+        requestSender = { submitPayment: jest.fn() };
+        requestTransformer = { transformWithHostedFormData: jest.fn() };
+
+        handler = new HostedInputPaymentHandler(
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            requestSender as PaymentRequestSender,
+            requestTransformer as PaymentRequestTransformer
+        );
+
+        data = getHostedFormOrderData();
+
+        fields = [
+            HostedFieldType.CardCode,
+            HostedFieldType.CardExpiry,
+            HostedFieldType.CardName,
+            HostedFieldType.CardNumber,
+        ];
+
+        values = {
+            [HostedFieldType.CardCode]: '123',
+            [HostedFieldType.CardExpiry]: '10 / 20',
+            [HostedFieldType.CardName]: 'Good Shopper',
+            [HostedFieldType.CardNumber]: '4111 1111 1111 1111',
+        };
+
+        jest.spyOn(inputAggregator, 'getInputValues')
+            .mockReturnValue(values);
+
+        jest.spyOn(requestSender, 'submitPayment')
+            .mockResolvedValue(getResponse(getPaymentResponseBody()));
+    });
+
+    it('validates user inputs', async () => {
+        jest.spyOn(inputValidator, 'validate');
+
+        await handler.handle({
+            type: HostedFieldEventType.SubmitRequested,
+            payload: { data, fields },
+        });
+
+        expect(inputValidator.validate)
+            .toHaveBeenCalledWith(values, { isCardCodeRequired: false });
+    });
+
+    it('posts event if validation fails', async () => {
+        jest.spyOn(inputValidator, 'validate')
+            .mockResolvedValue([
+                { fieldType: HostedFieldType.CardNumber, message: 'Card number is required' },
+            ]);
+
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle({
+            type: HostedFieldEventType.SubmitRequested,
+            payload: { data, fields },
+        });
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedInputEventType.ValidateFailed,
+                payload: {
+                    errors: [
+                        { fieldType: HostedFieldType.CardNumber, message: 'Card number is required' },
+                    ],
+                },
+            });
+    });
+
+    it('makes payment request with expected payload', async () => {
+        jest.spyOn(requestTransformer, 'transformWithHostedFormData')
+            .mockReturnValue(getPaymentRequestBody());
+
+        await handler.handle({
+            type: HostedFieldEventType.SubmitRequested,
+            payload: { data, fields },
+        });
+
+        expect(requestTransformer.transformWithHostedFormData)
+            .toHaveBeenCalled();
+        expect(requestSender.submitPayment)
+            .toHaveBeenCalledWith(getPaymentRequestBody());
+    });
+
+    it('posts event if payment submission succeeds', async () => {
+        jest.spyOn(eventPoster, 'post');
+
+        await handler.handle({
+            type: HostedFieldEventType.SubmitRequested,
+            payload: { data, fields },
+        });
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({ type: HostedInputEventType.SubmitSucceeded });
+    });
+
+    it('posts event if payment submission fails', async () => {
+        jest.spyOn(eventPoster, 'post');
+
+        jest.spyOn(requestSender, 'submitPayment')
+            .mockRejectedValue(getResponse(getErrorPaymentResponseBody()));
+
+        await handler.handle({
+            type: HostedFieldEventType.SubmitRequested,
+            payload: { data, fields },
+        });
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedInputEventType.SubmitFailed,
+                payload: {
+                    error: { code: 'insufficient_funds', message: 'Insufficient funds' },
+                },
+            });
+    });
+});

--- a/src/hosted-form/iframe-content/hosted-input-payment-handler.ts
+++ b/src/hosted-form/iframe-content/hosted-input-payment-handler.ts
@@ -1,0 +1,59 @@
+import { Response } from '@bigcommerce/request-sender';
+import { snakeCase } from 'lodash';
+
+import { PaymentErrorResponseBody } from '../../common/error';
+import { IframeEventPoster } from '../../common/iframe';
+import { PaymentRequestSender, PaymentRequestTransformer } from '../../payment';
+import { HostedFieldSubmitRequestEvent } from '../hosted-field-events';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputValidator from './hosted-input-validator';
+
+export default class HostedInputPaymentHandler {
+    constructor(
+        private _inputAggregator: HostedInputAggregator,
+        private _inputValidator: HostedInputValidator,
+        private _eventPoster: IframeEventPoster<HostedInputEvent>,
+        private _paymentRequestSender: PaymentRequestSender,
+        private _paymentRequestTransformer: PaymentRequestTransformer
+    ) {}
+
+    handle: (event: HostedFieldSubmitRequestEvent) => Promise<void> = async ({ payload: { data, fields } }) => {
+        const values = this._inputAggregator.getInputValues(field => fields.indexOf(field.getType()) !== -1);
+        const errors = await this._inputValidator.validate(values, {
+            isCardCodeRequired: data.paymentMethod && data.paymentMethod.config.cardCode === true,
+        });
+
+        if (errors.length > 0) {
+            return this._eventPoster.post({
+                type: HostedInputEventType.ValidateFailed,
+                payload: { errors },
+            });
+        }
+
+        try {
+            await this._paymentRequestSender.submitPayment(this._paymentRequestTransformer.transformWithHostedFormData(values, data));
+
+            this._eventPoster.post({ type: HostedInputEventType.SubmitSucceeded });
+        } catch (error) {
+            this._eventPoster.post({
+                type: HostedInputEventType.SubmitFailed,
+                payload: {
+                    error: this._isPaymentErrorResponse(error) ?
+                        error.body.errors[0] :
+                        { code: snakeCase(error.name), message: error.message },
+                },
+            });
+        }
+    };
+
+    private _isPaymentErrorResponse(response: any): response is Response<PaymentErrorResponseBody> {
+        const { body: { errors = [] } = {} } = response || {};
+
+        return (
+            typeof (errors[0] && errors[0].code) === 'string' &&
+            typeof (errors[0] && errors[0].message) === 'string'
+        );
+    }
+}

--- a/src/hosted-form/iframe-content/hosted-input.ts
+++ b/src/hosted-form/iframe-content/hosted-input.ts
@@ -84,7 +84,7 @@ export default class HostedInput {
         this._eventListener.stopListen();
     }
 
-    protected _formatChange(value: string): void {
+    protected _formatValue(value: string): void {
         this._input.value = value;
     }
 
@@ -166,7 +166,7 @@ export default class HostedInput {
         this._isTouched = true;
 
         this._validateChange(value);
-        this._formatChange(value);
+        this._formatValue(value);
         this._notifyChange(value);
 
         this._previousValue = value;

--- a/src/hosted-form/iframe-content/index.ts
+++ b/src/hosted-form/iframe-content/index.ts
@@ -5,3 +5,6 @@ export type HostedInputStyles = HostedInputStyles;
 export type HostedInputValues = HostedInputValues;
 
 export * from './hosted-input-events';
+export { default as CardExpiryFormatter } from './card-expiry-formatter';
+export { default as CardNumberFormatter } from './card-number-formatter';
+export { default as notifyInitializeError } from './notify-initialize-error';

--- a/src/hosted-form/iframe-content/index.ts
+++ b/src/hosted-form/iframe-content/index.ts
@@ -7,4 +7,5 @@ export type HostedInputValues = HostedInputValues;
 export * from './hosted-input-events';
 export { default as CardExpiryFormatter } from './card-expiry-formatter';
 export { default as CardNumberFormatter } from './card-number-formatter';
+export { default as initializeHostedInput } from './initialize-hosted-input';
 export { default as notifyInitializeError } from './notify-initialize-error';

--- a/src/hosted-form/iframe-content/initialize-hosted-input.ts
+++ b/src/hosted-form/iframe-content/initialize-hosted-input.ts
@@ -1,0 +1,17 @@
+import { IframeEventListener } from '../../common/iframe';
+import { HostedFieldEventMap } from '../hosted-field-events';
+
+import HostedInput from './hosted-input';
+import HostedInputFactory from './hosted-input-factory';
+import HostedInputInitializer from './hosted-input-initializer';
+import HostedInputOptions from './hosted-input-options';
+
+export default function initializeHostedInput(options: HostedInputOptions): Promise<HostedInput> {
+    const { containerId, parentOrigin } = options;
+    const initializer = new HostedInputInitializer(
+        new HostedInputFactory(parentOrigin),
+        new IframeEventListener<HostedFieldEventMap>(parentOrigin)
+    );
+
+    return initializer.initialize(containerId);
+}

--- a/src/hosted-form/iframe-content/map-to-accessibility-label.spec.ts
+++ b/src/hosted-form/iframe-content/map-to-accessibility-label.spec.ts
@@ -1,0 +1,25 @@
+import HostedFieldType from '../hosted-field-type';
+
+import mapToAccessibilityLabel from './map-to-accessibility-label';
+
+describe('mapToAccessibilityLabel()', () => {
+    it('returns label for card code input', () => {
+        expect(mapToAccessibilityLabel(HostedFieldType.CardCode))
+            .toEqual('CVC');
+    });
+
+    it('returns label for card expiry input', () => {
+        expect(mapToAccessibilityLabel(HostedFieldType.CardExpiry))
+            .toEqual('Expiration');
+    });
+
+    it('returns label for card name input', () => {
+        expect(mapToAccessibilityLabel(HostedFieldType.CardName))
+            .toEqual('Name on card');
+    });
+
+    it('returns label for card number input', () => {
+        expect(mapToAccessibilityLabel(HostedFieldType.CardNumber))
+            .toEqual('Credit card number');
+    });
+});

--- a/src/hosted-form/iframe-content/map-to-accessibility-label.ts
+++ b/src/hosted-form/iframe-content/map-to-accessibility-label.ts
@@ -1,0 +1,17 @@
+import HostedFieldType from '../hosted-field-type';
+
+export default function mapToAccessibilityLabel(type: HostedFieldType): string {
+    switch (type) {
+    case HostedFieldType.CardCode:
+        return 'CVC';
+
+    case HostedFieldType.CardExpiry:
+        return 'Expiration';
+
+    case HostedFieldType.CardName:
+        return 'Name on card';
+
+    case HostedFieldType.CardNumber:
+        return 'Credit card number';
+    }
+}

--- a/src/hosted-form/iframe-content/map-to-autocomplete-type.spec.ts
+++ b/src/hosted-form/iframe-content/map-to-autocomplete-type.spec.ts
@@ -1,0 +1,25 @@
+import HostedFieldType from '../hosted-field-type';
+
+import mapToAutocompleteType from './map-to-autocomplete-type';
+
+describe('mapToAutocompleteType()', () => {
+    it('returns autocomplete type for card code input', () => {
+        expect(mapToAutocompleteType(HostedFieldType.CardCode))
+            .toEqual('cc-csc');
+    });
+
+    it('returns autocomplete type for card expiry input', () => {
+        expect(mapToAutocompleteType(HostedFieldType.CardExpiry))
+            .toEqual('cc-exp');
+    });
+
+    it('returns autocomplete type for card name input', () => {
+        expect(mapToAutocompleteType(HostedFieldType.CardName))
+            .toEqual('cc-name');
+    });
+
+    it('returns autocomplete type for card number input', () => {
+        expect(mapToAutocompleteType(HostedFieldType.CardNumber))
+            .toEqual('cc-number');
+    });
+});

--- a/src/hosted-form/iframe-content/map-to-autocomplete-type.ts
+++ b/src/hosted-form/iframe-content/map-to-autocomplete-type.ts
@@ -1,0 +1,20 @@
+import HostedFieldType from '../hosted-field-type';
+
+export default function mapToAutocompleteType(type: HostedFieldType): string {
+    switch (type) {
+    case HostedFieldType.CardCode:
+        return 'cc-csc';
+
+    case HostedFieldType.CardExpiry:
+        return 'cc-exp';
+
+    case HostedFieldType.CardName:
+        return 'cc-name';
+
+    case HostedFieldType.CardNumber:
+        return 'cc-number';
+
+    default:
+        return '';
+    }
+}

--- a/src/hosted-form/iframe-content/notify-initialize-error.ts
+++ b/src/hosted-form/iframe-content/notify-initialize-error.ts
@@ -1,0 +1,13 @@
+import { IframeEventPoster } from '../../common/iframe';
+
+import { HostedInputAttachErrorEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputInitializeErrorData from './hosted-input-initialize-error-data';
+
+const poster = new IframeEventPoster<HostedInputAttachErrorEvent>('*', window.parent);
+
+export default function notifyInitializeError(error: HostedInputInitializeErrorData): void {
+    poster.post({
+        type: HostedInputEventType.AttachFailed,
+        payload: { error },
+    });
+}

--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -1,4 +1,4 @@
-import { CreditCardInstrument, HostedInstrument, VaultedInstrument } from '../payment';
+import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, VaultedInstrument } from '../payment';
 
 /**
  * An object that contains the information required for submitting an order.
@@ -39,5 +39,5 @@ export interface OrderPaymentRequestBody {
      * An object that contains the details of a credit card or vaulted payment
      * instrument.
      */
-    paymentData?: CreditCardInstrument | VaultedInstrument | HostedInstrument;
+    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | VaultedInstrument;
 }

--- a/src/payment/is-vaulted-instrument.ts
+++ b/src/payment/is-vaulted-instrument.ts
@@ -1,5 +1,13 @@
-import { PaymentInstrument, VaultedInstrument } from './payment';
+import { HostedVaultedInstrument, PaymentInstrument, VaultedInstrument } from './payment';
 
 export default function isVaultedInstrument(instrument: PaymentInstrument): instrument is VaultedInstrument {
     return Boolean((instrument as VaultedInstrument).instrumentId);
+}
+
+export function isHostedVaultedInstrument(instrument: PaymentInstrument): instrument is HostedVaultedInstrument {
+    return (
+        Boolean((instrument as HostedVaultedInstrument).instrumentId) &&
+        !instrument.hasOwnProperty('ccNumber') &&
+        !instrument.hasOwnProperty('ccCvv')
+    );
 }

--- a/src/payment/payment-request-transformer.spec.ts
+++ b/src/payment/payment-request-transformer.spec.ts
@@ -4,6 +4,8 @@ import { getCheckoutStoreStateWithOrder, getCheckoutWithGiftCertificates } from 
 import { MissingDataError } from '../common/error/errors';
 import { getConfig } from '../config/configs.mock';
 import { getCustomer } from '../customer/customers.mock';
+import { HostedFieldType } from '../hosted-form';
+import { getHostedFormOrderData } from '../hosted-form/hosted-form-order-data.mock';
 import { getOrder, getOrderMeta } from '../order/orders.mock';
 import { getConsignments } from '../shipping/consignments.mock';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
@@ -116,5 +118,20 @@ describe('PaymentRequestTransformer', () => {
         const paymentRequestBodyResponse = paymentRequestTransformer.transform(payment, selectors);
 
         expect(paymentRequestBodyResponse.paymentMethod).toEqual(expectedPaymentRequestBody.paymentMethod);
+    });
+
+    it('transforms from hosted form data', () => {
+        const result = paymentRequestTransformer.transformWithHostedFormData(
+            {
+                [HostedFieldType.CardNumber]: '4111 1111 1111 1111',
+                [HostedFieldType.CardCode]: '123',
+                [HostedFieldType.CardName]: 'BigCommerce',
+                [HostedFieldType.CardExpiry]: '10 / 20',
+            },
+            getHostedFormOrderData()
+        );
+
+        expect(result)
+            .toEqual(getPaymentRequestBody());
     });
 });

--- a/src/payment/payment-request-transformer.ts
+++ b/src/payment/payment-request-transformer.ts
@@ -5,22 +5,26 @@ import { mapToInternalCart } from '../cart';
 import { InternalCheckoutSelectors } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { mapToInternalCustomer } from '../customer';
+import { HostedFormOrderData } from '../hosted-form';
+import { CardExpiryFormatter, CardNumberFormatter, HostedInputValues } from '../hosted-form/iframe-content';
 import { mapToInternalOrder } from '../order';
 import { mapToInternalShippingOption } from '../shipping';
 
 import isVaultedInstrument from './is-vaulted-instrument';
 import Payment from './payment';
 import PaymentMethod from './payment-method';
-import PaymentMethodSelector from './payment-method-selector';
 import PaymentRequestBody from './payment-request-body';
 
 export default class PaymentRequestTransformer {
+    private _cardExpiryFormatter = new CardExpiryFormatter();
+    private _cardNumberFormatter = new CardNumberFormatter();
+
     transform(payment: Payment, checkoutState: InternalCheckoutSelectors): PaymentRequestBody {
         const billingAddress = checkoutState.billingAddress.getBillingAddress();
         const checkout = checkoutState.checkout.getCheckout();
         const customer = checkoutState.customer.getCustomer();
         const order = checkoutState.order.getOrder();
-        const paymentMethod = this._getPaymentMethod(checkoutState.paymentMethods, payment.methodId, payment.gatewayId);
+        const paymentMethod = checkoutState.paymentMethods.getPaymentMethod(payment.methodId, payment.gatewayId);
         const shippingAddress = checkoutState.shippingAddress.getShippingAddress();
         const consignments = checkoutState.consignments.getConsignments();
         const shippingOption = checkoutState.consignments.getShippingOption();
@@ -41,7 +45,7 @@ export default class PaymentRequestTransformer {
 
         return {
             authToken,
-            paymentMethod,
+            paymentMethod: paymentMethod && this._transformPaymentMethod(paymentMethod),
             customer: internalCustomer,
             billingAddress: billingAddress && mapToInternalAddress(billingAddress),
             shippingAddress: shippingAddress && mapToInternalAddress(shippingAddress, consignments),
@@ -66,17 +70,46 @@ export default class PaymentRequestTransformer {
         };
     }
 
-    private _getPaymentMethod(
-        paymentMethodSelector: PaymentMethodSelector,
-        methodId: string,
-        gatewayId?: string
-    ): PaymentMethod | undefined {
-        const paymentMethod = paymentMethodSelector.getPaymentMethod(methodId, gatewayId);
+    transformWithHostedFormData(values: HostedInputValues, data: HostedFormOrderData): PaymentRequestBody {
+        const { authToken, checkout, config, order, orderMeta, payment, paymentMethod, paymentMethodMeta } = data;
+        const consignment = checkout && checkout.consignments[0];
+        const shippingAddress = consignment && consignment.shippingAddress;
+        const shippingOption = consignment && consignment.selectedShippingOption;
 
-        if (!paymentMethod) {
-            return;
-        }
+        return {
+            authToken,
+            paymentMethod: paymentMethod && this._transformPaymentMethod(paymentMethod),
+            customer: order && order.billingAddress && checkout && mapToInternalCustomer(checkout.customer, order.billingAddress),
+            billingAddress: order && order.billingAddress && mapToInternalAddress(order.billingAddress),
+            shippingAddress: shippingAddress && checkout && mapToInternalAddress(shippingAddress, checkout.consignments),
+            shippingOption: shippingOption && mapToInternalShippingOption(shippingOption, true),
+            cart: checkout && mapToInternalCart(checkout),
+            order: order && mapToInternalOrder(order, orderMeta),
+            orderMeta,
+            payment: {
+                ...payment,
+                ccCvv: values.cardCode,
+                ccExpiry: this._cardExpiryFormatter.toObject(values.cardExpiry),
+                ccName: values.cardName,
+                ccNumber: this._cardNumberFormatter.unformat(values.cardNumber),
+            },
+            quoteMeta: {
+                request: {
+                    ...paymentMethodMeta,
+                    geoCountryCode: config && config.context.geoCountryCode,
+                },
+            },
+            source: 'bigcommerce-checkout-js-sdk',
+            store: config && pick(config.storeConfig.storeProfile, [
+                'storeHash',
+                'storeId',
+                'storeLanguage',
+                'storeName',
+            ]),
+        };
+    }
 
+    private _transformPaymentMethod(paymentMethod: PaymentMethod): PaymentMethod {
         if (paymentMethod.method === 'multi-option' && !paymentMethod.gateway) {
             return { ...paymentMethod, gateway: paymentMethod.id };
         }

--- a/src/payment/payments.mock.ts
+++ b/src/payment/payments.mock.ts
@@ -27,7 +27,7 @@ export function getCreditCardInstrument(): CreditCardInstrument {
     return {
         ccExpiry: {
             month: '10',
-            year: '20',
+            year: '2020',
         },
         ccName: 'BigCommerce',
         ccNumber: '4111111111111111',

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -3,7 +3,7 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitia
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError, PaymentMethodCancelledError, PaymentMethodFailedError } from '../../errors';
-import isVaultedInstrument from '../../is-vaulted-instrument';
+import isVaultedInstrument, { isHostedVaultedInstrument } from '../../is-vaulted-instrument';
 import Payment, { FormattedPayload, PaypalInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
@@ -112,7 +112,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             return Promise.resolve({ ...payment, paymentData: this._formattedPayload(nonce) });
         }
 
-        if (isVaultedInstrument(paymentData)) {
+        if (isVaultedInstrument(paymentData) || isHostedVaultedInstrument(paymentData)) {
             if (!isVaultingEnabled) {
                 throw new InvalidArgumentError('Vaulting is disabled but a vaulted instrument was being used for this transaction');
             }

--- a/src/payment/strategies/braintree/braintree.mock.ts
+++ b/src/payment/strategies/braintree/braintree.mock.ts
@@ -131,7 +131,7 @@ export function getBraintreeRequestData(): BraintreeRequestData {
                 },
                 cardholderName: 'BigCommerce',
                 cvv: '123',
-                expirationDate: '10/20',
+                expirationDate: '10/2020',
                 number: '4111111111111111',
                 options: {
                     validate: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const assetConfig = {
         'checkout-sdk': './src/index.ts',
         'checkout-button': './src/bundles/checkout-button.ts',
         'embedded-checkout': './src/bundles/embedded-checkout.ts',
+        'hosted-form': './src/bundles/hosted-form.ts',
         'internal-mappers': './src/bundles/internal-mappers.ts',
     },
 


### PR DESCRIPTION
## What?
* Add credit card number and expiry inputs.
* Add a function for creating and initialising hosted inputs.
* Export the hosted input initializer as a separate file.

## Why?
* We need `HostedCardNumberInput` and `HostedCardExpiryInput` subclasses because they are a special type of `HostedInput`. Both fields need to format input value in a special way. In addition, the card number field is responsible for handling the form submission event delivered from the host page.
* We want to export the initializer in a separate file because it is only intended to be used inside the hosted field iframe. Therefore, we shouldn't need to pull in the entire package.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
