### PR TITLE
CHECKOUT-4800 Add product_unavailable as unrecoverable error type

### DIFF
--- a/src/common/error/create-request-error-factory.ts
+++ b/src/common/error/create-request-error-factory.ts
@@ -17,6 +17,7 @@ export default function createRequestErrorFactory(): RequestErrorFactory {
         'order_completion_error',
         'order_could_not_be_finalized_error',
         'order_create_failed',
+        'product_unavailable',
         'provider_fatal_error',
         'provider_setup_error',
         'stock_too_low',


### PR DESCRIPTION
## What?
Adds `product_unavailable` to list of unrecoverable error type

## Why?
Because the shopper is required to go to cart page and remove unavailable items
This is a new error type introduced in:
https://github.com/bigcommerce/bigcommerce/pull/34453

## Testing / Proof
<img width="936" alt="Screen Shot 2020-04-07 at 12 44 56 pm" src="https://user-images.githubusercontent.com/1621894/78624736-b182f580-78cd-11ea-8ec0-ed722e507677.png">


@bigcommerce/checkout 