### PR TITLE
CHECKOUT-4421 Preselect billing country when billing address has not been set

### DIFF
--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -70,8 +70,79 @@ describe('CheckoutStoreSelector', () => {
         expect(selector.getCustomer()).toEqual(internalSelectors.customer.getCustomer());
     });
 
-    it('returns billing address', () => {
-        expect(selector.getBillingAddress()).toEqual(internalSelectors.billingAddress.getBillingAddress());
+    describe('#getBillingAddress()', () => {
+        it('returns billing address', () => {
+            expect(selector.getBillingAddress()).toEqual(internalSelectors.billingAddress.getBillingAddress());
+        });
+
+        it('returns geo-ip dummy billing address when billing address is undefined', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.billingAddress, 'getBillingAddress').mockReturnValue(undefined);
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getBillingAddress()).toEqual({
+                id: '',
+                address1: '',
+                address2: '',
+                city: '',
+                company: '',
+                country: '',
+                customFields: [],
+                email: '',
+                firstName: '',
+                lastName: '',
+                phone: '',
+                postalCode: '',
+                stateOrProvince: '',
+                stateOrProvinceCode: '',
+                countryCode: 'AU',
+            });
+        });
+
+        it('returns geo-ip dummy billing address when only email is defined in billing address', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.billingAddress, 'getBillingAddress')
+                .mockReturnValue({
+                    email: 'foo@bar.com',
+                    id: '2',
+                    address1: '',
+                    customFields: [],
+                });
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getBillingAddress()).toEqual({
+                id: '2',
+                address1: '',
+                address2: '',
+                city: '',
+                company: '',
+                country: '',
+                customFields: [],
+                email: 'foo@bar.com',
+                firstName: '',
+                lastName: '',
+                phone: '',
+                postalCode: '',
+                stateOrProvince: '',
+                stateOrProvinceCode: '',
+                countryCode: 'AU',
+            });
+        });
+
+        it('returns undefined if getBillingAddress & geoIp are not present', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.billingAddress, 'getBillingAddress').mockReturnValue(undefined);
+            jest.spyOn(internalSelectors.config, 'getContextConfig').mockReturnValue(undefined);
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getBillingAddress()).toBeUndefined();
+        });
     });
 
     describe('#getShippingAddress()', () => {


### PR DESCRIPTION
## What?
Preselect billing country when billing address has not been set

## Why?
So customers don't have to manually preselect country in billing section. This way, if merchant has google autocomplete feature, customers will get suggestions as they type address line 1 in billing section, without having to select a country first.

## Testing / Proof
unit

![billing](https://user-images.githubusercontent.com/1621894/70495083-a60f0000-1b61-11ea-8265-3cea44c13443.gif)


@bigcommerce/checkout @bigcommerce/payments
