### PR TITLE
fix(checkout): INT-3041 Fix GooglePay updating shipping address when purchasing digital items only

### DIFF
--- a/src/checkout-buttons/strategies/googlepay/googlepay-authorizenet-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-authorizenet-button-strategy.spec.ts
@@ -1,7 +1,8 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { getCartState } from '../../../cart/carts.mock';
+import { Cart } from '../../../cart';
+import { getCart, getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
@@ -19,6 +20,7 @@ import GooglePayButtonStrategy from './googlepay-button-strategy';
 import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
 
 describe('GooglePayCheckoutButtonStrategy', () => {
+    let cart: Cart;
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let checkoutButtonOptions: CheckoutButtonInitializeOptions;
@@ -41,6 +43,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             paymentMethods: getPaymentMethodsState(),
         });
 
+        cart = getCart();
         requestSender = createRequestSender();
 
         checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
@@ -68,6 +71,8 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             .mockReturnValue(Promise.resolve(store.getState()));
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
             .mockReturnValue(paymentMethod);
+        jest.spyOn(store.getState().cart, 'getCartOrThrow')
+            .mockReturnValue(cart);
         jest.spyOn(paymentProcessor, 'initialize')
             .mockReturnValue(Promise.resolve());
         jest.spyOn(paymentProcessor, 'deinitialize');
@@ -75,7 +80,11 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         walletButton = document.createElement('a');
         walletButton.setAttribute('id', 'mockButton');
         jest.spyOn(paymentProcessor, 'createButton')
-            .mockReturnValue(walletButton);
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
 
         container = document.createElement('div');
         container.setAttribute('id', 'googlePayCheckoutButton');
@@ -106,18 +115,13 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         it('fails to initialize the strategy if no container id is supplied', async () => {
             checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.UndefinedContainer);
 
-            try {
-                await strategy.initialize(checkoutButtonOptions);
-            } catch (error) {
-                expect(error).toBeInstanceOf(InvalidArgumentError);
-            }
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
         });
 
         it('fails to initialize the strategy if no valid container id is supplied', async () => {
             checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.InvalidContainer);
 
-            await expect(strategy.initialize(checkoutButtonOptions))
-                .rejects.toThrow(InvalidArgumentError);
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
         });
     });
 
@@ -155,18 +159,42 @@ describe('GooglePayCheckoutButtonStrategy', () => {
     });
 
     describe('#handleWalletButtonClick', () => {
-        it('handles wallet button event', async () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
             checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.GooglePayAuthorizeNet);
 
-            jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(getGooglePaymentDataMock()));
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
 
-            expect(paymentProcessor.initialize).not.toHaveBeenCalled();
+        it('handles wallet button event and updates shipping address', async () => {
             await strategy.initialize(checkoutButtonOptions);
 
-            walletButton.click();
             expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('handles wallet button event and does not update shipping address if cart has digital products only', async () => {
+            cart.lineItems.physicalItems = [];
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -4,6 +4,7 @@ import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { bindDecorator as bind } from '../../../common/utility';
 import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { getShippableItemsCount } from '../../../shipping';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
@@ -18,7 +19,7 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
         private _googlePayPaymentProcessor: GooglePayPaymentProcessor
     ) {}
 
-    initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
         const { containerId, methodId } = options;
 
         if (!containerId || !methodId) {
@@ -27,11 +28,10 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
 
         this._methodId = methodId;
 
-        return this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout())
-            .then(() => this._googlePayPaymentProcessor.initialize(this._getMethodId()))
-            .then(() => {
-                this._walletButton = this._createSignInButton(containerId);
-            });
+        await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        await this._googlePayPaymentProcessor.initialize(this._getMethodId());
+
+        this._walletButton = this._createSignInButton(containerId);
     }
 
     deinitialize(): Promise<void> {
@@ -68,11 +68,13 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
     @bind
     private async _handleWalletButtonClick(event: Event): Promise<void> {
         event.preventDefault();
+        const cart = this._store.getState().cart.getCartOrThrow();
+        const hasPhysicalItems = getShippableItemsCount(cart) > 0;
 
         try {
             const paymentData = await this._googlePayPaymentProcessor.displayWallet();
             await this._googlePayPaymentProcessor.handleSuccess(paymentData);
-            if (paymentData.shippingAddress) {
+            if (hasPhysicalItems && paymentData.shippingAddress) {
                 await this._googlePayPaymentProcessor.updateShippingAddress(paymentData.shippingAddress);
             }
             await this._onPaymentSelectComplete();

--- a/src/checkout-buttons/strategies/googlepay/googlepay-checkoutcom-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-checkoutcom-button-strategy.spec.ts
@@ -1,7 +1,8 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { getCartState } from '../../../cart/carts.mock';
+import { Cart } from '../../../cart';
+import { getCart, getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
@@ -11,6 +12,7 @@ import { getCustomerState } from '../../../customer/customers.mock';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayCheckoutcomInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonMethodType from '../checkout-button-method-type';
 
@@ -18,6 +20,7 @@ import GooglePayButtonStrategy from './googlepay-button-strategy';
 import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
 
 describe('GooglePayCheckoutButtonStrategy', () => {
+    let cart: Cart;
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let checkoutButtonOptions: CheckoutButtonInitializeOptions;
@@ -40,6 +43,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             paymentMethods: getPaymentMethodsState(),
         });
 
+        cart = getCart();
         requestSender = createRequestSender();
 
         checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
@@ -70,6 +74,9 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
             .mockReturnValue(paymentMethod);
 
+        jest.spyOn(store.getState().cart, 'getCartOrThrow')
+            .mockReturnValue(cart);
+
         jest.spyOn(formPoster, 'postForm')
             .mockReturnValue(Promise.resolve());
 
@@ -79,7 +86,11 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         walletButton.setAttribute('id', 'mockButton');
 
         jest.spyOn(paymentProcessor, 'createButton')
-            .mockReturnValue(walletButton);
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
 
         jest.spyOn(paymentProcessor, 'deinitialize');
 
@@ -109,16 +120,16 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
         });
 
-        it('fails to initialize the strategy if no container id is supplied', () => {
+        it('fails to initialize the strategy if no container id is supplied', async () => {
             checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM, Mode.UndefinedContainer);
 
-            expect(() => strategy.initialize(checkoutButtonOptions)).toThrow(InvalidArgumentError);
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
         });
 
-        it('fails to initialize the strategy if no valid container id is supplied', () => {
+        it('fails to initialize the strategy if no valid container id is supplied', async () => {
             checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM, Mode.InvalidContainer);
 
-            expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
         });
     });
 
@@ -153,6 +164,46 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             const button = document.getElementById(checkoutButtonOptions.containerId!);
 
             expect(button).toHaveProperty('firstChild', null);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM, Mode.GooglePayCheckoutcom);
+
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
+
+        it('handles wallet button event and updates shipping address', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('handles wallet button event and does not update shipping address if cart has digital products only', async () => {
+            cart.lineItems.physicalItems = [];
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
@@ -1,7 +1,8 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { getCartState } from '../../../cart/carts.mock';
+import { Cart } from '../../../cart';
+import { getCart, getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
@@ -19,6 +20,7 @@ import GooglePayButtonStrategy from './googlepay-button-strategy';
 import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
 
 describe('GooglePayCheckoutButtonStrategy', () => {
+    let cart: Cart;
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let checkoutButtonOptions: CheckoutButtonInitializeOptions;
@@ -41,6 +43,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             paymentMethods: getPaymentMethodsState(),
         });
 
+        cart = getCart();
         requestSender = createRequestSender();
 
         checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
@@ -68,6 +71,8 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             .mockReturnValue(Promise.resolve(store.getState()));
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
             .mockReturnValue(paymentMethod);
+        jest.spyOn(store.getState().cart, 'getCartOrThrow')
+            .mockReturnValue(cart);
         jest.spyOn(paymentProcessor, 'initialize')
             .mockReturnValue(Promise.resolve());
         jest.spyOn(paymentProcessor, 'deinitialize');
@@ -75,7 +80,11 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         walletButton = document.createElement('a');
         walletButton.setAttribute('id', 'mockButton');
         jest.spyOn(paymentProcessor, 'createButton')
-            .mockReturnValue(walletButton);
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
 
         container = document.createElement('div');
         container.setAttribute('id', 'googlePayCheckoutButton');
@@ -155,18 +164,42 @@ describe('GooglePayCheckoutButtonStrategy', () => {
     });
 
     describe('#handleWalletButtonClick', () => {
-        it('handles wallet button event', async () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
             checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_STRIPE, Mode.GooglePayStripe);
 
-            jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(getGooglePaymentDataMock()));
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
 
-            expect(paymentProcessor.initialize).not.toHaveBeenCalled();
+        it('handles wallet button event and updates shipping address', async () => {
             await strategy.initialize(checkoutButtonOptions);
 
-            walletButton.click();
             expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_STRIPE);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('handles wallet button event and does not update shipping address if cart has digital products only', async () => {
+            cart.lineItems.physicalItems = [];
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_STRIPE);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
@@ -1,13 +1,12 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { getCartState } from '../../../cart/carts.mock';
+import { getCart, getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
 import { getConfigState } from '../../../config/configs.mock';
-import { PaymentMethod } from '../../../payment';
-import { getPaymentMethod, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
@@ -22,7 +21,6 @@ describe('GooglePayCustomerStrategy', () => {
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let customerInitializeOptions: CustomerInitializeOptions;
-    let paymentMethod: PaymentMethod;
     let paymentProcessor: GooglePayPaymentProcessor;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
@@ -31,8 +29,6 @@ describe('GooglePayCustomerStrategy', () => {
     let walletButton: HTMLAnchorElement;
 
     beforeEach(() => {
-        paymentMethod = getPaymentMethod();
-
         store = createCheckoutStore({
             checkout: getCheckoutState(),
             customer: getCustomerState(),
@@ -65,15 +61,17 @@ describe('GooglePayCustomerStrategy', () => {
             .mockReturnValue(Promise.resolve());
         jest.spyOn(store, 'dispatch')
             .mockReturnValue(Promise.resolve(store.getState()));
-        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
-            .mockReturnValue(paymentMethod);
         jest.spyOn(paymentProcessor, 'initialize')
             .mockReturnValue(Promise.resolve());
 
         walletButton = document.createElement('a');
         walletButton.setAttribute('id', 'mockButton');
         jest.spyOn(paymentProcessor, 'createButton')
-            .mockReturnValue(walletButton);
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
 
         container = document.createElement('div');
         container.setAttribute('id', 'googlePayCheckoutButton');
@@ -94,31 +92,22 @@ describe('GooglePayCustomerStrategy', () => {
                 expect(paymentProcessor.createButton).toHaveBeenCalled();
             });
 
-            it('fails to initialize the strategy if no GooglePayCustomerInitializeOptions is provided ', async () => {
+            it('fails to initialize the strategy if no GooglePayCustomerInitializeOptions is provided ', () => {
                 customerInitializeOptions = getAuthNetCustomerInitializeOptions(Mode.Incomplete);
 
-                try {
-                    await strategy.initialize(customerInitializeOptions);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(InvalidArgumentError);
-                }
+                expect(() => strategy.initialize(customerInitializeOptions)).toThrow(InvalidArgumentError);
             });
 
-            it('fails to initialize the strategy if no methodid is supplied', async () => {
+            it('fails to initialize the strategy if no methodid is supplied', () => {
                 customerInitializeOptions = getAuthNetCustomerInitializeOptions(Mode.UndefinedMethodId);
 
-                try {
-                    await strategy.initialize(customerInitializeOptions);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(InvalidArgumentError);
-                }
+                expect(() => strategy.initialize(customerInitializeOptions)).toThrow(InvalidArgumentError);
             });
 
             it('fails to initialize the strategy if no valid container id is supplied', async () => {
                 customerInitializeOptions = getAuthNetCustomerInitializeOptions(Mode.InvalidContainer);
 
-                await expect(strategy.initialize(customerInitializeOptions))
-                    .rejects.toThrow(InvalidArgumentError);
+                await expect(strategy.initialize(customerInitializeOptions)).rejects.toThrow(InvalidArgumentError);
             });
         });
     });
@@ -208,23 +197,43 @@ describe('GooglePayCustomerStrategy', () => {
     });
 
     describe('#handleWalletButtonClick', () => {
-        it('handles wallet button event', async () => {
-            customerInitializeOptions = {
-                methodId: 'googlepayauthorizenet',
-                googlepayauthorizenet: {
-                    container: 'googlePayCheckoutButton',
-                },
-            };
+        const googlePaymentDataMock = getGooglePaymentDataMock();
 
-            jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(getGooglePaymentDataMock()));
+        beforeEach(() => {
+            customerInitializeOptions = getAuthNetCustomerInitializeOptions();
+
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
 
-            expect(paymentProcessor.initialize).not.toHaveBeenCalled();
+        it('displays the wallet and updates the shipping address', async () => {
             await strategy.initialize(customerInitializeOptions);
 
             walletButton.click();
-            expect(paymentProcessor.initialize).toHaveBeenCalledWith('googlepayauthorizenet');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('displays the wallet and does not update the shipping address if cart has digital products only', async () => {
+            const cart = getCart();
+            cart.lineItems.physicalItems = [];
+            jest.spyOn(store.getState().cart, 'getCartOrThrow')
+                .mockReturnValue(cart);
+
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
@@ -1,13 +1,12 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { getCartState } from '../../../cart/carts.mock';
+import { getCart, getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
 import { getConfigState } from '../../../config/configs.mock';
-import { PaymentMethod } from '../../../payment';
-import { getPaymentMethod, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayPaymentProcessor, GooglePayStripeInitializer } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
@@ -22,7 +21,6 @@ describe('GooglePayCustomerStrategy', () => {
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let customerInitializeOptions: CustomerInitializeOptions;
-    let paymentMethod: PaymentMethod;
     let paymentProcessor: GooglePayPaymentProcessor;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
@@ -31,8 +29,6 @@ describe('GooglePayCustomerStrategy', () => {
     let walletButton: HTMLAnchorElement;
 
     beforeEach(() => {
-        paymentMethod = getPaymentMethod();
-
         store = createCheckoutStore({
             checkout: getCheckoutState(),
             customer: getCustomerState(),
@@ -65,15 +61,17 @@ describe('GooglePayCustomerStrategy', () => {
             .mockReturnValue(Promise.resolve());
         jest.spyOn(store, 'dispatch')
             .mockReturnValue(Promise.resolve(store.getState()));
-        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
-            .mockReturnValue(paymentMethod);
         jest.spyOn(paymentProcessor, 'initialize')
             .mockReturnValue(Promise.resolve());
 
         walletButton = document.createElement('a');
         walletButton.setAttribute('id', 'mockButton');
         jest.spyOn(paymentProcessor, 'createButton')
-            .mockReturnValue(walletButton);
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
 
         container = document.createElement('div');
         container.setAttribute('id', 'googlePayCheckoutButton');
@@ -94,31 +92,22 @@ describe('GooglePayCustomerStrategy', () => {
                 expect(paymentProcessor.createButton).toHaveBeenCalled();
             });
 
-            it('fails to initialize the strategy if no GooglePayCustomerInitializeOptions is provided ', async () => {
+            it('fails to initialize the strategy if no GooglePayCustomerInitializeOptions is provided ', () => {
                 customerInitializeOptions = getStripeCustomerInitializeOptions(Mode.Incomplete);
 
-                try {
-                    await strategy.initialize(customerInitializeOptions);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(InvalidArgumentError);
-                }
+                expect(() => strategy.initialize(customerInitializeOptions)).toThrow(InvalidArgumentError);
             });
 
-            it('fails to initialize the strategy if no methodid is supplied', async () => {
+            it('fails to initialize the strategy if no methodid is supplied', () => {
                 customerInitializeOptions = getStripeCustomerInitializeOptions(Mode.UndefinedMethodId);
 
-                try {
-                    await strategy.initialize(customerInitializeOptions);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(InvalidArgumentError);
-                }
+                expect(() => strategy.initialize(customerInitializeOptions)).toThrow(InvalidArgumentError);
             });
 
             it('fails to initialize the strategy if no valid container id is supplied', async () => {
                 customerInitializeOptions = getStripeCustomerInitializeOptions(Mode.InvalidContainer);
 
-                await expect(strategy.initialize(customerInitializeOptions))
-                    .rejects.toThrow(InvalidArgumentError);
+                await expect(strategy.initialize(customerInitializeOptions)).rejects.toThrow(InvalidArgumentError);
             });
         });
     });
@@ -208,7 +197,9 @@ describe('GooglePayCustomerStrategy', () => {
     });
 
     describe('#handleWalletButtonClick', () => {
-        it('handles wallet button event', async () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
             customerInitializeOptions = {
                 methodId: 'googlepaystripe',
                 googlepaystripe: {
@@ -216,15 +207,38 @@ describe('GooglePayCustomerStrategy', () => {
                 },
             };
 
-            jest.spyOn(paymentProcessor, 'displayWallet').mockReturnValue(Promise.resolve(getGooglePaymentDataMock()));
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
 
-            expect(paymentProcessor.initialize).not.toHaveBeenCalled();
+        it('displays the wallet and updates the shipping address', async () => {
             await strategy.initialize(customerInitializeOptions);
 
             walletButton.click();
-            expect(paymentProcessor.initialize).toHaveBeenCalledWith('googlepaystripe');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('displays the wallet and does not update the shipping address if cart has digital products only', async () => {
+            const cart = getCart();
+            cart.lineItems.physicalItems = [];
+            jest.spyOn(store.getState().cart, 'getCartOrThrow')
+                .mockReturnValue(cart);
+
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
## What? [INT-3041](https://jira.bigcommerce.com/browse/INT-3041)
Validate if cart has physical items before attempting to update shipping address and avoid it of not necessary.

## Why?
Updating the shipping address is not necessary when there are only digital products, attempting to create a consignment with  only digital products causes the request to fail and thus the checkout cant be completed.

## Testing / Proof
[Demo video Cart Step](https://drive.google.com/file/d/1YD42g3ivzJ3vFqUQM6a9U1qHq7H10wjv/view?usp=sharing)
[Demo video customer step](https://drive.google.com/file/d/1_Md51j4cJxzCr4XEC4oTX6LmZ8JE388_/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments
