### PR TITLE
feat(payment): PAYPAL-675 Upgrade to 3DS v2 Braintree

### DIFF
--- a/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -118,6 +118,7 @@ describe('BraintreePaymentProcessor', () => {
                     removeFrame: expect.any(Function),
                     amount: 122,
                     nonce: 'my_nonce',
+                    onLookupComplete: expect.any(Function),
                 });
         });
 

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -150,6 +150,9 @@ export default class BraintreePaymentProcessor {
                 amount,
                 nonce,
                 removeFrame,
+                onLookupComplete: (_data, next) => {
+                    next();
+                },
             })
         );
 

--- a/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
@@ -77,7 +77,7 @@ describe('Braintree SDK Creator', () => {
         it('returns a promise that resolves to the 3ds client', async () => {
             const threeDSecure = await braintreeSDKCreator.get3DS();
 
-            expect(threeDSecureCreatorMock.create).toHaveBeenCalledWith({ client: clientMock });
+            expect(threeDSecureCreatorMock.create).toHaveBeenCalledWith({ client: clientMock, version: 2 });
             expect(threeDSecure).toBe(threeDSecureMock);
         });
 

--- a/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -67,7 +67,7 @@ export default class BraintreeSDKCreator {
                 this.getClient(),
                 this._braintreeScriptLoader.load3DS(),
             ])
-            .then(([client, threeDSecure]) => threeDSecure.create({ client }));
+            .then(([client, threeDSecure]) => threeDSecure.create({ client, version: 2}));
         }
 
         return this._3ds;

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -92,7 +92,7 @@ export interface BraintreeThreeDSecureOptions {
     showLoader?: boolean;
     addFrame(error: Error | undefined, iframe: HTMLIFrameElement): void;
     removeFrame(): void;
-    onLookupComplete(data: any, next: any): void;
+    onLookupComplete(data: BraintreeThreeDSecureVerificationData, next: () => void): void;
 }
 
 export interface BraintreeDataCollector extends BraintreeModule {
@@ -334,5 +334,17 @@ export interface BraintreeError extends Error {
 export interface BraintreeHostedFormError extends BraintreeError {
     details?: {
         invalidFieldKeys?: string[];
+    };
+}
+
+interface BraintreeThreeDSecureVerificationData {
+    lookup: {
+        threeDSecureVersion: string;
+    };
+    paymentMethod: BraintreeVerifyPayload;
+    requiresUserAuthentication: boolean;
+    threeDSecureInfo: {
+        liabilityShiftPossible: boolean;
+        liabilityShifted: boolean;
     };
 }

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -28,6 +28,10 @@ export interface BraintreeDataCollectorCreatorConfig extends BraintreeModuleCrea
     paypal?: boolean;
 }
 
+export interface BraintreeThreeDSecureCreatorConfig extends BraintreeModuleCreatorConfig {
+    version?: number;
+}
+
 export interface BraintreeHostedFieldsCreatorConfig extends BraintreeModuleCreatorConfig {
     fields: {
         number?: BraintreeHostedFieldOption;
@@ -63,7 +67,7 @@ export interface BraintreeHostedFieldOption {
 export interface BraintreeClientCreator extends BraintreeModuleCreator<BraintreeClient> { }
 export interface BraintreeDataCollectorCreator extends BraintreeModuleCreator<BraintreeDataCollector, BraintreeDataCollectorCreatorConfig> {}
 export interface BraintreeHostedFieldsCreator extends BraintreeModuleCreator<BraintreeHostedFields, BraintreeHostedFieldsCreatorConfig> {}
-export interface BraintreeThreeDSecureCreator extends BraintreeModuleCreator<BraintreeThreeDSecure> {}
+export interface BraintreeThreeDSecureCreator extends BraintreeModuleCreator<BraintreeThreeDSecure, BraintreeThreeDSecureCreatorConfig> {}
 export interface BraintreePaypalCreator extends BraintreeModuleCreator<BraintreePaypal> {}
 export interface BraintreePaypalCheckoutCreator extends BraintreeModuleCreator<BraintreePaypalCheckout> {}
 export interface BraintreeVisaCheckoutCreator extends BraintreeModuleCreator<BraintreeVisaCheckout> {}
@@ -88,6 +92,7 @@ export interface BraintreeThreeDSecureOptions {
     showLoader?: boolean;
     addFrame(error: Error | undefined, iframe: HTMLIFrameElement): void;
     removeFrame(): void;
+    onLookupComplete(data: any, next: any): void;
 }
 
 export interface BraintreeDataCollector extends BraintreeModule {


### PR DESCRIPTION
## What?
Update Braintree to 3DS v2
https://developers.braintreepayments.com/guides/3d-secure/migration/javascript/v3

## Why?
Because of right now we are supporting v1 only 

## Testing / Proof
3DS v1
<img width="1299" alt="Screenshot 2020-09-22 at 14 48 51" src="https://user-images.githubusercontent.com/54856617/93879586-a0476d00-fce4-11ea-93e5-ed2664b80124.png">

3DS v2
<img width="1373" alt="Screenshot 2020-09-22 at 14 57 54" src="https://user-images.githubusercontent.com/54856617/93879593-a2a9c700-fce4-11ea-9e7d-a92c437bf714.png">


@bigcommerce/checkout @bigcommerce/payments
