### PR TITLE
[WIP] fix(integrations): INT-2059 Lowercase validation for methodId

### DIFF
--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -146,6 +146,7 @@ describe('PaypalButtonStrategy', () => {
 
             await strategy.initialize(options);
         } catch (error) {
+            console.log(error);
             expect(error).toBeInstanceOf(MissingDataError);
         }
     });

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -145,8 +145,7 @@ describe('PaypalButtonStrategy', () => {
             } as CheckoutButtonInitializeOptions;
 
             await strategy.initialize(options);
-        } catch (error) {
-            console.log(error);
+        } catch (error) {        
             expect(error).toBeInstanceOf(MissingDataError);
         }
     });

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -145,7 +145,7 @@ describe('PaypalButtonStrategy', () => {
             } as CheckoutButtonInitializeOptions;
 
             await strategy.initialize(options);
-        } catch (error) {        
+        } catch (error) {
             expect(error).toBeInstanceOf(MissingDataError);
         }
     });

--- a/src/payment/payment-method-selector.ts
+++ b/src/payment/payment-method-selector.ts
@@ -33,7 +33,7 @@ export function createPaymentMethodSelectorFactory(): PaymentMethodSelectorFacto
     const getPaymentMethod = createSelector(
         (state: PaymentMethodState) => state.data,
         paymentMethods => (methodId: string, gatewayId?: string) => {
-            const lowerCaseMethod = methodId.toLowerCase();
+            const lowerCaseMethod = methodId ? methodId.toLowerCase() : '';
 
             return gatewayId ?
                 find(paymentMethods, paymentMethod => {

--- a/src/payment/payment-method-selector.ts
+++ b/src/payment/payment-method-selector.ts
@@ -33,9 +33,15 @@ export function createPaymentMethodSelectorFactory(): PaymentMethodSelectorFacto
     const getPaymentMethod = createSelector(
         (state: PaymentMethodState) => state.data,
         paymentMethods => (methodId: string, gatewayId?: string) => {
+            const lowerCaseMethod = methodId.toLowerCase();
+
             return gatewayId ?
-                find(paymentMethods, { id: methodId, gateway: gatewayId }) :
-                find(paymentMethods, { id: methodId });
+                find(paymentMethods, paymentMethod => {
+                    return (paymentMethod.id.toLowerCase() === lowerCaseMethod && paymentMethod.gateway === gatewayId);
+                }) :
+                find(paymentMethods, paymentMethod => {
+                    return (paymentMethod.id.toLowerCase() === lowerCaseMethod);
+                });
         }
     );
 


### PR DESCRIPTION
## What? [INT-2059](https://jira.bigcommerce.com/browse/INT-2059)

Adding lowercase validation for methodId on Payment Method retrieval

## Why?

When checking out using Adyen as Gateway some of the Payment Methods comes in mixed Upper and Lower Case, as you can see in the example below:

![image](https://user-images.githubusercontent.com/51794862/70592181-7d592b80-1b9e-11ea-96ff-50fbd1179060.png)

So, the `getPaymentMethod` method transforms the selected `methodId` and all the payment method listed on the `paymentMethods` array to lowercase in order to make a proper comparison and retrieve the selected Payment Method data.


## Testing / Proof

![int-2059](https://user-images.githubusercontent.com/51794862/70597006-d5972a00-1bac-11ea-91ea-8fb641ae3fd0.gif)


Ping @bigcommerce/checkout @bigcommerce/payments
