### PR TITLE
CHECKOUT-4799 Add Sign-in via Email support (passwordless login)

### DIFF
--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -15,6 +15,7 @@ import { OrderActionCreator, OrderRequestBody } from '../order';
 import { PaymentInitializeOptions, PaymentMethodActionCreator, PaymentRequestOptions, PaymentStrategyActionCreator } from '../payment';
 import { InstrumentActionCreator } from '../payment/instrument';
 import { ConsignmentsRequestBody, ConsignmentActionCreator, ConsignmentAssignmentRequestBody, ConsignmentUpdateRequestBody, ShippingCountryActionCreator, ShippingInitializeOptions, ShippingRequestOptions, ShippingStrategyActionCreator } from '../shipping';
+import { SignInEmailActionCreator } from '../signin-email';
 import { SpamProtectionActionCreator, SpamProtectionOptions } from '../spam-protection';
 import { StoreCreditActionCreator } from '../store-credit';
 import { Subscriptions, SubscriptionsActionCreator } from '../subscription';
@@ -60,6 +61,7 @@ export default class CheckoutService {
         private _paymentStrategyActionCreator: PaymentStrategyActionCreator,
         private _shippingCountryActionCreator: ShippingCountryActionCreator,
         private _shippingStrategyActionCreator: ShippingStrategyActionCreator,
+        private _signInEmailActionCreator: SignInEmailActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator,
         private _storeCreditActionCreator: StoreCreditActionCreator,
         private _subscriptionsActionCreator: SubscriptionsActionCreator
@@ -518,6 +520,21 @@ export default class CheckoutService {
         const action = this._customerStrategyActionCreator.deinitialize(options);
 
         return this._dispatch(action, { queueId: 'customerStrategy' });
+    }
+
+    /**
+     * Sends a email that contains a single-use sign-in link. When clicked, this link
+     * signs in the customer without requiring any password.
+     *
+     * @internal
+     * @param email - The email to be sent the sign-in link.
+     * @param options - Options for the send email request.
+     * @returns A promise that resolves to the current state.
+     */
+    sendSignInEmail(email: string, options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._signInEmailActionCreator.sendSignInEmail(email, options);
+
+        return this._dispatch(action, { queueId: 'signInEmail' });
     }
 
     /**

--- a/src/checkout/checkout-store-error-selector.spec.ts
+++ b/src/checkout/checkout-store-error-selector.spec.ts
@@ -59,6 +59,26 @@ describe('CheckoutStoreErrorSelector', () => {
         });
     });
 
+    describe('#getSignInEmailError()', () => {
+        it('returns error if theres one', () => {
+            jest.spyOn(selectors.signInEmail, 'getSendError').mockReturnValue(errorResponse);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
+            expect(errors.getSignInEmailError()).toEqual(errorResponse);
+            expect(selectors.signInEmail.getSendError).toHaveBeenCalled();
+        });
+
+        it('returns undefined if there is no error', () => {
+            jest.spyOn(selectors.signInEmail, 'getSendError').mockReturnValue(undefined);
+
+            const errors = createCheckoutStoreErrorSelector(selectors);
+
+            expect(errors.getSignInEmailError()).toEqual(undefined);
+            expect(selectors.signInEmail.getSendError).toHaveBeenCalled();
+        });
+    });
+
     describe('#getUpdateCheckoutError()', () => {
         it('returns error if there is an error when loading checkout', () => {
             jest.spyOn(selectors.checkout, 'getUpdateError').mockReturnValue(errorResponse);

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -259,6 +259,13 @@ export default interface CheckoutStoreErrorSelector {
      * @returns The error object if unable to load, otherwise undefined.
      */
     getLoadConfigError(): Error | undefined;
+
+    /**
+     * Returns an error if unable to send sign-in email.
+     *
+     * @returns The error object if unable to send email, otherwise undefined.
+     */
+    getSignInEmailError(): Error | undefined;
 }
 
 export type CheckoutStoreErrorSelectorFactory = (state: InternalCheckoutSelectors) => CheckoutStoreErrorSelector;
@@ -324,6 +331,7 @@ export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSel
             getLoadInstrumentsError: state.instruments.getLoadError,
             getDeleteInstrumentError: state.instruments.getDeleteError,
             getLoadConfigError: state.config.getLoadError,
+            getSignInEmailError: state.signInEmail.getSendError,
         };
 
         return {

--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -34,6 +34,10 @@ describe('CheckoutStoreSelector', () => {
         expect(selector.getOrder()).toEqual(internalSelectors.order.getOrder());
     });
 
+    it('returns sign-in email', () => {
+        expect(selector.getSignInEmail()).toEqual(internalSelectors.signInEmail.getEmail());
+    });
+
     it('returns config', () => {
         expect(selector.getConfig()).toEqual(internalSelectors.config.getStoreConfig());
     });

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -15,6 +15,7 @@ import { Order } from '../order';
 import { PaymentMethod } from '../payment';
 import { CardInstrument, PaymentInstrument } from '../payment/instrument';
 import { Consignment, ShippingOption } from '../shipping';
+import { SignInEmail } from '../signin-email';
 
 import Checkout from './checkout';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
@@ -48,6 +49,13 @@ export default interface CheckoutStoreSelector {
      * @returns The configuration object if it is loaded, otherwise undefined.
      */
     getConfig(): StoreConfig | undefined;
+
+    /**
+     * Gets the sign-in email.
+     *
+     * @returns The sign-in email object if sent, otherwise undefined
+     */
+    getSignInEmail(): SignInEmail | undefined;
 
     /**
      * Gets the shipping address of the current checkout.
@@ -397,6 +405,11 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         getCustomer => clone(getCustomer)
     );
 
+    const getSignInEmail = createSelector(
+        ({ signInEmail }: InternalCheckoutSelectors) => signInEmail.getEmail,
+        getEmail => clone(getEmail)
+    );
+
     const isPaymentDataRequired = createSelector(
         ({ payment }: InternalCheckoutSelectors) => payment.isPaymentDataRequired,
         isPaymentDataRequired => clone(isPaymentDataRequired)
@@ -463,6 +476,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             getCustomer: getCustomer(state),
             isPaymentDataRequired: isPaymentDataRequired(state),
             isPaymentDataSubmitted: isPaymentDataSubmitted(state),
+            getSignInEmail: getSignInEmail(state),
             getInstruments: getInstruments(state),
             getBillingAddressFields: getBillingAddressFields(state),
             getShippingAddressFields: getShippingAddressFields(state),

--- a/src/checkout/checkout-store-state.ts
+++ b/src/checkout/checkout-store-state.ts
@@ -10,6 +10,7 @@ import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payme
 import { InstrumentState } from '../payment/instrument';
 import { RemoteCheckoutState } from '../remote-checkout';
 import { ConsignmentState, ShippingCountryState, ShippingStrategyState } from '../shipping';
+import { SignInEmailState } from '../signin-email';
 import { StoreCreditState } from '../store-credit';
 import { SubscriptionsState } from '../subscription';
 
@@ -35,6 +36,7 @@ export default interface CheckoutStoreState {
     remoteCheckout: RemoteCheckoutState;
     shippingCountries: ShippingCountryState;
     shippingStrategies: ShippingStrategyState;
+    signInEmail: SignInEmailState;
     subscriptions: SubscriptionsState;
     storeCredit: StoreCreditState;
 }

--- a/src/checkout/checkout-store-status-selector.spec.ts
+++ b/src/checkout/checkout-store-status-selector.spec.ts
@@ -374,6 +374,26 @@ describe('CheckoutStoreStatusSelector', () => {
         });
     });
 
+    describe('#isSendingSignInEmail()', () => {
+        it('returns true if sending', () => {
+            jest.spyOn(selectors.signInEmail, 'isSending').mockReturnValue(true);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
+            expect(statuses.isSendingSignInEmail()).toEqual(true);
+            expect(selectors.signInEmail.isSending).toHaveBeenCalled();
+        });
+
+        it('returns false if not sending', () => {
+            jest.spyOn(selectors.signInEmail, 'isSending').mockReturnValue(false);
+
+            const statuses = createCheckoutStoreStatusSelector(selectors);
+
+            expect(statuses.isSendingSignInEmail()).toEqual(false);
+            expect(selectors.signInEmail.isSending).toHaveBeenCalled();
+        });
+    });
+
     describe('#isUpdatingBillingAddress()', () => {
         it('returns true if updating billing address', () => {
             jest.spyOn(selectors.billingAddress, 'isUpdating').mockReturnValue(true);

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -255,6 +255,13 @@ export default interface CheckoutStoreStatusSelector {
     isRemovingCoupon(): boolean;
 
     /**
+     * Checks whether a sign-in email is being sent.
+     *
+     * @returns True if sending a sign-in email, otherwise false
+     */
+    isSendingSignInEmail(): boolean;
+
+    /**
      * Checks whether the current customer is applying a gift certificate.
      *
      * @returns True if applying a gift certificate, otherwise false.
@@ -419,6 +426,7 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
             isLoadingInstruments: state.instruments.isLoading,
             isDeletingInstrument: state.instruments.isDeleting,
             isLoadingConfig: state.config.isLoading,
+            isSendingSignInEmail: state.signInEmail.isSending,
             isCustomerStepPending: isCustomerStepPending(state),
             isPaymentStepPending: isPaymentStepPending(state),
         };

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -135,6 +135,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         shippingCountries: getShippingCountriesState(),
         shippingStrategies: { data: {}, errors: {}, statuses: {} },
         subscriptions: { errors: {}, statuses: {} },
+        signInEmail: { errors: {}, statuses: {} },
         storeCredit: { errors: {}, statuses: {} },
     };
 }

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -13,6 +13,7 @@ import { OrderActionCreator, OrderRequestSender } from '../order';
 import { createPaymentClient, createPaymentStrategyRegistry, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentStrategyActionCreator } from '../payment';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
 import { createShippingStrategyRegistry, ConsignmentActionCreator, ConsignmentRequestSender, ShippingCountryActionCreator, ShippingCountryRequestSender, ShippingStrategyActionCreator } from '../shipping';
+import { SignInEmailActionCreator, SignInEmailRequestSender } from '../signin-email';
 import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../spam-protection';
 import { StoreCreditActionCreator, StoreCreditRequestSender } from '../store-credit';
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subscription';
@@ -96,6 +97,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         ),
         new ShippingCountryActionCreator(new ShippingCountryRequestSender(requestSender, { locale })),
         new ShippingStrategyActionCreator(createShippingStrategyRegistry(store, requestSender)),
+        new SignInEmailActionCreator(new SignInEmailRequestSender(requestSender)),
         spamProtectionActionCreator,
         new StoreCreditActionCreator(new StoreCreditRequestSender(requestSender)),
         subscriptionsActionCreator

--- a/src/checkout/create-checkout-store-reducer.ts
+++ b/src/checkout/create-checkout-store-reducer.ts
@@ -12,6 +12,7 @@ import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '..
 import { instrumentReducer } from '../payment/instrument';
 import { remoteCheckoutReducer } from '../remote-checkout';
 import { consignmentReducer, shippingCountryReducer, shippingStrategyReducer } from '../shipping';
+import { signInEmailReducer } from '../signin-email';
 import { storeCreditReducer } from '../store-credit';
 import { subscriptionsReducer } from '../subscription';
 
@@ -39,6 +40,7 @@ export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState
         remoteCheckout: remoteCheckoutReducer,
         shippingCountries: shippingCountryReducer,
         shippingStrategies: shippingStrategyReducer,
+        signInEmail: signInEmailReducer,
         subscriptions: subscriptionsReducer,
         storeCredit: storeCreditReducer,
     });

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -12,6 +12,7 @@ import { createPaymentMethodSelectorFactory, createPaymentSelectorFactory, creat
 import { createInstrumentSelectorFactory } from '../payment/instrument';
 import { createRemoteCheckoutSelectorFactory } from '../remote-checkout';
 import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, createShippingStrategySelectorFactory } from '../shipping';
+import { createSignInEmailSelectorFactory } from '../signin-email';
 import { createStoreCreditSelectorFactory } from '../store-credit';
 import { createSubscriptionsSelectorFactory } from '../subscription';
 
@@ -49,6 +50,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createPaymentSelector = createPaymentSelectorFactory();
     const createStoreCreditSelector = createStoreCreditSelectorFactory();
     const createSubscriptionsSelector = createSubscriptionsSelectorFactory();
+    const createSignInEmailSelector = createSignInEmailSelectorFactory();
 
     return (state, options = {}) => {
         const billingAddress = createBillingAddressSelector(state.billingAddress);
@@ -70,6 +72,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const shippingStrategies = createShippingStrategySelector(state.shippingStrategies);
         const subscriptions = createSubscriptionsSelector(state.subscriptions);
         const storeCredit = createStoreCreditSelector(state.storeCredit);
+        const signInEmail = createSignInEmailSelector(state.signInEmail);
 
         // Compose selectors
         const consignments = createConsignmentSelector(state.consignments, cart);
@@ -99,6 +102,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             shippingAddress,
             shippingCountries,
             shippingStrategies,
+            signInEmail,
             subscriptions,
             storeCredit,
         };

--- a/src/checkout/internal-checkout-selectors.ts
+++ b/src/checkout/internal-checkout-selectors.ts
@@ -11,6 +11,7 @@ import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from 
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import { ConsignmentSelector, ShippingAddressSelector, ShippingCountrySelector, ShippingStrategySelector } from '../shipping';
+import { SignInEmailSelector } from '../signin-email';
 import { StoreCreditSelector } from '../store-credit';
 import { SubscriptionsSelector } from '../subscription';
 
@@ -38,6 +39,7 @@ export default interface InternalCheckoutSelectors {
     shippingAddress: ShippingAddressSelector;
     shippingCountries: ShippingCountrySelector;
     shippingStrategies: ShippingStrategySelector;
+    signInEmail: SignInEmailSelector;
     subscriptions: SubscriptionsSelector;
     storeCredit: StoreCreditSelector;
 }

--- a/src/signin-email/index.ts
+++ b/src/signin-email/index.ts
@@ -1,0 +1,8 @@
+export * from './signin-email-actions';
+export { SignInEmail } from './signin-email';
+
+export { default as SignInEmailRequestSender } from './signin-email-request-sender';
+export { default as SignInEmailActionCreator } from './signin-email-action-creator';
+export { default as SignInEmailState } from './signin-email-state';
+export { default as signInEmailReducer } from './signin-email-reducer';
+export { default as SignInEmailSelector, SignInEmailSelectorFactory, createSignInEmailSelectorFactory } from './signin-email-selector';

--- a/src/signin-email/signin-email-action-creator.spec.ts
+++ b/src/signin-email/signin-email-action-creator.spec.ts
@@ -1,0 +1,71 @@
+import { createRequestSender, Response } from '@bigcommerce/request-sender';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+
+import { SignInEmail } from './signin-email';
+import SignInEmailActionCreator from './signin-email-action-creator';
+import { SignInEmailActionType } from './signin-email-actions';
+import SignInEmailRequestSender from './signin-email-request-sender';
+
+describe('SubscriptionsActionCreator', () => {
+    let signInEmailActionCreator: SignInEmailActionCreator;
+    let signInEmailRequestSender: SignInEmailRequestSender;
+    let errorResponse: Response<Error>;
+    let response: Response<SignInEmail>;
+
+    beforeEach(() => {
+        response = getResponse({ sent_email: 'f', expiry: 0 });
+        errorResponse = getErrorResponse();
+        signInEmailRequestSender = new SignInEmailRequestSender(createRequestSender());
+
+        jest.spyOn(signInEmailRequestSender, 'sendSignInEmail').mockImplementation(() => Promise.resolve(response));
+
+        signInEmailActionCreator = new SignInEmailActionCreator(
+            signInEmailRequestSender
+        );
+    });
+
+    describe('#sendSignInEmail()', () => {
+        describe('when store has a signed-in shopper', () => {
+            it('emits billing actions if able to continue as guest', async () => {
+                const actions = await from(signInEmailActionCreator.sendSignInEmail('f'))
+                    .pipe(toArray())
+                    .toPromise();
+
+                expect(actions).toEqual([
+                    { type: SignInEmailActionType.SendSignInEmailRequested },
+                    { type: SignInEmailActionType.SendSignInEmailSucceeded, payload: response.body },
+                ]);
+            });
+
+            it('emits error actions if unable to continue as guest', async () => {
+                jest.spyOn(signInEmailRequestSender, 'sendSignInEmail')
+                    .mockReturnValue(Promise.reject(getErrorResponse()));
+
+                const errorHandler = jest.fn(action => of(action));
+
+                const actions = await from(signInEmailActionCreator.sendSignInEmail('f'))
+                    .pipe(
+                        catchError(errorHandler),
+                        toArray()
+                    )
+                    .toPromise();
+
+                expect(errorHandler).toHaveBeenCalled();
+                expect(actions).toEqual([
+                    { type: SignInEmailActionType.SendSignInEmailRequested },
+                    { type: SignInEmailActionType.SendSignInEmailFailed, payload: errorResponse, error: true },
+                ]);
+            });
+
+            it('sends request to create billing address', async () => {
+                await from(signInEmailActionCreator.sendSignInEmail('f', {}))
+                    .toPromise();
+
+                expect(signInEmailRequestSender.sendSignInEmail).toHaveBeenCalledWith('f', {});
+            });
+        });
+    });
+});

--- a/src/signin-email/signin-email-action-creator.ts
+++ b/src/signin-email/signin-email-action-creator.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@bigcommerce/data-store';
+import { concat, defer, of, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { throwErrorAction } from '../common/error';
+import { RequestOptions } from '../common/http-request';
+
+import { SendSignInEmailAction, SignInEmailActionType } from './signin-email-actions';
+import SignInEmailRequestSender from './signin-email-request-sender';
+
+export default class SignInEmailActionCreator {
+    constructor(
+        private _requestSender: SignInEmailRequestSender
+    ) {}
+
+    sendSignInEmail(
+        email: string,
+        options?: RequestOptions
+    ): Observable<SendSignInEmailAction> {
+        return concat(
+            of(createAction(SignInEmailActionType.SendSignInEmailRequested)),
+            defer(async () => {
+                const { body } = await this._requestSender.sendSignInEmail(email, options);
+
+                return createAction(SignInEmailActionType.SendSignInEmailSucceeded, body);
+            })
+        ).pipe(
+            catchError(error => throwErrorAction(SignInEmailActionType.SendSignInEmailFailed, error))
+        );
+    }
+}

--- a/src/signin-email/signin-email-actions.ts
+++ b/src/signin-email/signin-email-actions.ts
@@ -1,0 +1,25 @@
+import { Action } from '@bigcommerce/data-store';
+
+import { SignInEmail } from './signin-email';
+
+export enum SignInEmailActionType {
+    SendSignInEmailRequested = 'SEND_SIGNIN_EMAIL_REQUESTED',
+    SendSignInEmailSucceeded = 'SEND_SIGNIN_EMAIL_SUCCEEDED',
+    SendSignInEmailFailed = 'SEND_SIGNIN_EMAIL_FAILED',
+}
+export type SendSignInEmailAction =
+    SendSignInEmailRequestedAction |
+    SendSignInEmailSucceededAction |
+    SendSignInEmailFailedAction;
+
+export interface SendSignInEmailRequestedAction extends Action {
+    type: SignInEmailActionType.SendSignInEmailRequested;
+}
+
+export interface SendSignInEmailSucceededAction extends Action<SignInEmail> {
+    type: SignInEmailActionType.SendSignInEmailSucceeded;
+}
+
+export interface SendSignInEmailFailedAction extends Action<Error> {
+    type: SignInEmailActionType.SendSignInEmailFailed;
+}

--- a/src/signin-email/signin-email-reducer.spec.ts
+++ b/src/signin-email/signin-email-reducer.spec.ts
@@ -1,0 +1,51 @@
+import { createAction } from '@bigcommerce/data-store';
+
+import { RequestError } from '../common/error/errors';
+import { getErrorResponse } from '../common/http-request/responses.mock';
+
+import { SignInEmail } from './signin-email';
+import { SignInEmailActionType } from './signin-email-actions';
+import signInEmailReducer from './signin-email-reducer';
+import SignInEmailState from './signin-email-state';
+
+describe('signInEmailReducer', () => {
+    let initialState: SignInEmailState;
+
+    beforeEach(() => {
+        initialState = { errors: {}, statuses: {} };
+    });
+
+    it('returns pending when subscriptions update requested', () => {
+        const action = createAction(SignInEmailActionType.SendSignInEmailRequested);
+        const output = signInEmailReducer(initialState, action);
+
+        expect(output).toEqual({
+            data: undefined,
+            errors: { sendError: undefined },
+            statuses: { isSending: true },
+        });
+    });
+
+    it('returns clean state when subscriptions updated', () => {
+        const email: SignInEmail = { sent_email: 'f', expiry: 0 };
+        const action = createAction(SignInEmailActionType.SendSignInEmailSucceeded, email);
+        const output = signInEmailReducer(initialState, action);
+
+        expect(output).toEqual({
+            data: action.payload,
+            errors: { sendError: undefined },
+            statuses: { isSending: false },
+        });
+    });
+
+    it('returns error when subscriptions failed to update', () => {
+        const action = createAction(SignInEmailActionType.SendSignInEmailFailed, new RequestError(getErrorResponse()));
+        const output = signInEmailReducer(initialState, action);
+
+        expect(output).toEqual({
+            data: undefined,
+            errors: { sendError: action.payload },
+            statuses: { isSending: false },
+        });
+    });
+});

--- a/src/signin-email/signin-email-reducer.ts
+++ b/src/signin-email/signin-email-reducer.ts
@@ -1,0 +1,67 @@
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
+import { objectMerge, objectSet } from '../common/utility';
+
+import { SignInEmail } from './signin-email';
+import { SendSignInEmailAction, SignInEmailActionType } from './signin-email-actions';
+import SignInEmailState, { DEFAULT_STATE, SignInEmailErrorsState, SignInEmailStatusesState } from './signin-email-state';
+
+export default function signInEmailReducer(
+    state: SignInEmailState = DEFAULT_STATE,
+    action: Action
+): SignInEmailState {
+    const reducer = combineReducers<SignInEmailState>({
+        data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
+        statuses: statusesReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: SignInEmail | undefined,
+    action: SendSignInEmailAction
+): SignInEmail | undefined {
+    switch (action.type) {
+    case SignInEmailActionType.SendSignInEmailSucceeded:
+        return objectMerge(data, action.payload);
+
+    default:
+        return data;
+    }
+}
+
+function errorsReducer(
+    errors: SignInEmailErrorsState = DEFAULT_STATE.errors,
+    action: SendSignInEmailAction
+): SignInEmailErrorsState {
+    switch (action.type) {
+    case SignInEmailActionType.SendSignInEmailRequested:
+    case SignInEmailActionType.SendSignInEmailSucceeded:
+        return objectSet(errors, 'sendError', undefined);
+
+    case SignInEmailActionType.SendSignInEmailFailed:
+        return objectSet(errors, 'sendError', action.payload);
+
+    default:
+        return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: SignInEmailStatusesState = DEFAULT_STATE.statuses,
+    action: SendSignInEmailAction
+): SignInEmailStatusesState {
+    switch (action.type) {
+    case SignInEmailActionType.SendSignInEmailRequested:
+        return objectSet(statuses, 'isSending', true);
+
+    case SignInEmailActionType.SendSignInEmailFailed:
+    case SignInEmailActionType.SendSignInEmailSucceeded:
+        return objectSet(statuses, 'isSending', false);
+    default:
+        return statuses;
+    }
+}

--- a/src/signin-email/signin-email-request-sender.spec.ts
+++ b/src/signin-email/signin-email-request-sender.spec.ts
@@ -1,0 +1,47 @@
+import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
+
+import { ContentType } from '../common/http-request';
+
+import SignInEmailRequestSender from './signin-email-request-sender';
+
+describe('SignInEmailRequestSender', () => {
+    let signInEmailRequestSender: SignInEmailRequestSender;
+    let requestSender: RequestSender;
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+
+        jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
+
+        signInEmailRequestSender = new SignInEmailRequestSender(requestSender);
+    });
+
+    describe('#sendSignInEmail()', () => {
+        it('sends sign-in email', async () => {
+            await signInEmailRequestSender.sendSignInEmail('foo');
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                '/login.php?action=passwordless_login',
+                {
+                    body: { email: 'foo' },
+                    headers: { Accept: ContentType.JsonV1 },
+                    timeout: undefined,
+                }
+            );
+        });
+
+        it('sends sign-in email with timeout', async () => {
+            const options = { timeout: createTimeout() };
+            await signInEmailRequestSender.sendSignInEmail('foo', options);
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                '/login.php?action=passwordless_login',
+                {
+                    ...options,
+                    body: { email: 'foo' },
+                    headers: { Accept: ContentType.JsonV1 },
+                }
+            );
+        });
+    });
+});

--- a/src/signin-email/signin-email-request-sender.ts
+++ b/src/signin-email/signin-email-request-sender.ts
@@ -1,0 +1,18 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { ContentType, RequestOptions } from '../common/http-request';
+
+import { SignInEmail } from './signin-email';
+
+export default class SignInEmailRequestSender {
+    constructor(
+        private _requestSender: RequestSender
+    ) {}
+
+    sendSignInEmail(email: string, { timeout }: RequestOptions = {}): Promise<Response<SignInEmail>> {
+        const url = '/login.php?action=passwordless_login';
+        const headers = { Accept: ContentType.JsonV1 };
+
+        return this._requestSender.post(url, { body: { email }, headers, timeout });
+    }
+}

--- a/src/signin-email/signin-email-selector.spec.ts
+++ b/src/signin-email/signin-email-selector.spec.ts
@@ -1,0 +1,79 @@
+import { SignInEmail } from './signin-email';
+import SignInEmailSelector, { createSignInEmailSelectorFactory, SignInEmailSelectorFactory } from './signin-email-selector';
+
+describe('SignInEmailSelector', () => {
+    let signInEmailSelector: SignInEmailSelector;
+    let createSignInEmailSelector: SignInEmailSelectorFactory;
+
+    beforeEach(() => {
+        createSignInEmailSelector = createSignInEmailSelectorFactory();
+    });
+
+    describe('#getEmail()', () => {
+        it('returns email if present', () => {
+            const email: SignInEmail = {
+                sent_email: 'f',
+                expiry: 0,
+            };
+
+            signInEmailSelector = createSignInEmailSelector({
+                data: email,
+                errors: {},
+                statuses: {},
+            });
+
+            expect(signInEmailSelector.getEmail()).toEqual(email);
+        });
+
+        it('returns no error if not present', () => {
+            signInEmailSelector = createSignInEmailSelector({
+                errors: {},
+                statuses: {},
+            });
+
+            expect(signInEmailSelector.getSendError()).toBeUndefined();
+        });
+    });
+
+    describe('#getSendError()', () => {
+        it('returns error if present', () => {
+            const sendError = new Error();
+
+            signInEmailSelector = createSignInEmailSelector({
+                errors: { sendError },
+                statuses: {},
+            });
+
+            expect(signInEmailSelector.getSendError()).toEqual(sendError);
+        });
+
+        it('returns no error if not present', () => {
+            signInEmailSelector = createSignInEmailSelector({
+                errors: {},
+                statuses: {},
+            });
+
+            expect(signInEmailSelector.getSendError()).toBeUndefined();
+        });
+    });
+
+    describe('#isUpdating()', () => {
+        it('returns true if sending email', () => {
+            signInEmailSelector = createSignInEmailSelector({
+                errors: {},
+                statuses: { isSending: true },
+            });
+
+            expect(signInEmailSelector.isSending()).toEqual(true);
+        });
+
+        it('returns false if not sending email', () => {
+            signInEmailSelector = createSignInEmailSelector({
+                errors: {},
+                statuses: {},
+            });
+
+            expect(signInEmailSelector.isSending()).toEqual(false);
+        });
+    });
+});

--- a/src/signin-email/signin-email-selector.ts
+++ b/src/signin-email/signin-email-selector.ts
@@ -1,0 +1,41 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { createSelector } from '../common/selector';
+
+import { SignInEmail } from './signin-email';
+import SignInEmailState, { DEFAULT_STATE } from './signin-email-state';
+
+export default interface SignInEmailSelector {
+    getEmail(): SignInEmail | undefined;
+    getSendError(): Error | undefined;
+    isSending(): boolean;
+}
+
+export type SignInEmailSelectorFactory = (state: SignInEmailState) => SignInEmailSelector;
+
+export function createSignInEmailSelectorFactory(): SignInEmailSelectorFactory {
+    const getEmail = createSelector(
+        (state: SignInEmailState) => state.data,
+        signInEmail => () => signInEmail
+    );
+
+    const getSendError = createSelector(
+        (state: SignInEmailState) => state.errors.sendError,
+        error => () => error
+    );
+
+    const isSending = createSelector(
+        (state: SignInEmailState) => !!state.statuses.isSending,
+        status => () => status
+    );
+
+    return memoizeOne((
+        state: SignInEmailState = DEFAULT_STATE
+    ): SignInEmailSelector => {
+        return {
+            getEmail: getEmail(state),
+            getSendError: getSendError(state),
+            isSending: isSending(state),
+        };
+    });
+}

--- a/src/signin-email/signin-email-state.ts
+++ b/src/signin-email/signin-email-state.ts
@@ -1,0 +1,20 @@
+import { SignInEmail } from './signin-email';
+
+export default interface SignInEmailState {
+    data?: SignInEmail;
+    errors: SignInEmailErrorsState;
+    statuses: SignInEmailStatusesState;
+}
+
+export interface SignInEmailErrorsState {
+    sendError?: Error;
+}
+
+export interface SignInEmailStatusesState {
+    isSending?: boolean;
+}
+
+export const DEFAULT_STATE: SignInEmailState = {
+    errors: {},
+    statuses: {},
+};

--- a/src/signin-email/signin-email.ts
+++ b/src/signin-email/signin-email.ts
@@ -1,0 +1,4 @@
+export interface SignInEmail {
+    sent_email: string;
+    expiry: number;
+}

--- a/src/subscription/subscriptions-request-sender.spec.ts
+++ b/src/subscription/subscriptions-request-sender.spec.ts
@@ -5,7 +5,7 @@ import { ContentType } from '../common/http-request';
 import { Subscriptions } from './subscriptions';
 import SubscriptionsRequestSender from './subscriptions-request-sender';
 
-describe('CustomerRequestSender', () => {
+describe('SubscriptionsRequestSender', () => {
     let subscriptionsRequestSender: SubscriptionsRequestSender;
     let requestSender: RequestSender;
 


### PR DESCRIPTION
## What?
Add sign-in via email support (passwordless login).

## Why?
To provide a facade to `login.php` API and keep state of sent emails.

## Testing / Proof
unit

@bigcommerce/checkout 
