### PR TITLE
CHECKOUT-4571 Add StepTracker service

### DIFF
--- a/src/analytics/analytics-step-tracker.spec.ts
+++ b/src/analytics/analytics-step-tracker.spec.ts
@@ -1,0 +1,481 @@
+import { createCheckoutService } from '..';
+import { CheckoutService } from '../checkout';
+import { getCheckoutWithCoupons } from '../checkout/checkouts.mock';
+import { InvalidArgumentError } from '../common/error/errors';
+import { ShopperCurrency } from '../config';
+import { getConfig } from '../config/configs.mock';
+import { Order } from '../order';
+import { getOrder } from '../order/orders.mock';
+import { getPaymentMethod } from '../payment/payment-methods.mock';
+import { getShippingOption } from '../shipping/shipping-options.mock';
+
+import AnalyticsStepTracker, { AnalyticStepId, AnalyticStepType } from './analytics-step-tracker';
+
+describe('AnalyticsStepTracker', () => {
+    let checkoutService: CheckoutService;
+    let analyticsStepTracker: AnalyticsStepTracker;
+    let sessionStorage: any;
+    let analytics: any;
+
+    const VIEWED_EVENT_NAME = 'Checkout Step Viewed';
+    const COMPLETED_EVENT_NAME = 'Checkout Step Completed';
+    const storedData = {
+        103: {
+            brand: 'OFS',
+            category: 'Cat 1',
+        },
+        104: {
+            brand: 'Digitalia',
+            category: 'Ebooks, Audio Books',
+        },
+    };
+
+    beforeEach(() => {
+        analytics = { track: jest.fn() };
+        sessionStorage = {
+            getItem: jest.fn(() => JSON.stringify(storedData)),
+            setItem: jest.fn(),
+            removeItem: jest.fn(),
+        };
+
+        checkoutService = createCheckoutService();
+
+        jest.spyOn(checkoutService.getState().data, 'getCheckout')
+            .mockReturnValue(getCheckoutWithCoupons());
+
+        jest.spyOn(checkoutService.getState().data, 'getConfig')
+            .mockReturnValue({
+                ...getConfig().storeConfig,
+                shopperCurrency: {
+                    code: 'JPY',
+                    exchangeRate: 1.01,
+                } as ShopperCurrency,
+            });
+
+        analyticsStepTracker = new AnalyticsStepTracker(
+            checkoutService,
+            sessionStorage,
+            analytics
+        );
+    });
+
+    describe('#trackCheckoutStarted()', () => {
+        beforeEach(() => {
+            analyticsStepTracker.trackCheckoutStarted();
+        });
+
+        it('saves the category and brand data to the storage', () => {
+            expect(sessionStorage.setItem)
+                .toHaveBeenCalledWith(
+                    'ORDER_ITEMS_b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                    JSON.stringify(storedData)
+                );
+        });
+
+        it('only tracks analytics once', () => {
+            analyticsStepTracker.trackCheckoutStarted();
+            analyticsStepTracker.trackCheckoutStarted();
+
+            expect(analytics.track).toBeCalledTimes(1);
+        });
+
+        it('tracks the affiliation', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    affiliation: 's1504098821',
+                })
+            );
+        });
+
+        it('tracks the currency', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    currency: 'JPY',
+                })
+            );
+        });
+
+        it('tracks the expected tax', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    tax: 3.03,
+                })
+            );
+        });
+
+        it('tracks the expected revenue', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    revenue: 191.9,
+                })
+            );
+        });
+
+        it('tracks the expected shipping cost', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    shipping: 15.15,
+                })
+            );
+        });
+
+        it('tracks the coupons', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    coupon: 'savebig2015,279F507D817E3E7',
+                })
+            );
+        });
+
+        it('tracks the products', () => {
+            expect(analytics.track).toHaveBeenCalledWith(
+                'Checkout Started',
+                expect.objectContaining({
+                    products: [{
+                        product_id: 103,
+                        sku: 'CLC',
+                        name: 'Canvas Laundry Cart',
+                        price: 200,
+                        quantity: 1,
+                        image_url: '/images/canvas-laundry-cart.jpg',
+                        brand: 'OFS',
+                        category: 'Cat 1',
+                        variant: 'n:v',
+                    }, {
+                        product_id: 104,
+                        sku: 'CLX',
+                        name: 'Digital Book',
+                        price: 200,
+                        quantity: 1,
+                        image_url: '/images/digital-book.jpg',
+                        brand: 'Digitalia',
+                        category: 'Ebooks, Audio Books',
+                        variant: 'm:l',
+                    }, {
+                        name: '$100 Gift Certificate',
+                        price: 101,
+                        product_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                        quantity: 1,
+                    }],
+                })
+            );
+        });
+    });
+
+    describe('#trackOrderComplete()', () => {
+        describe('when order is not complete', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getOrder').mockReturnValue({
+                    isComplete: false,
+                } as Order);
+                analyticsStepTracker.trackOrderComplete();
+            });
+
+            it('does not send any data', () => {
+                expect(analytics.track).not.toHaveBeenCalled();
+            });
+
+            it('doest not remove the category and brand data from the storage', () => {
+                expect(sessionStorage.removeItem).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when there are no saved items', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getOrder')
+                    .mockReturnValue(getOrder());
+
+                sessionStorage.getItem = jest.fn(() => null);
+                analyticsStepTracker.trackOrderComplete();
+            });
+
+            it('does not send any data', () => {
+                expect(analytics.track).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when there is a complete order', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getOrder')
+                    .mockReturnValue(getOrder());
+
+                analyticsStepTracker.trackOrderComplete();
+            });
+
+            it('tracks the order id', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        orderId: 295,
+                    })
+                );
+            });
+
+            it('tracks the order affiliation', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        affiliation: 's1504098821',
+                    })
+                );
+            });
+
+            it('tracks the order grand total', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        revenue: 191.9,
+                    })
+                );
+            });
+
+            it('tracks the order shipping cost', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        shipping: 15.15,
+                    })
+                );
+            });
+
+            it('tracks the order discount amount', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        discount: 10.1,
+                    })
+                );
+            });
+
+            it('tracks the order coupons as a single, comma-separated string', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        coupon: 'savebig2015,279F507D817E3E7',
+                    })
+                );
+            });
+
+            it('tracks the order currency', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        currency: 'JPY',
+                    })
+                );
+            });
+
+            it('tracks the tax total value', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        tax: 3.03,
+                    })
+                );
+            });
+
+            it('tracks the product list', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    'Order Completed',
+                    expect.objectContaining({
+                        products: [{
+                            product_id: 103,
+                            sku: 'CLC',
+                            name: 'Canvas Laundry Cart',
+                            price: 200,
+                            quantity: 1,
+                            image_url: '/images/canvas-laundry-cart.jpg',
+                            brand: 'OFS',
+                            category: 'Cat 1',
+                            variant: 'n:v',
+                        }, {
+                            product_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                            name: '$100 Gift Certificate',
+                            price: 101,
+                            quantity: 1,
+                        }],
+                    })
+                );
+            });
+
+            it('reads data from session storage', () => {
+                expect(sessionStorage.getItem)
+                    .toHaveBeenCalledWith('ORDER_ITEMS_b20deef40f9699e48671bbc3fef6ca44dc80e3c7');
+            });
+
+            it('removes the category and brand data to the storage', () => {
+                expect(sessionStorage.removeItem)
+                    .toHaveBeenCalledWith('ORDER_ITEMS_b20deef40f9699e48671bbc3fef6ca44dc80e3c7');
+            });
+        });
+    });
+
+    describe('#trackStepViewed()', () => {
+        beforeEach(() => {
+            analyticsStepTracker.trackStepViewed('payment');
+        });
+
+        it('sends step viewed tracking data to GA for the given step with current currency', () => {
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.PAYMENT, currency: 'JPY' });
+        });
+
+        it('sends step completed & viewed tracking data to GA for all the steps before given step (including current step)', () => {
+            expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(AnalyticStepId.CUSTOMER));
+            expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(AnalyticStepId.BILLING));
+            expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(AnalyticStepId.SHIPPING));
+
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.PAYMENT, currency: 'JPY' });
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.CUSTOMER, currency: 'JPY' });
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.BILLING, currency: 'JPY' });
+            expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.SHIPPING, currency: 'JPY' });
+        });
+
+        it('throws exception when custom invaid step order is passed', () => {
+            expect(() => new AnalyticsStepTracker(
+                checkoutService,
+                sessionStorage,
+                analytics,
+                {
+                    checkoutSteps: [
+                        'shipping',
+                        'billying' as AnalyticStepType,
+                        'payment',
+                        'customer',
+                    ],
+                }
+            )).toThrowError(InvalidArgumentError);
+        });
+
+        describe('when custom step order is passed', () => {
+            let analyticsStepTrackerCustomOrder: AnalyticsStepTracker;
+
+            beforeEach(() => {
+                analyticsStepTrackerCustomOrder = new AnalyticsStepTracker(
+                    checkoutService,
+                    sessionStorage,
+                    analytics,
+                    {
+                        checkoutSteps: ['shipping', 'billing', 'payment', 'customer'],
+                    }
+                );
+            });
+
+            it('only sends step viewed and complete for defined previous steps', () => {
+                (analytics.track as jest.Mock).mockClear();
+
+                analyticsStepTrackerCustomOrder.trackStepViewed('billing');
+
+                expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.BILLING, currency: 'JPY' });
+                expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.SHIPPING, currency: 'JPY' });
+                expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(AnalyticStepId.SHIPPING));
+
+                expect(analytics.track).not.toHaveBeenCalledWith(COMPLETED_EVENT_NAME, expect.objectContaining({ step: AnalyticStepId.BILLING }));
+                expect(analytics.track).not.toHaveBeenCalledWith(COMPLETED_EVENT_NAME, expect.objectContaining({ step: AnalyticStepId.PAYMENT }));
+                expect(analytics.track).not.toHaveBeenCalledWith(COMPLETED_EVENT_NAME, expect.objectContaining({ step: AnalyticStepId.CUSTOMER }));
+                expect(analytics.track).not.toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.PAYMENT, currency: 'JPY' });
+                expect(analytics.track).not.toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.CUSTOMER, currency: 'JPY' });
+            });
+        });
+
+        describe('when no checkout steps', () => {
+            let analyticsStepTrackerNoBackfill: AnalyticsStepTracker;
+
+            beforeEach(() => {
+                analyticsStepTrackerNoBackfill = new AnalyticsStepTracker(
+                    checkoutService,
+                    sessionStorage,
+                    analytics,
+                    { checkoutSteps: [] }
+                );
+            });
+
+            it('only sends step viewed event for passed step', () => {
+                (analytics.track as jest.Mock).mockClear();
+
+                analyticsStepTrackerNoBackfill.trackStepViewed('payment');
+
+                expect(analytics.track).not.toHaveBeenCalledWith(COMPLETED_EVENT_NAME, expect.anything());
+
+                expect(analytics.track).toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.PAYMENT, currency: 'JPY' });
+                expect(analytics.track).not.toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.CUSTOMER, currency: 'JPY' });
+                expect(analytics.track).not.toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.BILLING, currency: 'JPY' });
+                expect(analytics.track).not.toHaveBeenCalledWith(VIEWED_EVENT_NAME, { step: AnalyticStepId.SHIPPING, currency: 'JPY' });
+            });
+        });
+    });
+
+    describe('#trackStepCompleted()', () => {
+        describe('when no information is available', () => {
+            beforeEach(() => {
+                analyticsStepTracker.trackStepCompleted('payment');
+            });
+
+            it('sends an empty shippingMethod property when neither paymentMethod nor shippingMethod are specified', () => {
+                expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, buildCompletedPayload(AnalyticStepId.PAYMENT));
+            });
+        });
+
+        describe('when there is information available', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getSelectedShippingOption')
+                    .mockReturnValue(getShippingOption());
+
+                jest.spyOn(checkoutService.getState().data, 'getSelectedPaymentMethod')
+                    .mockReturnValue(getPaymentMethod());
+
+                analyticsStepTracker.trackStepCompleted('payment');
+            });
+
+            it('sends the shippingMethod and payment data', () => {
+                expect(analytics.track).toHaveBeenCalledWith(
+                    COMPLETED_EVENT_NAME,
+                    {
+                        step: AnalyticStepId.PAYMENT,
+                        shippingMethod: 'Flat Rate',
+                        paymentMethod: 'Authorizenet',
+                        currency: 'JPY',
+                    }
+                );
+            });
+
+            it('calls track only once per step', () => {
+                analytics.track.mockReset();
+                analyticsStepTracker.trackStepCompleted('payment');
+                expect(analytics.track).toHaveBeenCalledTimes(0);
+            });
+
+            it('sends step complete event again if different shippingMethod method is selected', () => {
+                jest.spyOn(checkoutService.getState().data, 'getSelectedShippingOption')
+                        .mockReturnValue({
+                            ...getShippingOption(),
+                            id: 'id-foo',
+                            description: 'foo',
+                        });
+
+                jest.spyOn(checkoutService.getState().data, 'getSelectedPaymentMethod')
+                    .mockReturnValue(undefined);
+
+                analyticsStepTracker.trackStepCompleted('shipping');
+
+                expect(analytics.track).toHaveBeenLastCalledWith(
+                    COMPLETED_EVENT_NAME,
+                    {
+                        step: AnalyticStepId.SHIPPING,
+                        shippingMethod: 'foo',
+                        currency: 'JPY',
+                    }
+                );
+            });
+        });
+    });
+
+    function buildCompletedPayload(step: AnalyticStepId) {
+        return { step, shippingMethod: ' ', currency: 'JPY' };
+    }
+});

--- a/src/analytics/analytics-step-tracker.ts
+++ b/src/analytics/analytics-step-tracker.ts
@@ -1,0 +1,459 @@
+import { keys } from 'lodash';
+
+import { LineItemMap } from '../cart';
+import { Checkout, CheckoutService } from '../checkout';
+import { InvalidArgumentError } from '../common/error/errors';
+import { ShopperCurrency, StoreProfile } from '../config';
+import { Coupon } from '../coupon';
+import { Order } from '../order';
+import { ShippingOption } from '../shipping';
+
+import { AnalyticsTracker } from './analytics-tracker-window';
+import StepTracker from './step-tracker';
+
+export interface StepTrackerConfig {
+    checkoutSteps?: AnalyticStepType[];
+}
+
+export type AnalyticStepType = 'customer' | 'shipping' | 'billing' | 'payment';
+
+const ORDER_ITEMS_STORAGE_KEY = 'ORDER_ITEMS';
+
+export enum AnalyticStepId {
+    CUSTOMER = 1,
+    SHIPPING,
+    BILLING,
+    PAYMENT,
+}
+
+const ANALYTIC_STEPS: { [key: string]: AnalyticStepId } = {
+    customer: AnalyticStepId.CUSTOMER,
+    shipping: AnalyticStepId.SHIPPING,
+    billing: AnalyticStepId.BILLING,
+    payment: AnalyticStepId.PAYMENT,
+};
+
+export default class AnalyticsStepTracker implements StepTracker {
+    private _checkoutStarted: boolean = false;
+    private _completedSteps: { [key: string]: boolean } = {};
+    private _viewedSteps: { [key in AnalyticStepId]?: boolean; } = {};
+    private _analyticStepOrder: AnalyticStepType[] = [
+        'customer',
+        'shipping',
+        'billing',
+        'payment',
+    ];
+
+    constructor(
+        private checkoutService: CheckoutService,
+        private storage: StorageFallback,
+        private analytics: AnalyticsTracker,
+        { checkoutSteps }: StepTrackerConfig = {}
+    ) {
+        if (checkoutSteps !== undefined) {
+            if (checkoutSteps.some(value => !(value in ANALYTIC_STEPS))) {
+                throw new InvalidArgumentError(
+                    `Invalid checkout steps provided. Valid values are: ${keys(ANALYTIC_STEPS).join(', ')}.`
+                );
+            }
+            this._analyticStepOrder = checkoutSteps;
+
+        }
+    }
+
+    trackCheckoutStarted(): void {
+        if (this._checkoutStarted) {
+            return;
+        }
+
+        const checkout = this.getCheckout();
+
+        if (!checkout) {
+            return;
+        }
+
+        const {
+            coupons,
+            grandTotal,
+            shippingCostTotal,
+            taxTotal,
+            cart: {
+                lineItems,
+                discountAmount,
+                id,
+            },
+        } = checkout;
+
+        const extraItemsData = this.saveExtraItemsData(id, lineItems);
+
+        this.analytics.track('Checkout Started', this.getTrackingPayload({
+            revenue: grandTotal,
+            shipping: shippingCostTotal,
+            tax: taxTotal,
+            discount: discountAmount,
+            coupons,
+            lineItems,
+            extraItemsData,
+        }));
+
+        this._checkoutStarted = true;
+    }
+
+    trackOrderComplete(): void {
+        const order = this.getOrder();
+
+        if (!order) {
+            return;
+        }
+
+        const {
+            isComplete,
+            orderId,
+            orderAmount,
+            shippingCostTotal,
+            taxTotal,
+            discountAmount,
+            coupons,
+            lineItems,
+            cartId,
+        } = order;
+
+        if (!isComplete) {
+            return;
+        }
+
+        const extraItemsData = this.readExtraItemsData(cartId);
+
+        if (extraItemsData === null) {
+            return;
+        }
+
+        this.analytics.track('Order Completed', this.getTrackingPayload({
+            orderId,
+            revenue: orderAmount,
+            shipping: shippingCostTotal,
+            tax: taxTotal,
+            discount: discountAmount,
+            coupons,
+            extraItemsData,
+            lineItems,
+        }));
+
+        this.clearExtraItemData(cartId);
+    }
+
+    trackStepViewed(step: AnalyticStepType): void {
+        const stepId = this.getIdFromStep(step);
+
+        if (!stepId || this.hasStepViewed(stepId)) {
+            return;
+        }
+
+        this.trackViewed(stepId);
+        this.backfill(stepId);
+    }
+
+    trackStepCompleted(step: AnalyticStepType): void {
+        const stepId = this.getIdFromStep(step);
+
+        if (!stepId || this.hasStepCompleted(stepId)) {
+            return;
+        }
+
+        this.backfill(stepId);
+        this.trackCompleted(stepId);
+    }
+
+    private backfill(stepId: AnalyticStepId): void {
+        for (const i of this._analyticStepOrder) {
+            const id = this.getIdFromStep(i);
+
+            if (!id) {
+                break;
+            }
+
+            if (!this.hasStepViewed(id)) {
+                this.trackViewed(id);
+            }
+
+            if (id === stepId) {
+                break;
+            }
+
+            if (!this.hasStepCompleted(id)) {
+                this.trackCompleted(id);
+            }
+        }
+    }
+
+    private trackCompleted(stepId: AnalyticStepId): void {
+        const shippingMethod = this.getSelectedShippingOption();
+        const { code: currency = '' } = this.getShopperCurrency() || {};
+        const paymentMethod = this.getPaymentMethodName();
+
+        const payload: {
+            step: number;
+            currency: string;
+            shippingMethod?: string;
+            paymentMethod?: string;
+        } = {
+            step: stepId,
+            currency,
+        };
+
+        if (shippingMethod) {
+            payload.shippingMethod = shippingMethod.description;
+        }
+
+        if (paymentMethod) {
+            payload.paymentMethod = paymentMethod;
+        }
+
+        // due to an issue with the way the segment library works, we must send at least one of the two
+        // options--otherwise it rejects the track call with no diagnostic messages. however, if we blindly
+        // include both options, it sends a single comma for the value, which is undesireable. by only adding
+        // one of the two (shippingMethod here being arbitrarily chosen), we always have at least one value, but
+        // never send two empty values.
+        if (!payload.shippingMethod && !payload.paymentMethod) {
+            payload.shippingMethod = ' ';
+        }
+
+        this.analytics.track('Checkout Step Completed', payload);
+
+        const shippingMethodId = shippingMethod ? shippingMethod.id : '';
+        const completedStepId = stepId === AnalyticStepId.SHIPPING ?
+            `${stepId}-${shippingMethodId}` :
+            stepId;
+
+        this._completedSteps[completedStepId] = true;
+    }
+
+    private getTrackingPayload({
+        orderId,
+        revenue,
+        shipping,
+        tax,
+        discount,
+        coupons,
+        extraItemsData,
+        lineItems,
+    }: {
+        orderId?: number;
+        revenue: number;
+        shipping: number;
+        tax: number;
+        discount: number;
+        coupons: Coupon[];
+        extraItemsData: ExtraItemsData;
+        lineItems: LineItemMap;
+    }) {
+        const { code = '' } = this.getShopperCurrency() || {};
+        const { storeName = '' } = this.getStoreProfile() || {};
+
+        return {
+            orderId,
+            affiliation: storeName,
+            revenue: this.toShopperCurrency(revenue),
+            shipping: this.toShopperCurrency(shipping),
+            tax: this.toShopperCurrency(tax),
+            discount: this.toShopperCurrency(discount),
+            coupon: (coupons || []).map(coupon => coupon.code).join(','),
+            currency: code,
+            products: this.getProducts(extraItemsData, lineItems),
+        };
+    }
+
+    private hasStepCompleted(stepId: AnalyticStepId): boolean {
+        const shippingOption = this.getSelectedShippingOption();
+        const shippingMethodId = shippingOption ? shippingOption.id : '';
+
+        return this._completedSteps.hasOwnProperty(stepId) ||
+            (
+                stepId === AnalyticStepId.SHIPPING &&
+                this._completedSteps.hasOwnProperty(`${stepId}-${shippingMethodId}`)
+            );
+    }
+
+    private hasStepViewed(stepId: AnalyticStepId): boolean {
+        return !!this._viewedSteps[stepId];
+    }
+
+    private getIdFromStep(step: string): AnalyticStepId | null {
+        const name = step.split('.');
+
+        return ANALYTIC_STEPS[name[0]] || null;
+    }
+
+    private trackViewed(stepId: AnalyticStepId): void {
+        const currency = this.getShopperCurrency();
+
+        this.analytics.track('Checkout Step Viewed', {
+            step: stepId,
+            currency: currency ? currency.code : '',
+        });
+
+        this._viewedSteps[stepId] = true;
+    }
+
+    private getOrder(): Order | undefined {
+        const { data: { getOrder } } = this.checkoutService.getState();
+
+        return getOrder();
+    }
+
+    private getCheckout(): Checkout | undefined {
+        const { data: { getCheckout } } = this.checkoutService.getState();
+
+        return getCheckout();
+    }
+
+    private getShopperCurrency(): ShopperCurrency | undefined {
+        const { data: { getConfig } } = this.checkoutService.getState();
+        const config = getConfig();
+
+        return config && config.shopperCurrency;
+    }
+
+    private getStoreProfile(): StoreProfile | undefined {
+        const { data: { getConfig } } = this.checkoutService.getState();
+        const config = getConfig();
+
+        return config && config.storeProfile;
+    }
+
+    private toShopperCurrency(amount: number): number {
+        const { exchangeRate = 1 } = this.getShopperCurrency() || {};
+
+        return Math.round(amount * exchangeRate * 100) / 100;
+    }
+
+    private saveExtraItemsData(id: string, lineItems: LineItemMap): ExtraItemsData {
+        const data = [
+            ...lineItems.physicalItems,
+            ...lineItems.digitalItems,
+        ].reduce((result, item) => {
+            result[item.productId] = {
+                brand: item.brand ? item.brand : '',
+                category: item.categoryNames ? item.categoryNames.join(', ') : '',
+            };
+
+            return result;
+        }, {} as ExtraItemsData);
+
+        try {
+            this.storage.setItem(this.getStorageKey(id), JSON.stringify(data));
+
+            return data;
+        } catch (err) {
+            return {};
+        }
+    }
+
+    private getStorageKey(id: string): string {
+        return id ? `${ORDER_ITEMS_STORAGE_KEY}_${id}` : '';
+    }
+
+    private readExtraItemsData(id: string): ExtraItemsData | null {
+        try {
+            const item = this.storage.getItem(this.getStorageKey(id));
+
+            return item ? JSON.parse(item) : null;
+        } catch (err) {
+            return null;
+        }
+    }
+
+    private clearExtraItemData(id: string): void {
+        try {
+            this.storage.removeItem(this.getStorageKey(id));
+        } catch (err) {
+            // silently ignore the failure
+        }
+    }
+
+    private getSelectedShippingOption(): ShippingOption | null {
+        const { data } = this.checkoutService.getState();
+        const shippingOption = data.getSelectedShippingOption();
+
+        return (shippingOption && shippingOption.id && shippingOption.description) ?
+            shippingOption :
+            null;
+    }
+
+    private getPaymentMethodName(): string {
+        const { data } = this.checkoutService.getState();
+        const paymentMethod = data.getSelectedPaymentMethod();
+
+        return (paymentMethod && paymentMethod.config) ?
+            paymentMethod.config.displayName || '' :
+            '';
+    }
+
+    private getProducts(itemsData: ExtraItemsData, lineItems: LineItemMap): AnalyticsProduct[] {
+        const customItems: AnalyticsProduct[] = (lineItems.customItems || []).map(item => ({
+            product_id: item.id,
+            sku: item.sku,
+            price: item.listPrice,
+            quantity: item.quantity,
+            name: item.name,
+        }));
+
+        const giftCertificateItems: AnalyticsProduct[] = lineItems.giftCertificates.map(item => {
+            return {
+                product_id: item.id,
+                price: this.toShopperCurrency(item.amount),
+                name: item.name,
+                quantity: 1,
+            };
+        });
+
+        const physicalAndDigitalItems: AnalyticsProduct[] = [
+            ...lineItems.physicalItems,
+            ...lineItems.digitalItems,
+        ].map(item => {
+            let itemAttributes;
+
+            if (item.options && item.options.length) {
+                itemAttributes = item.options.map(option => `${option.name}:${option.value}`);
+                itemAttributes.sort();
+            }
+
+            return {
+                product_id: item.productId,
+                sku: item.sku,
+                price: item.listPrice,
+                image_url: item.imageUrl,
+                name: item.name,
+                quantity: item.quantity,
+                brand: itemsData[item.productId] ? itemsData[item.productId].brand : '',
+                category: itemsData[item.productId] ? itemsData[item.productId].category : '',
+                variant: (itemAttributes || []).join(', '),
+            };
+        });
+
+        return [
+            ...customItems,
+            ...physicalAndDigitalItems,
+            ...giftCertificateItems,
+        ];
+    }
+}
+
+export interface AnalyticsProduct {
+    product_id: string | number;
+    price: number;
+    quantity: number;
+    name: string;
+    sku?: string;
+    image_url?: string;
+    category?: string;
+    variant?: string;
+    brand?: string;
+}
+
+export interface ExtraItemsData {
+    [productId: string]: {
+        brand: string;
+        category: string;
+    };
+}

--- a/src/analytics/analytics-tracker-window.ts
+++ b/src/analytics/analytics-tracker-window.ts
@@ -1,0 +1,7 @@
+export interface AnalyticsTracker {
+    track(step: string, data: any): void;
+}
+
+export default interface AnalyticsTrackerWindow extends Window {
+    analytics: AnalyticsTracker;
+}

--- a/src/analytics/create-step-tracker.spec.ts
+++ b/src/analytics/create-step-tracker.spec.ts
@@ -1,0 +1,72 @@
+import { createCheckoutService, CheckoutService } from '../checkout';
+import { MissingDataError } from '../common/error/errors';
+import { StoreConfig } from '../config';
+
+import AnalyticsStepTracker from './analytics-step-tracker';
+import AnalyticsTrackerWindow, { AnalyticsTracker } from './analytics-tracker-window';
+import createStepTracker from './create-step-tracker';
+import NoopStepTracker from './noop-step-tracker';
+
+declare let window: AnalyticsTrackerWindow;
+
+describe('createStepTracker', () => {
+    let checkoutService: CheckoutService;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+    });
+
+    describe('#createStepTracker()', () => {
+        describe('when checkoutService has not been initialized', () => {
+            it('returns instance of noop logger', () => {
+                expect(() => createStepTracker(checkoutService)).toThrowError(MissingDataError);
+            });
+        });
+
+        describe('when window.analytics is undefined', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                    checkoutSettings: {
+                        isAnalyticsEnabled: true,
+                    },
+                } as StoreConfig);
+            });
+
+            it('returns instance of noop logger', () => {
+                expect(createStepTracker(checkoutService)).toBeInstanceOf(NoopStepTracker);
+            });
+        });
+
+        describe('when analytics settings is disabled', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                    checkoutSettings: {
+                        isAnalyticsEnabled: false,
+                    },
+                } as StoreConfig);
+
+                window.analytics = {} as AnalyticsTracker;
+            });
+
+            it('returns instance of noop logger', () => {
+                expect(createStepTracker(checkoutService)).toBeInstanceOf(NoopStepTracker);
+            });
+        });
+
+        describe('when window.analytics is defined and analytics setting enabled', () => {
+            beforeEach(() => {
+                jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue({
+                    checkoutSettings: {
+                        isAnalyticsEnabled: true,
+                    },
+                } as StoreConfig);
+
+                window.analytics = {} as AnalyticsTracker;
+            });
+
+            it('returns instance of AnalyticsStepTracker', () => {
+                expect(createStepTracker(checkoutService)).toBeInstanceOf(AnalyticsStepTracker);
+            });
+        });
+    });
+});

--- a/src/analytics/create-step-tracker.ts
+++ b/src/analytics/create-step-tracker.ts
@@ -1,0 +1,55 @@
+import localStorageFallback from 'local-storage-fallback';
+
+import { CheckoutService } from '../checkout';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+
+import AnalyticsStepTracker, { StepTrackerConfig } from './analytics-step-tracker';
+import { isAnalyticsTrackerWindow } from './is-analytics-step-tracker-window';
+import NoopStepTracker from './noop-step-tracker';
+import StepTracker from './step-tracker';
+
+/**
+ * Creates an instance of `StepTracker`.
+ *
+ * @remarks
+ * ```js
+ * const checkoutService = createCheckoutService();
+ * await checkoutService.loadCheckout();
+ * const stepTracker = createStepTracker(checkoutService);
+ *
+ * stepTracker.trackCheckoutStarted();
+ * ```
+ *
+ * @alpha
+ * Please note that `StepTracker` is currently in an early stage
+ * of development. Therefore the API is unstable and not ready for public
+ * consumption.
+ *
+ * @param CheckoutService - An instance of CheckoutService
+ * @param StepTrackerConfig - A step tracker config object
+ * @returns an instance of `StepTracker`.
+ */
+export default function createStepTracker(
+    checkoutService: CheckoutService,
+    stepTrackerConfig?: StepTrackerConfig
+): StepTracker {
+    const { data } = checkoutService.getState();
+    const config = data.getConfig();
+
+    if (!config) {
+        throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+    }
+
+    const { isAnalyticsEnabled } = config.checkoutSettings;
+
+    if (isAnalyticsEnabled && isAnalyticsTrackerWindow(window)) {
+        return new AnalyticsStepTracker(
+            checkoutService,
+            localStorageFallback,
+            window.analytics,
+            stepTrackerConfig
+        );
+    }
+
+    return new NoopStepTracker();
+}

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -1,0 +1,2 @@
+export { default as createStepTracker } from './create-step-tracker';
+export { default as StepTracker } from './step-tracker';

--- a/src/analytics/is-analytics-step-tracker-window.ts
+++ b/src/analytics/is-analytics-step-tracker-window.ts
@@ -1,0 +1,5 @@
+import AnalyticsTrackerWindow from './analytics-tracker-window';
+
+export function isAnalyticsTrackerWindow(window: Window): window is AnalyticsTrackerWindow {
+    return Boolean((window as AnalyticsTrackerWindow).analytics);
+}

--- a/src/analytics/noop-step-tracker.ts
+++ b/src/analytics/noop-step-tracker.ts
@@ -1,0 +1,19 @@
+import StepTracker from './step-tracker';
+
+export default class NoopStepTracker implements StepTracker {
+    trackCheckoutStarted(): void {
+        return;
+    }
+
+    trackOrderComplete(): void {
+        return;
+    }
+
+    trackStepViewed(): void {
+        return;
+    }
+
+    trackStepCompleted(): void {
+        return;
+    }
+}

--- a/src/analytics/step-tracker.ts
+++ b/src/analytics/step-tracker.ts
@@ -1,0 +1,6 @@
+export default interface StepTracker {
+    trackOrderComplete(): void;
+    trackCheckoutStarted(): void;
+    trackStepViewed(step: string): void;
+    trackStepCompleted(step: string): void;
+}

--- a/src/cart/internal-carts.mock.ts
+++ b/src/cart/internal-carts.mock.ts
@@ -33,28 +33,28 @@ export function getCart(): InternalCart {
             {
                 id: '667',
                 type: 'ItemDigitalEntity',
-                name: 'Canvas Laundry Cart',
+                name: 'Digital Book',
                 downloadsPageUrl: 'url.php',
-                imageUrl: '/images/canvas-laundry-cart.jpg',
+                imageUrl: '/images/digital-book.jpg',
                 quantity: 1,
-                brand: 'OFS',
-                sku: 'CLC',
+                brand: 'Digitalia',
+                sku: 'CLX',
                 amount: 200,
                 discount: 0,
                 amountAfterDiscount: 200,
                 attributes: [
                     {
-                        name: 'n',
-                        value: 'v',
+                        name: 'm',
+                        value: 'l',
                     },
                 ],
                 integerAmount: 20000,
                 integerDiscount: 0,
                 integerAmountAfterDiscount: 20000,
-                variantId: 71,
+                variantId: 72,
                 addedByPromotion: false,
-                productId: 103,
-                categoryNames: ['Cat 1'],
+                productId: 104,
+                categoryNames: ['Ebooks', 'Audio Books'],
             },
             {
                 id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
@@ -148,8 +148,8 @@ export function getCart(): InternalCart {
             amount: 0,
         },
         taxSubtotal: {
-            amount: 0,
-            integerAmount: 0,
+            amount: 3,
+            integerAmount: 300,
         },
         taxes: [
             {
@@ -158,8 +158,8 @@ export function getCart(): InternalCart {
             },
         ],
         taxTotal: {
-            amount: 0,
-            integerAmount: 0,
+            amount: 3,
+            integerAmount: 300,
         },
         handling: {
             amount: 8,

--- a/src/cart/line-items.mock.ts
+++ b/src/cart/line-items.mock.ts
@@ -39,15 +39,15 @@ export function getPhysicalItem(): PhysicalItem {
 export function getDigitalItem(): DigitalItem {
     return {
         id: '667',
-        variantId: 71,
-        productId: 103,
-        sku: 'CLC',
-        name: 'Canvas Laundry Cart',
-        url: '/canvas-laundry-cart/',
+        variantId: 72,
+        productId: 104,
+        sku: 'CLX',
+        name: 'Digital Book',
+        url: '/digital-book/',
         quantity: 1,
-        brand: 'OFS',
+        brand: 'Digitalia',
         isTaxable: true,
-        imageUrl: '/images/canvas-laundry-cart.jpg',
+        imageUrl: '/images/digital-book.jpg',
         discounts: [],
         discountAmount: 0,
         couponAmount: 0,
@@ -63,14 +63,14 @@ export function getDigitalItem(): DigitalItem {
         addedByPromotion: false,
         options: [
             {
-                name: 'n',
+                name: 'm',
                 nameId: 1,
-                value: 'v',
+                value: 'l',
                 valueId: 3,
             },
         ],
         categories: [[{name: 'Cat 1'}], [{name: 'Cat 2'}], [{name: 'Cat 3'}]],
-        categoryNames: ['Cat 1'],
+        categoryNames: ['Ebooks', 'Audio Books'],
     };
 }
 

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -43,7 +43,7 @@ export function getCheckout(): Checkout {
         shippingCostTotal: 15,
         shippingCostBeforeDiscount: 20,
         handlingCostTotal: 8,
-        taxTotal: 0,
+        taxTotal: 3,
         subtotal: 190,
         grandTotal: 190,
         outstandingBalance: 190,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 export * from './config-actions';
 
-export { default as Config, StoreConfig } from './config';
+export { default as Config, StoreConfig, StoreProfile, ShopperCurrency } from './config';
 export { default as ConfigActionCreator } from './config-action-creator';
 export { default as ConfigSelector, ConfigSelectorFactory, createConfigSelectorFactory } from './config-selector';
 export { default as configReducer } from './config-reducer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { embedCheckout } from './embedded-checkout';
 export { createEmbeddedCheckoutMessenger } from './embedded-checkout/iframe-content';
 export { createLanguageService } from './locale';
 export { createCurrencyService } from './currency';
+export { createStepTracker } from './analytics';


### PR DESCRIPTION
## What?
Adds step tracker service. This has been extracted from https://github.com/bigcommerce/checkout-js/tree/master/src/app/analytics with the difference that the backfill is off by default, and a custom step order can be passed.

## Why?
So custom checkouts built using Checkout SDK can benefit from enhance e-commerce.

## Testing / Proof
unit

@bigcommerce/checkout
