### PR TITLE
CHECKOUT-4789: Export `createEmbeddedCheckoutMessenger` function in embedded-checkout bundle

### DIFF
--- a/src/bundles/embedded-checkout.ts
+++ b/src/bundles/embedded-checkout.ts
@@ -1,1 +1,2 @@
 export { embedCheckout } from '../embedded-checkout';
+export { createEmbeddedCheckoutMessenger } from '../embedded-checkout/iframe-content';


### PR DESCRIPTION
## What?
Export `createEmbeddedCheckoutMessenger` function in embedded-checkout bundle.

## Why?
So it can be used as a part of that sub-bundle.

## Testing / Proof
None

@bigcommerce/checkout @bigcommerce/payments
