### PR TITLE
feat(payment): PAYPAL-522 Reopen automatically PayPal popup

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -87,9 +87,9 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         try {
             return await this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment }));
         } catch (error) {
-            const isNotTransactionRejected = !(error instanceof RequestError) || !some(error.body.errors, {code: 'transaction_rejected'});
+            const isInsufficientFundsError = (error instanceof RequestError) && some(error.body.errors, {code: 'transaction_rejected'});
 
-            if (isNotTransactionRejected || attempts > 2) {
+            if (!isInsufficientFundsError || attempts > 2) {
                 return Promise.reject(error);
             }
 


### PR DESCRIPTION
## What?
Reopen automatically PayPal popup on the Checkout page when purchase request is failing
The goal is to handle a scenario when there is not enough money on a Buyer's account/credit card. Popup should be opened automatically no more than 3 times. When purchase fails the 3rd time then front-end should show an error message 

## Why?
The goal is to handle a scenario when there is not enough money on a Buyer's account/credit card

## Testing / Proof
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/32959076/86581068-3db5bf00-bf88-11ea-952d-6133cb0bd7f8.gif)


@bigcommerce/checkout @bigcommerce/payments
