### PR TITLE
feat(checkout): INT-2992 Make store credit usable with bolt

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -515,6 +515,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             paymentMethodActionCreator,
+            storeCreditActionCreator,
             new BoltScriptLoader(scriptLoader)
         )
 );


### PR DESCRIPTION
## What? [INT-2992](https://jira.bigcommerce.com/browse/INT-2992)
Use `storeCreditActionCreator` on bolt
## Why?
To allow bolt to accept store credit

### Sibling PR
https://github.com/bigcommerce/bigcommerce/pull/36460

## Testing / Proof
[Demo Video](https://drive.google.com/file/d/1rv3P9eXVmzmD_roLiFoiIQaitZsEcAta/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments
