### PR TITLE
feat(common): ORDERS-3323 Ensure coupon codes are upper case.

### DIFF
--- a/src/analytics/analytics-step-tracker.spec.ts
+++ b/src/analytics/analytics-step-tracker.spec.ts
@@ -127,7 +127,7 @@ describe('AnalyticsStepTracker', () => {
             expect(analytics.track).toHaveBeenCalledWith(
                 'Checkout Started',
                 expect.objectContaining({
-                    coupon: 'savebig2015,279F507D817E3E7',
+                    coupon: 'SAVEBIG2015,279F507D817E3E7',
                 })
             );
         });
@@ -256,7 +256,7 @@ describe('AnalyticsStepTracker', () => {
                 expect(analytics.track).toHaveBeenCalledWith(
                     'Order Completed',
                     expect.objectContaining({
-                        coupon: 'savebig2015,279F507D817E3E7',
+                        coupon: 'SAVEBIG2015,279F507D817E3E7',
                     })
                 );
             });

--- a/src/analytics/analytics-step-tracker.ts
+++ b/src/analytics/analytics-step-tracker.ts
@@ -257,7 +257,7 @@ export default class AnalyticsStepTracker implements StepTracker {
             shipping: this.toShopperCurrency(shipping),
             tax: this.toShopperCurrency(tax),
             discount: this.toShopperCurrency(discount),
-            coupon: (coupons || []).map(coupon => coupon.code).join(','),
+            coupon: (coupons || []).map(coupon => coupon.code.toUpperCase()).join(','),
             currency: code,
             products: this.getProducts(extraItemsData, lineItems),
         };


### PR DESCRIPTION
## What?
Convert coupon codes to upper case before sending to analytics.

## Why?
Coupon codes are case insensitive, so `foo` and `FOO` are handled the same by our system, but are being counted as unique entries by downstream analytics consumers, confusing merchants.

## Testing / Proof
Unit test updated.

@bigcommerce/checkout @bigcommerce/orders 
