### PR TITLE
feat(payments): PAYPAL-508 Mark up flow additional params

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -63,7 +63,8 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
     private async _getOrderId(methodId: string): Promise<string> {
         const state = this._store.getState();
         const cart = state.cart.getCartOrThrow();
-        const { approveUrl, orderId } = await this._paypalCommerceRequestSender.setupPayment(methodId, cart.id);
+        const provider = methodId === 'paypalcommercecredit' ? 'paypalcommercecreditcheckout' : 'paypalcommercecheckout';
+        const { approveUrl, orderId } = await this._paypalCommerceRequestSender.setupPayment(provider, cart.id);
 
         if (approveUrl) {
             await this._paypalCommercePaymentProcessor.paymentPayPal(approveUrl);


### PR DESCRIPTION
## What?
Mark up flow additional params

## Why?
As we do not use PayPal SDK on the front end on markup flow, we do not pass commit=true in SDK params, but PayPal backend still needs to know which mode are going with, in order to show buyer proper info on PayPal side.

## Testing / Proof
<img width="1669" alt="Screen Shot 2020-06-25 at 1 14 26 PM" src="https://user-images.githubusercontent.com/32959076/85701217-d4ab8d00-b6e5-11ea-8fb2-c25e015bf536.png">


@bigcommerce/checkout @bigcommerce/payments
