### PR TITLE
fix(payment): INT-2759 Do not mount GiroPay component while initializing payment strategy

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -158,16 +158,6 @@ describe('AdyenV2PaymentStrategy', () => {
                     .rejects.toThrow(NotInitializedError);
             });
 
-            it('fails mounting GiroPay payment component', async () => {
-                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
-                    .mockReturnValue(getAdyenV2(AdyenPaymentMethodType.GiroPay));
-
-                paymentComponent = getFailingComponent();
-
-                await expect(strategy.initialize(options))
-                    .rejects.toThrow(NotInitializedError);
-            });
-
             it('fails mounting card verification component', async () => {
                 cardVerificationComponent = getFailingComponent();
 
@@ -178,6 +168,15 @@ describe('AdyenV2PaymentStrategy', () => {
             it('does not call adyenCheckout.create when initializing AliPay', async () => {
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValue(getAdyenV2(AdyenPaymentMethodType.AliPay));
+
+                await strategy.initialize(options);
+
+                expect(adyenCheckout.create).not.toBeCalled();
+            });
+
+            it('does not call adyenCheckout.create when initializing GiroPay', async () => {
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValue(getAdyenV2(AdyenPaymentMethodType.GiroPay));
 
                 await strategy.initialize(options);
 
@@ -322,10 +321,10 @@ describe('AdyenV2PaymentStrategy', () => {
 
             it('calls submit payment with SEPA component', async () => {
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
-                    .mockReturnValue(getAdyenV2(AdyenPaymentMethodType.GiroPay));
+                    .mockReturnValue(getAdyenV2(AdyenPaymentMethodType.SEPA));
 
                 await strategy.initialize(options);
-                await strategy.execute(getOrderRequestBody(AdyenPaymentMethodType.GiroPay));
+                await strategy.execute(getOrderRequestBody(AdyenPaymentMethodType.SEPA));
 
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledTimes(1);
                 expect(adyenCheckout.create).toHaveBeenCalledTimes(1);

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -258,7 +258,6 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
 
                     break;
 
-                case AdyenPaymentMethodType.GiroPay:
                 case AdyenPaymentMethodType.iDEAL:
                 case AdyenPaymentMethodType.SEPA:
                     if (!adyenv2.hasVaultedInstruments) {
@@ -286,6 +285,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                     break;
 
                 case AdyenPaymentMethodType.AliPay:
+                case AdyenPaymentMethodType.GiroPay:
                 case AdyenPaymentMethodType.Sofort:
                 case AdyenPaymentMethodType.Vipps:
                 case AdyenPaymentMethodType.WeChatPayQR:


### PR DESCRIPTION
## What? [INT-2759](https://jira.bigcommerce.com/browse/INT-2759)
Edited the order on the switch of the initialization for the APM's for Adyen v2, because GiroPay needed to be initializated as AliPay does to not show the Button on the checkout page and just select GyroPay and click Place order

## Why?
to initialize Giropay correctly and can pay with it

![image](https://user-images.githubusercontent.com/42655796/84424170-4f07e780-abe5-11ea-93ed-d6a8901428cb.png)


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
