### PR TITLE
perf(payment): INT-2926 Avoid unnecessary calls to payments/amazonpay

### DIFF
--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -6,6 +6,7 @@ import { Registry } from '../common/registry';
 
 import createCheckoutButtonRegistry from './create-checkout-button-registry';
 import { CheckoutButtonStrategy } from './strategies';
+import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { BraintreePaypalButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 
@@ -38,5 +39,9 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with GooglePay on Stripe Credit registered', () => {
         expect(registry.get('googlepaystripe')).toEqual(expect.any(GooglePayButtonStrategy));
+    });
+
+    it('returns registry with AmazonPayV2 registered', () => {
+        expect(registry.get('amazonpay')).toEqual(expect.any(AmazonPayV2ButtonStrategy));
     });
 });

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -149,7 +149,7 @@ export default function createCheckoutButtonRegistry(
         new AmazonPayV2ButtonStrategy(
             store,
             checkoutActionCreator,
-            createAmazonPayV2PaymentProcessor(store)
+            createAmazonPayV2PaymentProcessor()
         )
     );
 

--- a/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
+++ b/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
@@ -1,14 +1,6 @@
 import { AmazonPayV2ButtonParams } from '../../../payment/strategies/amazon-pay-v2';
 
-export interface AmazonPayV2ButtonInitializeOptions {
-    /**
-     * @alpha
-     */
-    containerId: string;
-
-    /**
-     * A set of options to render the AmazonPayV2 checkout button.
-     * @alpha
-     */
-    options: AmazonPayV2ButtonParams;
-}
+/**
+ * The required config to render the AmazonPayV2 buttton.
+ */
+export type AmazonPayV2ButtonInitializeOptions = AmazonPayV2ButtonParams;

--- a/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -1,8 +1,12 @@
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { AmazonPayV2PaymentProcessor, AmazonPayV2PayOptions, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
+import { PaymentMethod } from '../../../payment';
+import { AmazonPayV2ButtonParams, AmazonPayV2PaymentProcessor, AmazonPayV2PayOptions, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
+import { getShippableItemsCount } from '../../../shipping';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+import { AmazonPayV2ButtonInitializeOptions } from './amazon-pay-v2-button-options';
 
 export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy {
     private _walletButton?: HTMLElement;
@@ -14,16 +18,16 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
     ) { }
 
     async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
-        const { containerId, methodId } = options;
+        const { containerId, methodId, amazonpay } = options;
 
         if (!containerId || !methodId) {
-            throw new InvalidArgumentError('Unable to proceed because "containerId" argument is not provided.');
+            throw new InvalidArgumentError('Unable to proceed because "containerId" or "methodId" argument is not provided.');
         }
 
-        await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
-        await this._amazonPayV2PaymentProcessor.initialize(methodId);
+        const paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(methodId);
 
-        this._walletButton = this._createSignInButton(containerId, methodId);
+        await this._amazonPayV2PaymentProcessor.initialize(paymentMethod);
+        this._walletButton = await this._createSignInButton(containerId, paymentMethod, amazonpay);
     }
 
     deinitialize(): Promise<void> {
@@ -35,25 +39,24 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
         return Promise.resolve();
     }
 
-    private _createSignInButton(containerId: string, methodId: string): HTMLElement {
+    private async _createSignInButton(containerId: string, paymentMethod: PaymentMethod, options?: AmazonPayV2ButtonInitializeOptions): Promise<HTMLElement> {
         const container = document.getElementById(containerId);
 
         if (!container) {
             throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
         }
 
-        const state = this._store.getState();
-        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+        const amazonButtonOptions = options ?? await this._getAmazonPayV2ButtonOptions(paymentMethod);
+
+        this._amazonPayV2PaymentProcessor.createButton(`#${containerId}`, amazonButtonOptions);
+
+        return container;
+    }
+
+    private async _getAmazonPayV2ButtonOptions(paymentMethod: PaymentMethod): Promise<AmazonPayV2ButtonParams> {
+        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         const cart = state.cart.getCart();
-        const config = state.config.getStoreConfig();
-
-        if (!config) {
-            throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
-        }
-
-        if (!paymentMethod) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
+        const { storeProfile: { shopPath } } = state.config.getStoreConfigOrThrow();
 
         const {
             config: {
@@ -64,34 +67,28 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
                 checkoutLanguage,
                 ledgerCurrency,
                 checkoutSessionMethod,
-                region,
                 extractAmazonCheckoutSessionId,
             },
         } = paymentMethod;
 
-        if (!merchantId) {
-            throw new InvalidArgumentError();
+        if (!merchantId || !ledgerCurrency || !shopPath) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const amazonButtonOptions = {
+        return {
             merchantId,
-            sandbox: !!testMode,
-            checkoutLanguage,
-            ledgerCurrency,
-            region,
-            productType: cart && cart.lineItems.physicalItems.length === 0 ?
-                AmazonPayV2PayOptions.PayOnly :
-                AmazonPayV2PayOptions.PayAndShip,
             createCheckoutSession: {
+                url: `${shopPath}/remote-checkout/${paymentMethod.id}/payment-session`,
                 method: checkoutSessionMethod,
-                url: `${config.storeProfile.shopPath}/remote-checkout/${methodId}/payment-session`,
                 extractAmazonCheckoutSessionId,
             },
+            sandbox: !!testMode,
+            ledgerCurrency,
+            checkoutLanguage,
+            productType: cart && getShippableItemsCount(cart) === 0 ?
+                AmazonPayV2PayOptions.PayOnly :
+                AmazonPayV2PayOptions.PayAndShip,
             placement: AmazonPayV2Placement.Cart,
         };
-
-        this._amazonPayV2PaymentProcessor.createButton(`#${containerId}`, amazonButtonOptions);
-
-        return container;
     }
 }

--- a/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button.mock.ts
+++ b/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button.mock.ts
@@ -6,6 +6,8 @@ export enum Mode {
     Full,
     UndefinedContainer,
     InvalidContainer,
+    UndefinedMethodId,
+    UndefinedAmazonPay,
 }
 
 export function getAmazonPayV2CheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButtonInitializeOptions {
@@ -13,7 +15,7 @@ export function getAmazonPayV2CheckoutButtonOptions(mode: Mode = Mode.Full): Che
     const containerId = 'amazonpayCheckoutButton';
     const undefinedContainerId = { containerId: '' };
     const invalidContainerId = { containerId: 'invalid_container' };
-    const amazonPayV2Options = { containerId, getAmazonPayV2ButtonParamsMock };
+    const amazonPayV2Options = { containerId, amazonpay: getAmazonPayV2ButtonParamsMock() };
 
     switch (mode) {
         case Mode.UndefinedContainer:
@@ -22,6 +24,10 @@ export function getAmazonPayV2CheckoutButtonOptions(mode: Mode = Mode.Full): Che
             return { ...methodId, ...invalidContainerId };
         case Mode.Full:
             return { ...methodId, ...amazonPayV2Options };
+        case Mode.UndefinedMethodId:
+            return { ...amazonPayV2Options } as CheckoutButtonInitializeOptions;
+        case Mode.UndefinedAmazonPay:
+            return { ...getAmazonPayV2CheckoutButtonOptions(Mode.Full), amazonpay: undefined };
         default:
             return { ...methodId, containerId };
     }

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -68,8 +68,9 @@ export default function createCustomerStrategyRegistry(
     registry.register('amazonpay', () =>
         new AmazonPayV2CustomerStrategy(
             store,
+            paymentMethodActionCreator,
             remoteCheckoutActionCreator,
-            createAmazonPayV2PaymentProcessor(store)
+            createAmazonPayV2PaymentProcessor()
         )
     );
 

--- a/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
+++ b/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
@@ -1,7 +1,9 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from '../../../common/error/errors';
+import { PaymentMethodActionCreator } from '../../../payment';
 import { AmazonPayV2PaymentProcessor, AmazonPayV2PayOptions, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
+import { getShippableItemsCount } from '../../../shipping';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
@@ -10,6 +12,7 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
 
     constructor(
         private _store: CheckoutStore,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor
     ) {}
@@ -17,13 +20,14 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
     async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { methodId, amazonpay } = options;
 
-        if (!amazonpay) {
-            throw new InvalidArgumentError('Unable to proceed because "options.amazonpay" argument is not provided.');
+        if (!methodId || !amazonpay) {
+            throw new InvalidArgumentError('Unable to proceed because "options.methodId" or "options.amazonpay" argument is not provided.');
         }
-        if (!methodId) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
-        await this._amazonPayV2PaymentProcessor.initialize(methodId);
+
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        await this._amazonPayV2PaymentProcessor.initialize(paymentMethod);
         this._walletButton = this._createSignInButton(amazonpay.container, methodId);
 
         return this._store.getState();
@@ -52,7 +56,7 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
             return Promise.resolve(this._store.getState());
         }
 
-        await this._amazonPayV2PaymentProcessor.signout(payment.providerId);
+        await this._amazonPayV2PaymentProcessor.signout();
 
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
@@ -88,7 +92,6 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
                 checkoutLanguage,
                 ledgerCurrency,
                 checkoutSessionMethod,
-                region,
                 extractAmazonCheckoutSessionId,
             },
         } = paymentMethod;
@@ -102,8 +105,7 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
             sandbox: !!testMode,
             checkoutLanguage,
             ledgerCurrency,
-            region,
-            productType: cart && cart.lineItems.physicalItems.length === 0 ?
+            productType: cart && getShippableItemsCount(cart) === 0 ?
                 AmazonPayV2PayOptions.PayOnly :
                 AmazonPayV2PayOptions.PayAndShip,
             createCheckoutSession: {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -161,7 +161,7 @@ export default function createPaymentStrategyRegistry(
             paymentMethodActionCreator,
             orderActionCreator,
             paymentActionCreator,
-            createAmazonPayV2PaymentProcessor(store)
+            createAmazonPayV2PaymentProcessor()
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -239,7 +239,7 @@ export function getAffirm(): PaymentMethod {
     };
 }
 
-export function getAmazonPayV2(): PaymentMethod {
+export function getAmazonPayV2(region = 'us'): PaymentMethod {
     return {
         config: {
             displayName: 'AMAZON PAY',
@@ -251,9 +251,12 @@ export function getAmazonPayV2(): PaymentMethod {
         },
         id: 'amazonpay',
         initializationData: {
+            buttonColor: 'Gold',
             checkoutLanguage: 'en_US',
+            checkoutSessionMethod: 'GET',
+            extractAmazonCheckoutSessionId: 'token',
             ledgerCurrency: 'USD',
-            region: 'us',
+            region,
         },
         logoUrl: '',
         method: 'credit-card',
@@ -534,6 +537,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getAffirm(),
         getAfterpay(),
         getAmazonPay(),
+        getAmazonPayV2(),
         getAuthorizenet(),
         getBlueSnapV2(),
         getBraintree(),

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -1,83 +1,37 @@
-import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
-import { getCheckoutState } from '../../../checkout/checkouts.mock';
-import { MissingDataError, NotInitializedError } from '../../../common/error/errors';
-import { getConfigState } from '../../../config/configs.mock';
-import { getCustomerState } from '../../../customer/customers.mock';
-import PaymentMethodActionCreator from '../../payment-method-action-creator';
-import PaymentMethodRequestSender from '../../payment-method-request-sender';
-import { getAmazonPayV2, getPaymentMethodsState } from '../../payment-methods.mock';
+import { NotInitializedError } from '../../../common/error/errors';
+import { getAmazonPayV2 } from '../../payment-methods.mock';
 
-import { AmazonPayV2Client } from './amazon-pay-v2';
+import { AmazonPayV2ButtonParams, AmazonPayV2SDK } from './amazon-pay-v2';
 import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 import { getAmazonPayV2ButtonParamsMock, getAmazonPayV2SDKMock } from './amazon-pay-v2.mock';
 
 describe('AmazonPayV2PaymentProcessor', () => {
-    let processor: AmazonPayV2PaymentProcessor;
-    let paymentMethodActionCreator: PaymentMethodActionCreator;
     let amazonPayV2ScriptLoader: AmazonPayV2ScriptLoader;
-    let store: CheckoutStore;
-    let clientMock: AmazonPayV2Client;
-    let requestSender: RequestSender;
+    let processor: AmazonPayV2PaymentProcessor;
+    let amazonPayV2SDKMock: AmazonPayV2SDK;
 
     beforeEach(() => {
-        const scriptLoader = createScriptLoader();
-
-        store = createCheckoutStore({
-            checkout: getCheckoutState(),
-            customer: getCustomerState(),
-            config: getConfigState(),
-            cart: getCartState(),
-            paymentMethods: getPaymentMethodsState(),
-        });
-        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
-        amazonPayV2ScriptLoader = new AmazonPayV2ScriptLoader(scriptLoader);
-        requestSender = createRequestSender();
-
-        processor =  new AmazonPayV2PaymentProcessor(
-            store,
-            paymentMethodActionCreator,
+        amazonPayV2ScriptLoader = new AmazonPayV2ScriptLoader(createScriptLoader());
+        processor = new AmazonPayV2PaymentProcessor(
             amazonPayV2ScriptLoader
         );
+        amazonPayV2SDKMock = getAmazonPayV2SDKMock();
+
+        jest.spyOn(amazonPayV2ScriptLoader, 'load').mockResolvedValue(amazonPayV2SDKMock);
     });
 
     describe('#initialize', () => {
-        beforeEach(() => {
-            const amazonPayV2SDK = getAmazonPayV2SDKMock();
-            clientMock = {
-                renderButton: jest.fn(() => Promise.resolve(new HTMLElement())),
-                bindChangeAction: () => null,
-                signout: () => null,
-            };
-            amazonPayV2SDK.Pay.renderButton = jest.fn(() => clientMock);
-
-            jest.spyOn(amazonPayV2ScriptLoader, 'load').mockReturnValue(Promise.resolve(amazonPayV2SDK));
-        });
-
         it('creates an instance of AmazonPayV2PaymentProcessor', () => {
             expect(processor).toBeInstanceOf(AmazonPayV2PaymentProcessor);
         });
 
         it('initializes processor successfully', async () => {
-            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getAmazonPayV2());
-            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
-
-            await processor.initialize('amazonpay');
+            await processor.initialize(getAmazonPayV2());
 
             expect(amazonPayV2ScriptLoader.load).toHaveBeenCalled();
-        });
-
-        it('fails to initialize processor without paymentMethod', async () => {
-            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(undefined);
-            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
-
-            await expect(processor.initialize('amazonpay') ).rejects.toThrow(MissingDataError);
         });
     });
 
@@ -91,33 +45,17 @@ describe('AmazonPayV2PaymentProcessor', () => {
         const sessionId = 'ACB123';
         const buttonName = 'bindableButton';
 
-        beforeEach(() => {
-            const amazonPayV2SDK = getAmazonPayV2SDKMock();
-            clientMock = {
-                renderButton: (jest.fn(() => Promise.resolve())),
-                bindChangeAction: jest.fn(),
-                signout: () => null,
-            };
-
-            amazonPayV2SDK.Pay = clientMock;
-
-            jest.spyOn(amazonPayV2ScriptLoader, 'load').mockReturnValue(Promise.resolve(amazonPayV2SDK));
-            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getAmazonPayV2());
-            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
-        });
-
         it('bind the button successfully', async () => {
             const bindOptions = {
                 amazonCheckoutSessionId: sessionId,
                 changeAction: 'changePayment',
             };
 
-            await processor.initialize('amazonMaxo');
+            await processor.initialize(getAmazonPayV2());
 
             processor.bindButton(buttonName, sessionId, 'changePayment');
 
-            expect(clientMock.bindChangeAction).toHaveBeenCalledWith(`#${buttonName}`, bindOptions);
+            expect(amazonPayV2SDKMock.Pay.bindChangeAction).toHaveBeenCalledWith(`#${buttonName}`, bindOptions);
         });
 
         it('does not bind the button if the processor is not initialized previously', () => {
@@ -125,67 +63,32 @@ describe('AmazonPayV2PaymentProcessor', () => {
         });
     });
 
-    describe('#signout', () => {
-        const methodId = 'amazonmaxo';
+    describe('#signOut', () => {
+        it('signs out succesfully', async () => {
+            await processor.initialize(getAmazonPayV2());
+            await processor.signout();
 
-        beforeEach(() => {
-            const amazonMaxoSDK = getAmazonPayV2SDKMock();
-            clientMock = {
-                renderButton: (jest.fn(() => Promise.resolve())),
-                bindChangeAction: jest.fn(),
-                signout:  jest.fn(),
-            };
-
-            amazonMaxoSDK.Pay = clientMock;
-
-            jest.spyOn(amazonPayV2ScriptLoader, 'load').mockReturnValue(Promise.resolve(amazonMaxoSDK));
-            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getAmazonPayV2());
-            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
-        });
-
-        it('loads the SDK when the SDK is not loaded', async () => {
-            await processor.signout(methodId);
-
-            expect(amazonPayV2ScriptLoader.load).toHaveBeenCalled();
-        });
-
-        it('signouts succesfully when the SDK is previouly loaded', async () => {
-            await processor.initialize('amazonMaxo');
-
-            await processor.signout(methodId);
-
-            expect(clientMock.signout).toHaveBeenCalled();
+            expect(amazonPayV2SDKMock.Pay.signout).toHaveBeenCalled();
         });
     });
 
     describe('#createButton', () => {
+        const containerId = 'amazonpay-container';
+        let amazonPayV2ButtonParams: AmazonPayV2ButtonParams;
+
         beforeEach(() => {
-            const amazonPayV2SDK = getAmazonPayV2SDKMock();
-            clientMock = {
-                renderButton: jest.fn(() => Promise.resolve()),
-                bindChangeAction: () => null,
-                signout: () => null,
-            };
-
-            amazonPayV2SDK.Pay = clientMock;
-
-            jest.spyOn(amazonPayV2ScriptLoader, 'load').mockReturnValue(Promise.resolve(amazonPayV2SDK));
-            jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(getAmazonPayV2());
-            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(Promise.resolve(store.getState()));
+            amazonPayV2ButtonParams = getAmazonPayV2ButtonParamsMock();
         });
 
         it('creates the html button element', async () => {
-            await processor.initialize('amazonpay');
-            await processor.createButton('container', getAmazonPayV2ButtonParamsMock());
+            await processor.initialize(getAmazonPayV2());
+            processor.createButton(containerId, amazonPayV2ButtonParams);
 
-            expect(clientMock.renderButton).toHaveBeenCalled();
+            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(containerId, amazonPayV2ButtonParams);
         });
 
-        it('throws an error when amazonPayV2SDK is not initialized', async () => {
-
-            await expect(() => {processor.createButton('container', getAmazonPayV2ButtonParamsMock()); } ).toThrow(NotInitializedError);
+        it('throws an error when amazonPayV2SDK is not initialized', () => {
+            expect(() => processor.createButton(containerId, amazonPayV2ButtonParams)).toThrow(NotInitializedError);
         });
     });
 });

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -1,24 +1,19 @@
-import { CheckoutStore } from '../../../checkout';
-import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
-import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentMethod } from '../..';
+import { AmazonPayV2ButtonInitializeOptions } from '../../../checkout-buttons/strategies/amazon-pay-v2';
+import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 
-import { AmazonPayV2ButtonParams, AmazonPayV2ChangeActionType, AmazonPayV2SDK } from './amazon-pay-v2';
+import { AmazonPayV2ChangeActionType, AmazonPayV2SDK } from './amazon-pay-v2';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 
 export default class AmazonPayV2PaymentProcessor {
     private _amazonPayV2SDK?: AmazonPayV2SDK;
-    private _methodId?: string;
 
     constructor(
-        private _store: CheckoutStore,
-        private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _amazonPayV2ScriptLoader: AmazonPayV2ScriptLoader
     ) { }
 
-    initialize(methodId: string): Promise<void> {
-        this._methodId = methodId;
-
-        return this._configureWallet();
+    async initialize(paymentMethod: PaymentMethod): Promise<void> {
+        this._amazonPayV2SDK = await this._amazonPayV2ScriptLoader.load(paymentMethod);
     }
 
     deinitialize(): Promise<void> {
@@ -28,55 +23,29 @@ export default class AmazonPayV2PaymentProcessor {
     }
 
     bindButton(buttonId: string, sessionId: string, changeAction: AmazonPayV2ChangeActionType): void {
-        if (!this._amazonPayV2SDK) {
-            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-        }
-
-        this._amazonPayV2SDK.Pay.bindChangeAction(`#${buttonId}`, {
+        this._getAmazonPayV2SDK().Pay.bindChangeAction(`#${buttonId}`, {
             amazonCheckoutSessionId: sessionId,
             changeAction,
         });
     }
 
-    createButton(containerId: string, params: AmazonPayV2ButtonParams): HTMLElement {
-        if (!this._amazonPayV2SDK) {
-            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-        }
-
-        return this._amazonPayV2SDK.Pay.renderButton(containerId, params);
+    createButton(containerId: string, options: AmazonPayV2ButtonInitializeOptions): HTMLElement {
+        return this._getAmazonPayV2SDK().Pay.renderButton(containerId, options);
     }
 
-    async signout(methodId: string): Promise<void> {
-        this._methodId = methodId;
-
-        if (!this._amazonPayV2SDK) {
-            await this._configureWallet();
-
-            return this.signout(methodId);
-        } else {
+    async signout(): Promise<void> {
+        if (this._amazonPayV2SDK) {
             this._amazonPayV2SDK.Pay.signout();
         }
 
         return Promise.resolve();
     }
 
-    private async _configureWallet(): Promise<void> {
-        const methodId = this._getMethodId();
-        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
-        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
-
-        if (!paymentMethod) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
-
-        this._amazonPayV2SDK = await this._amazonPayV2ScriptLoader.load(paymentMethod);
-    }
-
-    private _getMethodId(): string {
-        if (!this._methodId) {
+    private _getAmazonPayV2SDK(): AmazonPayV2SDK {
+        if (!this._amazonPayV2SDK) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        return this._methodId;
+        return this._amazonPayV2SDK;
     }
 }

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-script-loader.spec.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-script-loader.spec.ts
@@ -1,10 +1,11 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '../../errors';
+import { getAmazonPayV2 as getPaymentMethodMock } from '../../payment-methods.mock';
 
 import { AmazonPayV2HostWindow, AmazonPayV2SDK } from './amazon-pay-v2';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
-import { getAmazonPayV2SDKMock, getPaymentMethodMock } from './amazon-pay-v2.mock';
+import { getAmazonPayV2SDKMock } from './amazon-pay-v2.mock';
 
 describe('AmazonPayV2ScriptLoader', () => {
     let amazonPayV2ScriptLoader: AmazonPayV2ScriptLoader;

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -1,4 +1,5 @@
 import PaymentMethod from '../../payment-method';
+import { getAmazonPayV2 } from '../../payment-methods.mock';
 
 import { AmazonPayV2ButtonParams, AmazonPayV2CheckoutLanguage, AmazonPayV2LedgerCurrency, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
 
@@ -13,35 +14,7 @@ export function getAmazonPayV2SDKMock(): AmazonPayV2SDK {
 }
 
 export function getPaymentMethodMockUndefinedMerchant(): PaymentMethod {
-    return Object.assign({}, getPaymentMethodMock(), { config: { merchantId: undefined } });
-}
-
-export function getPaymentMethodMock(region = 'us'): PaymentMethod {
-    return {
-        id: 'amazonpay',
-        config: {
-            displayName: 'AMAZON PAY',
-            helpText: '',
-            isVaultingEnabled: false,
-            merchantId: 'checkout_amazonpay',
-            requireCustomerCode: false,
-            testMode: true,
-        },
-        method: 'method',
-        supportedCards: [
-            'VISA',
-            'AMEX',
-            'MC',
-        ],
-        type: 'PAYMENT_TYPE_API',
-        clientToken: 'token',
-        nonce: 'nonce',
-        initializationData: {
-            checkoutLanguage: 'en_US',
-            ledgerCurrency: 'USD',
-            region,
-        },
-    };
+    return { ...getAmazonPayV2(), config: { merchantId: undefined } };
 }
 
 export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParams {
@@ -49,6 +22,8 @@ export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParams {
         checkoutLanguage: 'en_US' as AmazonPayV2CheckoutLanguage,
         createCheckoutSession: {
             url: 'https://my-dev-store.store.bcdev/remote-checkout/amazonpay/payment-session',
+            method: 'GET',
+            extractAmazonCheckoutSessionId: 'token',
         },
         ledgerCurrency: 'USD' as AmazonPayV2LedgerCurrency,
         merchantId: 'checkout_amazonpay',

--- a/src/payment/strategies/amazon-pay-v2/create-amazon-pay-v2-payment-processor.ts
+++ b/src/payment/strategies/amazon-pay-v2/create-amazon-pay-v2-payment-processor.ts
@@ -1,22 +1,10 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
-
-import { CheckoutStore } from '../../../checkout';
-import PaymentMethodActionCreator from '../../payment-method-action-creator';
-import PaymentMethodRequestSender from '../../payment-method-request-sender';
 
 import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 
-export default function createAmazonPayV2PaymentProcessor(store: CheckoutStore): AmazonPayV2PaymentProcessor {
-    const requestSender = createRequestSender();
-    const scriptLoader = getScriptLoader();
-
+export default function createAmazonPayV2PaymentProcessor(): AmazonPayV2PaymentProcessor {
     return new AmazonPayV2PaymentProcessor(
-        store,
-        new PaymentMethodActionCreator(
-            new PaymentMethodRequestSender(requestSender)
-        ),
-        new AmazonPayV2ScriptLoader(scriptLoader)
+        new AmazonPayV2ScriptLoader(getScriptLoader())
     );
 }

--- a/src/shipping/create-shipping-strategy-registry.ts
+++ b/src/shipping/create-shipping-strategy-registry.ts
@@ -40,7 +40,7 @@ export default function createShippingStrategyRegistry(
             store,
             consignmentActionCreator,
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
-            createAmazonPayV2PaymentProcessor(store),
+            createAmazonPayV2PaymentProcessor(),
             new ShippingStrategyActionCreator(registry)
         )
     );


### PR DESCRIPTION
## What? [INT-2926](https://jira.bigcommerce.com/browse/INT-2926)
- Prevents `AmazonPayV2PaymentProcessor` from calling payments/amazonpay, strategies are now in charge of that.
- ~~`AmazonPayV2ButtonStrategy` is initialized entirely with data from bcapp when the template is rendered.~~
- `AmazonPayV2ButtonStrategy` is initialized from BC App template data if available, otherwise I make the required API calls.
- I did some clean up on `AmazonPayV2` strategies and tests.

## Why?
Because the Amazon team noticed a slight delay loading their buttons in our end.

## Testing / Proof
CIrcleCI and...

**BEFORE** / **AFTER**
<img src="https://user-images.githubusercontent.com/4843328/89460081-56ec8f80-d72f-11ea-8ec1-f94d6215be4e.png" width="300"> <img src="https://user-images.githubusercontent.com/4843328/89460086-57852600-d72f-11ea-99df-74c9993f04db.png" width="300">
<img src="https://user-images.githubusercontent.com/4843328/89469213-9c648900-d73e-11ea-862a-4640dce2310c.png" width="300"> <img src="https://user-images.githubusercontent.com/4843328/89469216-9cfd1f80-d73e-11ea-9ad1-f67da17f863f.png" width="300">

## Dependencies
~~This PR depends on [bigcommerce/pull/36413](https://github.com/bigcommerce/bigcommerce/pull/36413)~~
This PR partially depends on [bigcommerce/pull/36413](https://github.com/bigcommerce/bigcommerce/pull/36413)

@bigcommerce/checkout @bigcommerce/payments
