### PR TITLE
CHECKOUT-5025: Fix Elavon Converge strategy so that it can utilise hosted payment form

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -473,6 +473,7 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
+            hostedFormFactory,
             formPoster
         )
     );

--- a/src/payment/strategies/converge/converge-payment-strategy.spec.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.spec.ts
@@ -10,6 +10,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutVali
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
+import { HostedFormFactory } from '../../../hosted-form';
 import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
@@ -21,12 +22,14 @@ import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import * as paymentStatusTypes from '../../payment-status-types';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
+import { CreditCardPaymentStrategy } from '../credit-card';
 
 import ConvergePaymentStrategy from './converge-payment-strategy';
 
 describe('ConvergeaymentStrategy', () => {
     let finalizeOrderAction: Observable<FinalizeOrderAction>;
     let formPoster: FormPoster;
+    let hostedFormFactory: HostedFormFactory;
     let orderActionCreator: OrderActionCreator;
     let paymentActionCreator: PaymentActionCreator;
     let store: CheckoutStore;
@@ -51,6 +54,7 @@ describe('ConvergeaymentStrategy', () => {
 
         formPoster = createFormPoster();
         store = createCheckoutStore(getCheckoutStoreState());
+        hostedFormFactory = {} as HostedFormFactory;
 
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
@@ -74,6 +78,7 @@ describe('ConvergeaymentStrategy', () => {
             store,
             orderActionCreator,
             paymentActionCreator,
+            hostedFormFactory,
             formPoster
         );
     });
@@ -203,5 +208,10 @@ describe('ConvergeaymentStrategy', () => {
         } catch (error) {
             expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
         }
+    });
+
+    it('is special type of credit card strategy', () => {
+        expect(strategy)
+            .toBeInstanceOf(CreditCardPaymentStrategy);
     });
 });

--- a/src/payment/strategies/converge/converge-payment-strategy.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.ts
@@ -3,34 +3,27 @@ import { some } from 'lodash';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { RequestError } from '../../../common/error/errors';
+import { HostedFormFactory } from '../../../hosted-form';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentArgumentInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentRequestOptions } from '../../payment-request-options';
 import * as paymentStatusTypes from '../../payment-status-types';
-import PaymentStrategy from '../payment-strategy';
+import { CreditCardPaymentStrategy } from '../credit-card';
 
-export default class ConvergePaymentStrategy implements PaymentStrategy {
+export default class ConvergePaymentStrategy extends CreditCardPaymentStrategy {
     constructor(
-        private _store: CheckoutStore,
-        private _orderActionCreator: OrderActionCreator,
-        private _paymentActionCreator: PaymentActionCreator,
+        store: CheckoutStore,
+        orderActionCreator: OrderActionCreator,
+        paymentActionCreator: PaymentActionCreator,
+        hostedFormFactory: HostedFormFactory,
         private _formPoster: FormPoster
-    ) {}
+    ) {
+        super(store, orderActionCreator, paymentActionCreator, hostedFormFactory);
+    }
 
     execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        const { payment, ...order } = payload;
-        const paymentData = payment && payment.paymentData;
-
-        if (!payment || !paymentData) {
-            throw new PaymentArgumentInvalidError(['payment.paymentData']);
-        }
-
-        return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
-            .then(() =>
-                this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }))
-            )
+        return super.execute(payload, options)
             .catch(error => {
                 if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
                     return Promise.reject(error);
@@ -55,13 +48,5 @@ export default class ConvergePaymentStrategy implements PaymentStrategy {
         }
 
         return Promise.reject(new OrderFinalizationNotRequiredError());
-    }
-
-    initialize(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
-    }
-
-    deinitialize(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
     }
 }


### PR DESCRIPTION
## What?
Make `ConvergePaymentStrategy` inherit `CreditCardPaymentStrategy` strategy.

## Why?
So that it can utilise hosted payment forms.

## Testing / Proof
Unit / Manual

<img width="573" alt="Screen Shot 2020-07-13 at 11 43 19 am" src="https://user-images.githubusercontent.com/667603/87265144-53d1fb00-c505-11ea-8258-44ee1891fc51.png">

@bigcommerce/checkout @bigcommerce/payments
