### PR TITLE
INT-2577 Create a strategy for Bolt

### DIFF
--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -1,4 +1,4 @@
-import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, VaultedInstrument } from '../payment';
+import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument } from '../payment';
 
 /**
  * An object that contains the information required for submitting an order.
@@ -36,8 +36,8 @@ export interface OrderPaymentRequestBody {
     gatewayId?: string;
 
     /**
-     * An object that contains the details of a credit card or vaulted payment
-     * instrument.
+     * An object that contains the details of a credit card, vaulted payment
+     * instrument or nonce instrument.
      */
-    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | VaultedInstrument;
+    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument;
 }

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -25,6 +25,7 @@ import { AffirmPaymentStrategy, AffirmScriptLoader } from './strategies/affirm';
 import { AfterpayPaymentStrategy, AfterpayScriptLoader } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy, AmazonPayScriptLoader } from './strategies/amazon-pay';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
+import { BoltPaymentStrategy } from './strategies/bolt';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVisaCheckoutPaymentStrategy, VisaCheckoutScriptLoader } from './strategies/braintree';
 import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow } from './strategies/cardinal';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
@@ -430,6 +431,14 @@ export default function createPaymentStrategyRegistry(
             new StripeScriptLoader(scriptLoader)
         )
     );
+
+    registry.register(PaymentStrategyType.BOLT, () =>
+        new BoltPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator
+        )
+);
 
     return registry;
 }

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -5,6 +5,7 @@ enum PaymentStrategyType {
     AMAZON = 'amazon',
     AUTHORIZENET_GOOGLE_PAY = 'googlepayauthorizenet',
     BLUESNAPV2 = 'bluesnapv2',
+    BOLT = 'bolt',
     CREDIT_CARD = 'creditcard',
     CYBERSOURCE = 'cybersource',
     KLARNA = 'klarna',

--- a/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -1,0 +1,117 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction } from '@bigcommerce/data-store';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MissingDataError } from '../../../common/error/errors';
+import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import { PaymentRequestOptions } from '../../payment-request-options';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+
+import BoltPaymentStrategy from './bolt-payment-strategy';
+
+describe('BoltPaymentStrategy', () => {
+    let orderActionCreator: OrderActionCreator;
+    let paymentRequestTransformer: PaymentRequestTransformer;
+    let paymentRequestSender: PaymentRequestSender;
+    let paymentActionCreator: PaymentActionCreator;
+    let options: PaymentRequestOptions;
+    let payload: OrderRequestBody;
+    let store: CheckoutStore;
+    let strategy: BoltPaymentStrategy;
+    let submitOrderAction: Observable<SubmitOrderAction>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        orderActionCreator = new OrderActionCreator(
+            new OrderRequestSender(createRequestSender()),
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+        );
+        paymentRequestTransformer = new PaymentRequestTransformer();
+        paymentRequestSender = new PaymentRequestSender(createPaymentClient());
+        paymentActionCreator = new PaymentActionCreator(
+            paymentRequestSender,
+            orderActionCreator,
+            paymentRequestTransformer
+        );
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        payload = {
+            payment: {
+                methodId: 'bolt',
+                paymentData: {
+                    nonce: 'fooNonce',
+                },
+            },
+        };
+        options = { methodId: 'bolt' };
+
+        jest.spyOn(store, 'dispatch');
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        strategy = new BoltPaymentStrategy(store, orderActionCreator, paymentActionCreator);
+    });
+
+    it('returns checkout state when initializing the strategy', async () => {
+        await expect(strategy.initialize()).resolves.toEqual(store.getState());
+    });
+
+    it('returns checkout state when deinitializing the strategy', async () => {
+        await expect(strategy.deinitialize()).resolves.toEqual(store.getState());
+    });
+
+    it('does not finalize the strategy as it is not required', async () => {
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+    });
+
+    it('executes the strategy successfully', async () => {
+        const expectedPayload = {
+            methodId: 'bolt',
+            paymentData: {
+                nonce: 'fooNonce',
+            },
+        };
+
+        await strategy.execute(payload, options);
+        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayload);
+    });
+
+    it('fails to execute the strategy if no payment is provided', async () => {
+        payload.payment = undefined;
+
+        await expect(strategy.execute(payload, options)).rejects.toThrow(PaymentArgumentInvalidError);
+    });
+
+    it('fails to execute the strategy if no method id is provided', async () => {
+        payload.payment = {
+            methodId: '',
+        };
+
+        await expect(strategy.execute(payload, options)).rejects.toThrow(MissingDataError);
+    });
+
+    it('fails to execute the strategy if no nonce is provided', async () => {
+        payload.payment = {
+            methodId: 'bolt',
+            paymentData: { },
+        };
+
+        await expect(strategy.execute(payload, options)).rejects.toThrow(MissingDataError);
+    });
+});

--- a/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -1,0 +1,54 @@
+import { isNonceLike } from '../..';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+export default class BoltPaymentStrategy implements PaymentStrategy {
+    constructor(
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator
+    ) { }
+
+    initialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    async execute(payload: OrderRequestBody, _options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        const { methodId, paymentData } = payment;
+
+        if (!methodId) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        if (!paymentData || !isNonceLike(paymentData)) {
+            throw new MissingDataError(MissingDataErrorType.MissingPayment);
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, _options));
+
+        return this._store.dispatch(this._paymentActionCreator.submitPayment({
+            methodId,
+            paymentData,
+        }));
+    }
+
+    finalize(): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+}

--- a/src/payment/strategies/bolt/index.ts
+++ b/src/payment/strategies/bolt/index.ts
@@ -1,0 +1,1 @@
+export { default as BoltPaymentStrategy } from './bolt-payment-strategy';


### PR DESCRIPTION
## What?
Create a payment strategy for bolt that allows a `nonce` to be submitted as payment.

## Why?
Bolt is a provider consumes checkout-sdk in its marketplace app, currently it submits orders and payments via the offline payment strategy and using other provider as its gateway, this strategy will allow the bolt app to submit the orders and payments to the corresponding bolt gateway .

## Testing / Proof
Unit testing.

@bigcommerce/checkout  @bigcommerce/payments  @bigcommerce/apex-integrations 
