### PR TITLE
feat(payment): INT-2410 Add stripe account as configuration

### DIFF
--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -124,18 +124,20 @@ describe('StripeV3PaymentStrategy', () => {
             return expect(promise).resolves.toBe(store.getState());
         });
 
-        it('does not load stripe V3 if initialization options are not provided', () => {
+        it('does not load stripe V3 if initialization options are not provided', async () => {
             stripeV3Options.stripev3 = undefined;
 
-            expect(() => strategy.initialize(stripeV3Options))
-                .toThrow(InvalidArgumentError);
+            const response = strategy.initialize(stripeV3Options);
+
+            return expect(response).rejects.toThrow(InvalidArgumentError);
         });
 
         it('does not load stripe V3 if paymentMethod is not provided', () => {
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(undefined);
 
-            expect(() => strategy.initialize(stripeV3Options))
-                .toThrow(MissingDataError);
+            const response = strategy.initialize(stripeV3Options);
+
+            return expect(response).rejects.toThrow(MissingDataError);
         });
     });
 

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -30,7 +30,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         private _stripeScriptLoader: StripeV3ScriptLoader
     ) {}
 
-    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const stripeOptions = options.stripev3;
 
         if (!stripeOptions) {
@@ -43,20 +43,17 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        return this._stripeScriptLoader.load(paymentMethod.initializationData.stripePublishableKey, paymentMethod.initializationData.stripeConnectedAccount)
-            .then(stripeJs => {
-                this._stripeV3Client = stripeJs;
-                const elements = this._stripeV3Client.elements();
-                const cardElement = elements.create('card', {
-                    style: stripeOptions.style,
-                });
+        this._stripeV3Client = await this._stripeScriptLoader.load(
+            paymentMethod.initializationData.stripePublishableKey,
+            paymentMethod.initializationData.stripeConnectedAccount);
+        const elements = this._stripeV3Client.elements();
+        const cardElement = elements.create('card', {
+            style: stripeOptions.style,
+        });
+        cardElement.mount(`#${stripeOptions.containerId}`);
+        this._cardElement = cardElement;
 
-                cardElement.mount(`#${stripeOptions.containerId}`);
-
-                this._cardElement = cardElement;
-
-                return Promise.resolve(this._store.getState());
-            });
+        return Promise.resolve(this._store.getState());
     }
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -43,7 +43,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        return this._stripeScriptLoader.load(paymentMethod.initializationData.stripePublishableKey)
+        return this._stripeScriptLoader.load(paymentMethod.initializationData.stripePublishableKey, paymentMethod.initializationData.stripeConnectedAccount)
             .then(stripeJs => {
                 this._stripeV3Client = stripeJs;
                 const elements = this._stripeV3Client.elements();

--- a/src/payment/strategies/stripev3/stripev3-script-loader.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-script-loader.spec.ts
@@ -29,13 +29,13 @@ describe('StripeV3PayScriptLoader', () => {
         });
 
         it('loads the JS', async () => {
-            await stripeV3ScriptLoader.load('publishableKey');
+            await stripeV3ScriptLoader.load('publishableKey', 'stripeAccount');
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith('https://js.stripe.com/v3/');
         });
 
         it('returns the JS from the window', async () => {
-            const stripeJs = await stripeV3ScriptLoader.load('publishableKey');
+            const stripeJs = await stripeV3ScriptLoader.load('publishableKey', 'stripeAccount');
 
             expect(stripeJs).toBe(stripeV3JsMock);
         });
@@ -48,7 +48,7 @@ describe('StripeV3PayScriptLoader', () => {
             });
 
             try {
-                await stripeV3ScriptLoader.load('publishableKey');
+                await stripeV3ScriptLoader.load('publishableKey', 'stripeAccount');
             } catch (error) {
                 expect(error).toBeInstanceOf(StandardError);
             }

--- a/src/payment/strategies/stripev3/stripev3-script-loader.ts
+++ b/src/payment/strategies/stripev3/stripev3-script-loader.ts
@@ -10,7 +10,7 @@ export default class StripeV3ScriptLoader {
         private _window: StripeHostWindow = window
     ) {}
 
-    load(publishableKey: string): Promise<StripeV3Client> {
+    load(publishableKey: string, stripeAccount: string): Promise<StripeV3Client> {
         return this._scriptLoader
             .loadScript('https://js.stripe.com/v3/')
             .then(() => {
@@ -20,6 +20,7 @@ export default class StripeV3ScriptLoader {
 
                 return this._window.Stripe(publishableKey, {
                     betas: ['payment_intent_beta_3'],
+                    stripeAccount,
                 });
             });
     }

--- a/src/payment/strategies/stripev3/stripev3.ts
+++ b/src/payment/strategies/stripev3/stripev3.ts
@@ -7,6 +7,7 @@ export interface StripeHostWindow extends Window {
 
 export interface StripeV3JsOptions {
     betas: string[];
+    stripeAccount: string;
 }
 
 export interface StripeV3Client {


### PR DESCRIPTION
## What?
Add stripe account when Stripe V3 script is loaded

## Why?
Stripe is requiring to add Stripe Account to identify each merchant

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/78845017-0bb6b000-79cd-11ea-8dfd-034b3bfb84ec.png)
![image](https://user-images.githubusercontent.com/35146660/78845118-4ddff180-79cd-11ea-8e8d-a48a9ef4bdc0.png)


@bigcommerce/checkout @bigcommerce/apex-integrations 
