### PR TITLE
feat(payment): INT-2286 Use credit_card as payment method instead of card

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -49,7 +49,7 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'paymetric',
         method: 'credit_card',
     },
-    'barclaycard.card': {
+    'barclaycard.credit_card': {
         provider: 'barclaycard',
         method: 'credit_card',
     },


### PR DESCRIPTION
## What? [INT-2286](https://jira.bigcommerce.com/browse/INT-2286)
Rename supported payment instrument to `credit_card`.

## Why?
To match with the new naming convention, so the stored credit cards are able to be  displayed and used.

## SIbling PRs
https://github.com/bigcommerce/bigpay/pull/2181
https://github.com/bigcommerce/bigcommerce/pull/33239

## Testing / Proof
<img width="1238" alt="Screen Shot 2020-01-21 at 10 53 56 AM" src="https://user-images.githubusercontent.com/35502707/72825846-64cc3e80-3c3d-11ea-8ef9-bdf68afcc530.png">


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
