### PR TITLE
[WIP] feat(payment): PAYMENTS-5425 Implement the UX for Carding remediation solution

### DIFF
--- a/src/hosted-form/hosted-form-order-data.ts
+++ b/src/hosted-form/hosted-form-order-data.ts
@@ -4,6 +4,12 @@ import { Order, OrderMeta } from '../order';
 import { HostedCreditCardInstrument, HostedVaultedInstrument, PaymentInstrumentMeta, PaymentMethod, PaymentMethodMeta } from '../payment';
 
 export default interface HostedFormOrderData {
+    additionalAction?: {
+        type?: string;
+        data?: {
+            human_verification_token?: string;
+        };
+    };
     authToken: string;
     checkout?: Checkout;
     config?: Config;

--- a/src/hosted-form/hosted-form.ts
+++ b/src/hosted-form/hosted-form.ts
@@ -59,10 +59,10 @@ export default class HostedForm {
         });
     }
 
-    async submit(payload: OrderPaymentRequestBody): Promise<void> {
+    async submit(payload: OrderPaymentRequestBody, paymentRecaptchaToken?: string): Promise<void> {
         return await this._getFirstField().submitForm(
             this._fields.map(field => field.getType()),
-            this._payloadTransformer.transform(payload)
+            this._payloadTransformer.transform(payload, paymentRecaptchaToken)
         );
     }
 

--- a/src/payment/payment-request-body.ts
+++ b/src/payment/payment-request-body.ts
@@ -8,8 +8,13 @@ import { PaymentInstrument } from './payment';
 import PaymentMethod from './payment-method';
 
 export default interface PaymentRequestBody {
+    additionalAction?: {
+        type?: string;
+        data?: {
+            human_verification_token?: string;
+        };
+    };
     authToken: string;
-    payment?: PaymentInstrument;
     billingAddress?: InternalAddress;
     cart?: InternalCart;
     customer?: InternalCustomer;
@@ -17,6 +22,7 @@ export default interface PaymentRequestBody {
     orderMeta?: {
         deviceFingerprint?: string;
     };
+    payment?: PaymentInstrument;
     paymentMethod?: PaymentMethod;
     quoteMeta?: {
         request?: {

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -7,6 +7,7 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitia
 import { Customer } from '../../../customer';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getGoogleRecapthaToken } from '../../../spam-protection';
 import { PaymentArgumentInvalidError, PaymentMethodFailedError } from '../../errors';
 import isVaultedInstrument from '../../is-vaulted-instrument';
 import { HostedInstrument } from '../../payment';
@@ -87,7 +88,10 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                                         },
                                     };
 
-                                    return this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload));
+                                    return this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload))
+                                        .catch(error => getGoogleRecapthaToken(this._store, error)
+                                            .then((token: string) => this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload, token)))
+                                        );
                                 });
                         });
                 }
@@ -131,7 +135,10 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                                     },
                                 };
 
-                                return this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload));
+                                return this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload))
+                                    .catch(error => getGoogleRecapthaToken(this._store, error)
+                                        .then((token: string) => this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload, token)))
+                                    );
                             });
                     });
             });

--- a/src/spam-protection/carding-protection-action-creator.ts
+++ b/src/spam-protection/carding-protection-action-creator.ts
@@ -1,0 +1,71 @@
+import { createAction, ThunkAction } from '@bigcommerce/data-store';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { concat, defer, of } from 'rxjs';
+import { catchError, switchMap, take } from 'rxjs/operators';
+
+import { InternalCheckoutSelectors } from '../checkout';
+import { throwErrorAction } from '../common/error';
+
+import { createSpamProtection } from './';
+import { SpamProtectionChallengeNotCompletedError, SpamProtectionFailedError } from './errors';
+import GoogleRecaptcha from './google-recaptcha';
+import { SpamProtectionAction, SpamProtectionActionType } from './spam-protection-actions';
+import { SpamProtectionOptions } from './spam-protection-options';
+
+export default class CardingProtectionActionCreator {
+    _googleRecaptcha: GoogleRecaptcha;
+
+    constructor(
+        private _recaptchaSitekey: string
+    ) {
+        this._googleRecaptcha = createSpamProtection(createScriptLoader());
+    }
+
+    initialize(options?: SpamProtectionOptions): ThunkAction<SpamProtectionAction, InternalCheckoutSelectors> {
+        return () => concat(
+            of(createAction(SpamProtectionActionType.InitializeRequested, undefined)),
+            defer(async () => {
+                const cardingProtectionElementId = options ? options.containerId : 'cardingProtectionContainer';
+
+                let cardingProtectionElement = document.getElementById(cardingProtectionElementId);
+                if (cardingProtectionElement && cardingProtectionElement.parentNode) {
+                    cardingProtectionElement.parentNode.removeChild(cardingProtectionElement);
+                }
+
+                cardingProtectionElement = document.createElement('div');
+                cardingProtectionElement.setAttribute('id', cardingProtectionElementId);
+                document.body.appendChild(cardingProtectionElement);
+
+                await this._googleRecaptcha.load(cardingProtectionElementId, this._recaptchaSitekey);
+
+                return createAction(SpamProtectionActionType.InitializeSucceeded);
+            })
+        ).pipe(
+            catchError(error => throwErrorAction(SpamProtectionActionType.InitializeFailed, error))
+        );
+    }
+
+    execute(): any {
+        return (store: any) => defer(() => {
+            return concat(
+                of(createAction(SpamProtectionActionType.ExecuteRequested, undefined)),
+                this.initialize()(store),
+                this._googleRecaptcha.execute()
+                    .pipe(take(1))
+                    .pipe(switchMap(async ({ error, token }) => {
+                        if (error instanceof SpamProtectionChallengeNotCompletedError) {
+                            throw error;
+                        }
+
+                        if (error || !token) {
+                            throw new SpamProtectionFailedError();
+                        }
+
+                        return token;
+                    }))
+            ).pipe(
+                catchError(error => throwErrorAction(SpamProtectionActionType.ExecuteFailed, error))
+            );
+        });
+    }
+}

--- a/src/spam-protection/get-google-recaptcha-token.ts
+++ b/src/spam-protection/get-google-recaptcha-token.ts
@@ -1,0 +1,16 @@
+
+import { ReadableDataStore } from '@bigcommerce/data-store';
+
+import { InternalCheckoutSelectors } from '../checkout';
+
+import CardingProtectionActionCreator from './carding-protection-action-creator';
+
+export default function getGoogleRecapthaToken(store: ReadableDataStore<InternalCheckoutSelectors>, error: any) {
+    const { additional_action_required, status } = error;
+    if (status === 'additional_action_required' && additional_action_required && additional_action_required.type === 'recaptcha_v2_verification') {
+        const cardingProtectionActionCreator = new CardingProtectionActionCreator(additional_action_required.data.key);
+
+        return cardingProtectionActionCreator.execute()(store).toPromise();
+    }
+    throw error;
+}

--- a/src/spam-protection/index.ts
+++ b/src/spam-protection/index.ts
@@ -2,6 +2,8 @@ export * from './spam-protection-actions';
 export * from './spam-protection-options';
 
 export { default as createSpamProtection } from './create-spam-protection';
+export { default as getGoogleRecapthaToken } from './get-google-recaptcha-token';
+export { default as CardingProtectionActionCreator } from './carding-protection-action-creator';
 export { default as GoogleRecaptcha } from './google-recaptcha';
 export { default as SpamProtectionActionCreator } from './spam-protection-action-creator';
 export { default as SpamProtectionRequestSender } from './spam-protection-request-sender';


### PR DESCRIPTION
**This work is still in progress**
**Approach 1**

## What?
For credit card payment, after checkout sdk sends payment payload to BigPay, if `human_verification_required` response is returned from BigPay, Google Recaptcha instance is created to verify that the shopper is a human. It's invisible if Google thinks the shopper is human, and shows a challenge if Google thinks the shopper is a bot. 

Once ReCAPTCHA is completed, it'll re-send the payment request to BigPay with almost the same payload, except for the additional token that was just created when completing the ReCAPTCHA.

## Why?
To protect our stores from spammers using long lists of credit cards number to place fraudulent orders.

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments
