### PR TITLE
fix(payment): PAYPAL-406 Checkout order after approval issue

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -65,7 +65,9 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         const cart = state.cart.getCartOrThrow();
         const { approveUrl, orderId } = await this._paypalCommerceRequestSender.setupPayment(methodId, cart.id);
 
-        await this._paypalCommercePaymentProcessor.paymentPayPal(approveUrl);
+        if (approveUrl) {
+            await this._paypalCommercePaymentProcessor.paymentPayPal(approveUrl);
+        }
 
         return orderId;
     }


### PR DESCRIPTION
## What?
Checkout order after approval issue

## Why?
The issue is when checkout is started with SPB, interrupted and general checkout flow started

## Testing / Proof
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/32959076/81810193-385d6a80-952b-11ea-933f-ca8d21117817.gif)

@bigcommerce/checkout @bigcommerce/payments
