### PR TITLE
feat(payments): bump bigpay-client to 5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1279,9 +1279,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.11.0.tgz",
-      "integrity": "sha512-5i+jd7CswjLh6wgnwe4YjH3G6nkiAI16oaDLomslDwsQHhAbUtZ4GqIrMVgj6oleP2cBazjRCy1NlkhRcdJbUQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.12.0.tgz",
+      "integrity": "sha512-n6FD4gZVWmUsbotijw+xy2AVvuUd/snL4hzmNVzSifs+IbbMSrntYUk9UsIwxUYouk/6ZmAaYKB6UvZ87xrzpw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^25.2.0",
@@ -1465,9 +1465,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
-          "integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw=="
+          "version": "7.11.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
+          "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA=="
         },
         "@babel/template": {
           "version": "7.10.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@bigcommerce/bigpay-client": "^5.11.0",
+    "@bigcommerce/bigpay-client": "^5.12.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
bump bigpay-client to 5.12

## Why?
released https://github.com/bigcommerce/bigpay-client-js/pull/107

## Testing / Proof
unit / manual

@bigcommerce/checkout @bigcommerce/payments
