### PR TITLE
CHECKOUT-4640 Fix state when consent is provided

### DIFF
--- a/src/billing/billing-address-reducer.spec.ts
+++ b/src/billing/billing-address-reducer.spec.ts
@@ -4,9 +4,11 @@ import { CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
+import { CustomerActionType } from '../customer';
 import { OrderActionType } from '../order';
 import { getOrder } from '../order/orders.mock';
 
+import { BillingAddressActionType } from './billing-address-actions';
 import billingAddressReducer from './billing-address-reducer';
 import BillingAddressState from './billing-address-state';
 
@@ -56,6 +58,71 @@ describe('billingAddressReducer', () => {
         expect(output).toEqual({
             errors: { loadError: action.payload },
             statuses: { isLoading: false },
+        });
+    });
+
+    it('returns pending when continueAsGuest requested', () => {
+        const action = createAction(BillingAddressActionType.ContinueAsGuestRequested, new RequestError(getErrorResponse()));
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { continueAsGuestError: undefined },
+            statuses: { isContinuingAsGuest: true },
+        });
+    });
+
+    it('returns pending when customer update requested', () => {
+        const action = createAction(CustomerActionType.UpdateCustomerRequested, new RequestError(getErrorResponse()));
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { continueAsGuestError: undefined },
+            statuses: { isContinuingAsGuest: true },
+        });
+    });
+
+    it('returns data when continueAsGuest succeeded', () => {
+        const action = createAction(BillingAddressActionType.ContinueAsGuestSucceeded, getCheckout());
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            data: action.payload && action.payload.billingAddress,
+            errors: {
+                continueAsGuestError: undefined,
+            },
+            statuses: {
+                isContinuingAsGuest: false,
+            },
+        });
+    });
+
+    it('returns clean state when customer updated', () => {
+        const action = createAction(CustomerActionType.UpdateCustomerSucceeded, new RequestError(getErrorResponse()));
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { continueAsGuestError: undefined },
+            statuses: { isContinuingAsGuest: false },
+        });
+    });
+
+    it('returns error when continueAsGuest failed', () => {
+        const action = createAction(BillingAddressActionType.ContinueAsGuestFailed, new RequestError(getErrorResponse()));
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { continueAsGuestError: action.payload },
+            statuses: { isContinuingAsGuest: false },
+        });
+    });
+
+    it('returns error when customer failed to update', () => {
+        const action = createAction(CustomerActionType.UpdateCustomerFailed, new RequestError(getErrorResponse()));
+        const output = billingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            errors: { continueAsGuestError: action.payload },
+            statuses: { isContinuingAsGuest: false },
         });
     });
 });

--- a/src/billing/billing-address-reducer.ts
+++ b/src/billing/billing-address-reducer.ts
@@ -3,6 +3,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
 import { objectSet, replace } from '../common/utility';
+import { CustomerActionType, UpdateCustomerAction } from '../customer';
 import { OrderAction, OrderActionType } from '../order';
 
 import BillingAddress from './billing-address';
@@ -40,7 +41,7 @@ function dataReducer(
 
 function errorsReducer(
     errors: BillingAddressErrorsState = DEFAULT_STATE.errors,
-    action: CheckoutAction | BillingAddressAction | OrderAction
+    action: CheckoutAction | BillingAddressAction | OrderAction | UpdateCustomerAction
 ): BillingAddressErrorsState {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
@@ -57,10 +58,13 @@ function errorsReducer(
     case BillingAddressActionType.UpdateBillingAddressFailed:
         return objectSet(errors, 'updateError', action.payload);
 
+    case CustomerActionType.UpdateCustomerRequested:
+    case CustomerActionType.UpdateCustomerSucceeded:
     case BillingAddressActionType.ContinueAsGuestRequested:
     case BillingAddressActionType.ContinueAsGuestSucceeded:
         return objectSet(errors, 'continueAsGuestError', undefined);
 
+    case CustomerActionType.UpdateCustomerFailed:
     case BillingAddressActionType.ContinueAsGuestFailed:
         return objectSet(errors, 'continueAsGuestError', action.payload);
 
@@ -71,7 +75,7 @@ function errorsReducer(
 
 function statusesReducer(
     statuses: BillingAddressStatusesState = DEFAULT_STATE.statuses,
-    action: CheckoutAction | BillingAddressAction | OrderAction
+    action: CheckoutAction | BillingAddressAction | OrderAction | UpdateCustomerAction
 ): BillingAddressStatusesState {
     switch (action.type) {
     case CheckoutActionType.LoadCheckoutRequested:
@@ -89,8 +93,11 @@ function statusesReducer(
         return objectSet(statuses, 'isUpdating', false);
 
     case BillingAddressActionType.ContinueAsGuestRequested:
+    case CustomerActionType.UpdateCustomerRequested:
         return objectSet(statuses, 'isContinuingAsGuest', true);
 
+    case CustomerActionType.UpdateCustomerSucceeded:
+    case CustomerActionType.UpdateCustomerFailed:
     case BillingAddressActionType.ContinueAsGuestFailed:
     case BillingAddressActionType.ContinueAsGuestSucceeded:
         return objectSet(statuses, 'isContinuingAsGuest', false);

--- a/src/customer/index.ts
+++ b/src/customer/index.ts
@@ -4,7 +4,7 @@ export { default as InternalCustomer } from './internal-customer';
 export { default as Customer, CustomerAddress } from './customer';
 
 export { default as createCustomerStrategyRegistry } from './create-customer-strategy-registry';
-export { CustomerAction, CustomerActionType } from './customer-actions';
+export { CustomerAction, CustomerActionType, UpdateCustomerAction } from './customer-actions';
 export { default as customerReducer } from './customer-reducer';
 export { default as CustomerActionCreator } from './customer-action-creator';
 export { default as CustomerCredentials } from './customer-credentials';


### PR DESCRIPTION
## What?
Update billing state when updating customer (so far it's only consent).

## Why?
Because if updating consent failed, it would get stuck in a "loading" state

## Testing / Proof
unit

@bigcommerce/checkout 