### PR TITLE
feat(payment): PAYPAL-276 Change header in createOrder request

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -8,7 +8,7 @@ import { from, of } from 'rxjs';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { INTERNAL_USE_ONLY } from '../../../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY } from '../../../common/http-request';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { PaymentMethod, PaymentMethodActionType } from '../../../payment';
 import { getPaypalCommerce } from '../../../payment/payment-methods.mock';
@@ -206,7 +206,7 @@ describe('PaypalCommerceButtonStrategy', () => {
 
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
-            'Content-Type': 'application/x-www-form-urlencoded',
+            'Content-Type': ContentType.Json,
         };
 
         expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommerce', expect.objectContaining({

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -4,7 +4,7 @@ import { RequestSender } from '@bigcommerce/request-sender';
 import { Cart } from '../../../cart';
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { INTERNAL_USE_ONLY } from '../../../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY } from '../../../common/http-request';
 import { ApproveDataOptions, ButtonsOptions, PaypalButtonStyleOptions, PaypalCommerceScriptLoader, PaypalCommerceScriptOptions, StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape  } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
@@ -106,15 +106,13 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
     private _setupPayment(cart: Cart): Promise<string> {
         const cartId = cart.id;
         const url = '/api/storefront/payment/paypalcommerce';
+        const body = { cartId };
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
-            'Content-Type': 'application/x-www-form-urlencoded',
+            'Content-Type': ContentType.Json,
         };
 
-        return this._requestSender.post(url, {
-                headers,
-                body: { cartId },
-            })
+        return this._requestSender.post(url, { headers, body })
             .then(res => res.body.orderId);
     }
 


### PR DESCRIPTION
## What?
Change header to 'Content-Type': 'application/json' in createOrder request

## Why?
The body should be passed in as a JsonBody as an argument for the controller action

## Testing / Proof
<img width="780" alt="Screen Shot 2020-03-19 at 5 14 49 PM" src="https://user-images.githubusercontent.com/32959076/77082811-47c9a700-6a05-11ea-83c8-105f6fb3f51c.png">

@bigcommerce/checkout @bigcommerce/payments
