### PR TITLE
docs(payment): INT-3089 Remove the @Alpha modifier to AmazonPayV2

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -21,7 +21,6 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
     /**
      * The options that are required to facilitate AmazonPayV2. They can be
      * omitted unless you need to support AmazonPayV2.
-     * @alpha
      */
     amazonpay?: AmazonPayV2ButtonInitializeOptions;
 

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -1,7 +1,4 @@
 enum CheckoutButtonMethodType {
-    /**
-     * @alpha
-     */
     AMAZON_PAY_V2 = 'amazonpay',
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -38,7 +38,6 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
     /**
      * The options that are required to initialize the customer step of checkout
      * when using AmazonPayV2.
-     * @alpha
      */
     amazonpay?: AmazonPayV2CustomerInitializeOptions;
 

--- a/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-initialize-options.ts
+++ b/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-initialize-options.ts
@@ -9,7 +9,6 @@
 export default interface AmazonPayV2CustomerInitializeOptions {
     /**
      * The ID of a container which the sign-in button should insert into.
-     * @alpha
      */
     container: string;
 }

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -62,7 +62,6 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
     /**
      * The options that are required to initialize the AmazonPayV2 payment
      * method. They can be omitted unless you need to support AmazonPayV2.
-     * @alpha
      */
     amazonpay?: AmazonPayV2PaymentInitializeOptions;
 

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -5,9 +5,6 @@ enum PaymentStrategyType {
     AFTERPAY = 'afterpay',
     AMAZON = 'amazon',
     AUTHORIZENET_GOOGLE_PAY = 'googlepayauthorizenet',
-    /**
-     * @alpha
-     */
     AMAZONPAYV2 = 'amazonpay',
     BLUESNAPV2 = 'bluesnapv2',
     BOLT = 'bolt',

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-initialize-options.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-initialize-options.ts
@@ -11,7 +11,6 @@ export default interface AmazonPayV2PaymentInitializeOptions {
      * This editButtonId is used to set an event listener, provide an element ID
      * if you want users to be able to select a different payment method by
      * clicking on a button. It should be an HTML element.
-     * @alpha
      */
     editButtonId?: string;
 }

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -1,7 +1,7 @@
 import PaymentMethod from '../../payment-method';
 import { getAmazonPayV2 } from '../../payment-methods.mock';
 
-import { AmazonPayV2ButtonParams, AmazonPayV2CheckoutLanguage, AmazonPayV2LedgerCurrency, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
+import { AmazonPayV2ButtonParams, AmazonPayV2CheckoutLanguage, AmazonPayV2LedgerCurrency, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
 
 export function getAmazonPayV2SDKMock(): AmazonPayV2SDK {
     return {
@@ -28,7 +28,7 @@ export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParams {
         ledgerCurrency: 'USD' as AmazonPayV2LedgerCurrency,
         merchantId: 'checkout_amazonpay',
         placement: 'Checkout' as AmazonPayV2Placement,
-        productType: 'PayAndShip',
+        productType: 'PayAndShip' as AmazonPayV2PayOptions,
         sandbox: true,
     };
 }

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -9,8 +9,25 @@ export interface AmazonPayV2SDK {
 }
 
 export interface AmazonPayV2Client {
+    /**
+     * Render the Amazon Pay button to a HTML container element.
+     *
+     * @param containerId - HTML element id.
+     * @param params - Button rendering params.
+     */
     renderButton(containerId: string, params: AmazonPayV2ButtonParams): HTMLElement;
+
+    /**
+     * Bind click events to HTML elements, so that when the element is clicked, the buyer can select a different shipping address or payment method.
+     *
+     * @param buttonId - HTML element id.
+     * @param options - Element binding options.
+     */
     bindChangeAction(buttonId: string, options: AmazonPayV2ChangeActionOptions): void;
+
+    /**
+     * Allow buyers to sign out from their Amazon account.
+     */
     signout(): void;
 }
 
@@ -22,12 +39,39 @@ export interface AmazonPayV2HostWindow extends Window {
  * @alpha
  */
 export interface AmazonPayV2ButtonParams {
+    /**
+     * Amazon Pay merchant account identifier.
+     */
     merchantId: string;
+
+    /**
+     * Configuration for calling the endpoint to Create Checkout Session.
+     */
     createCheckoutSession: AmazonPayV2CheckoutSession;
+
+    /**
+     * Placement of the Amazon Pay button on your website.
+     */
     placement: AmazonPayV2Placement;
+
+    /**
+     * Ledger currency provided during registration for the given merchant identifier.
+     */
     ledgerCurrency: AmazonPayV2LedgerCurrency;
-    productType?: string;
+
+    /**
+     * Product type selected for checkout. Default is 'PayAndShip'.
+     */
+    productType?: AmazonPayV2PayOptions;
+
+    /**
+     * Language used to render the button and text on Amazon Pay hosted pages.
+     */
     checkoutLanguage?: AmazonPayV2CheckoutLanguage;
+
+    /**
+     * Sets button to Sandbox environment. Default is false.
+     */
     sandbox?: boolean;
 }
 
@@ -35,15 +79,33 @@ export interface AmazonPayV2ButtonParams {
  * @alpha
  */
 export interface AmazonPayV2CheckoutSession {
+    /**
+     * Endpoint URL to Create Checkout Session.
+     */
     url: string;
-    method?: string;
+
+    /**
+     * HTTP request method. Default is 'POST'.
+     */
+    method?: 'GET' | 'POST';
+
+    /**
+     * Checkout Session ID parameter in the response. Default is 'checkoutSessionId'.
+     */
     extractAmazonCheckoutSessionId?: string;
 }
 
 export type AmazonPayV2ChangeActionType = 'changeAddress' | 'changePayment';
 
 export interface AmazonPayV2ChangeActionOptions {
+    /**
+     * Amazon Pay Checkout Session identifier.
+     */
     amazonCheckoutSessionId: string;
+
+    /**
+     * Update requested by the buyer.
+     */
     changeAction: AmazonPayV2ChangeActionType;
 }
 
@@ -58,12 +120,12 @@ export enum AmazonPayV2Regions {
  * @alpha
  */
 export enum AmazonPayV2CheckoutLanguage {
-    es_ES = 'es_ES',
-    en_GB = 'en_GB',
     en_US = 'en_US',
+    en_GB = 'en_GB',
     de_DE = 'de_DE',
     fr_FR = 'fr_FR',
     it_IT = 'it_IT',
+    es_ES = 'es_ES',
     ja_JP = 'ja_JP',
 }
 
@@ -71,10 +133,19 @@ export enum AmazonPayV2CheckoutLanguage {
  * @alpha
  */
 export enum AmazonPayV2Placement {
+    /** Initial or main page. */
     Home = 'Home',
+
+    /** Product details page. */
     Product = 'Product',
+
+    /** Cart review page before buyer starts checkout. */
     Cart = 'Cart',
+
+    /** Any page after buyer starts checkout. */
     Checkout = 'Checkout',
+
+    /** Any page that doesn't fit the previous descriptions. */
     Other = 'Other',
 }
 
@@ -82,13 +153,16 @@ export enum AmazonPayV2Placement {
  * @alpha
  */
 export enum AmazonPayV2LedgerCurrency {
-    eu = 'EUR',
-    jp = 'JPY',
-    uk = 'GBP',
-    us = 'USD',
+    USD = 'USD',
+    EUR = 'EUR',
+    GBP = 'GBP',
+    JPY = 'JPY',
 }
 
 export enum AmazonPayV2PayOptions {
+    /** Select this product type if you need the buyer's shipping details. */
     PayAndShip = 'PayAndShip',
+
+    /** Select this product type if you do not need the buyer's shipping details. */
     PayOnly = 'PayOnly',
 }

--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -35,9 +35,6 @@ export interface AmazonPayV2HostWindow extends Window {
     amazon?: AmazonPayV2SDK;
 }
 
-/**
- * @alpha
- */
 export interface AmazonPayV2ButtonParams {
     /**
      * Amazon Pay merchant account identifier.
@@ -75,9 +72,6 @@ export interface AmazonPayV2ButtonParams {
     sandbox?: boolean;
 }
 
-/**
- * @alpha
- */
 export interface AmazonPayV2CheckoutSession {
     /**
      * Endpoint URL to Create Checkout Session.
@@ -116,9 +110,6 @@ export enum AmazonPayV2Regions {
     us = 'na',
 }
 
-/**
- * @alpha
- */
 export enum AmazonPayV2CheckoutLanguage {
     en_US = 'en_US',
     en_GB = 'en_GB',
@@ -129,9 +120,6 @@ export enum AmazonPayV2CheckoutLanguage {
     ja_JP = 'ja_JP',
 }
 
-/**
- * @alpha
- */
 export enum AmazonPayV2Placement {
     /** Initial or main page. */
     Home = 'Home',
@@ -149,9 +137,6 @@ export enum AmazonPayV2Placement {
     Other = 'Other',
 }
 
-/**
- * @alpha
- */
 export enum AmazonPayV2LedgerCurrency {
     USD = 'USD',
     EUR = 'EUR',

--- a/src/shipping/shipping-request-options.ts
+++ b/src/shipping/shipping-request-options.ts
@@ -36,7 +36,6 @@ export interface ShippingInitializeOptions<T = {}> extends ShippingRequestOption
     /**
      * The options that are required to initialize the shipping step of checkout
      * when using AmazonPayV2.
-     * @alpha
      */
     amazonpay?: AmazonPayV2ShippingInitializeOptions;
 }

--- a/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-initialize-options.ts
+++ b/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-initialize-options.ts
@@ -11,7 +11,6 @@ export default interface AmazonPayV2ShippingInitializeOptions {
      * This editAddressButtonId is used to set an event listener, provide an
      * element ID if you want users to be able to select a different shipping
      * address by clicking on a button. It should be an HTML element.
-     * @alpha
      */
     editAddressButtonId?: string;
 }


### PR DESCRIPTION
## What? [INT-3089](https://jira.bigcommerce.com/browse/INT-3089)
- Improved documentation.
- Removed the `@alpha` modifier to all the new introduced params. (See #910)

## Why?
To indicate that Amazon Pay V2 has been officially released.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
