### PR TITLE
feat(checkout): INT-2779 Add vaulting support for Orbital

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -69,6 +69,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'bluesnapv2',
         method: 'credit_card',
     },
+    orbital: {
+        provider: 'orbital',
+        method: 'credit_card',
+    },
     paymetric: {
         provider: 'paymetric',
         method: 'credit_card',


### PR DESCRIPTION
## What?
[INT-2779](https://jira.bigcommerce.com/browse/INT-2779): Add vaulting feature for Orbital.

## Why?
To display vaulted cards with Orbital at checkout screen.

## Testing / Proof
Vaulted credit card on Orbital at checkout:
![image](https://user-images.githubusercontent.com/46331158/91754998-02063280-eb90-11ea-9577-6765c728e78c.png)

## Sibling PR

* [Bigpay # 2938](https://github.com/bigcommerce/bigpay/pull/2938)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 