### PR TITLE
feat(payment): INT-3001 Add 3DS2 support to converge payment integration

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -30,7 +30,7 @@ import { BoltAppPaymentStrategy, BoltScriptLoader } from './strategies/bolt';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVisaCheckoutPaymentStrategy, VisaCheckoutScriptLoader } from './strategies/braintree';
 import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow } from './strategies/cardinal';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
-import { ConvergePaymentStrategy } from './strategies/converge';
+import { ConvergePaymentStrategy, ConvergeScriptLoader } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
@@ -475,7 +475,9 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             hostedFormFactory,
-            formPoster
+            formPoster,
+            new ConvergeScriptLoader(scriptLoader),
+            paymentMethodActionCreator
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -269,6 +269,38 @@ export function getAmazonPayV2(region = 'us'): PaymentMethod {
     };
 }
 
+export function getConverge(is3dsV2Enabled = false, clientToken = ''): PaymentMethod {
+    return {
+        config: {
+            displayName: 'Pay Now',
+            helpText: '',
+            isVaultingEnabled: false,
+            merchantId: 'checkout_converge',
+            requireCustomerCode: false,
+            testMode: true,
+        },
+        id: 'converge',
+        initializationData: {
+            is3dsV2Enabled,
+            currencyCode: '826',
+            orderId: '100',
+            token: 'token',
+        },
+        method: 'credit-card',
+        supportedCards: [
+            'VISA',
+            'MC',
+            'AMEX',
+            'DISCOVER',
+            'DINERS',
+            'MAESTRO',
+            'JCB',
+        ],
+        type: 'PAYMENT_TYPE_API',
+        clientToken,
+    };
+}
+
 export function getAmazonPay(): PaymentMethod {
     return {
         id: 'amazon',
@@ -545,6 +577,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getBraintreePaypalCredit(),
         getBraintreeVisaCheckout(),
         getCheckoutcom(),
+        getConverge(),
         getGooglePay(),
         getKlarna(),
         getPaypalExpress(),

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -14,7 +14,7 @@ export type PaymentInstrument = (
     CreditCardInstrument |
     CreditCardInstrument & WithHostedFormNonce |
     CryptogramInstrument |
-    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument> |
+    FormattedPayload<AdyenV2Instrument | ConvergeInstrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument> |
     HostedInstrument |
     NonceInstrument |
     ThreeDSVaultedInstrument |
@@ -25,6 +25,20 @@ export type PaymentInstrument = (
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
+}
+
+export interface ConvergeInstrument {
+    threeDSServerTransID: string;
+    dsTransID: string;
+    transStatus: string;
+    authenticated: boolean;
+    credit_card: {
+        account_name: string;
+        month: string;
+        number: string;
+        verification_value?: string;
+        year: string;
+    };
 }
 
 export interface CreditCardInstrument {

--- a/src/payment/strategies/converge/converge-payment-strategy.spec.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.spec.ts
@@ -1,30 +1,36 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
-import { createRequestSender } from '@bigcommerce/request-sender';
-import { createScriptLoader } from '@bigcommerce/script-loader';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../..';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
 import { HostedFormFactory } from '../../../hosted-form';
-import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderPaymentRequestBody, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getOrder } from '../../../order/orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import { getConverge } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import * as paymentStatusTypes from '../../payment-status-types';
-import { getErrorPaymentResponseBody } from '../../payments.mock';
+import { getErrorPaymentResponseBody, getPayment } from '../../payments.mock';
 import { CreditCardPaymentStrategy } from '../credit-card';
 
+import { MissingDataError, MissingDataErrorType, RequestError } from './../../../common/error/errors';
+import { PaymentInitializeOptions } from './../../payment-request-options';
+import { ConvergeSDK } from './converge';
 import ConvergePaymentStrategy from './converge-payment-strategy';
+import ConvergeScriptLoader from './converge-script-loader';
+import { getConvergeConfirmPaymentResponse, getConvergeMock } from './converge.mock';
 
 describe('ConvergeaymentStrategy', () => {
     let finalizeOrderAction: Observable<FinalizeOrderAction>;
@@ -33,28 +39,39 @@ describe('ConvergeaymentStrategy', () => {
     let orderActionCreator: OrderActionCreator;
     let paymentActionCreator: PaymentActionCreator;
     let store: CheckoutStore;
-    let orderRequestSender: OrderRequestSender;
     let strategy: ConvergePaymentStrategy;
     let submitOrderAction: Observable<SubmitOrderAction>;
     let submitPaymentAction: Observable<SubmitPaymentAction>;
+    let convergeScriptLoader: ConvergeScriptLoader;
+    let paymentMethodMock: PaymentMethod;
+    let scriptLoader: ScriptLoader;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let requestSender: RequestSender;
 
     beforeEach(() => {
-        orderRequestSender = new OrderRequestSender(createRequestSender());
+        requestSender = createRequestSender();
+        scriptLoader = createScriptLoader();
+
         orderActionCreator = new OrderActionCreator(
-            orderRequestSender,
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new OrderRequestSender(requestSender),
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
         );
+
+        paymentMethodMock = getConverge();
 
         paymentActionCreator = new PaymentActionCreator(
             new PaymentRequestSender(createPaymentClient()),
             orderActionCreator,
             new PaymentRequestTransformer(),
-            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+            new PaymentHumanVerificationHandler(createSpamProtection(scriptLoader))
         );
+
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
 
         formPoster = createFormPoster();
         store = createCheckoutStore(getCheckoutStoreState());
         hostedFormFactory = {} as HostedFormFactory;
+        convergeScriptLoader = new ConvergeScriptLoader(scriptLoader);
 
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
@@ -74,144 +91,272 @@ describe('ConvergeaymentStrategy', () => {
         jest.spyOn(paymentActionCreator, 'submitPayment')
             .mockReturnValue(submitPaymentAction);
 
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+            .mockResolvedValue(store.getState());
+
         strategy = new ConvergePaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,
             hostedFormFactory,
-            formPoster
+            formPoster,
+            convergeScriptLoader,
+            paymentMethodActionCreator
         );
     });
 
-    it('submits order without payment data', async () => {
-        const payload = getOrderRequestBody();
-        const options = { methodId: 'converge' };
-
-        await strategy.execute(payload, options);
-
-        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), options);
-        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    it('creates an instance of ConvergePaymentStrategy', () => {
+        expect(strategy).toBeInstanceOf(ConvergePaymentStrategy);
     });
 
-    it('submits payment separately', async () => {
-        const payload = getOrderRequestBody();
-        const options = { methodId: 'converge' };
+    describe('#initialize()', () => {
+        let initializeOptions: PaymentInitializeOptions;
 
-        await strategy.execute(payload, options);
+        beforeEach(() => {
+            initializeOptions = { methodId: 'converge' };
+            jest.spyOn(convergeScriptLoader, 'load')
+                .mockResolvedValue(getConvergeMock());
+        });
 
-        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payload.payment);
-        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
-    });
+        it('loads converge script', async () => {
+            paymentMethodMock.initializationData.is3dsV2Enabled = true;
+            paymentMethodMock.clientToken = 'myToken';
 
-    it('returns checkout state', async () => {
-        const output = await strategy.execute(getOrderRequestBody());
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(paymentMethodMock);
 
-        expect(output).toEqual(store.getState());
-    });
+            await expect(strategy.initialize(initializeOptions)).resolves.toBe(store.getState());
 
-    it('posts 3ds data to Converge if 3ds is enabled', async () => {
-        const error = new RequestError(getResponse({
-            ...getErrorPaymentResponseBody(),
-            errors: [
-                { code: 'three_d_secure_required' },
-            ],
-            three_ds_result: {
-                acs_url: 'https://acs/url',
-                callback_url: 'https://callback/url',
-                payer_auth_request: 'payer_auth_request',
-                merchant_data: 'merchant_data',
-            },
-            status: 'error',
-        }));
+            expect(convergeScriptLoader.load).toHaveBeenCalled();
+        });
 
-        jest.spyOn(paymentActionCreator, 'submitPayment')
-            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+        it('throws error if client token is missing', async () => {
+            paymentMethodMock.initializationData.is3dsV2Enabled = true;
 
-        strategy.execute(getOrderRequestBody());
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(paymentMethodMock);
 
-        await new Promise(resolve => process.nextTick(resolve));
+            await expect(strategy.initialize(initializeOptions)).rejects.toThrow(MissingDataError);
+        });
 
-        expect(formPoster.postForm).toHaveBeenCalledWith('https://acs/url', {
-            PaReq: 'payer_auth_request',
-            TermUrl: 'https://callback/url',
-            MD: 'merchant_data',
+        it('loads a single instance of Elavon3DSWebSDK', async () => {
+            paymentMethodMock.initializationData.is3dsV2Enabled = true;
+            paymentMethodMock.clientToken = 'myToken';
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(paymentMethodMock);
+
+            await expect(strategy.initialize(initializeOptions)).resolves.toBe(store.getState());
+            await expect(strategy.initialize(initializeOptions)).resolves.toBe(store.getState());
+
+            expect(convergeScriptLoader.load).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not load converge if initialization options are not provided', () => {
+            initializeOptions.methodId = '';
+
+            const promise = strategy.initialize(initializeOptions);
+
+            return expect(promise).rejects.toThrow(new MissingDataError(MissingDataErrorType.MissingPaymentMethod));
         });
     });
 
-    it('does not post 3ds data to Converge if 3ds is not enabled', async () => {
-        const response = new RequestError(getResponse(getErrorPaymentResponseBody()));
+    describe('#execute()', () => {
+        let orderRequestBody: OrderRequestBody;
+        let initializeOptions: PaymentInitializeOptions;
+        const convergeMock: ConvergeSDK = getConvergeMock();
 
-        jest.spyOn(paymentActionCreator, 'submitPayment')
-            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, response)));
+        beforeEach(() => {
+            initializeOptions = { methodId: 'converge' };
+            orderRequestBody = {
+                ...getOrderRequestBody(),
+                payment: {
+                    ...getPayment() as OrderPaymentRequestBody,
+                    methodId: 'converge',
+                },
+            };
 
-        try {
-            await strategy.execute(getOrderRequestBody());
-        } catch (error) {
-            expect(error).toBeInstanceOf(RequestError);
+            jest.spyOn(convergeScriptLoader, 'load')
+                .mockResolvedValue(convergeMock);
+        });
+
+        it('submits order with payment data to sdk v2', async () => {
+            paymentMethodMock.initializationData.is3dsV2Enabled = true;
+            paymentMethodMock.clientToken = 'myToken';
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(paymentMethodMock);
+
+            convergeMock.web3dsFlow = jest.fn().mockResolvedValue(getConvergeConfirmPaymentResponse());
+
+            await strategy.initialize(initializeOptions);
+
+            await strategy.execute(omit(orderRequestBody, 'order'), initializeOptions);
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(orderRequestBody, 'payment'), initializeOptions);
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({
+                methodId: 'converge',
+                paymentData: {
+                    formattedPayload: {
+                        authenticated: true,
+                        threeDSServerTransID: '9e7bbadd-f37e-4988-8b73-dd0887c0b834',
+                        dsTransID: '9b7c00f0-a0bc-47a6-8f2f-b97445ccda49',
+                        transStatus: 'Y',
+                        credit_card: {
+                            account_name: 'BigCommerce',
+                            month: '10',
+                            number: '4111111111111111',
+                            verification_value: '123',
+                            year: '2020',
+                        },
+                    },
+                },
+            });
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledTimes(1);
+        });
+
+        it('posts 3ds data to Converge if 3ds is enabled to sdk v2', async () => {
+            paymentMethodMock.initializationData.is3dsV2Enabled = true;
+            paymentMethodMock.clientToken = 'myToken';
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(paymentMethodMock);
+
+            convergeMock.web3dsFlow = jest.fn().mockResolvedValue(getConvergeConfirmPaymentResponse());
+
+            await strategy.initialize(initializeOptions);
+
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [
+                    { code: 'three_d_secure_required' },
+                ],
+                three_ds_result: {
+                    acs_url: 'https://acs/url',
+                    callback_url: 'https://callback/url',
+                    payer_auth_request: 'payer_auth_request',
+                    merchant_data: 'merchant_data',
+                },
+                status: 'error',
+            }));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+            strategy.execute(orderRequestBody);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('https://acs/url', {
+                PaReq: 'payer_auth_request',
+                TermUrl: 'https://callback/url',
+                MD: 'merchant_data',
+            });
+        });
+
+        it('submits order without payment data', async () => {
+            await strategy.execute(orderRequestBody, initializeOptions);
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(orderRequestBody, 'payment'), initializeOptions);
+            expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+        });
+
+        it('submits payment separately', async () => {
+            await strategy.execute(orderRequestBody, initializeOptions);
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(orderRequestBody.payment);
+            expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+        });
+
+        it('returns checkout state', async () => {
+            await expect(strategy.execute(orderRequestBody)).resolves.toBe(store.getState());
+        });
+
+        it('posts 3ds data to Converge if 3ds is enabled', async () => {
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [
+                    { code: 'three_d_secure_required' },
+                ],
+                three_ds_result: {
+                    acs_url: 'https://acs/url',
+                    callback_url: 'https://callback/url',
+                    payer_auth_request: 'payer_auth_request',
+                    merchant_data: 'merchant_data',
+                },
+                status: 'error',
+            }));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+            strategy.execute(orderRequestBody);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('https://acs/url', {
+                PaReq: 'payer_auth_request',
+                TermUrl: 'https://callback/url',
+                MD: 'merchant_data',
+            });
+        });
+
+        it('does not load converge if 3ds is not required', async () => {
+            const response = new RequestError(getResponse(getErrorPaymentResponseBody()));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, response)));
+
+            await expect(strategy.execute(orderRequestBody)).rejects.toThrow(RequestError);
             expect(formPoster.postForm).not.toHaveBeenCalled();
-        }
+        });
+
+        it('is special type of credit card strategy', () => {
+            expect(strategy)
+                .toBeInstanceOf(CreditCardPaymentStrategy);
+        });
     });
 
-    it('finalizes order if order is created and payment is finalized', async () => {
-        const state = store.getState();
+    describe('#finalize()', () => {
+        it('throws an error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toBeInstanceOf(OrderFinalizationNotRequiredError);
+        });
 
-        jest.spyOn(state.order, 'getOrder')
-            .mockReturnValue(getOrder());
+        it('finalizes order if order is created and payment is finalized', async () => {
+            const state = store.getState();
 
-        jest.spyOn(state.payment, 'getPaymentStatus')
-            .mockReturnValue(paymentStatusTypes.FINALIZE);
+            jest.spyOn(state.order, 'getOrder')
+                .mockReturnValue(getOrder());
 
-        await strategy.finalize();
+            jest.spyOn(state.payment, 'getPaymentStatus')
+                .mockReturnValue(paymentStatusTypes.FINALIZE);
 
-        expect(orderActionCreator.finalizeOrder).toHaveBeenCalled();
-        expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
-    });
-
-    it('does not finalize order if order is not created', async () => {
-        const state = store.getState();
-
-        jest.spyOn(state.order, 'getOrder')
-            .mockReturnValue(null);
-
-        try {
             await strategy.finalize();
-        } catch (error) {
+
+            expect(orderActionCreator.finalizeOrder).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
+        });
+
+        it('does not finalize order if order is not created', async () => {
+            const state = store.getState();
+
+            jest.spyOn(state.order, 'getOrder')
+                .mockReturnValue(null);
+
+            await expect(strategy.finalize()).rejects.toBeInstanceOf(OrderFinalizationNotRequiredError);
             expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
             expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
-            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
-        }
-    });
+        });
 
-    it('does not finalize order if order is not finalized', async () => {
-        const state = store.getState();
+        it('does not finalize order if order is not finalized', async () => {
+            const state = store.getState();
 
-        jest.spyOn(state.payment, 'getPaymentStatus')
-            .mockReturnValue(paymentStatusTypes.INITIALIZE);
+            jest.spyOn(state.payment, 'getPaymentStatus')
+                .mockReturnValue(paymentStatusTypes.INITIALIZE);
 
-        try {
-            await strategy.finalize();
-        } catch (error) {
+            await expect(strategy.finalize()).rejects.toBeInstanceOf(OrderFinalizationNotRequiredError);
             expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
             expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
-            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
-        }
-    });
-
-    it('throws error if order is missing', async () => {
-        const state = store.getState();
-
-        jest.spyOn(state.order, 'getOrder')
-            .mockReturnValue(null);
-
-        try {
-            await strategy.finalize();
-        } catch (error) {
-            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
-        }
-    });
-
-    it('is special type of credit card strategy', () => {
-        expect(strategy)
-            .toBeInstanceOf(CreditCardPaymentStrategy);
+        });
     });
 });

--- a/src/payment/strategies/converge/converge-payment-strategy.ts
+++ b/src/payment/strategies/converge/converge-payment-strategy.ts
@@ -2,31 +2,100 @@ import { FormPoster } from '@bigcommerce/form-poster';
 import { some } from 'lodash';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { RequestError } from '../../../common/error/errors';
+import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
 import { HostedFormFactory } from '../../../hosted-form';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import isCreditCardLike from '../../is-credit-card-like';
 import PaymentActionCreator from '../../payment-action-creator';
-import { PaymentRequestOptions } from '../../payment-request-options';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import * as paymentStatusTypes from '../../payment-status-types';
 import { CreditCardPaymentStrategy } from '../credit-card';
 
+import { Converge3DSRequestorAuthenticationIndicator, ConvergeMessageCategory, ConvergePurchaseExponent, ConvergeRequestParams, ConvergeResponseData, ConvergeSDK, ConvergeTransactionType } from './converge';
+import ConvergeScriptLoader from './converge-script-loader';
+
 export default class ConvergePaymentStrategy extends CreditCardPaymentStrategy {
+    private _convergeSDK?: ConvergeSDK;
+
     constructor(
         store: CheckoutStore,
         orderActionCreator: OrderActionCreator,
         paymentActionCreator: PaymentActionCreator,
         hostedFormFactory: HostedFormFactory,
-        private _formPoster: FormPoster
+        private _formPoster: FormPoster,
+        private _convergeScriptLoader: ConvergeScriptLoader,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator
     ) {
         super(store, orderActionCreator, paymentActionCreator, hostedFormFactory);
     }
 
-    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        return super.execute(payload, options)
-            .catch(error => {
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options;
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(methodId);
+
+        const is3dsV2 = paymentMethod.initializationData.is3dsV2Enabled;
+
+        if (is3dsV2) {
+            const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+            const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+            if (!paymentMethod || !paymentMethod.clientToken) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            this._convergeSDK = await this._loadConvergeJs(paymentMethod.clientToken);
+
+            return this._store.getState();
+        } else {
+            return Promise.resolve(this._store.getState());
+        }
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+
+        if (!payment || !payment.paymentData || !isCreditCardLike(payment.paymentData)) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        const { paymentData: { ccNumber, ccExpiry, ccCvv, ccName } } = payment;
+
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(payment.methodId);
+
+        const is3dsV2 = paymentMethod.initializationData.is3dsV2Enabled;
+
+        if (is3dsV2) {
+            const { threeDSServerTransID, dsTransID, transStatus, authenticated } = await this.request3DSWebSDK(payload);
+
+            await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+            try {
+                return await this._store.dispatch(this._paymentActionCreator.submitPayment({
+                    ...payment,
+                    paymentData: {
+                        formattedPayload: {
+                            authenticated,
+                            threeDSServerTransID,
+                            dsTransID,
+                            transStatus,
+                            credit_card: {
+                                account_name: ccName,
+                                month: ccExpiry.month,
+                                number: ccNumber,
+                                verification_value: ccCvv,
+                                year: ccExpiry.year,
+                            },
+                        },
+                    },
+                }));
+            } catch (error) {
                 if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
-                    return Promise.reject(error);
+                    throw error;
                 }
 
                 return new Promise(() => {
@@ -36,7 +105,24 @@ export default class ConvergePaymentStrategy extends CreditCardPaymentStrategy {
                         MD: error.body.three_ds_result.merchant_data,
                     });
                 });
-            });
+            }
+        } else {
+            try {
+                return await super.execute(payload, options);
+            } catch (error) {
+                if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
+                    throw error;
+                }
+
+                return new Promise(() => {
+                    this._formPoster.postForm(error.body.three_ds_result.acs_url, {
+                        PaReq: error.body.three_ds_result.payer_auth_request,
+                        TermUrl: error.body.three_ds_result.callback_url,
+                        MD: error.body.three_ds_result.merchant_data,
+                    });
+                });
+            }
+        }
     }
 
     finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
@@ -48,5 +134,56 @@ export default class ConvergePaymentStrategy extends CreditCardPaymentStrategy {
         }
 
         return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    request3DSWebSDK(payload: OrderRequestBody): Promise <ConvergeResponseData> {
+        const requestParams = this._getRequestParams(payload);
+
+        return this._getConvergeSDK().web3dsFlow(requestParams);
+    }
+
+    private async _loadConvergeJs(clientToken: string): Promise <ConvergeSDK> {
+        if (this._convergeSDK) { return Promise.resolve(this._convergeSDK); }
+
+        return await this._convergeScriptLoader.load(clientToken);
+    }
+
+    private _getConvergeSDK(): ConvergeSDK {
+        if (!this._convergeSDK) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._convergeSDK;
+    }
+
+    private _getRequestParams(payload: OrderRequestBody): ConvergeRequestParams {
+        const { payment } = payload;
+        const checkout = this._store.getState().checkout.getCheckoutOrThrow();
+
+        if (!payment || !payment.paymentData || !isCreditCardLike(payment.paymentData)) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        const { paymentData: { ccExpiry: { year, month }, ccNumber: acctNumber } } = payment;
+        const cardExpiryDate = year.substr(-2) + month;
+
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(payment.methodId);
+
+        const { currencyCode, messageId } = paymentMethod.initializationData;
+
+        const purchaseAmount = Math.trunc(checkout.grandTotal * 100).toString();
+
+        return {
+            messageId,
+            cardExpiryDate,
+            purchaseCurrency: currencyCode,
+            acctNumber,
+            purchaseAmount,
+            purchaseExponent: ConvergePurchaseExponent.USD,
+            messageCategory: ConvergeMessageCategory.PaymentAuthentication,
+            transType: ConvergeTransactionType.Purchase,
+            threeDSRequestorAuthenticationInd: Converge3DSRequestorAuthenticationIndicator.PaymentTransaction,
+        };
     }
 }

--- a/src/payment/strategies/converge/converge-script-loader.spec.ts
+++ b/src/payment/strategies/converge/converge-script-loader.spec.ts
@@ -1,0 +1,57 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentMethodClientUnavailableError } from '../../errors';
+
+import { ConvergeHostWindow } from './converge';
+import ConvergeScriptLoader from './converge-script-loader';
+import { getConvergeMock } from './converge.mock';
+
+describe('ConvergeScriptLoader', () => {
+    let convergeScriptLoader: ConvergeScriptLoader;
+    let scriptLoader: ScriptLoader;
+    let mockWindow: ConvergeHostWindow;
+
+    beforeEach(() => {
+        mockWindow = {} as ConvergeHostWindow;
+        scriptLoader = {} as ScriptLoader;
+        convergeScriptLoader = new ConvergeScriptLoader(scriptLoader, mockWindow);
+    });
+
+    describe('#load()', () => {
+        const convergeMock = getConvergeMock();
+
+        const sdk3DS2 = 'https://uat.gw.fraud.eu.elavonaws.com/sdk-web-js/0.13.2/3ds2-web-sdk.min.js';
+        const libUrl = 'https://libs.fraud.elavon.com/sdk-web-js/0.12.0/3ds2-web-sdk.min.js';
+
+        beforeEach(() => {
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.Elavon3DSWebSDK = jest.fn(() => convergeMock);
+
+                return Promise.resolve();
+            });
+        });
+
+        it('loads the JS', async () => {
+            await convergeScriptLoader.load('token');
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(libUrl);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(sdk3DS2);
+        });
+
+        it('returns the JS from the window', async () => {
+            const convergeJs = await convergeScriptLoader.load('token');
+
+            expect(convergeJs).toBe(convergeMock);
+        });
+
+        it('throws an error when window is not set', async () => {
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.Elavon3DSWebSDK = undefined;
+
+                return Promise.resolve();
+            });
+
+            await expect(convergeScriptLoader.load('token')).rejects.toThrow(PaymentMethodClientUnavailableError);
+        });
+    });
+});

--- a/src/payment/strategies/converge/converge-script-loader.ts
+++ b/src/payment/strategies/converge/converge-script-loader.ts
@@ -1,0 +1,29 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentMethodClientUnavailableError } from '../../errors';
+
+import { ConvergeHostWindow, ConvergeSDK } from './converge';
+
+const libUrl = 'https://libs.fraud.elavon.com/sdk-web-js/0.12.0/3ds2-web-sdk.min.js';
+const sdk3DS2 = 'https://uat.gw.fraud.eu.elavonaws.com/sdk-web-js/0.13.2/3ds2-web-sdk.min.js';
+const baseUrl = 'https://uat.gw.fraud.eu.elavonaws.com/3ds2';
+
+export default class ConvergeScriptLoader {
+    constructor(
+        private _scriptLoader: ScriptLoader,
+        private _window: ConvergeHostWindow = window
+    ) {}
+
+    async load(token?: string): Promise<ConvergeSDK> {
+        await Promise.all([
+            this._scriptLoader.loadScript(sdk3DS2),
+            this._scriptLoader.loadScript(libUrl),
+        ]);
+
+        if (!this._window.Elavon3DSWebSDK) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return new this._window.Elavon3DSWebSDK({baseUrl, token});
+    }
+}

--- a/src/payment/strategies/converge/converge.mock.ts
+++ b/src/payment/strategies/converge/converge.mock.ts
@@ -1,0 +1,29 @@
+import { ConvergeResponseData, ConvergeSDK } from './converge';
+
+export function getConvergeMock(): ConvergeSDK {
+    return { web3dsFlow: jest.fn( )};
+}
+
+export function getConvergeConfirmPaymentResponse(): ConvergeResponseData {
+    return {
+        messageType: 'RReq',
+        messageVersion: '2.1.0',
+        threeDSServerTransID: '9e7bbadd-f37e-4988-8b73-dd0887c0b834',
+        dsTransID: '9b7c00f0-a0bc-47a6-8f2f-b97445ccda49',
+        acsTransID: '5f13f964-08e9-4c5b-839c-590fb3deb7b1',
+        acsReferenceNumber: 'ELAVON_ACS_EMULATOR_REF_NUMBER32',
+        acsOperatorID: 'ELAVON_ACS_EMULATOR_OPERATOR_ID1',
+        dsReferenceNumber: 'ELAVON_3DS_DS_EMULATOR_REF_NUM32',
+        transStatus: 'Y',
+        authenticationType: '01',
+        acsChallengeMandated: 'Y',
+        acsURL: 'https://uat.acs.fraud.eu.elavonaws.com/acs/challenge/VISA',
+        authenticationValue: 'KbFvasJ8VhUsgVk5eUue7yS8Z/M=',
+        eci: '05',
+        interactionCounter: '01',
+        messageCategory: '01',
+        authenticated: true,
+        message: 'Account Verification Successful',
+        messageId: '0b0deb70-3249-4c73-9cf5-92f6cac231af',
+    };
+}

--- a/src/payment/strategies/converge/converge.ts
+++ b/src/payment/strategies/converge/converge.ts
@@ -1,0 +1,70 @@
+export interface ConvergeSDK {
+    web3dsFlow(request: ConvergeRequestParams): Promise<ConvergeResponseData>;
+}
+
+export interface ConvergeHostWindow extends Window {
+    Elavon3DSWebSDK?: new (options: ConvergeOptions) => ConvergeSDK;
+}
+
+export interface ConvergeOptions {
+    baseUrl: string;
+    token?: string;
+}
+
+export enum ConvergeMessageCategory {
+    PaymentAuthentication = '01',
+}
+
+export enum ConvergePurchaseExponent {
+    USD = '2',
+}
+
+export enum ConvergeTransactionType {
+    Purchase = '01',
+}
+
+export enum Converge3DSRequestorAuthenticationIndicator {
+    PaymentTransaction = '01',
+}
+
+export interface ConvergeRequestParams {
+    messageId: string;
+    purchaseAmount: string;
+    purchaseCurrency: string;
+    purchaseExponent: ConvergePurchaseExponent;
+    acctNumber: string;
+    cardExpiryDate: string;
+    messageCategory: ConvergeMessageCategory;
+    transType: ConvergeTransactionType;
+    threeDSRequestorAuthenticationInd: Converge3DSRequestorAuthenticationIndicator;
+}
+
+export interface ConvergeRequestData {
+    messageId: string;
+    purchaseAmount: string;
+    acctNumber: string;
+    cardExpiryDate: string;
+    purchaseCurrency: string;
+}
+
+export interface ConvergeResponseData {
+    acsChallengeMandated: string;
+    acsOperatorID: string;
+    acsReferenceNumber: string;
+    acsTransID: string;
+    acsURL: string;
+    authenticated: boolean;
+    authenticationType: string;
+    authenticationValue: string;
+    dsReferenceNumber: string;
+    dsTransID: string;
+    eci: string;
+    interactionCounter: string;
+    message: string;
+    messageCategory: string;
+    messageId: string;
+    messageType: string;
+    messageVersion: string;
+    threeDSServerTransID: string;
+    transStatus: string;
+}

--- a/src/payment/strategies/converge/index.ts
+++ b/src/payment/strategies/converge/index.ts
@@ -1,1 +1,4 @@
+export * from './converge';
+
 export { default as ConvergePaymentStrategy } from './converge-payment-strategy';
+export { default as ConvergeScriptLoader } from './converge-script-loader';


### PR DESCRIPTION
[INT-3001](https://jira.bigcommerce.com/browse/INT-3001)

## What?
Add 3DS2 support to converge payment integration.

## Why?
3DS 2 is more secure because it makes a call to deviceFingerprint method.

## Testing / Proof
https://drive.google.com/file/d/1hl0FeyE2rpZF7QhKB-ujJK6oZIA_kkA-/view?usp=sharing

## How can this change be undone in case of failure?
1. Revert this PR

## Siblings
https://github.com/bigcommerce/bigcommerce/pull/36739
https://github.com/bigcommerce/bigpay/pull/2907

ping @bigcommerce/apex-integrations.