### PR TITLE
CHECKOUT-3818 Update coupon state when shipping option is updated

### DIFF
--- a/src/coupon/coupon-reducer.spec.ts
+++ b/src/coupon/coupon-reducer.spec.ts
@@ -7,6 +7,7 @@ import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 import { OrderActionType } from '../order';
 import { getOrder } from '../order/orders.mock';
+import { ConsignmentActionType } from '../shipping';
 
 import { CouponActionType } from './coupon-actions';
 import couponReducer from './coupon-reducer';
@@ -25,6 +26,14 @@ describe('couponReducer()', () => {
 
     it('returns new state when coupon gets removed', () => {
         const action = createAction(CouponActionType.RemoveCouponSucceeded, getCheckout());
+
+        expect(couponReducer(initialState, action)).toEqual(expect.objectContaining({
+            data: [],
+        }));
+    });
+
+    it('returns new state when shipping option is updated', () => {
+        const action = createAction(ConsignmentActionType.UpdateShippingOptionSucceeded, getCheckout());
 
         expect(couponReducer(initialState, action)).toEqual(expect.objectContaining({
             data: [],

--- a/src/coupon/coupon-reducer.ts
+++ b/src/coupon/coupon-reducer.ts
@@ -4,6 +4,7 @@ import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
 import { arrayReplace, objectSet } from '../common/utility';
 import { OrderAction, OrderActionType } from '../order';
+import { ConsignmentAction, ConsignmentActionType } from '../shipping';
 
 import Coupon from './coupon';
 import { CouponAction, CouponActionType } from './coupon-actions';
@@ -24,11 +25,12 @@ export default function couponReducer(
 
 function dataReducer(
     data: Coupon[] | undefined,
-    action: CouponAction | CheckoutAction | OrderAction
+    action: CouponAction | CheckoutAction | OrderAction | ConsignmentAction
 ): Coupon[] | undefined {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutSucceeded:
     case CouponActionType.ApplyCouponSucceeded:
+    case ConsignmentActionType.UpdateShippingOptionSucceeded:
     case CouponActionType.RemoveCouponSucceeded:
     case OrderActionType.LoadOrderSucceeded:
         return arrayReplace(data, action.payload && action.payload.coupons);


### PR DESCRIPTION
## What?
Update coupon state when shipping option is updated successfully.

## Why?
Because some coupon codes are linked to specific shipping options. If a coupon linked to a shipping option was added, but then a different shipping option was selected, the API automatically removes the coupon code. We need to reflect this in the checkout state otherwise it will cause problems preventing checking out.

## Testing / Proof
unit

![coupon](https://user-images.githubusercontent.com/1621894/72779614-a0ccc700-3c70-11ea-90d6-8c183babed20.gif)


@bigcommerce/checkout @bigcommerce/payments
