### PR TITLE
fix(payment): PAYMENTS-4997 After deleting a PP account from checkout,…

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -996,17 +996,21 @@ describe('CheckoutService', () => {
     describe('#deleteInstrument()', () => {
         it('deletes an instrument', async () => {
             const instrumentId = '456';
-            const action = of(createAction('DELETE_INSTRUMENT'));
-
+            const deleteAction = of(createAction('DELETE_INSTRUMENT'));
             jest.spyOn(instrumentActionCreator, 'deleteInstrument')
-                .mockReturnValue(action);
+                .mockReturnValue(deleteAction);
 
             jest.spyOn(store, 'dispatch');
+
+            const loadAction = of(createAction('LOAD_INSTRUMENTS'));
+            jest.spyOn(instrumentActionCreator, 'loadInstruments')
+                .mockReturnValue(loadAction);
 
             await checkoutService.deleteInstrument(instrumentId);
 
             expect(instrumentActionCreator.deleteInstrument).toHaveBeenCalledWith(instrumentId);
-            expect(store.dispatch).toHaveBeenCalledWith(action, undefined);
+            expect(store.dispatch).toHaveBeenCalledWith(deleteAction, undefined);
+            expect(instrumentActionCreator.loadInstruments).toHaveBeenCalled();
         });
     });
 

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -1054,7 +1054,8 @@ export default class CheckoutService {
     deleteInstrument(instrumentId: string): Promise<CheckoutSelectors> {
         const action = this._instrumentActionCreator.deleteInstrument(instrumentId);
 
-        return this._dispatch(action);
+        return this._dispatch(action)
+            .then(() => this.loadInstruments());
     }
 
     /**

--- a/src/payment/instrument/instrument-reducer.spec.ts
+++ b/src/payment/instrument/instrument-reducer.spec.ts
@@ -1,5 +1,3 @@
-import { reject } from 'lodash';
-
 import { createRequestErrorFactory } from '../../common/error';
 import { getErrorResponse } from '../../common/http-request/responses.mock';
 
@@ -92,7 +90,7 @@ describe('instrumentReducer()', () => {
 
         expect(instrumentReducer(initialState, action)).toEqual({
             ...initialState,
-            data: reject(initialInstruments, initialInstruments[0]),
+            data: initialInstruments,
             meta: action.meta,
             errors: { deleteError: undefined },
             statuses: {

--- a/src/payment/instrument/instrument-reducer.ts
+++ b/src/payment/instrument/instrument-reducer.ts
@@ -29,11 +29,6 @@ function dataReducer(
     case InstrumentActionType.LoadInstrumentsSucceeded:
         return arrayReplace(data, action.payload && action.payload.vaultedInstruments || []);
 
-    case InstrumentActionType.DeleteInstrumentSucceeded:
-        return arrayReplace(data, data.filter(instrument =>
-            instrument.bigpayToken !== (action.meta && action.meta.instrumentId)
-        ));
-
     default:
         return data;
     }


### PR DESCRIPTION
… all accounts with same email are deleted but not removed from available vaulted accounts list unless page is refreshed

## What?
After an account instrument is deleted from checkout manage modal, the available vaulted accounts when returning from instruments manage modal are updated to fetch the new vaulted accounts list from backend, rather than filtering it on frontend.

## Why?
Deleting a vaulted account actually deletes all vaulted accounts with the same email address on DB. This should be reflected properly on UI. 

Before this PR, If a PP account is vaulted twice as two instruments for the same customer on the same store, when one of those instruments is deleted, the other instrument for the same PP account is also deleted on DB. However, after returning from Manage modal to checkout page, the user finds the other instrument of the same account in the list of available vaulted accounts while it's actually deleted. The correct list is not fetched unless the page in refreshed.

## Testing / Proof
Unit Tests
Screen records

**Before**
![Screen Recording 2020-01-14 at 10 46 19 am](https://user-images.githubusercontent.com/36555311/72301631-836d8b00-36bb-11ea-95f4-7e811f67b941.gif)

**After**
![Screen Recording 2020-01-14 at 10 13 24 am](https://user-images.githubusercontent.com/36555311/72301147-ff66d380-36b9-11ea-90a4-fab27845cf9d.gif)

@bigcommerce/checkout @bigcommerce/payments
