### PR TITLE
CHECKOUT-4789: Apply polyfills to external dependencies for targeted environments

### DIFF
--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -49,29 +49,48 @@ async function getBaseConfig() {
     };
 };
 
-const babelLoaderRule = {
-    test: /\.[tj]s$/,
-    include: srcPath,
-    loader: 'babel-loader',
-    options: {
-        presets: [
-            [
-                '@babel/preset-env',
-                {
-                    corejs: 3,
-                    targets: [
-                        'defaults',
-                        'ie 11',
-                    ],
-                    useBuiltIns: 'usage',
-                },
-            ]
+const babelEnvPreset = [
+    '@babel/preset-env',
+    {
+        corejs: 3,
+        targets: [
+            'defaults',
+            'ie 11',
         ],
+        useBuiltIns: 'usage',
     },
-};
+];
+
+const babelLoaderRules = [
+    {
+        test: /\.[tj]s$/,
+        loader: 'babel-loader',
+        include: srcPath,
+        options: {
+            presets: [
+                babelEnvPreset,
+            ],
+        },
+    },
+    {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        include: path.join(__dirname, 'node_modules'),
+        exclude: [
+            /\/node_modules\/core-js\//,
+            /\/node_modules\/webpack\//,
+        ],
+        options: {
+            presets: [
+                babelEnvPreset,
+            ],
+            sourceType: 'unambiguous',
+        }
+    },
+];
 
 module.exports = {
-    babelLoaderRule,
+    babelLoaderRules,
     getBaseConfig,
     libraryEntries,
     libraryName,

--- a/webpack-server.config.js
+++ b/webpack-server.config.js
@@ -5,7 +5,7 @@ const { DefinePlugin } = require('webpack');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
 const { getNextVersion, transformManifest } = require('./scripts/webpack');
-const { babelLoaderRule, getBaseConfig, libraryEntries, libraryName, srcPath } = require('./webpack-common.config');
+const { babelLoaderRules, getBaseConfig, libraryEntries, libraryName, srcPath } = require('./webpack-common.config');
 
 const baseOutputPath = path.join(__dirname, 'dist-server');
 
@@ -27,7 +27,7 @@ async function getServerConfig(options, argv) {
         },
         module: {
             rules: [
-                babelLoaderRule,
+                ...babelLoaderRules,
                 ...baseConfig.module.rules,
             ],
         },
@@ -62,7 +62,7 @@ async function getServerLoaderConfig(options, argv) {
         },
         module: {
             rules: [
-                babelLoaderRule,
+                ...babelLoaderRules,
                 ...baseConfig.module.rules,
             ],
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { DefinePlugin } = require('webpack');
 const nodeExternals = require('webpack-node-externals');
 
-const { babelLoaderRule, getBaseConfig, libraryEntries, libraryName } = require('./webpack-common.config');
+const { babelLoaderRules, getBaseConfig, libraryEntries, libraryName } = require('./webpack-common.config');
 
 const outputPath = path.join(__dirname, 'dist');
 
@@ -21,7 +21,7 @@ async function getUmdConfig(options, argv) {
         },
         module: {
             rules: [
-                babelLoaderRule,
+                ...babelLoaderRules,
                 ...baseConfig.module.rules,
             ],
         },


### PR DESCRIPTION
## What?
Apply polyfills to external dependencies for targeted environments

## Why?
Before this change, `babel-env` doesn't apply to `node_modules` dependencies (it only applies to our own code). As a result, the UMD bundle doesn't work on its own in IE11 if some of those dependencies use features that need to be polyfilled.

Right now this problem only affects payment buttons in PDP and cart page because they are provided by the UMD bundle. I believe it has been a problem since October last year when we bumped the version from 1.21.0 to 1.41.0 (however, I'm surprised that we haven't had any support ticket regarding it 🤔). 

On the other hand, UCO uses the CJS bundle and has a different way of applying the `babel-env` so it doesn't get affected by this problem (it applies the entire `core-js` library for its targeted environment instead of applying based on usage).

## Testing / Proof
|Before|After|
|-|-|
|<img width="1430" alt="Screen Shot 2020-04-02 at 10 00 42 am" src="https://user-images.githubusercontent.com/667603/78194458-f0c5d680-74c8-11ea-9c83-ae8527acd597.png">|<img width="1428" alt="Screen Shot 2020-04-02 at 9 58 58 am" src="https://user-images.githubusercontent.com/667603/78194468-fa4f3e80-74c8-11ea-90d5-cb1be8278854.png">|

@bigcommerce/checkout @bigcommerce/payments
