### PR TITLE
CHECKOUT-4995: Pass additional action data to hosted forms

### DIFF
--- a/src/payment/payment-request-transformer.spec.ts
+++ b/src/payment/payment-request-transformer.spec.ts
@@ -166,6 +166,37 @@ describe('PaymentRequestTransformer', () => {
             });
     });
 
+    it('transforms from hosted form data with additional data', () => {
+        const additionalAction = {
+            type: 'recaptcha_v2_verification',
+            data: {
+                human_verification_token: 'googleRecaptchaToken',
+            },
+        };
+
+        const result = paymentRequestTransformer.transformWithHostedFormData(
+            {
+                [HostedFieldType.CardNumber]: '4111 1111 1111 1111',
+                [HostedFieldType.CardCode]: '123',
+                [HostedFieldType.CardName]: 'BigCommerce',
+                [HostedFieldType.CardExpiry]: '10 / 20',
+            },
+            {
+                ...getHostedFormOrderData(),
+                additionalAction,
+            },
+            'nonce'
+        );
+
+        expect(result)
+            .toEqual(merge({}, getPaymentRequestBody(), {
+                additionalAction,
+                payment: {
+                    hostedFormNonce: 'nonce',
+                },
+            }));
+    });
+
     it('returns additinalAction within request if provided in payment parameter', () => {
         const additionalActionMock = {
             type: 'recaptcha_v2_verification',

--- a/src/payment/payment-request-transformer.ts
+++ b/src/payment/payment-request-transformer.ts
@@ -73,12 +73,13 @@ export default class PaymentRequestTransformer {
     }
 
     transformWithHostedFormData(values: HostedInputValues, data: HostedFormOrderData, nonce: string): PaymentRequestBody {
-        const { authToken, checkout, config, order, orderMeta, payment = {}, paymentMethod, paymentMethodMeta } = data;
+        const { additionalAction, authToken, checkout, config, order, orderMeta, payment = {}, paymentMethod, paymentMethodMeta } = data;
         const consignment = checkout && checkout.consignments[0];
         const shippingAddress = consignment && consignment.shippingAddress;
         const shippingOption = consignment && consignment.selectedShippingOption;
 
         return {
+            additionalAction,
             authToken,
             paymentMethod: paymentMethod && this._transformPaymentMethod(paymentMethod),
             customer: order && order.billingAddress && checkout && mapToInternalCustomer(checkout.customer, order.billingAddress),


### PR DESCRIPTION
## What?
Pass additional action data to hosted forms.

## Why?
We're not passing it to the form at the moment. If it's not passed, it can't be sent to complete the human verification process.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
