### PR TITLE
CHECKOUT-4205: Reload checkout page if for some reason form expires or invalidates after initial page load

### DIFF
--- a/src/hosted-form/hosted-form-factory.ts
+++ b/src/hosted-form/hosted-form-factory.ts
@@ -3,6 +3,7 @@ import { pick } from 'lodash';
 import { ReadableCheckoutStore } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import { BrowserStorage } from '../common/storage';
 import { CardInstrument } from '../payment/instrument';
 
 import HostedField from './hosted-field';
@@ -10,6 +11,8 @@ import HostedFieldType from './hosted-field-type';
 import HostedForm from './hosted-form';
 import HostedFormOptions, { HostedCardFieldOptionsMap, HostedStoredCardFieldOptionsMap } from './hosted-form-options';
 import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
+
+const STORAGE_NAMESPACE = 'BigCommerce.HostedField';
 
 export default class HostedFormFactory {
     constructor(
@@ -38,6 +41,8 @@ export default class HostedFormFactory {
                     options.styles || {},
                     new IframeEventPoster(host),
                     new IframeEventListener(host),
+                    new BrowserStorage(STORAGE_NAMESPACE),
+                    window.location,
                     'instrumentId' in fieldOptions ?
                         this._getCardInstrument(fieldOptions.instrumentId) :
                         undefined


### PR DESCRIPTION
## What?
Reload the checkout page if, for some reason, the form expires or invalidates after the initial page load.

## Why?
This error scenario can potentially happen. This is a measure to prevent it from happening. By reloading the page, the shopper can generate a new payment form and recover from the error.

I've also added in a check to make sure the shopper won't get into a redirect loop - just in case if there's anything unexpected that prevents the recovery attempt from working.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
