### PR TITLE
feat(checkout): INT-2274 Add vaulting support for Checkout.com

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -53,6 +53,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'barclaycard',
         method: 'credit_card',
     },
+    checkoutcom: {
+        provider: 'checkoutcom',
+        method: 'credit_card',
+    },
 };
 
 export default supportedInstruments;


### PR DESCRIPTION
## What?
Add checkout.com to the list of supported payment instruments.

## Why?
So vaulted cards with checkout.com can be selected.

## Testing / Proof
![Screen Shot 2020-04-03 at 11 32 40 AM](https://user-images.githubusercontent.com/35502707/78388828-eece4700-759e-11ea-91e4-6b9ee3d2b9e7.png)


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
