### PR TITLE
INT-2001 Enable support for Store Credit on both versions of Klarna

### DIFF
--- a/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
@@ -75,6 +75,7 @@ describe('KlarnaPaymentStrategy', () => {
                 methodId: paymentMethod.id,
                 gatewayId: paymentMethod.gateway,
             },
+            useStoreCredit: true,
         });
 
         loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod, { methodId: paymentMethod.id }));
@@ -214,7 +215,7 @@ describe('KlarnaPaymentStrategy', () => {
                 .toHaveBeenCalledWith('klarna', { authorizationToken: 'bar' });
 
             expect(orderActionCreator.submitOrder)
-                .toHaveBeenCalledWith({ ...payload, payment: omit(payload.payment, 'paymentData'), useStoreCredit: false }, undefined);
+                .toHaveBeenCalledWith({ ...payload, payment: omit(payload.payment, 'paymentData'), useStoreCredit: true }, undefined);
 
             expect(store.dispatch).toHaveBeenCalledWith(initializePaymentAction);
             expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);

--- a/src/payment/strategies/klarna/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.ts
@@ -73,9 +73,7 @@ export default class KlarnaPaymentStrategy implements PaymentStrategy {
                 this._orderActionCreator.submitOrder({
                     ...payload,
                     payment: paymentPayload,
-                    // Note: API currently doesn't support using Store Credit with Klarna.
-                    // To prevent deducting customer's store credit, set it as false.
-                    useStoreCredit: false,
+                    useStoreCredit: payload.useStoreCredit,
                 }, options)
             ));
     }

--- a/src/payment/strategies/klarnav2/klarnav2-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarnav2/klarnav2-payment-strategy.spec.ts
@@ -79,6 +79,7 @@ describe('KlarnaV2PaymentStrategy', () => {
                 methodId: paymentMethod.id,
                 gatewayId: paymentMethod.gateway,
             },
+            useStoreCredit: true,
         });
 
         loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod, { methodId: paymentMethod.id }));
@@ -104,12 +105,12 @@ describe('KlarnaV2PaymentStrategy', () => {
         const onLoad = jest.fn();
 
         beforeEach(async () => {
-            await strategy.initialize({ methodId: paymentMethod.id, klarnav2: { container: '#container', onLoad } });
+            await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway, klarnav2: { container: '#container', onLoad } });
         });
 
         it('throws InvalidArgumentError when klarnav2 is not provided',  async () => {
             const rejectedSpy = jest.fn();
-            await strategy.initialize({ methodId: paymentMethod.id, klarna: { container: '#container', onLoad } }).catch(rejectedSpy);
+            await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway, klarna: { container: '#container', onLoad } }).catch(rejectedSpy);
             expect(rejectedSpy).toHaveBeenCalledWith(new InvalidArgumentError('Unable to load widget because "options.klarnav2" argument is not provided.'));
         });
 
@@ -131,7 +132,7 @@ describe('KlarnaV2PaymentStrategy', () => {
 
     describe('#execute()', () => {
         beforeEach(async () => {
-            await strategy.initialize({ methodId: paymentMethod.id, klarnav2: { container: '#container' } });
+            await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway, klarnav2: { container: '#container' } });
         });
 
         it('authorizes against klarnav2', () => {
@@ -156,7 +157,7 @@ describe('KlarnaV2PaymentStrategy', () => {
             jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
 
-            await strategy.initialize({ methodId: paymentMethod.id, klarnav2: { container: '#container' } });
+            await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway, klarnav2: { container: '#container' } });
             strategy.execute(payload);
 
             expect(klarnaPayments.authorize)
@@ -178,7 +179,7 @@ describe('KlarnaV2PaymentStrategy', () => {
             jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
 
-            await strategy.initialize({ methodId: paymentMethod.id, klarnav2: { container: '#container' } });
+            await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway, klarnav2: { container: '#container' } });
 
             strategy.execute(payload);
 
@@ -199,7 +200,7 @@ describe('KlarnaV2PaymentStrategy', () => {
                 scriptLoader
             );
 
-            strategy.initialize({ methodId: paymentMethod.id, klarnav2: { container: '#container' } });
+            strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway, klarnav2: { container: '#container' } });
 
             try {
                 await strategy.execute(payload);
@@ -215,7 +216,7 @@ describe('KlarnaV2PaymentStrategy', () => {
                 .toHaveBeenCalledWith('klarna', { authorizationToken: 'bar' });
 
             expect(orderActionCreator.submitOrder)
-                .toHaveBeenCalledWith({ ...payload, payment: omit(payload.payment, 'paymentData'), useStoreCredit: false }, undefined);
+                .toHaveBeenCalledWith({ ...payload, payment: omit(payload.payment, 'paymentData'), useStoreCredit: true }, undefined);
 
             expect(store.dispatch).toHaveBeenCalledWith(initializePaymentAction);
             expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);


### PR DESCRIPTION
[INT-2001](https://jira.bigcommerce.com/browse/INT-2001)
## What?
Enabling the store credit support feature

## Why?
Klarna payment method now supports store credit so we want to enable that functionality

## Testing / Proof
[DEMO](https://drive.google.com/file/d/1xfE5JMXO-mLMmoUprw2QvkHzUq8WHsUx/view?usp=sharing)

## Siblings PRs
[BIGPAY](https://github.com/bigcommerce/bigpay/pull/2365)
[BIGPAY_CLIENT](https://github.com/bigcommerce-labs/bigpay-client-php/pull/160)
[BCAPP](https://github.com/bigcommerce/bigcommerce/pull/34301)

## Dependencies
[BIGPAY](https://github.com/bigcommerce/bigpay/pull/2365)
[BIGPAY_CLIENT](https://github.com/bigcommerce-labs/bigpay-client-php/pull/160)
[BCAPP](https://github.com/bigcommerce/bigcommerce/pull/34301)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
