### PR TITLE
fix(shipping): INT-2832 Handle custom fields for AmazonPayV2

### DIFF
--- a/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.ts
+++ b/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.ts
@@ -1,6 +1,7 @@
 import { noop } from 'rxjs';
 
 import { ConsignmentActionCreator, ShippingStrategyActionCreator } from '../..';
+import { AddressRequestBody } from '../../../address';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
@@ -19,8 +20,21 @@ export default class AmazonPayV2ShippingStrategy implements ShippingStrategy {
         private _shippingStrategyActionCreator: ShippingStrategyActionCreator
     ) {}
 
-    updateAddress(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
+    updateAddress(address: AddressRequestBody, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {
+        const shippingAddress = this._store.getState().shippingAddress.getShippingAddress();
+
+        if (!shippingAddress) {
+            throw new MissingDataError(MissingDataErrorType.MissingShippingAddress);
+        }
+
+        const updateAddressRequestBody = {
+            ...shippingAddress,
+            customFields: address.customFields,
+        };
+
+        return this._store.dispatch(
+            this._consignmentActionCreator.updateAddress(updateAddressRequestBody, options)
+        );
     }
 
     selectOption(optionId: string, options?: ShippingRequestOptions): Promise<InternalCheckoutSelectors> {


### PR DESCRIPTION
## What? [INT-2832](https://jira.bigcommerce.com/browse/INT-2832)
Provide support to save custom fields for the shipping address when using Amazon Pay V2.

## Why?
Because it's not possible to place the order using AmazonPayV2 with custom address fields defined by merchants. Almost the same as #793.

## Testing / Proof
CircleCI

## Dependencies
[checkout-js/pull/333](https://github.com/bigcommerce/checkout-js/pull/333) depends on this PR.

@bigcommerce/checkout @bigcommerce/payments
