### PR TITLE
feat(payment): PAYPAL-483 Pass merchant ID on PayPal button for PPCP

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -119,7 +119,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
     }
 
     private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart): PaypalCommerceScriptOptions {
-        const { clientId, intent, isPayPalCreditAvailable } = initializationData;
+        const { clientId, intent, isPayPalCreditAvailable, merchantId } = initializationData;
         const disableFunding: DisableFundingType = [ 'card' ];
 
         if (!isPayPalCreditAvailable) {
@@ -128,6 +128,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
 
         return {
             clientId,
+            merchantId,
             commit: false,
             currency: cart.currency.code,
             disableFunding,

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -29,6 +29,7 @@ describe('PaypalCommerceScriptLoader', () => {
     describe('loads PayPalCommerce script with client Id, currency EUR, intent, disableFunding, commit', () => {
         const options: PaypalCommerceScriptOptions = {
             clientId: 'aaa',
+            merchantId: 'bbb',
             currency: 'EUR',
             disableFunding: ['credit', 'card'],
             intent: 'capture',
@@ -59,6 +60,7 @@ describe('PaypalCommerceScriptLoader', () => {
     describe('loads PayPalCommerce script with client Id and currency USD',  () => {
         const options: PaypalCommerceScriptOptions = {
             clientId: 'aaa',
+            merchantId: 'bbb',
             currency: 'USD',
         };
 
@@ -86,7 +88,15 @@ describe('PaypalCommerceScriptLoader', () => {
 
     it('throw error without client Id', async () => {
         try {
-            await paypalLoader.loadPaypalCommerce({ clientId: '', currency: 'USD' });
+            await paypalLoader.loadPaypalCommerce({ clientId: '', merchantId: 'bbb', currency: 'USD' });
+        } catch (error) {
+            expect(error).toEqual( new InvalidArgumentError());
+        }
+    });
+
+    it('throw error without merchant Id', async () => {
+        try {
+            await paypalLoader.loadPaypalCommerce({ clientId: 'aaa', merchantId: '', currency: 'USD' });
         } catch (error) {
             expect(error).toEqual( new InvalidArgumentError());
         }
@@ -101,7 +111,7 @@ describe('PaypalCommerceScriptLoader', () => {
             });
 
         try {
-            await paypalLoader.loadPaypalCommerce({ clientId: 'aaa', currency: 'USD' });
+            await paypalLoader.loadPaypalCommerce({ clientId: 'aaa', merchantId: 'bbb', currency: 'USD' });
         } catch (error) {
             expect(error).toEqual(expectedError);
         }
@@ -116,7 +126,7 @@ describe('PaypalCommerceScriptLoader', () => {
             });
 
         try {
-            await paypalLoader.loadPaypalCommerce({clientId: 'aaa', currency: 'EUR'});
+            await paypalLoader.loadPaypalCommerce({clientId: 'aaa', merchantId: 'bbb', currency: 'EUR'});
         } catch (error) {
             expect(error).toEqual(new PaymentMethodClientUnavailableError());
         }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -16,7 +16,7 @@ export default class PaypalCommerceScriptLoader {
     }
 
     async loadPaypalCommerce(options: PaypalCommerceScriptOptions): Promise<PaypalCommerceSDK> {
-        if (!options || !options.clientId) {
+        if (!options || !options.clientId || !options.merchantId) {
             throw new InvalidArgumentError();
         }
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -81,6 +81,7 @@ export interface PaypalCommerceHostWindow extends Window {
 
 export interface PaypalCommerceInitializationData {
     clientId: string;
+    merchantId: string;
     intent?: 'capture' | 'authorize';
     isPayPalCreditAvailable?: boolean;
 }
@@ -89,6 +90,7 @@ export type DisableFundingType = Array<'credit' | 'card'>;
 
 export interface PaypalCommerceScriptOptions {
     clientId: string;
+    merchantId: string;
     currency?: string;
     commit?: boolean;
     intent?: 'capture' | 'authorize';


### PR DESCRIPTION
## What?
Pass merchant ID on PayPal button for PPCP

## Why?
This is needed so that the PayPal Shopping feature knows which merchants to target for PayPal Store Cash

## Testing / Proof
<img width="1122" alt="Screen Shot 2020-06-09 at 5 51 30 PM" src="https://user-images.githubusercontent.com/32959076/84163209-e3edd200-aa79-11ea-8ac3-dd385714c980.png">


@bigcommerce/checkout @bigcommerce/payments
