### PR TITLE
CHECKOUT-4842: Trigger event when "enter" key is pressed in one of hosted payment fields

### DIFF
--- a/src/hosted-form/hosted-form-factory.ts
+++ b/src/hosted-form/hosted-form-factory.ts
@@ -54,7 +54,7 @@ export default class HostedFormFactory {
             fields,
             new IframeEventListener(host),
             new HostedFormOrderDataTransformer(this._store),
-            pick(options, 'onBlur', 'onFocus', 'onCardTypeChange', 'onValidate')
+            pick(options, 'onBlur', 'onEnter', 'onFocus', 'onCardTypeChange', 'onValidate')
         );
     }
 

--- a/src/hosted-form/hosted-form-options.ts
+++ b/src/hosted-form/hosted-form-options.ts
@@ -1,17 +1,19 @@
 import HostedFieldType from './hosted-field-type';
-import { HostedInputBlurEvent, HostedInputCardTypeChangeEvent, HostedInputFocusEvent, HostedInputStyles, HostedInputValidateEvent } from './iframe-content';
+import { HostedInputBlurEvent, HostedInputCardTypeChangeEvent, HostedInputEnterEvent, HostedInputFocusEvent, HostedInputStyles, HostedInputValidateEvent } from './iframe-content';
 
 export default interface HostedFormOptions {
     fields: HostedFieldOptionsMap;
     styles?: HostedFieldStylesMap;
     onBlur?(data: HostedFieldBlurEventData): void;
     onCardTypeChange?(data: HostedFieldCardTypeChangeEventData): void;
+    onEnter?(data: HostedFieldEnterEventData): void;
     onFocus?(data: HostedFieldFocusEventData): void;
     onValidate?(data: HostedFieldValidateEventData): void;
 }
 
 export type HostedFieldBlurEventData = HostedInputBlurEvent['payload'];
 export type HostedFieldCardTypeChangeEventData = HostedInputCardTypeChangeEvent['payload'];
+export type HostedFieldEnterEventData = HostedInputEnterEvent['payload'];
 export type HostedFieldFocusEventData = HostedInputFocusEvent['payload'];
 export type HostedFieldValidateEventData = HostedInputValidateEvent['payload'];
 

--- a/src/hosted-form/hosted-form.spec.ts
+++ b/src/hosted-form/hosted-form.spec.ts
@@ -9,7 +9,7 @@ import { getHostedFormOrderData } from './hosted-form-order-data.mock';
 import { HostedInputEventMap, HostedInputEventType } from './iframe-content';
 
 describe('HostedForm', () => {
-    let callbacks: Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onValidate'>;
+    let callbacks: Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onEnter' | 'onFocus' | 'onValidate'>;
     let eventListener: IframeEventListener<HostedInputEventMap>;
     let fields: HostedField[];
     let form: HostedForm;
@@ -20,11 +20,13 @@ describe('HostedForm', () => {
         detach: jest.fn(),
         getType: jest.fn(),
         submitForm: jest.fn(),
+        validateForm: jest.fn(),
     };
 
     beforeEach(() => {
         callbacks = {
             onBlur: jest.fn(),
+            onEnter: jest.fn(),
             onFocus: jest.fn(),
             onCardTypeChange: jest.fn(),
             onValidate: jest.fn(),
@@ -155,6 +157,36 @@ describe('HostedForm', () => {
 
         expect(callbacks.onBlur)
             .toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
+    });
+
+    it('notifies when enter key is pressed', async () => {
+        jest.spyOn(fields[0], 'validateForm')
+            .mockResolvedValue(undefined);
+
+        eventListener.trigger({
+            type: HostedInputEventType.Entered,
+            payload: { fieldType: HostedFieldType.CardCode },
+        });
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(callbacks.onEnter)
+            .toHaveBeenCalledWith({ fieldType: HostedFieldType.CardCode });
+    });
+
+    it('validates form when enter key is pressed', async () => {
+        jest.spyOn(fields[0], 'validateForm')
+            .mockResolvedValue(undefined);
+
+        eventListener.trigger({
+            type: HostedInputEventType.Entered,
+            payload: { fieldType: HostedFieldType.CardCode },
+        });
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(fields[0].validateForm)
+            .toHaveBeenCalled();
     });
 
     it('returns card type', () => {

--- a/src/hosted-form/iframe-content/hosted-autocomplete-fieldset.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-autocomplete-fieldset.spec.ts
@@ -5,21 +5,21 @@ import HostedInput from './hosted-input';
 import HostedInputAggregator from './hosted-input-aggregator';
 
 describe('HostedAutocompleteFieldset', () => {
-    let container: HTMLElement;
+    let container: HTMLFormElement;
     let fieldset: HostedAutocompleteFieldset;
     let inputAggregator: Pick<HostedInputAggregator, 'getInputs'>;
 
     beforeEach(() => {
         inputAggregator = { getInputs: jest.fn() };
+
+        container = document.createElement('form');
+        document.body.appendChild(container);
+
         fieldset = new HostedAutocompleteFieldset(
-            'input-container',
+            container,
             [HostedFieldType.CardExpiry, HostedFieldType.CardName],
             inputAggregator as HostedInputAggregator
         );
-
-        container = document.createElement('div');
-        container.id = 'input-container';
-        document.body.appendChild(container);
     });
 
     afterEach(() => {

--- a/src/hosted-form/iframe-content/hosted-autocomplete-fieldset.ts
+++ b/src/hosted-form/iframe-content/hosted-autocomplete-fieldset.ts
@@ -1,6 +1,5 @@
 import { kebabCase } from 'lodash';
 
-import { InvalidHostedFormConfigError } from '../errors';
 import HostedFieldType from '../hosted-field-type';
 
 import HostedInputAggregator from './hosted-input-aggregator';
@@ -10,7 +9,7 @@ export default class HostedAutocompleteFieldset {
     private _inputs: HTMLInputElement[];
 
     constructor(
-        private _containerId: string,
+        private _form: HTMLFormElement,
         private _fieldTypes: HostedFieldType[],
         private _inputAggregator: HostedInputAggregator
     ) {
@@ -18,13 +17,7 @@ export default class HostedAutocompleteFieldset {
     }
 
     attach(): void {
-        const container = document.getElementById(this._containerId);
-
-        if (!container) {
-            throw new InvalidHostedFormConfigError('Unable to proceed because the provided container ID is not valid.');
-        }
-
-        this._inputs.forEach(input => container.appendChild(input));
+        this._inputs.forEach(input => this._form.appendChild(input));
     }
 
     detach(): void {

--- a/src/hosted-form/iframe-content/hosted-card-expiry-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-card-expiry-input.spec.ts
@@ -11,7 +11,7 @@ import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 
 describe('HostedCardExpiryInput', () => {
-    let container: HTMLDivElement;
+    let container: HTMLFormElement;
     let eventListener: Pick<IframeEventListener<HostedFieldEventMap>, 'addListener' | 'listen' | 'stopListen'>;
     let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'post' | 'setTarget'>;
     let expiryFormatter: Pick<CardExpiryFormatter, 'format'>;
@@ -42,8 +42,11 @@ describe('HostedCardExpiryInput', () => {
         paymentHandler = { handle: jest.fn() };
         styles = { default: { color: 'rgb(255, 255, 255)' } };
 
+        container = document.createElement('form');
+        document.body.appendChild(container);
+
         input = new HostedCardExpiryInput(
-            'input-container',
+            container,
             'Expiration',
             'Card expiration',
             'cc-expiry',
@@ -56,10 +59,6 @@ describe('HostedCardExpiryInput', () => {
             paymentHandler as HostedInputPaymentHandler,
             expiryFormatter as CardExpiryFormatter
         );
-
-        container = document.createElement('div');
-        container.id = 'input-container';
-        document.body.appendChild(container);
     });
 
     afterEach(() => {

--- a/src/hosted-form/iframe-content/hosted-card-expiry-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-expiry-input.ts
@@ -15,7 +15,7 @@ export default class HostedCardExpiryInput extends HostedInput {
      * @internal
      */
     constructor(
-        containerId: string,
+        form: HTMLFormElement,
         placeholder: string,
         accessibilityLabel: string,
         autocomplete: string,
@@ -30,7 +30,7 @@ export default class HostedCardExpiryInput extends HostedInput {
     ) {
         super(
             HostedFieldType.CardExpiry,
-            containerId,
+            form,
             placeholder,
             accessibilityLabel,
             autocomplete,

--- a/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
@@ -14,7 +14,7 @@ import HostedInputValidator from './hosted-input-validator';
 
 describe('HostedCardNumberInput', () => {
     let autocompleteFieldset: HostedAutocompleteFieldset;
-    let container: HTMLDivElement;
+    let container: HTMLFormElement;
     let eventListener: Pick<IframeEventListener<HostedFieldEventMap>, 'addListener' | 'listen' | 'stopListen'>;
     let eventPoster: Pick<IframeEventPoster<HostedInputEvent>, 'setTarget' | 'post'>;
     let input: HostedInput;
@@ -25,8 +25,11 @@ describe('HostedCardNumberInput', () => {
     let styles: HostedInputStylesMap;
 
     beforeEach(() => {
+        container = document.createElement('form');
+        document.body.appendChild(container);
+
         autocompleteFieldset = new HostedAutocompleteFieldset(
-            'input-container',
+            container,
             [HostedFieldType.CardCode, HostedFieldType.CardExpiry, HostedFieldType.CardName],
             new HostedInputAggregator(window.parent)
         );
@@ -51,7 +54,7 @@ describe('HostedCardNumberInput', () => {
         styles = { default: { color: 'rgb(255, 255, 255)' } };
 
         input = new HostedCardNumberInput(
-            'input-container',
+            container,
             'Full name',
             'Cardholder name',
             'cc-name',
@@ -65,10 +68,6 @@ describe('HostedCardNumberInput', () => {
             autocompleteFieldset,
             numberFormatter as CardNumberFormatter
         );
-
-        container = document.createElement('div');
-        container.id = 'input-container';
-        document.body.appendChild(container);
     });
 
     afterEach(() => {

--- a/src/hosted-form/iframe-content/hosted-card-number-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.ts
@@ -19,7 +19,7 @@ export default class HostedCardNumberInput extends HostedInput {
      * @internal
      */
     constructor(
-        containerId: string,
+        form: HTMLFormElement,
         placeholder: string,
         accessibilityLabel: string,
         autocomplete: string,
@@ -35,7 +35,7 @@ export default class HostedCardNumberInput extends HostedInput {
     ) {
         super(
             HostedFieldType.CardNumber,
-            containerId,
+            form,
             placeholder,
             accessibilityLabel,
             autocomplete,

--- a/src/hosted-form/iframe-content/hosted-input-events.ts
+++ b/src/hosted-form/iframe-content/hosted-input-events.ts
@@ -14,6 +14,7 @@ export enum HostedInputEventType {
     Blurred = 'HOSTED_INPUT:BLURRED',
     Changed = 'HOSTED_INPUT:CHANGED',
     CardTypeChanged = 'HOSTED_INPUT:CARD_TYPE_CHANGED',
+    Entered = 'HOSTED_INPUT:ENTERED',
     Focused = 'HOSTED_INPUT:FOCUSED',
     SubmitSucceeded = 'HOSTED_INPUT:SUBMIT_SUCCEEDED',
     SubmitFailed = 'HOSTED_INPUT:SUBMIT_FAILED',
@@ -28,6 +29,7 @@ export interface HostedInputEventMap {
     [HostedInputEventType.Blurred]: HostedInputBlurEvent;
     [HostedInputEventType.Changed]: HostedInputChangeEvent;
     [HostedInputEventType.CardTypeChanged]: HostedInputCardTypeChangeEvent;
+    [HostedInputEventType.Entered]: HostedInputEnterEvent;
     [HostedInputEventType.Focused]: HostedInputFocusEvent;
     [HostedInputEventType.SubmitSucceeded]: HostedInputSubmitSuccessEvent;
     [HostedInputEventType.SubmitFailed]: HostedInputSubmitErrorEvent;
@@ -42,6 +44,7 @@ export type HostedInputEvent = (
     HostedInputBlurEvent |
     HostedInputChangeEvent |
     HostedInputCardTypeChangeEvent |
+    HostedInputEnterEvent |
     HostedInputFocusEvent |
     HostedInputSubmitSuccessEvent |
     HostedInputSubmitErrorEvent |
@@ -89,6 +92,13 @@ export interface HostedInputCardTypeChangeEvent {
 
 export interface HostedInputFocusEvent {
     type: HostedInputEventType.Focused;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputEnterEvent {
+    type: HostedInputEventType.Entered;
     payload: {
         fieldType: HostedFieldType;
     };

--- a/src/hosted-form/iframe-content/hosted-input-factory.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.spec.ts
@@ -13,20 +13,20 @@ describe('HostedInputFactory', () => {
     });
 
     it('creates card number field', () => {
-        expect(factory.create('input-container', HostedFieldType.CardNumber))
+        expect(factory.create(document.createElement('form'), HostedFieldType.CardNumber))
             .toBeInstanceOf(HostedCardNumberInput);
     });
 
     it('creates card expiry field', () => {
-        expect(factory.create('input-container', HostedFieldType.CardExpiry))
+        expect(factory.create(document.createElement('form'), HostedFieldType.CardExpiry))
             .toBeInstanceOf(HostedCardExpiryInput);
     });
 
     it('creates regular input field for other field types', () => {
-        expect(factory.create('input-container', HostedFieldType.CardCode))
+        expect(factory.create(document.createElement('form'), HostedFieldType.CardCode))
             .toBeInstanceOf(HostedInput);
 
-        expect(factory.create('input-container', HostedFieldType.CardName))
+        expect(factory.create(document.createElement('form'), HostedFieldType.CardName))
             .toBeInstanceOf(HostedInput);
     });
 });

--- a/src/hosted-form/iframe-content/hosted-input-factory.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.ts
@@ -24,7 +24,7 @@ export default class HostedInputFactory {
     ) {}
 
     create(
-        containerId: string,
+        form: HTMLFormElement,
         type: HostedFieldType,
         styles: HostedInputStylesMap = {},
         fontUrls: string[] = [],
@@ -35,27 +35,26 @@ export default class HostedInputFactory {
         const autocomplete = mapToAutocompleteType(type);
 
         if (type === HostedFieldType.CardNumber) {
-            return this._createNumberInput(containerId, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
+            return this._createNumberInput(form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
         }
 
         if (type === HostedFieldType.CardNumberVerification) {
-            return this._createNumberInput(containerId, styles, fontUrls, placeholder, accessibilityLabel, autocomplete, cardInstrument);
+            return this._createNumberInput(form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete, cardInstrument);
         }
 
         if (type === HostedFieldType.CardExpiry) {
-            return this._createExpiryInput(containerId, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
+            return this._createExpiryInput(form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
         }
 
         if (type === HostedFieldType.CardCodeVerification) {
-            return this._createInput(type, containerId, styles, fontUrls, placeholder, accessibilityLabel, autocomplete, cardInstrument);
+            return this._createInput(type, form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete, cardInstrument);
         }
 
-        return this._createInput(type, containerId, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
+        return this._createInput(type, form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
     }
 
     private _createExpiryInput(
-        containerId:
-        string,
+        form: HTMLFormElement,
         styles: HostedInputStylesMap,
         fontUrls: string[],
         placeholder: string,
@@ -63,7 +62,7 @@ export default class HostedInputFactory {
         autocomplete: string = ''
     ): HostedCardExpiryInput {
         return new HostedCardExpiryInput(
-            containerId,
+            form,
             placeholder,
             accessibilityLabel,
             autocomplete,
@@ -79,7 +78,7 @@ export default class HostedInputFactory {
     }
 
     private _createNumberInput(
-        containerId: string,
+        form: HTMLFormElement,
         styles: HostedInputStylesMap,
         fontUrls: string[],
         placeholder: string,
@@ -88,7 +87,7 @@ export default class HostedInputFactory {
         cardInstrument?: CardInstrument
     ): HostedCardNumberInput {
         return new HostedCardNumberInput(
-            containerId,
+            form,
             placeholder,
             accessibilityLabel,
             autocomplete,
@@ -100,7 +99,7 @@ export default class HostedInputFactory {
             new HostedInputValidator(cardInstrument),
             this._createPaymentHandler(cardInstrument),
             new HostedAutocompleteFieldset(
-                containerId,
+                form,
                 [HostedFieldType.CardCode, HostedFieldType.CardExpiry, HostedFieldType.CardName],
                 new HostedInputAggregator(window.parent)
             ),
@@ -110,7 +109,7 @@ export default class HostedInputFactory {
 
     private _createInput(
         type: HostedFieldType,
-        containerId: string,
+        form: HTMLFormElement,
         styles: HostedInputStylesMap,
         fontUrls: string[],
         placeholder: string,
@@ -120,7 +119,7 @@ export default class HostedInputFactory {
     ): HostedInput {
         return new HostedInput(
             type,
-            containerId,
+            form,
             placeholder,
             accessibilityLabel,
             autocomplete,


### PR DESCRIPTION
## What?
Trigger `onEnter` event callback when "enter" key is pressed in one of the hosted payment fields. With this callback, the client application can submit an order when it is triggered.

## Why?
With this change, shoppers can use their keyboard to place an order after filling in their credit card details.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
