### PR TITLE
feat(payment): PAYMENTS-5513 add setAsDefaultInstrument feature during vaulting or vaulted payments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1279,9 +1279,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.9.0.tgz",
-      "integrity": "sha512-AiocWVss9uSpDI4PV408tl8bvyC/Ga5t1rwgJPQX32E7VjRDjNKbpXOQjkW1Y4yLf83usNbLJ1V+UCxb6KGxmg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.10.0.tgz",
+      "integrity": "sha512-+MmCBkjdJebZN87MvcHAYA9j28b6ClmqzFKbf//zXBgGF+hjwaxk/pVTGd2rDKEVT3DgzFJub0shs6khE2RjtA==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^25.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1298,13 +1298,12 @@
           }
         },
         "@babel/generator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "requires": {
-            "@babel/types": "^7.10.4",
+            "@babel/types": "^7.10.5",
             "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           },
           "dependencies": {
@@ -1334,11 +1333,11 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
-          "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.10.5"
           }
         },
         "@babel/helper-module-imports": {
@@ -1350,17 +1349,17 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
-          "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
           "requires": {
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
             "@babel/helper-simple-access": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
             "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.4",
-            "lodash": "^4.17.13"
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -1466,9 +1465,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA=="
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -1481,28 +1480,28 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.4",
+            "@babel/generator": "^7.10.5",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.4",
-            "@babel/types": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
-            "lodash": "^4.17.13"
+            "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.13",
+            "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -1721,23 +1720,23 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.4.tgz",
-              "integrity": "sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==",
+              "version": "7.10.5",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
+              "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
               "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/generator": "^7.10.5",
+                "@babel/helper-module-transforms": "^7.10.5",
                 "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.10.4",
+                "@babel/parser": "^7.10.5",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4",
+                "@babel/traverse": "^7.10.5",
+                "@babel/types": "^7.10.5",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
                 "json5": "^2.1.2",
-                "lodash": "^4.17.13",
+                "lodash": "^4.17.19",
                 "resolve": "^1.3.2",
                 "semver": "^5.4.1",
                 "source-map": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@bigcommerce/bigpay-client": "^5.9.0",
+    "@bigcommerce/bigpay-client": "^5.10.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -279,7 +279,7 @@ describe('PaymentActionCreator', () => {
             const payment = getPayment();
             const { methodId, gatewayId } = payment;
 
-            paymentActionCreator.initializeOffsitePayment({ methodId, gatewayId, shouldSaveInstrument: true, setAsDefaultInstrument: true })(store);
+            paymentActionCreator.initializeOffsitePayment({ methodId, gatewayId, shouldSaveInstrument: true, shouldSetAsDefaultInstrument: true })(store);
 
             expect(paymentRequestTransformer.transform).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/src/payment/payment-action-creator.spec.ts
+++ b/src/payment/payment-action-creator.spec.ts
@@ -179,7 +179,9 @@ describe('PaymentActionCreator', () => {
     describe('#initializeOffsitePayment()', () => {
         it('dispatches actions to data store', async () => {
             const payment = getPayment();
-            const actions = await from(paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId)(store))
+            const { methodId, gatewayId } = payment;
+
+            const actions = await from(paymentActionCreator.initializeOffsitePayment({ methodId, gatewayId })(store))
                 .pipe(toArray())
                 .toPromise();
 
@@ -197,7 +199,9 @@ describe('PaymentActionCreator', () => {
 
             const errorHandler = jest.fn(action => of(action));
             const payment = getPayment();
-            const actions = await from(paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId)(store))
+            const { methodId, gatewayId } = payment;
+
+            const actions = await from(paymentActionCreator.initializeOffsitePayment({ methodId, gatewayId })(store))
                 .pipe(
                     catchError(errorHandler),
                     toArray()
@@ -226,8 +230,9 @@ describe('PaymentActionCreator', () => {
             const cancelPayment = new CancellablePromise<undefined>(new Promise(noop));
             const errorHandler = jest.fn(action => of(action));
             const payment = getPayment();
+            const { methodId, gatewayId } = payment;
 
-            const actions = from(paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId, undefined, undefined, undefined, cancelPayment.promise)(store))
+            const actions = from(paymentActionCreator.initializeOffsitePayment({ methodId, gatewayId, promise: cancelPayment.promise })(store))
                 .pipe(
                     catchError(errorHandler),
                     toArray()
@@ -254,10 +259,9 @@ describe('PaymentActionCreator', () => {
 
         it('passes "set_as_default_stored_instrument" flag as null to the paymentRequestTransformer when vaulting, but not as default', () => {
             const payment = getPayment();
+            const { methodId, gatewayId } = payment;
 
-            paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId, undefined, true)(store);
-
-            expect(paymentRequestTransformer.transform).toHaveBeenCalledWith(expect.anything(), expect.anything());
+            paymentActionCreator.initializeOffsitePayment({ methodId, gatewayId, shouldSaveInstrument: true })(store);
 
             expect(paymentRequestTransformer.transform).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -273,10 +277,9 @@ describe('PaymentActionCreator', () => {
 
         it('passes "set_as_default_stored_instrument" flag as true to the paymentRequestTransformer when vaulting and making default', () => {
             const payment = getPayment();
+            const { methodId, gatewayId } = payment;
 
-            paymentActionCreator.initializeOffsitePayment(payment.methodId, payment.gatewayId, undefined, true, undefined, undefined, true)(store);
-
-            expect(paymentRequestTransformer.transform).toHaveBeenCalledWith(expect.anything(), expect.anything());
+            paymentActionCreator.initializeOffsitePayment({ methodId, gatewayId, shouldSaveInstrument: true, setAsDefaultInstrument: true })(store);
 
             expect(paymentRequestTransformer.transform).toHaveBeenCalledWith(
                 expect.objectContaining({

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -12,6 +12,19 @@ import { InitializeOffsitePaymentAction, PaymentActionType, SubmitPaymentAction 
 import PaymentRequestSender from './payment-request-sender';
 import PaymentRequestTransformer from './payment-request-transformer';
 
+interface InitializeOffsitePaymentSettings {
+    methodId: string;
+    gatewayId?: string;
+    instrumentId?: string;
+    target?: string;
+    promise?: Promise<undefined>;
+    shouldSaveInstrument?: boolean;
+    setAsDefaultInstrument?: boolean;
+}
+
+type InitializeOffsitePayment = (settings: InitializeOffsitePaymentSettings)
+    => ThunkAction<InitializeOffsitePaymentAction, InternalCheckoutSelectors>;
+
 export default class PaymentActionCreator {
     constructor(
         private _paymentRequestSender: PaymentRequestSender,
@@ -47,15 +60,15 @@ export default class PaymentActionCreator {
         );
     }
 
-    initializeOffsitePayment(
-        methodId: string,
-        gatewayId?: string,
-        instrumentId?: string,
-        shouldSaveInstrument?: boolean,
-        target?: string,
-        promise?: Promise<undefined>,
-        setAsDefaultInstrument?: boolean
-    ): ThunkAction<InitializeOffsitePaymentAction, InternalCheckoutSelectors> {
+    initializeOffsitePayment: InitializeOffsitePayment = ({
+        methodId,
+        gatewayId,
+        instrumentId,
+        target,
+        promise,
+        shouldSaveInstrument,
+        setAsDefaultInstrument,
+    }) => {
         return store => {
             let paymentData: FormattedPayload<FormattedHostedInstrument | FormattedVaultedInstrument> | undefined;
 
@@ -80,5 +93,5 @@ export default class PaymentActionCreator {
                 catchError(error => throwErrorAction(PaymentActionType.InitializeOffsitePaymentFailed, error))
             );
         };
-    }
+    };
 }

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -53,7 +53,8 @@ export default class PaymentActionCreator {
         instrumentId?: string,
         shouldSaveInstrument?: boolean,
         target?: string,
-        promise?: Promise<undefined>
+        promise?: Promise<undefined>,
+        setAsDefaultInstrument?: boolean
     ): ThunkAction<InitializeOffsitePaymentAction, InternalCheckoutSelectors> {
         return store => {
             let paymentData: FormattedPayload<FormattedHostedInstrument | FormattedVaultedInstrument> | undefined;
@@ -61,7 +62,12 @@ export default class PaymentActionCreator {
             if (instrumentId) {
                 paymentData = { formattedPayload: { bigpay_token: instrumentId } };
             } else if (shouldSaveInstrument) {
-                paymentData = { formattedPayload: { vault_payment_instrument: shouldSaveInstrument } };
+                paymentData = {
+                    formattedPayload: {
+                        vault_payment_instrument: shouldSaveInstrument,
+                        set_as_default_stored_instrument: setAsDefaultInstrument || null,
+                    },
+                };
             }
 
             const payload = this._paymentRequestTransformer.transform({ gatewayId, methodId, paymentData }, store.getState());

--- a/src/payment/payment-action-creator.ts
+++ b/src/payment/payment-action-creator.ts
@@ -19,7 +19,7 @@ interface InitializeOffsitePaymentSettings {
     target?: string;
     promise?: Promise<undefined>;
     shouldSaveInstrument?: boolean;
-    setAsDefaultInstrument?: boolean;
+    shouldSetAsDefaultInstrument?: boolean;
 }
 
 type InitializeOffsitePayment = (settings: InitializeOffsitePaymentSettings)
@@ -67,7 +67,7 @@ export default class PaymentActionCreator {
         target,
         promise,
         shouldSaveInstrument,
-        setAsDefaultInstrument,
+        shouldSetAsDefaultInstrument,
     }) => {
         return store => {
             let paymentData: FormattedPayload<FormattedHostedInstrument | FormattedVaultedInstrument> | undefined;
@@ -78,7 +78,7 @@ export default class PaymentActionCreator {
                 paymentData = {
                     formattedPayload: {
                         vault_payment_instrument: shouldSaveInstrument,
-                        set_as_default_stored_instrument: setAsDefaultInstrument || null,
+                        set_as_default_stored_instrument: shouldSetAsDefaultInstrument || null,
                     },
                 };
             }

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -36,6 +36,7 @@ export interface CreditCardInstrument {
     ccNumber: string;
     ccCvv?: string;
     shouldSaveInstrument?: boolean;
+    setAsDefaultInstrument?: boolean;
     extraData?: any;
     threeDSecure?: ThreeDSecure | ThreeDSecureToken;
 }
@@ -53,6 +54,7 @@ export type AdyenV2Instrument = AdyenV2Token | AdyenV2Card;
 export interface NonceInstrument {
     nonce: string;
     shouldSaveInstrument?: boolean;
+    setAsDefaultInstrument?: boolean;
     deviceSessionId?: string;
 }
 
@@ -95,10 +97,12 @@ export interface ThreeDSecureToken {
 
 export interface HostedInstrument {
     shouldSaveInstrument?: boolean;
+    setAsDefaultInstrument?: boolean;
 }
 
 export interface PaypalInstrument {
     vault_payment_instrument: boolean | null;
+    set_as_default_stored_instrument: boolean | null;
     device_info: string | null;
     paypal_account: {
         token: string;
@@ -121,6 +125,7 @@ interface AdyenV2Card {
 
 export interface FormattedHostedInstrument {
     vault_payment_instrument: boolean | null;
+    set_as_default_stored_instrument: boolean | null;
 }
 
 export interface FormattedVaultedInstrument {

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -36,7 +36,7 @@ export interface CreditCardInstrument {
     ccNumber: string;
     ccCvv?: string;
     shouldSaveInstrument?: boolean;
-    setAsDefaultInstrument?: boolean;
+    shouldSetAsDefaultInstrument?: boolean;
     extraData?: any;
     threeDSecure?: ThreeDSecure | ThreeDSecureToken;
 }
@@ -54,7 +54,7 @@ export type AdyenV2Instrument = AdyenV2Token | AdyenV2Card;
 export interface NonceInstrument {
     nonce: string;
     shouldSaveInstrument?: boolean;
-    setAsDefaultInstrument?: boolean;
+    shouldSetAsDefaultInstrument?: boolean;
     deviceSessionId?: string;
 }
 
@@ -97,7 +97,7 @@ export interface ThreeDSecureToken {
 
 export interface HostedInstrument {
     shouldSaveInstrument?: boolean;
-    setAsDefaultInstrument?: boolean;
+    shouldSetAsDefaultInstrument?: boolean;
 }
 
 export interface PaypalInstrument {

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -1,5 +1,3 @@
-// TODO: setAsDefaultInstrument tests
-
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
@@ -19,6 +17,7 @@ import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import { getAdyenV2 } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
+import { getCreditCardInstrument } from '../../payments.mock';
 
 import { AdyenAdditionalActionState, AdyenComponentState, AdyenError, AdyenPaymentMethodType, AdyenV2PaymentStrategy, AdyenV2ScriptLoader, ResultCode } from '.';
 import { AdyenComponent } from './adyenv2';
@@ -272,6 +271,82 @@ describe('AdyenV2PaymentStrategy', () => {
                 expect(adyenCheckout.create).toHaveBeenCalledTimes(2);
             });
 
+            it('calls submitPayment, passing a set as default flag, when paying with a vaulted instrument that should be defaulted', async () => {
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(submitPaymentAction);
+
+                await strategy.initialize(options);
+                await strategy.execute({
+                    useStoreCredit: false,
+                    payment: { methodId: 'scheme', paymentData: { instrumentId: '123', setAsDefaultInstrument: true } },
+                  });
+
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                set_as_default_stored_instrument: true,
+                            }),
+                        }),
+                    })
+                );
+            });
+
+            it('calls submitPayment, passing a vault flag, when paying with an instrument that should be vaulted', async () => {
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(submitPaymentAction);
+
+                await strategy.initialize(options);
+                await strategy.execute({
+                    payment: {
+                        methodId: 'scheme',
+                        paymentData: {
+                            ...getCreditCardInstrument(),
+                            shouldSaveInstrument: true,
+                        },
+                    },
+                });
+
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                vault_payment_instrument: true,
+                                set_as_default_stored_instrument: null,
+                            }),
+                        }),
+                    })
+                );
+            });
+
+            it('calls submitPayment, passing both a vault and set as default flag, when paying with an instrument that should be vaulted and defaulted', async () => {
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(submitPaymentAction);
+
+                await strategy.initialize(options);
+                await strategy.execute({
+                    payment: {
+                        methodId: 'scheme',
+                        paymentData: {
+                            ...getCreditCardInstrument(),
+                            shouldSaveInstrument: true,
+                            setAsDefaultInstrument: true,
+                        },
+                    },
+                });
+
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            formattedPayload: expect.objectContaining({
+                                vault_payment_instrument: true,
+                                set_as_default_stored_instrument: true,
+                            }),
+                        }),
+                    })
+                );
+            });
+
             it('additional action component fires back onError', async () => {
                 let additionalActionComponentWithError: AdyenComponent;
                 const adyenError = getAdyenError();
@@ -389,6 +464,30 @@ describe('AdyenV2PaymentStrategy', () => {
                     },
                 }));
                 expect(adyenCheckout.create).toHaveBeenCalledTimes(0);
+            });
+
+            it('calls submitPayment, passing a set as default flag, when paying with vaulted account that should be defaulted', async () => {
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValue(getAdyenV2(AdyenPaymentMethodType.GiroPay));
+
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(submitPaymentAction);
+
+                options = getInitializeOptions(true);
+
+                await strategy.initialize(options);
+                await strategy.execute({
+                    useStoreCredit: false,
+                    payment: { methodId: 'giropay', paymentData: { instrumentId: '123', setAsDefaultInstrument: true } },
+                });
+
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expect.objectContaining({
+                    paymentData: expect.objectContaining({
+                        formattedPayload: expect.objectContaining({
+                            set_as_default_stored_instrument: true,
+                        }),
+                    }),
+                }));
             });
 
             it('returns 3DS2 ChallengeShopper flow with no callbacks', async () => {

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -278,7 +278,7 @@ describe('AdyenV2PaymentStrategy', () => {
                 await strategy.initialize(options);
                 await strategy.execute({
                     useStoreCredit: false,
-                    payment: { methodId: 'scheme', paymentData: { instrumentId: '123', setAsDefaultInstrument: true } },
+                    payment: { methodId: 'scheme', paymentData: { instrumentId: '123', shouldSetAsDefaultInstrument: true } },
                   });
 
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
@@ -330,7 +330,7 @@ describe('AdyenV2PaymentStrategy', () => {
                         paymentData: {
                             ...getCreditCardInstrument(),
                             shouldSaveInstrument: true,
-                            setAsDefaultInstrument: true,
+                            shouldSetAsDefaultInstrument: true,
                         },
                     },
                 });
@@ -478,7 +478,7 @@ describe('AdyenV2PaymentStrategy', () => {
                 await strategy.initialize(options);
                 await strategy.execute({
                     useStoreCredit: false,
-                    payment: { methodId: 'giropay', paymentData: { instrumentId: '123', setAsDefaultInstrument: true } },
+                    payment: { methodId: 'giropay', paymentData: { instrumentId: '123', shouldSetAsDefaultInstrument: true } },
                 });
 
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -1,3 +1,5 @@
+// TODO: setAsDefaultInstrument tests
+
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
@@ -248,7 +250,7 @@ describe('AdyenV2PaymentStrategy', () => {
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expect.objectContaining({
                     methodId: 'scheme',
                     paymentData: {
-                        formattedPayload: {
+                        formattedPayload: expect.objectContaining({
                             bigpay_token : {
                                 credit_card_number_confirmation: 'ENCRYPTED_CARD_NUMBER',
                                 token: '123',
@@ -264,7 +266,7 @@ describe('AdyenV2PaymentStrategy', () => {
                                 screen_width: 0,
                                 time_zone_offset: expect.anything(),
                             },
-                        },
+                        }),
                     },
                 }));
                 expect(adyenCheckout.create).toHaveBeenCalledTimes(2);
@@ -371,7 +373,7 @@ describe('AdyenV2PaymentStrategy', () => {
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expect.objectContaining({
                     methodId: 'giropay',
                     paymentData: {
-                        formattedPayload: {
+                        formattedPayload: expect.objectContaining({
                             bigpay_token : {
                                 token: '123',
                             },
@@ -383,7 +385,7 @@ describe('AdyenV2PaymentStrategy', () => {
                                 screen_width: 0,
                                 time_zone_offset: expect.anything(),
                             },
-                        },
+                        }),
                     },
                 }));
                 expect(adyenCheckout.create).toHaveBeenCalledTimes(0);

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -120,7 +120,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                                 }),
                             },
                             browser_info: getBrowserInfo(),
-                            vault_payment_instrument: shouldSaveInstrument,
+                            vault_payment_instrument: shouldSaveInstrument || null,
                             set_as_default_stored_instrument: setAsDefaultInstrument || null,
                         },
                     },

--- a/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.spec.ts
@@ -103,14 +103,13 @@ describe('BlueSnapV2PaymentStrategy', () => {
         await strategy.execute(payload, options);
 
         expect(paymentActionCreator.initializeOffsitePayment)
-            .toHaveBeenCalledWith(
-                options.methodId,
-                options.gatewayId,
-                undefined,
-                false,
-                'bluesnapv2_hosted_payment_page',
-                expect.any(Promise)
-            );
+            .toHaveBeenCalledWith({
+                methodId: options.methodId,
+                gatewayId: options.gatewayId,
+                shouldSaveInstrument: false,
+                target: 'bluesnapv2_hosted_payment_page',
+                promise: expect.any(Promise),
+            });
         expect(store.dispatch).toHaveBeenCalledWith(initializeOffsitePaymentAction);
     });
 

--- a/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.ts
+++ b/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.ts
@@ -47,14 +47,13 @@ export default class BlueSnapV2PaymentStrategy implements PaymentStrategy {
 
         onLoad(frame, () => promise.cancel(new PaymentMethodCancelledError()));
 
-        return this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment(
-            payment.methodId,
-            payment.gatewayId,
-            undefined,
-            false,
-            frame.name,
-            promise.promise
-        ));
+        return this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment({
+            methodId: payment.methodId,
+            gatewayId: payment.gatewayId,
+            shouldSaveInstrument: false,
+            target: frame.name,
+            promise: promise.promise,
+        }));
     }
 
     finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -155,6 +155,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 paymentData: {
                     formattedPayload: {
                         vault_payment_instrument: null,
+                        set_as_default_stored_instrument: null,
                         device_info: 'my_session_id',
                         paypal_account: {
                             token: 'my_tokenized_card',
@@ -220,6 +221,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 paymentData: {
                     formattedPayload: {
                         vault_payment_instrument: null,
+                        set_as_default_stored_instrument: null,
                         device_info: null,
                         paypal_account: {
                             token: 'some-nonce',
@@ -334,6 +336,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                     paymentData: {
                         formattedPayload: {
                             vault_payment_instrument: null,
+                            set_as_default_stored_instrument: null,
                             device_info: 'my_session_id',
                             paypal_account: {
                                 token: 'my_tokenized_card',
@@ -379,6 +382,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                     paymentData: {
                         formattedPayload: {
                             vault_payment_instrument: true,
+                            set_as_default_stored_instrument: null,
                             device_info: 'my_session_id',
                             paypal_account: {
                                 token: 'my_tokenized_card',
@@ -420,6 +424,55 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
                 expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+            });
+
+            it('sends set_as_default_stored_instrument set to null when vaulting and NOT making default', async () => {
+                paymentMethodMock.config.isVaultingEnabled = true;
+
+                await braintreePaypalPaymentStrategy.initialize(options);
+                await braintreePaypalPaymentStrategy.execute({
+                    payment: {
+                        methodId: 'braintreepaypal',
+                        paymentData: {
+                            shouldSaveInstrument: true,
+                        },
+                    },
+                }, options);
+
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        paymentData: {
+                            formattedPayload: expect.objectContaining({
+                                set_as_default_stored_instrument: null,
+                            }),
+                        },
+                    })
+                );
+            });
+
+            it('sends set_as_default_stored_instrument set to true when vaulting and making default', async () => {
+                paymentMethodMock.config.isVaultingEnabled = true;
+
+                await braintreePaypalPaymentStrategy.initialize(options);
+                await braintreePaypalPaymentStrategy.execute({
+                    payment: {
+                        methodId: 'braintreepaypal',
+                        paymentData: {
+                            shouldSaveInstrument: true,
+                            setAsDefaultInstrument: true,
+                        },
+                    },
+                }, options);
+
+                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        paymentData: {
+                            formattedPayload: expect.objectContaining({
+                                set_as_default_stored_instrument: true,
+                            }),
+                        },
+                    })
+                );
             });
 
             it('throws if vaulting is enabled and trying to save an instrument', async () => {

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -459,7 +459,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                         methodId: 'braintreepaypal',
                         paymentData: {
                             shouldSaveInstrument: true,
-                            setAsDefaultInstrument: true,
+                            shouldSetAsDefaultInstrument: true,
                         },
                     },
                 }, options);

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -143,14 +143,15 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             sessionId,
         ]) => ({
             ...payment,
-            paymentData: this._formattedPayload(nonce, details && details.email, sessionId, paymentData.shouldSaveInstrument),
+            paymentData: this._formattedPayload(nonce, details && details.email, sessionId, paymentData.shouldSaveInstrument, paymentData.setAsDefaultInstrument),
         }));
     }
 
-    private _formattedPayload(token: string, email?: string, sessionId?: string, vaultPaymentInstrument?: boolean): FormattedPayload<PaypalInstrument> {
+    private _formattedPayload(token: string, email?: string, sessionId?: string, vaultPaymentInstrument?: boolean, setAsDefaultInstrument?: boolean): FormattedPayload<PaypalInstrument> {
         return {
             formattedPayload: {
                 vault_payment_instrument: vaultPaymentInstrument || null,
+                set_as_default_stored_instrument: setAsDefaultInstrument || null,
                 device_info: sessionId || null,
                 paypal_account: {
                     token,

--- a/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -143,15 +143,15 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
             sessionId,
         ]) => ({
             ...payment,
-            paymentData: this._formattedPayload(nonce, details && details.email, sessionId, paymentData.shouldSaveInstrument, paymentData.setAsDefaultInstrument),
+            paymentData: this._formattedPayload(nonce, details && details.email, sessionId, paymentData.shouldSaveInstrument, paymentData.shouldSetAsDefaultInstrument),
         }));
     }
 
-    private _formattedPayload(token: string, email?: string, sessionId?: string, vaultPaymentInstrument?: boolean, setAsDefaultInstrument?: boolean): FormattedPayload<PaypalInstrument> {
+    private _formattedPayload(token: string, email?: string, sessionId?: string, vaultPaymentInstrument?: boolean, shouldSetAsDefaultInstrument?: boolean): FormattedPayload<PaypalInstrument> {
         return {
             formattedPayload: {
                 vault_payment_instrument: vaultPaymentInstrument || null,
-                set_as_default_stored_instrument: setAsDefaultInstrument || null,
+                set_as_default_stored_instrument: shouldSetAsDefaultInstrument || null,
                 device_info: sessionId || null,
                 paypal_account: {
                     token,

--- a/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
@@ -105,7 +105,7 @@ describe('OffsitePaymentStrategy', () => {
     it('initializes offsite payment flow', async () => {
         await strategy.execute(payload, options);
 
-        expect(paymentActionCreator.initializeOffsitePayment).toHaveBeenCalledWith(options.methodId, options.gatewayId, null, null);
+        expect(paymentActionCreator.initializeOffsitePayment).toHaveBeenCalledWith(options.methodId, options.gatewayId, null, null, undefined, undefined, null);
         expect(store.dispatch).toHaveBeenCalledWith(initializeOffsitePaymentAction);
     });
 

--- a/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.spec.ts
@@ -105,7 +105,10 @@ describe('OffsitePaymentStrategy', () => {
     it('initializes offsite payment flow', async () => {
         await strategy.execute(payload, options);
 
-        expect(paymentActionCreator.initializeOffsitePayment).toHaveBeenCalledWith(options.methodId, options.gatewayId, null, null, undefined, undefined, null);
+        expect(paymentActionCreator.initializeOffsitePayment).toHaveBeenCalledWith({
+            methodId: options.methodId,
+            gatewayId: options.gatewayId,
+        });
         expect(store.dispatch).toHaveBeenCalledWith(initializeOffsitePaymentAction);
     });
 

--- a/src/payment/strategies/offsite/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.ts
@@ -19,24 +19,25 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
         const { payment, ...order } = payload;
         const orderPayload = this._shouldSubmitFullPayload(payment) ? payload : order;
         const paymentData = payment && payment.paymentData;
-        const instrumentId = paymentData && (paymentData as VaultedInstrument).instrumentId;
-        const shouldSaveInstrument = paymentData && (paymentData as HostedInstrument).shouldSaveInstrument;
-        const setAsDefaultInstrument = paymentData && (paymentData as HostedInstrument).setAsDefaultInstrument;
+        const instrumentId = paymentData && (paymentData as VaultedInstrument).instrumentId || undefined;
+        const shouldSaveInstrument = paymentData && (paymentData as HostedInstrument).shouldSaveInstrument || undefined;
+        const setAsDefaultInstrument = paymentData && (paymentData as HostedInstrument).setAsDefaultInstrument || undefined;
 
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
         }
 
+        const { methodId, gatewayId } = payment;
+
         return this._store.dispatch(this._orderActionCreator.submitOrder(orderPayload, options))
             .then(() =>
-                this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment(
-                    payment.methodId,
-                    payment.gatewayId,
+            this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment({
+                    methodId,
+                    gatewayId,
                     instrumentId,
                     shouldSaveInstrument,
-                    undefined,
-                    undefined,
-                    setAsDefaultInstrument))
+                    setAsDefaultInstrument,
+                }))
             );
     }
 

--- a/src/payment/strategies/offsite/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.ts
@@ -21,6 +21,7 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
         const paymentData = payment && payment.paymentData;
         const instrumentId = paymentData && (paymentData as VaultedInstrument).instrumentId;
         const shouldSaveInstrument = paymentData && (paymentData as HostedInstrument).shouldSaveInstrument;
+        const setAsDefaultInstrument = paymentData && (paymentData as HostedInstrument).setAsDefaultInstrument;
 
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
@@ -32,7 +33,10 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
                     payment.methodId,
                     payment.gatewayId,
                     instrumentId,
-                    shouldSaveInstrument))
+                    shouldSaveInstrument,
+                    undefined,
+                    undefined,
+                    setAsDefaultInstrument))
             );
     }
 

--- a/src/payment/strategies/offsite/offsite-payment-strategy.ts
+++ b/src/payment/strategies/offsite/offsite-payment-strategy.ts
@@ -21,7 +21,7 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
         const paymentData = payment && payment.paymentData;
         const instrumentId = paymentData && (paymentData as VaultedInstrument).instrumentId || undefined;
         const shouldSaveInstrument = paymentData && (paymentData as HostedInstrument).shouldSaveInstrument || undefined;
-        const setAsDefaultInstrument = paymentData && (paymentData as HostedInstrument).setAsDefaultInstrument || undefined;
+        const shouldSetAsDefaultInstrument = paymentData && (paymentData as HostedInstrument).shouldSetAsDefaultInstrument || undefined;
 
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
@@ -36,7 +36,7 @@ export default class OffsitePaymentStrategy implements PaymentStrategy {
                     gatewayId,
                     instrumentId,
                     shouldSaveInstrument,
-                    setAsDefaultInstrument,
+                    shouldSetAsDefaultInstrument,
                 }))
             );
     }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -100,6 +100,7 @@ describe('PaypalCommercePaymentStrategy', () => {
                 paymentData: {
                     formattedPayload: {
                         vault_payment_instrument: null,
+                        set_as_default_stored_instrument: null,
                         device_info: null,
                         paypal_account: {
                             order_id: paymentMethod.initializationData.orderId,

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -38,6 +38,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         const paymentData =  {
             formattedPayload: {
                 vault_payment_instrument: null,
+                set_as_default_stored_instrument: null,
                 device_info: null,
                 paypal_account: {
                     order_id: orderId,

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -267,7 +267,7 @@ describe('StripeV3PaymentStrategy', () => {
                     methodId: 'stripev3',
                     paymentData: {
                         instrumentId: 'token',
-                        setAsDefaultInstrument: true,
+                        shouldSetAsDefaultInstrument: true,
                     },
                 },
             };
@@ -280,7 +280,7 @@ describe('StripeV3PaymentStrategy', () => {
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
                 expect.objectContaining({
                     paymentData: expect.objectContaining({
-                        setAsDefaultInstrument: true,
+                        shouldSetAsDefaultInstrument: true,
                     }),
                 })
             );

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -261,6 +261,31 @@ describe('StripeV3PaymentStrategy', () => {
             }
         });
 
+        it('passes on the "make default" flag when submitting payment with a stored instrument', async () => {
+            const payload = {
+                payment: {
+                    methodId: 'stripev3',
+                    paymentData: {
+                        instrumentId: 'token',
+                        setAsDefaultInstrument: true,
+                    },
+                },
+            };
+
+            jest.spyOn(stripeScriptLoader, 'load').mockReturnValue(Promise.resolve(stripeV3JsMock));
+
+            await strategy.initialize(options);
+            await strategy.execute(payload);
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paymentData: expect.objectContaining({
+                        setAsDefaultInstrument: true,
+                    }),
+                })
+            );
+        });
+
         it('creates the order and submit payment with alipay', async () => {
             paymentMethodMock = { ...getStripeV3(StripeElementType.Alipay), clientToken: 'myToken' };
             loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: `stripev3?method=${paymentMethodMock.id }`}));

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -53,7 +53,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         }
 
         const { paymentData, gatewayId, methodId } = payment;
-        const { shouldSaveInstrument = false, setAsDefaultInstrument = false } = paymentData as HostedInstrument;
+        const { shouldSaveInstrument = false, shouldSetAsDefaultInstrument = false } = paymentData as HostedInstrument;
         await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
         if (isVaultedInstrument(paymentData)) {
@@ -89,7 +89,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                     ...paymentData,
                     nonce: paymentIntent.id,
                     shouldSaveInstrument,
-                    setAsDefaultInstrument,
+                    shouldSetAsDefaultInstrument,
                 },
             };
         }

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -53,7 +53,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         }
 
         const { paymentData, gatewayId, methodId } = payment;
-        const { shouldSaveInstrument = false } = paymentData as HostedInstrument;
+        const { shouldSaveInstrument = false, setAsDefaultInstrument = false } = paymentData as HostedInstrument;
         await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
         if (isVaultedInstrument(paymentData)) {
@@ -89,6 +89,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                     ...paymentData,
                     nonce: paymentIntent.id,
                     shouldSaveInstrument,
+                    setAsDefaultInstrument,
                 },
             };
         }


### PR DESCRIPTION
…g vaulting or vaulted payments

## What?
Refactoring the silly signature of `initializeOffsitePayment` to make it more extensible. (arguably should have been in a different PR)

Adding support for a new `setAsDefaultInstrument` field for vaulted and vault-able payloads

## Why?
To allow for vaulted instruments to be set set as the default during payment

## Testing / Proof
Unit and manual

@bigcommerce/checkout @bigcommerce/payments
