### PR TITLE
docs(common): CHECKOUT-5136 Updating the links in Getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ The library also provides integrations with all the payment methods supported by
 * Klarna
 * AfterPay
 
-Using this library in conjunction with your favorite UI framework, it is possible to build a bespoke checkout UI for a store, that can be augmented with additional features. We provide a basic [reference implementation](https://github.com/bigcommerce/checkout-sdk-js-example) of a custom checkout written in React to get you started.
+Using this library in conjunction with your favorite UI framework, it is possible to build a bespoke checkout UI for a store, that can be augmented with additional features. We provide a basic [reference implementation](https://github.com/bigcommerce/checkout-sdk-js-example) of a custom checkout written in React to get you started. **Please note that this reference implementation is not production ready.** 
 
 
 ## Getting started
 
 The Checkout JS SDK is the easiest way to build a bespoke checkout into your store’s theme. We have created the following tutorials to help you get started.
-* [Build with vanilla JS](https://developer.bigcommerce.com/stencil-docs/template-files/customize-stencil-checkout/checkout-js-sdk/getting-started-in-vanilla-js) - This tutorial will walk through the first steps for building a custom checkout directly into the theme files using vanilla JS.
-* [Run example app in Cornerstone](https://developer.bigcommerce.com/stencil-docs/template-files/customize-stencil-checkout/checkout-js-sdk/implement-a-custom-checkout) - This tutorial will take you through the steps to integrate the custom checkout provided by our reference implementation into the Cornerstone theme.
+* [Checkout SDK Quickstart](https://developer.bigcommerce.com/stencil-docs/customizing-checkout/checkout-sdk-quickstart) - This tutorial will walk through the first steps for building a custom checkout by installing the Checkout JS SDK and initial theme setup.
+* [Checkout SDK Tutorial](https://developer.bigcommerce.com/stencil-docs/customizing-checkout/checkout-sdk-example) - This tutorial will take you through the steps to integrate the custom checkout provided by our reference implementation into the Cornerstone theme.
 
 
 ## Installation


### PR DESCRIPTION
## What?
- Updating the "Getting started" section to link to the correct tutorials.
- Making note to say the example checkout app is not Production ready.

## Why?
Improve Checkout JS SDK documentation to make it easier for developers to get started using the SDK.

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments @capsula4 
