### PR TITLE
PAYMENTS-4848 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1183,9 +1183,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.0.0.tgz",
-      "integrity": "sha512-xM9AJJPCXGHRVAtfCWBTTNHiWC2tn8pVSvpecuDyAU+VcqA0W9xxpUedlJzioAPQly3qbMQvl8CpKX0fSuiHWw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.2.0.tgz",
+      "integrity": "sha512-k6uKSaNa8HRiNFLAlDGCTdDguVzpMOuQ1wjFoPI8qVrKqJDSP2TqXMxo8cOYIVBABW23yPGVV1dEZZzlT3e2cw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.2.1",
         "deep-assign": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@bigcommerce/bigpay-client": "^5.0.0",
+    "@bigcommerce/bigpay-client": "^5.2.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.3.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump bigpay-client-js version to send transit times where applicable

## Why?
https://jira.bigcommerce.com/browse/PROJECT-3123 - transit time will be used by Cybersource for fraud scoring

## Testing / Proof
Manual testing: 
https://github.com/bigcommerce/bigpay-client-js/pull/90

Manual and unit tests: 
https://github.com/bigcommerce/bigpay/pull/2009


@jvpcode @bigcommerce/payments
