### PR TITLE
INT-2001 Reload widget when apply store credit checkbox state changes

### DIFF
--- a/src/payment/strategies/klarnav2/klarnav2-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarnav2/klarnav2-payment-strategy.spec.ts
@@ -99,6 +99,8 @@ describe('KlarnaV2PaymentStrategy', () => {
 
         jest.spyOn(scriptLoader, 'load')
             .mockImplementation(() => Promise.resolve(klarnaPayments));
+
+        jest.spyOn(store, 'subscribe');
     });
 
     describe('#initialize()', () => {
@@ -116,6 +118,11 @@ describe('KlarnaV2PaymentStrategy', () => {
 
         it('loads script when initializing strategy', () => {
             expect(scriptLoader.load).toHaveBeenCalledTimes(1);
+        });
+
+        it('loads store subscribe once', () => {
+            store.notifyState();
+            expect(store.subscribe).toHaveBeenCalledTimes(1);
         });
 
         it('loads payments widget', () => {


### PR DESCRIPTION
[INT-2001](https://jira.bigcommerce.com/browse/INT-2001)
## What?
We are reloading the widget each time the apply store credit checkbox state changes

## Why?
We need to update the klarna session with the final amount to pay

## Testing / Proof
[DEMO](https://drive.google.com/file/d/1RZMjQds1ZZJoGIDZpZvKBtqP24ZK43Zw/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
