### PR TITLE
CHECKOUT-4205: Improve the way validation errors are returned to the caller

### DIFF
--- a/src/common/iframe/iframe-event-poster.ts
+++ b/src/common/iframe/iframe-event-poster.ts
@@ -22,11 +22,11 @@ export default class IframeEventPoster<TEvent> {
     }
 
     post(event: TEvent): void;
-    post<TSuccessEvent extends IframeEvent, TErrorEvent extends IframeEvent>(
+    post<TSuccessEvent extends IframeEvent = IframeEvent, TErrorEvent extends IframeEvent = IframeEvent>(
         event: TEvent,
         options: IframeEventPostOptions<TSuccessEvent, TErrorEvent>
     ): Promise<TSuccessEvent>;
-    post<TSuccessEvent extends IframeEvent, TErrorEvent extends IframeEvent>(
+    post<TSuccessEvent extends IframeEvent = IframeEvent, TErrorEvent extends IframeEvent = IframeEvent>(
         event: TEvent,
         options?: IframeEventPostOptions<TSuccessEvent, TErrorEvent>
     ): Promise<TSuccessEvent> | void {

--- a/src/hosted-form/errors/index.ts
+++ b/src/hosted-form/errors/index.ts
@@ -1,2 +1,3 @@
 export { default as InvalidHostedFormConfigError } from './invalid-hosted-form-config-error';
 export { default as InvalidHostedFormError } from './invalid-hosted-form-error';
+export { default as InvalidHostedFormValueError } from './invalid-hosted-form-value-error';

--- a/src/hosted-form/errors/invalid-hosted-form-value-error.ts
+++ b/src/hosted-form/errors/invalid-hosted-form-value-error.ts
@@ -1,0 +1,18 @@
+import { flatMap, map, values } from 'lodash';
+
+import { StandardError } from '../../common/error/errors';
+import { HostedInputValidateErrorDataMap } from '../iframe-content';
+
+export default class InvalidHostedFormValueError extends StandardError {
+    constructor(
+        public errors: HostedInputValidateErrorDataMap
+    ) {
+        super([
+            'Unable to proceed due to invalid user input values',
+            ...flatMap(values(errors), fieldErrors => map(fieldErrors, ({ message }) => message)),
+        ].join('. '));
+
+        this.name = 'InvalidHostedFormValueError';
+        this.type = 'invalid_hosted_form_value';
+    }
+}

--- a/src/hosted-form/hosted-field-events.ts
+++ b/src/hosted-form/hosted-field-events.ts
@@ -5,16 +5,19 @@ import HostedFormOrderData from './hosted-form-order-data';
 export enum HostedFieldEventType {
     AttachRequested = 'HOSTED_FIELD:ATTACH_REQUESTED',
     SubmitRequested = 'HOSTED_FIELD:SUBMITTED_REQUESTED',
+    ValidateRequested = 'HOSTED_FIELD:VALIDATE_REQUESTED',
 }
 
 export interface HostedFieldEventMap {
     [HostedFieldEventType.AttachRequested]: HostedFieldAttachEvent;
     [HostedFieldEventType.SubmitRequested]: HostedFieldSubmitRequestEvent;
+    [HostedFieldEventType.ValidateRequested]: HostedFieldValidateRequestEvent;
 }
 
 export type HostedFieldEvent = (
     HostedFieldAttachEvent |
-    HostedFieldSubmitRequestEvent
+    HostedFieldSubmitRequestEvent |
+    HostedFieldValidateRequestEvent
 );
 
 export interface HostedFieldAttachEvent {
@@ -33,4 +36,8 @@ export interface HostedFieldSubmitRequestEvent {
         data: HostedFormOrderData;
         fields: HostedFieldType[];
     };
+}
+
+export interface HostedFieldValidateRequestEvent {
+    type: HostedFieldEventType.ValidateRequested;
 }

--- a/src/hosted-form/hosted-field.ts
+++ b/src/hosted-form/hosted-field.ts
@@ -3,12 +3,12 @@ import { catchError, switchMap, take } from 'rxjs/operators';
 
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 
-import { InvalidHostedFormConfigError, InvalidHostedFormError } from './errors';
+import { InvalidHostedFormConfigError, InvalidHostedFormError, InvalidHostedFormValueError } from './errors';
 import { HostedFieldEvent, HostedFieldEventType } from './hosted-field-events';
 import HostedFieldType from './hosted-field-type';
 import { HostedFieldStylesMap } from './hosted-form-options';
 import HostedFormOrderData from './hosted-form-order-data';
-import { HostedInputAttachErrorEvent, HostedInputEventMap, HostedInputEventType, HostedInputSubmitErrorEvent } from './iframe-content';
+import { HostedInputAttachErrorEvent, HostedInputEventMap, HostedInputEventType, HostedInputSubmitErrorEvent, HostedInputValidateEvent } from './iframe-content';
 
 export default class HostedField {
     private _iframe: HTMLIFrameElement;
@@ -109,6 +109,18 @@ export default class HostedField {
             }
 
             throw event;
+        }
+    }
+
+    async validate(): Promise<void> {
+        const { payload } = await this._eventPoster.post<HostedInputValidateEvent>({
+            type: HostedFieldEventType.ValidateRequested,
+        }, {
+            successType: HostedInputEventType.Validated,
+        });
+
+        if (!payload.isValid) {
+            throw new InvalidHostedFormValueError(payload.errors);
         }
     }
 

--- a/src/hosted-form/hosted-form-factory.ts
+++ b/src/hosted-form/hosted-form-factory.ts
@@ -42,7 +42,7 @@ export default class HostedFormFactory {
             fields,
             new IframeEventListener(host),
             new HostedFormOrderDataTransformer(this._store),
-            pick(options, 'onBlur', 'onFocus', 'onCardTypeChange', 'onValidateError')
+            pick(options, 'onBlur', 'onFocus', 'onCardTypeChange', 'onValidate')
         );
     }
 }

--- a/src/hosted-form/hosted-form-options.ts
+++ b/src/hosted-form/hosted-form-options.ts
@@ -1,5 +1,5 @@
 import HostedFieldType from './hosted-field-type';
-import { HostedInputBlurEvent, HostedInputCardTypeChangeEvent, HostedInputFocusEvent, HostedInputStyles, HostedInputValidateErrorEvent } from './iframe-content';
+import { HostedInputBlurEvent, HostedInputCardTypeChangeEvent, HostedInputFocusEvent, HostedInputStyles, HostedInputValidateEvent } from './iframe-content';
 
 export default interface HostedFormOptions {
     fields: HostedFieldOptionsMap;
@@ -7,13 +7,13 @@ export default interface HostedFormOptions {
     onBlur?(data: HostedFieldBlurEventData): void;
     onCardTypeChange?(data: HostedFieldCardTypeChangeEventData): void;
     onFocus?(data: HostedFieldFocusEventData): void;
-    onValidateError?(data: HostedFieldValidateErrorEventData): void;
+    onValidate?(data: HostedFieldValidateEventData): void;
 }
 
 export type HostedFieldBlurEventData = HostedInputBlurEvent['payload'];
 export type HostedFieldCardTypeChangeEventData = HostedInputCardTypeChangeEvent['payload'];
 export type HostedFieldFocusEventData = HostedInputFocusEvent['payload'];
-export type HostedFieldValidateErrorEventData = HostedInputValidateErrorEvent['payload'];
+export type HostedFieldValidateEventData = HostedInputValidateEvent['payload'];
 
 export interface HostedFieldOptionsMap {
     [HostedFieldType.CardCode]?: HostedFieldOptions;

--- a/src/hosted-form/hosted-form.spec.ts
+++ b/src/hosted-form/hosted-form.spec.ts
@@ -9,7 +9,7 @@ import { getHostedFormOrderData } from './hosted-form-order-data.mock';
 import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
 
 describe('HostedForm', () => {
-    let callbacks: Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onValidateError'>;
+    let callbacks: Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onValidate'>;
     let eventListener: IframeEventListener<HostedInputEventMap>;
     let fields: HostedField[];
     let form: HostedForm;
@@ -27,7 +27,7 @@ describe('HostedForm', () => {
             onBlur: jest.fn(),
             onFocus: jest.fn(),
             onCardTypeChange: jest.fn(),
-            onValidateError: jest.fn(),
+            onValidate: jest.fn(),
         };
 
         fields = [
@@ -118,16 +118,23 @@ describe('HostedForm', () => {
             .toHaveBeenCalledWith({ cardType: 'visa' });
     });
 
-    it('notifies when validation fails', () => {
-        eventListener.trigger({
-            type: HostedInputEventType.ValidateFailed,
-            payload: { errors: [{ fieldType: HostedFieldType.CardCode, message: 'Missing required data' }] },
-        });
+    it('notifies when validation happens', () => {
+        const payload = {
+            isValid: false,
+            errors: {
+                cardCode: [
+                    { fieldType: HostedFieldType.CardCode, type: 'required', message: 'Missing required data' },
+                ],
+                cardExpiry: [],
+                cardName: [],
+                cardNumber: [],
+            },
+        };
 
-        expect(callbacks.onValidateError)
-            .toHaveBeenCalledWith({
-                errors: [{ fieldType: HostedFieldType.CardCode, message: 'Missing required data' }],
-            });
+        eventListener.trigger({ type: HostedInputEventType.Validated, payload });
+
+        expect(callbacks.onValidate)
+            .toHaveBeenCalledWith(payload);
     });
 
     it('notifies when input receives focus event', () => {

--- a/src/hosted-form/hosted-form.ts
+++ b/src/hosted-form/hosted-form.ts
@@ -10,7 +10,7 @@ import HostedFormOptions from './hosted-form-options';
 import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
 import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
 
-type HostedFormEventCallbacks = Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onValidateError'>;
+type HostedFormEventCallbacks = Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onValidate'>;
 
 export default class HostedForm {
     constructor(
@@ -19,12 +19,12 @@ export default class HostedForm {
         private _payloadTransformer: HostedFormOrderDataTransformer,
         eventCallbacks: HostedFormEventCallbacks
     ) {
-        const { onBlur = noop, onCardTypeChange = noop, onFocus = noop, onValidateError: onValidateError = noop } = eventCallbacks;
+        const { onBlur = noop, onCardTypeChange = noop, onFocus = noop, onValidate = noop } = eventCallbacks;
 
         this._eventListener.addListener(HostedInputEventType.Blurred, ({ payload }) => onBlur(payload));
         this._eventListener.addListener(HostedInputEventType.CardTypeChanged, ({ payload }) => onCardTypeChange(payload));
         this._eventListener.addListener(HostedInputEventType.Focused, ({ payload }) => onFocus(payload));
-        this._eventListener.addListener(HostedInputEventType.ValidateFailed, ({ payload }) => onValidateError(payload));
+        this._eventListener.addListener(HostedInputEventType.Validated, ({ payload }) => onValidate(payload));
     }
 
     async attach(): Promise<void> {
@@ -50,6 +50,10 @@ export default class HostedForm {
             this._fields.map(field => field.getType()),
             this._payloadTransformer.transform(payload)
         );
+    }
+
+    async validate(): Promise<void> {
+        return await this._getNumberField().validate();
     }
 
     private _getNumberField(): HostedField {

--- a/src/hosted-form/iframe-content/hosted-input-events.ts
+++ b/src/hosted-form/iframe-content/hosted-input-events.ts
@@ -2,7 +2,7 @@ import { PaymentErrorData } from '../../common/error';
 import HostedFieldType from '../hosted-field-type';
 
 import HostedInputInitializeErrorData from './hosted-input-initialize-error-data';
-import HostedInputValidateErrorData from './hosted-input-validate-error-data';
+import HostedInputValidateResults from './hosted-input-validate-results';
 
 // Event types
 export enum HostedInputEventType {
@@ -14,7 +14,7 @@ export enum HostedInputEventType {
     Focused = 'HOSTED_INPUT:FOCUSED',
     SubmitSucceeded = 'HOSTED_INPUT:SUBMIT_SUCCEEDED',
     SubmitFailed = 'HOSTED_INPUT:SUBMIT_FAILED',
-    ValidateFailed = 'HOSTED_INPUT:VALIDATE_FAILED',
+    Validated = 'HOSTED_INPUT:VALIDATED',
 }
 
 // Event mapping
@@ -27,7 +27,7 @@ export interface HostedInputEventMap {
     [HostedInputEventType.Focused]: HostedInputFocusEvent;
     [HostedInputEventType.SubmitSucceeded]: HostedInputSubmitSuccessEvent;
     [HostedInputEventType.SubmitFailed]: HostedInputSubmitErrorEvent;
-    [HostedInputEventType.ValidateFailed]: HostedInputValidateErrorEvent;
+    [HostedInputEventType.Validated]: HostedInputValidateEvent;
 }
 
 // Events
@@ -40,7 +40,7 @@ export type HostedInputEvent = (
     HostedInputFocusEvent |
     HostedInputSubmitSuccessEvent |
     HostedInputSubmitErrorEvent |
-    HostedInputValidateErrorEvent
+    HostedInputValidateEvent
 );
 
 export interface HostedInputAttachSuccessEvent {
@@ -93,9 +93,7 @@ export interface HostedInputSubmitErrorEvent {
     };
 }
 
-export interface HostedInputValidateErrorEvent {
-    type: HostedInputEventType.ValidateFailed;
-    payload: {
-        errors: HostedInputValidateErrorData[];
-    };
+export interface HostedInputValidateEvent {
+    type: HostedInputEventType.Validated;
+    payload: HostedInputValidateResults;
 }

--- a/src/hosted-form/iframe-content/hosted-input-initializer.ts
+++ b/src/hosted-form/iframe-content/hosted-input-initializer.ts
@@ -53,6 +53,7 @@ export default class HostedInputInitializer {
 
                 node.style.height = '100%';
                 node.style.width = '100%';
+                node.style.overflow = 'hidden';
                 node.style.padding = '0';
                 node.style.margin = '0';
             });

--- a/src/hosted-form/iframe-content/hosted-input-validate-results.ts
+++ b/src/hosted-form/iframe-content/hosted-input-validate-results.ts
@@ -1,9 +1,10 @@
 import HostedFieldType from '../hosted-field-type';
 
-export default interface HostedInputValidateErrorData {
-    fieldType: string;
-    message: string;
-    type: string;
+import HostedInputValidateErrorData from './hosted-input-validate-error-data';
+
+export default interface HostedInputValidateResults {
+    errors: HostedInputValidateErrorDataMap;
+    isValid: boolean;
 }
 
 export interface HostedInputValidateErrorDataMap {

--- a/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-validator.spec.ts
@@ -1,8 +1,10 @@
+import HostedInputValidateResults from './hosted-input-validate-results';
 import HostedInputValidator from './hosted-input-validator';
 import HostedInputValues from './hosted-input-values';
 
 describe('HostedInputValidator', () => {
     let validData: HostedInputValues;
+    let validResults: HostedInputValidateResults;
     let validator: HostedInputValidator;
 
     beforeEach(() => {
@@ -13,83 +15,146 @@ describe('HostedInputValidator', () => {
             cardNumber: '4111 1111 1111 1111',
         };
 
+        validResults = {
+            isValid: true,
+            errors: {
+                cardExpiry: [],
+                cardName: [],
+                cardNumber: [],
+            },
+        };
+
         validator = new HostedInputValidator();
     });
 
     it('does not throw error if data is valid', async () => {
         expect(await validator.validate(validData))
-            .toEqual([]);
+            .toEqual(validResults);
     });
 
     it('returns error if card number is missing', async () => {
         expect(await validator.validate({ ...validData, cardNumber: '' }))
-            .toEqual([
-                { fieldType: 'cardNumber', message: 'Credit card number is required' },
-                { fieldType: 'cardNumber', message: 'Credit card number must be valid' },
-            ]);
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardNumber: [
+                        { fieldType: 'cardNumber', type: 'required', message: 'Credit card number is required' },
+                        { fieldType: 'cardNumber', type: 'invalid_card_number', message: 'Credit card number must be valid' },
+                    ],
+                },
+            });
     });
 
     it('returns error if card number is invalid', async () => {
         expect(await validator.validate({ ...validData, cardNumber: '9999 9999 9999 9999' }))
-            .toEqual([
-                { fieldType: 'cardNumber', message: 'Credit card number must be valid' },
-            ]);
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardNumber: [
+                        { fieldType: 'cardNumber', type: 'invalid_card_number', message: 'Credit card number must be valid' },
+                    ],
+                },
+            });
     });
 
     it('returns error if card name is missing', async () => {
         expect(await validator.validate({ ...validData, cardName: '' }))
-            .toEqual([
-                { fieldType: 'cardName', message: 'Full name is required' },
-            ]);
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardName: [
+                        { fieldType: 'cardName', type: 'required', message: 'Full name is required' },
+                    ],
+                },
+            });
     });
 
     it('returns error if expiry date is missing', async () => {
         expect(await validator.validate({ ...validData, cardExpiry: '' }))
-            .toEqual([
-                { fieldType: 'cardExpiry', message: 'Expiration date is required' },
-                { fieldType: 'cardExpiry', message: 'Expiration date must be a valid future date in MM / YY format' },
-            ]);
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardExpiry: [
+                        { fieldType: 'cardExpiry', type: 'required', message: 'Expiration date is required' },
+                        { fieldType: 'cardExpiry', type: 'invalid_card_expiry', message: 'Expiration date must be a valid future date in MM / YY format' },
+                    ],
+                },
+            });
     });
 
     it('returns error if expiry date is invalid', async () => {
         expect(await validator.validate({ ...validData, cardExpiry: '2030 / 12' }))
-            .toEqual([
-                { fieldType: 'cardExpiry', message: 'Expiration date must be a valid future date in MM / YY format' },
-            ]);
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardExpiry: [
+                        { fieldType: 'cardExpiry', type: 'invalid_card_expiry', message: 'Expiration date must be a valid future date in MM / YY format' },
+                    ],
+                },
+            });
     });
 
     it('returns error if expiry date is in past', async () => {
-        expect(await validator.validate({ ...validData, cardExpiry: '12 / 10' }))
-            .toEqual([
-                { fieldType: 'cardExpiry', message: 'Expiration date must be a valid future date in MM / YY format' },
-            ]);
+        expect(await validator.validate({ ...validData, cardExpiry: '2030 / 12' }))
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardExpiry: [
+                        { fieldType: 'cardExpiry', type: 'invalid_card_expiry', message: 'Expiration date must be a valid future date in MM / YY format' },
+                    ],
+                },
+            });
     });
 
     it('returns error if card code is missing when required', async () => {
         expect(await validator.validate({ ...validData, cardCode: '' }, { isCardCodeRequired: true }))
-            .toEqual([
-                { fieldType: 'cardCode', message: 'CVV is required' },
-                { fieldType: 'cardCode', message: 'CVV must be valid' },
-            ]);
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardCode: [
+                        { fieldType: 'cardCode', type: 'required', message: 'CVV is required' },
+                        { fieldType: 'cardCode', type: 'invalid_card_code', message: 'CVV must be valid' },
+                    ],
+                },
+            });
     });
 
     it('returns error if card code is invalid when required', async () => {
         expect(await validator.validate({ ...validData, cardCode: '99999' }, { isCardCodeRequired: true }))
-            .toEqual([
-                { fieldType: 'cardCode', message: 'CVV must be valid' },
-            ]);
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardCode: [
+                        { fieldType: 'cardCode', type: 'invalid_card_code', message: 'CVV must be valid' },
+                    ],
+                },
+            });
     });
 
     it('returns error if card code is invalid for given card number', async () => {
         // Card code for American Express should have 4 digts
         expect(await validator.validate({ ...validData, cardCode: '123', cardNumber: '378282246310005' }, { isCardCodeRequired: true }))
-            .toEqual([
-                { fieldType: 'cardCode', message: 'CVV must be valid' },
-            ]);
+            .toEqual({
+                isValid: false,
+                errors: {
+                    ...validResults.errors,
+                    cardCode: [
+                        { fieldType: 'cardCode', type: 'invalid_card_code', message: 'CVV must be valid' },
+                    ],
+                },
+            });
     });
 
     it('does not return error if card code is not required', async () => {
         expect(await validator.validate({ ...validData, cardCode: '' }))
-            .toEqual([]);
+            .toEqual(validResults);
     });
 });

--- a/src/hosted-form/iframe-content/index.ts
+++ b/src/hosted-form/iframe-content/index.ts
@@ -1,8 +1,10 @@
 export * from './hosted-input-events';
 
+export { default as initializeHostedInput } from './initialize-hosted-input';
+export { default as notifyInitializeError } from './notify-initialize-error';
 export { default as CardExpiryFormatter } from './card-expiry-formatter';
 export { default as CardNumberFormatter } from './card-number-formatter';
 export { default as HostedInputStyles } from './hosted-input-styles';
 export { default as HostedInputValues } from './hosted-input-values';
-export { default as initializeHostedInput } from './initialize-hosted-input';
-export { default as notifyInitializeError } from './notify-initialize-error';
+export { default as HostedInputValidateErrorData, HostedInputValidateErrorDataMap } from './hosted-input-validate-error-data';
+export { default as HostedInputValidateResults } from './hosted-input-validate-results';

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.ts
@@ -86,7 +86,8 @@ export default class CreditCardPaymentStrategy implements PaymentStrategy {
             throw new PaymentArgumentInvalidError(['payment.methodId']);
         }
 
-        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
+        return form.validate()
+            .then(() => this._store.dispatch(this._orderActionCreator.submitOrder(order, options)))
             .then(() => form.submit(payment))
             .then(() => this._store.dispatch(this._orderActionCreator.loadCurrentOrder()));
     }


### PR DESCRIPTION
## What?
* Change `onValidateError` callback to `onValidate`. It is now called every time the hosted fields are validated instead of only when an error is detected. It is better this way because not only we need to tell the caller when a validation error occurs so it can display an error message to the end user; we also have to tell the caller when it is fixed so it can remove the error message from the UI.
* Pass the error `type` to the caller when a validation error occurs, i.e.: `invalid_card_number`. The caller can then check the `type` property and display a translated error message accordingly.
* Add a `validate` method to `HostedForm` so it is possible to validate the hosted fields before submitting an order.

## Why?
Without these changes, it's more difficult for the client app to handle validation errors.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
