### PR TITLE
CHECKOUT-4760 Update address type to include shouldSaveAddress attribute

### DIFF
--- a/src/address/address.ts
+++ b/src/address/address.ts
@@ -2,6 +2,7 @@ export type AddressKey = keyof Address;
 
 export default interface Address extends AddressRequestBody {
     country: string;
+    shouldSaveAddress?: boolean;
 }
 
 export interface AddressRequestBody {

--- a/src/address/map-from-internal-address.spec.ts
+++ b/src/address/map-from-internal-address.spec.ts
@@ -8,6 +8,6 @@ import mapFromInternalAddress from './map-from-internal-address';
 describe('mapFromInternalAddress()', () => {
     it('maps from internal address', () => {
         expect(mapFromInternalAddress(getInternalBillingAddress()))
-            .toEqual(omit(getBillingAddress(), 'email'));
+            .toEqual(omit(getBillingAddress(), 'email', 'shouldSaveAddress'));
     });
 });

--- a/src/billing/billing-addresses.mock.ts
+++ b/src/billing/billing-addresses.mock.ts
@@ -16,6 +16,7 @@ export function getBillingAddress(): BillingAddress {
         country: 'United States',
         countryCode: 'US',
         postalCode: '95555',
+        shouldSaveAddress: true,
         phone: '555-555-5555',
         customFields: [],
     };

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -341,7 +341,8 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             const billingAddress = getBillingAddress();
             const context = getContextConfig();
             const isEmptyBillingAddress = !billingAddress ||
-                values(omit(billingAddress, 'email', 'id')).every(val => !val || !val.length);
+                values(omit(billingAddress, 'shouldSaveAddress', 'email', 'id'))
+                    .every(val => !val || !val.length);
 
             if (isEmptyBillingAddress) {
                 if (!context || !context.geoCountryCode) {

--- a/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay/amazon-pay-payment-strategy.spec.ts
@@ -372,7 +372,7 @@ describe('AmazonPayPaymentStrategy', () => {
                 referenceId: '511ed7ed-221c-418c-8286-f5102e49220b',
             }));
 
-        const { email, ...address } = getBillingAddress();
+        const { email, shouldSaveAddress, ...address } = getBillingAddress();
 
         expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(address);
         expect(store.dispatch).toHaveBeenCalledWith(initializeBillingAction);

--- a/src/shipping/shipping-addresses.mock.ts
+++ b/src/shipping/shipping-addresses.mock.ts
@@ -14,6 +14,7 @@ export function getShippingAddress(): Address {
         countryCode: 'US',
         postalCode: '95555',
         phone: '555-555-5555',
+        shouldSaveAddress: true,
         customFields: [],
     };
 }

--- a/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon/amazon-pay-shipping-strategy.spec.ts
@@ -1,6 +1,7 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { omit } from 'lodash';
 import { of } from 'rxjs';
 
 import { ConsignmentRequestSender } from '../..';
@@ -163,7 +164,7 @@ describe('AmazonPayShippingStrategy', () => {
             });
 
         expect(consignmentActionCreator.updateAddress)
-            .toHaveBeenCalledWith(getShippingAddress());
+            .toHaveBeenCalledWith(omit(getShippingAddress(), 'shouldSaveAddress'));
 
         expect(store.dispatch).toHaveBeenCalledWith(initializeShippingAction);
         expect(store.dispatch).toHaveBeenCalledWith(updateAddressAction);


### PR DESCRIPTION
## What?
 Expose `shouldSaveAddress` attribute

## Why?
So clients can opt-out from the automatic behaviour that saves addresses.

## Testing / Proof
n/a

@bigcommerce/checkout @bigcommerce/payments
