### PR TITLE
CHECKOUT-4879 Expose flash messages

### DIFF
--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -30,6 +30,10 @@ describe('CheckoutStoreSelector', () => {
         expect(selector.getCheckout()).toEqual(internalSelectors.checkout.getCheckout());
     });
 
+    it('returns flash messages', () => {
+        expect(selector.getFlashMessages()).toEqual(internalSelectors.config.getFlashMessages());
+    });
+
     it('returns order', () => {
         expect(selector.getOrder()).toEqual(internalSelectors.order.getOrder());
     });

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -6,7 +6,7 @@ import { BillingAddress } from '../billing';
 import { Cart } from '../cart';
 import { createSelector } from '../common/selector';
 import { cloneResult as clone } from '../common/utility';
-import { StoreConfig } from '../config';
+import { FlashMessage, FlashMessageType, StoreConfig } from '../config';
 import { Coupon, GiftCertificate } from '../coupon';
 import { Customer } from '../customer';
 import { FormField } from '../form';
@@ -146,6 +146,17 @@ export default interface CheckoutStoreSelector {
      * undefined if otherwise.
      */
     getSelectedPaymentMethod(): PaymentMethod | undefined;
+
+    /**
+     * Gets the available flash messages.
+     *
+     * Flash messages contain messages set by the server,
+     * e.g: when trying to sign in using an invalid email link.
+     *
+     * @param type - The type of flash messages to be returned. Optional
+     * @returns The flash messages if available, otherwise undefined.
+     */
+    getFlashMessages(type?: FlashMessageType): FlashMessage[] | undefined;
 
     /**
      * Gets the current cart.
@@ -453,6 +464,11 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         })
     );
 
+    const getFlashMessages = createSelector(
+        ({ config }: InternalCheckoutSelectors) => config.getFlashMessages,
+        getFlashMessages => clone(getFlashMessages)
+    );
+
     return memoizeOne((
         state: InternalCheckoutSelectors
     ): CheckoutStoreSelector => {
@@ -460,6 +476,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             getCheckout: getCheckout(state),
             getOrder: getOrder(state),
             getConfig: getConfig(state),
+            getFlashMessages: getFlashMessages(state),
             getShippingAddress: getShippingAddress(state),
             getShippingOptions: getShippingOptions(state),
             getConsignments: getConsignments(state),

--- a/src/config/config-selector.spec.ts
+++ b/src/config/config-selector.spec.ts
@@ -1,10 +1,13 @@
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
+import { FlashMessage } from './config';
 import ConfigSelector, { createConfigSelectorFactory, ConfigSelectorFactory } from './config-selector';
+import ConfigState from './config-state';
 
 describe('ConfigSelector', () => {
     let configSelector: ConfigSelector;
+    let configStateWithMessages: ConfigState;
     let createConfigSelector: ConfigSelectorFactory;
     let state: CheckoutStoreState;
 
@@ -32,6 +35,51 @@ describe('ConfigSelector', () => {
 
             // tslint:disable-next-line:no-non-null-assertion
             expect(configSelector.getContextConfig()).toEqual(state.config.data!.context);
+        });
+    });
+
+    describe('#getFlashMessages', () => {
+        const flashMessages: FlashMessage[] = [
+            { type: 'info', message: 'm_info' },
+            { type: 'error', message: 'm_error' },
+            { type: 'warning', message: 'm_warning' },
+            { type: 'success', message: 'm_success' },
+        ];
+
+        beforeEach(() => {
+            configStateWithMessages = {
+                ...state.config,
+                data: {
+                    // tslint:disable-next-line: no-non-null-assertion
+                    ...state.config.data!,
+                    context: {
+                        // tslint:disable-next-line: no-non-null-assertion
+                        ...state.config.data!.context,
+                        flashMessages,
+                    },
+                },
+            };
+        });
+
+        it('returns all the flash messages', () => {
+            configSelector = createConfigSelector(configStateWithMessages);
+
+            expect(configSelector.getFlashMessages())
+                .toEqual(flashMessages);
+        });
+
+        it('returns the flash message matching the provided filter', () => {
+            configSelector = createConfigSelector(configStateWithMessages);
+
+            expect(configSelector.getFlashMessages('error'))
+                .toEqual([flashMessages[1]]);
+        });
+
+        it('returns empty array when no messages available', () => {
+            configSelector = createConfigSelector(state.config);
+
+            expect(configSelector.getFlashMessages())
+                .toEqual([]);
         });
     });
 

--- a/src/config/config-selector.ts
+++ b/src/config/config-selector.ts
@@ -2,11 +2,12 @@ import { memoizeOne } from '@bigcommerce/memoize';
 
 import { createSelector } from '../common/selector';
 
-import Config, { ContextConfig, StoreConfig } from './config';
+import Config, { ContextConfig, FlashMessage, FlashMessageType, StoreConfig } from './config';
 import ConfigState, { DEFAULT_STATE } from './config-state';
 
 export default interface ConfigSelector {
     getConfig(): Config | undefined;
+    getFlashMessages(type?: FlashMessageType): FlashMessage[] | undefined;
     getStoreConfig(): StoreConfig | undefined;
     getContextConfig(): ContextConfig | undefined;
     getExternalSource(): string | undefined;
@@ -21,6 +22,25 @@ export function createConfigSelectorFactory(): ConfigSelectorFactory {
     const getConfig = createSelector(
         (state: ConfigState) => state.data,
         data => () => data
+    );
+
+    const getFlashMessages = createSelector(
+        (state: ConfigState) => state.data,
+        data => (filterType?: FlashMessageType) => {
+            if (!data) {
+                return;
+            }
+
+            const { flashMessages } = data.context;
+
+            if (!flashMessages) {
+                return;
+            }
+
+            return filterType !== undefined ?
+                flashMessages.filter(({ type }) => filterType === type) :
+                flashMessages;
+        }
     );
 
     const getStoreConfig = createSelector(
@@ -53,6 +73,7 @@ export function createConfigSelectorFactory(): ConfigSelectorFactory {
     ): ConfigSelector => {
         return {
             getConfig: getConfig(state),
+            getFlashMessages: getFlashMessages(state),
             getStoreConfig: getStoreConfig(state),
             getContextConfig: getContextConfig(state),
             getExternalSource: getExternalSource(state),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -108,10 +108,17 @@ export interface CustomizationConfig {
     languageData: any[];
 }
 
+export type FlashMessageType = 'error' | 'info' | 'warning' | 'success';
+
+export interface FlashMessage {
+    type: FlashMessageType;
+    message: string;
+}
+
 export interface ContextConfig {
     checkoutId?: string;
     geoCountryCode: string;
-    flashMessages: any[];
+    flashMessages: FlashMessage[];
     payment: {
         formId?: string;
         token?: string;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 export * from './config-actions';
 
-export { default as Config, StoreConfig, StoreProfile, ShopperCurrency } from './config';
+export { default as Config, StoreConfig, StoreProfile, ShopperCurrency, FlashMessage, FlashMessageType } from './config';
 export { default as ConfigActionCreator } from './config-action-creator';
 export { default as ConfigSelector, ConfigSelectorFactory, createConfigSelectorFactory } from './config-selector';
 export { default as configReducer } from './config-reducer';


### PR DESCRIPTION
## What?
Expose error FlashMessage via `data.getFlashMessages()`

## Why?
So clients using Sign-in Email Link feature can access the error when the link is invalid.

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
