### PR TITLE
feat(payment): PAYPAL-539 MerchantId does not required

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -45,7 +45,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         }
 
         const paramsScript = this._getParamsScript(initializationData, cart);
-        const paypal = await this._paypalScriptLoader.loadPaypalCommerce(paramsScript);
+        const paypal = await this._paypalScriptLoader.loadPaypalCommerce(paramsScript, initializationData.isProgressiveOnboardingAvailable);
 
         return paypal.Buttons(buttonParams).render(`#${options.containerId}`);
     }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -86,19 +86,35 @@ describe('PaypalCommerceScriptLoader', () => {
         });
     });
 
+    it('do not add merchant Id if it is null and enable progressive onboarding', async () => {
+        const options: PaypalCommerceScriptOptions = { clientId: 'aaa', merchantId: undefined };
+
+        jest.spyOn(loader, 'loadScript')
+            .mockImplementation((url: string) => {
+                (window as PaypalCommerceHostWindow).paypal = paypal;
+
+                expect(url).toEqual(expect.stringContaining('client-id=aaa'));
+                expect(url).not.toEqual(expect.stringContaining('merchant-id=undefined'));
+
+                return Promise.resolve();
+            });
+
+        await paypalLoader.loadPaypalCommerce(options, true);
+    });
+
+    it('throw error without merchant Id and disable progressive onboarding ', async () => {
+        try {
+            await paypalLoader.loadPaypalCommerce({ clientId: '', merchantId: '', currency: 'USD' }, false);
+        } catch (error) {
+            expect(error).toEqual(new InvalidArgumentError());
+        }
+    });
+
     it('throw error without client Id', async () => {
         try {
             await paypalLoader.loadPaypalCommerce({ clientId: '', merchantId: 'bbb', currency: 'USD' });
         } catch (error) {
-            expect(error).toEqual( new InvalidArgumentError());
-        }
-    });
-
-    it('throw error without merchant Id', async () => {
-        try {
-            await paypalLoader.loadPaypalCommerce({ clientId: 'aaa', merchantId: '', currency: 'USD' });
-        } catch (error) {
-            expect(error).toEqual( new InvalidArgumentError());
+            expect(error).toEqual(new InvalidArgumentError());
         }
     });
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -104,9 +104,9 @@ describe('PaypalCommerceScriptLoader', () => {
 
     it('throw error without merchant Id and disable progressive onboarding ', async () => {
         try {
-            await paypalLoader.loadPaypalCommerce({ clientId: '', merchantId: '', currency: 'USD' }, false);
+            await paypalLoader.loadPaypalCommerce({ clientId: 'aaa', merchantId: '', currency: 'USD' }, false);
         } catch (error) {
-            expect(error).toEqual(new InvalidArgumentError());
+            expect(error).toEqual(new InvalidArgumentError(`Unable to proceed because "merchantId" argument in PayPal script is not provided.`));
         }
     });
 
@@ -114,7 +114,7 @@ describe('PaypalCommerceScriptLoader', () => {
         try {
             await paypalLoader.loadPaypalCommerce({ clientId: '', merchantId: 'bbb', currency: 'USD' });
         } catch (error) {
-            expect(error).toEqual(new InvalidArgumentError());
+            expect(error).toEqual(new InvalidArgumentError(`Unable to proceed because "clientId" argument in PayPal script is not provided.`));
         }
     });
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -16,9 +16,7 @@ export default class PaypalCommerceScriptLoader {
     }
 
     async loadPaypalCommerce(options: PaypalCommerceScriptOptions, isProgressiveOnboardingAvailable?: boolean): Promise<PaypalCommerceSDK> {
-        if (!options || !options.clientId || (!options.merchantId && !isProgressiveOnboardingAvailable)) {
-            throw new InvalidArgumentError();
-        }
+        this.validateParams(options, isProgressiveOnboardingAvailable);
 
         const { disableFunding } = options;
         const updatedOptions = disableFunding
@@ -39,5 +37,23 @@ export default class PaypalCommerceScriptLoader {
         }
 
         return this._window.paypal;
+    }
+
+    validateParams(options: PaypalCommerceScriptOptions, isProgressiveOnboardingAvailable?: boolean): void {
+        const CLIENT_ID = 'clientId';
+        const MERCHANT_ID = 'merchantId';
+        let param;
+
+        if (!options) {
+            param = 'options';
+        } else if (!options[CLIENT_ID]) {
+            param = CLIENT_ID;
+        } else if (!options[MERCHANT_ID] && !isProgressiveOnboardingAvailable) {
+            param = MERCHANT_ID;
+        }
+
+        if (param) {
+            throw new InvalidArgumentError(`Unable to proceed because "${param}" argument in PayPal script is not provided.`);
+        }
     }
 }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -1,5 +1,5 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
-import { kebabCase } from 'lodash';
+import { isNil, kebabCase } from 'lodash';
 
 import { InvalidArgumentError } from '../../../common/error/errors';
 import { PaymentMethodClientUnavailableError } from '../../errors';
@@ -15,8 +15,8 @@ export default class PaypalCommerceScriptLoader {
         this._window = window;
     }
 
-    async loadPaypalCommerce(options: PaypalCommerceScriptOptions): Promise<PaypalCommerceSDK> {
-        if (!options || !options.clientId || !options.merchantId) {
+    async loadPaypalCommerce(options: PaypalCommerceScriptOptions, isProgressiveOnboardingAvailable?: boolean): Promise<PaypalCommerceSDK> {
+        if (!options || !options.clientId || (!options.merchantId && !isProgressiveOnboardingAvailable)) {
             throw new InvalidArgumentError();
         }
 
@@ -26,6 +26,7 @@ export default class PaypalCommerceScriptLoader {
             : options;
 
         const params = (Object.keys(updatedOptions) as Array<keyof PaypalCommerceScriptOptions>)
+            .filter(key => !isNil(options[key]))
             .map(key => `${kebabCase(key)}=${options[key]}`)
             .join('&');
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -81,16 +81,17 @@ export interface PaypalCommerceHostWindow extends Window {
 
 export interface PaypalCommerceInitializationData {
     clientId: string;
-    merchantId: string;
+    merchantId?: string;
     intent?: 'capture' | 'authorize';
     isPayPalCreditAvailable?: boolean;
+    isProgressiveOnboardingAvailable?: boolean;
 }
 
 export type DisableFundingType = Array<'credit' | 'card'>;
 
 export interface PaypalCommerceScriptOptions {
     clientId: string;
-    merchantId: string;
+    merchantId?: string;
     currency?: string;
     commit?: boolean;
     intent?: 'capture' | 'authorize';


### PR DESCRIPTION
## What?
MerchantId does not required for progressive onboarding
Added filter for options for paypal script, because script doesn't work if option is null or undefined

## Why?
It will be new implementation for progressive onboarding

## Testing / Proof
![Screen-Recording-2020-07-14-at-12 27 54-PM](https://user-images.githubusercontent.com/32959076/87410465-05892e80-c5cf-11ea-9701-e4618f293933.gif)
![Screen-Recording-2020-07-14-at-12 25 12-PM](https://user-images.githubusercontent.com/32959076/87410473-091cb580-c5cf-11ea-8150-4b2e77ab5be6.gif)


@bigcommerce/checkout @bigcommerce/payments
