### PR TITLE
CHECKOUT-5135: Fix `onValidate` callback not getting called with correct error type and not getting called when tokenize returns validation error

### DIFF
--- a/src/payment/errors/index.ts
+++ b/src/payment/errors/index.ts
@@ -5,3 +5,4 @@ export { default as PaymentMethodClientUnavailableError } from './payment-method
 export { default as PaymentMethodDeclinedError } from './payment-method-declined-error';
 export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';
 export { default as PaymentInstrumentNotValidError } from './payment-instrument-not-valid-error';
+export { default as PaymentInvalidFormError, PaymentInvalidFormErrorDetails } from './payment-invalid-form-error';

--- a/src/payment/errors/payment-invalid-form-error.ts
+++ b/src/payment/errors/payment-invalid-form-error.ts
@@ -1,0 +1,17 @@
+import { StandardError } from '../../common/error/errors';
+
+export interface PaymentInvalidFormErrorDetails {
+    [key: string]: Array<{ message: string; type: string }>;
+}
+
+export default class PaymentInvalidFormError extends StandardError {
+    constructor(
+        public details: PaymentInvalidFormErrorDetails,
+        message?: string
+    ) {
+        super(message || 'Unable to proceed because the payment form contains invalid data.');
+
+        this.name = 'PaymentInvalidFormError';
+        this.type = 'payment_invalid_form';
+    }
+}

--- a/src/payment/strategies/braintree/braintree-regular-field.ts
+++ b/src/payment/strategies/braintree/braintree-regular-field.ts
@@ -44,6 +44,14 @@ export default class BraintreeRegularField {
         this._input.parentNode?.removeChild(this._input);
     }
 
+    on(event: string, callback: () => void): void {
+        this._input.addEventListener(event, callback);
+    }
+
+    off(event: string, callback: () => void): void {
+        this._input.removeEventListener(event, callback);
+    }
+
     private _applyStyles(styles?: BraintreeFormFieldStyles): void {
         if (!styles) {
             return;

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -323,6 +323,11 @@ export interface BraintreeVerifyPayload {
 export interface BraintreeError extends Error {
     type: 'CUSTOMER' | 'MERCHANT' | 'NETWORK' | 'INTERNAL' | 'UNKNOWN';
     code: string;
-    details: object;
     message: string;
+}
+
+export interface BraintreeHostedFormError extends BraintreeError {
+    details?: {
+        invalidFieldKeys?: string[];
+    };
 }


### PR DESCRIPTION
## What?
Fix `onValidate` callback not getting called with the correct error type and not getting called when `tokenize` returns a validation error.

Related PR: https://github.com/bigcommerce/checkout-js/pull/408

## Why?
Otherwise, the client doesn't get notified with the correct error type, therefore cannot display errors correctly to the end user.

## Testing / Proof
CircleCI + Manual

### Before
<img width="728" alt="Screen Shot 2020-09-14 at 9 17 10 am" src="https://user-images.githubusercontent.com/667603/93035736-2f1f0e80-f681-11ea-8b4d-c4dc0ebdd029.png">

### After
<img width="505" alt="Screen Shot 2020-09-14 at 9 00 34 am" src="https://user-images.githubusercontent.com/667603/93035732-2c241e00-f681-11ea-984d-926fafb28250.png">

@bigcommerce/checkout @bigcommerce/payments
