### PR TITLE
CHECKOUT-5099: Remove unused key from settings object

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -91,7 +91,6 @@ export interface CheckoutSettings {
     isAnalyticsEnabled: boolean;
     isCardVaultingEnabled: boolean;
     isCouponCodeCollapsed: boolean;
-    isHostedPaymentFormEnabled: boolean;
     isPaymentRequestEnabled: boolean;
     isPaymentRequestCanMakePaymentEnabled: boolean;
     isSpamProtectionEnabled: boolean;

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -28,7 +28,6 @@ export function getConfig(): Config {
                 googleRecaptchaSitekey: 'sitekey',
                 isAnalyticsEnabled: false,
                 isCardVaultingEnabled: true,
-                isHostedPaymentFormEnabled: false,
                 isPaymentRequestEnabled: false,
                 isPaymentRequestCanMakePaymentEnabled: false,
                 isCouponCodeCollapsed: true,


### PR DESCRIPTION
## What?
Remove the unused key `isHostedPaymentFormEnabled` from `Config` object.

## Why?
It's no longer needed after this https://github.com/bigcommerce/checkout-sdk-js/pull/938

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
