### PR TITLE
CHECKOUT-4416 Include custom items IDs when calling updateShippingAddress

### DIFF
--- a/src/shipping/consignment-action-creator.spec.ts
+++ b/src/shipping/consignment-action-creator.spec.ts
@@ -5,6 +5,7 @@ import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
 import { Address } from '../address';
+import { getCart } from '../cart/carts.mock';
 import { createCheckoutStore, Checkout, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { getCheckout, getCheckoutState, getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../common/error/errors';
@@ -887,6 +888,19 @@ describe('consignmentActionCreator', () => {
         });
 
         it('sends request to update shipping address in first consignment', async () => {
+            jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    customItems: [
+                        {
+                            id: 'custom',
+                            quantity: 1,
+                        },
+                    ],
+                },
+            });
+
             await from(consignmentActionCreator.updateAddress(address, options)(store))
                 .toPromise();
 
@@ -898,6 +912,10 @@ describe('consignmentActionCreator', () => {
                     lineItems: [
                         {
                             itemId: '666',
+                            quantity: 1,
+                        },
+                        {
+                            itemId: 'custom',
                             quantity: 1,
                         },
                     ],

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -153,7 +153,7 @@ export default class ConsignmentActionCreator {
         options?: RequestOptions<CheckoutParams>
     ): ThunkAction<CreateConsignmentsAction | UpdateConsignmentAction, InternalCheckoutSelectors> {
         return store => {
-            const consignment = this._getConsignmentRequestBody(address, store);
+            const consignment = this._getUpdateAddressRequestBody(address, store);
             const consignments = store.getState().consignments.getConsignments();
 
             if (consignments && consignments.length) {
@@ -284,7 +284,7 @@ export default class ConsignmentActionCreator {
         };
     }
 
-    private _getConsignmentRequestBody(
+    private _getUpdateAddressRequestBody(
         shippingAddress: AddressRequestBody,
         store: ReadableCheckoutStore
     ): ConsignmentRequestBody {
@@ -294,15 +294,14 @@ export default class ConsignmentActionCreator {
         if (!cart) {
             throw new MissingDataError(MissingDataErrorType.MissingCart);
         }
+        const { physicalItems, customItems = [] } = cart.lineItems;
 
         return {
             shippingAddress,
-            lineItems: (cart.lineItems && cart.lineItems.physicalItems || [])
-                .map(item => ({
-                    itemId: item.id,
-                    quantity: item.quantity,
-                })
-            ),
+            lineItems: [ ...physicalItems, ...customItems ].map(item => ({
+                itemId: item.id,
+                quantity: item.quantity,
+            })),
         };
     }
 


### PR DESCRIPTION
## What?
Include custom items IDs when in payload when calling `updateShippingAddress`

## Why?
In case a cart only has custom items, `updateShippingAddress` would fail since there were no items ids in the payload.

Reported in https://github.com/bigcommerce/checkout-sdk-js/issues/701

## Testing / Proof
unit

@bigcommerce/checkout 
