### PR TITLE
feat(payment): INT-3032 Add ES/EUR support to Klarna

### DIFF
--- a/src/payment/strategies/klarnav2/klarna-supported-countries.ts
+++ b/src/payment/strategies/klarnav2/klarna-supported-countries.ts
@@ -1,2 +1,2 @@
-export const supportedCountries = ['AT', 'DE', 'DK', 'FI', 'GB', 'NL', 'NO', 'SE', 'CH', 'NZ'];
+export const supportedCountries = ['AT', 'CH', 'DE', 'DK', 'ES', 'FI', 'GB', 'NL', 'NO', 'NZ', 'SE'];
 export const supportedCountriesRequiringStates = ['AU'];


### PR DESCRIPTION
## What? [INT-3032](https://jira.bigcommerce.com/browse/INT-3032)

- Add ES/EUR support to Klarna

## Why?

As a merchant based in Spain, with an EU Klarna account, I want to be able to accept payment in EUR.

## Sibling PR's
https://github.com/bigcommerce/bigpay/pull/2919
https://github.com/bigcommerce/bigcommerce/pull/36826

## Testing / Proof
<img width="1170" alt="Screen Shot 2020-08-28 at 2 26 31 PM" src="https://user-images.githubusercontent.com/42154828/91608098-865f7800-e93a-11ea-89f7-8dfb85c7348b.png">

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
