### PR TITLE
CHECKOUT-4187: Submit PR to static server repo instead

### DIFF
--- a/scripts/circleci/update-server.sh
+++ b/scripts/circleci/update-server.sh
@@ -19,6 +19,11 @@ cp -r dist-server/$RELEASE_VERSION_DIR /tmp/repo-server/public
 cd /tmp/repo-server
 git config user.email $GIT_USER_EMAIL
 git config user.name $GIT_USER_NAME
+git checkout -b $RELEASE_VERSION
 git add public
 git commit -m "chore(release): $RELEASE_VERSION"
-git push --follow-tags origin master
+git push --follow-tags origin $RELEASE_VERSION
+
+# Submit PR against master
+sudo apt install hub
+hub pull-request -m "chore(release): $RELEASE_VERSION"


### PR DESCRIPTION
## What?
Submit PR to static server repo instead

## Why?
In order to trigger the release flow, as our deployment tool only looks at merged PRs. 

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
