### PR TITLE
feat(payment): INT-3016 remove phone number parameter in request if field is empty in Stripev3

### DIFF
--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -135,6 +135,23 @@ export function getStripeBillingAddress(): StripeBillingDetails {
     };
 }
 
+export function getStripeBillingAddressWithoutPhone(): StripeBillingDetails {
+    const billingAddress = getBillingAddress();
+
+    return {
+        address: {
+            city: billingAddress.city,
+            country: billingAddress.countryCode,
+            line1: billingAddress.address1,
+            line2: billingAddress.address2,
+            postal_code: billingAddress.postalCode,
+            state: billingAddress.stateOrProvinceCode,
+        },
+        name: `${billingAddress.firstName} ${billingAddress.lastName}`,
+        email: billingAddress.email,
+    };
+}
+
 export function getStripeShippingAddressGuestUserWithoutAddress(): StripeConfirmCardPaymentData {
     return {
         shipping: {

--- a/src/shipping/ShippableItem.ts
+++ b/src/shipping/ShippableItem.ts
@@ -1,0 +1,8 @@
+import { PhysicalItem } from '../cart';
+
+import { Consignment } from './index';
+
+export default interface ShippableItem extends PhysicalItem {
+    consignment?: Consignment;
+    key: string;
+}

--- a/src/shipping/findConsignment.ts
+++ b/src/shipping/findConsignment.ts
@@ -1,0 +1,10 @@
+import { find, includes } from 'lodash';
+
+import { Consignment } from './index';
+
+export default function findConsignment(
+    consignments: Consignment[],
+    itemId: string
+): Consignment | undefined {
+    return find(consignments, consignment => includes(consignment.lineItemIds, itemId));
+}

--- a/src/shipping/getLineItemsCount.spec.ts
+++ b/src/shipping/getLineItemsCount.spec.ts
@@ -1,0 +1,18 @@
+import { getPhysicalItem } from '../cart/line-items.mock';
+
+import getLineItemsCount from './getLineItemsCount';
+
+describe('getLineItemsCount()', () => {
+    it('returns zero if empty array', () => {
+        expect(getLineItemsCount([]))
+            .toEqual(0);
+    });
+
+    it('returns the sum of quantities', () => {
+        expect(getLineItemsCount([
+            getPhysicalItem(),
+            getPhysicalItem(),
+        ]))
+            .toEqual(2);
+    });
+});

--- a/src/shipping/getLineItemsCount.ts
+++ b/src/shipping/getLineItemsCount.ts
@@ -1,0 +1,7 @@
+import { reduce } from 'lodash';
+
+import { LineItem } from '../cart';
+
+export default function getLineItemsCount(lineItems: LineItem[]): number {
+    return reduce(lineItems, (total, item) => total + item.quantity, 0);
+}

--- a/src/shipping/getShippableItemsCount.spec.ts
+++ b/src/shipping/getShippableItemsCount.spec.ts
@@ -1,0 +1,91 @@
+import { getCart } from '../cart/carts.mock';
+import { getDigitalItem, getGiftCertificateItem, getPhysicalItem } from '../cart/line-items.mock';
+
+import { getConsignment } from './consignments.mock';
+import getShippableLineItems from './getShippableLineItems';
+
+describe('getShippableLineItems()', () => {
+    it('returns empty if only digital items', () => {
+        expect(getShippableLineItems({
+            ...getCart(),
+            lineItems: {
+                digitalItems: [ getDigitalItem() ],
+                physicalItems: [],
+                giftCertificates: [],
+            },
+        }, []))
+            .toHaveLength(0);
+    });
+
+    it('returns empty if only gift certificates items', () => {
+        expect(getShippableLineItems({
+            ...getCart(),
+            lineItems: {
+                digitalItems: [],
+                physicalItems: [],
+                giftCertificates: [ getGiftCertificateItem() ],
+            },
+        }, []))
+            .toHaveLength(0);
+    });
+
+    it('returns empty if only physical items added by promotions', () => {
+        expect(getShippableLineItems({
+            ...getCart(),
+            lineItems: {
+                digitalItems: [],
+                physicalItems: [ {
+                    ...getPhysicalItem(),
+                    addedByPromotion: true,
+                }],
+                giftCertificates: [],
+            },
+        }, []))
+            .toHaveLength(0);
+    });
+
+    it('splits physical items quantities', () => {
+        const items = getShippableLineItems({
+            ...getCart(),
+            lineItems: {
+                digitalItems: [],
+                physicalItems: [
+                    {
+                        ...getPhysicalItem(),
+                        quantity: 2,
+                    },
+                ],
+                giftCertificates: [],
+            },
+        }, []);
+
+        expect(items).toHaveLength(2);
+        expect(items[0]).toMatchObject(expect.objectContaining(getPhysicalItem()));
+        expect(items[1]).toMatchObject(expect.objectContaining(getPhysicalItem()));
+    });
+
+    it('adds consignment information when available', () => {
+        const consignment = {
+            ...getConsignment(),
+            lineItemIds: [ getPhysicalItem().id as string ],
+        };
+
+        const items = getShippableLineItems({
+            ...getCart(),
+            lineItems: {
+                digitalItems: [],
+                physicalItems: [
+                    {
+                        ...getPhysicalItem(),
+                        quantity: 2,
+                    },
+                ],
+                giftCertificates: [],
+            },
+        }, [
+            consignment,
+        ]);
+
+        expect(items[0].consignment).toMatchObject(expect.objectContaining(consignment));
+    });
+});

--- a/src/shipping/getShippableItemsCount.ts
+++ b/src/shipping/getShippableItemsCount.ts
@@ -1,0 +1,7 @@
+import { Cart } from '../cart';
+
+import getLineItemsCount from './getLineItemsCount';
+
+export default function getShippableItemsCount(cart: Cart): number {
+    return getLineItemsCount(cart.lineItems.physicalItems.filter(item => !item.addedByPromotion));
+}

--- a/src/shipping/getShippableLineItems.ts
+++ b/src/shipping/getShippableLineItems.ts
@@ -1,0 +1,42 @@
+import { reduce } from 'lodash';
+
+import { Cart, PhysicalItem } from '../cart';
+
+import findConsignment from './findConsignment';
+import { Consignment } from './index';
+import ShippableItem from './ShippableItem';
+
+export default function getShippableLineItems(
+    cart: Cart,
+    consignments: Consignment[]
+): ShippableItem[] {
+    return reduce(
+        (cart && cart.lineItems.physicalItems) || [],
+        (result, item, i) => (
+            !item.addedByPromotion ?
+                result.concat(...splitItem(item, consignments, i)) :
+                result
+        ),
+        [] as ShippableItem[]
+    );
+}
+
+function splitItem(
+    item: PhysicalItem,
+    consignments: Consignment[],
+    lineItemIndex: number
+): ShippableItem[] {
+    let splitItems: ShippableItem[] = [];
+    const consignment = findConsignment(consignments, item.id as string);
+
+    for (let i = 0; i < item.quantity; i++) {
+        splitItems = splitItems.concat({
+            ...item,
+            key: `${item.variantId}-${item.productId}-${lineItemIndex}-${i}`,
+            consignment,
+            quantity: 1,
+        });
+    }
+
+    return splitItems;
+}

--- a/src/shipping/index.ts
+++ b/src/shipping/index.ts
@@ -26,5 +26,6 @@ export { default as ShippingStrategySelector, ShippingStrategySelectorFactory, c
 export { default as ShippingStrategyState } from './shipping-strategy-state';
 export { default as shippingStrategyReducer } from './shipping-strategy-reducer';
 
+export { default as getShippableItemsCount } from './getShippableItemsCount';
 export { default as mapToInternalShippingOption } from './map-to-internal-shipping-option';
 export { default as mapToInternalShippingOptions } from './map-to-internal-shipping-options';


### PR DESCRIPTION
## What? [INT-3016](https://jira.bigcommerce.com/browse/INT-3016)
remove phone number parameter in request if phone number field is empty in Stripe v3.

## Why?
If phone it is not provided on checkout it throws an error, with this change it is not going to failed even if phone it is not provided.

## Testing / Proof
[Testing proof Video](https://drive.google.com/file/d/1a4odPJv0wl-bxmPcrFkJWOKUtUSej0wI/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations
