### PR TITLE
feat(payments): [AdyenV2] INT-3084 Autopopulate card holder name

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -421,6 +421,7 @@ describe('AdyenV2PaymentStrategy', () => {
                     placeholders: expect.any(Object),
                     onChange: expect.any(Function),
                     data: {
+                        holderName: 'Test Tester',
                         billingAddress: {
                             street: '12345 Testing Way',
                             houseNumberOrName: '',

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -220,6 +220,8 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         }
 
         const {
+            firstName,
+            lastName,
             address1: street,
             address2: houseNumberOrName,
             postalCode,
@@ -229,6 +231,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         } = billingAddress;
 
         return {
+            holderName: `${firstName} ${lastName}`,
             billingAddress: {
                 street,
                 houseNumberOrName,


### PR DESCRIPTION
## What? [INT-3084](https://jira.bigcommerce.com/browse/INT-3084)

## Why?
I want my merchants to offer their shoppers less friction while checking out with ACH APM.

## Testing / Proof

- Unit

- Manual

## How can this change be undone in case of failure?
1. Revert this PR


@bigcommerce/checkout @bigcommerce/payments
