### PR TITLE
CHECKOUT-4205: Remove CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # @bigcommerce/checkout-sdk
 
-[![CircleCI](https://circleci.com/gh/bigcommerce/checkout-sdk-js/tree/master.svg?style=svg)](https://circleci.com/gh/bigcommerce/checkout-sdk-js/tree/master)
-
 Checkout JS SDK provides you with the tools you need to build your own checkout solution for a BigCommerce store.
 
 The SDK has a convenient application interface for starting and completing a checkout flow. Behind the interface, it handles all the necessary interactions with our Storefront APIs and other payment SDKs. So you can focus on creating a checkout experience that is unique to your business.


### PR DESCRIPTION
## What?
Remove the CircleCI badge.

## Why?
Ever since we've changed our release process, the badge has been showing up as "failed". I think it's because our tag commit is marked as "skipped". As it doesn't get run, it shows up as "failed". I don't really want to spend time figuring out why the badge doesn't show up properly so I'm just going to remove it.

## Testing / Proof
None

@bigcommerce/checkout @bigcommerce/payments
