### PR TITLE
CHECKOUT-4947: Modify Braintree credit card strategy to use hosted form service when feature is enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1279,9 +1279,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.10.0.tgz",
-      "integrity": "sha512-+MmCBkjdJebZN87MvcHAYA9j28b6ClmqzFKbf//zXBgGF+hjwaxk/pVTGd2rDKEVT3DgzFJub0shs6khE2RjtA==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.11.0.tgz",
+      "integrity": "sha512-5i+jd7CswjLh6wgnwe4YjH3G6nkiAI16oaDLomslDwsQHhAbUtZ4GqIrMVgj6oleP2cBazjRCy1NlkhRcdJbUQ==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^25.2.0",
@@ -1298,11 +1298,11 @@
           }
         },
         "@babel/generator": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+          "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
           "requires": {
-            "@babel/types": "^7.10.5",
+            "@babel/types": "^7.11.0",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           },
@@ -1333,11 +1333,11 @@
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+          "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
           "requires": {
-            "@babel/types": "^7.10.5"
+            "@babel/types": "^7.11.0"
           }
         },
         "@babel/helper-module-imports": {
@@ -1349,16 +1349,16 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+          "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
           "requires": {
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
             "@babel/helper-simple-access": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
             "@babel/template": "^7.10.4",
-            "@babel/types": "^7.10.5",
+            "@babel/types": "^7.11.0",
             "lodash": "^4.17.19"
           }
         },
@@ -1391,11 +1391,11 @@
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
           "requires": {
-            "@babel/types": "^7.10.4"
+            "@babel/types": "^7.11.0"
           }
         },
         "@babel/helpers": {
@@ -1465,9 +1465,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
+          "integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw=="
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -1480,25 +1480,25 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+          "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.5",
+            "@babel/generator": "^7.11.0",
             "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.10.4",
-            "@babel/parser": "^7.10.5",
-            "@babel/types": "^7.10.5",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.11.0",
+            "@babel/types": "^7.11.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+          "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -1720,18 +1720,18 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.10.5",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-              "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
+              "version": "7.11.1",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
+              "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
               "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.5",
-                "@babel/helper-module-transforms": "^7.10.5",
+                "@babel/generator": "^7.11.0",
+                "@babel/helper-module-transforms": "^7.11.0",
                 "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.10.5",
+                "@babel/parser": "^7.11.1",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.10.5",
-                "@babel/types": "^7.10.5",
+                "@babel/traverse": "^7.11.0",
+                "@babel/types": "^7.11.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@bigcommerce/bigpay-client": "^5.10.0",
+    "@bigcommerce/bigpay-client": "^5.11.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -19,7 +19,8 @@ export type PaymentInstrument = (
     NonceInstrument |
     ThreeDSVaultedInstrument |
     VaultedInstrument |
-    VaultedInstrument & WithHostedFormNonce
+    VaultedInstrument & WithHostedFormNonce |
+    VaultedInstrumentWithNonceVerification
 );
 
 export interface PaymentInstrumentMeta {
@@ -62,6 +63,11 @@ export interface VaultedInstrument {
     instrumentId: string;
     ccCvv?: string;
     ccNumber?: string;
+}
+
+export interface VaultedInstrumentWithNonceVerification {
+    instrumentId: string;
+    nonce: string;
 }
 
 export interface ThreeDSVaultedInstrument extends VaultedInstrument {

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -1,11 +1,13 @@
+import { pick } from 'lodash';
+
+import { Address } from '../../../address';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError, PaymentMethodFailedError } from '../../errors';
-import isCreditCardLike from '../../is-credit-card-like';
 import isVaultedInstrument from '../../is-vaulted-instrument';
-import Payment, { PaymentInstrument } from '../../payment';
+import { CreditCardInstrument, NonceInstrument, PaymentInstrument, PaymentInstrumentMeta, VaultedInstrumentWithNonceVerification } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
@@ -15,6 +17,7 @@ import BraintreePaymentProcessor from './braintree-payment-processor';
 
 export default class BraintreeCreditCardPaymentStrategy implements PaymentStrategy {
     private _is3dsEnabled?: boolean;
+    private _isHostedFormInitialized?: boolean;
     private _deviceSessionId?: string;
 
     constructor(
@@ -27,7 +30,6 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
 
     async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(options.methodId));
-
         const paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId);
 
         if (!paymentMethod || !paymentMethod.clientToken) {
@@ -36,8 +38,14 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
 
         try {
             this._braintreePaymentProcessor.initialize(paymentMethod.clientToken, options.braintree);
-            this._is3dsEnabled = paymentMethod.config.is3dsEnabled;
 
+            if (this._isHostedPaymentFormEnabled(options.methodId, options.gatewayId) && options.braintree?.form) {
+                await this._braintreePaymentProcessor.initializeHostedForm(options.braintree.form);
+
+                this._isHostedFormInitialized = true;
+            }
+
+            this._is3dsEnabled = paymentMethod.config.is3dsEnabled;
             this._deviceSessionId = await this._braintreePaymentProcessor.getSessionId();
         } catch (error) {
             this._handleError(error);
@@ -46,34 +54,58 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
         return this._store.getState();
     }
 
-    execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+    async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const { payment, ...order } = orderRequest;
 
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
         }
 
-        return this._store.dispatch(
+        const state = await this._store.dispatch(
             this._orderActionCreator.submitOrder(order, options)
-        )
-            .then(state =>
-                state.payment.isPaymentDataRequired(order.useStoreCredit) && payment ?
-                    this._preparePaymentData(payment) :
-                    Promise.resolve(payment as Payment)
-            )
-            .then(payment =>
-                this._store.dispatch(this._paymentActionCreator.submitPayment(payment))
-            )
-            .catch((error: Error) => this._handleError(error));
+        );
+
+        const {
+            billingAddress: { getBillingAddressOrThrow },
+            order: { getOrderOrThrow },
+            payment: { isPaymentDataRequired },
+        } = state;
+
+        if (!isPaymentDataRequired(order.useStoreCredit)) {
+            return state;
+        }
+
+        try {
+            return this._store.dispatch(this._paymentActionCreator.submitPayment({
+                ...payment,
+                paymentData: this._isHostedFormInitialized ?
+                    await this._prepareHostedPaymentData(
+                        payment,
+                        getBillingAddressOrThrow(),
+                        getOrderOrThrow().orderAmount
+                    ) :
+                    await this._preparePaymentData(
+                        payment,
+                        getBillingAddressOrThrow(),
+                        getOrderOrThrow().orderAmount
+                    ),
+            }));
+        } catch (error) {
+            this._handleError(error);
+        }
     }
 
     finalize(): Promise<InternalCheckoutSelectors> {
         return Promise.reject(new OrderFinalizationNotRequiredError());
     }
 
-    deinitialize(): Promise<InternalCheckoutSelectors> {
-        return this._braintreePaymentProcessor.deinitialize()
-            .then(() => this._store.getState());
+    async deinitialize(): Promise<InternalCheckoutSelectors> {
+        await Promise.all([
+            this._braintreePaymentProcessor.deinitialize(),
+            this._braintreePaymentProcessor.deinitializeHostedForm(),
+        ]);
+
+        return this._store.getState();
     }
 
     private _handleError(error: Error): never {
@@ -84,37 +116,95 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
         throw error;
     }
 
-    private _isUsingVaulting(paymentData: PaymentInstrument): boolean {
-        if (isCreditCardLike(paymentData)) {
-            return Boolean(paymentData.shouldSaveInstrument);
+    private async _preparePaymentData(payment: OrderPaymentRequestBody, billingAddress: Address, orderAmount: number): Promise<PaymentInstrument & PaymentInstrumentMeta> {
+        const commonPaymentData = { deviceSessionId: this._deviceSessionId };
+
+        if (this._isSubmittingWithStoredCard(payment) || this._isStoringNewCard(payment)) {
+            return {
+                ...commonPaymentData,
+                ...payment.paymentData,
+            };
         }
 
-        return isVaultedInstrument(paymentData);
+        if (this._shouldPerform3DSVerification(payment)) {
+            return {
+                ...commonPaymentData,
+                ...this._mapToNonceInstrument({
+                    ...payment.paymentData,
+                    ...await this._braintreePaymentProcessor.verifyCard(payment, billingAddress, orderAmount),
+                }),
+            };
+        }
+
+        return {
+            ...commonPaymentData,
+            ...this._mapToNonceInstrument({
+                ...payment.paymentData,
+                ...await this._braintreePaymentProcessor.tokenizeCard(payment, billingAddress),
+            }),
+        };
     }
 
-    private async _preparePaymentData(payment: OrderPaymentRequestBody): Promise<Payment> {
-        const { paymentData } = payment;
-        const state = this._store.getState();
+    private async _prepareHostedPaymentData(payment: OrderPaymentRequestBody, billingAddress: Address, orderAmount: number): Promise<PaymentInstrument & PaymentInstrumentMeta> {
+        const commonPaymentData = { deviceSessionId: this._deviceSessionId };
 
-        if (paymentData && this._isUsingVaulting(paymentData)) {
-            return Promise.resolve(payment as Payment);
+        if (this._shouldPerform3DSVerification(payment)) {
+            return {
+                ...commonPaymentData,
+                ...this._mapToNonceInstrument({
+                    ...payment.paymentData,
+                    ...await this._braintreePaymentProcessor.verifyCardWithHostedForm(billingAddress, orderAmount),
+                }),
+            };
         }
 
-        const order = state.order.getOrder();
-        const billingAddress = state.billingAddress.getBillingAddress();
-
-        if (!order) {
-            throw new MissingDataError(MissingDataErrorType.MissingOrder);
+        if (this._isSubmittingWithStoredCard(payment)) {
+            return {
+                ...commonPaymentData,
+                ...this._mapToVaultedInstrumentWithNonceVerification({
+                    ...payment.paymentData,
+                    ...await this._braintreePaymentProcessor.tokenizeHostedFormForStoredCardVerification(),
+                }),
+            };
         }
 
-        if (!billingAddress) {
-            throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
+        return {
+            ...commonPaymentData,
+            ...this._mapToNonceInstrument({
+                ...payment.paymentData,
+                ...await this._braintreePaymentProcessor.tokenizeHostedForm(billingAddress),
+            }),
+        };
+    }
+
+    private _mapToNonceInstrument(instrument: PaymentInstrument): NonceInstrument {
+        return pick(instrument as NonceInstrument, 'nonce', 'shouldSaveInstrument');
+    }
+
+    private _mapToVaultedInstrumentWithNonceVerification(instrument: PaymentInstrument): VaultedInstrumentWithNonceVerification {
+        return pick(instrument as VaultedInstrumentWithNonceVerification, 'nonce', 'instrumentId');
+    }
+
+    private _isHostedPaymentFormEnabled(methodId?: string, gatewayId?: string): boolean {
+        if (!methodId) {
+            return false;
         }
 
-        const updatedPaymentData = this._is3dsEnabled ?
-            await this._braintreePaymentProcessor.verifyCard(payment, billingAddress, order.orderAmount) :
-            await this._braintreePaymentProcessor.tokenizeCard(payment, billingAddress);
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(methodId, gatewayId);
 
-        return ({...payment, paymentData: {...updatedPaymentData, deviceSessionId: this._deviceSessionId} });
+        return paymentMethod.config.isHostedFormEnabled === true;
+    }
+
+    private _isSubmittingWithStoredCard(payment: OrderPaymentRequestBody): boolean {
+        return !!(payment.paymentData && isVaultedInstrument(payment.paymentData));
+    }
+
+    private _isStoringNewCard(payment: OrderPaymentRequestBody): boolean {
+        return !!(payment.paymentData && (payment.paymentData as CreditCardInstrument | NonceInstrument)?.shouldSaveInstrument);
+    }
+
+    private _shouldPerform3DSVerification(payment: OrderPaymentRequestBody): boolean {
+        return !!(this._is3dsEnabled && !this._isSubmittingWithStoredCard(payment));
     }
 }

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -6,8 +6,9 @@ import { OrderPaymentRequestBody } from '../../../order';
 import { PaymentMethodCancelledError } from '../../errors';
 import { CreditCardInstrument, NonceInstrument } from '../../payment';
 
-import { BraintreePaypal, BraintreeRequestData, BraintreeShippingAddressOverride, BraintreeTokenizePayload, BraintreeVerifyPayload } from './braintree';
-import { BraintreePaymentInitializeOptions, BraintreeThreeDSecureOptions } from './braintree-payment-options';
+import { BraintreePaypal, BraintreeRequestData, BraintreeShippingAddressOverride, BraintreeThreeDSecure, BraintreeTokenizePayload, BraintreeVerifyPayload } from './braintree';
+import BraintreeHostedForm from './braintree-hosted-form';
+import { BraintreeFormOptions, BraintreePaymentInitializeOptions, BraintreeThreeDSecureOptions } from './braintree-payment-options';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 
 export interface PaypalConfig {
@@ -24,6 +25,7 @@ export default class BraintreePaymentProcessor {
 
     constructor(
         private _braintreeSDKCreator: BraintreeSDKCreator,
+        private _braintreeHostedForm: BraintreeHostedForm,
         private _overlay: Overlay
     ) {}
 
@@ -36,15 +38,21 @@ export default class BraintreePaymentProcessor {
         return this._braintreeSDKCreator.getPaypal();
     }
 
-    tokenizeCard(payment: OrderPaymentRequestBody, billingAddress: Address): Promise<NonceInstrument> {
-        const { paymentData } = payment;
-        const requestData = this._mapToCreditCard(paymentData as CreditCardInstrument, billingAddress);
+    async tokenizeCard(payment: OrderPaymentRequestBody, billingAddress: Address): Promise<NonceInstrument> {
+        const requestData = this._mapToCreditCard(payment.paymentData as CreditCardInstrument, billingAddress);
+        const client = await this._braintreeSDKCreator.getClient();
+        const { creditCards } = await client.request(requestData);
 
-        return this._braintreeSDKCreator.getClient()
-            .then(client => client.request(requestData))
-            .then(({ creditCards }) => ({
-                nonce: creditCards[0].nonce,
-            }));
+        return { nonce: creditCards[0].nonce };
+    }
+
+    async verifyCard(payment: OrderPaymentRequestBody, billingAddress: Address, amount: number): Promise<BraintreeVerifyPayload> {
+        const [{ nonce }, threeDSecure] = await Promise.all([
+            this.tokenizeCard(payment, billingAddress),
+            this._braintreeSDKCreator.get3DS(),
+        ]);
+
+        return this._present3DSChallenge(threeDSecure, amount, nonce);
     }
 
     paypal({ shouldSaveInstrument, ...config }: PaypalConfig): Promise<BraintreeTokenizePayload> {
@@ -73,40 +81,6 @@ export default class BraintreePaymentProcessor {
             });
     }
 
-    verifyCard(payment: OrderPaymentRequestBody, billingAddress: Address, amount: number): Promise<BraintreeVerifyPayload> {
-        if (!this._threeDSecureOptions) {
-            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-        }
-
-        const { addFrame, removeFrame } = this._threeDSecureOptions;
-
-        return Promise.all([
-            this.tokenizeCard(payment, billingAddress),
-            this._braintreeSDKCreator.get3DS(),
-        ]).then(([paymentData, threeDSecure]) => {
-            const { nonce } = paymentData;
-            const cancelVerifyCard = () => threeDSecure.cancelVerifyCard()
-                .then(response => {
-                    verification.cancel(new PaymentMethodCancelledError());
-
-                    return response;
-                });
-
-            const verification = new CancellablePromise(
-                threeDSecure.verifyCard({
-                    addFrame: (error, iframe) => {
-                        addFrame(error, iframe, cancelVerifyCard);
-                    },
-                    amount,
-                    nonce,
-                    removeFrame,
-                })
-            );
-
-            return verification.promise;
-        });
-    }
-
     getSessionId(): Promise<string | undefined> {
         return this._braintreeSDKCreator.getDataCollector()
             .then(({ deviceData }) => deviceData);
@@ -125,13 +99,64 @@ export default class BraintreePaymentProcessor {
         return this._braintreeSDKCreator.teardown();
     }
 
-    private _mapToCreditCard(creditCard: CreditCardInstrument, billingAddress: Address): BraintreeRequestData {
-        let streetAddress = billingAddress.address1;
+    async initializeHostedForm(options: BraintreeFormOptions): Promise<void> {
+        await this._braintreeHostedForm.initialize(options);
+    }
 
-        if (billingAddress.address2) {
-            streetAddress = ` ${billingAddress.address2}`;
+    async deinitializeHostedForm(): Promise<void> {
+        await this._braintreeHostedForm.deinitialize();
+    }
+
+    tokenizeHostedForm(billingAddress: Address): Promise<NonceInstrument> {
+        return this._braintreeHostedForm.tokenize(billingAddress);
+    }
+
+    tokenizeHostedFormForStoredCardVerification(): Promise<NonceInstrument> {
+        return this._braintreeHostedForm.tokenizeForStoredCardVerification();
+    }
+
+    async verifyCardWithHostedForm(billingAddress: Address, amount: number): Promise<NonceInstrument> {
+        const [{ nonce }, threeDSecure] = await Promise.all([
+            this._braintreeHostedForm.tokenize(billingAddress),
+            this._braintreeSDKCreator.get3DS(),
+        ]);
+
+        return this._present3DSChallenge(threeDSecure, amount, nonce);
+    }
+
+    private _present3DSChallenge(
+        threeDSecure: BraintreeThreeDSecure,
+        amount: number,
+        nonce: string
+    ): Promise<BraintreeVerifyPayload> {
+        if (!this._threeDSecureOptions) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
+        const { addFrame, removeFrame } = this._threeDSecureOptions;
+        const cancelVerifyCard = async () => {
+            const response = await threeDSecure.cancelVerifyCard();
+
+            verification.cancel(new PaymentMethodCancelledError());
+
+            return response;
+        };
+
+        const verification = new CancellablePromise(
+            threeDSecure.verifyCard({
+                addFrame: (error, iframe) => {
+                    addFrame(error, iframe, cancelVerifyCard);
+                },
+                amount,
+                nonce,
+                removeFrame,
+            })
+        );
+
+        return verification.promise;
+    }
+
+    private _mapToCreditCard(creditCard: CreditCardInstrument, billingAddress?: Address): BraintreeRequestData {
         return {
             data: {
                 creditCard: {
@@ -142,10 +167,12 @@ export default class BraintreePaymentProcessor {
                     options: {
                         validate: false,
                     },
-                    billingAddress: {
+                    billingAddress: billingAddress && {
                         countryName: billingAddress.country,
                         postalCode: billingAddress.postalCode,
-                        streetAddress,
+                        streetAddress: billingAddress.address2 ?
+                            `${billingAddress.address1} ${billingAddress.address2}` :
+                            billingAddress.address1,
                     },
                 },
             },

--- a/src/payment/strategies/braintree/create-braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/create-braintree-payment-processor.ts
@@ -2,6 +2,7 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { Overlay } from '../../../common/overlay';
 
+import BraintreeHostedForm from './braintree-hosted-form';
 import BraintreePaymentProcessor from './braintree-payment-processor';
 import BraintreeScriptLoader from './braintree-script-loader';
 import BraintreeSDKCreator from './braintree-sdk-creator';
@@ -9,7 +10,12 @@ import BraintreeSDKCreator from './braintree-sdk-creator';
 export default function createBraintreePaymentProcessor(scriptLoader: ScriptLoader) {
     const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader);
     const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+    const braintreeHostedForm = new BraintreeHostedForm(braintreeSDKCreator);
     const overlay = new Overlay();
 
-    return new BraintreePaymentProcessor(braintreeSDKCreator, overlay);
+    return new BraintreePaymentProcessor(
+        braintreeSDKCreator,
+        braintreeHostedForm,
+        overlay
+    );
 }


### PR DESCRIPTION
## What?
Modify `BraintreeCreditCardStrategy` to use `BraintreeHostedForm` (introduced in #939) when the feature is enabled and the required options are passed.

## Why?
So we can accept credit card details using Braintree's hosted payment form.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
