### PR TITLE
CHECKOUT-4947: Inspect payment method object to determine whether hosted payment form is enabled for payment method

### DIFF
--- a/src/payment/payment-method-config.ts
+++ b/src/payment/payment-method-config.ts
@@ -5,6 +5,7 @@ export default interface PaymentMethodConfig {
     hasDefaultStoredInstrument?: boolean;
     helpText?: string;
     is3dsEnabled?: boolean;
+    isHostedFormEnabled?: boolean;
     isVaultingCvvEnabled?: boolean;
     isVaultingEnabled?: boolean;
     isVisaCheckoutEnabled?: boolean;

--- a/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.spec.ts
@@ -10,7 +10,6 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutVali
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
-import { getConfig } from '../../../config/configs.mock';
 import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../hosted-form';
 import { FinalizeOrderAction, LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
@@ -19,6 +18,7 @@ import { getOrder } from '../../../order/orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import { getPaymentMethod } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
@@ -224,10 +224,10 @@ describe('CreditCardRedirectPaymentStrategy', () => {
             loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
             state = store.getState();
 
-            jest.spyOn(state.config, 'getStoreConfig')
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
                 .mockReturnValue(merge(
-                    getConfig().storeConfig,
-                    { checkoutSettings: { isHostedPaymentFormEnabled: true } }
+                    getPaymentMethod(),
+                    { config: { isHostedFormEnabled: true } }
                 ));
 
             jest.spyOn(orderActionCreator, 'loadCurrentOrder')

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
@@ -7,7 +7,6 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { getConfig } from '../../../config/configs.mock';
 import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../hosted-form';
 import { LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
@@ -16,6 +15,7 @@ import { getOrder } from '../../../order/orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
+import { getPaymentMethod } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
@@ -126,10 +126,10 @@ describe('CreditCardPaymentStrategy', () => {
             loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
             state = store.getState();
 
-            jest.spyOn(state.config, 'getStoreConfig')
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
                 .mockReturnValue(merge(
-                    getConfig().storeConfig,
-                    { checkoutSettings: { isHostedPaymentFormEnabled: true } }
+                    getPaymentMethod(),
+                    { config: { isHostedFormEnabled: true } }
                 ));
 
             jest.spyOn(orderActionCreator, 'loadCurrentOrder')
@@ -222,10 +222,10 @@ describe('CreditCardPaymentStrategy', () => {
             loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
             state = store.getState();
 
-            jest.spyOn(state.config, 'getStoreConfig')
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
                 .mockReturnValue(merge(
-                    getConfig().storeConfig,
-                    { checkoutSettings: { isHostedPaymentFormEnabled: true } }
+                    getPaymentMethod(),
+                    { config: { isHostedFormEnabled: true } }
                 ));
 
             jest.spyOn(orderActionCreator, 'loadCurrentOrder')

--- a/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
@@ -87,6 +87,9 @@ describe('WepayPaymentStrategy', () => {
         jest.spyOn(paymentActionCreator, 'submitPayment')
             .mockReturnValue(submitPaymentAction);
 
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(paymentMethod);
+
         jest.spyOn(store, 'dispatch');
     });
 


### PR DESCRIPTION
## What?
Inspect `PaymentMethod` object to determine whether a payment method supports hosted payment form. 

## Why?
At the moment, we inspect the checkout settings object to check if the feature is enabled or not. However, it is not sufficient because the availability of the feature also depends on individual payment methods. To address this problem, we'll introduce a flag at the payment method level so that it can differ between different methods.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
