### PR TITLE
fix(payment): INT-2418 Use SecurityNumber as a safeguard

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.ts
@@ -776,5 +776,5 @@ export type AdyenComponentState = (
 );
 
 export default function isCardState(param: any): param is CardState {
-    return param && typeof param.data.paymentMethod.encryptedCardNumber === 'string';
+    return param && typeof param.data.paymentMethod.encryptedSecurityCode === 'string';
 }


### PR DESCRIPTION
## What?
Change safeguard to validate against SecurityCode rather that card number as this isn't present in case no TSV validation is fired.

## Why?
If there's no TSV involved safeguard returns false and payment gets processed as it was regular credit card payment.

## Testing / Proof
..

## How can this change be undone in case of failure?
Revert this PR

@bigcommerce/checkout @bigcommerce/payments
