### PR TITLE
CHECKOUT-5135: Reset Braintree hosted form initialisation state

### DIFF
--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -471,6 +471,32 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
             expect(braintreePaymentProcessorMock.deinitialize).toHaveBeenCalled();
             expect(braintreePaymentProcessorMock.deinitializeHostedForm).toHaveBeenCalled();
         });
+
+        it('it resets hosted form initialization state', async () => {
+            braintreePaymentProcessorMock.deinitialize = jest.fn(() => Promise.resolve());
+            paymentMethodMock.config.isHostedFormEnabled = true;
+
+            await braintreeCreditCardPaymentStrategy.initialize({
+                methodId: paymentMethodMock.id,
+                braintree: {
+                    form: {
+                        fields: {
+                            cardName: { containerId: 'cardName' },
+                            cardNumber: { containerId: 'cardNumber' },
+                            cardExpiry: { containerId: 'cardExpiry' },
+                        },
+                    },
+                },
+            });
+
+            await braintreeCreditCardPaymentStrategy.deinitialize();
+            await braintreeCreditCardPaymentStrategy.execute(getOrderRequestBody());
+
+            expect(braintreePaymentProcessorMock.tokenizeHostedForm)
+                .not.toHaveBeenCalled();
+            expect(braintreePaymentProcessorMock.tokenizeCard)
+                .toHaveBeenCalled();
+        });
     });
 
     describe('#finalize()', () => {

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -100,6 +100,8 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
     }
 
     async deinitialize(): Promise<InternalCheckoutSelectors> {
+        this._isHostedFormInitialized = false;
+
         await Promise.all([
             this._braintreePaymentProcessor.deinitialize(),
             this._braintreePaymentProcessor.deinitializeHostedForm(),


### PR DESCRIPTION
## What?
Set `isHostedFormInitialized` flag back to false when `deinitialize` is called.

## Why?
The user can be switching between using a form vs not using a form. For example, you switch from using a stored credit card that requires verification vs a card that doesn't required verification. If this flag is not reset to false accordingly, we'll always try to submit with the hosted form, which may already be cleaned up / teared down.

## Testing / Proof
CircleCI + Manual

### Before
![tokenize_teardown_before](https://user-images.githubusercontent.com/667603/93415792-ae158080-f8e7-11ea-9d19-74bf61272b29.gif)

### After
![tokenize_teardown](https://user-images.githubusercontent.com/667603/93415809-b66dbb80-f8e7-11ea-9730-ad51e8312d31.gif)

@bigcommerce/checkout @bigcommerce/payments
