### PR TITLE
fix(checkout): CHECKOUT-4245 handle custom fields for amazon pay

### DIFF
--- a/src/shipping/shipping-addresses.mock.ts
+++ b/src/shipping/shipping-addresses.mock.ts
@@ -17,3 +17,26 @@ export function getShippingAddress(): Address {
         customFields: [],
     };
 }
+
+export function getShippingAddressWithCustomFields(): Address {
+    return {
+        firstName: 'Amazon',
+        lastName: 'Tester',
+        company: 'Bigcommerce',
+        address1: '12345 Amazon Test',
+        address2: 'Test Street',
+        city: 'Testing City',
+        stateOrProvince: 'New York',
+        stateOrProvinceCode: 'NY',
+        country: 'United States',
+        countryCode: 'US',
+        postalCode: '95555',
+        phone: '666-666-6666',
+        customFields: [
+            {
+                fieldId: 'field_25',
+                fieldValue: '33',
+            },
+        ],
+    };
+}

--- a/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.spec.ts
@@ -14,7 +14,7 @@ import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRe
 import ConsignmentActionCreator from '../../consignment-action-creator';
 import { ConsignmentActionType } from '../../consignment-actions';
 import { getFlatRateOption } from '../../internal-shipping-options.mock';
-import { getShippingAddress } from '../../shipping-addresses.mock';
+import { getShippingAddress, getShippingAddressWithCustomFields } from '../../shipping-addresses.mock';
 import { ShippingStrategyActionType } from '../../shipping-strategy-actions';
 
 import AmazonPayShippingStrategy from './amazon-pay-shipping-strategy';
@@ -266,6 +266,28 @@ describe('AmazonPayShippingStrategy', () => {
         const output = await strategy.selectOption(method.id, options);
 
         expect(consignmentActionCreator.selectShippingOption).toHaveBeenCalledWith(method.id, options);
+        expect(store.dispatch).toHaveBeenCalledWith(action);
+        expect(output).toEqual(store.getState());
+    });
+
+    it('updates address with provided custom fields and existing address', async () => {
+        const strategy = new AmazonPayShippingStrategy(store, consignmentActionCreator, paymentMethodActionCreator, remoteCheckoutActionCreator, scriptLoader);
+        const options = {};
+        const amazonShippingAddress = getShippingAddress();
+        const address = getShippingAddressWithCustomFields();
+        const action = of(createAction(ConsignmentActionType.UpdateConsignmentRequested));
+
+        jest.spyOn(consignmentActionCreator, 'updateAddress')
+            .mockReturnValue(action);
+
+        jest.spyOn(store, 'dispatch');
+
+        const output = await strategy.updateAddress(address, options);
+
+        expect(consignmentActionCreator.updateAddress).toHaveBeenCalledWith({
+            ...amazonShippingAddress,
+            customFields: address.customFields,
+        }, options);
         expect(store.dispatch).toHaveBeenCalledWith(action);
         expect(output).toEqual(store.getState());
     });

--- a/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.ts
+++ b/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.ts
@@ -1,6 +1,6 @@
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 
-import { isInternalAddressEqual, mapFromInternalAddress } from '../../../address';
+import { isInternalAddressEqual, mapFromInternalAddress, AddressRequestBody } from '../../../address';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
@@ -61,8 +61,15 @@ export default class AmazonPayShippingStrategy implements ShippingStrategy {
         return Promise.resolve(this._store.getState());
     }
 
-    updateAddress(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
+    updateAddress(address: AddressRequestBody, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
+        const updateAddressRequestBody = {
+            ...this._store.getState().shippingAddress.getShippingAddress(),
+            customFields: address.customFields,
+        } as AddressRequestBody;
+
+        return this._store.dispatch(
+            this._consignmentActionCreator.updateAddress(updateAddressRequestBody, options)
+        );
     }
 
     selectOption(optionId: string, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {


### PR DESCRIPTION
## What?
Provide support to save custom fields for shipping address when using amazon pay

## Why?
At the moment the custom form fields are not submitted to the API when using amazon pay account.

@bigcommerce/checkout @bigcommerce/payments
