### PR TITLE
CHECKOUT-5029: Return error if hosted field iframe is removed during asynchronous call

### DIFF
--- a/src/common/dom/detachment-observer.spec.ts
+++ b/src/common/dom/detachment-observer.spec.ts
@@ -1,0 +1,67 @@
+import { EventEmitter } from 'events';
+import { noop } from 'lodash';
+
+import DetachmentObserver from './detachment-observer';
+import { UnexpectedDetachmentError } from './errors';
+import { MutationObserverFactory } from './mutation-observer';
+
+describe('DetachmentObserver', () => {
+    let mutationEventEmitter: EventEmitter;
+    let mutationObserver: Pick<MutationObserver, 'disconnect' | 'observe'>;
+    let mutationObserverFactory: Pick<MutationObserverFactory, 'create'>;
+    let subject: DetachmentObserver;
+
+    beforeEach(() => {
+        mutationEventEmitter = new EventEmitter();
+
+        mutationObserver = {
+            observe: jest.fn(),
+            disconnect: jest.fn(),
+        };
+
+        mutationObserverFactory = {
+            create: jest.fn(callback => {
+                mutationEventEmitter.on('remove', callback);
+
+                return mutationObserver;
+            }),
+        };
+
+        subject = new DetachmentObserver(
+            mutationObserverFactory as MutationObserverFactory
+        );
+    });
+
+    it('throws error and stops observing if targetted element is removed before promise is resolved', async () => {
+        const element = document.createElement('div');
+        const promise = new Promise(noop);
+        const output = subject.ensurePresence([element], promise);
+
+        mutationEventEmitter.emit('remove', [{ removedNodes: [element] }]);
+
+        try {
+            await output;
+        } catch (error) {
+            expect(error)
+                .toEqual(expect.any(UnexpectedDetachmentError));
+
+            expect(mutationObserver.disconnect)
+                .toHaveBeenCalled();
+        }
+    });
+
+    it('returns promised value and stops observing if targetted element is not removed before promise is resolved', async () => {
+        const eventEmitter = new EventEmitter();
+        const element = document.createElement('div');
+        const promise = new Promise(resolve => eventEmitter.on('resolve', resolve));
+        const output = subject.ensurePresence([element], promise);
+
+        eventEmitter.emit('resolve', 'foobar');
+
+        expect(await output)
+            .toEqual('foobar');
+
+        expect(mutationObserver.disconnect)
+            .toHaveBeenCalled();
+    });
+});

--- a/src/common/dom/detachment-observer.ts
+++ b/src/common/dom/detachment-observer.ts
@@ -1,0 +1,45 @@
+import { CancellablePromise } from '../utility';
+
+import { UnexpectedDetachmentError } from './errors';
+import { MutationObserverFactory } from './mutation-observer';
+
+export default class DetachmentObserver {
+    constructor(
+        private _mutationObserver: MutationObserverFactory
+    ) {}
+
+    async ensurePresence<T>(targets: Node[], promise: Promise<T>): Promise<T> {
+        const cancellable = new CancellablePromise(promise);
+
+        const observer = this._mutationObserver.create(mutationsList => {
+            mutationsList.forEach(mutation => {
+                const removedTargets = Array.from(mutation.removedNodes)
+                    .filter(node =>
+                        targets.some(target =>
+                            node === target || node.contains(target)
+                        )
+                    );
+
+                if (removedTargets.length === 0) {
+                    return;
+                }
+
+                cancellable.cancel(new UnexpectedDetachmentError());
+            });
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        try {
+            const output = await cancellable.promise;
+
+            observer.disconnect();
+
+            return output;
+        } catch (error) {
+            observer.disconnect();
+
+            throw error;
+        }
+    }
+}

--- a/src/common/dom/errors/index.ts
+++ b/src/common/dom/errors/index.ts
@@ -1,0 +1,1 @@
+export { default as UnexpectedDetachmentError } from './unexpected-detachment-error';

--- a/src/common/dom/errors/unexpected-detachment-error.ts
+++ b/src/common/dom/errors/unexpected-detachment-error.ts
@@ -1,0 +1,10 @@
+import { StandardError } from '../../error/errors';
+
+export default class UnexpectedDetachmentError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to proceed because the required element is unexpectedly detached from the page.');
+
+        this.name = 'UnexpectedDetachmentError';
+        this.type = 'unexpected_detachment';
+    }
+}

--- a/src/common/dom/index.ts
+++ b/src/common/dom/index.ts
@@ -2,3 +2,4 @@ export * from './mutation-observer';
 
 export { default as isElementId } from './is-element-id';
 export { default as setUniqueElementId } from './set-unique-element-id';
+export { default as DetachmentObserver } from './detachment-observer';

--- a/src/hosted-form/hosted-form-factory.ts
+++ b/src/hosted-form/hosted-form-factory.ts
@@ -2,6 +2,7 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { pick } from 'lodash';
 
 import { ReadableCheckoutStore } from '../checkout';
+import { DetachmentObserver, MutationObserverFactory } from '../common/dom';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 import { CardInstrument } from '../payment/instrument';
@@ -38,6 +39,7 @@ export default class HostedFormFactory {
                     options.styles || {},
                     new IframeEventPoster(host),
                     new IframeEventListener(host),
+                    new DetachmentObserver(new MutationObserverFactory()),
                     'instrumentId' in fieldOptions ?
                         this._getCardInstrument(fieldOptions.instrumentId) :
                         undefined


### PR DESCRIPTION
## What?
Return an error if a hosted field iframe is removed during an asynchronous call.

## Why?
Otherwise, the promise of the asynchronous call won't get resolved or rejected. As a result, callers that subscribe to the promise would be waiting indefinitely for a result.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
