### PR TITLE
docs(payment): INT-2119 Add the @alpha modifier to AmazonPayV2

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -21,6 +21,7 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
     /**
      * The options that are required to facilitate AmazonPayV2. They can be
      * omitted unless you need to support AmazonPayV2.
+     * @alpha
      */
     amazonpay?: AmazonPayV2ButtonInitializeOptions;
 

--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -19,8 +19,8 @@ export interface CheckoutButtonOptions extends RequestOptions {
 
 export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
     /**
-     * The options that are required to facilitate Amazon Pay v2. They can be
-     * omitted unless you need to support Amazon Pay v2.
+     * The options that are required to facilitate AmazonPayV2. They can be
+     * omitted unless you need to support AmazonPayV2.
      */
     amazonpay?: AmazonPayV2ButtonInitializeOptions;
 

--- a/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
+++ b/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
@@ -2,5 +2,9 @@ import { AmazonPayV2ButtonParams } from '../../../payment/strategies/amazon-pay-
 
 export interface AmazonPayV2ButtonInitializeOptions {
     containerId: string;
+
+    /**
+     * A set of options to render the AmazonPayV2 checkout button.
+     */
     options: AmazonPayV2ButtonParams;
 }

--- a/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
+++ b/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
@@ -1,10 +1,14 @@
 import { AmazonPayV2ButtonParams } from '../../../payment/strategies/amazon-pay-v2';
 
 export interface AmazonPayV2ButtonInitializeOptions {
+    /**
+     * @alpha
+     */
     containerId: string;
 
     /**
      * A set of options to render the AmazonPayV2 checkout button.
+     * @alpha
      */
     options: AmazonPayV2ButtonParams;
 }

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -1,4 +1,7 @@
 enum CheckoutButtonMethodType {
+    /**
+     * @alpha
+     */
     AMAZON_PAY_V2 = 'amazonpay',
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -38,6 +38,7 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
     /**
      * The options that are required to initialize the customer step of checkout
      * when using AmazonPayV2.
+     * @alpha
      */
     amazonpay?: AmazonPayV2CustomerInitializeOptions;
 

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -37,7 +37,7 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
 
     /**
      * The options that are required to initialize the customer step of checkout
-     * when using Amazon Pay v2.
+     * when using AmazonPayV2.
      */
     amazonpay?: AmazonPayV2CustomerInitializeOptions;
 

--- a/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-initialize-options.ts
+++ b/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-initialize-options.ts
@@ -9,6 +9,7 @@
 export default interface AmazonPayV2CustomerInitializeOptions {
     /**
      * The ID of a container which the sign-in button should insert into.
+     * @alpha
      */
     container: string;
 }

--- a/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-initialize-options.ts
+++ b/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-initialize-options.ts
@@ -1,7 +1,14 @@
+/**
+ * A set of options that are required to initialize the customer step of
+ * checkout in order to support AmazonPayV2.
+ *
+ * When AmazonPayV2 is initialized, a sign-in button will be inserted into the
+ * DOM. When the customer clicks on it, they will be redirected to Amazon to
+ * sign in.
+ */
 export default interface AmazonPayV2CustomerInitializeOptions {
     /**
-     * This container is used to set an event listener, provide an element ID if you want
-     * users to be able to launch the AmazonPayV2 modal by clicking on a button.
+     * The ID of a container which the sign-in button should insert into.
      */
     container: string;
 }

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -25,6 +25,7 @@ export interface PaymentRequestOptions extends RequestOptions {
      * The identifier of the payment method.
      */
     methodId: string;
+
     /**
      * The identifier of the payment provider providing the payment method. This
      * option is only required if the provider offers multiple payment options.
@@ -59,7 +60,7 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
     amazon?: AmazonPayPaymentInitializeOptions;
 
     /**
-     * The options that are required to initialize the Amazon Pay payment
+     * The options that are required to initialize the AmazonPayV2 payment
      * method. They can be omitted unless you need to support AmazonPayV2.
      */
     amazonpay?: AmazonPayV2PaymentInitializeOptions;

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -62,6 +62,7 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
     /**
      * The options that are required to initialize the AmazonPayV2 payment
      * method. They can be omitted unless you need to support AmazonPayV2.
+     * @alpha
      */
     amazonpay?: AmazonPayV2PaymentInitializeOptions;
 

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -5,6 +5,9 @@ enum PaymentStrategyType {
     AFTERPAY = 'afterpay',
     AMAZON = 'amazon',
     AUTHORIZENET_GOOGLE_PAY = 'googlepayauthorizenet',
+    /**
+     * @alpha
+     */
     AMAZONPAYV2 = 'amazonpay',
     BLUESNAPV2 = 'bluesnapv2',
     BOLT = 'bolt',

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-initialize-options.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-initialize-options.ts
@@ -1,8 +1,16 @@
+/**
+ * A set of options that are required to initialize the payment step of
+ * checkout in order to support AmazonPayV2.
+ *
+ * When AmazonPayV2 is initialized, a change payment button will be bound.
+ * When the customer clicks on it, they will be redirected to Amazon to
+ * select a different payment method.
+ */
 export default interface AmazonPayV2PaymentInitializeOptions {
     /**
-     * This editButtonId is used to set an event listener, provide an element ID if you want
-     * users to be able to select a different payment method by clicking on a button.
-     * It should be an HTML element.
+     * This editButtonId is used to set an event listener, provide an element ID
+     * if you want users to be able to select a different payment method by
+     * clicking on a button. It should be an HTML element.
      */
     editButtonId?: string;
 }

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-initialize-options.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-initialize-options.ts
@@ -11,6 +11,7 @@ export default interface AmazonPayV2PaymentInitializeOptions {
      * This editButtonId is used to set an event listener, provide an element ID
      * if you want users to be able to select a different payment method by
      * clicking on a button. It should be an HTML element.
+     * @alpha
      */
     editButtonId?: string;
 }

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -18,6 +18,9 @@ export interface AmazonPayV2HostWindow extends Window {
     amazon?: AmazonPayV2SDK;
 }
 
+/**
+ * @alpha
+ */
 export interface AmazonPayV2ButtonParams {
     merchantId: string;
     createCheckoutSession: AmazonPayV2CheckoutSession;
@@ -28,6 +31,9 @@ export interface AmazonPayV2ButtonParams {
     sandbox?: boolean;
 }
 
+/**
+ * @alpha
+ */
 export interface AmazonPayV2CheckoutSession {
     url: string;
     method?: string;
@@ -48,6 +54,9 @@ export enum AmazonPayV2Regions {
     us = 'na',
 }
 
+/**
+ * @alpha
+ */
 export enum AmazonPayV2CheckoutLanguage {
     es_ES = 'es_ES',
     en_GB = 'en_GB',
@@ -58,6 +67,9 @@ export enum AmazonPayV2CheckoutLanguage {
     ja_JP = 'ja_JP',
 }
 
+/**
+ * @alpha
+ */
 export enum AmazonPayV2Placement {
     Home = 'Home',
     Product = 'Product',
@@ -66,6 +78,9 @@ export enum AmazonPayV2Placement {
     Other = 'Other',
 }
 
+/**
+ * @alpha
+ */
 export enum AmazonPayV2LedgerCurrency {
     eu = 'EUR',
     jp = 'JPY',

--- a/src/shipping/shipping-request-options.ts
+++ b/src/shipping/shipping-request-options.ts
@@ -36,6 +36,7 @@ export interface ShippingInitializeOptions<T = {}> extends ShippingRequestOption
     /**
      * The options that are required to initialize the shipping step of checkout
      * when using AmazonPayV2.
+     * @alpha
      */
     amazonpay?: AmazonPayV2ShippingInitializeOptions;
 }

--- a/src/shipping/shipping-request-options.ts
+++ b/src/shipping/shipping-request-options.ts
@@ -32,9 +32,10 @@ export interface ShippingInitializeOptions<T = {}> extends ShippingRequestOption
      * when using Amazon Pay.
      */
     amazon?: AmazonPayShippingInitializeOptions;
+
     /**
-     * The options that are required to initialize the edit button and shipping step
-     * when using Amazon Pay v2.
+     * The options that are required to initialize the shipping step of checkout
+     * when using AmazonPayV2.
      */
     amazonpay?: AmazonPayV2ShippingInitializeOptions;
 }

--- a/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-initialize-options.ts
+++ b/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-initialize-options.ts
@@ -11,6 +11,7 @@ export default interface AmazonPayV2ShippingInitializeOptions {
      * This editAddressButtonId is used to set an event listener, provide an
      * element ID if you want users to be able to select a different shipping
      * address by clicking on a button. It should be an HTML element.
+     * @alpha
      */
     editAddressButtonId?: string;
 }

--- a/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-initialize-options.ts
+++ b/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-initialize-options.ts
@@ -1,12 +1,16 @@
 /**
  * A set of options that are required to initialize the shipping step of
- * checkout in order to support Amazon Pay V2.
+ * checkout in order to support AmazonPayV2.
+ *
+ * When AmazonPayV2 is initialized, a change shipping button will be bound.
+ * When the customer clicks on it, they will be redirected to Amazon to
+ * select a different shipping address.
  */
 export default interface AmazonPayV2ShippingInitializeOptions {
     /**
-     * This editAddressButtonId is used to set an event listener, provide an element ID if you want
-     * users to be able to select a different shipping address by clicking on a button.
-     * It should be an HTML element.
+     * This editAddressButtonId is used to set an event listener, provide an
+     * element ID if you want users to be able to select a different shipping
+     * address by clicking on a button. It should be an HTML element.
      */
     editAddressButtonId?: string;
 }


### PR DESCRIPTION
## What?
- Improved documentation.
- Added the `@alpha` modifier to all the new introduced params.

## Why?
To indicate that Amazon Pay V2 is in an early stage of development.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
