### PR TITLE
feat(payment): INT-2279 Create a strategy for credit cards with redirect and add support to Checkout.com

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -30,6 +30,7 @@ import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow } from '
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
+import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
 import { createGooglePayPaymentProcessor, GooglePayBraintreeInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
@@ -133,6 +134,16 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             hostedFormFactory
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM, () =>
+        new CreditCardRedirectPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory,
+            formPoster
         )
     );
 

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -4,6 +4,7 @@ enum PaymentStrategyType {
     AFTERPAY = 'afterpay',
     AMAZON = 'amazon',
     BLUESNAPV2 = 'bluesnapv2',
+    CHECKOUTCOM = 'checkoutcom',
     CREDIT_CARD = 'creditcard',
     CYBERSOURCE = 'cybersource',
     KLARNA = 'klarna',

--- a/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.spec.ts
@@ -1,0 +1,330 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { merge, omit } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { getConfig } from '../../../config/configs.mock';
+import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../hosted-form';
+import { FinalizeOrderAction, LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getOrder } from '../../../order/orders.mock';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+import * as paymentStatusTypes from '../../payment-status-types';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+
+import CreditCardRedirectPaymentStrategy from './credit-card-redirect-payment-strategy';
+
+describe('CreditCardRedirectPaymentStrategy', () => {
+    let formFactory: HostedFormFactory;
+    let finalizeOrderAction: Observable<FinalizeOrderAction>;
+    let formPoster: FormPoster;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let orderRequestSender: OrderRequestSender;
+    let strategy: CreditCardRedirectPaymentStrategy;
+    let submitOrderAction: Observable<SubmitOrderAction>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+
+    beforeEach(() => {
+        formFactory = new HostedFormFactory(store);
+        requestSender = createRequestSender();
+        orderRequestSender = new OrderRequestSender(requestSender);
+        orderActionCreator = new OrderActionCreator(
+            orderRequestSender,
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer()
+        );
+
+        formPoster = createFormPoster();
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(store, 'dispatch');
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockImplementation((_url, _data, callback = () => {}) => callback());
+
+        jest.spyOn(orderActionCreator, 'finalizeOrder')
+            .mockReturnValue(finalizeOrderAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        strategy = new CreditCardRedirectPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formFactory,
+            formPoster
+        );
+    });
+
+    it('submits order without payment data', async () => {
+        const payload = getOrderRequestBody();
+        const options = { methodId: 'methodId' };
+
+        await strategy.execute(payload, options);
+
+        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), options);
+        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    });
+
+    it('submits payment separately', async () => {
+        const payload = getOrderRequestBody();
+        const options = { methodId: 'methodId' };
+
+        await strategy.execute(payload, options);
+
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payload.payment);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+    });
+
+    it('returns checkout state', async () => {
+        const output = await strategy.execute(getOrderRequestBody());
+
+        expect(output).toEqual(store.getState());
+    });
+
+    it('posts 3ds data to the provided acs_url if 3ds is enabled', async () => {
+        const error = new RequestError(getResponse({
+            ...getErrorPaymentResponseBody(),
+            errors: [
+                { code: 'three_d_secure_required' },
+            ],
+            three_ds_result: {
+                acs_url: 'https://acs/url',
+                callback_url: 'https://callback/url',
+                payer_auth_request: 'payer_auth_request',
+                merchant_data: 'merchant_data',
+            },
+            status: 'error',
+        }));
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+        strategy.execute(getOrderRequestBody());
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(formPoster.postForm).toHaveBeenCalledWith('https://acs/url', {
+            PaReq: 'payer_auth_request',
+            TermUrl: 'https://callback/url',
+            MD: 'merchant_data',
+        });
+    });
+
+    it('does not post 3ds data to the provided acs_url if 3ds is not enabled', async () => {
+        const response = new RequestError(getResponse(getErrorPaymentResponseBody()));
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, response)));
+
+        await expect(strategy.execute(getOrderRequestBody())).rejects.toThrow(RequestError);
+        expect(formPoster.postForm).not.toHaveBeenCalled();
+    });
+
+    it('finalizes order if order is created and payment is finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(getOrder());
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.FINALIZE);
+
+        await strategy.finalize();
+
+        expect(orderActionCreator.finalizeOrder).toHaveBeenCalled();
+        expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not created', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.INITIALIZE);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('throws error if order is missing', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+    });
+
+    describe('when hosted form is enabled', () => {
+        let form: Pick<HostedForm, 'attach' | 'submit' | 'validate'>;
+        let initializeOptions: PaymentInitializeOptions;
+        let loadOrderAction: Observable<LoadOrderSucceededAction>;
+        let state: InternalCheckoutSelectors;
+
+        beforeEach(() => {
+            form = {
+                attach: jest.fn(() => Promise.resolve()),
+                submit: jest.fn(() => Promise.resolve()),
+                validate: jest.fn(() => Promise.resolve()),
+            };
+            initializeOptions = {
+                creditCard: {
+                    form: {
+                        fields: {
+                            [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                            [HostedFieldType.CardName]: { containerId: 'card-name' },
+                            [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                        },
+                    },
+                },
+                methodId: 'checkoutcom',
+            };
+            loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
+            state = store.getState();
+
+            jest.spyOn(state.config, 'getStoreConfig')
+                .mockReturnValue(merge(
+                    getConfig().storeConfig,
+                    { checkoutSettings: { isHostedPaymentFormEnabled: true } }
+                ));
+
+            jest.spyOn(orderActionCreator, 'loadCurrentOrder')
+                .mockReturnValue(loadOrderAction);
+
+            jest.spyOn(formFactory, 'create')
+                .mockReturnValue(form);
+        });
+
+        it('creates hosted form', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(formFactory.create)
+                .toHaveBeenCalledWith(
+                    'https://bigpay.integration.zone',
+                    'dc030783-6129-4ee3-8e06-6f4270df1527',
+                    // tslint:disable-next-line:no-non-null-assertion
+                    initializeOptions.creditCard!.form!
+                );
+        });
+
+        it('attaches hosted form to container', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(form.attach)
+                .toHaveBeenCalled();
+        });
+
+        it('submits payment data with hosted form', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(form.submit)
+                .toHaveBeenCalledWith(payload.payment);
+        });
+
+        it('validates user input before submitting data', async () => {
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(getOrderRequestBody());
+
+            expect(form.validate)
+                .toHaveBeenCalled();
+        });
+
+        it('does not submit payment data with hosted form if validation fails', async () => {
+            jest.spyOn(form, 'validate')
+                .mockRejectedValue(new Error());
+
+            try {
+                await strategy.initialize(initializeOptions);
+                await strategy.execute(getOrderRequestBody());
+            } catch (error) {
+                expect(form.submit)
+                    .not.toHaveBeenCalled();
+            }
+        });
+
+        it('loads current order after payment submission', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(loadOrderAction);
+        });
+
+        it('posts 3ds data to the provided acs_url if 3ds is enabled', async () => {
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [
+                    { code: 'three_d_secure_required' },
+                ],
+                three_ds_result: {
+                    acs_url: 'https://acs/url',
+                    callback_url: 'https://callback/url',
+                    payer_auth_request: 'payer_auth_request',
+                    merchant_data: 'merchant_data',
+                },
+                status: 'error',
+            }));
+
+            jest.spyOn(form, 'submit')
+                .mockRejectedValue(error);
+
+            await strategy.initialize(initializeOptions);
+            strategy.execute(getOrderRequestBody());
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('https://acs/url',
+            {
+                PaReq: 'payer_auth_request',
+                TermUrl: 'https://callback/url',
+                MD: 'merchant_data',
+            });
+            expect(orderActionCreator.loadCurrentOrder)
+                .not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.ts
+++ b/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.ts
@@ -1,0 +1,96 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { some } from 'lodash';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentRequestOptions } from '../../payment-request-options';
+import * as paymentStatusTypes from '../../payment-status-types';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+export default class CreditCardRedirectPaymentStrategy extends CreditCardPaymentStrategy {
+    constructor(
+        protected _store: CheckoutStore,
+        protected _orderActionCreator: OrderActionCreator,
+        protected _paymentActionCreator: PaymentActionCreator,
+        protected _hostedFormFactory: HostedFormFactory,
+        protected _formPoster: FormPoster
+    ) {
+        super(
+            _store,
+            _orderActionCreator,
+            _paymentActionCreator,
+            _hostedFormFactory
+        );
+    }
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const order = state.order.getOrder();
+
+        if (order && state.payment.getPaymentStatus() === paymentStatusTypes.FINALIZE) {
+            return this._store.dispatch(this._orderActionCreator.finalizeOrder(order.orderId, options));
+        }
+
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    protected async _executeWithoutHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+        const paymentData = payment && payment.paymentData;
+
+        if (!payment || !paymentData) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+        return await this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }))
+        .catch(error => {
+            if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
+                return Promise.reject(error);
+            }
+
+            return new Promise(() => this._formPoster.postForm(error.body.three_ds_result.acs_url, {
+                PaReq: error.body.three_ds_result.payer_auth_request || null,
+                TermUrl: error.body.three_ds_result.callback_url || null,
+                MD: error.body.three_ds_result.merchant_data || null,
+            }));
+        });
+    }
+
+    protected async _executeWithHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>  {
+        const { payment, ...order } = payload;
+        const form = this._hostedForm;
+
+        if (!form) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (!payment || !payment.methodId) {
+            throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+
+        try {
+            await form.validate();
+            await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+            await form.submit(payment);
+        } catch (error) {
+            if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
+                return Promise.reject(error);
+            }
+
+            return new Promise(() => this._formPoster.postForm(error.body.three_ds_result.acs_url, {
+                PaReq: error.body.three_ds_result.payer_auth_request || null,
+                TermUrl: error.body.three_ds_result.callback_url || null,
+                MD: error.body.three_ds_result.merchant_data || null,
+            }));
+        }
+
+        return await this._store.dispatch(this._orderActionCreator.loadCurrentOrder());
+    }
+}

--- a/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.ts
+++ b/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.ts
@@ -49,8 +49,9 @@ export default class CreditCardRedirectPaymentStrategy extends CreditCardPayment
 
         await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
-        return await this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }))
-        .catch(error => {
+        try {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }));
+        } catch (error) {
             if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
                 return Promise.reject(error);
             }
@@ -60,7 +61,7 @@ export default class CreditCardRedirectPaymentStrategy extends CreditCardPayment
                 TermUrl: error.body.three_ds_result.callback_url || null,
                 MD: error.body.three_ds_result.merchant_data || null,
             }));
-        });
+        }
     }
 
     protected async _executeWithHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>  {

--- a/src/payment/strategies/credit-card-redirect/index.ts
+++ b/src/payment/strategies/credit-card-redirect/index.ts
@@ -1,0 +1,1 @@
+export { default as CreditCardRedirectPaymentStrategy } from './credit-card-redirect-payment-strategy';

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.ts
@@ -60,7 +60,7 @@ export default class CreditCardPaymentStrategy implements PaymentStrategy {
         return Promise.resolve(this._store.getState());
     }
 
-    private _executeWithoutHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    protected _executeWithoutHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const { payment, ...order } = payload;
         const paymentData = payment && payment.paymentData;
 
@@ -74,7 +74,7 @@ export default class CreditCardPaymentStrategy implements PaymentStrategy {
             );
     }
 
-    private _executeWithHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>  {
+    protected _executeWithHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>  {
         const { payment, ...order } = payload;
         const form = this._hostedForm;
 
@@ -92,7 +92,7 @@ export default class CreditCardPaymentStrategy implements PaymentStrategy {
             .then(() => this._store.dispatch(this._orderActionCreator.loadCurrentOrder()));
     }
 
-    private _isHostedPaymentFormEnabled(): boolean {
+    protected _isHostedPaymentFormEnabled(): boolean {
         const { config } = this._store.getState();
         const { checkoutSettings: { isHostedPaymentFormEnabled = false } = {} } = config.getStoreConfig() || {};
 


### PR DESCRIPTION
## What? [INT-2279](https://jira.bigcommerce.com/browse/INT-2279)
Create a payment strategy to support redirect when using a credit card form, and register checkout.com with this strategy.

## Why?
So redirecting to pages such as checkout.com's 3DS challenge is possible.

## Testing / Proof
[Demo Video](https://drive.google.com/open?id=1JorF1Z5HE_2ASfpcJj0MG81kkA0UTk4P)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce @bigcommerce/intersys-integrations 
