### PR TITLE
CHECKOUT-4852: Rethrow spam protection cancellation error and make sure spam protection execution status is accurate

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -1118,8 +1118,6 @@ describe('CheckoutService', () => {
         it('executes spam check', async () => {
             await checkoutService.executeSpamCheck();
 
-            expect(spamProtectionActionCreator.initialize)
-                .toHaveBeenCalled();
             expect(spamProtectionActionCreator.execute)
                 .toHaveBeenCalled();
         });

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -1151,14 +1151,9 @@ export default class CheckoutService {
      * @returns A promise that resolves to the current state.
      */
     executeSpamCheck(): Promise<CheckoutSelectors> {
-        const action = this._spamProtectionActionCreator.initialize();
+        const action = this._spamProtectionActionCreator.execute();
 
-        return this._dispatch(action, { queueId: 'spamProtection' })
-            .then(() => {
-                const action = this._spamProtectionActionCreator.execute();
-
-                return this._dispatch(action, { queueId: 'spamProtection' });
-            });
+        return this._dispatch(action, { queueId: 'spamProtection' });
     }
 
     /**

--- a/src/spam-protection/google-recaptcha.spec.ts
+++ b/src/spam-protection/google-recaptcha.spec.ts
@@ -102,8 +102,12 @@ describe('GoogleRecaptcha', () => {
             }
         });
 
-        it('throws an error if google recaptcha is not initialized', () => {
-            expect(() => googleRecaptcha.execute()).toThrow(NotInitializedError);
+        it('throws an error if google recaptcha is not initialized', async () => {
+            try {
+                await googleRecaptcha.execute().toPromise();
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
         });
 
         it('execute google recaptcha', async () => {

--- a/src/spam-protection/spam-protection-action-creator.ts
+++ b/src/spam-protection/spam-protection-action-creator.ts
@@ -49,15 +49,9 @@ export default class SpamProtectionActionCreator {
     }
 
     execute(): ThunkAction<SpamProtectionAction, InternalCheckoutSelectors> {
-        return store => {
-            const state = store.getState();
-            const checkout = state.checkout.getCheckout();
-
-            if (!checkout) {
-                throw new MissingDataError(MissingDataErrorType.MissingCheckout);
-            }
-
-            const { shouldExecuteSpamCheck } = checkout;
+        return store => defer(() => {
+            const { checkout } = store.getState();
+            const { id: checkoutId, shouldExecuteSpamCheck } = checkout.getCheckoutOrThrow();
 
             if (!shouldExecuteSpamCheck) {
                 return empty();
@@ -65,19 +59,21 @@ export default class SpamProtectionActionCreator {
 
             return concat(
                 of(createAction(SpamProtectionActionType.ExecuteRequested, undefined)),
+                this.initialize()(store),
                 this._googleRecaptcha.execute()
                     .pipe(take(1))
-                    .pipe(switchMap(({ error, token }) => {
+                    .pipe(switchMap(async ({ error, token }) => {
                         if (error || !token) {
                             throw new SpamProtectionFailedError();
                         }
 
-                        return this._requestSender.validate(checkout.id, token)
-                            .then(({ body }) => createAction(SpamProtectionActionType.ExecuteSucceeded, body));
+                        const { body } = await this._requestSender.validate(checkoutId, token);
+
+                        return createAction(SpamProtectionActionType.ExecuteSucceeded, body);
                     }))
             ).pipe(
                 catchError(error => throwErrorAction(SpamProtectionActionType.ExecuteFailed, error))
             );
-        };
+        });
     }
 }

--- a/src/spam-protection/spam-protection-action-creator.ts
+++ b/src/spam-protection/spam-protection-action-creator.ts
@@ -6,7 +6,7 @@ import { InternalCheckoutSelectors } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 
-import { SpamProtectionFailedError } from './errors';
+import { SpamProtectionChallengeNotCompletedError, SpamProtectionFailedError } from './errors';
 import GoogleRecaptcha from './google-recaptcha';
 import { SpamProtectionAction, SpamProtectionActionType } from './spam-protection-actions';
 import { SpamProtectionOptions } from './spam-protection-options';
@@ -63,6 +63,10 @@ export default class SpamProtectionActionCreator {
                 this._googleRecaptcha.execute()
                     .pipe(take(1))
                     .pipe(switchMap(async ({ error, token }) => {
+                        if (error instanceof SpamProtectionChallengeNotCompletedError) {
+                            throw error;
+                        }
+
                         if (error || !token) {
                             throw new SpamProtectionFailedError();
                         }


### PR DESCRIPTION
## What?
1. Rethrow `SpamProtectionChallengeNotCompletedError` instead of converting it into the more general `SpamProtectionFailedError`.
1. Make sure `isExecutingSpamCheck` returns true as soon as `executeSpamCheck` is called, by taking consideration of the time that's required to load and render the reCaptcha widget.

## Why?
1. Otherwise, the client application can't tell the difference between an actual application error versus an error thrown due to the end user choosing not the complete the reCaptcha challenge.
1. Otherwise, `isExecutingSpamCheck` won't immediately return `true` even though the asynchronous action is already being executed.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
