### PR TITLE
feat(payment): INT-2541 Add Laybuy strategy

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -35,6 +35,7 @@ import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
 import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
+import { LaybuyPaymentStrategy } from './strategies/laybuy';
 import { LegacyPaymentStrategy } from './strategies/legacy';
 import { MasterpassPaymentStrategy, MasterpassScriptLoader } from './strategies/masterpass';
 import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
@@ -431,6 +432,15 @@ export default function createPaymentStrategyRegistry(
 
     registry.register(PaymentStrategyType.CONVERGE, () =>
         new ConvergePaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formPoster
+        )
+    );
+
+    registry.register(PaymentStrategyType.LAYBUY, () =>
+        new LaybuyPaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -11,6 +11,7 @@ enum PaymentStrategyType {
     CYBERSOURCE = 'cybersource',
     KLARNA = 'klarna',
     KLARNAV2 = 'klarnav2',
+    LAYBUY = 'laybuy',
     LEGACY = 'legacy',
     OFFLINE = 'offline',
     OFFSITE = 'offsite',

--- a/src/payment/strategies/laybuy/index.ts
+++ b/src/payment/strategies/laybuy/index.ts
@@ -1,0 +1,1 @@
+export { default as LaybuyPaymentStrategy } from './laybuy-payment-strategy';

--- a/src/payment/strategies/laybuy/laybuy-payment-strategy.spec.ts
+++ b/src/payment/strategies/laybuy/laybuy-payment-strategy.spec.ts
@@ -105,13 +105,13 @@ describe('LaybuyPaymentStrategy', () => {
         it('redirect to Laybuy if additional action is required', async () => {
             const error = new RequestError(getResponse({
                 ...getErrorPaymentResponseBody(),
-                errors: [
-                    { code: 'additional_action_required' },
-                ],
-                provider_data: {
-                    redirect_url: 'https://sandbox-payment.laybuy..com',
+                additional_action_required: {
+                    data : {
+                        redirect_url: 'https://sandbox-payment.laybuy..com',
+                    },
+                    type: 'offsite_redirect',
                 },
-                status: 'error',
+                status: 'additional_action_required',
             }));
 
             jest.spyOn(paymentActionCreator, 'submitPayment')

--- a/src/payment/strategies/laybuy/laybuy-payment-strategy.spec.ts
+++ b/src/payment/strategies/laybuy/laybuy-payment-strategy.spec.ts
@@ -1,0 +1,167 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { omit } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+
+import LaybuyPaymentStrategy from './laybuy-payment-strategy';
+
+describe('LaybuyPaymentStrategy', () => {
+    let finalizeOrderAction: Observable<FinalizeOrderAction>;
+    let formPoster: FormPoster;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let store: CheckoutStore;
+    let orderRequestSender: OrderRequestSender;
+    let strategy: LaybuyPaymentStrategy;
+    let submitOrderAction: Observable<SubmitOrderAction>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+
+    beforeEach(() => {
+        orderRequestSender = new OrderRequestSender(createRequestSender());
+        orderActionCreator = new OrderActionCreator(
+            orderRequestSender,
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        formPoster = createFormPoster();
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(store, 'dispatch');
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockImplementation((_url, _data, callback = () => {}) => callback());
+
+        jest.spyOn(orderActionCreator, 'finalizeOrder')
+            .mockReturnValue(finalizeOrderAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        strategy = new LaybuyPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formPoster
+        );
+    });
+
+    describe('#execute()', () => {
+        it('submits order without payment data', async () => {
+            const payload = getOrderRequestBody();
+            const options = { methodId: 'laybuy' };
+
+            await strategy.execute(payload, options);
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), options);
+            expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+        });
+
+        it('returns checkout state', async () => {
+            const output = await strategy.execute(getOrderRequestBody());
+
+            expect(output).toEqual(store.getState());
+        });
+
+        it('throws error when undefined payment is provided', async () => {
+            const payload = {
+                payment: undefined,
+            };
+
+            await expect(strategy.execute(payload)).rejects.toThrow(PaymentArgumentInvalidError);
+        });
+
+        it('redirect to Laybuy if additional action is required', async () => {
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [
+                    { code: 'additional_action_required' },
+                ],
+                provider_data: {
+                    redirect_url: 'https://sandbox-payment.laybuy..com',
+                },
+                status: 'error',
+            }));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+            strategy.execute(getOrderRequestBody());
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('https://sandbox-payment.laybuy..com', {});
+        });
+
+        it('reject payment when error is different to additional_action_required', async () => {
+            const response = new RequestError(getResponse(getErrorPaymentResponseBody()));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, response)));
+
+            await expect(strategy.execute(getOrderRequestBody())).rejects.toThrowError(response);
+
+            expect(formPoster.postForm).not.toHaveBeenCalled();
+        });
+
+        it('submits payment separately', async () => {
+            const payload = getOrderRequestBody();
+            const options = { methodId: 'laybuy' };
+            await strategy.execute(payload, options);
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payload.payment);
+            expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+        });
+    });
+
+    describe('#initialize()', () => {
+        it('returns the state', async () => {
+            expect(await strategy.initialize()).toEqual(store.getState());
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws an error to inform that order finalization is not required', async () => {
+            const promise = strategy.finalize();
+
+            return expect(promise).rejects.toBeInstanceOf(OrderFinalizationNotRequiredError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('returns the state', async () => {
+            expect(await strategy.deinitialize()).toEqual(store.getState());
+        });
+    });
+});

--- a/src/payment/strategies/laybuy/laybuy-payment-strategy.ts
+++ b/src/payment/strategies/laybuy/laybuy-payment-strategy.ts
@@ -1,0 +1,57 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { some } from 'lodash';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { RequestError } from '../../../common/error/errors';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+export default class LaybuyPaymentStrategy implements PaymentStrategy {
+
+    constructor(
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _formPoster: FormPoster
+    ) {}
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+        const paymentData = payment && payment.paymentData;
+
+        if (!payment || !paymentData) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+        try {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({...payment, paymentData}));
+        } catch (error) {
+
+            if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'additional_action_required' })) {
+                return Promise.reject(error);
+            }
+
+            return new Promise(() => {
+                this._formPoster.postForm(error.body.provider_data.redirect_url, { });
+            });
+        }
+    }
+
+    finalize(): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+}


### PR DESCRIPTION
## What? [INT-2541](https://jira.bigcommerce.com/browse/INT-2541)
Add Laybuy strategy

## Why?

A new payment strategy is required to support Laybuy.

## Testing / Proof
[Video](https://drive.google.com/file/d/1Mnkg1hPXa9zG1CweNys8czFBb-B-KW1k/view?usp=sharing)
 
<img width="690" alt="Screen Shot 2020-04-21 at 11 03 53 AM" src="https://user-images.githubusercontent.com/42154828/79887425-63d3b600-83c0-11ea-9281-0bc170a9d126.png">


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
