### PR TITLE
CHECKOUT-4777: Use bigcommerce/internal-node orb to install npm dependencies in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,27 +19,13 @@ version: 2.1
 orbs:
   ci: bigcommerce/internal@volatile
   node: bigcommerce/internal-node@volatile
-  checkout-sdk-js:
-    commands:
-      install_dependencies:
-        steps:
-          - restore_cache:
-              keys:
-                - checkout-sdk-js
-          - run:
-              name: "Install NPM dependencies"
-              command: npm ci
-          - save_cache:
-              key: checkout-sdk-js
-              paths:
-                - ~/.npm
 
 jobs:
   test:
     <<: *node_executor
     steps:
       - ci/pre-setup
-      - checkout-sdk-js/install_dependencies
+      - node/npm-install
       - run:
           name: "Run unit tests"
           command: npm run test:series -- --coverage
@@ -51,7 +37,7 @@ jobs:
     <<: *node_executor
     steps:
       - ci/pre-setup
-      - checkout-sdk-js/install_dependencies
+      - node/npm-install
       - run:
           name: "Run linter"
           command: npm run lint
@@ -77,7 +63,7 @@ jobs:
     <<: *node_executor
     steps:
       - ci/pre-setup
-      - checkout-sdk-js/install_dependencies
+      - node/npm-install
       - run:
           name: "Configure Git user"
           command: |
@@ -112,7 +98,7 @@ jobs:
     <<: *node_executor
     steps:
       - ci/pre-setup
-      - checkout-sdk-js/install_dependencies
+      - node/npm-install
       - attach_workspace:
           at: /tmp
       - run:


### PR DESCRIPTION
## What?
Use `bigcommerce/internal-node` orb to install npm dependencies in CircleCI.

## Why?
Previously we define our own installation command within this project because the installation command provided by our internal node orb didn't use `npm ci`. Now it does. It also fixes other issues, such as our dependency cache doesn't get updated when we update our package lock file.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
