### PR TITLE
feat(payment): INT-3061 added mandate field on order interface

### DIFF
--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -31,6 +31,7 @@ export default interface Order {
     status: string;
     taxes: Tax[];
     taxTotal: number;
+    mandate?: string;
 }
 
 export type OrderPayments = Array<GatewayOrderPayment | GiftCertificateOrderPayment>;


### PR DESCRIPTION
## What?
Added mandate field on order interface

## Why?
In order to show mandate on order on checkout confirmation Page.

## Testing / Proof

## Sibling PR's
[Checkout JS #404](https://github.com/bigcommerce/checkout-js/pull/404)
[Bigpay #2906](https://github.com/bigcommerce/bigpay/pull/2906)
[BigCommerce #36755](https://github.com/bigcommerce/bigcommerce/pull/36755)