### PR TITLE
fix(payment): INT-2691 Remove integrity & crossorigin attributes for AdyenV2

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -4,7 +4,7 @@ import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { AdyenHostWindow } from './adyenv2';
 import AdyenV2ScriptLoader from './adyenv2-script-loader';
-import { getAdyenClient, getAdyenConfiguration, getLoadScriptOptions } from './adyenv2.mock';
+import { getAdyenClient, getAdyenConfiguration } from './adyenv2.mock';
 
 describe('AdyenV2ScriptLoader', () => {
     let adyenV2ScriptLoader: AdyenV2ScriptLoader;
@@ -44,7 +44,7 @@ describe('AdyenV2ScriptLoader', () => {
         it('loads the JS and CSS', async () => {
             await adyenV2ScriptLoader.load(configuration);
 
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl, getLoadScriptOptions());
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
             expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
         });
 

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -14,13 +14,7 @@ export default class AdyenV2ScriptLoader {
     async load(configuration: AdyenConfiguration): Promise<AdyenClient> {
         await Promise.all([
             this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.css`),
-            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.js`, {
-                    async: false,
-                    attributes: {
-                        integrity: 'sha384-j+P95C9gdyJZ9LTUtvrMDElDvFEeTCelUsE89yfnDfP7nbOXS3N0+e5nb0CLTdx/',
-                        crossorigin: 'anonymous',
-                    },
-                }),
+            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.0/adyen.js`),
         ]);
 
         if (!this._window.AdyenCheckout) {

--- a/src/payment/strategies/adyenv2/adyenv2.mock.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.mock.ts
@@ -1,5 +1,3 @@
-import { LoadScriptOptions } from '@bigcommerce/script-loader';
-
 import { RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
 import { OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
@@ -205,14 +203,4 @@ export function getUnknownError(): RequestError {
         ...getUnknownErrorResponse(),
         ...getErrorPaymentResponseBody(),
     }));
-}
-
-export function getLoadScriptOptions(): LoadScriptOptions {
-    return {
-        async: false,
-        attributes: {
-            integrity: 'sha384-j+P95C9gdyJZ9LTUtvrMDElDvFEeTCelUsE89yfnDfP7nbOXS3N0+e5nb0CLTdx/',
-            crossorigin: 'anonymous',
-        },
-    };
 }


### PR DESCRIPTION
## What?
Remove attributes as they seem to be blocking Adyen components suite from been loaded.

## Why?
It is blocking merchants from loading Adyen Components

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments
