### PR TITLE
fix(payments): INT-2195 Fix barclaycard supported instrument mapping

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -49,9 +49,9 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'paymetric',
         method: 'credit_card',
     },
-    card: {
+    'barclaycard.card': {
         provider: 'barclaycard',
-        method: 'card',
+        method: 'credit_card',
     },
 };
 


### PR DESCRIPTION
## What? [INT-2195](https://jira.bigcommerce.com/browse/INT-2195)
Change how barclaycard's supported Instruments are mapped.

## Why? 

After https://github.com/bigcommerce/checkout-sdk-js/pull/743 was merged, supported Instruments mapping method changed while barclaycard was in development, it must be changed to match with the new mapping method used so the vaulted cards can be displayed.

## Testing / Proof
<img width="1502" alt="Screen Shot 2019-12-11 at 10 57 23 AM" src="https://user-images.githubusercontent.com/35502707/70642572-0acf6680-1c05-11ea-8fca-5245cf2e130f.png">


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
