### PR TITLE
CHECKOUT-4754: Send an additional header to provide information about the checkout variant that is used to pay for an order

### DIFF
--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -5,7 +5,7 @@ import { BillingAddressActionCreator, BillingAddressRequestSender } from '../bil
 import { ErrorActionCreator } from '../common/error';
 import { getDefaultLogger } from '../common/log';
 import { getEnvironment } from '../common/utility';
-import { ConfigActionCreator, ConfigRequestSender, ConfigState } from '../config';
+import { ConfigActionCreator, ConfigRequestSender, ConfigState, ConfigWindow } from '../config';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
 import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '../customer';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
@@ -53,6 +53,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     const config: ConfigState = {
         meta: {
             externalSource: options && options.externalSource,
+            variantIdentificationToken: (window as ConfigWindow).checkoutVariantIdentificationToken,
         },
         errors: {},
         statuses: {},

--- a/src/config/config-selector.ts
+++ b/src/config/config-selector.ts
@@ -11,6 +11,7 @@ export default interface ConfigSelector {
     getStoreConfig(): StoreConfig | undefined;
     getContextConfig(): ContextConfig | undefined;
     getExternalSource(): string | undefined;
+    getVariantIdentificationToken(): string | undefined;
     getLoadError(): Error | undefined;
     isLoading(): boolean;
 }
@@ -58,6 +59,11 @@ export function createConfigSelectorFactory(): ConfigSelectorFactory {
         data => () => data
     );
 
+    const getVariantIdentificationToken = createSelector(
+        (state: ConfigState) => state.meta && state.meta.variantIdentificationToken,
+        data => () => data
+    );
+
     const getLoadError = createSelector(
         (state: ConfigState) => state.errors.loadError,
         error => () => error
@@ -77,6 +83,7 @@ export function createConfigSelectorFactory(): ConfigSelectorFactory {
             getStoreConfig: getStoreConfig(state),
             getContextConfig: getContextConfig(state),
             getExternalSource: getExternalSource(state),
+            getVariantIdentificationToken: getVariantIdentificationToken(state),
             getLoadError: getLoadError(state),
             isLoading: isLoading(state),
         };

--- a/src/config/config-state.ts
+++ b/src/config/config-state.ts
@@ -9,6 +9,7 @@ export default interface ConfigState {
 
 export interface ConfigMetaState {
     externalSource?: string;
+    variantIdentificationToken?: string;
 }
 
 export interface ConfigErrorsState {

--- a/src/config/config-window.ts
+++ b/src/config/config-window.ts
@@ -1,0 +1,3 @@
+export default interface ConfigWindow extends Window {
+    checkoutVariantIdentificationToken?: string;
+}

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -133,6 +133,7 @@ export function getConfigState(): ConfigState {
         data: getConfig(),
         meta: {
             externalSource: 'Partner',
+            variantIdentificationToken: 'default',
         },
         errors: {},
         statuses: {},

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -6,3 +6,4 @@ export { default as ConfigSelector, ConfigSelectorFactory, createConfigSelectorF
 export { default as configReducer } from './config-reducer';
 export { default as ConfigRequestSender } from './config-request-sender';
 export { default as ConfigState, DEFAULT_STATE } from './config-state';
+export { default as ConfigWindow } from './config-window';

--- a/src/order/order-action-creator.spec.ts
+++ b/src/order/order-action-creator.spec.ts
@@ -304,14 +304,22 @@ describe('OrderActionCreator', () => {
             await from(orderActionCreator.submitOrder(getOrderRequestBody())(store))
                 .toPromise();
 
-            expect(orderRequestSender.submitOrder).toHaveBeenCalledWith(getInternalOrderRequestBody(), undefined);
+            expect(orderRequestSender.submitOrder)
+                .toHaveBeenCalledWith(
+                    getInternalOrderRequestBody(),
+                    { headers: { checkoutVariant: 'default' } }
+                );
         });
 
         it('submits order payload without payment data', async () => {
             await from(orderActionCreator.submitOrder(omit(getOrderRequestBody(), 'payment'))(store))
                 .toPromise();
 
-            expect(orderRequestSender.submitOrder).toHaveBeenCalledWith(omit(getInternalOrderRequestBody(), 'payment'), undefined);
+            expect(orderRequestSender.submitOrder)
+                .toHaveBeenCalledWith(
+                    omit(getInternalOrderRequestBody(), 'payment'),
+                    { headers: { checkoutVariant: 'default' } }
+                );
         });
 
         it('does not submit order if cart verification fails', async () => {

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -68,6 +68,7 @@ export default class OrderActionCreator {
             defer(() => {
                 const state = store.getState();
                 const externalSource = state.config.getExternalSource();
+                const variantIdentificationToken = state.config.getVariantIdentificationToken();
                 const checkout = state.checkout.getCheckout();
 
                 if (!checkout) {
@@ -80,11 +81,18 @@ export default class OrderActionCreator {
 
                 return from(
                     this._checkoutValidator.validate(checkout, options)
-                        .then(() => this._orderRequestSender.submitOrder(this._mapToOrderRequestBody(
-                            payload,
-                            checkout.customerMessage,
-                            externalSource
-                        ), options))
+                        .then(() => this._orderRequestSender.submitOrder(
+                            this._mapToOrderRequestBody(
+                                payload,
+                                checkout.customerMessage,
+                                externalSource
+                            ),
+                            {
+                                ...options,
+                                headers: {
+                                    checkoutVariant: variantIdentificationToken,
+                                },
+                            }))
                 ).pipe(
                     switchMap(response => concat(
                         // TODO: Remove once we can submit orders using storefront API

--- a/src/order/order-request-sender.spec.ts
+++ b/src/order/order-request-sender.spec.ts
@@ -119,6 +119,19 @@ describe('OrderRequestSender', () => {
                 body: payload,
             });
         });
+
+        it('submits order with checkout variant header when provided', async () => {
+            const payload = {};
+            const headers = { checkoutVariant: 'default' };
+
+            await orderRequestSender.submitOrder(payload, { headers });
+
+            expect(requestSender.post)
+                .toHaveBeenCalledWith('/internalapi/v1/checkout/order', {
+                    body: payload,
+                    headers: { 'X-Checkout-Variant': headers.checkoutVariant },
+                });
+        });
     });
 
     describe('#finalizeOrder()', () => {

--- a/src/order/order-request-sender.spec.ts
+++ b/src/order/order-request-sender.spec.ts
@@ -103,9 +103,10 @@ describe('OrderRequestSender', () => {
             const output = await orderRequestSender.submitOrder(payload);
 
             expect(output).toEqual(response);
-            expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order', {
+            expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order', expect.objectContaining({
                 body: payload,
-            });
+                headers: expect.anything(),
+            }));
         });
 
         it('submits order and returns response with timeout', async () => {
@@ -114,13 +115,13 @@ describe('OrderRequestSender', () => {
             const output = await orderRequestSender.submitOrder(payload, options);
 
             expect(output).toEqual(response);
-            expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order', {
+            expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order', expect.objectContaining({
                 ...options,
                 body: payload,
-            });
+            }));
         });
 
-        it('submits order with checkout variant header when provided', async () => {
+        it('submits order with checkout variant header and library version when variant is provided', async () => {
             const payload = {};
             const headers = { checkoutVariant: 'default' };
 
@@ -129,7 +130,24 @@ describe('OrderRequestSender', () => {
             expect(requestSender.post)
                 .toHaveBeenCalledWith('/internalapi/v1/checkout/order', {
                     body: payload,
-                    headers: { 'X-Checkout-Variant': headers.checkoutVariant },
+                    headers: {
+                        'X-Checkout-Variant': headers.checkoutVariant,
+                        'X-Checkout-SDK-Version': expect.any(String),
+                    },
+                });
+        });
+
+        it('submits order with library version', async () => {
+            const payload = {};
+
+            await orderRequestSender.submitOrder(payload);
+
+            expect(requestSender.post)
+                .toHaveBeenCalledWith('/internalapi/v1/checkout/order', {
+                    body: payload,
+                    headers: {
+                        'X-Checkout-SDK-Version': expect.any(String),
+                    },
                 });
         });
     });

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -1,4 +1,5 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
+import { isNil, omitBy } from 'lodash';
 
 import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
 
@@ -6,6 +7,12 @@ import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import Order from './order';
 import OrderParams from './order-params';
+
+export interface SubmitOrderRequestOptions extends RequestOptions {
+    headers?: {
+        checkoutVariant?: string;
+    };
+}
 
 export default class OrderRequestSender {
     constructor(
@@ -35,10 +42,14 @@ export default class OrderRequestSender {
         });
     }
 
-    submitOrder(body: InternalOrderRequestBody, { timeout }: RequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
+    submitOrder(body: InternalOrderRequestBody, { headers, timeout }: SubmitOrderRequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
         const url = '/internalapi/v1/checkout/order';
 
-        return this._requestSender.post(url, { body, timeout });
+        return this._requestSender.post(url, {
+            body,
+            headers: headers && omitBy({ 'X-Checkout-Variant': headers.checkoutVariant }, isNil),
+            timeout,
+        });
     }
 
     finalizeOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -47,7 +47,10 @@ export default class OrderRequestSender {
 
         return this._requestSender.post(url, {
             body,
-            headers: headers && omitBy({ 'X-Checkout-Variant': headers.checkoutVariant }, isNil),
+            headers: omitBy({
+                'X-Checkout-Variant': headers && headers.checkoutVariant,
+                'X-Checkout-SDK-Version': LIBRARY_VERSION,
+            }, isNil),
             timeout,
         });
     }


### PR DESCRIPTION
## What?
Send an additional header to provide information about the checkout variant that is used to pay for an order.

## Why?
It's an optional parameter that can help us identify whether the default checkout or a custom checkout is used to complete a checkout process.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
