### PR TITLE
feat(payment): PAYPAL-539 MerchantId does not required 

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -86,17 +86,25 @@ describe('PaypalCommerceScriptLoader', () => {
         });
     });
 
+    it('do not add merchant Id if it is null', async () => {
+        const options: PaypalCommerceScriptOptions = { clientId: 'aaa', merchantId: undefined };
+
+        jest.spyOn(loader, 'loadScript')
+            .mockImplementation((url: string) => {
+                (window as PaypalCommerceHostWindow).paypal = paypal;
+
+                expect(url).toEqual(expect.stringContaining('client-id=aaa'));
+                expect(url).not.toEqual(expect.stringContaining('merchant-id=undefined'));
+
+                return Promise.resolve();
+            });
+
+        await paypalLoader.loadPaypalCommerce(options);
+    });
+
     it('throw error without client Id', async () => {
         try {
             await paypalLoader.loadPaypalCommerce({ clientId: '', merchantId: 'bbb', currency: 'USD' });
-        } catch (error) {
-            expect(error).toEqual( new InvalidArgumentError());
-        }
-    });
-
-    it('throw error without merchant Id', async () => {
-        try {
-            await paypalLoader.loadPaypalCommerce({ clientId: 'aaa', merchantId: '', currency: 'USD' });
         } catch (error) {
             expect(error).toEqual( new InvalidArgumentError());
         }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -1,5 +1,5 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
-import { kebabCase } from 'lodash';
+import { isNil, kebabCase } from 'lodash';
 
 import { InvalidArgumentError } from '../../../common/error/errors';
 import { PaymentMethodClientUnavailableError } from '../../errors';
@@ -16,7 +16,7 @@ export default class PaypalCommerceScriptLoader {
     }
 
     async loadPaypalCommerce(options: PaypalCommerceScriptOptions): Promise<PaypalCommerceSDK> {
-        if (!options || !options.clientId || !options.merchantId) {
+        if (!options || !options.clientId) {
             throw new InvalidArgumentError();
         }
 
@@ -26,6 +26,7 @@ export default class PaypalCommerceScriptLoader {
             : options;
 
         const params = (Object.keys(updatedOptions) as Array<keyof PaypalCommerceScriptOptions>)
+            .filter(key => !isNil(options[key]))
             .map(key => `${kebabCase(key)}=${options[key]}`)
             .join('&');
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -81,7 +81,7 @@ export interface PaypalCommerceHostWindow extends Window {
 
 export interface PaypalCommerceInitializationData {
     clientId: string;
-    merchantId: string;
+    merchantId?: string;
     intent?: 'capture' | 'authorize';
     isPayPalCreditAvailable?: boolean;
 }
@@ -90,7 +90,7 @@ export type DisableFundingType = Array<'credit' | 'card'>;
 
 export interface PaypalCommerceScriptOptions {
     clientId: string;
-    merchantId: string;
+    merchantId?: string;
     currency?: string;
     commit?: boolean;
     intent?: 'capture' | 'authorize';


### PR DESCRIPTION

## What?
MerchantId does not required for progressive onboarding
Added filter for options for paypal script, because script doesn't work if option is null or undefined 

## Why?
It will be new implementation for progressive onboarding

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments
