### PR TITLE
CHECKOUT-4640 Add support for marketing emails consent

### DIFF
--- a/src/billing/billing-address-action-creator.spec.ts
+++ b/src/billing/billing-address-action-creator.spec.ts
@@ -1,3 +1,4 @@
+import { createErrorAction } from '@bigcommerce/data-store';
 import { createRequestSender, Response } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
 import { from, of } from 'rxjs';
@@ -8,33 +9,41 @@ import { createCheckoutStore, Checkout, CheckoutStore, CheckoutStoreState } from
 import { getCheckout, getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { MissingDataError, StandardError } from '../common/error/errors';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { CustomerAction, CustomerActionType, CustomerRequestSender } from '../customer';
 
 import { BillingAddressRequestBody } from './billing-address';
 import BillingAddressActionCreator from './billing-address-action-creator';
-import { BillingAddressAction, BillingAddressActionType, UpdateBillingAddressAction } from './billing-address-actions';
+import { BillingAddressAction, BillingAddressActionType, ContinueAsGuestAction, UpdateBillingAddressAction } from './billing-address-actions';
 import BillingAddressRequestSender from './billing-address-request-sender';
 import { getBillingAddress } from './billing-addresses.mock';
+import { UpdateCustomerError } from './errors';
 
 describe('BillingAddressActionCreator', () => {
     let address: AddressRequestBody;
     let billingAddressActionCreator: BillingAddressActionCreator;
     let billingAddressRequestSender: BillingAddressRequestSender;
+    let customerRequestSender: CustomerRequestSender;
     let errorResponse: Response<Error>;
     let response: Response<Checkout>;
     let state: CheckoutStoreState;
     let store: CheckoutStore;
-    let actions: BillingAddressAction[] | BillingAddressAction | undefined;
+    let actions: Array<BillingAddressAction | CustomerAction> | BillingAddressAction | ContinueAsGuestAction | CustomerAction | undefined;
 
     beforeEach(() => {
         response = getResponse(getCheckout());
         errorResponse = getErrorResponse();
         state = getCheckoutStoreState();
         billingAddressRequestSender = new BillingAddressRequestSender(createRequestSender());
+        customerRequestSender = new CustomerRequestSender(createRequestSender());
 
         jest.spyOn(billingAddressRequestSender, 'updateAddress').mockImplementation(() => Promise.resolve(response));
         jest.spyOn(billingAddressRequestSender, 'createAddress').mockImplementation(() => Promise.resolve(response));
+        jest.spyOn(customerRequestSender, 'updateCustomer').mockImplementation(() => Promise.resolve(response));
 
-        billingAddressActionCreator = new BillingAddressActionCreator(billingAddressRequestSender);
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            billingAddressRequestSender,
+            customerRequestSender
+        );
         address = getBillingAddress();
     });
 
@@ -90,7 +99,74 @@ describe('BillingAddressActionCreator', () => {
                 });
             });
 
-            it('emits actions if able to continue as guest', async () => {
+            it('emits customer actions if marketingEmailConsent is true', async () => {
+                actions = await from(billingAddressActionCreator.continueAsGuest({
+                    ...guestCredentials,
+                    marketingEmailConsent: true,
+                })(store))
+                    .pipe(toArray())
+                    .toPromise();
+
+                expect(actions).toContainEqual({ type: CustomerActionType.UpdateCustomerRequested });
+                expect(actions).toContainEqual({ type: CustomerActionType.UpdateCustomerSucceeded, payload: response.body });
+            });
+
+            it('emits failed customer actions if failed to update', async () => {
+                jest.spyOn(customerRequestSender, 'updateCustomer')
+                    .mockReturnValue(Promise.reject(getErrorResponse()));
+
+                const errorHandler = jest.fn();
+
+                actions = await from(billingAddressActionCreator.continueAsGuest({
+                    ...guestCredentials,
+                    marketingEmailConsent: true,
+                })(store))
+                    .pipe(
+                        catchError(error => {
+                            errorHandler(error);
+
+                            return of(error);
+                        }),
+                        toArray()
+                    )
+                    .toPromise();
+
+                expect(errorHandler)
+                    .toHaveBeenCalledWith(createErrorAction(CustomerActionType.UpdateCustomerFailed, new UpdateCustomerError()));
+
+                expect(actions).toContainEqual({ type: CustomerActionType.UpdateCustomerRequested });
+                expect(actions).toContainEqual(expect.objectContaining({
+                    type: CustomerActionType.UpdateCustomerFailed,
+                }));
+            });
+
+            it('sends request to update customer if marketingEmailConsent is false', async () => {
+                await from(billingAddressActionCreator.continueAsGuest({
+                    ...guestCredentials,
+                    marketingEmailConsent: false,
+                }, {})(store))
+                    .toPromise();
+
+                expect(customerRequestSender.updateCustomer).toHaveBeenCalledWith({
+                    email: guestCredentials.email,
+                    acceptsMarketing: false,
+                }, {});
+            });
+
+            it('sends request to update customer if marketingEmailConsent is true', async () => {
+                await from(billingAddressActionCreator.continueAsGuest({
+                    ...guestCredentials,
+                    marketingEmailConsent: true,
+                }, {})(store))
+                    .toPromise();
+
+                expect(customerRequestSender.updateCustomer).toHaveBeenCalledWith({
+                    email: guestCredentials.email,
+                    acceptsMarketing: true,
+                }, {});
+            });
+
+            it('emits billing actions if able to continue as guest', async () => {
                 actions = await from(billingAddressActionCreator.continueAsGuest(guestCredentials)(store))
                     .pipe(toArray())
                     .toPromise();

--- a/src/billing/errors/index.ts
+++ b/src/billing/errors/index.ts
@@ -1,1 +1,2 @@
 export { default as UnableToContinueAsGuestError } from './unable-to-continue-as-guest-error';
+export { default as UpdateCustomerError } from './update-customer-error';

--- a/src/billing/errors/update-customer-error.ts
+++ b/src/billing/errors/update-customer-error.ts
@@ -1,0 +1,13 @@
+import { RequestError } from '../../common/error/errors';
+
+/**
+ * This error should be thrown when the customer fails to be updated
+ */
+export default class UpdateCustomerError extends RequestError {
+    constructor(response?: Response) {
+        super(response);
+
+        this.name = 'UpdateCustomerError';
+        this.type = 'update_customer';
+    }
+}

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -11,7 +11,7 @@ import { getResponse } from '../common/http-request/responses.mock';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { getConfig } from '../config/configs.mock';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
-import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '../customer';
+import { createCustomerStrategyRegistry, CustomerRequestSender, CustomerStrategyActionCreator } from '../customer';
 import { getFormFields } from '../form/form.mock';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { getCountriesResponseBody } from '../geography/countries.mock';
@@ -42,6 +42,7 @@ import createCheckoutStore from './create-checkout-store';
 describe('CheckoutService', () => {
     let billingAddressActionCreator: BillingAddressActionCreator;
     let billingAddressRequestSender: BillingAddressRequestSender;
+    let customerRequestSender: CustomerRequestSender;
     let checkoutActionCreator: CheckoutActionCreator;
     let instrumentRequestSender: InstrumentRequestSender;
     let countryRequestSender: CountryRequestSender;
@@ -92,6 +93,7 @@ describe('CheckoutService', () => {
             .mockResolvedValue(getResponse(getCountriesResponseBody()));
 
         billingAddressRequestSender = new BillingAddressRequestSender(requestSender);
+        customerRequestSender = new CustomerRequestSender(requestSender);
 
         jest.spyOn(billingAddressRequestSender, 'updateAddress')
             .mockResolvedValue(getResponse(merge({}, getCheckout(), {
@@ -174,7 +176,10 @@ describe('CheckoutService', () => {
 
         checkoutValidator = new CheckoutValidator(checkoutRequestSender);
 
-        billingAddressActionCreator = new BillingAddressActionCreator(billingAddressRequestSender);
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            billingAddressRequestSender,
+            customerRequestSender
+        );
 
         configActionCreator = new ConfigActionCreator(configRequestSender);
 

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -7,7 +7,7 @@ import { getDefaultLogger } from '../common/log';
 import { getEnvironment } from '../common/utility';
 import { ConfigActionCreator, ConfigRequestSender, ConfigState } from '../config';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
-import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '../customer';
+import { createCustomerStrategyRegistry, CustomerRequestSender, CustomerStrategyActionCreator } from '../customer';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { createPaymentClient, createPaymentStrategyRegistry, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentStrategyActionCreator } from '../payment';
@@ -72,7 +72,10 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
 
     return new CheckoutService(
         store,
-        new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender)),
+        new BillingAddressActionCreator(
+            new BillingAddressRequestSender(requestSender),
+            new CustomerRequestSender(requestSender)
+        ),
         new CheckoutActionCreator(checkoutRequestSender, configActionCreator),
         configActionCreator,
         new ConsignmentActionCreator(new ConsignmentRequestSender(requestSender), checkoutRequestSender),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -97,8 +97,10 @@ export interface CheckoutSettings {
     orderTermsAndConditions: string;
     orderTermsAndConditionsLink: string;
     orderTermsAndConditionsType: string;
+    privacyPolicyUrl: string;
     shippingQuoteFailedMessage: string;
     realtimeShippingProviders: string[];
+    requiresMarketingConsent: boolean;
     remoteCheckoutProviders: any[];
 }
 

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -37,12 +37,14 @@ export function getConfig(): Config {
                 orderTermsAndConditions: '',
                 orderTermsAndConditionsLink: '',
                 orderTermsAndConditionsType: '',
+                privacyPolicyUrl: '',
                 shippingQuoteFailedMessage: 'Unfortunately one or more items in your cart can\'t be shipped to your location. Please choose a different delivery address.',
                 realtimeShippingProviders: [
                     'Fedex',
                     'UPS',
                     'USPS',
                 ],
+                requiresMarketingConsent: false,
                 remoteCheckoutProviders: [],
             },
             currency: {

--- a/src/customer/customer-actions.ts
+++ b/src/customer/customer-actions.ts
@@ -2,6 +2,7 @@ import { Action } from '@bigcommerce/data-store';
 
 import { LoadCheckoutAction } from '../checkout';
 
+import { CurrentCustomer } from './customer';
 import { InternalCustomerResponseData } from './internal-customer-responses';
 
 export enum CustomerActionType {
@@ -12,9 +13,14 @@ export enum CustomerActionType {
     SignOutCustomerRequested = 'SIGN_OUT_CUSTOMER_REQUESTED',
     SignOutCustomerSucceeded = 'SIGN_OUT_CUSTOMER_SUCCEEDED',
     SignOutCustomerFailed = 'SIGN_OUT_CUSTOMER_FAILED',
+
+    UpdateCustomerRequested = 'UPDATE_CUSTOMER_REQUESTED',
+    UpdateCustomerSucceeded = 'UPDATE_CUSTOMER_SUCCEEDED',
+    UpdateCustomerFailed = 'UPDATE_CUSTOMER_FAILED',
 }
 
 export type CustomerAction =
+    UpdateCustomerAction |
     SignInCustomerAction |
     SignOutCustomerAction;
 
@@ -29,6 +35,11 @@ export type SignOutCustomerAction =
     SignOutCustomerSucceededAction |
     SignOutCustomerFailedAction |
     LoadCheckoutAction;
+
+export type UpdateCustomerAction =
+    UpdateCustomerRequestedAction |
+    UpdateCustomerSucceededAction |
+    UpdateCustomerFailedAction;
 
 export interface SignInCustomerRequestedAction extends Action {
     type: CustomerActionType.SignInCustomerRequested;
@@ -52,4 +63,16 @@ export interface SignOutCustomerSucceededAction extends Action<InternalCustomerR
 
 export interface SignOutCustomerFailedAction extends Action<Error> {
     type: CustomerActionType.SignOutCustomerFailed;
+}
+
+export interface UpdateCustomerRequestedAction extends Action {
+    type: CustomerActionType.UpdateCustomerRequested;
+}
+
+export interface UpdateCustomerSucceededAction extends Action<CurrentCustomer> {
+    type: CustomerActionType.UpdateCustomerSucceeded;
+}
+
+export interface UpdateCustomerFailedAction extends Action<Error> {
+    type: CustomerActionType.UpdateCustomerFailed;
 }

--- a/src/customer/customer-request-sender.ts
+++ b/src/customer/customer-request-sender.ts
@@ -1,7 +1,8 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions } from '../common/http-request';
 
+import { CurrentCustomer } from './customer';
 import CustomerCredentials from './customer-credentials';
 import { InternalCustomerResponseBody } from './internal-customer-responses';
 
@@ -9,6 +10,13 @@ export default class CustomerRequestSender {
     constructor(
         private _requestSender: RequestSender
     ) {}
+
+    updateCustomer(customer: CurrentCustomer, { timeout }: RequestOptions = {}): Promise<Response<CurrentCustomer>> {
+        const url = '/api/storefront/customer';
+        const headers = { Accept: ContentType.JsonV1 };
+
+        return this._requestSender.post(url, { body: customer, headers, timeout });
+    }
 
     signInCustomer(credentials: CustomerCredentials, { timeout }: RequestOptions = {}): Promise<Response<InternalCustomerResponseBody>> {
         const url = '/internalapi/v1/checkout/customer';

--- a/src/customer/customer.ts
+++ b/src/customer/customer.ts
@@ -21,3 +21,11 @@ export interface CustomerGroup  {
     id: number;
     name: string;
 }
+
+// todo: Eventually we should
+// (1) Merge CurrentCustomer with Customer (once done in API first);
+// (2) Rename `Customer` to `CheckoutCustomer` (breaking change)
+export interface CurrentCustomer {
+    email: string;
+    acceptsMarketing: boolean;
+}

--- a/src/customer/guest-credentials.ts
+++ b/src/customer/guest-credentials.ts
@@ -1,4 +1,5 @@
 export default interface GuestCredentials {
     id?: string;
     email: string;
+    marketingEmailConsent?: boolean;
 }

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -5,6 +5,7 @@ import { getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { CustomerRequestSender } from '../customer';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
@@ -54,7 +55,10 @@ export default function createPaymentStrategyRegistry(
     const scriptLoader = getScriptLoader();
     const paymentRequestTransformer = new PaymentRequestTransformer();
     const paymentRequestSender = new PaymentRequestSender(paymentClient);
-    const billingAddressActionCreator = new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender));
+    const billingAddressActionCreator = new BillingAddressActionCreator(
+        new BillingAddressRequestSender(requestSender),
+        new CustomerRequestSender(requestSender)
+    );
     const braintreePaymentProcessor = createBraintreePaymentProcessor(scriptLoader);
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const checkoutValidator = new CheckoutValidator(checkoutRequestSender);

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -10,6 +10,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutStor
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError, RequestError } from '../../../common/error/errors';
 import { getErrorResponse } from '../../../common/http-request/responses.mock';
+import { CustomerRequestSender } from '../../../customer';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
@@ -95,7 +96,10 @@ describe('AmazonPayPaymentStrategy', () => {
                 data: undefined,
             },
         });
-        billingAddressActionCreator = new BillingAddressActionCreator(billingAddressRequestSender);
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            billingAddressRequestSender,
+            new CustomerRequestSender(createRequestSender())
+        );
         orderActionCreator = new OrderActionCreator(
             orderRequestSender,
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))

--- a/src/payment/strategies/googlepay/create-googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/create-googlepay-payment-processor.ts
@@ -3,6 +3,7 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
 import { CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { CustomerRequestSender } from '../../../customer';
 import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
@@ -23,7 +24,8 @@ export default function createGooglePayPaymentProcessor(store: CheckoutStore, in
         new GooglePayScriptLoader(scriptLoader),
         initializer,
         new BillingAddressActionCreator(
-            new BillingAddressRequestSender(requestSender)
+            new BillingAddressRequestSender(requestSender),
+            new CustomerRequestSender(requestSender)
         ),
         new ConsignmentActionCreator(
             new ConsignmentRequestSender(requestSender),

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
@@ -7,6 +7,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore } from '../..
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { getConfigState } from '../../../config/configs.mock';
+import { CustomerRequestSender } from '../../../customer';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
 import PaymentMethod from '../../payment-method';
@@ -33,7 +34,10 @@ describe('GooglePayPaymentProcessor', () => {
 
     beforeEach(() => {
         const scriptLoader = createScriptLoader();
-        billingAddressActionCreator = new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender));
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(requestSender),
+            new CustomerRequestSender(requestSender)
+        );
 
         store = createCheckoutStore({
             checkout: getCheckoutState(),


### PR DESCRIPTION
## What?
Add support for marketing emails consent for guest shoppers

## Why?
GDPR compliance

## Testing / Proof
unit

@bigcommerce/checkout 