### PR TITLE
CHECKOUT-4742 Update customer object when continuing as guest

### DIFF
--- a/src/customer/customer-reducer.spec.ts
+++ b/src/customer/customer-reducer.spec.ts
@@ -1,3 +1,4 @@
+import { BillingAddressActionType, ContinueAsGuestAction } from '../billing';
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
 
@@ -15,6 +16,17 @@ describe('customerReducer()', () => {
     it('returns new state with customer data when checkout is loaded successfully', () => {
         const action: CheckoutAction = {
             type: CheckoutActionType.LoadCheckoutSucceeded,
+            payload: getCheckout(),
+        };
+
+        expect(customerReducer(initialState, action)).toEqual(expect.objectContaining({
+            data: getCustomer(),
+        }));
+    });
+
+    it('returns new state with customer data when continue as guest is successful', () => {
+        const action: ContinueAsGuestAction = {
+            type: BillingAddressActionType.ContinueAsGuestSucceeded,
             payload: getCheckout(),
         };
 

--- a/src/customer/customer-reducer.ts
+++ b/src/customer/customer-reducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from '@bigcommerce/data-store';
 
+import { BillingAddressActionType, ContinueAsGuestAction } from '../billing';
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { objectMerge } from '../common/utility';
 
@@ -8,9 +9,9 @@ import CustomerState, { DEFAULT_STATE } from './customer-state';
 
 export default function customerReducer(
     state: CustomerState = DEFAULT_STATE,
-    action: CheckoutAction
+    action: CheckoutAction | ContinueAsGuestAction
 ): CustomerState {
-    const reducer = combineReducers<CustomerState, CheckoutAction>({
+    const reducer = combineReducers<CustomerState, CheckoutAction | ContinueAsGuestAction>({
         data: dataReducer,
     });
 
@@ -19,9 +20,10 @@ export default function customerReducer(
 
 function dataReducer(
     data: Customer | undefined,
-    action: CheckoutAction
+    action: CheckoutAction | ContinueAsGuestAction
 ): Customer | undefined {
     switch (action.type) {
+    case BillingAddressActionType.ContinueAsGuestSucceeded:
     case CheckoutActionType.LoadCheckoutSucceeded:
         return objectMerge(data, action.payload && action.payload.customer);
 

--- a/src/customer/customer.ts
+++ b/src/customer/customer.ts
@@ -9,6 +9,7 @@ export default interface Customer {
     fullName: string;
     isGuest: boolean;
     lastName: string;
+    shouldEncourageSignIn: boolean;
     customerGroup?: CustomerGroup;
 }
 

--- a/src/customer/customers.mock.ts
+++ b/src/customer/customers.mock.ts
@@ -12,6 +12,7 @@ export function getGuestCustomer(): Customer {
         isGuest: true,
         lastName: '',
         storeCredit: 0,
+        shouldEncourageSignIn: false,
         customerGroup: {
             id: 0,
             name: '',
@@ -27,6 +28,7 @@ export function getCustomer(): Customer {
         fullName: 'Foo Bar',
         lastName: 'Bar',
         storeCredit: 0,
+        shouldEncourageSignIn: false,
         addresses: [
             {
                 ...getShippingAddress(),


### PR DESCRIPTION
## What?
Update customer object when continuing as guest

## Why?
Because when continuing as guest, we might set `shouldEncourageSignIn` flag

## Testing / Proof
unit

@bigcommerce/checkout