### PR TITLE
feat(payment): INT-2613 remove receipt_email in stripe-strategy

### DIFF
--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -261,7 +261,6 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         if (customer) {
             return {
                 ...shippingDetails,
-                receipt_email: customer.email,
                 save_payment_method: shouldSaveInstrument,
             };
         } else {

--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -129,7 +129,6 @@ export function getStripeCardPaymentOptionsWithSignedUser(): StripeHandleCardPay
             },
             name: `${customer.firstName} ${customer.lastName}`,
         },
-        receipt_email: customer.email,
         save_payment_method: false,
     };
 }


### PR DESCRIPTION
## What? **[INT-2613](https://jira.bigcommerce.com/browse/INT-2613)**

remove receipt_email in stripe-strategy

## Why?

because I'm validating the receipt_email in big pay and the functionality is controlled by a toggle in the settings page

## Siblings Prs

https://github.com/bigcommerce/bigcommerce/pull/35006
https://github.com/bigcommerce/bigpay/pull/2522
https://github.com/bigcommerce-labs/ng-payments/pull/1021

## Testing / Proof
Toggle settings page 
<img width="389" alt="Screen Shot 2020-05-13 at 9 36 39 AM" src="https://user-images.githubusercontent.com/42154828/81829859-fae3e780-9500-11ea-8c4a-f90bdf1d45b6.png">


When Toggle Add receipt_email in settings page is on
<img width="1397" alt="Screen Shot 2020-05-13 at 9 55 49 AM" src="https://user-images.githubusercontent.com/42154828/81829399-75f8ce00-9500-11ea-8a37-986fd4df4444.png">

When Toggle Add receipt_email in settings page is off
<img width="1509" alt="Screen Shot 2020-05-13 at 9 56 27 AM" src="https://user-images.githubusercontent.com/42154828/81829411-7abd8200-9500-11ea-9127-a2c2b5c30af2.png">

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
