### PR TITLE
CHECKOUT-4904 Pass useStoreCredit: undefined to amazonpay if not provided

### DIFF
--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -294,7 +294,7 @@ describe('AmazonPayPaymentStrategy', () => {
     });
 
     it('reinitializes payment method before submitting order', async () => {
-        const payload = getOrderRequestBody();
+        const payload = omit(getOrderRequestBody(), 'useStoreCredit');
         const options = { methodId: paymentMethod.id };
         const { referenceId = '' } = getRemoteCheckoutStateData().amazon || {};
 
@@ -304,7 +304,11 @@ describe('AmazonPayPaymentStrategy', () => {
         await strategy.execute(payload, options);
 
         expect(remoteCheckoutActionCreator.initializePayment)
-            .toHaveBeenCalledWith(payload.payment && payload.payment.methodId, { referenceId, useStoreCredit: false });
+            // tslint:disable-next-line: no-non-null-assertion
+            .toHaveBeenCalledWith(payload.payment!.methodId, {
+                referenceId,
+                useStoreCredit: undefined,
+            });
 
         expect(orderActionCreator.submitOrder)
             .toHaveBeenCalledWith({

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.ts
@@ -87,7 +87,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const { payment: { paymentData, ...paymentPayload }, useStoreCredit = false } = payload;
+        const { payment: { paymentData, ...paymentPayload }, useStoreCredit } = payload;
 
         if (options && this._paymentMethod && this._paymentMethod.config.is3dsEnabled) {
             return this._processPaymentWith3ds(
@@ -236,7 +236,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
         );
     }
 
-    private _processPaymentWith3ds(sellerId: string, referenceId: string, methodId: string, useStoreCredit: boolean, options: PaymentRequestOptions): Promise<never> {
+    private _processPaymentWith3ds(sellerId: string, referenceId: string, methodId: string, useStoreCredit: boolean | undefined, options: PaymentRequestOptions): Promise<never> {
         return new Promise((_, reject) => {
             if (!this._window.OffAmazonPayments) {
                 return reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
@@ -247,7 +247,7 @@ export default class AmazonPayPaymentStrategy implements PaymentStrategy {
                 referenceId,
                 (confirmationFlow: AmazonPayConfirmationFlow) => {
                     return this._store.dispatch(
-                        this._orderActionCreator.submitOrder({useStoreCredit}, options)
+                        this._orderActionCreator.submitOrder({ useStoreCredit }, options)
                     )
                         .then(() => this._store.dispatch(
                             this._remoteCheckoutActionCreator.initializePayment(methodId, {


### PR DESCRIPTION
## What?
Don't assume `useStoreCredit:false` if not provided.

## Why?
Because there are other ways to set store credit. If this is not passed, shouldn't be assumed false as it could overwrite the value set using the store credit endpoint.

## Testing / Proof
unit

@bigcommerce/checkout @bigcommerce/payments
