### PR TITLE
CHECKOUT-5115 CHECKOUT-5116 CHECKOUT-5117: Set correct type for card number verification field

### DIFF
--- a/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
@@ -54,6 +54,7 @@ describe('HostedCardNumberInput', () => {
         styles = { default: { color: 'rgb(255, 255, 255)' } };
 
         input = new HostedCardNumberInput(
+            HostedFieldType.CardNumber,
             container,
             'Full name',
             'Cardholder name',

--- a/src/hosted-form/iframe-content/hosted-card-number-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.ts
@@ -19,6 +19,7 @@ export default class HostedCardNumberInput extends HostedInput {
      * @internal
      */
     constructor(
+        type: HostedFieldType,
         form: HTMLFormElement,
         placeholder: string,
         accessibilityLabel: string,
@@ -34,7 +35,7 @@ export default class HostedCardNumberInput extends HostedInput {
         private _formatter: CardNumberFormatter
     ) {
         super(
-            HostedFieldType.CardNumber,
+            type,
             form,
             placeholder,
             accessibilityLabel,

--- a/src/hosted-form/iframe-content/hosted-input-factory.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.spec.ts
@@ -17,6 +17,15 @@ describe('HostedInputFactory', () => {
             .toBeInstanceOf(HostedCardNumberInput);
     });
 
+    it('creates card number verification field', () => {
+        const input = factory.create(document.createElement('form'), HostedFieldType.CardNumberVerification);
+
+        expect(input)
+            .toBeInstanceOf(HostedCardNumberInput);
+        expect(input.getType())
+            .toEqual(HostedFieldType.CardNumberVerification);
+    });
+
     it('creates card expiry field', () => {
         expect(factory.create(document.createElement('form'), HostedFieldType.CardExpiry))
             .toBeInstanceOf(HostedCardExpiryInput);

--- a/src/hosted-form/iframe-content/hosted-input-factory.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.ts
@@ -36,11 +36,11 @@ export default class HostedInputFactory {
         const autocomplete = mapToAutocompleteType(type);
 
         if (type === HostedFieldType.CardNumber) {
-            return this._createNumberInput(form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
+            return this._createNumberInput(type, form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
         }
 
         if (type === HostedFieldType.CardNumberVerification) {
-            return this._createNumberInput(form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete, cardInstrument);
+            return this._createNumberInput(type, form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete, cardInstrument);
         }
 
         if (type === HostedFieldType.CardExpiry) {
@@ -79,6 +79,7 @@ export default class HostedInputFactory {
     }
 
     private _createNumberInput(
+        type: HostedFieldType,
         form: HTMLFormElement,
         styles: HostedInputStylesMap,
         fontUrls: string[],
@@ -88,6 +89,7 @@ export default class HostedInputFactory {
         cardInstrument?: CardInstrument
     ): HostedCardNumberInput {
         return new HostedCardNumberInput(
+            type,
             form,
             placeholder,
             accessibilityLabel,


### PR DESCRIPTION
## What?
Set the correct `type` for card number verification fields.

## Why?
Before this change, it is set to `CardNumber`. It should be set to `CardNumberVerification` instead. If it's not set correctly, we won't be sending the expected `credit_card_number_confirmation` value to the server when paying with a stored credit card for an order that ships to an untrusted shipping address.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
