### PR TITLE
feat(payments): INT-3086 Support mounting individual card fields on StripeV3

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -450,7 +450,7 @@ export function getZip(): PaymentMethod {
     };
 }
 
-export function getStripeV3(method: string = 'card'): PaymentMethod {
+export function getStripeV3(method: string = 'card', shouldUseIndividualCardFields: boolean = false): PaymentMethod {
     return {
         id: method,
         logoUrl: '',
@@ -463,6 +463,7 @@ export function getStripeV3(method: string = 'card'): PaymentMethod {
         },
         initializationData: {
             stripePublishableKey: 'key',
+            useIndividualCardFields: shouldUseIndividualCardFields,
         },
         type: 'PAYMENT_TYPE_API',
         clientToken: 'clientToken',

--- a/src/payment/strategies/stripev3/stripev3-initialize-options.ts
+++ b/src/payment/strategies/stripev3/stripev3-initialize-options.ts
@@ -1,4 +1,4 @@
-import { StripeElementOptions } from './stripev3';
+import { IndividualCardElementOptions, StripeElementOptions } from './stripev3';
 
 /**
  * A set of options that are required to initialize the Stripe payment method.
@@ -7,14 +7,12 @@ import { StripeElementOptions } from './stripev3';
  * payment provider as iframes, will be inserted into the current page. These
  * options provide a location and styling for each of the form fields.
  */
+
 export default interface StripeV3PaymentInitializeOptions {
     /**
      * The location to insert the credit card number form field.
      */
     containerId: string;
 
-    /**
-     * The set of CSS styles to apply to all form fields.
-     */
-    options?: StripeElementOptions;
+    options?: StripeElementOptions | IndividualCardElementOptions;
 }

--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -3,6 +3,7 @@ import { OrderRequestBody } from '../../../order';
 import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 
+import { IndividualCardElementOptions, StripeV3PaymentInitializeOptions } from './index';
 import { PaymentMethodCreateParams, StripeBillingDetails, StripeConfirmCardPaymentData, StripeElementType, StripeShippingAddress, StripeV3Client } from './stripev3';
 
 export function getStripeV3JsMock(): StripeV3Client {
@@ -61,23 +62,80 @@ export function getStripeV3InitializeOptionsMock(stripeElementType: StripeElemen
     };
 }
 
-export function getStripeV3OrderRequestBodyMock(stripeElementType: StripeElementType = StripeElementType.CreditCard): OrderRequestBody {
+export function getStripeV3InitializeOptionsMockSingleElements(includeZipCode: boolean = false): PaymentInitializeOptions {
+    const paymentInitializeOptions: PaymentInitializeOptions = {
+        methodId: 'card',
+    };
+
+    const stripeV3PaymentInitializeOptions: StripeV3PaymentInitializeOptions = {
+        containerId: 'stripe-card-component-field',
+    };
+
+    const individualCardElementOptions: IndividualCardElementOptions = {
+        cardCvcElementOptions: {
+            containerId: 'stripe-cvc-component-field',
+            classes: {
+                base: 'form-input optimizedCheckout-form-input',
+            },
+            placeholder: 'CVV',
+        },
+        cardExpiryElementOptions: {
+            containerId: 'stripe-expiry-component-field',
+            classes: {
+                base: 'form-input optimizedCheckout-form-input',
+            },
+            placeholder: 'MM / YY',
+        },
+        cardNumberElementOptions: {
+            containerId: 'stripe-number-component-field',
+            classes: {
+                base: 'form-input optimizedCheckout-form-input',
+            },
+            placeholder: 'Card number',
+            showIcon: true,
+        },
+    };
+
+    if (includeZipCode) {
+        return {
+            ...paymentInitializeOptions,
+            stripev3: {
+                ...stripeV3PaymentInitializeOptions,
+                options: {
+                    ...individualCardElementOptions,
+                    zipCodeElementOptions: { containerId: 'stripe-postal-code-component-field' },
+                },
+            },
+        };
+    }
+
+    return {
+        ...paymentInitializeOptions,
+        stripev3: {
+            ...stripeV3PaymentInitializeOptions,
+            options: individualCardElementOptions,
+        },
+    };
+}
+
+export function getStripeV3OrderRequestBodyMock(stripeElementType: StripeElementType = StripeElementType.CreditCard, shouldSaveInstrument: boolean = false): OrderRequestBody {
     return {
         payment: {
             methodId: stripeElementType,
             paymentData: {
-                shouldSaveInstrument: false,
+                shouldSaveInstrument,
             },
         },
     };
 }
 
-export function getStripeV3OrderRequestBodyVIMock(stripeElementType: StripeElementType = StripeElementType.CreditCard): OrderRequestBody {
+export function getStripeV3OrderRequestBodyVaultMock(stripeElementType: StripeElementType = StripeElementType.CreditCard, shouldSetAsDefaultInstrument: boolean = false): OrderRequestBody {
     return {
         payment: {
             methodId: stripeElementType,
             paymentData: {
                 instrumentId: 'token',
+                shouldSetAsDefaultInstrument,
             },
         },
     };

--- a/src/payment/strategies/stripev3/stripev3.ts
+++ b/src/payment/strategies/stripev3/stripev3.ts
@@ -1,12 +1,14 @@
 interface BaseElementOptions {
+    /**
+     * Customize the appearance of an element using CSS properties passed in a [Style](https://stripe.com/docs/js/appendix/style) object,
+     * which consists of CSS properties nested under objects for each variant.
+     */
     style?: StripeElementStyle;
 
-    classes?: StripeElementClasses;
-
     /**
-     * Hides the icon in the Element. Default is false.
+     * Set custom class names on the container DOM element when the Stripe element is in a particular state.
      */
-    hideIcon?: boolean;
+    classes?: StripeElementClasses;
 
     /**
      * Applies a disabled state to the Element such that user input is not accepted. Default is false.
@@ -190,6 +192,43 @@ export interface CardElementOptions extends BaseElementOptions {
      * Appearance of the icon in the Element.
      */
     iconStyle?: IconStyle;
+
+    /*
+     * Hides the icon in the Element, Default is false
+     */
+    hideIcon?: boolean;
+
+}
+
+interface BaseIndividualElementOptions extends BaseElementOptions  {
+    containerId: string;
+}
+
+export interface CardNumberElementOptions extends BaseIndividualElementOptions {
+    /*
+     * Placeholder
+     */
+    placeholder?: string;
+
+    showIcon?: boolean;
+    /**
+     * Appearance of the icon in the Element. Either `solid` or `default`
+     */
+    iconStyle?: IconStyle;
+}
+
+export interface CardExpiryElementOptions extends BaseIndividualElementOptions {
+    /*
+     * Placeholder
+     */
+    placeholder?: string;
+}
+
+export interface CardCvcElementOptions extends BaseIndividualElementOptions {
+    /*
+     * Placeholder
+     */
+    placeholder?: string;
 }
 
 export interface IbanElementOptions extends BaseElementOptions {
@@ -217,11 +256,10 @@ export interface IdealElementOptions extends BaseElementOptions {
      * Hides the icon in the Element. Default is false.
      */
     hideIcon?: boolean;
+}
 
-    /**
-     * Applies a disabled state to the Element such that user input is not accepted. Default is false.
-     */
-    disabled?: boolean;
+export interface ZipCodeElementOptions {
+    containerId: string;
 }
 
 export enum IconStyle {
@@ -229,10 +267,6 @@ export enum IconStyle {
     Default = 'default',
 }
 
-/**
- * Customize the appearance of an element using CSS properties passed in a `Style` object,
- * which consists of CSS properties nested under objects for each variant.
- */
 export interface StripeElementStyle {
     /**
      * Base variant—all other variants inherit from these styles.
@@ -255,9 +289,6 @@ export interface StripeElementStyle {
     invalid?: StripeElementStyleVariant;
 }
 
-/**
- * Set custom class names on the container DOM element when the Stripe element is in a particular state.
- */
 export interface StripeElementClasses {
     /**
      * The base class applied to the container. Defaults to StripeElement.
@@ -463,7 +494,7 @@ export interface StripeConfirmSepaPaymentData {
 
 export type StripeConfirmPaymentData = StripeConfirmAlipayPaymentData | StripeConfirmCardPaymentData | StripeConfirmIdealPaymentData | StripeConfirmSepaPaymentData | undefined;
 
-export type StripeElementOptions = CardElementOptions | IdealElementOptions | IbanElementOptions;
+export type StripeElementOptions = CardElementOptions | CardExpiryElementOptions | CardNumberElementOptions | CardCvcElementOptions | IdealElementOptions | IbanElementOptions | ZipCodeElementOptions;
 
 export interface StripeElement {
     /**
@@ -486,7 +517,7 @@ export interface StripeElement {
 
 export interface StripeElements {
     /**
-     * Creates a `AlipayElement` | `CardElement` | `IdealBankElement` | `IbanElement`.
+     * Creates a `AlipayElement` | `CardElement` | `CardCvcElement` |`CardExpiryElement` | `CardExpiryElement` | `CardNumberElement` | `IdealBankElement` | `IbanElement`.
      */
     create(
         elementType: StripeElementType,
@@ -747,6 +778,9 @@ export interface StripeHostWindow extends Window {
 
 export enum StripeElementType {
     Alipay = 'alipay',
+    CardCvc = 'cardCvc',
+    CardExpiry = 'cardExpiry',
+    CardNumber = 'cardNumber',
     CreditCard = 'card',
     iDEAL = 'idealBank',
     Sepa = 'iban',
@@ -797,4 +831,21 @@ export interface StripeAdditionalActionError {
         errors?: Array<{ code: string; message?: string }>;
         additional_action_required: StripeAdditionalAction;
     };
+}
+
+export interface StripeCardElements {
+    [index: number]: StripeElement;
+}
+
+export interface IndividualCardElementOptions {
+    cardCvcElementOptions: CardCvcElementOptions;
+    cardExpiryElementOptions: CardExpiryElementOptions;
+    cardNumberElementOptions: CardNumberElementOptions;
+    zipCodeElementOptions?: ZipCodeElementOptions;
+}
+
+export default function isIndividualCardElementOptions(individualCardElementOptions: unknown): individualCardElementOptions is IndividualCardElementOptions {
+    return Boolean((individualCardElementOptions as IndividualCardElementOptions).cardNumberElementOptions) &&
+        Boolean((individualCardElementOptions as IndividualCardElementOptions).cardCvcElementOptions) &&
+        Boolean((individualCardElementOptions as IndividualCardElementOptions).cardExpiryElementOptions);
 }


### PR DESCRIPTION
## What? [INT-3086](https://jira.bigcommerce.com/browse/INT-3086)

## Why?
I want to offer my merchants the ability to display single card component or independent for each field.

## Testing / Proof
-- Unit
-- Manual

## How can this change be undone in case of failure?
1. Revert this PR

## Sibling PRs
[checkout-js](https://github.com/bigcommerce/checkout-js/pull/420)
[bcapp](https://github.com/bigcommerce/bigcommerce/pull/37309)

@bigcommerce/checkout @bigcommerce/payments
