### PR TITLE
feat(payments): INT-2748 Adding sezzle strategy

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -34,10 +34,10 @@ import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
+import { ExternalPaymentStrategy } from './strategies/external';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
 import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
-import { LaybuyPaymentStrategy } from './strategies/laybuy';
 import { LegacyPaymentStrategy } from './strategies/legacy';
 import { MasterpassPaymentStrategy, MasterpassScriptLoader } from './strategies/masterpass';
 import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
@@ -478,7 +478,16 @@ export default function createPaymentStrategyRegistry(
     );
 
     registry.register(PaymentStrategyType.LAYBUY, () =>
-        new LaybuyPaymentStrategy(
+        new ExternalPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formPoster
+        )
+    );
+
+    registry.register(PaymentStrategyType.SEZZLE, () =>
+        new ExternalPaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -45,6 +45,7 @@ enum PaymentStrategyType {
     WE_PAY = 'wepay',
     MASTERPASS = 'masterpass',
     STRIPE_GOOGLE_PAY = 'googlepaystripe',
+    SEZZLE = 'sezzle',
     ZIP = 'zip',
     CONVERGE = 'converge',
 }

--- a/src/payment/strategies/external/external-payment-strategy.spec.ts
+++ b/src/payment/strategies/external/external-payment-strategy.spec.ts
@@ -21,16 +21,16 @@ import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
 
-import LaybuyPaymentStrategy from './laybuy-payment-strategy';
+import ExternalPaymentStrategy from './external-payment-strategy';
 
-describe('LaybuyPaymentStrategy', () => {
+describe('ExternalPaymentStrategy', () => {
     let finalizeOrderAction: Observable<FinalizeOrderAction>;
     let formPoster: FormPoster;
     let orderActionCreator: OrderActionCreator;
     let paymentActionCreator: PaymentActionCreator;
     let store: CheckoutStore;
     let orderRequestSender: OrderRequestSender;
-    let strategy: LaybuyPaymentStrategy;
+    let strategy: ExternalPaymentStrategy;
     let submitOrderAction: Observable<SubmitOrderAction>;
     let submitPaymentAction: Observable<SubmitPaymentAction>;
 
@@ -69,7 +69,7 @@ describe('LaybuyPaymentStrategy', () => {
         jest.spyOn(paymentActionCreator, 'submitPayment')
             .mockReturnValue(submitPaymentAction);
 
-        strategy = new LaybuyPaymentStrategy(
+        strategy = new ExternalPaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,

--- a/src/payment/strategies/external/external-payment-strategy.ts
+++ b/src/payment/strategies/external/external-payment-strategy.ts
@@ -9,7 +9,7 @@ import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-export default class LaybuyPaymentStrategy implements PaymentStrategy {
+export default class ExternalPaymentStrategy implements PaymentStrategy {
 
     constructor(
         private _store: CheckoutStore,

--- a/src/payment/strategies/external/index.ts
+++ b/src/payment/strategies/external/index.ts
@@ -1,0 +1,1 @@
+export { default as ExternalPaymentStrategy } from './external-payment-strategy';

--- a/src/payment/strategies/laybuy/index.ts
+++ b/src/payment/strategies/laybuy/index.ts
@@ -1,1 +1,0 @@
-export { default as LaybuyPaymentStrategy } from './laybuy-payment-strategy';


### PR DESCRIPTION
## What?  [INT-2748](https://jira.bigcommerce.com/browse/INT-2748)
Adding sezzle payment in the registry as external payment 

## Why?
It does a laybuy's refactoring because sezzle and laybuy are similar and both are mapped as external payments, it's required to support sezzle, using the same strategy

## Testing / Proof
<img width="1680" alt="sezzle" src="https://user-images.githubusercontent.com/4907027/84797561-94e6f600-afbf-11ea-8e2e-48c38232b2f8.png">


@bigcommerce/checkout @bigcommerce/payments
@bigcommerce/apex-integrations