### PR TITLE
fix(payment): INT-2431 Adds expiration date for Bancontact payments

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -117,9 +117,11 @@ export interface FormattedHostedInstrument {
 
 export interface FormattedVaultedInstrument {
     bigpay_token: {
-        credit_card_number_confirmation?: string;
-        verification_value?: string;
         token: string;
+        credit_card_number_confirmation?: string;
+        expiry_month?: string;
+        expiry_year?: string;
+        verification_value?: string;
     } | string | null;
 }
 

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -235,6 +235,8 @@ describe('AdyenV2PaymentStrategy', () => {
                                 credit_card_number_confirmation: 'ENCRYPTED_CARD_NUMBER',
                                 token: '123',
                                 verification_value: 'ENCRYPTED_CVV',
+                                expiry_month: 'ENCRYPTED_EXPIRY_MONTH',
+                                expiry_year: 'ENCRYPTED_EXPIRY_YEAR',
                             },
                             browser_info: {
                                 color_depth: 24,

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -80,15 +80,17 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                 }
 
                 if (paymentData && isVaultedInstrument(paymentData) && isCardState(componentState)) {
-                    const { encryptedCardNumber, encryptedSecurityCode } = componentState.data.paymentMethod;
+                    const { encryptedCardNumber, encryptedSecurityCode, encryptedExpiryMonth, encryptedExpiryYear } = componentState.data.paymentMethod;
 
                     return this._store.dispatch(this._paymentActionCreator.submitPayment({
                         ...payment,
                         paymentData: {
                             formattedPayload: {
                                 bigpay_token: {
-                                    credit_card_number_confirmation: encryptedCardNumber,
                                     token: paymentData.instrumentId,
+                                    credit_card_number_confirmation: encryptedCardNumber,
+                                    expiry_month: encryptedExpiryMonth,
+                                    expiry_year: encryptedExpiryYear,
                                     verification_value: encryptedSecurityCode,
                                 },
                                 browser_info: getBrowserInfo(),


### PR DESCRIPTION
## What?
Validate Expiry Date when using a vaulted Bancontact instrument as they don't use CVV

## Why?
Expiration Date is not validated when checking out with a vaulted instrument in Bancontact.

## Testing / Proof

- Manual


## How can this change be undone in case of failure?
1. Revert this PR


@bigcommerce/checkout @bigcommerce/payments
