### PR TITLE
CHECKOUT-4187: Push branch to static server repo instead

### DIFF
--- a/scripts/circleci/update-server.sh
+++ b/scripts/circleci/update-server.sh
@@ -19,6 +19,7 @@ cp -r dist-server/$RELEASE_VERSION_DIR /tmp/repo-server/public
 cd /tmp/repo-server
 git config user.email $GIT_USER_EMAIL
 git config user.name $GIT_USER_NAME
+git checkout -b $RELEASE_VERSION
 git add public
 git commit -m "chore(release): $RELEASE_VERSION"
-git push --follow-tags origin master
+git push --follow-tags origin $RELEASE_VERSION


### PR DESCRIPTION
## What?
Push branch to static server repo instead

## Why?
For now, we can't make PRs directly.

## Testing / Proof
None

@bigcommerce/checkout @bigcommerce/payments
