### PR TITLE
refactor(payment): INT-2995 Avoid setting up Affirm.js from string code

### DIFF
--- a/src/payment/strategies/affirm/affirm-script-loader.spec.ts
+++ b/src/payment/strategies/affirm/affirm-script-loader.spec.ts
@@ -3,9 +3,11 @@ import { StandardError } from '../../../common/error/errors';
 import { Affirm, AffirmHostWindow } from './affirm';
 import AffirmScriptLoader from './affirm-script-loader';
 import { getAffirmScriptMock } from './affirm.mock';
-import affirmJS from './affirmJs';
+import { default as affirmJS } from './affirmJs';
 
 jest.mock('./affirmJs');
+
+const affirmJsMock = affirmJS as jest.Mock<void>;
 
 describe('AffirmScriptLoader', () => {
     let affirmScriptLoader: AffirmScriptLoader;
@@ -21,7 +23,7 @@ describe('AffirmScriptLoader', () => {
 
         beforeEach(() => {
             affirmScript = getAffirmScriptMock();
-            affirmJS.mockImplementation(() => {
+            affirmJsMock.mockImplementation(() => {
                 affirmWindow.affirm = affirmScript;
             });
         });
@@ -42,7 +44,7 @@ describe('AffirmScriptLoader', () => {
         });
 
         it('throws error when window is not set', async () => {
-            affirmJS.mockImplementation(() => {
+            affirmJsMock.mockImplementation(() => {
                 affirmWindow.affirm = undefined;
             });
 

--- a/src/payment/strategies/affirm/affirm-script-loader.ts
+++ b/src/payment/strategies/affirm/affirm-script-loader.ts
@@ -8,7 +8,7 @@ export default class AffirmScriptLoader {
         public _window: AffirmHostWindow = window
     ) { }
 
-    load(apikey?: string, testMode?: boolean): Promise<Affirm> {
+    load(apikey: string = '', testMode?: boolean): Promise<Affirm> {
         const scriptURI = this._getScriptURI(testMode);
 
         loadAffirmJS(apikey, scriptURI);

--- a/src/payment/strategies/affirm/affirmJs.ts
+++ b/src/payment/strategies/affirm/affirmJs.ts
@@ -1,12 +1,68 @@
 /**
  * Used this approach as Affirm uses snipped for initializing. Please refer to Affirm documentation in: https://docs.affirm.com/Integrate_Affirm/Direct_API#1._Add_Affirm.js
  */
-export default Function(`
-'use strict';
-return function loadAffirmJS(apiKey, scriptURL) {
-    var _affirm_config = {
-        public_api_key:  apiKey,
-        script:          scriptURL
+import { Affirm, AffirmHostWindow } from './affirm';
+
+interface AffirmConfig {
+    public_api_key: string;
+    script: string;
+}
+
+export default function loadAffirmJS(apiKey: string, scriptURL: string) {
+    const _AFFIRM_CONFIG: AffirmConfig = {
+        public_api_key: apiKey,
+        script: scriptURL,
     };
-    (function(l,g,m,e,a,f,b){var d,c=l[m]||{},h=document.createElement(f),n=document.getElementsByTagName(f)[0],k=function(a,b,c){return function(){a[b]._.push([c,arguments])}};c[e]=k(c,e,"set");d=c[e];c[a]={};c[a]._=[];d._=[];c[a][b]=k(c,a,b);a=0;for(b="set add save post open empty reset on off trigger ready setProduct".split(" ");a<b.length;a++)d[b[a]]=k(c,e,b[a]);a=0;for(b=["get","token","url","items"];a<b.length;a++)d[b[a]]=function(){};h.async=!0;h.src=g[f];n.parentNode.insertBefore(h,n);delete g[f];d(g);l[m]=c})(window,_affirm_config,"affirm","checkout","ui","script","ready");
-}`)();
+
+    (function foo(m: AffirmHostWindow | any, g: AffirmConfig, n: 'affirm', d: 'checkout', a: 'ui', e: 'script', h: 'ready', c: 'jsReady') {
+        const b = m[n] || {};
+        const k = document.createElement(e);
+        const p = document.getElementsByTagName(e)[0];
+        const l = function bar(a: Affirm | any, b: keyof Affirm, c: string) {
+            return function baz() {
+                a[b]._.push([c, arguments]);
+            };
+        };
+        b[d] = l(b, d, 'set');
+        const f = b[d];
+        b[a] = {};
+        b[a]._ = [];
+        f._ = [];
+        b._ = [];
+        b[a][h] = l(b, a, h);
+        b[c] = function qux() {
+            b._.push([h, arguments]);
+        };
+        let a1 = 0;
+        for (
+          const c1 = 'set add save post open empty reset on off trigger ready setProduct'.split(
+            ' '
+          );
+          a1 < c1.length;
+          a1++
+        ) {
+            f[c1[a1]] = l(b, d, c1[a1]);
+        }
+        let a2 = 0;
+        for (const c2 = ['get', 'token', 'url', 'items']; a2 < c2.length; a2++) {
+            f[c2[a2]] = function foobar() {};
+        }
+        k.async = !0;
+        k.src = g[e];
+        if (p.parentNode) {
+            p.parentNode.insertBefore(k, p);
+        }
+        delete g[e];
+        f(g);
+        m[n] = b;
+    })(
+        window,
+        _AFFIRM_CONFIG,
+        'affirm',
+        'checkout',
+        'ui',
+        'script',
+        'ready',
+        'jsReady'
+    );
+}


### PR DESCRIPTION
## What? [INT-2995](https://jira.bigcommerce.com/browse/INT-2995)
Changed the Affirm.js initialization approach to avoid calling `Function()`. Please refer to Affirm documentation: https://docs.affirm.com/Integrate_Affirm/Direct_API#1._Add_Affirm.js

## Why?
Because #928 

## Testing / Proof
CircleCI
![image](https://user-images.githubusercontent.com/4843328/90191020-b37e2900-dd85-11ea-9d92-4415303b7257.png)

@bigcommerce/checkout @bigcommerce/payments
