### PR TITLE
Fix(Payment): Fixed Chase Pay sign in link

### DIFF
--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
@@ -134,6 +134,7 @@ describe('ChasePayPaymentStrategy', () => {
         walletButton = document.createElement('a');
         container.setAttribute('id', 'login');
         walletButton.setAttribute('id', 'mockButton');
+        walletButton.textContent = 'Sign in to  Chase Pay';
         document.body.appendChild(container);
         document.body.appendChild(walletButton);
 
@@ -162,6 +163,7 @@ describe('ChasePayPaymentStrategy', () => {
         beforeEach(() => {
             chasePayInitializeOptions = { logoContainer: 'login', walletButton: 'mockButton' };
             initializeOptions = { methodId: 'chasepay', chasepay: chasePayInitializeOptions };
+            jest.useFakeTimers();
         });
 
         it('loads chasepay in test mode if enabled', async () => {
@@ -251,7 +253,7 @@ describe('ChasePayPaymentStrategy', () => {
 
         it('adds the event listener to the wallet button', async () => {
             await strategy.initialize(initializeOptions);
-
+            jest.runAllTimers();
             expect(walletButton.addEventListener).toHaveBeenCalled();
         });
 
@@ -291,17 +293,16 @@ describe('ChasePayPaymentStrategy', () => {
 
         it('check if element exist in the DOM', async () => {
             await strategy.initialize(initializeOptions);
-
             expect(document.getElementById).toHaveBeenCalledWith(chasePayInitializeOptions.logoContainer);
         });
 
         it('dispatch widget interaction when wallet button is clicked', async () => {
             await strategy.initialize(initializeOptions);
+            jest.runAllTimers();
 
             const chasepayButton = document.getElementById(chasePayInitializeOptions.walletButton || '');
-
             if (chasepayButton) {
-                await chasepayButton.click();
+                chasepayButton.click();
             }
 
             expect(store.dispatch).toBeCalledWith(expect.any(Observable), { queueId: 'widgetInteraction' });
@@ -309,11 +310,11 @@ describe('ChasePayPaymentStrategy', () => {
 
         it('triggers widget interaction when wallet button is clicked', async () => {
             await strategy.initialize(initializeOptions);
+            jest.runAllTimers();
 
             const chasepayButton = document.getElementById(chasePayInitializeOptions.walletButton || '');
-
             if (chasepayButton) {
-                await chasepayButton.click();
+                chasepayButton.click();
             }
 
             expect(paymentStrategyActionCreator.widgetInteraction).toHaveBeenCalled();
@@ -433,8 +434,9 @@ describe('ChasePayPaymentStrategy', () => {
             initializeOptions = { methodId: 'chasepay', chasepay: { logoContainer: 'login', walletButton: 'mockButton' } };
             submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
             orderActionCreator.submitOrder = jest.fn(() => submitOrderAction);
-
+            jest.useFakeTimers();
             await strategy.initialize(initializeOptions);
+            jest.runAllTimers();
         });
 
         it('deinitializes wallet button', async () => {

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
@@ -47,12 +47,19 @@ export default class ChasePayPaymentStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to initialize payment because "options.chasepay" argument is not provided.');
         }
 
-        const walletButton = options.chasepay.walletButton && document.getElementById(options.chasepay.walletButton);
+        const linkIsLoaded = setInterval(() => {
+            const walletButton = options.chasepay?.walletButton && document.getElementById(options.chasepay.walletButton);
+            const isChase = (walletButton as HTMLInputElement)?.textContent?.indexOf('Chase');
+            if (!walletButton) {
+                clearInterval(linkIsLoaded);
+            }
 
-        if (walletButton) {
-            this._walletButton = walletButton;
-            this._walletButton.addEventListener('click', this._handleWalletButtonClick);
-        }
+            if (walletButton && isChase && isChase > -1 ) {
+                this._walletButton = walletButton;
+                this._walletButton?.addEventListener('click', this._handleWalletButtonClick);
+                clearInterval(linkIsLoaded);
+            }
+        }, 100);
 
         return this._configureWallet(options.chasepay)
             .then(() => this._store.getState());


### PR DESCRIPTION
## What? [INT-2901](https://jira.bigcommerce.com/browse/INT-2901)
Implement a Interval function to try to find correct a element and add the event listener to it

## Why?
Because as other payments has the same ID it was adding the event listener to the previous element

## Testing / Proof

![testing](https://user-images.githubusercontent.com/69221626/90670520-f1150300-e218-11ea-9941-eed0a9ecdc65.gif)


This fix will be made in checkout-js

@bigcommerce/checkout @bigcommerce/payments
