### PR TITLE
feat(payment): PAYPAL-227 Pass theme settings to PP script

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-options.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-options.ts
@@ -1,6 +1,8 @@
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+
 export interface PaypalCommerceButtonInitializeOptions {
     /**
      * A set of styling options for the checkout button.
      */
-    style?: any;
+    style?: PaypalButtonStyleOptions;
 }

--- a/src/payment/strategies/paypal-commerce/index.ts
+++ b/src/payment/strategies/paypal-commerce/index.ts
@@ -1,3 +1,4 @@
-export { PaypalCommerceSDK, ButtonsOptions, ApproveDataOptions, PaypalCommerceScriptOptions, PaypalCommerceHostWindow } from './paypal-commerce-sdk';
+export * from './paypal-commerce-sdk';
+
 export { default as PaypalCommerceScriptLoader } from './paypal-commerce-script-loader';
 export { default as PaypalCommercePaymentStrategy } from './paypal-commerce-payment-strategy';

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -3,8 +3,43 @@ export interface ApproveDataOptions {
     orderID: string;
 }
 
+export enum StyleButtonLabel {
+    paypal = 'paypal',
+    checkout = 'checkout',
+    buynow = 'buynow',
+    pay = 'pay',
+    installment = 'installment',
+}
+
+export enum StyleButtonLayout {
+    vertical = 'vertical',
+    horizontal = 'horizontal',
+}
+
+export enum StyleButtonColor {
+    gold = 'gold',
+    blue = 'blue',
+    silver = 'silver',
+    black = 'black',
+    white = 'white',
+}
+
+export enum StyleButtonShape {
+    pill = 'pill',
+    rect = 'rect' ,
+}
+
+export interface PaypalButtonStyleOptions {
+    layout?: StyleButtonLayout;
+    color?: StyleButtonColor;
+    shape?: StyleButtonShape;
+    height?: 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 | 40 | 41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 | 51 | 52 | 53 | 54 | 55;
+    label?: StyleButtonLabel;
+    tagline?: boolean;
+}
+
 export interface ButtonsOptions {
-    enableStandardCardFields?: boolean;
+    style?: PaypalButtonStyleOptions;
     createOrder(): Promise<string>;
     onApprove(data: ApproveDataOptions): void;
 }


### PR DESCRIPTION
## What?
Get theme settings and pass it to PayPal buttons initialization script
Edit currency - now form cart (not from config)

## Why?
For changing styles smart-buttons

## Testing / Proof
<img width="547" alt="Screen Shot 2020-03-05 at 12 00 06 PM" src="https://user-images.githubusercontent.com/32959076/75970362-e2d86200-5ed8-11ea-9475-2562cabaeef4.png">


@bigcommerce/checkout @bigcommerce/payments
