### PR TITLE
feat(payment): PAYPAL-365 choses paypalcredit method on the checkout

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -3,6 +3,10 @@ export interface ApproveDataOptions {
     orderID: string;
 }
 
+export interface ClickDataOptions {
+    fundingSource: string;
+}
+
 export interface OrderData {
     orderId: string;
     approveUrl: string;
@@ -62,6 +66,7 @@ export interface ButtonsOptions {
     style?: PaypalButtonStyleOptions;
     createOrder(): Promise<string>;
     onApprove(data: ApproveDataOptions): void;
+    onClick(data: ClickDataOptions): void;
 }
 
 export interface PaypalCommerceSDK {


### PR DESCRIPTION
## What?
Choses paypalcommercecredit method on the checkout page

## Why?
Merchant should see paypalcommercecredit method on the checkout page after chosen this method in the spb

## Testing / Proof
<img width="895" alt="Screen Shot 2020-05-13 at 10 37 35 AM" src="https://user-images.githubusercontent.com/32959076/81784617-cd4d6d00-9505-11ea-9dd8-72bdc110fd14.png">


@bigcommerce/checkout @bigcommerce/payments
