### PR TITLE
CHECKOUT-4947: Introduce object responsible for initialising and using Braintree hosted fields

### DIFF
--- a/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -1,0 +1,335 @@
+import { EventEmitter } from 'events';
+
+import { getBillingAddress } from '../../../billing/billing-addresses.mock';
+import { NotInitializedError } from '../../../common/error/errors';
+
+import { BraintreeHostedFields } from './braintree';
+import BraintreeHostedForm from './braintree-hosted-form';
+import { BraintreeFormOptions } from './braintree-payment-options';
+import BraintreeSDKCreator from './braintree-sdk-creator';
+
+describe('BraintreeHostedForm', () => {
+    let braintreeSdkCreator: Pick<BraintreeSDKCreator, 'createHostedFields'>;
+    let cardFields: Pick<BraintreeHostedFields, 'on' | 'tokenize' | 'teardown'>;
+    let cardFieldsEventEmitter: EventEmitter;
+    let containers: HTMLElement[];
+    let formOptions: BraintreeFormOptions;
+    let subject: BraintreeHostedForm;
+
+    function appendContainer(id: string): HTMLElement {
+        const container = document.createElement('div');
+
+        container.id = id;
+        document.body.appendChild(container);
+
+        return container;
+    }
+
+    beforeEach(() => {
+        cardFieldsEventEmitter = new EventEmitter();
+
+        cardFields = {
+            on: jest.fn((eventName, callback) => {
+                cardFieldsEventEmitter.on(eventName, callback);
+            }),
+            tokenize: jest.fn(() => Promise.resolve({ nonce: 'foobar_nonce' })),
+            teardown: jest.fn(),
+        };
+
+        braintreeSdkCreator = {
+            createHostedFields: jest.fn(() => Promise.resolve(cardFields as BraintreeHostedFields)),
+        };
+
+        formOptions = {
+            fields: {
+                cardCode: { containerId: 'cardCode', placeholder: 'Card code' },
+                cardName: { containerId: 'cardName', placeholder: 'Card name' },
+                cardNumber: { containerId: 'cardNumber', placeholder: 'Card number' },
+                cardExpiry: { containerId: 'cardExpiry', placeholder: 'Card expiry' },
+            },
+            styles: {
+                default: {
+                    color: '#000',
+                },
+                error: {
+                    color: '#f00',
+                    fontWeight: 'bold',
+                },
+                focus: {
+                    color: '#00f',
+                },
+            },
+        };
+
+        subject = new BraintreeHostedForm(braintreeSdkCreator as BraintreeSDKCreator);
+
+        containers = [
+            appendContainer('cardCode'),
+            appendContainer('cardName'),
+            appendContainer('cardNumber'),
+            appendContainer('cardExpiry'),
+        ];
+    });
+
+    afterEach(() => {
+        containers.forEach(container => {
+            container.parentElement?.removeChild(container);
+        });
+    });
+
+    it('creates and configures hosted fields', async () => {
+        await subject.initialize(formOptions);
+
+        expect(braintreeSdkCreator.createHostedFields)
+            .toHaveBeenCalledWith({
+                fields: {
+                    cvv: {
+                        container: '#cardCode',
+                        placeholder: 'Card code',
+                    },
+                    expirationDate: {
+                        container: '#cardExpiry',
+                        placeholder: 'Card expiry',
+                    },
+                    number: {
+                        container: '#cardNumber',
+                        placeholder: 'Card number',
+                    },
+                },
+                styles: {
+                    input: {
+                        color: '#000',
+                    },
+                    '.invalid': {
+                        color: '#f00',
+                        'font-weight': 'bold',
+                    },
+                    ':focus': {
+                        color: '#00f',
+                    },
+                },
+            });
+    });
+
+    it('creates and configures hosted fields for stored card verification', async () => {
+        await subject.initialize({
+            ...formOptions,
+            fields: {
+                cardCodeVerification: {
+                    containerId: 'cardCode',
+                    placeholder: 'Card code',
+                    instrumentId: 'foobar_instrument_id',
+                },
+                cardNumberVerification: {
+                    containerId: 'cardNumber',
+                    placeholder: 'Card number',
+                    instrumentId: 'foobar_instrument_id',
+                },
+            },
+            styles: {
+                default: {
+                    color: '#000',
+                },
+                error: {
+                    color: '#f00',
+                    fontWeight: 'bold',
+                },
+                focus: {
+                    color: '#00f',
+                },
+            },
+        });
+
+        expect(braintreeSdkCreator.createHostedFields)
+            .toHaveBeenCalledWith({
+                fields: {
+                    cvv: {
+                        container: '#cardCode',
+                        placeholder: 'Card code',
+                    },
+                    number: {
+                        container: '#cardNumber',
+                        placeholder: 'Card number',
+                    },
+                },
+                styles: {
+                    input: {
+                        color: '#000',
+                    },
+                    '.invalid': {
+                        color: '#f00',
+                        'font-weight': 'bold',
+                    },
+                    ':focus': {
+                        color: '#00f',
+                    },
+                },
+            });
+    });
+
+    it('notifies when field receives focus', async () => {
+        const handleFocus = jest.fn();
+
+        await subject.initialize({
+            ...formOptions,
+            onFocus: handleFocus,
+        });
+
+        cardFieldsEventEmitter.emit('focus', { emittedBy: 'cvv' });
+
+        expect(handleFocus)
+            .toHaveBeenCalledWith({ fieldType: 'cardCode' });
+    });
+
+    it('notifies when field loses focus', async () => {
+        const handleBlur = jest.fn();
+
+        await subject.initialize({
+            ...formOptions,
+            onBlur: handleBlur,
+        });
+
+        cardFieldsEventEmitter.emit('blur', { emittedBy: 'cvv' });
+
+        expect(handleBlur)
+            .toHaveBeenCalledWith({ fieldType: 'cardCode' });
+    });
+
+    it('notifies when input receives submit event', async () => {
+        const handleEnter = jest.fn();
+
+        await subject.initialize({
+            ...formOptions,
+            onEnter: handleEnter,
+        });
+
+        cardFieldsEventEmitter.emit('inputSubmitRequest', { emittedBy: 'cvv' });
+
+        expect(handleEnter)
+            .toHaveBeenCalledWith({ fieldType: 'cardCode' });
+    });
+
+    it('notifies when card number changes', async () => {
+        const handleCardTypeChange = jest.fn();
+
+        await subject.initialize({
+            ...formOptions,
+            onCardTypeChange: handleCardTypeChange,
+        });
+
+        cardFieldsEventEmitter.emit('cardTypeChange', { cards: [{ type: 'Visa' }] });
+
+        expect(handleCardTypeChange)
+            .toHaveBeenCalledWith({ cardType: 'Visa' });
+    });
+
+    it('notifies when there are validation errors', async () => {
+        const handleValidate = jest.fn();
+
+        await subject.initialize({
+            ...formOptions,
+            onValidate: handleValidate,
+        });
+
+        cardFieldsEventEmitter.emit('validityChange', {
+            fields: {
+                cvv: { isValid: false },
+                number: { isValid: false },
+                expirationDate: { isValid: false },
+            },
+        });
+
+        expect(handleValidate)
+            .toHaveBeenCalledWith({
+                errors: {
+                    cardCode: [{
+                        fieldType: 'cardCode',
+                        message: 'Invalid card number',
+                        type: 'invalid_card_number',
+                    }],
+                    cardNumber: [{
+                        fieldType: 'cardNumber',
+                        message: 'Invalid card number',
+                        type: 'invalid_card_number',
+                    }],
+                    cardExpiry: [{
+                        fieldType: 'cardExpiry',
+                        message: 'Invalid card number',
+                        type: 'invalid_card_number',
+                    }],
+                },
+                isValid: false,
+            });
+    });
+
+    it('notifies when there are no more validation errors', async () => {
+        const handleValidate = jest.fn();
+
+        await subject.initialize({
+            ...formOptions,
+            onValidate: handleValidate,
+        });
+
+        cardFieldsEventEmitter.emit('validityChange', {
+            fields: {
+                cvv: { isValid: true },
+                number: { isValid: true },
+                expirationDate: { isValid: true },
+            },
+        });
+
+        expect(handleValidate)
+            .toHaveBeenCalledWith({
+                errors: {
+                    cardCode: undefined,
+                    cardNumber: undefined,
+                    cardExpiry: undefined,
+                },
+                isValid: true,
+            });
+    });
+
+    it('tokenizes data through hosted fields', async () => {
+        await subject.initialize(formOptions);
+
+        const billingAddress = getBillingAddress();
+        const cardNameInput = document.querySelector('#cardName input') as HTMLInputElement;
+
+        cardNameInput.value = 'Foobar';
+
+        await subject.tokenize(billingAddress);
+
+        expect(cardFields.tokenize)
+            .toHaveBeenCalledWith({
+                billingAddress: {
+                    countryName: billingAddress.country,
+                    postalCode: billingAddress.postalCode,
+                    streetAddress: billingAddress.address1,
+                },
+                cardholderName: 'Foobar',
+            });
+    });
+
+    it('tokenizes data through hosted fields for stored card verification', async () => {
+        await subject.initialize(formOptions);
+
+        const cardNameInput = document.querySelector('#cardName input') as HTMLInputElement;
+
+        cardNameInput.value = 'Foobar';
+
+        await subject.tokenizeForStoredCardVerification();
+
+        expect(cardFields.tokenize)
+            .toHaveBeenCalledWith({
+                cardholderName: 'Foobar',
+            });
+    });
+
+    it('throws error if trying to tokenize before initialization', async () => {
+        try {
+            await subject.tokenize(getBillingAddress());
+        } catch (error) {
+            expect(error).toBeInstanceOf(NotInitializedError);
+        }
+    });
+});

--- a/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -1,0 +1,250 @@
+import { isNil, omitBy, Dictionary } from 'lodash';
+
+import { Address } from '../../../address';
+import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { NonceInstrument } from '../../payment';
+
+import { BraintreeBillingAddressRequestData, BraintreeHostedFields, BraintreeHostedFieldsCreatorConfig, BraintreeHostedFieldsState } from './braintree';
+import { BraintreeFormFieldsMap, BraintreeFormFieldStyles, BraintreeFormFieldStylesMap, BraintreeFormFieldType, BraintreeFormFieldValidateEventData, BraintreeFormOptions, BraintreeStoredCardFieldsMap } from './braintree-payment-options';
+import BraintreeRegularField from './braintree-regular-field';
+import BraintreeSDKCreator from './braintree-sdk-creator';
+import { isBraintreeFormFieldsMap } from './is-braintree-form-fields-map';
+
+enum BraintreeHostedFormType {
+    CreditCard,
+    StoredCardVerification,
+}
+
+export default class BraintreeHostedForm {
+    private _cardFields?: BraintreeHostedFields;
+    private _cardNameField?: BraintreeRegularField;
+    private _formOptions?: BraintreeFormOptions;
+    private _type?: BraintreeHostedFormType;
+
+    constructor(
+        private _braintreeSDKCreator: BraintreeSDKCreator
+    ) {}
+
+    async initialize(options: BraintreeFormOptions): Promise<void> {
+        this._formOptions = options;
+
+        this._type = isBraintreeFormFieldsMap(options.fields) ?
+            BraintreeHostedFormType.CreditCard :
+            BraintreeHostedFormType.StoredCardVerification;
+
+        this._cardFields = await this._braintreeSDKCreator.createHostedFields({
+            fields: this._mapFieldOptions(options.fields),
+            styles: options.styles && this._mapStyleOptions(options.styles),
+        });
+
+        this._cardFields.on('blur', this._handleBlur);
+        this._cardFields.on('focus', this._handleFocus);
+        this._cardFields.on('cardTypeChange', this._handleCardTypeChange);
+        this._cardFields.on('validityChange', this._handleValidityChange);
+        this._cardFields.on('inputSubmitRequest', this._handleInputSubmitRequest);
+
+        if (isBraintreeFormFieldsMap(options.fields)) {
+            this._cardNameField = new BraintreeRegularField(
+                options.fields.cardName,
+                options.styles
+            );
+            this._cardNameField.attach();
+        }
+    }
+
+    async deinitialize(): Promise<void> {
+        await this._cardFields?.teardown();
+        this._cardNameField?.detach();
+    }
+
+    async tokenize(billingAddress: Address): Promise<NonceInstrument> {
+        if (!this._cardFields) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const { nonce } = await this._cardFields.tokenize(omitBy({
+            billingAddress: billingAddress && this._mapBillingAddress(billingAddress),
+            cardholderName: this._cardNameField?.getValue(),
+        }, isNil));
+
+        return { nonce };
+    }
+
+    async tokenizeForStoredCardVerification(): Promise<NonceInstrument> {
+        if (!this._cardFields) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const { nonce } = await this._cardFields.tokenize(omitBy({
+            cardholderName: this._cardNameField?.getValue(),
+        }, isNil));
+
+        return { nonce };
+    }
+
+    private _mapBillingAddress(billingAddress: Address): BraintreeBillingAddressRequestData {
+        return {
+            countryName: billingAddress.country,
+            postalCode: billingAddress.postalCode,
+            streetAddress: billingAddress.address2 ?
+                `${billingAddress.address1} ${billingAddress.address2}` :
+                billingAddress.address1,
+        };
+    }
+
+    private _mapFieldOptions(
+        fields: BraintreeFormFieldsMap | BraintreeStoredCardFieldsMap
+    ): BraintreeHostedFieldsCreatorConfig['fields'] {
+        if (isBraintreeFormFieldsMap(fields)) {
+            return omitBy({
+                number: {
+                    container: `#${fields.cardNumber.containerId}`,
+                    placeholder: fields.cardNumber.placeholder,
+                },
+                expirationDate: {
+                    container: `#${fields.cardExpiry.containerId}`,
+                    placeholder: fields.cardExpiry.placeholder,
+                },
+                cvv: fields.cardCode && {
+                    container: `#${fields.cardCode.containerId}`,
+                    placeholder: fields.cardCode.placeholder,
+                },
+            }, isNil);
+        }
+
+        return omitBy({
+            number: fields.cardNumberVerification && {
+                container: `#${fields.cardNumberVerification.containerId}`,
+                placeholder: fields.cardNumberVerification.placeholder,
+            },
+            cvv: fields.cardCodeVerification && {
+                container: `#${fields.cardCodeVerification.containerId}`,
+                placeholder: fields.cardCodeVerification.placeholder,
+            },
+        }, isNil);
+    }
+
+    private _mapStyleOptions(
+        options: BraintreeFormFieldStylesMap
+    ): BraintreeHostedFieldsCreatorConfig['styles'] {
+        const mapStyles = (styles: BraintreeFormFieldStyles = {}) => omitBy({
+            color: styles.color,
+            'font-family': styles.fontFamily,
+            'font-size': styles.fontSize,
+            'font-weight': styles.fontWeight,
+        }, isNil) as Dictionary<string>;
+
+        return {
+            input: mapStyles(options.default),
+            '.invalid': mapStyles(options.error),
+            ':focus': mapStyles(options.focus),
+        };
+    }
+
+    private _mapFieldType(type: string): BraintreeFormFieldType {
+        switch (type) {
+        case 'number':
+            return this._type === BraintreeHostedFormType.StoredCardVerification ?
+                BraintreeFormFieldType.CardNumberVerification :
+                BraintreeFormFieldType.CardNumber;
+
+        case 'expirationDate':
+            return BraintreeFormFieldType.CardExpiry;
+
+        case 'cvv':
+            return this._type === BraintreeHostedFormType.StoredCardVerification ?
+                BraintreeFormFieldType.CardCodeVerification :
+                BraintreeFormFieldType.CardCode;
+
+        default:
+            throw new Error('Unexpected field type');
+        }
+    }
+
+    private _mapStoredCardVerificationErrors(
+        fields: BraintreeHostedFieldsState['fields']
+    ): BraintreeFormFieldValidateEventData['errors'] {
+        return this._type === BraintreeHostedFormType.StoredCardVerification ?
+            {
+                [BraintreeFormFieldType.CardCodeVerification]: !fields.cvv || fields.cvv.isValid ? undefined : [{
+                    fieldType: 'cardCodeVerification',
+                    message: 'Invalid card code',
+                    type: 'invalid_card_code',
+                }],
+                [BraintreeFormFieldType.CardNumberVerification]: !fields.number || fields.number.isValid ? undefined : [{
+                    fieldType: 'cardNumberVerification',
+                    message: 'Invalid card number',
+                    type: 'invalid_card_number',
+                }],
+            } :
+            {
+                [BraintreeFormFieldType.CardCode]: !fields.cvv || fields.cvv.isValid ? undefined : [{
+                    fieldType: 'cardCode',
+                    message: 'Invalid card number',
+                    type: 'invalid_card_number',
+                }],
+                [BraintreeFormFieldType.CardExpiry]: !fields.expirationDate || fields.expirationDate.isValid ? undefined : [{
+                    fieldType: 'cardExpiry',
+                    message: 'Invalid card number',
+                    type: 'invalid_card_number',
+                }],
+                [BraintreeFormFieldType.CardNumber]: !fields.number || fields.number.isValid ? undefined : [{
+                    fieldType: 'cardNumber',
+                    message: 'Invalid card number',
+                    type: 'invalid_card_number',
+                }],
+            };
+    }
+
+    private _handleBlur: (event: BraintreeHostedFieldsState) => void = event => {
+        if (!this._formOptions?.onBlur) {
+            return;
+        }
+
+        this._formOptions.onBlur({
+            fieldType: this._mapFieldType(event.emittedBy),
+        });
+    };
+
+    private _handleFocus: (event: BraintreeHostedFieldsState) => void = event => {
+        if (!this._formOptions?.onFocus) {
+            return;
+        }
+
+        this._formOptions.onFocus({
+            fieldType: this._mapFieldType(event.emittedBy),
+        });
+    };
+
+    private _handleCardTypeChange: (event: BraintreeHostedFieldsState) => void = event => {
+        if (!this._formOptions?.onCardTypeChange) {
+            return;
+        }
+
+        this._formOptions.onCardTypeChange({
+            cardType: event.cards[0]?.type,
+        });
+    };
+
+    private _handleInputSubmitRequest: (event: BraintreeHostedFieldsState) => void = event => {
+        if (!this._formOptions?.onEnter) {
+            return;
+        }
+
+        this._formOptions.onEnter({
+            fieldType: this._mapFieldType(event.emittedBy),
+        });
+    };
+
+    private _handleValidityChange: (event: BraintreeHostedFieldsState) => void = event => {
+        if (!this._formOptions?.onValidate) {
+            return;
+        }
+
+        this._formOptions.onValidate({
+            isValid: (Object.keys(event.fields) as Array<keyof BraintreeHostedFieldsState['fields']>)
+                .every(key => event.fields[key]?.isValid),
+            errors: this._mapStoredCardVerificationErrors(event.fields),
+        });
+    };
+}

--- a/src/payment/strategies/braintree/braintree-payment-options.ts
+++ b/src/payment/strategies/braintree/braintree-payment-options.ts
@@ -7,6 +7,14 @@ import { BraintreeVerifyPayload } from './braintree';
  */
 export interface BraintreePaymentInitializeOptions {
     threeDSecure?: BraintreeThreeDSecureOptions;
+
+    /**
+     * @alpha
+     * Please note that this option is currently in an early stage of
+     * development. Therefore the API is unstable and not ready for public
+     * consumption.
+     */
+    form?: BraintreeFormOptions;
 }
 
 /**
@@ -36,4 +44,88 @@ export interface BraintreeThreeDSecureOptions {
      * the current page.
      */
     removeFrame(): void;
+}
+
+export interface BraintreeFormOptions {
+    fields: BraintreeFormFieldsMap | BraintreeStoredCardFieldsMap;
+    styles?: BraintreeFormFieldStylesMap;
+    onBlur?(data: BraintreeFormFieldBlurEventData): void;
+    onCardTypeChange?(data: BraintreeFormFieldCardTypeChangeEventData): void;
+    onFocus?(data: BraintreeFormFieldFocusEventData): void;
+    onValidate?(data: BraintreeFormFieldValidateEventData): void;
+    onEnter?(data: BraintreeFormFieldEnterEventData): void;
+}
+
+export enum BraintreeFormFieldType {
+    CardCode = 'cardCode',
+    CardCodeVerification = 'cardCodeVerification',
+    CardExpiry = 'cardExpiry',
+    CardName = 'cardName',
+    CardNumber = 'cardNumber',
+    CardNumberVerification = 'cardNumberVerification',
+}
+
+export interface BraintreeFormFieldsMap {
+    [BraintreeFormFieldType.CardCode]?: BraintreeFormFieldOptions;
+    [BraintreeFormFieldType.CardExpiry]: BraintreeFormFieldOptions;
+    [BraintreeFormFieldType.CardName]: BraintreeFormFieldOptions;
+    [BraintreeFormFieldType.CardNumber]: BraintreeFormFieldOptions;
+}
+
+export interface BraintreeStoredCardFieldsMap {
+    [BraintreeFormFieldType.CardCodeVerification]?: BraintreeStoredCardFieldOptions;
+    [BraintreeFormFieldType.CardNumberVerification]?: BraintreeStoredCardFieldOptions;
+}
+
+export interface BraintreeFormFieldOptions {
+    containerId: string;
+    placeholder?: string;
+}
+
+export interface BraintreeStoredCardFieldOptions extends BraintreeFormFieldOptions {
+    instrumentId: string;
+}
+
+export interface BraintreeFormFieldStylesMap {
+    default?: BraintreeFormFieldStyles;
+    error?: BraintreeFormFieldStyles;
+    focus?: BraintreeFormFieldStyles;
+}
+
+export type BraintreeFormFieldStyles = Partial<Pick<
+    CSSStyleDeclaration,
+    'color' |
+    'fontFamily' |
+    'fontSize' |
+    'fontWeight'
+>>;
+
+export interface BraintreeFormFieldKeyboardEventData {
+    fieldType: string;
+}
+
+export type BraintreeFormFieldBlurEventData = BraintreeFormFieldKeyboardEventData;
+export type BraintreeFormFieldEnterEventData = BraintreeFormFieldKeyboardEventData;
+export type BraintreeFormFieldFocusEventData = BraintreeFormFieldKeyboardEventData;
+
+export interface BraintreeFormFieldCardTypeChangeEventData {
+    cardType?: string;
+}
+
+export interface BraintreeFormFieldValidateEventData {
+    errors: {
+        [BraintreeFormFieldType.CardCode]?: BraintreeFormFieldValidateErrorData[];
+        [BraintreeFormFieldType.CardExpiry]?: BraintreeFormFieldValidateErrorData[];
+        [BraintreeFormFieldType.CardName]?: BraintreeFormFieldValidateErrorData[];
+        [BraintreeFormFieldType.CardNumber]?: BraintreeFormFieldValidateErrorData[];
+        [BraintreeFormFieldType.CardCodeVerification]?: BraintreeFormFieldValidateErrorData[];
+        [BraintreeFormFieldType.CardNumberVerification]?: BraintreeFormFieldValidateErrorData[];
+    };
+    isValid: boolean;
+}
+
+export interface BraintreeFormFieldValidateErrorData {
+    fieldType: string;
+    message: string;
+    type: string;
 }

--- a/src/payment/strategies/braintree/braintree-regular-field.ts
+++ b/src/payment/strategies/braintree/braintree-regular-field.ts
@@ -1,0 +1,66 @@
+import { InvalidArgumentError } from '../../../common/error/errors';
+
+import { BraintreeFormFieldOptions, BraintreeFormFieldStyles, BraintreeFormFieldStylesMap } from './braintree-payment-options';
+
+export default class BraintreeRegularField {
+    private _input: HTMLInputElement;
+
+    constructor(
+        private _options: BraintreeFormFieldOptions,
+        private _styles?: BraintreeFormFieldStylesMap
+    ) {
+        this._input = document.createElement('input');
+        this._input.style.backgroundColor = 'transparent';
+        this._input.style.border = '0';
+        this._input.style.display = 'block';
+        this._input.style.height = '100%';
+        this._input.style.margin = '0';
+        this._input.style.outline = 'none';
+        this._input.style.padding = '0';
+        this._input.style.width = '100%';
+        this._input.placeholder = this._options.placeholder || '';
+
+        this._input.addEventListener('blur', this._handleBlur);
+        this._input.addEventListener('focus', this._handleFocus);
+
+        this._applyStyles(this._styles?.default);
+    }
+
+    getValue(): string {
+        return this._input.value;
+    }
+
+    attach(): void {
+        const container = document.getElementById(this._options.containerId);
+
+        if (!container) {
+            throw new InvalidArgumentError();
+        }
+
+        container.appendChild(this._input);
+    }
+
+    detach(): void {
+        this._input.parentNode?.removeChild(this._input);
+    }
+
+    private _applyStyles(styles?: BraintreeFormFieldStyles): void {
+        if (!styles) {
+            return;
+        }
+
+        const styleKeys = Object.keys(styles) as Array<keyof BraintreeFormFieldStyles>;
+
+        styleKeys.forEach(key => {
+            this._input.style[key] = styles[key] || '';
+        });
+    }
+
+    private _handleBlur: (event: Event) => void = () => {
+        this._applyStyles(this._styles?.default);
+    };
+
+    private _handleFocus: (event: Event) => void = () => {
+        this._applyStyles(this._styles?.focus);
+    };
+}

--- a/src/payment/strategies/braintree/braintree-script-loader.spec.ts
+++ b/src/payment/strategies/braintree/braintree-script-loader.spec.ts
@@ -2,9 +2,9 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { StandardError } from '../../../common/error/errors';
 
-import { BraintreeClientCreator, BraintreeDataCollector, BraintreeHostWindow, BraintreeModuleCreator, BraintreeThreeDSecure, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
+import { BraintreeClientCreator, BraintreeDataCollector, BraintreeHostedFields, BraintreeHostWindow, BraintreeModuleCreator, BraintreeThreeDSecure, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
 import BraintreeScriptLoader from './braintree-script-loader';
-import { getClientMock, getDataCollectorMock, getGooglePayMock, getModuleCreatorMock, getThreeDSecureMock, getVisaCheckoutMock } from './braintree.mock';
+import { getClientMock, getDataCollectorMock, getGooglePayMock, getHostedFieldsMock, getModuleCreatorMock, getThreeDSecureMock, getVisaCheckoutMock } from './braintree.mock';
 
 describe('BraintreeScriptLoader', () => {
     let braintreeScriptLoader: BraintreeScriptLoader;
@@ -156,6 +156,33 @@ describe('BraintreeScriptLoader', () => {
             } catch (error) {
                 expect(error).toBeInstanceOf(StandardError);
             }
+        });
+    });
+
+    describe('#loadHostedFields()', () => {
+        let hostedFields: BraintreeModuleCreator<BraintreeHostedFields>;
+
+        beforeEach(() => {
+            hostedFields = getModuleCreatorMock(getHostedFieldsMock());
+
+            scriptLoader.loadScript = jest.fn(() => {
+                // tslint:disable-next-line:no-non-null-assertion
+                mockWindow.braintree!.hostedFields = hostedFields;
+
+                return Promise.resolve();
+            });
+        });
+
+        it('loads hosted fields module', async () => {
+            await braintreeScriptLoader.loadHostedFields();
+
+            expect(scriptLoader.loadScript)
+                .toHaveBeenCalledWith('//js.braintreegateway.com/web/3.59.0/js/hosted-fields.min.js');
+        });
+
+        it('returns hosted fields from window', async () => {
+            expect(await braintreeScriptLoader.loadHostedFields())
+                .toBe(hostedFields);
         });
     });
 });

--- a/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -3,7 +3,7 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 import { GooglePayCreator } from '../googlepay';
 
-import { BraintreeClientCreator, BraintreeDataCollectorCreator, BraintreeHostWindow, BraintreePaypalCheckoutCreator, BraintreePaypalCreator, BraintreeThreeDSecureCreator, BraintreeVisaCheckoutCreator } from './braintree';
+import { BraintreeClientCreator, BraintreeDataCollectorCreator, BraintreeHostedFieldsCreator, BraintreeHostWindow, BraintreePaypalCheckoutCreator, BraintreePaypalCreator, BraintreeThreeDSecureCreator, BraintreeVisaCheckoutCreator } from './braintree';
 
 export default class BraintreeScriptLoader {
     constructor(
@@ -93,5 +93,15 @@ export default class BraintreeScriptLoader {
 
                 return this._window.braintree.googlePayment;
             });
+    }
+
+    async loadHostedFields(): Promise<BraintreeHostedFieldsCreator> {
+        await this._scriptLoader.loadScript('//js.braintreegateway.com/web/3.59.0/js/hosted-fields.min.js');
+
+        if (!this._window.braintree || !this._window.braintree.hostedFields) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this._window.braintree.hostedFields;
     }
 }

--- a/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -1,6 +1,6 @@
 import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 
-import { BraintreeClient, BraintreeDataCollector, BraintreeModule, BraintreePaypal, BraintreePaypalCheckout, BraintreeThreeDSecure, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
+import { BraintreeClient, BraintreeDataCollector, BraintreeHostedFields, BraintreeHostedFieldsCreatorConfig, BraintreeModule, BraintreePaypal, BraintreePaypalCheckout, BraintreeThreeDSecure, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
 import BraintreeScriptLoader from './braintree-script-loader';
 
 export default class BraintreeSDKCreator {
@@ -119,6 +119,17 @@ export default class BraintreeSDKCreator {
         }
 
         return this._googlePay;
+    }
+
+    async createHostedFields(
+        options: Pick<BraintreeHostedFieldsCreatorConfig, 'fields' | 'styles'>
+    ): Promise<BraintreeHostedFields> {
+        const [client, hostedFields] = await Promise.all([
+            this.getClient(),
+            this._braintreeScriptLoader.loadHostedFields(),
+        ]);
+
+        return hostedFields.create({ ...options, client });
     }
 
     teardown(): Promise<void> {

--- a/src/payment/strategies/braintree/braintree.mock.ts
+++ b/src/payment/strategies/braintree/braintree.mock.ts
@@ -1,7 +1,7 @@
 import { OrderPaymentRequestBody } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 
-import { BraintreeClient, BraintreeDataCollector, BraintreeModule, BraintreeModuleCreator, BraintreePaypalCheckout, BraintreeRequestData, BraintreeShippingAddressOverride, BraintreeThreeDSecure, BraintreeTokenizePayload, BraintreeTokenizeResponse, BraintreeVerifyPayload, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
+import { BraintreeClient, BraintreeDataCollector, BraintreeHostedFields, BraintreeModule, BraintreeModuleCreator, BraintreePaypalCheckout, BraintreeRequestData, BraintreeShippingAddressOverride, BraintreeThreeDSecure, BraintreeTokenizePayload, BraintreeTokenizeResponse, BraintreeVerifyPayload, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
 import { BraintreeThreeDSecureOptions } from './braintree-payment-options';
 
 export function getClientMock(): BraintreeClient {
@@ -43,6 +43,14 @@ export function getPaypalCheckoutMock(): BraintreePaypalCheckout {
         createPayment: jest.fn((() => Promise.resolve())),
         teardown: jest.fn(),
         tokenizePayment: jest.fn(() => Promise.resolve(getTokenizePayload())),
+    };
+}
+
+export function getHostedFieldsMock(): BraintreeHostedFields {
+    return {
+        teardown: jest.fn(() => Promise.resolve()),
+        tokenize: jest.fn(() => Promise.resolve(getTokenizePayload())),
+        on: jest.fn(),
     };
 }
 

--- a/src/payment/strategies/braintree/is-braintree-form-fields-map.ts
+++ b/src/payment/strategies/braintree/is-braintree-form-fields-map.ts
@@ -1,0 +1,16 @@
+import { BraintreeFormFieldsMap, BraintreeStoredCardFieldsMap } from './braintree-payment-options';
+
+export function isBraintreeFormFieldsMap(
+    fields: BraintreeFormFieldsMap | BraintreeStoredCardFieldsMap
+): fields is BraintreeFormFieldsMap {
+    return !!(fields as BraintreeFormFieldsMap).cardNumber;
+}
+
+export function isBraintreeStoredCardFieldsMap(
+    fields: BraintreeFormFieldsMap | BraintreeStoredCardFieldsMap
+): fields is BraintreeStoredCardFieldsMap {
+    return !!(
+        (fields as BraintreeStoredCardFieldsMap).cardCodeVerification ||
+        (fields as BraintreeStoredCardFieldsMap).cardNumberVerification
+    );
+}


### PR DESCRIPTION
## What?
Introduce an object responsible for initialising and using Braintree hosted fields.

## Why?
We want an abstraction so that it is easier for our code to interact with the Braintree hosted fields module. It acts as a facade that bridges the difference between the interface we want to offer to our clients and the interface Braintree offers to us.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
