### PR TITLE
CHECKOUT-4203: Use hosted payment form for credit card payment if feature is enabled

### DIFF
--- a/src/hosted-form/iframe-content/index.ts
+++ b/src/hosted-form/iframe-content/index.ts
@@ -1,11 +1,8 @@
-import HostedInputStyles from './hosted-input-styles';
-import HostedInputValues from './hosted-input-values';
-
-export type HostedInputStyles = HostedInputStyles;
-export type HostedInputValues = HostedInputValues;
-
 export * from './hosted-input-events';
+
 export { default as CardExpiryFormatter } from './card-expiry-formatter';
 export { default as CardNumberFormatter } from './card-number-formatter';
+export { default as HostedInputStyles } from './hosted-input-styles';
+export { default as HostedInputValues } from './hosted-input-values';
 export { default as initializeHostedInput } from './initialize-hosted-input';
 export { default as notifyInitializeError } from './notify-initialize-error';

--- a/src/hosted-form/index.ts
+++ b/src/hosted-form/index.ts
@@ -1,10 +1,6 @@
-import HostedFormOptions from './hosted-form-options';
-import HostedFormOrderData from './hosted-form-order-data';
-
-export type HostedFormOptions = HostedFormOptions;
-export type HostedFormOrderData = HostedFormOrderData;
-
 export { default as HostedFieldType } from './hosted-field-type';
 export { default as HostedForm } from './hosted-form';
 export { default as HostedFormFactory } from './hosted-form-factory';
+export { default as HostedFormOptions } from './hosted-form-options';
 export { default as HostedFormOrderDataTransformer } from './hosted-form-order-data-transformer';
+export { default as HostedFormOrderData } from './hosted-form-order-data';

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -5,6 +5,7 @@ import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { GoogleRecaptcha, SpamProtectionActionCreator } from '../order/spam-protection';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
@@ -67,6 +68,7 @@ export default function createPaymentStrategyRegistry(
     const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
     const paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator);
     const formPoster = createFormPoster();
+    const hostedFormFactory = new HostedFormFactory(store);
 
     registry.register(PaymentStrategyType.ADYENV2, () =>
         new AdyenV2PaymentStrategy(
@@ -115,7 +117,8 @@ export default function createPaymentStrategyRegistry(
         new CreditCardPaymentStrategy(
             store,
             orderActionCreator,
-            paymentActionCreator
+            paymentActionCreator,
+            hostedFormFactory
         )
     );
 
@@ -306,6 +309,7 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
+            hostedFormFactory,
             new WepayRiskClient(scriptLoader)
         )
     );

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -4,6 +4,7 @@ import { AdyenV2PaymentInitializeOptions } from './strategies/adyenv2';
 import { AmazonPayPaymentInitializeOptions } from './strategies/amazon-pay';
 import { BraintreePaymentInitializeOptions, BraintreeVisaCheckoutPaymentInitializeOptions } from './strategies/braintree';
 import { ChasePayInitializeOptions } from './strategies/chasepay';
+import { CreditCardPaymentInitializeOptions } from './strategies/credit-card';
 import { GooglePayPaymentInitializeOptions } from './strategies/googlepay';
 import { KlarnaPaymentInitializeOptions } from './strategies/klarna';
 import { MasterpassPaymentInitializeOptions } from './strategies/masterpass';
@@ -34,6 +35,8 @@ export interface PaymentRequestOptions extends RequestOptions {
  * current checkout flow.
  */
 export interface PaymentInitializeOptions extends PaymentRequestOptions {
+    creditCard?: CreditCardPaymentInitializeOptions;
+
     /**
      * The options that are required to initialize the AdyenV2 payment
      * method. They can be omitted unless you need to support AdyenV2.

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -10,6 +10,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStor
 import { getCheckoutStoreState, getCheckoutStoreStateWithOrder } from '../checkout/checkouts.mock';
 import { MissingDataError } from '../common/error/errors';
 import { getCustomerState } from '../customer/customers.mock';
+import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../order';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 import { getOrderRequestBody } from '../order/internal-orders.mock';
@@ -59,7 +60,8 @@ describe('PaymentStrategyActionCreator', () => {
                 new PaymentRequestSender(createPaymentClient()),
                 orderActionCreator,
                 new PaymentRequestTransformer()
-            )
+            ),
+            new HostedFormFactory(store)
         );
         noPaymentDataStrategy = new NoPaymentDataRequiredPaymentStrategy(
             store,

--- a/src/payment/strategies/credit-card/credit-card-payment-initialize-options.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-initialize-options.ts
@@ -1,0 +1,5 @@
+import { HostedFormOptions } from '../../../hosted-form';
+
+export default interface CreditCardPaymentInitializeOptions {
+    form: HostedFormOptions;
+}

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
@@ -2,22 +2,28 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { omit } from 'lodash';
+import { merge, omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
-import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
-import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { getConfig } from '../../../config/configs.mock';
+import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../hosted-form';
+import { LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getOrder } from '../../../order/orders.mock';
 import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
+import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import CreditCardPaymentStrategy from './credit-card-payment-strategy';
 
 describe('CreditCardPaymentStrategy', () => {
+    let formFactory: HostedFormFactory;
     let orderActionCreator: OrderActionCreator;
     let paymentActionCreator: PaymentActionCreator;
     let store: CheckoutStore;
@@ -26,7 +32,7 @@ describe('CreditCardPaymentStrategy', () => {
     let submitPaymentAction: Observable<Action>;
 
     beforeEach(() => {
-        store = createCheckoutStore();
+        store = createCheckoutStore(getCheckoutStoreState());
 
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
@@ -43,7 +49,14 @@ describe('CreditCardPaymentStrategy', () => {
             new SpamProtectionActionCreator(createSpamProtection(createScriptLoader()))
         );
 
-        strategy = new CreditCardPaymentStrategy(store, orderActionCreator, paymentActionCreator);
+        formFactory = new HostedFormFactory(store);
+
+        strategy = new CreditCardPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formFactory
+        );
 
         jest.spyOn(store, 'dispatch');
 
@@ -84,5 +97,83 @@ describe('CreditCardPaymentStrategy', () => {
         } catch (error) {
             expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
         }
+    });
+
+    describe('when hosted form is enabled', () => {
+        let form: Pick<HostedForm, 'attach' | 'submit'>;
+        let initializeOptions: PaymentInitializeOptions;
+        let loadOrderAction: Observable<LoadOrderSucceededAction>;
+        let state: InternalCheckoutSelectors;
+
+        beforeEach(() => {
+            form = {
+                attach: jest.fn(() => Promise.resolve()),
+                submit: jest.fn(() => Promise.resolve()),
+            };
+            initializeOptions = {
+                creditCard: {
+                    form: {
+                        fields: {
+                            [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                            [HostedFieldType.CardName]: { containerId: 'card-name' },
+                            [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                        },
+                    },
+                },
+                methodId: 'authorizenet',
+            };
+            loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
+            state = store.getState();
+
+            jest.spyOn(state.config, 'getStoreConfig')
+                .mockReturnValue(merge(
+                    getConfig().storeConfig,
+                    { checkoutSettings: { isHostedPaymentFormEnabled: true } }
+                ));
+
+            jest.spyOn(orderActionCreator, 'loadCurrentOrder')
+                .mockReturnValue(loadOrderAction);
+
+            jest.spyOn(formFactory, 'create')
+                .mockReturnValue(form);
+        });
+
+        it('creates hosted form', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(formFactory.create)
+                .toHaveBeenCalledWith(
+                    'https://bigpay.integration.zone',
+                    'dc030783-6129-4ee3-8e06-6f4270df1527',
+                    // tslint:disable-next-line:no-non-null-assertion
+                    initializeOptions.creditCard!.form!
+                );
+        });
+
+        it('attaches hosted form to container', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(form.attach)
+                .toHaveBeenCalled();
+        });
+
+        it('submits payment data with hosted form', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(form.submit).toHaveBeenCalledWith(payload.payment);
+        });
+
+        it('loads current order after payment submission', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(loadOrderAction);
+        });
     });
 });

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.ts
@@ -1,4 +1,6 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { HostedForm, HostedFormFactory } from '../../../hosted-form';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
@@ -7,13 +9,58 @@ import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-r
 import PaymentStrategy from '../payment-strategy';
 
 export default class CreditCardPaymentStrategy implements PaymentStrategy {
+    private _hostedForm?: HostedForm;
+
     constructor(
         private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator,
-        private _paymentActionCreator: PaymentActionCreator
+        private _paymentActionCreator: PaymentActionCreator,
+        private _hostedFormFactory: HostedFormFactory
     ) {}
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._isHostedPaymentFormEnabled() ?
+            this._executeWithHostedForm(payload, options) :
+            this._executeWithoutHostedForm(payload, options);
+    }
+
+    finalize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        if (!this._isHostedPaymentFormEnabled()) {
+            return Promise.resolve(this._store.getState());
+        }
+
+        const formOptions = options && options.creditCard && options.creditCard.form;
+        const { config } = this._store.getState();
+        const { paymentSettings: { bigpayBaseUrl: host = '' } = {} } = config.getStoreConfig() || {};
+        const { payment: { formId = '' } = {} } = config.getContextConfig() || {};
+
+        if (!formOptions || !formId) {
+            throw new InvalidArgumentError();
+        }
+
+        const form = this._hostedFormFactory.create(host, formId, formOptions);
+
+        return form.attach()
+            .then(() => {
+                this._hostedForm = form;
+
+                return this._store.getState();
+            });
+    }
+
+    deinitialize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (this._hostedForm) {
+            this._hostedForm.detach();
+        }
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _executeWithoutHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const { payment, ...order } = payload;
         const paymentData = payment && payment.paymentData;
 
@@ -27,15 +74,27 @@ export default class CreditCardPaymentStrategy implements PaymentStrategy {
             );
     }
 
-    finalize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        return Promise.reject(new OrderFinalizationNotRequiredError());
+    private _executeWithHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>  {
+        const { payment, ...order } = payload;
+        const form = this._hostedForm;
+
+        if (!form) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (!payment || !payment.methodId) {
+            throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+
+        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
+            .then(() => form.submit(payment))
+            .then(() => this._store.dispatch(this._orderActionCreator.loadCurrentOrder()));
     }
 
-    initialize(_options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
-    }
+    private _isHostedPaymentFormEnabled(): boolean {
+        const { config } = this._store.getState();
+        const { checkoutSettings: { isHostedPaymentFormEnabled = false } = {} } = config.getStoreConfig() || {};
 
-    deinitialize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
+        return isHostedPaymentFormEnabled;
     }
 }

--- a/src/payment/strategies/credit-card/index.ts
+++ b/src/payment/strategies/credit-card/index.ts
@@ -1,1 +1,2 @@
 export { default as CreditCardPaymentStrategy } from './credit-card-payment-strategy';
+export { default as CreditCardPaymentInitializeOptions } from './credit-card-payment-initialize-options';

--- a/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
@@ -6,6 +6,7 @@ import { merge } from 'lodash';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, SpamProtectionActionCreator } from '../../../order/spam-protection';
@@ -55,6 +56,7 @@ describe('WepayPaymentStrategy', () => {
             store,
             orderActionCreator,
             paymentActionCreator,
+            new HostedFormFactory(store),
             wepayRiskClient
         );
 

--- a/src/payment/strategies/wepay/wepay-payment-strategy.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.ts
@@ -1,6 +1,7 @@
 import { merge } from 'lodash';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
@@ -13,9 +14,10 @@ export default class WepayPaymentStrategy extends CreditCardPaymentStrategy {
         store: CheckoutStore,
         orderActionCreator: OrderActionCreator,
         paymentActionCreator: PaymentActionCreator,
+        hostedFormFactory: HostedFormFactory,
         private _wepayRiskClient: WepayRiskClient
     ) {
-        super(store, orderActionCreator, paymentActionCreator);
+        super(store, orderActionCreator, paymentActionCreator, hostedFormFactory);
     }
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {


### PR DESCRIPTION
## What?
Use a hosted payment form to accept credit card details if the feature is enabled.

## Why?
This allows us to roll out the feature gradually.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
