### PR TITLE
feat(payment): INT-1710 Add support for ACH & Vipps on Adyen

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -209,6 +209,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
 
         switch (paymentMethodName) {
             case AdyenPaymentMethodType.CreditCard:
+            case AdyenPaymentMethodType.ACH:
             case AdyenPaymentMethodType.Bancontact:
             case AdyenPaymentMethodType.GiroPay:
             case AdyenPaymentMethodType.iDEAL:
@@ -238,6 +239,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
 
             case AdyenPaymentMethodType.AliPay:
             case AdyenPaymentMethodType.Sofort:
+            case AdyenPaymentMethodType.Vipps:
             case AdyenPaymentMethodType.WeChatPayQR:
                 this._updateComponentState({
                     data: {

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -22,8 +22,8 @@ describe('AdyenV2ScriptLoader', () => {
     describe('#load()', () => {
         const adyenClient = getAdyenCheckout();
         const configuration = getAdyenConfiguration();
-        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.5.0/adyen.js';
-        const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.5.0/adyen.css';
+        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.6.0/adyen.js';
+        const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.6.0/adyen.css';
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -13,8 +13,8 @@ export default class AdyenV2ScriptLoader {
 
     load(configuration: AdyenConfiguration): Promise<AdyenCheckout> {
         return Promise.all([
-            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.5.0/adyen.css`),
-            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.5.0/adyen.js`),
+            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.6.0/adyen.css`),
+            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.6.0/adyen.js`),
         ])
         .then(() => {
             if (!this._window.AdyenCheckout) {

--- a/src/payment/strategies/adyenv2/adyenv2.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.ts
@@ -31,13 +31,15 @@ export enum AdyenComponentType {
 }
 
 export enum AdyenPaymentMethodType {
+    ACH = 'ach',
     AliPay = 'alipay',
     Bancontact = 'bcmc',
-    iDEAL = 'ideal',
     CreditCard = 'scheme',
+    iDEAL = 'ideal',
     GiroPay = 'giropay',
     SEPA = 'sepadirectdebit',
     Sofort = 'directEbanking',
+    Vipps = 'vipps',
     WeChatPayQR = 'wechatpayQR',
 }
 


### PR DESCRIPTION
## What?
I want to be able to offer my United States shoppers ACH payment method and my Norse shoppers Vipps payment method respectively through Adyen

## Why?
So that I can give them alternative methods to pay so that they are more likely to purchase.

## Testing / Proof
![image](https://user-images.githubusercontent.com/8570490/77125796-9890ce00-6a0c-11ea-99fc-8ae9782711a6.png)

## How can this change be undone in case of failure?
1. Revert this PR

@bigcommerce/checkout @bigcommerce/payments
