### PR TITLE
INT-2427 Use ExpiryDate while paying with a vaulted Bancontact card rather than CVV

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.ts
@@ -776,5 +776,6 @@ export type AdyenComponentState = (
 );
 
 export default function isCardState(param: any): param is CardState {
-    return param && typeof param.data.paymentMethod.encryptedSecurityCode === 'string';
+    return param && typeof param.data.paymentMethod.encryptedSecurityCode === 'string' ||
+        typeof param.data.paymentMethod.encryptedExpiryMonth === 'string';
 }


### PR DESCRIPTION
[INT-2427](https://jira.bigcommerce.com/browse/INT-2427)

## What?
Use ExpiryDate while paying with a vaulted Bancontact card rather than CVV

## Why?
Bancontact cards do not have CVV

## Testing / Proof
![image](https://user-images.githubusercontent.com/8570490/77021829-83a13580-694d-11ea-8d25-a470430d0055.png)


## How can this change be undone in case of failure?
Revert this PR

@bigcommerce/checkout @bigcommerce/payments
