### PR TITLE
fix(payment): INT-3010 Fix Zip store credit implementation

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -463,6 +463,7 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             paymentMethodActionCreator,
             storeCreditActionCreator,
+            remoteCheckoutActionCreator,
             new ZipScriptLoader(scriptLoader),
             requestSender
         )


### PR DESCRIPTION
## What? [INT-3010](https://jira.bigcommerce.com/browse/INT-3010)
Restore the `remoteCheckoutActionCreator` calls for Zip

## Why?
This call stores the `useStoreCredit` on the backend, so when loading the payment method, the store credit can still be applied. 
Apply Store Credit unsets this variable in the backend, but is later required in the `loadPaymentMethod`call.
## Testing / Proof
[Demo Video](https://drive.google.com/file/d/1ZH8JuYecxlImYbYcI8abkxvpvHHS8khD/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments
