### PR TITLE
feat(payment): INT-3027 Implementing client key

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -483,6 +483,7 @@ export function getAdyenV2(method: string = 'scheme'): PaymentMethod {
         },
         initializationData: {
             originKey: 'YOUR_ORIGIN_KEY',
+            clientKey: 'YOUR_CLIENT_KEY',
         },
         type: 'PAYMENT_TYPE_API',
         clientToken: 'clientToken',

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -43,11 +43,23 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         this._paymentInitializeOptions = adyenv2;
 
         const paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(options.methodId);
+        const clientSideAuthentication = {
+            key: '',
+            value: '',
+        };
+
+        if (paymentMethod.initializationData.originKey) {
+            clientSideAuthentication.key = 'originKey';
+            clientSideAuthentication.value = paymentMethod.initializationData.originKey;
+        } else {
+            clientSideAuthentication.key = 'clientKey';
+            clientSideAuthentication.value = paymentMethod.initializationData.clientKey;
+        }
 
         this._adyenClient = await this._scriptLoader.load({
             environment:  paymentMethod.initializationData.environment,
             locale: this._locale,
-            originKey: paymentMethod.initializationData.originKey,
+            [clientSideAuthentication.key]: clientSideAuthentication.value,
             paymentMethodsResponse: paymentMethod.initializationData.paymentMethodsResponse,
         });
 

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -22,6 +22,7 @@ describe('AdyenV2ScriptLoader', () => {
     describe('#load()', () => {
         const adyenClient = getAdyenClient();
         const configuration = getAdyenConfiguration();
+        const configurationWithClientKey = getAdyenConfiguration(false);
         const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js';
         const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css';
 
@@ -48,8 +49,14 @@ describe('AdyenV2ScriptLoader', () => {
             expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
         });
 
-        it('returns the JS from the window', async () => {
+        it('returns the JS from the window using originKey', async () => {
             const adyenJs = await adyenV2ScriptLoader.load(configuration);
+
+            expect(adyenJs).toBe(adyenClient);
+        });
+
+        it('returns the JS from the window using clientKey', async () => {
+            const adyenJs = await adyenV2ScriptLoader.load(configurationWithClientKey);
 
             expect(adyenJs).toBe(adyenClient);
         });

--- a/src/payment/strategies/adyenv2/adyenv2.mock.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.mock.ts
@@ -70,10 +70,13 @@ export function getAdyenClient(): AdyenClient {
     };
 }
 
-export function getAdyenConfiguration(): AdyenConfiguration {
-    return {
+export function getAdyenConfiguration(useOriginKey: boolean = true): AdyenConfiguration {
+    return useOriginKey ? {
         environment: 'test',
         originKey: 'YOUR_ORIGIN_KEY',
+    } : {
+        environment: 'test',
+        clientKey: 'YOUR_CLIENT_KEY',
     };
 }
 

--- a/src/payment/strategies/adyenv2/adyenv2.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.ts
@@ -195,7 +195,12 @@ export interface AdyenConfiguration {
     /*
      * The Origin Key of your website.
      */
-    originKey: string;
+    originKey?: string;
+
+    /*
+     * The Client Key of your Adyen account.
+     */
+    clientKey?: string;
 
     /*
      * Supported from Components version 3.0.0 and later. The full paymentMethods response,


### PR DESCRIPTION
## What? [INT-3027](https://jira.bigcommerce.com/browse/INT-3027)

Added client key to authenticate requests from the web environment according to https://docs.adyen.com/development-resources/client-side-authentication

## Why?

As a a merchant that has a subdomains BC stores, when I enable configure AdyenV2
I want to be able to accept payment from through any of my subdomains that have my AdyenV2 account configured,
So that I can accept payment through them with my same AdyenV2 account.

## Testing / Proof
![ezgif-1-0cbc21107013](https://user-images.githubusercontent.com/69487174/91599799-7771c900-e92c-11ea-81d6-8b9f5395bf3a.gif)


## Dependencies

[bigcommerce/bigcommerce#36823](https://github.com/bigcommerce/bigcommerce/pull/36823)
[bigcommerce/ng-payments#1119](https://github.com/bigcommerce/ng-payments/pull/1119)
[bigcommerce/bigpay#2913](https://github.com/bigcommerce/bigpay/pull/2913)

## How can this change be undone in case of failure?
1. Revert this PR

ping @bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations.
