### PR TITLE
feat(payment): INT-2907 Avoid returns duplicate vaulted instruments

### DIFF
--- a/src/payment/instrument/instrument-selector.ts
+++ b/src/payment/instrument/instrument-selector.ts
@@ -4,7 +4,7 @@ import { filter, flatMap, isMatch, values } from 'lodash';
 import { createSelector } from '../../common/selector';
 import PaymentMethod from '../payment-method';
 
-import PaymentInstrument, { AccountInstrument, CardInstrument } from './instrument';
+import PaymentInstrument, { CardInstrument } from './instrument';
 import InstrumentState, { DEFAULT_STATE, InstrumentMeta } from './instrument-state';
 import supportedInstruments from './supported-payment-instruments';
 
@@ -15,7 +15,7 @@ export default interface InstrumentSelector {
     getInstrumentsMeta(): InstrumentMeta | undefined;
     getLoadError(): Error | undefined;
     getDeleteError(instrumentId?: string): Error | undefined;
-    isLoading(): boolean ;
+    isLoading(): boolean;
     isDeleting(instrumentId?: string): boolean;
 }
 
@@ -61,19 +61,13 @@ export function createInstrumentSelectorFactory(): InstrumentSelectorFactory {
                 return;
             }
 
-            const cardInstruments = flatMap(supportedInstruments, card =>
-                filter(instruments, (instrument: PaymentInstrument): instrument is CardInstrument => {
-                    return card.method === 'credit_card' && isMatch(instrument, card);
+            const allSupportedInstruments = flatMap(supportedInstruments, supportedProvider => 
+                filter(instruments, (instrument: PaymentInstrument): instrument is PaymentInstrument => {
+                    return isMatch(instrument, supportedProvider);
                 })
             );
 
-            const accountInstruments = flatMap(supportedInstruments, account =>
-                filter(instruments, (instrument: PaymentInstrument): instrument is AccountInstrument => {
-                    return isMatch(instrument, account);
-                })
-            );
-
-            return [...cardInstruments, ...accountInstruments];
+            return allSupportedInstruments;
         }
     );
 

--- a/src/payment/instrument/instrument-selector.ts
+++ b/src/payment/instrument/instrument-selector.ts
@@ -61,7 +61,7 @@ export function createInstrumentSelectorFactory(): InstrumentSelectorFactory {
                 return;
             }
 
-            const allSupportedInstruments = flatMap(supportedInstruments, supportedProvider => 
+            const allSupportedInstruments = flatMap(supportedInstruments, supportedProvider =>
                 filter(instruments, (instrument: PaymentInstrument): instrument is PaymentInstrument => {
                     return isMatch(instrument, supportedProvider);
                 })


### PR DESCRIPTION
## What?
When calling getInstruments on a checkout app built around the Checkout SDK, the results are duplicated in the array returned

## Why?
Because previously we filter the instrument to determine if there are card instruments or account instruments, but we determine that getInstruments need to return all the instruments and if we need only account instruments or card instruments then use the methods getCardInstruments or in case of account create it.

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/89666883-bfa74980-d8a0-11ea-97dc-d4deb7ab48b5.png)
![image](https://user-images.githubusercontent.com/35146660/89667475-ce423080-d8a1-11ea-9122-eed30f57c3b4.png)




@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
