### PR TITLE
feat(payment): PAYMENTS-5513 add setAsDefaultInstrument to the nonce mapping white list

### DIFF
--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -210,6 +210,24 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
                 .toHaveBeenCalledWith(payload.payment);
         });
 
+        it('passes on optional flags to save and to make default', async () => {
+            const payload = merge({}, orderRequestBody, {
+                payment: { paymentData: { shouldSaveInstrument: true, shouldSetAsDefaultInstrument: true } },
+            });
+
+            await braintreeCreditCardPaymentStrategy.execute(payload, options);
+
+            expect(paymentActionCreator.submitPayment)
+                .toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        paymentData: expect.objectContaining({
+                            shouldSaveInstrument: true,
+                            shouldSetAsDefaultInstrument: true,
+                        }),
+                    })
+                );
+        });
+
         it('does nothing to VaultedInstruments', async () => {
             const payload = {
                 ...orderRequestBody,
@@ -332,6 +350,29 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
                             nonce: 'my_tokenized_card_with_hosted_form',
                         },
                     });
+            });
+
+            it('passes on optional flags to save and to make default', async () => {
+                await braintreeCreditCardPaymentStrategy.initialize({
+                    methodId: paymentMethodMock.id,
+                    braintree: initializeOptions,
+                });
+
+                const payload = merge({}, orderRequestBody, {
+                    payment: { paymentData: { shouldSaveInstrument: true, shouldSetAsDefaultInstrument: true } },
+                });
+
+                await braintreeCreditCardPaymentStrategy.execute(payload, options);
+
+                expect(paymentActionCreator.submitPayment)
+                    .toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            paymentData: expect.objectContaining({
+                                shouldSaveInstrument: true,
+                                shouldSetAsDefaultInstrument: true,
+                            }),
+                        })
+                    );
             });
 
             it('verifies payment data with 3DS through hosted form and submits it if 3DS is enabled', async () => {

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -178,7 +178,7 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
     }
 
     private _mapToNonceInstrument(instrument: PaymentInstrument): NonceInstrument {
-        return pick(instrument as NonceInstrument, 'nonce', 'shouldSaveInstrument');
+        return pick(instrument as NonceInstrument, 'nonce', 'shouldSaveInstrument', 'shouldSetAsDefaultInstrument');
     }
 
     private _mapToVaultedInstrumentWithNonceVerification(instrument: PaymentInstrument): VaultedInstrumentWithNonceVerification {


### PR DESCRIPTION
## What?
Adding `setAsDefaultInstrument` to the nonce mapping function's white list for Braintree

## Why?
Currently it is being stripped out before it can reach the API and therefor the user's request to default that instrument is not honoured 

## Testing / Proof
Unit tests

@bigcommerce/checkout @bigcommerce/payments
