### PR TITLE
feat(payment): PAYPAL-265 Markup flow

### DIFF
--- a/src/cart/cart-selector.ts
+++ b/src/cart/cart-selector.ts
@@ -1,12 +1,15 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { createSelector } from '../common/selector';
+import { guard } from '../common/utility';
 
 import Cart from './cart';
 import CartState, { DEFAULT_STATE } from './cart-state';
 
 export default interface CartSelector {
     getCart(): Cart | undefined;
+    getCartOrThrow(): Cart;
     getLoadError(): Error | undefined;
     isLoading(): boolean;
 }
@@ -17,6 +20,13 @@ export function createCartSelectorFactory() {
     const getCart = createSelector(
         (state: CartState) => state.data,
         cart => () => cart
+    );
+
+    const getCartOrThrow = createSelector(
+        getCart,
+        getCart => () => {
+          return guard(getCart(), () => new MissingDataError(MissingDataErrorType.MissingCart));
+        }
     );
 
     const getLoadError = createSelector(
@@ -34,6 +44,7 @@ export function createCartSelectorFactory() {
     ): CartSelector => {
         return {
             getCart: getCart(state),
+            getCartOrThrow: getCartOrThrow(state),
             getLoadError: getLoadError(state),
             isLoading: isLoading(state),
         };

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -29,12 +29,8 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         }
 
         state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
-        const cart = state.cart.getCart();
+        const cart = state.cart.getCartOrThrow();
         const paypalOptions = options.paypalCommerce;
-
-        if (!cart) {
-            throw new MissingDataError(MissingDataErrorType.MissingCart);
-        }
 
         const buttonParams: ButtonsOptions = {
             createOrder: () => this._setupPayment(cart.id),

--- a/src/common/overlay/index.ts
+++ b/src/common/overlay/index.ts
@@ -1,1 +1,1 @@
-export { default as Overlay } from './overlay';
+export { default as Overlay, OverlayShowOptions } from './overlay';

--- a/src/common/overlay/overlay-style.ts
+++ b/src/common/overlay/overlay-style.ts
@@ -1,0 +1,83 @@
+interface OverlayStyleOptions {
+    background?: string;
+    id?: string;
+    transitionDuration?: number;
+    classLayout?: string;
+    classOverlayText?: string;
+    classClose?: string;
+}
+
+export default function getOverlayStyle(options: OverlayStyleOptions): HTMLElement {
+    const { id, background, transitionDuration, classLayout, classOverlayText, classClose } = options;
+    const styles = document.createElement('style');
+    const addClassLayout = classLayout ? `, .${classLayout}` : '';
+
+    styles.id = `${id}--styles`;
+    styles.type = 'text/css';
+    styles.innerText = `
+        #${id}${addClassLayout} {
+            display: block;
+            height: 100%;
+            width: 100%;
+            left: 0;
+            top: 0;
+            position: fixed;
+            z-index: 2147483647;
+        }
+        #${id} {
+            transition: opacity ${transitionDuration}ms ease-out;
+            background: ${background};
+            opacity: 0;
+        }
+    `;
+
+    if (classOverlayText) {
+        styles.innerText += `
+             #${id} {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+             }
+             #${id} .${classOverlayText} {
+                color: white;
+                max-width: 330px;
+                font-size: 1.2em;
+                text-align: center;
+             }
+        `;
+    }
+
+    if (classClose) {
+        styles.innerText += `
+            #${id} {
+                opacity: 1;
+            }
+            .${classLayout} .${classClose} {
+                position: fixed;
+                right: 16px;
+                top: 16px;
+                width: 16px;
+                height: 16px;
+                opacity: 0.6;
+                cursor: pointer;
+                z-index: 3147483647;
+            }
+            .${classLayout} .${classClose}::after, .${classLayout} .${classClose}::before {
+                position: absolute;
+                left: 8px;
+                content: '';
+                height: 16px;
+                width: 2px;
+                background-color: #fff;
+            }
+            .${classLayout} .${classClose}::after {
+                transform: rotate(-45deg);
+            }
+            .${classLayout} .${classClose}::before {
+                transform: rotate(45deg);
+            }
+        `;
+    }
+
+    return styles;
+}

--- a/src/common/overlay/overlay.spec.ts
+++ b/src/common/overlay/overlay.spec.ts
@@ -4,88 +4,211 @@ import Overlay from './overlay';
 describe('Overlay', () => {
     let overlay: Overlay;
 
-    beforeEach(() => {
-        overlay = new Overlay({
-            id: 'overlay',
-            transitionDuration: 400,
+    describe('only overlay element', () => {
+        beforeEach(() => {
+            overlay = new Overlay({
+                id: 'overlay',
+                transitionDuration: 400,
+            });
+        });
+
+        afterEach(() => {
+            const element = document.getElementById('overlay');
+
+            if (element) {
+                element.parentElement!.removeChild(element);
+            }
+        });
+
+        it('shows element', () => {
+            overlay.show();
+
+            const element = document.getElementById('overlay');
+
+            expect(element).toBeTruthy();
+        });
+
+        it('shows styles', () => {
+            overlay.show();
+
+            const styles = document.getElementById('overlay--styles');
+
+            expect(styles).toBeTruthy();
+        });
+
+        it('triggers click handler if it is provided', () => {
+            const onClick = jest.fn();
+
+            overlay.show({ onClick });
+
+            const element = document.getElementById('overlay');
+
+            element!.dispatchEvent(new MouseEvent('click'));
+
+            expect(onClick).toHaveBeenCalled();
+        });
+
+        it('fades element into view', async () => {
+            overlay.show();
+
+            const element = document.getElementById('overlay');
+
+            await new Promise(resolve => {
+                setTimeout(resolve, 400);
+            });
+
+            expect(element!.style.opacity).toEqual('1');
+        });
+
+        it('fades element out of view', async () => {
+            overlay.show();
+
+            const element = document.getElementById('overlay');
+
+            overlay.remove();
+
+            await new Promise(resolve => {
+                setTimeout(resolve, 400);
+            });
+
+            expect(element!.style.opacity).toEqual('0');
+        });
+
+        it('removes click handler when element is removed', () => {
+            const onClick = jest.fn();
+
+            overlay.show({ onClick });
+
+            const element = document.getElementById('overlay');
+
+            overlay.remove();
+
+            element!.dispatchEvent(new MouseEvent('click'));
+
+            expect(onClick).not.toHaveBeenCalled();
         });
     });
 
-    afterEach(() => {
-        const element = document.getElementById('overlay');
-
-        if (element) {
-            element.parentElement!.removeChild(element);
-        }
-    });
-
-    it('shows element on top of everything else', () => {
-        overlay.show();
-
-        const element = document.getElementById('overlay');
-
-        expect(element).toBeTruthy();
-        expect(element!.style.background).toEqual('rgba(0, 0, 0, 0.8)');
-        expect(element!.style.height).toEqual('100%');
-        expect(element!.style.left).toEqual('0px');
-        expect(element!.style.position).toEqual('fixed');
-        expect(element!.style.top).toEqual('0px');
-        expect(element!.style.width).toEqual('100%');
-        expect(element!.style.zIndex).toEqual('2147483647');
-    });
-
-    it('triggers click handler if it is provided', () => {
-        const onClick = jest.fn();
-
-        overlay.show({ onClick });
-
-        const element = document.getElementById('overlay');
-
-        element!.dispatchEvent(new MouseEvent('click'));
-
-        expect(onClick).toHaveBeenCalled();
-    });
-
-    it('fades element into view', async () => {
-        overlay.show();
-
-        const element = document.getElementById('overlay');
-
-        expect(element!.style.opacity).toEqual('0');
-
-        await new Promise(resolve => {
-            setTimeout(resolve, 400);
+    describe('with close element', () => {
+        beforeEach(() => {
+            overlay = new Overlay({ hasCloseButton: true });
         });
 
-        expect(element!.style.opacity).toEqual('1');
-    });
+        afterEach(() => {
+            const element = document.querySelector('.checkoutOverlay--layout');
 
-    it('fades element out of view', async () => {
-        overlay.show();
-
-        const element = document.getElementById('overlay');
-
-        overlay.remove();
-
-        await new Promise(resolve => {
-            setTimeout(resolve, 400);
+            if (element) {
+                element.parentElement!.removeChild(element);
+            }
         });
 
-        expect(element!.style.opacity).toEqual('0');
+        it('shows layout element', () => {
+            overlay.show();
+
+            const element = document.querySelector('.checkoutOverlay--layout');
+
+            expect(element).toBeTruthy();
+        });
+
+        it('shows close element', () => {
+            overlay.show();
+
+            const element = document.querySelector('.checkoutOverlay--close');
+
+            expect(element).toBeTruthy();
+        });
+
+        it('triggers click handler if it is provided', () => {
+            const onClick = jest.fn();
+
+            overlay.show({ onClick });
+
+            const element = document.getElementById('checkoutOverlay');
+
+            element!.dispatchEvent(new MouseEvent('click'));
+
+            expect(onClick).toHaveBeenCalled();
+        });
+
+        it('triggers close click handler if it is provided', () => {
+            const onClickClose = jest.fn();
+
+            overlay.show({ onClickClose });
+
+            const closeElement = document.querySelector('.checkoutOverlay--close');
+
+            closeElement!.dispatchEvent(new MouseEvent('click'));
+
+            expect(onClickClose).toHaveBeenCalled();
+        });
+
+        it('removes click handler when element is removed', () => {
+            const onClickClose = jest.fn();
+
+            overlay.show({ onClickClose });
+
+            const closeElement = document.querySelector('.checkoutOverlay--close');
+
+            overlay.remove();
+
+            closeElement!.dispatchEvent(new MouseEvent('click'));
+
+            expect(onClickClose).not.toHaveBeenCalled();
+        });
     });
 
-    it('removes click handler when element is removed', () => {
-        const onClick = jest.fn();
+    describe('with modal and inner element', () => {
+        beforeEach(() => {
+            const innerHtml = document.createElement('div');
+            innerHtml.id = 'innerElement';
+            overlay = new Overlay({ innerHtml });
+        });
 
-        overlay.show({ onClick });
+        afterEach(() => {
+            const element = document.getElementById('checkoutOverlay');
 
-        const element = document.getElementById('overlay');
+            if (element) {
+                element.parentElement!.removeChild(element);
+            }
+        });
 
-        overlay.remove();
+        it('shows overlayText element', () => {
+            overlay.show();
 
-        element!.dispatchEvent(new MouseEvent('click'));
+            const modal = document.querySelector('.checkoutOverlay--overlayText');
 
-        expect(onClick).not.toHaveBeenCalled();
+            expect(modal).toBeTruthy();
+        });
+
+        it('shows inner element', () => {
+            overlay.show();
+
+            const innerElement = document.getElementById('innerElement');
+
+            expect(innerElement).toBeTruthy();
+        });
+
+        it('shows Document Fragment of inner elements', () => {
+            const innerElement = document.createElement('div');
+            innerElement.id = 'innerElement';
+
+            const innerElement2 = document.createElement('div');
+            innerElement2.id = 'innerElement2';
+
+            const fragment = document.createDocumentFragment();
+            fragment.appendChild(innerElement);
+            fragment.appendChild(innerElement2);
+
+            overlay = new Overlay({ innerHtml: fragment });
+
+            overlay.show();
+
+            const element = document.getElementById('innerElement');
+            const element2 = document.getElementById('innerElement2');
+
+            expect(element).toBeTruthy();
+            expect(element2).toBeTruthy();
+        });
     });
 });
 // tslint:enable:no-non-null-assertion

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -40,7 +40,7 @@ import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
 import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy, PaypalScriptLoader } from './strategies/paypal';
-import { PaypalCommercePaymentStrategy } from './strategies/paypal-commerce';
+import { PaypalCommercePaymentProcessor, PaypalCommercePaymentStrategy, PaypalCommerceRequestSender } from './strategies/paypal-commerce';
 import { SagePayPaymentStrategy } from './strategies/sage-pay';
 import { SquarePaymentStrategy, SquareScriptLoader } from './strategies/square';
 import { StripeScriptLoader, StripeV3PaymentStrategy } from './strategies/stripev3';
@@ -243,7 +243,9 @@ export default function createPaymentStrategyRegistry(
         new PaypalCommercePaymentStrategy(
             store,
             orderActionCreator,
-            paymentActionCreator
+            paymentActionCreator,
+            new PaypalCommerceRequestSender(requestSender),
+            new PaypalCommercePaymentProcessor()
         )
     );
 

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -11,6 +11,7 @@ import { KlarnaPaymentInitializeOptions } from './strategies/klarna';
 import { KlarnaV2PaymentInitializeOptions } from './strategies/klarnav2';
 import { MasterpassPaymentInitializeOptions } from './strategies/masterpass';
 import { PaypalExpressPaymentInitializeOptions } from './strategies/paypal';
+import { PaypalCommercePaymentInitializeOptions } from './strategies/paypal-commerce';
 import { SquarePaymentInitializeOptions } from './strategies/square';
 import { StripeV3PaymentInitializeOptions } from './strategies/stripev3';
 
@@ -99,6 +100,13 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support PayPal Express.
      */
     paypalexpress?: PaypalExpressPaymentInitializeOptions;
+
+    /**
+     * @internal
+     * The options that are required to initialize the PayPal Commerce payment method.
+     * They can be omitted unless you need to support PayPal Commerce.
+     */
+    paypalcommerce?: PaypalCommercePaymentInitializeOptions;
 
     /**
      * The options that are required to initialize the Square payment method.

--- a/src/payment/strategies/paypal-commerce/index.ts
+++ b/src/payment/strategies/paypal-commerce/index.ts
@@ -3,3 +3,5 @@ export * from './paypal-commerce-sdk';
 export { default as PaypalCommerceScriptLoader } from './paypal-commerce-script-loader';
 export { default as PaypalCommercePaymentStrategy } from './paypal-commerce-payment-strategy';
 export { default as PaypalCommerceRequestSender } from './paypal-commerce-request-sender';
+export { default as PaypalCommercePaymentProcessor } from './paypal-commerce-payment-processor';
+export { default as PaypalCommercePaymentInitializeOptions } from './paypal-commerce-payment-initialize-options';

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-initialize-options.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-initialize-options.ts
@@ -1,0 +1,6 @@
+export default interface PaypalCommercePaymentInitializeOptions {
+    overlay?: {
+        helpText?: string;
+        continueText?: string;
+    };
+}

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
@@ -1,0 +1,51 @@
+import { MissingDataError } from '../../../common/error/errors';
+
+import { PaypalCommercePaymentProcessor } from './index';
+
+// tslint:disable:no-non-null-assertion
+describe('PaypalCommercePaymentProcessor', () => {
+    let paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor;
+    const focus = jest.fn();
+    const close = jest.fn();
+
+    beforeEach(() => {
+        window.open = jest.fn();
+
+        paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor();
+    });
+
+    it('call window.open', async () => {
+        try {
+            await paypalCommercePaymentProcessor.paymentPayPal('approveUrl');
+        } catch (error) {
+            expect(window.open).toHaveBeenCalled();
+        }
+    });
+
+    it('throw error when window closed', async () => {
+        await expect(paypalCommercePaymentProcessor.paymentPayPal('approveUrl')).rejects.toThrow(MissingDataError);
+    });
+
+    it('check event listener on message', async () => {
+        window.open = jest.fn(() => ({ focus, close }));
+        const map: {[key: string]: any}  = {};
+
+        window.addEventListener = jest.fn((event, cb) => {
+            if (event === 'message') {
+                setTimeout(() => {
+                    cb({
+                        origin: 'https://www.paypal.com',
+                        data: JSON.stringify({ operation: 'return_to_merchant', updateParent: true }),
+                    });
+                });
+            }
+
+            map[event] = cb;
+        });
+
+        const res = await paypalCommercePaymentProcessor.paymentPayPal('approveUrl');
+
+        expect(res).toEqual(true);
+    });
+});
+// tslint:enable:no-non-null-assertion

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -1,0 +1,111 @@
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { Overlay } from '../../../common/overlay';
+
+const modalWidth = 450;
+const modalHeight = 600;
+
+export interface ProcessorOptions {
+    overlay?: {
+        helpText?: string;
+        continueText?: string;
+    };
+}
+
+export default class PaypalCommercePaymentProcessor {
+    private _window = window;
+    private _popup?: WindowProxy | null;
+    private _overlay?: Overlay;
+
+    constructor() {}
+
+    initialize({ overlay }: ProcessorOptions) {
+        this._overlay = new Overlay({ hasCloseButton: true, innerHtml: this._getOverlayElements(overlay) });
+    }
+
+    paymentPayPal(approveUrl: string): Promise<boolean> {
+        return new Promise((resolve, reject) => {
+            const paramsWindow =  this._getParamsWindow();
+
+            const closeWindow = (isResolve: boolean, isRemoveOverlay: boolean = true) => {
+                this._window.removeEventListener('message', messageHandler);
+
+                if (this._popup) {
+                    this._popup.close();
+                    this._popup = undefined;
+                }
+
+                if (isRemoveOverlay && this._overlay) {
+                    this._overlay.remove();
+                }
+
+                isResolve
+                    ? resolve(true)
+                    : reject(new MissingDataError(MissingDataErrorType.MissingPayment));
+            };
+
+            const messageHandler = (event: MessageEvent) => {
+                if (event.origin !== 'https://www.sandbox.paypal.com' && event.origin !== 'https://www.paypal.com') {
+                    return;
+                }
+
+                const data = JSON.parse(event.data);
+
+                if (data.operation === 'return_to_merchant' && data.updateParent) {
+                    this._window.removeEventListener('message', messageHandler);
+                    closeWindow(true);
+                }
+            };
+
+            this._window.addEventListener('message', messageHandler);
+            this._popup = this._window.open(approveUrl, 'PPFrame', paramsWindow);
+
+            const popupTick = setInterval(() => {
+                if (!this._popup || this._popup.closed) {
+                    clearInterval(popupTick);
+
+                    closeWindow(false);
+                }
+            }, 500);
+
+            if (this._overlay) {
+                this._overlay.show({
+                    onClick: () => this._popup ? this._popup.focus() : closeWindow(false),
+                    onClickClose: () => closeWindow(false, false),
+                });
+            }
+        });
+    }
+
+    deinitialize(): void {
+        this._overlay = undefined;
+    }
+
+    private _getOverlayElements(options: ProcessorOptions['overlay'] = {}): DocumentFragment {
+        const fragment = document.createDocumentFragment();
+        const helpText = document.createElement('div');
+        const continueText = document.createElement('strong');
+
+        helpText.className = 'paypal-commerce-overlay_text';
+        helpText.innerText = options.helpText || 'Don\'t see the secure PayPal browser? We\'ll help you re-launch the window to complete your flow. You might need to enable pop-ups in your browser in order to continue.';
+
+        continueText.className = 'paypal-commerce-overlay_link';
+        continueText.innerText = options.continueText || 'Click to continue';
+        continueText.style.marginTop = '15px';
+        continueText.style.display = 'block';
+        continueText.style.color = 'white';
+        continueText.style.textDecoration = 'underline';
+
+        fragment.appendChild(helpText);
+        fragment.appendChild(continueText);
+
+        return fragment;
+    }
+
+    private _getParamsWindow(): string {
+        return `
+            left=${Math.round((window.screen.height - modalWidth) / 2)},
+            top=${Math.round((window.screen.width - modalHeight) / 2)},
+            height=${modalHeight},width=${modalWidth},status=yes,toolbar=no,menubar=no,resizable=yes,scrollbars=no
+        `;
+    }
+}

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { createAction, Action } from '@bigcommerce/data-store';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
@@ -16,7 +17,7 @@ import { getPaypalCommerce } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import PaypalCommercePaymentStrategy from './paypal-commerce-payment-strategy';
+import { PaypalCommercePaymentProcessor, PaypalCommercePaymentStrategy, PaypalCommerceRequestSender } from './index';
 
 describe('PaypalCommercePaymentStrategy', () => {
     let orderActionCreator: OrderActionCreator;
@@ -27,11 +28,17 @@ describe('PaypalCommercePaymentStrategy', () => {
     let submitOrderAction: Observable<Action>;
     let submitPaymentAction: Observable<Action>;
     let options: PaymentInitializeOptions;
+    let requestSender: RequestSender;
+    let paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor;
+    let paypalCommerceRequestSender: PaypalCommerceRequestSender;
 
     beforeEach(() => {
         paymentMethod = { ...getPaypalCommerce() };
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+        requestSender = createRequestSender();
+        paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor();
+        paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
 
         store = createCheckoutStore(getCheckoutStoreState());
         options = { methodId: paymentMethod.id };
@@ -44,10 +51,17 @@ describe('PaypalCommercePaymentStrategy', () => {
         paymentActionCreator = {} as PaymentActionCreator;
         paymentActionCreator.submitPayment = jest.fn(() => submitPaymentAction);
 
+        paypalCommercePaymentProcessor.initialize = jest.fn();
+        paypalCommercePaymentProcessor.paymentPayPal = jest.fn(() => new Promise(resolve => resolve()));
+
+        paypalCommerceRequestSender.setupPayment = jest.fn(() => ({ orderId: 'orderId', approveUrl: 'approveUrl' }));
+
         paypalCommercePaymentStrategy = new PaypalCommercePaymentStrategy(
             store,
             orderActionCreator,
-            paymentActionCreator
+            paymentActionCreator,
+            paypalCommerceRequestSender,
+            paypalCommercePaymentProcessor
         );
     });
 
@@ -107,6 +121,19 @@ describe('PaypalCommercePaymentStrategy', () => {
             expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
         });
 
+        it('calls setupPayment and paymentPayPal without orderId (paypal) in paymentMethod', async () => {
+            paymentMethod.initializationData.orderId = null;
+
+            await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
+
+            await paypalCommercePaymentStrategy.initialize(options);
+
+            await paypalCommercePaymentStrategy.execute(orderRequestBody, options);
+
+            expect(paypalCommerceRequestSender.setupPayment).toHaveBeenCalled();
+            expect(paypalCommercePaymentProcessor.paymentPayPal).toHaveBeenCalled();
+        });
+
         it('throw error without payment data', async () => {
             orderRequestBody.payment = undefined;
 
@@ -121,20 +148,6 @@ describe('PaypalCommercePaymentStrategy', () => {
 
         it('throw error with mistake in methodId', async () => {
             options.methodId = '';
-            await paypalCommercePaymentStrategy.initialize(options);
-
-            try {
-                await paypalCommercePaymentStrategy.execute(orderRequestBody, options);
-            } catch (error) {
-                expect(error).toEqual(new MissingDataError(MissingDataErrorType.MissingPaymentMethod));
-            }
-        });
-
-        it('throw error without orderId (paypal) in paymentMethod', async () => {
-            paymentMethod.initializationData.orderId = null;
-
-            await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
-
             await paypalCommercePaymentStrategy.initialize(options);
 
             try {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -1,42 +1,46 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentRequestOptions } from '../../payment-request-options';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
+
+import { PaypalCommercePaymentProcessor, PaypalCommerceRequestSender } from './index';
 
 export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
 
     constructor(
         private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator,
-        private _paymentActionCreator: PaymentActionCreator
+        private _paymentActionCreator: PaymentActionCreator,
+        private _paypalCommerceRequestSender: PaypalCommerceRequestSender,
+        private _paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor
     ) {}
 
-    initialize(): Promise<InternalCheckoutSelectors> {
+    initialize({ paypalcommerce }: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        this._paypalCommercePaymentProcessor.initialize({ overlay: paypalcommerce && paypalcommerce.overlay });
+
         return Promise.resolve(this._store.getState());
     }
 
     async execute(payload: OrderRequestBody, options: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const { payment, ...order } = payload;
-        const paymentMethod = this._store.getState().paymentMethods.getPaymentMethod(options.methodId);
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
 
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
         }
 
-        if (!paymentMethod || !paymentMethod.initializationData.orderId) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
+        const orderId = paymentMethod.initializationData.orderId || await this._getOrderId();
 
         const paymentData =  {
             formattedPayload: {
                 vault_payment_instrument: null,
                 device_info: null,
                 paypal_account: {
-                    order_id: paymentMethod.initializationData.orderId,
+                    order_id: orderId,
                 },
             },
         };
@@ -51,6 +55,18 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
     }
 
     deinitialize(): Promise<InternalCheckoutSelectors> {
+        this._paypalCommercePaymentProcessor.deinitialize();
+
         return Promise.resolve(this._store.getState());
+    }
+
+    private async _getOrderId(): Promise<string> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const { approveUrl, orderId } = await this._paypalCommerceRequestSender.setupPayment(cart.id);
+
+        await this._paypalCommercePaymentProcessor.paymentPayPal(approveUrl);
+
+        return orderId;
     }
 }


### PR DESCRIPTION
## What?
For markup flow (flow when we start PayPal commerce flow on the checkout page, not on cart page), we need to implement logic that will send a request to `api/storefront/payment/paypalcommerce/`

after customer has chosen PayPal Commerce method and clicked Place Order.
After FE received a link from 
`api/storefront/payment/paypalcommerce/`, we need to forward customer to url based on the link

After approving in the paypal payment should continue 
 

## Why?
Paying in checkout page

## Testing / Proof
<img width="1227" alt="Screen Shot 2020-04-10 at 2 53 29 PM" src="https://user-images.githubusercontent.com/32959076/78989008-10997200-7b3b-11ea-9181-f2fa9c64041b.png">


@bigcommerce/checkout @bigcommerce/payments
