### PR TITLE
refactor(payment): INT-2687 Inject integrity and crossorigin attributes

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -4,7 +4,7 @@ import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { AdyenHostWindow } from './adyenv2';
 import AdyenV2ScriptLoader from './adyenv2-script-loader';
-import { getAdyenClient, getLiveAdyenConfiguration, getLoadScriptOptions, getTestAdyenConfiguration } from './adyenv2.mock';
+import { getAdyenClient, getLiveAdyenConfiguration, getLoadScriptOptions, getLoadStylesheetOptions, getTestAdyenConfiguration } from './adyenv2.mock';
 
 describe('AdyenV2ScriptLoader', () => {
     let adyenV2ScriptLoader: AdyenV2ScriptLoader;
@@ -12,6 +12,7 @@ describe('AdyenV2ScriptLoader', () => {
     let stylesheetLoader: StylesheetLoader;
     let mockWindow: AdyenHostWindow;
     const adyenClient = getAdyenClient();
+    const loadStylesheetOptions = getLoadStylesheetOptions();
 
     afterEach(() => {
         jest.restoreAllMocks();
@@ -44,7 +45,7 @@ describe('AdyenV2ScriptLoader', () => {
             await adyenV2ScriptLoader.load(configuration);
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, getLoadScriptOptions('test'));
-            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl, loadStylesheetOptions);
         });
 
         it('returns the JS from the window', async () => {
@@ -77,7 +78,7 @@ describe('AdyenV2ScriptLoader', () => {
             await adyenV2ScriptLoader.load(configuration);
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, getLoadScriptOptions('live'));
-            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl, loadStylesheetOptions);
         });
 
         it('returns the JS from the window', async () => {

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -4,47 +4,79 @@ import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { AdyenHostWindow } from './adyenv2';
 import AdyenV2ScriptLoader from './adyenv2-script-loader';
-import { getAdyenClient, getAdyenConfiguration } from './adyenv2.mock';
+import { getAdyenClient, getLiveAdyenConfiguration, getLoadScriptOptions, getTestAdyenConfiguration } from './adyenv2.mock';
 
 describe('AdyenV2ScriptLoader', () => {
     let adyenV2ScriptLoader: AdyenV2ScriptLoader;
     let scriptLoader: ScriptLoader;
     let stylesheetLoader: StylesheetLoader;
     let mockWindow: AdyenHostWindow;
+    const adyenClient = getAdyenClient();
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
 
     beforeEach(() => {
         mockWindow = {} as AdyenHostWindow;
         scriptLoader = {} as ScriptLoader;
         stylesheetLoader = {} as StylesheetLoader;
         adyenV2ScriptLoader = new AdyenV2ScriptLoader(scriptLoader, stylesheetLoader, mockWindow);
+
+        scriptLoader.loadScript = jest.fn(() => {
+            mockWindow.AdyenCheckout = jest.fn(
+                () => adyenClient
+            );
+
+            return Promise.resolve();
+        });
+
+        stylesheetLoader.loadStylesheet = jest.fn(() => Promise.resolve());
+
     });
 
-    describe('#load()', () => {
-        const adyenClient = getAdyenClient();
-        const configuration = getAdyenConfiguration();
+    describe('#load() on test mode', () => {
+        const configuration = getTestAdyenConfiguration();
         const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.8.0/adyen.js';
         const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.8.0/adyen.css';
 
-        beforeEach(() => {
+        it('loads the JS and CSS test mode', async () => {
+            await adyenV2ScriptLoader.load(configuration);
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, getLoadScriptOptions('test'));
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
+        });
+
+        it('returns the JS from the window', async () => {
+            const adyenJs = await adyenV2ScriptLoader.load(configuration);
+
+            expect(adyenJs).toBe(adyenClient);
+        });
+
+        it('throws an error when window is not set', async () => {
             scriptLoader.loadScript = jest.fn(() => {
-                mockWindow.AdyenCheckout = jest.fn(
-                    () => adyenClient
-                );
+                mockWindow.AdyenCheckout = undefined;
 
                 return Promise.resolve();
             });
 
-            stylesheetLoader.loadStylesheet = jest.fn(() => Promise.resolve());
+            try {
+                await adyenV2ScriptLoader.load(configuration);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
+            }
         });
+    });
 
-        afterEach(() => {
-            jest.restoreAllMocks();
-        });
+    describe('#load() on live mode', () => {
+        const configuration = getLiveAdyenConfiguration();
+        const jsUrl = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.8.0/adyen.js';
+        const cssUrl = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.8.0/adyen.css';
 
-        it('loads the JS and CSS', async () => {
+        it('loads the JS and CSS live mode', async () => {
             await adyenV2ScriptLoader.load(configuration);
 
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, getLoadScriptOptions('live'));
             expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
         });
 

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -12,9 +12,20 @@ export default class AdyenV2ScriptLoader {
     ) { }
 
     async load(configuration: AdyenConfiguration): Promise<AdyenClient> {
+        const checksums: { [id: string]: string } = {
+            test: 'sha384-j+P95C9gdyJZ9LTUtvrMDElDvFEeTCelUsE89yfnDfP7nbOXS3N0+e5nb0CLTdx/',
+            live: 'sha384-rwJ33r9d5uXn5L8KSr4UqcaSaAHs2NQNjtNCvclBkZ8P36yDAXQq65YPX+q1LiEr',
+        };
+
         await Promise.all([
             this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.css`),
-            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.js`),
+            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.js`, {
+                    async: false,
+                    attributes: {
+                        integrity: checksums[configuration.environment ? configuration.environment : 'test'],
+                        crossorigin: 'anonymous',
+                    },
+                }),
         ]);
 
         if (!this._window.AdyenCheckout) {

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -12,17 +12,23 @@ export default class AdyenV2ScriptLoader {
     ) { }
 
     async load(configuration: AdyenConfiguration): Promise<AdyenClient> {
-        const checksums: { [id: string]: string } = {
+        const checkSums: { [id: string]: string } = {
             test: 'sha384-j+P95C9gdyJZ9LTUtvrMDElDvFEeTCelUsE89yfnDfP7nbOXS3N0+e5nb0CLTdx/',
             live: 'sha384-rwJ33r9d5uXn5L8KSr4UqcaSaAHs2NQNjtNCvclBkZ8P36yDAXQq65YPX+q1LiEr',
         };
 
         await Promise.all([
-            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.css`),
+            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.css`, {
+                prepend: true,
+                attributes: {
+                    integrity: 'sha384-y1lKqffK5z+ENzddmGIfP3bcMRobxkjDt/9lyPAvV9H3JXbJYxCSD6L8TdyRMCGM',
+                    crossorigin: 'anonymous',
+                },
+            }),
             this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.js`, {
                     async: false,
                     attributes: {
-                        integrity: checksums[configuration.environment ? configuration.environment : 'test'],
+                        integrity: checkSums[configuration.environment ? configuration.environment : 'test'],
                         crossorigin: 'anonymous',
                     },
                 }),

--- a/src/payment/strategies/adyenv2/adyenv2.mock.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.mock.ts
@@ -1,3 +1,5 @@
+import { LoadScriptOptions } from '@bigcommerce/script-loader';
+
 import { RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
 import { OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
@@ -70,10 +72,17 @@ export function getAdyenClient(): AdyenClient {
     };
 }
 
-export function getAdyenConfiguration(): AdyenConfiguration {
+export function getTestAdyenConfiguration(): AdyenConfiguration {
     return {
         environment: 'test',
-        originKey: 'YOUR_ORIGIN_KEY',
+        originKey: 'YOUR_TEST_ORIGIN_KEY',
+    };
+}
+
+export function getLiveAdyenConfiguration(): AdyenConfiguration {
+    return {
+        environment: 'live',
+        originKey: 'YOUR_LIVE_ORIGIN_KEY',
     };
 }
 
@@ -212,4 +221,19 @@ export function getUnknownError(): RequestError {
         ...getUnknownErrorResponse(),
         ...getErrorPaymentResponseBody(),
     }));
+}
+
+export function getLoadScriptOptions(environment: string | undefined): LoadScriptOptions {
+    const checksums: { [id: string]: string } = {
+        test: 'sha384-j+P95C9gdyJZ9LTUtvrMDElDvFEeTCelUsE89yfnDfP7nbOXS3N0+e5nb0CLTdx/',
+        live: 'sha384-rwJ33r9d5uXn5L8KSr4UqcaSaAHs2NQNjtNCvclBkZ8P36yDAXQq65YPX+q1LiEr',
+    };
+
+    return {
+        async: false,
+        attributes: {
+            integrity: checksums[environment ? environment : 'test'],
+            crossorigin: 'anonymous',
+        },
+    };
 }

--- a/src/payment/strategies/adyenv2/adyenv2.mock.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.mock.ts
@@ -1,4 +1,4 @@
-import { LoadScriptOptions } from '@bigcommerce/script-loader';
+import { LoadScriptOptions, LoadStylesheetOptions } from '@bigcommerce/script-loader';
 
 import { RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
@@ -233,6 +233,16 @@ export function getLoadScriptOptions(environment: string | undefined): LoadScrip
         async: false,
         attributes: {
             integrity: checksums[environment ? environment : 'test'],
+            crossorigin: 'anonymous',
+        },
+    };
+}
+
+export function getLoadStylesheetOptions(): LoadStylesheetOptions {
+    return {
+        prepend: true,
+        attributes: {
+            integrity: 'sha384-y1lKqffK5z+ENzddmGIfP3bcMRobxkjDt/9lyPAvV9H3JXbJYxCSD6L8TdyRMCGM',
             crossorigin: 'anonymous',
         },
     };


### PR DESCRIPTION
## What?
Inject attributes while loading Adyen Stylesheet

## Why?
...

## Testing / Proof

- Unit

## How can this change be undone in case of failure?
1. Revert this PR

## Dependencies
Script Loader [#11](https://github.com/bigcommerce/script-loader-js/pull/11)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
