### PR TITLE
fix(payment): INT-3043 Apply store credit on StripeV3

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -504,6 +504,7 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             orderActionCreator,
             new StripeScriptLoader(scriptLoader),
+            storeCreditActionCreator,
             locale
         )
     );


### PR DESCRIPTION
## What? [INT-3043](https://jira.bigcommerce.com/browse/INT-3043)

## Why?
I want my merchants to be able to apply store credit for shoppers on StripeV3

## Testing / Proof

- Manual
- Unit

## Sibling PRs
[#36590](https://github.com/bigcommerce/bigcommerce/pull/36590)

## How can this change be undone in case of failure?
1. Revert this PR

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
