### PR TITLE
INT-2612 Vault SEPA accounts

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
@@ -27,6 +27,11 @@ export default interface AdyenV2PaymentInitializeOptions {
     cardVerificationContainerId?: string;
 
     /**
+     * True if the Adyen component has some Vaulted instrument
+     */
+    hasVaultedInstruments?: boolean;
+
+    /**
      * @deprecated
      * Use additionalActionOptions instead as this property will be removed in the future
      */

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -244,9 +244,6 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                 case AdyenPaymentMethodType.CreditCard:
                 case AdyenPaymentMethodType.ACH:
                 case AdyenPaymentMethodType.Bancontact:
-                case AdyenPaymentMethodType.GiroPay:
-                case AdyenPaymentMethodType.iDEAL:
-                case AdyenPaymentMethodType.SEPA:
                     paymentComponent = adyenClient.create(paymentMethod.method, {
                             ...adyenv2.options,
                             onChange: componentState => this._updateComponentState(componentState),
@@ -259,6 +256,33 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                         reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
                     }
 
+                    break;
+
+                case AdyenPaymentMethodType.GiroPay:
+                case AdyenPaymentMethodType.iDEAL:
+                case AdyenPaymentMethodType.SEPA:
+                    if (!adyenv2.hasVaultedInstruments) {
+                        paymentComponent = adyenClient.create(paymentMethod.method, {
+                                ...adyenv2.options,
+                                onChange: componentState => this._updateComponentState(componentState),
+                            }
+                        );
+
+                        try {
+                            paymentComponent.mount(`#${adyenv2.containerId}`);
+                        } catch (error) {
+                            reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+                        }
+
+                    } else {
+                        this._updateComponentState({
+                            data: {
+                                paymentMethod: {
+                                    type: paymentMethod.method,
+                                },
+                            },
+                        });
+                    }
                     break;
 
                 case AdyenPaymentMethodType.AliPay:

--- a/src/payment/strategies/adyenv2/adyenv2.mock.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.mock.ts
@@ -99,13 +99,14 @@ export function getComponentState(isValid: boolean = true): AdyenComponentState 
     };
 }
 
-export function getInitializeOptions(): PaymentInitializeOptions {
+export function getInitializeOptions(hasVaultedInstruments = false): PaymentInitializeOptions {
     return {
         methodId: 'adyenv2',
         adyenv2: {
             containerId: 'adyen-scheme-component-field',
             cardVerificationContainerId: 'adyen-custom-card-component-field',
             threeDS2ContainerId: 'adyen-scheme-3ds-component-field',
+            hasVaultedInstruments,
             options: {
                 hasHolderName: true,
                 styles: {},


### PR DESCRIPTION
## What? [INT-2612](https://jira.bigcommerce.com/browse/INT-2612)
Add support to Vault Bank accounts of SEPA

## Why?
To show saved bank instruments for SEPA, pay and delete instruments.

## Testing / Proof
![image](https://user-images.githubusercontent.com/42655796/80412001-c3373780-8892-11ea-97bb-a2931470797e.png)

## Depends on:
[INT-2437](https://github.com/bigcommerce/checkout-sdk-js/pull/818)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
