### PR TITLE
CHECKOUT-4655: Make Cardinal 3DS work with hosted payment form

### DIFF
--- a/src/billing/billing-address-selector.ts
+++ b/src/billing/billing-address-selector.ts
@@ -1,12 +1,15 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { createSelector } from '../common/selector';
+import { guard } from '../common/utility';
 
 import BillingAddress from './billing-address';
 import BillingAddressState, { DEFAULT_STATE } from './billing-address-state';
 
 export default interface BillingAddressSelector {
     getBillingAddress(): BillingAddress | undefined;
+    getBillingAddressOrThrow(): BillingAddress;
     getUpdateError(): Error | undefined;
     getContinueAsGuestError(): Error | undefined;
     getLoadError(): Error | undefined;
@@ -21,6 +24,13 @@ export function createBillingAddressSelectorFactory(): BillingAddressSelectorFac
     const getBillingAddress = createSelector(
         (state: BillingAddressState) => state.data,
         data => () => data
+    );
+
+    const getBillingAddressOrThrow = createSelector(
+        getBillingAddress,
+        getBillingAddress => () => {
+            return guard(getBillingAddress(), () => new MissingDataError(MissingDataErrorType.MissingBillingAddress));
+        }
     );
 
     const getUpdateError = createSelector(
@@ -58,6 +68,7 @@ export function createBillingAddressSelectorFactory(): BillingAddressSelectorFac
     ): BillingAddressSelector => {
         return {
             getBillingAddress: getBillingAddress(state),
+            getBillingAddressOrThrow: getBillingAddressOrThrow(state),
             getUpdateError: getUpdateError(state),
             getContinueAsGuestError: getContinueAsGuestError(state),
             getLoadError: getLoadError(state),

--- a/src/common/utility/guard.spec.ts
+++ b/src/common/utility/guard.spec.ts
@@ -1,0 +1,25 @@
+import { InvalidArgumentError } from '../error/errors';
+
+import guard from './guard';
+
+describe('guard()', () => {
+    it('throws error if value is null', () => {
+        expect(() => guard(null))
+            .toThrow();
+    });
+
+    it('throws error if value is undefined', () => {
+        expect(() => guard(undefined))
+            .toThrow();
+    });
+
+    it('does not throw error if value is 0', () => {
+        expect(() => guard(0))
+            .not.toThrow();
+    });
+
+    it('throws custom error if provided', () => {
+        expect(() => guard(null, () => new InvalidArgumentError()))
+            .toThrowError(InvalidArgumentError);
+    });
+});

--- a/src/common/utility/guard.ts
+++ b/src/common/utility/guard.ts
@@ -1,0 +1,7 @@
+export default function guard<T>(value: T, errorFactory?: () => Error): NonNullable<T> {
+    if (value === undefined || value === null) {
+        throw errorFactory ? errorFactory() : new Error('An unexpected error has occurred.');
+    }
+
+    return value as NonNullable<T>;
+}

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -6,6 +6,7 @@ export { default as cloneResult } from './clone-result';
 export { default as createFreezeProxy, createFreezeProxies } from './create-freeze-proxy';
 export { default as CacheKeyResolver } from './cache-key-resolver';
 export { default as CancellablePromise } from './cancellable-promise';
+export { default as guard } from './guard';
 export { default as getEnvironment } from './get-environment';
 export { default as isEqual } from './is-equal';
 export { default as isPlainObject } from './is-plain-object';

--- a/src/hosted-form/hosted-form.spec.ts
+++ b/src/hosted-form/hosted-form.spec.ts
@@ -156,4 +156,24 @@ describe('HostedForm', () => {
         expect(callbacks.onBlur)
             .toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
     });
+
+    it('returns card type', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.CardTypeChanged,
+            payload: { cardType: 'visa' },
+        });
+
+        expect(form.getCardType())
+            .toEqual('visa');
+    });
+
+    it('returns bin number', () => {
+        eventListener.trigger({
+            type: HostedInputEventType.BinChanged,
+            payload: { bin: '411111' },
+        });
+
+        expect(form.getBin())
+            .toEqual('411111');
+    });
 });

--- a/src/hosted-form/hosted-form.ts
+++ b/src/hosted-form/hosted-form.ts
@@ -12,6 +12,9 @@ import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
 type HostedFormEventCallbacks = Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onValidate'>;
 
 export default class HostedForm {
+    private _bin?: string;
+    private _cardType?: string;
+
     constructor(
         private _fields: HostedField[],
         private _eventListener: IframeEventListener<HostedInputEventMap>,
@@ -24,6 +27,17 @@ export default class HostedForm {
         this._eventListener.addListener(HostedInputEventType.CardTypeChanged, ({ payload }) => onCardTypeChange(payload));
         this._eventListener.addListener(HostedInputEventType.Focused, ({ payload }) => onFocus(payload));
         this._eventListener.addListener(HostedInputEventType.Validated, ({ payload }) => onValidate(payload));
+
+        this._eventListener.addListener(HostedInputEventType.CardTypeChanged, ({ payload }) => this._cardType = payload.cardType);
+        this._eventListener.addListener(HostedInputEventType.BinChanged, ({ payload }) => this._bin = payload.bin);
+    }
+
+    getBin(): string | undefined {
+        return this._bin;
+    }
+
+    getCardType(): string | undefined {
+        return this._cardType;
     }
 
     async attach(): Promise<void> {

--- a/src/hosted-form/iframe-content/hosted-card-number-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.ts
@@ -59,16 +59,24 @@ export default class HostedCardNumberInput extends HostedInput {
         const cardInfo = number(value).card;
         const prevCardInfo = this._previousValue && number(this._previousValue).card;
 
-        if (get(prevCardInfo, 'type') === get(cardInfo, 'type')) {
-            return;
+        if (get(prevCardInfo, 'type') !== get(cardInfo, 'type')) {
+            this._eventPoster.post({
+                type: HostedInputEventType.CardTypeChanged,
+                payload: {
+                    cardType: cardInfo ? cardInfo.type : undefined,
+                },
+            });
         }
 
-        this._eventPoster.post({
-            type: HostedInputEventType.CardTypeChanged,
-            payload: {
-                cardType: cardInfo ? cardInfo.type : undefined,
-            },
-        });
+        const bin = value.length >= 6 && number(value).isPotentiallyValid ? value.substr(0, 6) : '';
+        const prevBin = this._previousValue && this._previousValue.length >= 6 ? this._previousValue.substr(0, 6) : '';
+
+        if (bin !== prevBin) {
+            this._eventPoster.post({
+                type: HostedInputEventType.BinChanged,
+                payload: { bin },
+            });
+        }
     }
 
     protected _formatValue(value: string): void {

--- a/src/hosted-form/iframe-content/hosted-input-aggregator.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-aggregator.spec.ts
@@ -54,6 +54,17 @@ describe('HostedInputAggregator', () => {
             .toEqual(frames.map(frame => frame.hostedInput));
     });
 
+    it('does not throw error if there are other iframes in parent window that belong to different origin than itself', () => {
+        frames.push({
+            get hostedInput() {
+                throw new DOMException();
+            },
+        } as unknown as HostedInputWindow);
+
+        expect(aggregator.getInputs())
+            .toEqual(frames.slice(0, -1).map(frame => frame.hostedInput));
+    });
+
     it('gathers all adjacent hosted inputs that satisfy filter', () => {
         expect(aggregator.getInputs(field => includes([HostedFieldType.CardCode, HostedFieldType.CardExpiry], field.getType())))
             .toEqual([frames[0].hostedInput, frames[1].hostedInput]);

--- a/src/hosted-form/iframe-content/hosted-input-aggregator.ts
+++ b/src/hosted-form/iframe-content/hosted-input-aggregator.ts
@@ -10,13 +10,21 @@ export default class HostedInputAggregator {
     getInputs(filter?: (field: HostedInput) => boolean): HostedInput[] {
         return Array.prototype.slice.call(this._parentWindow.frames)
             .reduce((result: Window[], frame: Window) => {
-                const input = (frame as HostedInputWindow).hostedInput;
+                try {
+                    const input = (frame as HostedInputWindow).hostedInput;
 
-                if (!input || (filter && !filter(input))) {
-                    return result;
+                    if (!input || (filter && !filter(input))) {
+                        return result;
+                    }
+
+                    return [...result, input];
+                } catch (error) {
+                    if (error instanceof DOMException) {
+                        return result;
+                    }
+
+                    throw error;
                 }
-
-                return [...result, input];
             }, []);
     }
 

--- a/src/hosted-form/iframe-content/hosted-input-events.ts
+++ b/src/hosted-form/iframe-content/hosted-input-events.ts
@@ -10,6 +10,7 @@ import HostedInputValidateResults from './hosted-input-validate-results';
 export enum HostedInputEventType {
     AttachSucceeded = 'HOSTED_INPUT:ATTACH_SUCCEEDED',
     AttachFailed = 'HOSTED_INPUT:ATTACH_FAILED',
+    BinChanged = 'HOSTED_INPUT:BIN_CHANGED',
     Blurred = 'HOSTED_INPUT:BLURRED',
     Changed = 'HOSTED_INPUT:CHANGED',
     CardTypeChanged = 'HOSTED_INPUT:CARD_TYPE_CHANGED',
@@ -23,6 +24,7 @@ export enum HostedInputEventType {
 export interface HostedInputEventMap {
     [HostedInputEventType.AttachSucceeded]: HostedInputAttachSuccessEvent;
     [HostedInputEventType.AttachFailed]: HostedInputAttachErrorEvent;
+    [HostedInputEventType.BinChanged]: HostedInputBinChangeEvent;
     [HostedInputEventType.Blurred]: HostedInputBlurEvent;
     [HostedInputEventType.Changed]: HostedInputChangeEvent;
     [HostedInputEventType.CardTypeChanged]: HostedInputCardTypeChangeEvent;
@@ -36,6 +38,7 @@ export interface HostedInputEventMap {
 export type HostedInputEvent = (
     HostedInputAttachSuccessEvent |
     HostedInputAttachErrorEvent |
+    HostedInputBinChangeEvent |
     HostedInputBlurEvent |
     HostedInputChangeEvent |
     HostedInputCardTypeChangeEvent |
@@ -53,6 +56,13 @@ export interface HostedInputAttachErrorEvent {
     type: HostedInputEventType.AttachFailed;
     payload: {
         error: HostedInputInitializeErrorData;
+    };
+}
+
+export interface HostedInputBinChangeEvent {
+    type: HostedInputEventType.BinChanged;
+    payload: {
+        bin?: string;
     };
 }
 

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -127,6 +127,7 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
+            hostedFormFactory,
             new CardinalThreeDSecureFlow(
                 store,
                 paymentActionCreator,
@@ -173,6 +174,7 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
+            hostedFormFactory,
             new CardinalThreeDSecureFlow(
                 store,
                 paymentActionCreator,

--- a/src/payment/strategies/cardinal/cardinal-client.spec.ts
+++ b/src/payment/strategies/cardinal/cardinal-client.spec.ts
@@ -22,7 +22,7 @@ describe('CardinalClient', () => {
 
     describe('#initialize', () => {
         it('loads the cardinal sdk correctly', async () => {
-            await client.initialize('provider', false);
+            await client.load('provider', false);
 
             expect(cardinalScriptLoader.load).toHaveBeenCalled();
         });
@@ -52,7 +52,7 @@ describe('CardinalClient', () => {
                 call();
             });
 
-            await client.initialize('provider', true);
+            await client.load('provider', true);
             await client.configure('token');
 
             expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.SetupCompleted, expect.any(Function));
@@ -74,7 +74,7 @@ describe('CardinalClient', () => {
                 call(getCardinalValidatedData(CardinalValidatedAction.Error, false, 1020), '');
             });
 
-            await client.initialize('provider', true);
+            await client.load('provider', true);
 
             try {
                 await client.configure('token');
@@ -96,7 +96,7 @@ describe('CardinalClient', () => {
                 setupCall();
             });
 
-            await client.initialize('provider', true);
+            await client.load('provider', true);
             await client.configure('token');
         });
 
@@ -145,7 +145,7 @@ describe('CardinalClient', () => {
                 setupCall();
             });
 
-            await client.initialize('provider', true);
+            await client.load('provider', true);
             await client.configure('token');
         });
 

--- a/src/payment/strategies/cardinal/cardinal-client.ts
+++ b/src/payment/strategies/cardinal/cardinal-client.ts
@@ -23,12 +23,13 @@ export interface CardinalOrderData {
 
 export default class CardinalClient {
     private _sdk?: Promise<CardinalSDK>;
+    private _isConfigured: boolean = false;
 
     constructor(
         private _scriptLoader: CardinalScriptLoader
     ) {}
 
-    initialize(provider: string, testMode?: boolean): Promise<void> {
+    load(provider: string, testMode?: boolean): Promise<void> {
         if (!this._sdk) {
             this._sdk = this._scriptLoader.load(provider, testMode);
         }
@@ -37,11 +38,17 @@ export default class CardinalClient {
     }
 
     configure(clientToken: string): Promise<void> {
+        if (this._isConfigured) {
+            return Promise.resolve();
+        }
+
         return this._getClientSDK()
             .then(client => new Promise<void>((resolve, reject) => {
                 client.on(CardinalEventType.SetupCompleted, () => {
                     client.off(CardinalEventType.SetupCompleted);
                     client.off(CardinalEventType.Validated);
+
+                    this._isConfigured = true;
 
                     resolve();
                 });

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.spec.ts
@@ -1,173 +1,148 @@
-import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
-import { createAction, Action } from '@bigcommerce/data-store';
-import { createRequestSender } from '@bigcommerce/request-sender';
-import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
-import { of, Observable } from 'rxjs';
+import { of } from 'rxjs';
 
-import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
-import { getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
-import { MissingDataError } from '../../../common/error/errors';
-import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
-import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
-import { PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender } from '../../index';
 import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
 import { getCybersource } from '../../payment-methods.mock';
-import PaymentRequestTransformer from '../../payment-request-transformer';
-import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow } from '../cardinal';
+import { CardinalThreeDSecureFlow } from '../cardinal';
+import { CreditCardPaymentStrategy } from '../credit-card';
 
-import { CyberSourcePaymentStrategy } from './index';
+import CyberSourcePaymentStrategy from './cybersource-payment-strategy';
 
 describe('CyberSourcePaymentStrategy', () => {
-    let cardinalClient: CardinalClient;
-    let cardinalThreeDSecureFlow: CardinalThreeDSecureFlow;
-    let orderActionCreator: OrderActionCreator;
-    let payload: OrderRequestBody;
-    let paymentActionCreator: PaymentActionCreator;
-    let paymentMethodActionCreator: PaymentMethodActionCreator;
-    let paymentMethodMock: PaymentMethod;
-    let scriptLoader: CardinalScriptLoader;
+    let hostedFormFactory: HostedFormFactory;
+    let orderActionCreator: Pick<OrderActionCreator, 'submitOrder'>;
+    let paymentActionCreator: Pick<PaymentActionCreator, 'submitPayment'>;
+    let paymentMethod: PaymentMethod;
+    let state: InternalCheckoutSelectors;
     let store: CheckoutStore;
     let strategy: CyberSourcePaymentStrategy;
-    let submitOrderAction: Observable<Action>;
-    let submitPaymentAction: Observable<SubmitPaymentAction>;
+    let threeDSecureFlow: Pick<CardinalThreeDSecureFlow, 'prepare' | 'start'>;
 
     beforeEach(() => {
-        paymentMethodMock = { ...getCybersource(), clientToken: 'foo' };
-        store = createCheckoutStore(getCheckoutStoreStateWithOrder());
-        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
-        scriptLoader = new CardinalScriptLoader(createScriptLoader());
-        cardinalClient = new CardinalClient(scriptLoader);
+        paymentMethod = {
+            ...getCybersource(),
+            clientToken: 'foo',
+        };
 
-        orderActionCreator = new OrderActionCreator(
-            new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
-        );
+        store = createCheckoutStore();
 
-        paymentActionCreator = new PaymentActionCreator(
-            new PaymentRequestSender(createPaymentClient()),
-            orderActionCreator,
-            new PaymentRequestTransformer()
-        );
+        orderActionCreator = {
+            submitOrder: jest.fn(() => of()),
+        };
 
-        cardinalThreeDSecureFlow = new CardinalThreeDSecureFlow(
-            store,
-            paymentActionCreator,
-            paymentMethodActionCreator,
-            cardinalClient
-        );
+        paymentActionCreator = {
+            submitPayment: jest.fn(() => of()),
+        };
+
+        hostedFormFactory = {} as HostedFormFactory;
+
+        threeDSecureFlow = {
+            prepare: jest.fn(() => Promise.resolve()),
+            start: jest.fn(() => Promise.resolve()),
+        };
+
+        state = store.getState();
+
+        jest.spyOn(store, 'dispatch')
+            .mockResolvedValue(state);
+
+        jest.spyOn(store, 'getState')
+            .mockReturnValue(state);
+
+        jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(paymentMethod);
 
         strategy = new CyberSourcePaymentStrategy(
             store,
-            orderActionCreator,
-            paymentActionCreator,
-            cardinalThreeDSecureFlow
+            orderActionCreator as OrderActionCreator,
+            paymentActionCreator as PaymentActionCreator,
+            hostedFormFactory,
+            threeDSecureFlow as CardinalThreeDSecureFlow
         );
+    });
 
-        payload = merge({}, getOrderRequestBody(), {
-            payment: {
-                methodId: paymentMethodMock.id,
-                gatewayId: paymentMethodMock.gateway,
-            },
-        });
-
-        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
-        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
-
-        jest.spyOn(orderActionCreator, 'submitOrder')
-            .mockReturnValue(submitOrderAction);
-
-        jest.spyOn(paymentActionCreator, 'submitPayment')
-            .mockReturnValue(submitPaymentAction);
-
-        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethodMock);
-
-        jest.spyOn(cardinalThreeDSecureFlow, 'prepare').mockReturnValue(Promise.resolve());
-
-        jest.spyOn(cardinalThreeDSecureFlow, 'start').mockReturnValue(store.getState());
+    it('is special type of credit card strategy', () => {
+        expect(strategy)
+            .toBeInstanceOf(CreditCardPaymentStrategy);
     });
 
     describe('#initialize', () => {
-        it('initializes strategy successfully when 3DS is enabled', async () => {
-            await strategy.initialize({methodId: paymentMethodMock.id});
-
-            expect(cardinalThreeDSecureFlow.prepare).toHaveBeenCalled();
-        });
-
-        it('initializes strategy successfully when 3DS is disabled', async () => {
-            paymentMethodMock.config.is3dsEnabled = false;
-            await strategy.initialize({methodId: paymentMethodMock.id});
-
-            expect(cardinalThreeDSecureFlow.prepare).not.toHaveBeenCalled();
-        });
-
-        it('throws data missing error when payment method is not defined', async () => {
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(undefined);
+        it('throws error if payment method is not defined', async () => {
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockImplementation(() => { throw new Error(); });
 
             try {
-                await strategy.initialize({ methodId: paymentMethodMock.id });
+                await strategy.initialize({ methodId: paymentMethod.id });
             } catch (error) {
-                expect(error).toBeInstanceOf(MissingDataError);
+                expect(error)
+                    .toBeInstanceOf(Error);
             }
+        });
+
+        it('does not prepare 3DS flow if not enabled', async () => {
+            paymentMethod.config.is3dsEnabled = false;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(threeDSecureFlow.prepare)
+                .not.toHaveBeenCalled();
+        });
+
+        it('prepares 3DS flow if enabled', async () => {
+            paymentMethod.config.is3dsEnabled = true;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(threeDSecureFlow.prepare)
+                .toHaveBeenCalled();
         });
     });
 
     describe('#execute', () => {
-        it('throws data missing error when payment is undefined', async () => {
-            payload.payment = undefined;
+        let payload: OrderRequestBody;
 
-            await strategy.initialize({ methodId: paymentMethodMock.id });
+        beforeEach(() => {
+            payload = merge({}, getOrderRequestBody(), {
+                payment: {
+                    methodId: paymentMethod.id,
+                    gatewayId: paymentMethod.gateway,
+                },
+            });
+        });
+
+        it('throws error if payment method is not defined', async () => {
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockImplementation(() => { throw new Error(); });
+
             try {
                 await strategy.execute(payload);
             } catch (error) {
-                expect(error).toBeInstanceOf(MissingDataError);
+                expect(error)
+                    .toBeInstanceOf(Error);
             }
         });
 
-        it('throws error to inform that payment data is missing', async () => {
-            try {
-                await strategy.execute(payload);
-            } catch (error) {
-                expect(error).toBeInstanceOf(MissingDataError);
-            }
+        it('does not start 3DS flow if not enabled', async () => {
+            paymentMethod.config.is3dsEnabled = false;
+
+            await strategy.execute(payload);
+
+            expect(threeDSecureFlow.start)
+                .not.toHaveBeenCalled();
         });
 
-        it('completes the purchase successfully when 3DS is disabled', async () => {
-            paymentMethodMock.config.is3dsEnabled = false;
-            await strategy.initialize({ methodId: paymentMethodMock.id });
+        it('starts 3DS flow if enabled', async () => {
+            paymentMethod.config.is3dsEnabled = true;
 
-            const result = await strategy.execute(payload);
+            await strategy.execute(payload);
 
-            expect(cardinalThreeDSecureFlow.start).not.toHaveBeenCalled();
-            expect(result).toBe(store.getState());
-        });
-
-        it('completes the purchase successfully when 3DS is enabled', async () => {
-            await strategy.initialize({ methodId: paymentMethodMock.id });
-
-            const result = await strategy.execute(payload);
-
-            expect(cardinalThreeDSecureFlow.start).toHaveBeenCalled();
-            expect(result).toBe(store.getState());
-        });
-    });
-
-    describe('#deinitialize()', () => {
-        it('deinitializes strategy', async () => {
-            expect(await strategy.deinitialize()).toEqual(store.getState());
-        });
-    });
-
-    describe('#finalize()', () => {
-        it('throws error to inform that order finalization is not required', async () => {
-            try {
-                await strategy.finalize();
-            } catch (error) {
-                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
-            }
+            expect(threeDSecureFlow.start)
+                .toHaveBeenCalled();
         });
     });
 });

--- a/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
+++ b/src/payment/strategies/cybersource/cybersource-payment-strategy.ts
@@ -1,63 +1,53 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { HostedFormFactory } from '../../../hosted-form';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
-import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import PaymentActionCreator from '../../payment-action-creator';
-import PaymentMethod from '../../payment-method';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import { CardinalThreeDSecureFlow } from '../cardinal';
-import PaymentStrategy from '../payment-strategy';
+import { CreditCardPaymentStrategy } from '../credit-card';
 
-export default class CyberSourcePaymentStrategy implements PaymentStrategy {
-    private _paymentMethod?: PaymentMethod;
-
+export default class CyberSourcePaymentStrategy extends CreditCardPaymentStrategy {
     constructor(
-        private _store: CheckoutStore,
-        private _orderActionCreator: OrderActionCreator,
-        private _paymentActionCreator: PaymentActionCreator,
+        store: CheckoutStore,
+        orderActionCreator: OrderActionCreator,
+        paymentActionCreator: PaymentActionCreator,
+        hostedFormFactory: HostedFormFactory,
         private _threeDSecureFlow: CardinalThreeDSecureFlow
-    ) {}
-
-    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
-        const { methodId } = options;
-        this._paymentMethod = this._store.getState().paymentMethods.getPaymentMethod(methodId);
-
-        if (!this._paymentMethod) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
-
-        if (!this._paymentMethod.config.is3dsEnabled) {
-            return Promise.resolve(this._store.getState());
-        }
-
-        return this._threeDSecureFlow.prepare(methodId)
-            .then(() => this._store.getState());
+    ) {
+        super(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        );
     }
 
-    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        const { payment, ...order } = payload;
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        await super.initialize(options);
 
-        if (!payment) {
-            throw new MissingDataError(MissingDataErrorType.MissingPayment);
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(options.methodId);
+
+        if (paymentMethod.config.is3dsEnabled) {
+            await this._threeDSecureFlow.prepare(paymentMethod);
         }
 
-        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
-            .then(() => {
-                if (!this._paymentMethod) {
-                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-                }
-
-                return this._paymentMethod.config.is3dsEnabled ?
-                    this._threeDSecureFlow.start(payment) :
-                    this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
-            });
+        return this._store.getState();
     }
 
-    finalize(): Promise<InternalCheckoutSelectors> {
-        return Promise.reject(new OrderFinalizationNotRequiredError());
-    }
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment: { methodId = '' } = {} } = payload;
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
 
-    deinitialize(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
+        if (getPaymentMethodOrThrow(methodId).config.is3dsEnabled) {
+            return this._threeDSecureFlow.start(
+                super.execute.bind(this),
+                payload,
+                options,
+                this._hostedForm
+            );
+        }
+
+        return super.execute(payload, options);
     }
 }


### PR DESCRIPTION
## What?
Make Cardinal 3DS flow for Cybersource and PayPal Pro work with hosted payment form.

## Why?
Currently, we're including CC details in `Cardinal.continue` call - which is a call to prompt the shopper to complete the authentication required by the issuer of their card. But because we're using the Hybrid integration approach, it seems we don't have to do that because we are already passing the order and payment details to Cardinal when we make a lookup request to check the enrolment of the card. However, we do need to pass the BIN number to Songbird (Cardinal's client library) so that it can collect the device data required for the card issuer.

Based on the above, I had to change the code so that credit card details can be sent within the hosted payment iframes, while allowing Songbird work as intended in the host page (which is collecting device data and prompting authentication).

## Testing / Proof
Unit / Functional

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
