### PR TITLE
CHECKOUT-4897 Add redirect_to to SignInEmail

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -388,10 +388,12 @@ describe('CheckoutService', () => {
 
     describe('#sendSignInEmail()', () => {
         it('sends sign-in email', async () => {
-            const state = await checkoutService.sendSignInEmail('foo@bar.com');
+            const state = await checkoutService.sendSignInEmail({ email: 'foo@bar.com' });
 
             expect(signInEmailRequestSender.sendSignInEmail)
-                .toHaveBeenCalledWith('foo@bar.com', undefined);
+                .toHaveBeenCalledWith({
+                    email: 'foo@bar.com',
+                }, undefined);
 
             expect(state.data.getCheckout())
                 .toEqual(store.getState().checkout.getCheckout());

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -15,7 +15,7 @@ import { OrderActionCreator, OrderRequestBody } from '../order';
 import { PaymentInitializeOptions, PaymentMethodActionCreator, PaymentRequestOptions, PaymentStrategyActionCreator } from '../payment';
 import { InstrumentActionCreator } from '../payment/instrument';
 import { ConsignmentsRequestBody, ConsignmentActionCreator, ConsignmentAssignmentRequestBody, ConsignmentUpdateRequestBody, ShippingCountryActionCreator, ShippingInitializeOptions, ShippingRequestOptions, ShippingStrategyActionCreator } from '../shipping';
-import { SignInEmailActionCreator } from '../signin-email';
+import { SignInEmailActionCreator, SignInEmailRequestBody } from '../signin-email';
 import { SpamProtectionActionCreator, SpamProtectionOptions } from '../spam-protection';
 import { StoreCreditActionCreator } from '../store-credit';
 import { Subscriptions, SubscriptionsActionCreator } from '../subscription';
@@ -527,12 +527,12 @@ export default class CheckoutService {
      * signs in the customer without requiring any password.
      *
      * @internal
-     * @param email - The email to be sent the sign-in link.
+     * @param signInEmailRequest - The sign-in email request values.
      * @param options - Options for the send email request.
      * @returns A promise that resolves to the current state.
      */
-    sendSignInEmail(email: string, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._signInEmailActionCreator.sendSignInEmail(email, options);
+    sendSignInEmail(signInEmailRequest: SignInEmailRequestBody, options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._signInEmailActionCreator.sendSignInEmail(signInEmailRequest, options);
 
         return this._dispatch(action, { queueId: 'signInEmail' });
     }

--- a/src/signin-email/index.ts
+++ b/src/signin-email/index.ts
@@ -1,5 +1,5 @@
 export * from './signin-email-actions';
-export { SignInEmail } from './signin-email';
+export { SignInEmail, SignInEmailRequestBody } from './signin-email';
 
 export { default as SignInEmailRequestSender } from './signin-email-request-sender';
 export { default as SignInEmailActionCreator } from './signin-email-action-creator';

--- a/src/signin-email/signin-email-action-creator.spec.ts
+++ b/src/signin-email/signin-email-action-creator.spec.ts
@@ -30,7 +30,9 @@ describe('SubscriptionsActionCreator', () => {
     describe('#sendSignInEmail()', () => {
         describe('when store has a signed-in shopper', () => {
             it('emits billing actions if able to continue as guest', async () => {
-                const actions = await from(signInEmailActionCreator.sendSignInEmail('f'))
+                const actions = await from(signInEmailActionCreator.sendSignInEmail({
+                    email: 'f',
+                }))
                     .pipe(toArray())
                     .toPromise();
 
@@ -46,7 +48,9 @@ describe('SubscriptionsActionCreator', () => {
 
                 const errorHandler = jest.fn(action => of(action));
 
-                const actions = await from(signInEmailActionCreator.sendSignInEmail('f'))
+                const actions = await from(signInEmailActionCreator.sendSignInEmail({
+                    email: 'f',
+                }))
                     .pipe(
                         catchError(errorHandler),
                         toArray()
@@ -61,10 +65,14 @@ describe('SubscriptionsActionCreator', () => {
             });
 
             it('sends request to create billing address', async () => {
-                await from(signInEmailActionCreator.sendSignInEmail('f', {}))
+                await from(signInEmailActionCreator.sendSignInEmail({
+                    email: 'f',
+                    redirectUrl: 'f.c',
+                }, {}))
                     .toPromise();
 
-                expect(signInEmailRequestSender.sendSignInEmail).toHaveBeenCalledWith('f', {});
+                expect(signInEmailRequestSender.sendSignInEmail)
+                    .toHaveBeenCalledWith({ email: 'f', redirectUrl: 'f.c' }, {});
             });
         });
     });

--- a/src/signin-email/signin-email-action-creator.ts
+++ b/src/signin-email/signin-email-action-creator.ts
@@ -5,6 +5,7 @@ import { catchError } from 'rxjs/operators';
 import { throwErrorAction } from '../common/error';
 import { RequestOptions } from '../common/http-request';
 
+import { SignInEmailRequestBody } from './signin-email';
 import { SendSignInEmailAction, SignInEmailActionType } from './signin-email-actions';
 import SignInEmailRequestSender from './signin-email-request-sender';
 
@@ -14,13 +15,13 @@ export default class SignInEmailActionCreator {
     ) {}
 
     sendSignInEmail(
-        email: string,
+        emailRequest: SignInEmailRequestBody,
         options?: RequestOptions
     ): Observable<SendSignInEmailAction> {
         return concat(
             of(createAction(SignInEmailActionType.SendSignInEmailRequested)),
             defer(async () => {
-                const { body } = await this._requestSender.sendSignInEmail(email, options);
+                const { body } = await this._requestSender.sendSignInEmail(emailRequest, options);
 
                 return createAction(SignInEmailActionType.SendSignInEmailSucceeded, body);
             })

--- a/src/signin-email/signin-email-request-sender.spec.ts
+++ b/src/signin-email/signin-email-request-sender.spec.ts
@@ -17,28 +17,39 @@ describe('SignInEmailRequestSender', () => {
     });
 
     describe('#sendSignInEmail()', () => {
-        it('sends sign-in email', async () => {
-            await signInEmailRequestSender.sendSignInEmail('foo');
+        it('sends sign-in email with current location as default', async () => {
+            await signInEmailRequestSender.sendSignInEmail({
+                email: 'foo',
+            });
 
             expect(requestSender.post).toHaveBeenCalledWith(
                 '/login.php?action=passwordless_login',
                 {
-                    body: { email: 'foo' },
+                    body: {
+                        email: 'foo',
+                        redirect_url: '/',
+                    },
                     headers: { Accept: ContentType.JsonV1 },
                     timeout: undefined,
                 }
             );
         });
 
-        it('sends sign-in email with timeout', async () => {
+        it('sends sign-in email with provided optional parameters', async () => {
             const options = { timeout: createTimeout() };
-            await signInEmailRequestSender.sendSignInEmail('foo', options);
+            await signInEmailRequestSender.sendSignInEmail({
+                email: 'foo',
+                redirectUrl: 'foo.bar',
+            }, options);
 
             expect(requestSender.post).toHaveBeenCalledWith(
                 '/login.php?action=passwordless_login',
                 {
                     ...options,
-                    body: { email: 'foo' },
+                    body: {
+                        email: 'foo',
+                        redirect_url: 'foo.bar',
+                    },
                     headers: { Accept: ContentType.JsonV1 },
                 }
             );

--- a/src/signin-email/signin-email-request-sender.ts
+++ b/src/signin-email/signin-email-request-sender.ts
@@ -1,18 +1,30 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { ContentType, RequestOptions } from '../common/http-request';
+import { parseUrl } from '../common/url';
 
-import { SignInEmail } from './signin-email';
+import { SignInEmail, SignInEmailRequestBody } from './signin-email';
 
 export default class SignInEmailRequestSender {
     constructor(
         private _requestSender: RequestSender
     ) {}
 
-    sendSignInEmail(email: string, { timeout }: RequestOptions = {}): Promise<Response<SignInEmail>> {
+    sendSignInEmail(
+        {
+            email,
+            redirectUrl,
+        }: SignInEmailRequestBody,
+        {
+            timeout,
+        }: RequestOptions = {}
+    ): Promise<Response<SignInEmail>> {
         const url = '/login.php?action=passwordless_login';
         const headers = { Accept: ContentType.JsonV1 };
 
-        return this._requestSender.post(url, { body: { email }, headers, timeout });
+        return this._requestSender.post(url, { body: {
+            email,
+            redirect_url: redirectUrl || parseUrl(window.top.location.href).pathname,
+        }, headers, timeout });
     }
 }

--- a/src/signin-email/signin-email.ts
+++ b/src/signin-email/signin-email.ts
@@ -2,3 +2,8 @@ export interface SignInEmail {
     sent_email: string;
     expiry: number;
 }
+
+export interface SignInEmailRequestBody {
+    email: string;
+    redirectUrl?: string;
+}


### PR DESCRIPTION
## What?
Add redirect_to to sign in email request payload.

## Why?
Because by default it redirects to account page. We want this to redirect to checkout.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
