### PR TITLE
CHECKOUT-5089: Catch "permission denied" error when attempting to gather adjacent hosted inputs to support IE11

### DIFF
--- a/src/hosted-form/iframe-content/hosted-input-aggregator.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-aggregator.spec.ts
@@ -65,6 +65,28 @@ describe('HostedInputAggregator', () => {
             .toEqual(frames.slice(0, -1).map(frame => frame.hostedInput));
     });
 
+    it('does not throw error if there are other iframes in parent window that belong to different origin than itself in IE 11', () => {
+        frames.push({
+            get hostedInput() {
+                throw new DOMException();
+            },
+        } as unknown as HostedInputWindow);
+
+        expect(aggregator.getInputs())
+            .toEqual(frames.slice(0, -1).map(frame => frame.hostedInput));
+    });
+
+    it('does not fail silently if unable to gather adjacent hosted inputs for other reasons', () => {
+        frames.push({
+            get hostedInput() {
+                throw new TypeError();
+            },
+        } as unknown as HostedInputWindow);
+
+        expect(() => aggregator.getInputs())
+            .toThrowError(TypeError);
+    });
+
     it('gathers all adjacent hosted inputs that satisfy filter', () => {
         expect(aggregator.getInputs(field => includes([HostedFieldType.CardCode, HostedFieldType.CardExpiry], field.getType())))
             .toEqual([frames[0].hostedInput, frames[1].hostedInput]);

--- a/src/hosted-form/iframe-content/hosted-input-aggregator.ts
+++ b/src/hosted-form/iframe-content/hosted-input-aggregator.ts
@@ -23,6 +23,11 @@ export default class HostedInputAggregator {
                         return result;
                     }
 
+                    // IE11 doesn't throw `DOMException`
+                    if (error instanceof Error && error.message === 'Permission denied') {
+                        return result;
+                    }
+
                     throw error;
                 }
             }, []);


### PR DESCRIPTION
## What?
Catch  "permission denied" error when attempting to gather adjacent hosted inputs to support IE11.

## Why?
It's possible that the checkout page has iframes other than the hosted fields (i.e.: tracking iframes, live chat widgets). When attempting to gather hosted fields, we have to loop through every iframe that exists on the page and filter out the ones that are not hosted fields. We know which one to filter out because iframes that are not hosted fields come from a different origin and will throw an exception when trying to access them. Unfortunately, IE11 doesn't throw the standard `DOMException` error - it throws an `Error` instance with "Permission denied" message instead. As a result, our filtering logic fails.

## Testing / Proof
Unit + Manual

**Before**
<img width="680" alt="Screen Shot 2020-08-06 at 12 05 56 pm" src="https://user-images.githubusercontent.com/667603/89483017-75f62a80-d7de-11ea-9cbf-57fe06ed0fac.png">

**After**
<img width="757" alt="Screen Shot 2020-08-06 at 12 14 38 pm" src="https://user-images.githubusercontent.com/667603/89483027-7b537500-d7de-11ea-97ec-86a221f16677.png">

@bigcommerce/checkout @bigcommerce/payments
