### PR TITLE
feat(payment): PAYPAL-705 add messaging for PayPal banners

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-options.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-options.ts
@@ -5,4 +5,9 @@ export interface PaypalCommerceButtonInitializeOptions {
      * A set of styling options for the checkout button.
      */
     style?: PaypalButtonStyleOptions;
+
+    /**
+     * Container id for messaging banner container
+     */
+    messagingContainer?: string;
 }

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -94,6 +94,9 @@ describe('PaypalCommerceButtonStrategy', () => {
                 });
             });
 
+        jest.spyOn(paypalCommercePaymentProcessor, 'renderMessages')
+            .mockImplementation(() => {} );
+
         jest.spyOn(formPoster, 'postForm')
             .mockImplementation(() => {});
 
@@ -114,6 +117,7 @@ describe('PaypalCommerceButtonStrategy', () => {
             commit: false,
             currency: 'USD',
             intent: 'capture',
+            components: ['buttons', 'messages'],
             disableFunding: ['card', 'credit'],
         }};
 
@@ -130,6 +134,12 @@ describe('PaypalCommerceButtonStrategy', () => {
         };
 
         expect(paypalCommercePaymentProcessor.renderButtons).toHaveBeenCalledWith(cart.id, `#${options.containerId}`, buttonOption);
+    });
+
+    it('render PayPal messaging', async () => {
+        await strategy.initialize(options);
+
+        expect(paypalCommercePaymentProcessor.renderMessages).toHaveBeenCalledWith(cart.cartAmount, `#paypal-commerce-cart-messaging-banner`);
     });
 
     it('post payment details to server to set checkout data when PayPalCommerce payment details are tokenized', async () => {

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -55,6 +55,7 @@ describe('PaypalCommerceButtonStrategy', () => {
                 label: StyleButtonLabel.buynow,
                 height: 45,
             },
+            messagingContainer: 'paypal-commerce-cart-messaging-banner',
         };
 
         options = {
@@ -109,7 +110,7 @@ describe('PaypalCommerceButtonStrategy', () => {
 
     });
 
-    it('initializes PaypalCommerce and PayPal JS clients', async () => {
+    it('initializes PaypalCommerce and PayPal JS clients PayPal credit disabled', async () => {
         await strategy.initialize(options);
 
         const obj = { options : {
@@ -117,9 +118,27 @@ describe('PaypalCommerceButtonStrategy', () => {
             commit: false,
             currency: 'USD',
             intent: 'capture',
-            components: ['buttons', 'messages'],
+            components: ['buttons'],
             disableFunding: ['card', 'credit'],
         }};
+
+        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
+    });
+
+    it('initializes PaypalCommerce and PayPal JS clients PayPal credit enabled', async () => {
+        paymentMethod.initializationData.isPayPalCreditAvailable = true;
+        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
+
+        await strategy.initialize(options);
+
+        const obj = { options : {
+                clientId: 'abc',
+                commit: false,
+                currency: 'USD',
+                intent: 'capture',
+                components: ['buttons', 'messages'],
+                disableFunding: ['card'],
+            }};
 
         expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
     });
@@ -136,10 +155,20 @@ describe('PaypalCommerceButtonStrategy', () => {
         expect(paypalCommercePaymentProcessor.renderButtons).toHaveBeenCalledWith(cart.id, `#${options.containerId}`, buttonOption);
     });
 
-    it('render PayPal messaging', async () => {
+    it('render PayPal messaging with credit enabled', async () => {
+        paymentMethod.initializationData.isPayPalCreditAvailable = true;
+
+        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
+
         await strategy.initialize(options);
 
-        expect(paypalCommercePaymentProcessor.renderMessages).toHaveBeenCalledWith(cart.cartAmount, `#paypal-commerce-cart-messaging-banner`);
+        expect(paypalCommercePaymentProcessor.renderMessages).toHaveBeenCalledWith(cart.cartAmount, `#${paypalOptions.messagingContainer}`);
+    });
+
+    it('render PayPal messaging with credit disabled', async () => {
+        await strategy.initialize(options);
+
+        expect(paypalCommercePaymentProcessor.renderMessages).not.toHaveBeenCalled();
     });
 
     it('post payment details to server to set checkout data when PayPalCommerce payment details are tokenized', async () => {

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -3,13 +3,12 @@ import { FormPoster } from '@bigcommerce/form-poster';
 import { Cart } from '../../../cart';
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { ApproveDataOptions, ButtonsOptions, ClickDataOptions, DisableFundingType, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceScriptOptions } from '../../../payment/strategies/paypal-commerce';
+import { ApproveDataOptions, ButtonsOptions, ClickDataOptions, ComponentsScriptType, DisableFundingType, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceScriptOptions } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrategy {
     private _isCredit?: boolean;
-    private _messagingContainer = 'paypal-commerce-cart-messaging-banner';
 
     constructor(
         private _store: CheckoutStore,
@@ -40,7 +39,9 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         await this._paypalCommercePaymentProcessor.initialize({ options: this._getParamsScript(initializationData, cart) });
 
         this._paypalCommercePaymentProcessor.renderButtons(cart.id, `#${options.containerId}`, buttonParams);
-        this._paypalCommercePaymentProcessor.renderMessages(cart.cartAmount, `#${this._messagingContainer}`);
+        if (initializationData.isPayPalCreditAvailable && options.paypalCommerce?.messagingContainer) {
+            this._paypalCommercePaymentProcessor.renderMessages(cart.cartAmount, `#${options.paypalCommerce?.messagingContainer}`);
+        }
 
         return Promise.resolve();
     }
@@ -71,9 +72,12 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
     private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart): PaypalCommerceScriptOptions {
         const { clientId, intent, isPayPalCreditAvailable, merchantId } = initializationData;
         const disableFunding: DisableFundingType = [ 'card' ];
+        const components: ComponentsScriptType = ['buttons'];
 
         if (!isPayPalCreditAvailable) {
             disableFunding.push('credit');
+        } else {
+            components.push('messages');
         }
 
         return {
@@ -81,7 +85,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             merchantId,
             commit: false,
             currency: cart.currency.code,
-            components: ['buttons', 'messages'],
+            components,
             disableFunding,
             intent,
         };

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -9,6 +9,7 @@ import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrategy {
     private _isCredit?: boolean;
+    private _messagingContainer = 'paypal-commerce-cart-messaging-banner';
 
     constructor(
         private _store: CheckoutStore,
@@ -39,6 +40,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         await this._paypalCommercePaymentProcessor.initialize({ options: this._getParamsScript(initializationData, cart) });
 
         this._paypalCommercePaymentProcessor.renderButtons(cart.id, `#${options.containerId}`, buttonParams);
+        this._paypalCommercePaymentProcessor.renderMessages(cart.cartAmount, `#${this._messagingContainer}`);
 
         return Promise.resolve();
     }
@@ -79,6 +81,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             merchantId,
             commit: false,
             currency: cart.currency.code,
+            components: ['buttons', 'messages'],
             disableFunding,
             intent,
         };

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -1,7 +1,7 @@
 import { NotImplementedError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
-import { ButtonsOptions, DataPaypalCommerceScript, ParamsForProvider, PaypalButtonStyleOptions, PaypalCommerceButtons, PaypalCommerceHostedFields, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, PaypalCommerceSDKFunding, StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape } from './index';
+import { ButtonsOptions, DataPaypalCommerceScript, ParamsForProvider, PaypalButtonStyleOptions, PaypalCommerceButtons, PaypalCommerceHostedFields, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceMessages, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, PaypalCommerceSDKFunding, StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape } from './index';
 
 export interface OptionalParamsRenderButtons {
     paramsForProvider?: ParamsForProvider;
@@ -25,6 +25,7 @@ interface EventsHostedFields {
 export default class PaypalCommercePaymentProcessor {
     private _paypal?: PaypalCommerceSDK;
     private _paypalButtons?: PaypalCommerceButtons;
+    private _paypalMessages?: PaypalCommerceMessages;
     private _hostedFields?: PaypalCommerceHostedFields;
     private _fundingSource?: string;
 
@@ -76,6 +77,22 @@ export default class PaypalCommercePaymentProcessor {
         this._paypalButtons.render(container);
 
         return this._paypalButtons;
+    }
+
+    renderMessages(cartTotal: number, container: string): PaypalCommerceMessages {
+        if (!this._paypal || !this._paypal.Messages) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+        this._paypalMessages = this._paypal.Messages({
+            amount: cartTotal,
+            placement: 'cart',
+            style: {
+                layout: 'text',
+            },
+        });
+        this._paypalMessages.render(container);
+
+        return this._paypalMessages;
     }
 
     async renderHostedFields(cartId: string, params: ParamsRenderHostedFields, events?: EventsHostedFields): Promise<void> {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -55,6 +55,17 @@ export interface ButtonsOptions {
     onClick?(data: ClickDataOptions): void;
 }
 
+export interface MessagesOptions {
+    amount: number;
+    placement: string;
+    style?: MessagesStyleOptions;
+    fundingSource?: string;
+}
+
+export interface MessagesStyleOptions {
+    layout?: string;
+}
+
 export interface PaypalCommerceHostedFieldOption {
     selector: string;
     placeholder?: string;
@@ -114,6 +125,10 @@ export interface PaypalCommerceButtons {
     isEligible(): boolean;
 }
 
+export interface PaypalCommerceMessages {
+    render(id: string): void;
+}
+
 export interface PaypalCommerceSDKFunding {
     PAYPAL: string;
     CREDIT: string;
@@ -126,6 +141,7 @@ export interface PaypalCommerceSDK {
         render(data: PaypalCommerceHostedFieldsRenderOptions): Promise<PaypalCommerceHostedFields>;
     };
     Buttons(params: ButtonsOptions): PaypalCommerceButtons;
+    Messages(params: MessagesOptions): PaypalCommerceMessages;
 }
 
 export interface PaypalCommerceHostWindow extends Window {
@@ -143,7 +159,7 @@ export interface PaypalCommerceInitializationData {
 
 export type DisableFundingType = Array<'credit' | 'card'>;
 
-export type ComponentsScriptType = Array<'buttons' | 'hosted-fields'>;
+export type ComponentsScriptType = Array<'buttons' | 'messages' | 'hosted-fields'>;
 
 export interface PaypalCommerceScriptOptions {
     clientId: string;

--- a/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
@@ -2,6 +2,9 @@ import { PaypalCommerceSDK } from './paypal-commerce-sdk';
 
 export function getPaypalCommerceMock(): PaypalCommerceSDK {
     return {
+        Messages: () => ({
+            render: jest.fn(),
+        }),
         FUNDING: {
             PAYPAL: 'paypal',
             CREDIT: 'credit',


### PR DESCRIPTION
## What?

Adding banners initialization to the buttons renderer

## Why?

Implement banner with the dynamic prices on cart page

## Testing / Proof

![image](https://user-images.githubusercontent.com/51989411/93762162-b6d3c280-fc17-11ea-96c5-f4fd0bad802a.png)


@bigcommerce/checkout @bigcommerce/payments
