### PR TITLE
refactor(payment): INT-2922 Upgrade Adyen Component Library

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -22,8 +22,8 @@ describe('AdyenV2ScriptLoader', () => {
     describe('#load()', () => {
         const adyenClient = getAdyenClient();
         const configuration = getAdyenConfiguration();
-        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.8.1/adyen.js';
-        const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.8.1/adyen.css';
+        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js';
+        const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css';
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -13,8 +13,8 @@ export default class AdyenV2ScriptLoader {
 
     async load(configuration: AdyenConfiguration): Promise<AdyenClient> {
         await Promise.all([
-            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.1/adyen.css`),
-            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.8.1/adyen.js`),
+            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css`),
+            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js`),
         ]);
 
         if (!this._window.AdyenCheckout) {


### PR DESCRIPTION
## What? [INT-2922](https://jira.bigcommerce.com/browse/INT-2922)
Upgrade Adyen Components Library to v3.10.1

## Why?
To expose cumulative improvements and fixes provided by [this](https://docs.adyen.com/checkout/release-notes#web-components-3-10-1) new release.

## Testing / Proof

- Manual

- Unit

@bigcommerce/checkout @bigcommerce/payments
