### PR TITLE
CHECKOUT-4421: Return billing address if it is partially complete

### DIFF
--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -143,6 +143,17 @@ describe('CheckoutStoreSelector', () => {
 
             expect(selector.getBillingAddress()).toBeUndefined();
         });
+
+        it('returns address if address is partially defined but geo IP is not defined', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.billingAddress, 'getBillingAddress').mockReturnValue({ email: 'foo@bar.com' });
+            jest.spyOn(internalSelectors.config, 'getContextConfig').mockReturnValue(undefined);
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getBillingAddress()).toEqual({ email: 'foo@bar.com' });
+        });
     });
 
     describe('#getShippingAddress()', () => {

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -326,7 +326,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
 
             if (isEmptyBillingAddress) {
                 if (!context || !context.geoCountryCode) {
-                    return;
+                    return billingAddress;
                 }
 
                 return {


### PR DESCRIPTION
## What?
Return the billing address if it is partially complete and the geo IP of the shopper can't be determined.

## Why?
Otherwise, if the geo IP can't be determined, `getBillingAddress` will always returned undefined even if `email` is already provided for the billing address.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
