### PR TITLE
INT-2611 Update the klarna session before the widget is loaded (Klarna V2)

### DIFF
--- a/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
+++ b/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
@@ -79,9 +79,7 @@ export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to proceed because "payload.payment.gatewayId" argument is not provided.');
         }
 
-        this._updateOrder(gatewayId);
-
-        return new Promise<KlarnaLoadResponse>(resolve => {
+        return this._updateOrder(gatewayId).then(() => new Promise<KlarnaLoadResponse>(resolve => {
             const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
 
             if (!this._klarnaPayments || !paymentMethod.clientToken) {
@@ -93,9 +91,10 @@ export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
                 if (onLoad) {
                     onLoad(response);
                 }
+
                 resolve(response);
             });
-        });
+        }));
     }
 
     private _getUpdateSessionData(billingAddress: BillingAddress, shippingAddress?: Address): KlarnaUpdateSessionParams {


### PR DESCRIPTION
[INT-2611](https://jira.bigcommerce.com/browse/INT-2611)
## What?
Hitting an endpoint to update the klarna session

## Why?
Because we want to avoid mismatch between bigcommerce order and klarna order

## Sibling PRs
[INT-2611 BCAPP](https://github.com/bigcommerce/bigcommerce/pull/34949)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
