### PR TITLE
feat(payment): INT-2437 Add support for GooglePay on Adyen

### DIFF
--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -7,6 +7,7 @@ import { Registry } from '../common/registry';
 import createCheckoutButtonRegistry from './create-checkout-button-registry';
 import { CheckoutButtonStrategy } from './strategies';
 import { BraintreePaypalButtonStrategy } from './strategies/braintree';
+import { GooglePayButtonStrategy } from './strategies/googlepay';
 
 describe('createCheckoutButtonRegistry', () => {
     let registry: Registry<CheckoutButtonStrategy>;
@@ -21,5 +22,21 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with Braintree PayPal Credit registered', () => {
         expect(registry.get('braintreepaypalcredit')).toEqual(expect.any(BraintreePaypalButtonStrategy));
+    });
+
+    it('returns registry with GooglePay on Adyen Credit registered', () => {
+        expect(registry.get('googlepayadyenv2')).toEqual(expect.any(GooglePayButtonStrategy));
+    });
+
+    it('returns registry with GooglePay on Authorize.Net Credit registered', () => {
+        expect(registry.get('googlepayauthorizenet')).toEqual(expect.any(GooglePayButtonStrategy));
+    });
+
+    it('returns registry with GooglePay on Braintree Credit registered', () => {
+        expect(registry.get('googlepaybraintree')).toEqual(expect.any(GooglePayButtonStrategy));
+    });
+
+    it('returns registry with GooglePay on Stripe Credit registered', () => {
+        expect(registry.get('googlepaystripe')).toEqual(expect.any(GooglePayButtonStrategy));
     });
 });

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -6,7 +6,7 @@ import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
-import { createGooglePayPaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 import { PaypalCommerceRequestSender, PaypalCommerceScriptLoader } from '../payment/strategies/paypal-commerce';
@@ -58,6 +58,18 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             new MasterpassScriptLoader(scriptLoader)
         ));
+
+    registry.register(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2, () =>
+        new GooglePayButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayAdyenV2Initializer()
+            )
+        )
+    );
 
     registry.register(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, () =>
         new GooglePayButtonStrategy(

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -1,6 +1,7 @@
 enum CheckoutButtonMethodType {
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',
+    GOOGLEPAY_ADYENV2 = 'googlepayadyenv2',
     GOOGLEPAY_AUTHORIZENET = 'googlepayauthorizenet',
     GOOGLEPAY_BRAINTREE = 'googlepaybraintree',
     GOOGLEPAY_STRIPE = 'googlepaystripe',

--- a/src/checkout-buttons/strategies/googlepay/googlepay-adyenv2-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-adyenv2-button-strategy.spec.ts
@@ -10,7 +10,7 @@ import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
-import { createGooglePayPaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonMethodType from '../checkout-button-method-type';
@@ -50,7 +50,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
         paymentProcessor = createGooglePayPaymentProcessor(
             store,
-            new GooglePayAuthorizeNetInitializer()
+            new GooglePayAdyenV2Initializer()
         );
 
         formPoster = createFormPoster();
@@ -88,7 +88,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
     describe('#initialize()', () => {
         it('Creates the button', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2);
 
             await strategy.initialize(checkoutButtonOptions);
 
@@ -96,7 +96,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         });
 
         it('Validates if strategy has been initialized', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2);
 
             await strategy.initialize(checkoutButtonOptions);
 
@@ -104,7 +104,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         });
 
         it('fails to initialize the strategy if no container id is supplied', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.UndefinedContainer);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2, Mode.UndefinedContainer);
 
             try {
                 await strategy.initialize(checkoutButtonOptions);
@@ -114,7 +114,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         });
 
         it('fails to initialize the strategy if no valid container id is supplied', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.InvalidContainer);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2, Mode.InvalidContainer);
 
             await expect(strategy.initialize(checkoutButtonOptions))
                 .rejects.toThrow(InvalidArgumentError);
@@ -125,7 +125,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         let containerId: string;
 
         beforeAll(() => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.GooglePayAuthorizeNet);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2, Mode.GooglePayAdyenV2);
             containerId = checkoutButtonOptions.containerId;
         });
 
@@ -156,7 +156,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
     describe('#handleWalletButtonClick', () => {
         it('handles wallet button event', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.GooglePayAuthorizeNet);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2, Mode.GooglePayAdyenV2);
 
             jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(getGooglePaymentDataMock()));
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
@@ -166,7 +166,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             await strategy.initialize(checkoutButtonOptions);
 
             walletButton.click();
-            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET);
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2);
         });
     });
 });

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -12,9 +12,10 @@ import { getCustomerState } from '../../../customer/customers.mock';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
-import { createGooglePayPaymentProcessor, GooglePaymentData, GooglePayBraintreeInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayBraintreeInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
 
 import GooglePayButtonStrategy from './googlepay-button-strategy';
 import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
@@ -67,29 +68,23 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             paymentProcessor
         );
 
-        jest.spyOn(store, 'dispatch')
-            .mockReturnValue(Promise.resolve(store.getState()));
-
-        jest.spyOn(paymentProcessor, 'initialize')
-            .mockReturnValue(Promise.resolve());
-
-        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
-            .mockReturnValue(paymentMethod);
-
         jest.spyOn(formPoster, 'postForm')
             .mockReturnValue(Promise.resolve());
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethod);
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockReturnValue(Promise.resolve());
+        jest.spyOn(paymentProcessor, 'deinitialize');
 
-        container = document.createElement('div');
-        container.setAttribute('id', 'googlePayCheckoutButton');
         walletButton = document.createElement('a');
         walletButton.setAttribute('id', 'mockButton');
-
         jest.spyOn(paymentProcessor, 'createButton')
             .mockReturnValue(walletButton);
 
-        jest.spyOn(paymentProcessor, 'deinitialize');
-
-        container.appendChild(walletButton);
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
         document.body.appendChild(container);
     });
 
@@ -97,126 +92,87 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         document.body.removeChild(container);
     });
 
-    it('creates an instance of GooglePayButtonStrategy', () => {
-        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
-    });
-
     describe('#initialize()', () => {
+        it('Creates the button', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE);
 
-        describe('Payment method exist', () => {
+            await strategy.initialize(checkoutButtonOptions);
 
-            it('Creates the button', async () => {
-                checkoutButtonOptions = getCheckoutButtonOptions();
+            expect(paymentProcessor.createButton).toHaveBeenCalled();
+        });
 
+        it('Validates if strategy has been initialized', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE);
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
+        });
+
+        it('fails to initialize the strategy if no container id is supplied', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, Mode.UndefinedContainer);
+
+            try {
                 await strategy.initialize(checkoutButtonOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
 
-                expect(paymentProcessor.createButton).toHaveBeenCalled();
-            });
+        it('fails to initialize the strategy if no valid container id is supplied', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, Mode.InvalidContainer);
 
-            it('Validates if strategy is been initialized', async () => {
-                checkoutButtonOptions = getCheckoutButtonOptions();
-
-                await strategy.initialize(checkoutButtonOptions);
-
-                setTimeout(() => {
-                    strategy.initialize(checkoutButtonOptions);
-                }, 0);
-
-                strategy.initialize(checkoutButtonOptions);
-
-                expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
-            });
-
-            it('fails to initialize the strategy if no container id is supplied', async () => {
-                checkoutButtonOptions = getCheckoutButtonOptions(Mode.UndefinedContainer);
-
-                try {
-                    await strategy.initialize(checkoutButtonOptions);
-                } catch (e) {
-                    expect(e).toBeInstanceOf(InvalidArgumentError);
-                }
-            });
-
-            it('fails to initialize the strategy if no valid container id is supplied', async () => {
-                checkoutButtonOptions = getCheckoutButtonOptions(Mode.InvalidContainer);
-
-                try {
-                    await strategy.initialize(checkoutButtonOptions);
-                } catch (e) {
-                    expect(e).toBeInstanceOf(InvalidArgumentError);
-                }
-            });
+            await expect(strategy.initialize(checkoutButtonOptions))
+                .rejects.toThrow(InvalidArgumentError);
         });
     });
 
     describe('#deinitialize()', () => {
-        let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+        let containerId: string;
 
-        beforeEach(() => {
-            checkoutButtonOptions = getCheckoutButtonOptions(Mode.GooglePayBraintree);
+        beforeAll(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, Mode.GooglePayAuthorizeNet);
+            containerId = checkoutButtonOptions.containerId;
         });
 
         it('check if googlepay payment processor deinitialize is called', async () => {
             await strategy.initialize(checkoutButtonOptions);
 
-            strategy.deinitialize();
+            await strategy.deinitialize();
 
             expect(paymentProcessor.deinitialize).toBeCalled();
         });
 
-        it('succesfully deinitializes the strategy', async () => {
+        it('removes the child elements from attached to the containerId', async () => {
             await strategy.initialize(checkoutButtonOptions);
 
-            strategy.deinitialize();
+            const button = document.getElementById(containerId);
 
-            if (checkoutButtonOptions.containerId) {
-                const button = document.getElementById(checkoutButtonOptions.containerId);
+            expect(button).toHaveProperty('firstChild', walletButton);
 
-                if (button) {
-                    expect(button.firstChild).toBe(null);
-                }
-            }
-
-            container = document.createElement('div');
-            document.body.appendChild(container);
-        });
-
-        it('Validates if strategy is loaded before call deinitialize', async () => {
             await strategy.deinitialize();
 
-            if (checkoutButtonOptions.containerId) {
-                const button = document.getElementById(checkoutButtonOptions.containerId);
+            expect(button).toHaveProperty('firstChild', null);
+        });
 
-                if (button) {
-                    expect(button.firstChild).toBe(null);
-                }
-            }
-
-            container = document.createElement('div');
-            document.body.appendChild(container);
+        it('fails silently if strategy was not initialized', () => {
+            expect(async () => await strategy.deinitialize()).not.toThrow();
         });
     });
 
     describe('#handleWalletButtonClick', () => {
-        let googlePayOptions: CheckoutButtonInitializeOptions;
-        let paymentData: GooglePaymentData;
-
-        beforeEach(() => {
-            googlePayOptions = getCheckoutButtonOptions(Mode.GooglePayBraintree);
-
-            paymentData = getGooglePaymentDataMock();
-        });
-
         it('handles wallet button event', async () => {
-            jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(paymentData));
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, Mode.GooglePayAuthorizeNet);
+
+            jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(getGooglePaymentDataMock()));
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
 
-            await strategy.initialize(googlePayOptions).then(() => {
-                walletButton.click();
-            });
+            expect(paymentProcessor.initialize).not.toHaveBeenCalled();
+            await strategy.initialize(checkoutButtonOptions);
 
-            expect(paymentProcessor.initialize).toHaveBeenCalled();
+            walletButton.click();
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE);
         });
     });
 });

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -18,38 +18,42 @@ export enum Mode {
     Full,
     UndefinedContainer,
     InvalidContainer,
+    GooglePayAdyenV2,
     GooglePayAuthorizeNet,
     GooglePayBraintree,
     GooglePayStripe,
 }
 
-export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButtonInitializeOptions {
-    const methodId = { methodId: CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE };
+export function getCheckoutButtonOptions(methodId: CheckoutButtonMethodType, mode: Mode = Mode.Full): CheckoutButtonInitializeOptions {
     const containerId = 'googlePayCheckoutButton';
     const undefinedContainerId = { containerId: '' };
     const invalidContainerId = { containerId: 'invalid_container' };
+    const googlepayadyenv2 = { googlepayadyenv2: { buttonType: ButtonType.Short } };
     const googlepayauthorizenet = { googlepaybraintree: { buttonType: ButtonType.Short } };
     const googlepaybraintree = { googlepaybraintree: { buttonType: ButtonType.Short } };
     const googlepaystripe = { googlepaystripe: { buttonType: ButtonType.Short } };
 
     switch (mode) {
         case Mode.UndefinedContainer: {
-            return { ...methodId, ...undefinedContainerId };
+            return { methodId, ...undefinedContainerId };
         }
         case Mode.InvalidContainer: {
-            return { ...methodId, ...invalidContainerId };
+            return { methodId, ...invalidContainerId };
+        }
+        case Mode.GooglePayAdyenV2: {
+            return { methodId, containerId, ...googlepayadyenv2 };
         }
         case Mode.GooglePayAuthorizeNet: {
-            return { ...methodId, containerId, ...googlepayauthorizenet };
+            return { methodId, containerId, ...googlepayauthorizenet };
         }
         case Mode.GooglePayBraintree: {
-            return { ...methodId, containerId, ...googlepaybraintree };
+            return { methodId, containerId, ...googlepaybraintree };
         }
         case Mode.GooglePayStripe: {
-            return { ...methodId, containerId, ...googlepaystripe };
+            return { methodId, containerId, ...googlepaystripe };
         }
         default: {
-            return { ...methodId, containerId };
+            return { methodId, containerId };
         }
     }
 }

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -9,7 +9,7 @@ import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payme
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createBraintreeVisaCheckoutPaymentProcessor, BraintreeScriptLoader, BraintreeSDKCreator, VisaCheckoutScriptLoader } from '../payment/strategies/braintree';
 import { ChasePayScriptLoader } from '../payment/strategies/chasepay';
-import { createGooglePayPaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 
@@ -40,6 +40,18 @@ export default function createCustomerStrategyRegistry(
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(requestSender);
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender);
+
+    registry.register('googlepayadyenv2', () =>
+        new GooglePayCustomerStrategy(
+            store,
+            remoteCheckoutActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayAdyenV2Initializer()
+            ),
+            formPoster
+        )
+    );
 
     registry.register('amazon', () =>
         new AmazonPayCustomerStrategy(

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -56,6 +56,12 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      * The options that are required to initialize the GooglePay payment method.
      * They can be omitted unless you need to support GooglePay.
      */
+    googlepayadyenv2?: GooglePayCustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
     googlepayauthorizenet?: GooglePayCustomerInitializeOptions;
 
     /**

--- a/src/customer/strategies/googlepay/googlepay-customer-mock.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-mock.ts
@@ -19,6 +19,30 @@ export enum Mode {
     Incomplete,
 }
 
+export function getAdyenV2CustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
+    const methodId = { methodId: 'googlepayadyenv2' };
+    const undefinedMethodId = { methodId: undefined };
+    const container = { container: 'googlePayCheckoutButton' };
+    const invalidContainer = { container: 'invalid_container' };
+    const googlepayAdyenV2 = { googlepayadyenv2: { ...container } };
+    const googlepayAdyenV2WithInvalidContainer = { googlepayadyenv2: { ...invalidContainer } };
+
+    switch (mode) {
+        case Mode.Incomplete: {
+            return { ...methodId };
+        }
+        case Mode.UndefinedMethodId: {
+            return { ...undefinedMethodId, ...googlepayAdyenV2 };
+        }
+        case Mode.InvalidContainer: {
+            return { ...methodId, ...googlepayAdyenV2WithInvalidContainer };
+        }
+        default: {
+            return { ...methodId, ...googlepayAdyenV2 };
+        }
+    }
+}
+
 export function getAuthNetCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
     const methodId = { methodId: 'googlepayauthorizenet' };
     const undefinedMethodId = { methodId: undefined };

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -80,6 +80,10 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
     }
 
     private _getGooglePayOptions(options: CustomerInitializeOptions): GooglePayCustomerInitializeOptions {
+        if (options.methodId === 'googlepayadyenv2' && options.googlepayadyenv2) {
+            return options.googlepayadyenv2;
+        }
+
         if (options.methodId === 'googlepayauthorizenet' && options.googlepayauthorizenet) {
             return options.googlepayauthorizenet;
         }
@@ -95,6 +99,24 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         throw new InvalidArgumentError();
     }
 
+    @bind
+    private async _handleWalletButtonClick(event: Event): Promise<void> {
+        event.preventDefault();
+
+        try {
+            const paymentData = await this._googlePayPaymentProcessor.displayWallet();
+            await this._googlePayPaymentProcessor.handleSuccess(paymentData);
+            if (paymentData.shippingAddress) {
+                await this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress);
+            }
+            await this._onPaymentSelectComplete();
+        } catch (error) {
+            if (error && error.message !== 'CANCELED') {
+                throw error;
+            }
+        }
+    }
+
     private _onPaymentSelectComplete(): void {
         this._formPoster.postForm('/checkout.php', {
             headers: {
@@ -102,26 +124,5 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
         });
-    }
-
-    private _onError(error?: Error): void {
-        if (error && error.message !== 'CANCELED') {
-            throw error;
-        }
-    }
-
-    @bind
-    private _handleWalletButtonClick(event: Event): Promise<void> {
-        event.preventDefault();
-
-        return this._googlePayPaymentProcessor.displayWallet()
-            .then(paymentData => this._googlePayPaymentProcessor.handleSuccess(paymentData)
-            .then(() => {
-                if (paymentData.shippingAddress) {
-                    this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress);
-                }
-            }))
-            .then(() => this._onPaymentSelectComplete())
-            .catch(error => this._onError(error));
     }
 }

--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -52,6 +52,11 @@ describe('CreatePaymentStrategyRegistry', () => {
         expect(paymentStrategy).toBeInstanceOf(AdyenV2PaymentStrategy);
     });
 
+    it('can instantiate googlepayadyenv2', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.ADYENV2_GOOGLEPAY);
+        expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+
     it('can instantiate affirm', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.AFFIRM);
         expect(paymentStrategy).toBeInstanceOf(AffirmPaymentStrategy);

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -31,7 +31,7 @@ import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chas
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
-import { createGooglePayPaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
 import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
 import { LegacyPaymentStrategy } from './strategies/legacy';
@@ -84,6 +84,21 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             new AdyenV2ScriptLoader(scriptLoader, getStylesheetLoader()),
             locale
+        )
+    );
+
+    registry.register(PaymentStrategyType.ADYENV2_GOOGLEPAY, () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayAdyenV2Initializer()
+            )
         )
     );
 

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -124,6 +124,12 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * The options that are required to initialize the GooglePay Authorize.Net
      * payment method. They can be omitted unless you need to support GooglePay.
      */
+    googlepayadyenv2?: GooglePayPaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay Authorize.Net
+     * payment method. They can be omitted unless you need to support GooglePay.
+     */
     googlepayauthorizenet?: GooglePayPaymentInitializeOptions;
 
     /**

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -1,5 +1,6 @@
 enum PaymentStrategyType {
     ADYENV2 = 'adyenv2',
+    ADYENV2_GOOGLEPAY = 'googlepayadyenv2',
     AFFIRM = 'affirm',
     AFTERPAY = 'afterpay',
     AMAZON = 'amazon',

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -2,26 +2,27 @@ import { some } from 'lodash';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { getBrowserInfo } from '../../../common/browser-info';
-import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
+import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
 import isVaultedInstrument from '../../is-vaulted-instrument';
 import Payment, { HostedInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethod from '../../payment-method';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import isCardState, { isAccountState, AdyenAction, AdyenActionType, AdyenAdditionalAction, AdyenAdditionalActionState, AdyenCheckout, AdyenComponent, AdyenComponentState, AdyenComponentType, AdyenConfiguration, AdyenError, AdyenPaymentMethodType } from './adyenv2';
+import isCardState, { isAccountState, AdyenAction, AdyenActionType, AdyenAdditionalAction, AdyenAdditionalActionState, AdyenClient, AdyenComponent, AdyenComponentState, AdyenComponentType, AdyenError, AdyenPaymentMethodType } from './adyenv2';
 import AdyenV2PaymentInitializeOptions from './adyenv2-initialize-options';
 import AdyenV2ScriptLoader from './adyenv2-script-loader';
 
 export default class AdyenV2PaymentStrategy implements PaymentStrategy {
-    private _adyenCheckout?: AdyenCheckout;
-    private _adyenv2?: AdyenV2PaymentInitializeOptions;
-    private _paymentComponent?: AdyenComponent;
+    private _adyenClient?: AdyenClient;
     private _cardVerificationComponent?: AdyenComponent;
     private _componentState?: AdyenComponentState;
+    private _paymentComponent?: AdyenComponent;
+    private _paymentInitializeOptions?: AdyenV2PaymentInitializeOptions;
 
     constructor(
         private _store: CheckoutStore,
@@ -31,33 +32,30 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         private _locale: string
     ) {}
 
-    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { adyenv2 } = options;
 
         if (!adyenv2) {
             throw new InvalidArgumentError('Unable to initialize payment because "options.adyenv2" argument is not provided.');
         }
 
-        const paymentMethod = this._store.getState().paymentMethods.getPaymentMethod(options.methodId);
+        this._paymentInitializeOptions = adyenv2;
 
-        if (!paymentMethod) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
+        const paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(options.methodId);
 
-        this._adyenv2 = adyenv2;
-
-        const configuration: AdyenConfiguration = {
+        this._adyenClient = await this._scriptLoader.load({
             environment:  paymentMethod.initializationData.environment,
             locale: this._locale,
             originKey: paymentMethod.initializationData.originKey,
             paymentMethodsResponse: paymentMethod.initializationData.paymentMethodsResponse,
-        };
+        });
 
-        this._scriptLoader.load(configuration)
-            .then(adyenCheckout => {
-                this._adyenCheckout = adyenCheckout;
-                this._mountComponent(paymentMethod.method);
-            });
+        this._paymentComponent = await this._mountPaymentComponent(paymentMethod);
+
+        if (paymentMethod.method === AdyenPaymentMethodType.CreditCard ||
+            paymentMethod.method === AdyenPaymentMethodType.Bancontact) {
+            this._cardVerificationComponent = await this._mountCardVerificationComponent();
+        }
 
         return Promise.resolve(this._store.getState());
     }
@@ -108,7 +106,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                     }
                 }
 
-                const paymentPayload = {
+                return this._store.dispatch(this._paymentActionCreator.submitPayment({
                     methodId: payment.methodId,
                     paymentData: {
                         formattedPayload: {
@@ -122,9 +120,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                             vault_payment_instrument: shouldSaveInstrument,
                         },
                     },
-                };
-
-                return this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload));
+                }));
             })
             .catch(error => this._processAdditionalAction(error, shouldSaveInstrument));
     }
@@ -147,24 +143,24 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         return Promise.resolve(this._store.getState());
     }
 
-    private _getAdyenCheckout(): AdyenCheckout {
-        if (!this._adyenCheckout) {
+    private _getAdyenClient(): AdyenClient {
+        if (!this._adyenClient) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        return this._adyenCheckout;
+        return this._adyenClient;
     }
 
-    private _getAdyenV2PaymentInitializeOptions(): AdyenV2PaymentInitializeOptions {
-        if (!this._adyenv2) {
+    private _getPaymentInitializeOptions(): AdyenV2PaymentInitializeOptions {
+        if (!this._paymentInitializeOptions) {
             throw new InvalidArgumentError('"options.adyenv2" argument was not provided during initialization.');
         }
 
-        return this._adyenv2;
+        return this._paymentInitializeOptions;
     }
 
     private _getThreeDS2ChallengeWidgetSize(): string {
-        const { widgetSize } = this._getAdyenV2PaymentInitializeOptions().threeDS2Options;
+        const { widgetSize } = this._getPaymentInitializeOptions().threeDS2Options;
 
         if (!widgetSize) {
             return '05';
@@ -175,11 +171,11 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
 
     private _handleAction(additionalAction: AdyenAdditionalAction): Promise<Payment> {
         return new Promise((resolve, reject) => {
-            const { threeDS2ContainerId, additionalActionOptions } = this._getAdyenV2PaymentInitializeOptions();
+            const { threeDS2ContainerId, additionalActionOptions } = this._getPaymentInitializeOptions();
             const { onBeforeLoad, containerId, onLoad, onComplete } = additionalActionOptions;
             const adyenAction: AdyenAction = JSON.parse(additionalAction.action);
 
-            const additionalActionComponent = this._getAdyenCheckout().createFromAction(adyenAction, {
+            const additionalActionComponent = this._getAdyenClient().createFromAction(adyenAction, {
                 onAdditionalDetails: (additionalActionState: AdyenAdditionalActionState) => {
                     const paymentPayload = {
                         methodId: adyenAction.paymentMethodType,
@@ -214,59 +210,81 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         });
     }
 
-    private _mountComponent(paymentMethodName: string): void {
-        const adyenv2 = this._getAdyenV2PaymentInitializeOptions();
-        const adyenCheckout = this._getAdyenCheckout();
+    private _mountCardVerificationComponent(): Promise<AdyenComponent> {
+        const adyenv2 = this._getPaymentInitializeOptions();
+        const adyenClient = this._getAdyenClient();
+        let cardVerificationComponent: AdyenComponent;
 
-        switch (paymentMethodName) {
-            case AdyenPaymentMethodType.CreditCard:
-            case AdyenPaymentMethodType.ACH:
-            case AdyenPaymentMethodType.Bancontact:
-            case AdyenPaymentMethodType.GiroPay:
-            case AdyenPaymentMethodType.iDEAL:
-            case AdyenPaymentMethodType.SEPA:
-                const paymentComponent = adyenCheckout.create(paymentMethodName, {
-                        ...adyenv2.options,
-                        onChange: componentState => this._updateComponentState(componentState),
-                    }
-                );
-
-                paymentComponent.mount(`#${adyenv2.containerId}`);
-
-                this._paymentComponent = paymentComponent;
-
-                if (adyenv2.cardVerificationContainerId) {
-                    const cardVerificationComponent = adyenCheckout.create(AdyenComponentType.SecuredFields, {
-                        ...adyenv2.options,
-                        onChange: componentState => this._updateComponentState(componentState),
-                        onError: componentState => this._updateComponentState(componentState),
-                    });
-
-                    cardVerificationComponent.mount(`#${adyenv2.cardVerificationContainerId}`);
-
-                    this._cardVerificationComponent = cardVerificationComponent;
-                }
-                break;
-
-            case AdyenPaymentMethodType.AliPay:
-            case AdyenPaymentMethodType.Sofort:
-            case AdyenPaymentMethodType.Vipps:
-            case AdyenPaymentMethodType.WeChatPayQR:
-                this._updateComponentState({
-                    data: {
-                        paymentMethod: {
-                            type: paymentMethodName,
-                        },
-                    },
+        return new Promise((resolve, reject) => {
+            if (adyenv2.cardVerificationContainerId) {
+                cardVerificationComponent = adyenClient.create(AdyenComponentType.SecuredFields, {
+                    ...adyenv2.options,
+                    onChange: componentState => this._updateComponentState(componentState),
+                    onError: componentState => this._updateComponentState(componentState),
                 });
-        }
+
+                try {
+                    cardVerificationComponent.mount(`#${adyenv2.cardVerificationContainerId}`);
+                } catch (error) {
+                    reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+                }
+            }
+
+            resolve(cardVerificationComponent);
+        });
     }
 
-    private async _processAdditionalAction(error: any, shouldSaveInstrument?: boolean): Promise<any> {
+    private _mountPaymentComponent(paymentMethod: PaymentMethod): Promise<AdyenComponent> {
+        let paymentComponent: AdyenComponent;
+        const adyenv2 = this._getPaymentInitializeOptions();
+        const adyenClient = this._getAdyenClient();
+
+        return new Promise((resolve, reject) => {
+            switch (paymentMethod.method) {
+                case AdyenPaymentMethodType.CreditCard:
+                case AdyenPaymentMethodType.ACH:
+                case AdyenPaymentMethodType.Bancontact:
+                case AdyenPaymentMethodType.GiroPay:
+                case AdyenPaymentMethodType.iDEAL:
+                case AdyenPaymentMethodType.SEPA:
+                    paymentComponent = adyenClient.create(paymentMethod.method, {
+                            ...adyenv2.options,
+                            onChange: componentState => this._updateComponentState(componentState),
+                        }
+                    );
+
+                    try {
+                        paymentComponent.mount(`#${adyenv2.containerId}`);
+                    } catch (error) {
+                        reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+                    }
+
+                    break;
+
+                case AdyenPaymentMethodType.AliPay:
+                case AdyenPaymentMethodType.Sofort:
+                case AdyenPaymentMethodType.Vipps:
+                case AdyenPaymentMethodType.WeChatPayQR:
+                    this._updateComponentState({
+                        data: {
+                            paymentMethod: {
+                                type: paymentMethod.method,
+                            },
+                        },
+                    });
+            }
+
+            resolve(paymentComponent);
+        });
+    }
+
+    private async _processAdditionalAction(error: unknown, shouldSaveInstrument?: boolean): Promise<InternalCheckoutSelectors> {
         if (!(error instanceof RequestError) || !some(error.body.errors, {code: 'additional_action_required'})) {
             return Promise.reject(error);
         }
+
         const payment = await this._handleAction(error.body.provider_data);
+
         try {
             return await this._store.dispatch(this._paymentActionCreator.submitPayment({
                 ...payment,

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -4,7 +4,7 @@ import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { AdyenHostWindow } from './adyenv2';
 import AdyenV2ScriptLoader from './adyenv2-script-loader';
-import { getAdyenCheckout, getAdyenConfiguration } from './adyenv2.mock';
+import { getAdyenClient, getAdyenConfiguration } from './adyenv2.mock';
 
 describe('AdyenV2ScriptLoader', () => {
     let adyenV2ScriptLoader: AdyenV2ScriptLoader;
@@ -20,7 +20,7 @@ describe('AdyenV2ScriptLoader', () => {
     });
 
     describe('#load()', () => {
-        const adyenClient = getAdyenCheckout();
+        const adyenClient = getAdyenClient();
         const configuration = getAdyenConfiguration();
         const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.6.0/adyen.js';
         const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.6.0/adyen.css';
@@ -60,16 +60,6 @@ describe('AdyenV2ScriptLoader', () => {
 
                 return Promise.resolve();
             });
-
-            try {
-                await adyenV2ScriptLoader.load(configuration);
-            } catch (error) {
-                expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
-            }
-        });
-
-        it('throws an error when stylesheet is not loaded', async () => {
-            stylesheetLoader.loadStylesheet = jest.fn(() => Promise.reject());
 
             try {
                 await adyenV2ScriptLoader.load(configuration);

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -2,29 +2,25 @@ import { ScriptLoader, StylesheetLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
-import { AdyenCheckout, AdyenConfiguration, AdyenHostWindow } from './adyenv2';
+import { AdyenClient, AdyenConfiguration, AdyenHostWindow } from './adyenv2';
 
 export default class AdyenV2ScriptLoader {
     constructor(
         private _scriptLoader: ScriptLoader,
         private _stylesheetLoader: StylesheetLoader,
         private _window: AdyenHostWindow = window
-    ) {}
+    ) { }
 
-    load(configuration: AdyenConfiguration): Promise<AdyenCheckout> {
-        return Promise.all([
+    async load(configuration: AdyenConfiguration): Promise<AdyenClient> {
+        await Promise.all([
             this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.6.0/adyen.css`),
             this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.6.0/adyen.js`),
-        ])
-        .then(() => {
-            if (!this._window.AdyenCheckout) {
-                throw new PaymentMethodClientUnavailableError();
-            }
+        ]);
 
-            return new this._window.AdyenCheckout(configuration);
-        })
-        .catch(() => {
+        if (!this._window.AdyenCheckout) {
             throw new PaymentMethodClientUnavailableError();
-        });
+        }
+
+        return new this._window.AdyenCheckout(configuration);
     }
 }

--- a/src/payment/strategies/adyenv2/adyenv2.mock.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.mock.ts
@@ -5,7 +5,7 @@ import Payment from '../../payment';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import { getCreditCardInstrument, getErrorPaymentResponseBody, getVaultedInstrument } from '../../payments.mock';
 
-import { AdyenAdditionalActionErrorResponse, AdyenCheckout, AdyenComponentState, AdyenConfiguration, AdyenError, AdyenPaymentMethodType, ResultCode } from './adyenv2';
+import { AdyenAdditionalActionErrorResponse, AdyenClient, AdyenComponentState, AdyenConfiguration, AdyenError, AdyenPaymentMethodType, ResultCode } from './adyenv2';
 
 function getAdditionalActionErrorResponse(resultCode: ResultCode): AdyenAdditionalActionErrorResponse {
     return {
@@ -52,14 +52,7 @@ export function getAdditionalActionError(resultCode: ResultCode): RequestError {
     }));
 }
 
-export function getAdyenConfiguration(): AdyenConfiguration {
-    return {
-        environment: 'test',
-        originKey: 'YOUR_ORIGIN_KEY',
-    };
-}
-
-export function getAdyenCheckout(): AdyenCheckout {
+export function getAdyenClient(): AdyenClient {
     return {
         create: jest.fn(() => {
             return {
@@ -74,6 +67,13 @@ export function getAdyenCheckout(): AdyenCheckout {
                 unmount: jest.fn(),
             };
         }),
+    };
+}
+
+export function getAdyenConfiguration(): AdyenConfiguration {
+    return {
+        environment: 'test',
+        originKey: 'YOUR_ORIGIN_KEY',
     };
 }
 

--- a/src/payment/strategies/adyenv2/adyenv2.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.ts
@@ -37,6 +37,7 @@ export enum AdyenPaymentMethodType {
     CreditCard = 'scheme',
     iDEAL = 'ideal',
     GiroPay = 'giropay',
+    GooglePay = 'paywithgoogle',
     SEPA = 'sepadirectdebit',
     Sofort = 'directEbanking',
     Vipps = 'vipps',
@@ -169,8 +170,8 @@ export interface AdyenComponentEvents {
     onError?(state: AdyenComponentState, component: AdyenComponent): void;
 }
 
-export interface AdyenCheckout {
-    create(type: string, componentOptions?: AdyenCreditCardComponentOptions | AdyenIdealComponentOptions | AdyenCustomCardComponentOptions): AdyenComponent;
+export interface AdyenClient {
+    create(type: string, componentOptions?: AdyenComponentOptions): AdyenComponent;
 
     createFromAction(action: AdyenAction, componentOptions?: ThreeDS2DeviceFingerprintComponentOptions | ThreeDS2ChallengeComponentOptions ): AdyenComponent;
 }
@@ -273,7 +274,7 @@ export interface AdyenError {
 }
 
 export interface AdyenHostWindow extends Window {
-    AdyenCheckout?: new(configuration: AdyenConfiguration) => AdyenCheckout;
+    AdyenCheckout?: new(configuration: AdyenConfiguration) => AdyenClient;
 }
 
 export interface AdyenIdealComponentOptions {
@@ -783,6 +784,10 @@ export interface ThreeDS2DeviceFingerprintComponentOptions {
 
 export type AdyenComponentState = (
     CardState | WechatState
+);
+
+export type AdyenComponentOptions = (
+    AdyenCreditCardComponentOptions | AdyenIdealComponentOptions | AdyenCustomCardComponentOptions
 );
 
 export default function isCardState(param: any): param is CardState {

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.spec.ts
@@ -1,0 +1,40 @@
+import GooglePayAdyenV2Initializer from './googlepay-adyenv2-initializer';
+import { getAdyenV2PaymentDataMock, getAdyenV2PaymentDataRequest, getAdyenV2PaymentMethodMock, getAdyenV2TokenizedPayload, getCheckoutMock } from './googlepay.mock';
+
+describe('GooglePayAdyenV2Initializer', () => {
+    let googlePayInitializer: GooglePayAdyenV2Initializer;
+
+    beforeEach(() => {
+        googlePayInitializer = new GooglePayAdyenV2Initializer();
+    });
+
+    it('creates an instance of GooglePayAdyenV2Initializer', () => {
+        expect(googlePayInitializer).toBeInstanceOf(GooglePayAdyenV2Initializer);
+    });
+
+    describe('#initialize', () => {
+        it('initializes the google pay configuration for adyenv2', async () => {
+            const initialize = await googlePayInitializer.initialize(
+                getCheckoutMock(),
+                getAdyenV2PaymentMethodMock(),
+                false
+            );
+
+            expect(initialize).toEqual(getAdyenV2PaymentDataRequest());
+        });
+    });
+
+    describe('#teardown', () => {
+        it('teardown the initializer', () => {
+            expect(googlePayInitializer.teardown()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('#parseResponse', () => {
+        it('parses a response from google pay payload received', () => {
+            const tokenizePayload = googlePayInitializer.parseResponse(getAdyenV2PaymentDataMock());
+
+            expect(tokenizePayload).toEqual(getAdyenV2TokenizedPayload());
+        });
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
@@ -1,0 +1,108 @@
+import { round } from 'lodash';
+
+import { Checkout } from '../../../checkout';
+import PaymentMethod from '../../payment-method';
+
+import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload, TokenizeType } from './googlepay';
+
+export default class GooglePayAdyenV2Initializer implements GooglePayInitializer {
+    initialize(
+        checkout: Checkout,
+        paymentMethod: PaymentMethod,
+        hasShippingAddress: boolean
+    ): Promise<GooglePayPaymentDataRequestV2> {
+        return Promise.resolve(this._getGooglePayPaymentDataRequest(
+            checkout,
+            paymentMethod,
+            hasShippingAddress
+        ));
+    }
+
+    teardown(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    parseResponse(paymentData: GooglePaymentData): TokenizePayload {
+        const {
+            paymentMethodData: {
+                type,
+                tokenizationData: { token },
+                info: {
+                    cardNetwork: cardType,
+                    cardDetails: lastFour,
+                },
+            },
+        } = paymentData;
+
+        return {
+            type: type as TokenizeType,
+            nonce: token,
+            details: {
+                cardType,
+                lastFour,
+            },
+        };
+    }
+
+    private _getGooglePayPaymentDataRequest(
+        checkout: Checkout,
+        paymentMethod: PaymentMethod,
+        hasShippingAddress: boolean
+    ): GooglePayPaymentDataRequestV2 {
+        const {
+            outstandingBalance,
+            cart: {
+                currency: { code: currencyCode },
+            },
+        } = checkout;
+
+        const {
+            initializationData: {
+                gatewayMerchantId,
+                googleMerchantName: merchantName,
+                googleMerchantId: merchantId,
+                platformToken: authJwt,
+            },
+            supportedCards,
+        } = paymentMethod;
+
+        return {
+            apiVersion: 2,
+            apiVersionMinor: 0,
+            merchantInfo: {
+                authJwt,
+                merchantId,
+                merchantName,
+            },
+            allowedPaymentMethods: [{
+                type: 'CARD',
+                parameters: {
+                    allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                    allowedCardNetworks: supportedCards.map(card => card === 'MC' ? 'MASTERCARD' : card),
+                    billingAddressRequired: true,
+                    billingAddressParameters: {
+                        format: BillingAddressFormat.Full,
+                        phoneNumberRequired: true,
+                    },
+                },
+                tokenizationSpecification: {
+                    type: 'PAYMENT_GATEWAY',
+                    parameters: {
+                        gateway: 'adyen',
+                        gatewayMerchantId,
+                    },
+                },
+            }],
+            transactionInfo: {
+                currencyCode,
+                totalPriceStatus: 'FINAL',
+                totalPrice: round(outstandingBalance, 2).toFixed(2),
+            },
+            emailRequired: true,
+            shippingAddressRequired: !hasShippingAddress,
+            shippingAddressParameters: {
+                phoneNumberRequired: true,
+            },
+        };
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.spec.ts
@@ -1,38 +1,40 @@
 import GooglePayAuthorizeNetInitializer from './googlepay-authorizenet-initializer';
-import { getCheckoutMock, getGooglePaymentDataMockForAuthNet, getGooglePayAuthorizeNetPaymentDataRequestMock, getGooglePayTokenizePayloadAuthNet, getPaymentMethodMockForAuthNet } from './googlepay.mock';
+import { getAuthorizeNetPaymentDataMock,  getAuthorizeNetPaymentDataRequest,  getAuthorizeNetPaymentMethodMock, getAuthorizeNetTokenizedPayload, getCheckoutMock } from './googlepay.mock';
 
 describe('GooglePayAuthorizeNetInitializer', () => {
-    let googlePayAuthorizeNetInitializer: GooglePayAuthorizeNetInitializer;
+    let googlePayInitializer: GooglePayAuthorizeNetInitializer;
 
     beforeEach(() => {
-        googlePayAuthorizeNetInitializer = new GooglePayAuthorizeNetInitializer();
+        googlePayInitializer = new GooglePayAuthorizeNetInitializer();
     });
 
     it('creates an instance of GooglePayAuthorizeNetInitializer', () => {
-        expect(googlePayAuthorizeNetInitializer).toBeInstanceOf(GooglePayAuthorizeNetInitializer);
+        expect(googlePayInitializer).toBeInstanceOf(GooglePayAuthorizeNetInitializer);
     });
 
     describe('#initialize', () => {
         it('initializes the google pay configuration for authorize.net', async () => {
-            const initialize = await googlePayAuthorizeNetInitializer.initialize(
+            const initialize = await googlePayInitializer.initialize(
                 getCheckoutMock(),
-                getPaymentMethodMockForAuthNet(),
+                getAuthorizeNetPaymentMethodMock(),
                 false
             );
 
-            expect(initialize).toEqual(getGooglePayAuthorizeNetPaymentDataRequestMock());
+            expect(initialize).toEqual(getAuthorizeNetPaymentDataRequest());
         });
     });
 
     describe('#teardown', () => {
-        it('teardowns the initializer', () => expect(googlePayAuthorizeNetInitializer.teardown()).resolves.toBeUndefined());
+        it('teardown the initializer', () => {
+            expect(googlePayInitializer.teardown()).resolves.toBeUndefined();
+        });
     });
 
     describe('#parseResponse', () => {
         it('parses a response from google pay payload received', () => {
-            const tokenizePayload = googlePayAuthorizeNetInitializer.parseResponse(getGooglePaymentDataMockForAuthNet());
+            const tokenizePayload = googlePayInitializer.parseResponse(getAuthorizeNetPaymentDataMock());
 
-            expect(tokenizePayload).toEqual(getGooglePayTokenizePayloadAuthNet());
+            expect(tokenizePayload).toEqual(getAuthorizeNetTokenizedPayload());
         });
     });
 });

--- a/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.ts
@@ -3,7 +3,7 @@ import { round } from 'lodash';
 import { PaymentMethod } from '../..';
 import { Checkout } from '../../../checkout';
 
-import { GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizationSpecification, TokenizePayload, TokenizeType } from './googlepay';
+import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizationSpecification, TokenizePayload, TokenizeType } from './googlepay';
 
 const baseRequest = {
     apiVersion: 2,
@@ -109,7 +109,7 @@ export default class GooglePayAuthorizeNetInitializer implements GooglePayInitia
                 allowedCardNetworks: supportedCards.map(card => card === 'MC' ? 'MASTERCARD' : card),
                 billingAddressRequired: true,
                 billingAddressParameters: {
-                    format: 'FULL',
+                    format: BillingAddressFormat.Full,
                     phoneNumberRequired: true,
                 },
             },

--- a/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -5,7 +5,7 @@ import { MissingDataError, MissingDataErrorType } from '../../../common/error/er
 import PaymentMethod from '../../payment-method';
 import { BraintreeSDKCreator, GooglePayBraintreeSDK } from '../braintree';
 
-import { GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload } from './googlepay';
+import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload } from './googlepay';
 import { GooglePayBraintreeDataRequest, GooglePayBraintreePaymentDataRequestV1 } from './googlepay-braintree';
 
 export default class GooglePayBraintreeInitializer implements GooglePayInitializer {
@@ -108,7 +108,7 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
                     allowedCardNetworks: googlePayBraintreeDataRequestV1.cardRequirements.allowedCardNetworks,
                     billingAddressRequired: true,
                     billingAddressParameters: {
-                        format: 'FULL',
+                        format: BillingAddressFormat.Full,
                         phoneNumberRequired: true,
                     },
                 },

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -23,7 +23,7 @@ export default class GooglePayPaymentProcessor {
         private _googlePayScriptLoader: GooglePayScriptLoader,
         private _googlePayInitializer: GooglePayInitializer,
         private _billingAddressActionCreator: BillingAddressActionCreator,
-        private _consigmentActionCreator: ConsignmentActionCreator,
+        private _consignmentActionCreator: ConsignmentActionCreator,
         private _requestSender: RequestSender
     ) {}
 
@@ -68,7 +68,7 @@ export default class GooglePayPaymentProcessor {
 
     updateShippingAddress(shippingAddress: GooglePayAddress): Promise<InternalCheckoutSelectors> {
         return this._store.dispatch(
-            this._consigmentActionCreator.updateAddress(this._mapGooglePayAddressToShippingAddress(shippingAddress))
+            this._consignmentActionCreator.updateAddress(this._mapGooglePayAddressToShippingAddress(shippingAddress))
         );
     }
 

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -165,8 +165,6 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        const methodId = this._methodId;
-
         const {
             onError = () => {},
             onPaymentSelect = () => {},
@@ -181,6 +179,6 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                         onError(error);
                     }
                 });
-        }, { methodId }), { queueId: 'widgetInteraction' });
+        }, { methodId: this._methodId }), { queueId: 'widgetInteraction' });
     }
 }

--- a/src/payment/strategies/googlepay/googlepay-stripe-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-stripe-initializer.spec.ts
@@ -1,68 +1,40 @@
-import { InvalidArgumentError } from '../../../common/error/errors';
-
 import GooglePayStripeInitializer from './googlepay-stripe-initializer';
-import { getCheckoutMock, getGooglePaymentDataMock, getGooglePaymentStripeDataMock, getGooglePayStripePaymentDataRequestMock, getGooglePayTokenizePayloadStripe, getPaymentMethodMock } from './googlepay.mock';
+import { getCheckoutMock, getPaymentMethodMock, getStripePaymentDataMock, getStripePaymentDataRequest, getStripeTokenizedPayload } from './googlepay.mock';
 
 describe('GooglePayStripeInitializer', () => {
-    it('creates an instance of GooglePayStripeInitializer', () => {
-        const googlePayStripeInitializer = new GooglePayStripeInitializer();
+    let googlePayInitializer: GooglePayStripeInitializer;
 
-        expect(googlePayStripeInitializer).toBeInstanceOf(GooglePayStripeInitializer);
+    beforeEach(() => {
+        googlePayInitializer = new GooglePayStripeInitializer();
+    });
+
+    it('creates an instance of GooglePayStripeInitializer', () => {
+        expect(googlePayInitializer).toBeInstanceOf(GooglePayStripeInitializer);
     });
 
     describe('#initialize', () => {
-        let googlePayStripeInitializer: GooglePayStripeInitializer;
-
-        beforeEach(() => {
-            googlePayStripeInitializer = new GooglePayStripeInitializer();
-        });
-
-        it('initializes the google pay configuration for stripe', async () => {
-            const googlePayPaymentDataRequestV2 = await googlePayStripeInitializer.initialize(
+        it('initializes the google pay configuration for Stripe', async () => {
+            const initialize = await googlePayInitializer.initialize(
                 getCheckoutMock(),
                 getPaymentMethodMock(),
                 false
             );
 
-            expect(googlePayPaymentDataRequestV2).toEqual(getGooglePayStripePaymentDataRequestMock());
+            expect(initialize).toEqual(getStripePaymentDataRequest());
         });
     });
 
     describe('#teardown', () => {
-        let googlePayStripeInitializer: GooglePayStripeInitializer;
-
-        beforeEach(() => {
-            googlePayStripeInitializer = new GooglePayStripeInitializer();
-        });
-
-        it('teardowns the initializer', async () => {
-            await googlePayStripeInitializer.teardown().then(() => {
-                expect(googlePayStripeInitializer.teardown).toBeDefined();
-            });
+        it('teardown the initializer', () => {
+            expect(googlePayInitializer.teardown()).resolves.toBeUndefined();
         });
     });
 
     describe('#parseResponse', () => {
-        let googlePayStripeInitializer: GooglePayStripeInitializer;
-
-        beforeEach(() => {
-            googlePayStripeInitializer = new GooglePayStripeInitializer();
-        });
-
         it('parses a response from google pay payload received', () => {
-            const tokenizePayload = googlePayStripeInitializer.parseResponse(getGooglePaymentStripeDataMock());
+            const tokenizePayload = googlePayInitializer.parseResponse(getStripePaymentDataMock());
 
-            expect(tokenizePayload).toBeTruthy();
-            expect(tokenizePayload).toEqual(getGooglePayTokenizePayloadStripe());
-        });
-
-        it('throws when try to parse a response from google pay payload received', () => {
-            try {
-                googlePayStripeInitializer.parseResponse(getGooglePaymentDataMock());
-            } catch (error) {
-                expect(error).toBeInstanceOf(InvalidArgumentError);
-                expect(error).toEqual(new InvalidArgumentError('Unable to parse response from Google Pay.'));
-            }
+            expect(tokenizePayload).toEqual(getStripeTokenizedPayload());
         });
     });
 });

--- a/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
@@ -4,7 +4,7 @@ import { Checkout } from '../../../checkout';
 import { InvalidArgumentError } from '../../../common/error/errors';
 import PaymentMethod from '../../payment-method';
 
-import { GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload } from './googlepay';
+import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload } from './googlepay';
 
 export default class GooglePayStripeInitializer implements GooglePayInitializer {
     initialize(
@@ -60,7 +60,7 @@ export default class GooglePayStripeInitializer implements GooglePayInitializer 
                     allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'],
                     billingAddressRequired: true,
                     billingAddressParameters: {
-                        format: 'FULL',
+                        format: BillingAddressFormat.Full,
                         phoneNumberRequired: true,
                     },
                 },

--- a/src/payment/strategies/googlepay/googlepay.ts
+++ b/src/payment/strategies/googlepay/googlepay.ts
@@ -138,6 +138,17 @@ export interface TokenizationSpecification {
     };
 }
 
+export enum BillingAddressFormat {
+    /*
+     * Name, country code, and postal code (default).
+     */
+    Min = 'MIN',
+    /*
+     * Name, street address, locality, region, country code, and postal code.
+     */
+    Full = 'FULL',
+}
+
 export interface GooglePayPaymentDataRequestV2 {
     apiVersion: number;
     apiVersionMinor: number;
@@ -154,7 +165,7 @@ export interface GooglePayPaymentDataRequestV2 {
             allowPrepaidCards?: boolean;
             billingAddressRequired?: boolean;
             billingAddressParameters?: {
-                format?: string;
+                format?: BillingAddressFormat;
                 phoneNumberRequired?: boolean;
             };
         };

--- a/src/payment/strategies/googlepay/index.ts
+++ b/src/payment/strategies/googlepay/index.ts
@@ -3,6 +3,7 @@ export * from './googlepay-braintree';
 
 export { default as GooglePayScriptLoader } from './googlepay-script-loader';
 export { default as GooglePayPaymentStrategy } from './googlepay-payment-strategy';
+export { default as GooglePayAdyenV2Initializer } from './googlepay-adyenv2-initializer';
 export { default as GooglePayBraintreeInitializer } from './googlepay-braintree-initializer';
 export { default as GooglePayStripeInitializer } from './googlepay-stripe-initializer';
 export { default as GooglePayAuthorizeNetInitializer } from './googlepay-authorizenet-initializer';


### PR DESCRIPTION
## What?
I want to be able to offer my world shoppers GooglePay payment method through Adyen

## Why?
So that I can give them alternative methods to pay so that they are more likely to purchase.

## Testing / Proof

- Manual

- Unit

## How can this change be undone in case of failure?
1. Revert this PR

## Sibling PRs
[UCO](https://github.com/bigcommerce/checkout-js/pull/253)

@bigcommerce/checkout @bigcommerce/payments
