### PR TITLE
fix(payment): PAYPAL-726 Switch payment methods

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -113,14 +113,14 @@ describe('PaypalCommerceButtonStrategy', () => {
     it('initializes PaypalCommerce and PayPal JS clients PayPal credit disabled', async () => {
         await strategy.initialize(options);
 
-        const obj = { options : {
-            clientId: 'abc',
+        const obj = {
+            'client-id': 'abc',
             commit: false,
             currency: 'USD',
             intent: 'capture',
             components: ['buttons'],
-            disableFunding: ['card', 'credit'],
-        }};
+            'disable-funding': ['card', 'credit'],
+        };
 
         expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
     });
@@ -131,14 +131,14 @@ describe('PaypalCommerceButtonStrategy', () => {
 
         await strategy.initialize(options);
 
-        const obj = { options : {
-                clientId: 'abc',
+        const obj = {
+                'client-id': 'abc',
                 commit: false,
                 currency: 'USD',
                 intent: 'capture',
                 components: ['buttons', 'messages'],
-                disableFunding: ['card'],
-            }};
+                'disable-funding': ['card'],
+        };
 
         expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
     });

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -3,7 +3,7 @@ import { FormPoster } from '@bigcommerce/form-poster';
 import { Cart } from '../../../cart';
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { ApproveDataOptions, ButtonsOptions, ClickDataOptions, ComponentsScriptType, DisableFundingType, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceScriptOptions } from '../../../payment/strategies/paypal-commerce';
+import { ApproveDataOptions, ButtonsOptions, ClickDataOptions, ComponentsScriptType, DisableFundingType, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceScriptParams } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
@@ -36,7 +36,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             buttonParams.style = options.paypalCommerce.style;
         }
 
-        await this._paypalCommercePaymentProcessor.initialize({ options: this._getParamsScript(initializationData, cart) });
+        await this._paypalCommercePaymentProcessor.initialize(this._getParamsScript(initializationData, cart));
 
         this._paypalCommercePaymentProcessor.renderButtons(cart.id, `#${options.containerId}`, buttonParams);
         if (initializationData.isPayPalCreditAvailable && options.paypalCommerce?.messagingContainer) {
@@ -69,7 +69,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         });
     }
 
-    private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart): PaypalCommerceScriptOptions {
+    private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart): PaypalCommerceScriptParams {
         const { clientId, intent, isPayPalCreditAvailable, merchantId } = initializationData;
         const disableFunding: DisableFundingType = [ 'card' ];
         const components: ComponentsScriptType = ['buttons'];
@@ -81,12 +81,12 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         }
 
         return {
-            clientId,
-            merchantId,
+            'client-id': clientId,
+            'merchant-id': merchantId,
             commit: false,
             currency: cart.currency.code,
             components,
-            disableFunding,
+            'disable-funding': disableFunding,
             intent,
         };
     }

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -81,7 +81,6 @@ export default function createPaymentStrategyRegistry(
     const paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator, spamProtectionActionCreator);
     const formPoster = createFormPoster();
     const hostedFormFactory = new HostedFormFactory(store);
-    const paypalCommercePaymentProcessor = createPaypalCommercePaymentProcessor(scriptLoader, requestSender);
 
     registry.register(PaymentStrategyType.ADYENV2, () =>
         new AdyenV2PaymentStrategy(
@@ -285,7 +284,7 @@ export default function createPaymentStrategyRegistry(
         new PaypalCommerceCreditCardPaymentStrategy(
             store,
             paymentMethodActionCreator,
-            new PaypalCommerceHostedForm(paypalCommercePaymentProcessor),
+            new PaypalCommerceHostedForm(createPaypalCommercePaymentProcessor(scriptLoader, requestSender)),
             orderActionCreator,
             paymentActionCreator
         )
@@ -297,7 +296,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             paymentMethodActionCreator,
-            paypalCommercePaymentProcessor
+            createPaypalCommercePaymentProcessor(scriptLoader, requestSender)
         )
     );
 
@@ -307,7 +306,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             paymentMethodActionCreator,
-            paypalCommercePaymentProcessor,
+            createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
             true
         )
     );

--- a/src/payment/strategies/paypal-commerce/index.ts
+++ b/src/payment/strategies/paypal-commerce/index.ts
@@ -2,7 +2,7 @@ export * from './paypal-commerce-sdk';
 
 export * from './paypal-commerce-payment-initialize-options';
 
-export { default as PaypalCommerceScriptLoader, DataPaypalCommerceScript } from './paypal-commerce-script-loader';
+export { default as PaypalCommerceScriptLoader } from './paypal-commerce-script-loader';
 export { default as PaypalCommerceCreditCardPaymentStrategy } from './paypal-commerce-credit-card-payment-strategy';
 export { default as PaypalCommercePaymentStrategy } from './paypal-commerce-payment-strategy';
 export { default as PaypalCommerceRequestSender, ParamsForProvider } from './paypal-commerce-request-sender';

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
@@ -41,7 +41,7 @@ describe('PaypalCommercePaymentStrategy', () => {
     beforeEach(() => {
         const requestSender = createRequestSender();
 
-        paymentMethod = {...getPaypalCommerce()};
+        paymentMethod = { ...getPaypalCommerce(), clientToken: 'clientToken'};
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
         paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
@@ -75,13 +75,13 @@ describe('PaypalCommerceHostedForm', () => {
     });
 
     it('initialize paypalCommercePaymentProcessor', async () => {
-        await hostedForm.initialize(formOptions, '123', { options: { clientId: '' } });
+        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
 
-        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith({ options: { clientId: '' } });
+        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith({ 'client-id': '' });
     });
 
     it('render hosted fields with form fields', async () => {
-        await hostedForm.initialize(formOptions, '123', { options: { clientId: '' } });
+        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
 
         expect(paypalCommercePaymentProcessor.renderHostedFields)
             .toHaveBeenCalledWith('123', {
@@ -113,7 +113,7 @@ describe('PaypalCommerceHostedForm', () => {
                     instrumentId: 'foobar_instrument_id',
                 },
             },
-        }, '123', { options: { clientId: '' } });
+        }, '123', { 'client-id': '' });
 
         expect(paypalCommercePaymentProcessor.renderHostedFields)
             .toHaveBeenCalledWith('123', {
@@ -130,14 +130,14 @@ describe('PaypalCommerceHostedForm', () => {
     });
 
     it('submit hosted form should return orderId', async () => {
-        await hostedForm.initialize(formOptions, '123', { options: { clientId: '' } });
+        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
         const result = await hostedForm.submit();
 
         expect(result.orderId).toEqual(orderId);
     });
 
     it('submit hosted form should call submitHostedFields of paypalCommercePaymentProcessor', async () => {
-        await hostedForm.initialize(formOptions, '123', { options: { clientId: '' } });
+        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
         await hostedForm.submit();
 
         expect(paypalCommercePaymentProcessor.submitHostedFields).toHaveBeenCalled();
@@ -147,7 +147,7 @@ describe('PaypalCommerceHostedForm', () => {
         jest.spyOn(paypalCommercePaymentProcessor, 'submitHostedFields')
             .mockReturnValue(Promise.resolve({ orderId, liabilityShift: 'NO' }));
 
-        await hostedForm.initialize(formOptions, '123', { options: { clientId: '' } });
+        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
 
         await expect(hostedForm.submit(true)).rejects.toThrow(PaymentMethodFailedError);
     });

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
@@ -2,7 +2,7 @@ import { isNil, kebabCase, omitBy } from 'lodash';
 
 import { PaymentMethodFailedError } from '../../errors';
 
-import { DataPaypalCommerceScript, PaypalCommerceFormFieldStyles, PaypalCommerceFormFieldStylesMap, PaypalCommerceFormFieldType, PaypalCommerceFormFieldValidateEventData, PaypalCommerceFormOptions, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommercePaymentProcessor, PaypalCommerceRegularField } from './index';
+import { PaypalCommerceFormFieldStyles, PaypalCommerceFormFieldStylesMap, PaypalCommerceFormFieldType, PaypalCommerceFormFieldValidateEventData, PaypalCommerceFormOptions, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommercePaymentProcessor, PaypalCommerceRegularField, PaypalCommerceScriptParams } from './index';
 import { PaypalCommerceFormFieldsMap, PaypalCommerceStoredCardFieldsMap } from './paypal-commerce-payment-initialize-options';
 
 enum PaypalCommerceHostedFormType {
@@ -19,7 +19,7 @@ export default class PaypalCommerceHostedForm {
         private _paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor
     ) {}
 
-    async initialize(options: PaypalCommerceFormOptions, cartId: string, paramsScript: DataPaypalCommerceScript) {
+    async initialize(options: PaypalCommerceFormOptions, cartId: string, paramsScript: PaypalCommerceScriptParams) {
         await this._paypalCommercePaymentProcessor.initialize(paramsScript);
 
         this._formOptions = options;
@@ -57,6 +57,10 @@ export default class PaypalCommerceHostedForm {
         }
 
         return result;
+    }
+
+    deinitialize(): void {
+        this._paypalCommercePaymentProcessor.deinitialize();
     }
 
     private _mapFieldOptions(fields: PaypalCommerceFormFieldsMap | PaypalCommerceStoredCardFieldsMap): PaypalCommerceHostedFieldsRenderOptions['fields'] {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
@@ -6,7 +6,7 @@ import { Cart } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { NotImplementedError } from '../../../common/error/errors';
 
-import { ButtonsOptions, DataPaypalCommerceScript, ParamsRenderHostedFields, PaypalCommerceHostedFields, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostWindow, PaypalCommercePaymentProcessor, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK } from './index';
+import { ButtonsOptions, ParamsRenderHostedFields, PaypalCommerceHostedFields, PaypalCommerceHostedFieldsApprove, PaypalCommercePaymentProcessor, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceScriptParams, PaypalCommerceSDK } from './index';
 import { getPaypalCommerceMock } from './paypal-commerce.mock';
 
 describe('PaypalCommercePaymentProcessor', () => {
@@ -17,7 +17,7 @@ describe('PaypalCommercePaymentProcessor', () => {
     let paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor;
     let eventEmitter: EventEmitter;
     let cardFieldsEventEmitter: EventEmitter;
-    let initOptions: DataPaypalCommerceScript;
+    let initOptions: PaypalCommerceScriptParams;
     let hostedFormOptions: ParamsRenderHostedFields;
     let cardFields: PaypalCommerceHostedFields;
     let cart: Cart;
@@ -45,7 +45,7 @@ describe('PaypalCommercePaymentProcessor', () => {
 
         orderID = 'ORDER_ID';
         fundingSource = 'paypal';
-        initOptions = { options: { clientId: 'clientId' } };
+        initOptions = { 'client-id': 'clientId' };
         cart = { ...getCart() };
         submit = jest.fn(() => ({ orderId: orderID, liabilityShift: 'POSSIBLE' }));
 
@@ -170,20 +170,6 @@ describe('PaypalCommercePaymentProcessor', () => {
             await paypalCommercePaymentProcessor.renderButtons(cart.id, 'container');
 
             expect(render).toHaveBeenCalled();
-        });
-
-        it('calls loadPaypalCommerce with expected arguments', async () => {
-            jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce')
-                .mockImplementation(({ options }: DataPaypalCommerceScript) => {
-                    (window as PaypalCommerceHostWindow).paypal = paypal;
-
-                    expect(options).toMatchObject(initOptions.options);
-
-                    return Promise.resolve(paypal);
-                });
-
-            await paypalCommercePaymentProcessor.initialize(initOptions);
-            await paypalCommercePaymentProcessor.renderButtons(cart.id, 'container');
         });
 
         it('throws error if unable to setting PayPalCommerce button', async () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -1,7 +1,7 @@
 import { NotImplementedError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
-import { ButtonsOptions, DataPaypalCommerceScript, ParamsForProvider, PaypalButtonStyleOptions, PaypalCommerceButtons, PaypalCommerceHostedFields, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceHostedFieldsSubmitOptions, PaypalCommerceMessages, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, PaypalCommerceSDKFunding, StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape } from './index';
+import { ButtonsOptions, ParamsForProvider, PaypalButtonStyleOptions, PaypalCommerceButtons, PaypalCommerceHostedFields, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceHostedFieldsSubmitOptions, PaypalCommerceMessages, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceScriptParams, PaypalCommerceSDK, PaypalCommerceSDKFunding, StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape } from './index';
 
 export interface OptionalParamsRenderButtons {
     paramsForProvider?: ParamsForProvider;
@@ -34,7 +34,7 @@ export default class PaypalCommercePaymentProcessor {
         private _paypalCommerceRequestSender: PaypalCommerceRequestSender
     ) {}
 
-    async initialize(paramsScript: DataPaypalCommerceScript, isProgressiveOnboardingAvailable?: boolean): Promise<PaypalCommerceSDK> {
+    async initialize(paramsScript: PaypalCommerceScriptParams, isProgressiveOnboardingAvailable?: boolean): Promise<PaypalCommerceSDK> {
         this._paypal = await this._paypalScriptLoader.loadPaypalCommerce(paramsScript, isProgressiveOnboardingAvailable);
 
         return this._paypal;
@@ -135,7 +135,7 @@ export default class PaypalCommercePaymentProcessor {
     }
 
     deinitialize() {
-        this._paypalButtons?.close();
+        this._paypalButtons?.close?.();
 
         this._paypal = undefined;
         this._paypalButtons = undefined;

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -121,12 +121,12 @@ describe('PaypalCommercePaymentStrategy', () => {
             paymentMethod.initializationData.orderId = undefined;
             await paypalCommercePaymentStrategy.initialize(options);
 
-            const obj = { options : {
-                    clientId: 'abc',
+            const obj = {
+                    'client-id': 'abc',
                     commit: true,
                     currency: 'USD',
                     intent: 'capture',
-                }};
+                };
 
             expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
         });

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -9,7 +9,7 @@ import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import { ApproveDataOptions, ButtonsOptions, PaypalCommerceCreditCardPaymentInitializeOptions, PaypalCommerceInitializationData, PaypalCommercePaymentInitializeOptions, PaypalCommercePaymentProcessor, PaypalCommerceScriptOptions } from './index';
+import { ApproveDataOptions, ButtonsOptions, PaypalCommerceCreditCardPaymentInitializeOptions, PaypalCommerceInitializationData, PaypalCommercePaymentInitializeOptions, PaypalCommercePaymentProcessor, PaypalCommerceScriptParams } from './index';
 
 export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
     private _orderId?: string;
@@ -44,7 +44,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         const { container, onRenderButton, submitForm, style } = paypalcommerce;
         const { id: cartId, currency: { code: currencyCode } } = getCartOrThrow();
 
-        const paramsScript = { options: this._getOptionsScript(initializationData, currencyCode) };
+        const paramsScript = this._getOptionsScript(initializationData, currencyCode);
         const buttonParams: ButtonsOptions = { style, onApprove: data => this._tokenizePayment(data, submitForm) };
 
         await this._paypalCommercePaymentProcessor.initialize(paramsScript);
@@ -91,6 +91,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
 
     async deinitialize(): Promise<InternalCheckoutSelectors> {
         this._orderId = undefined;
+        this._paypalCommercePaymentProcessor.deinitialize();
 
         return Promise.resolve(this._store.getState());
     }
@@ -104,12 +105,12 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         submitForm();
     }
 
-    private _getOptionsScript(initializationData: PaypalCommerceInitializationData, currencyCode: Cart['currency']['code']): PaypalCommerceScriptOptions {
+    private _getOptionsScript(initializationData: PaypalCommerceInitializationData, currencyCode: Cart['currency']['code']): PaypalCommerceScriptParams {
         const { clientId, intent, merchantId } = initializationData;
 
         return {
-            clientId,
-            merchantId,
+            'client-id': clientId,
+            'merchant-id': merchantId,
             commit: true,
             currency: currencyCode,
             intent,

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -4,21 +4,27 @@ import { InvalidArgumentError } from '../../../common/error/errors';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import PaypalCommerceScriptLoader from './paypal-commerce-script-loader';
-import { PaypalCommerceHostWindow, PaypalCommerceScriptOptions, PaypalCommerceSDK } from './paypal-commerce-sdk';
+import { PaypalCommerceHostWindow, PaypalCommerceScriptParams, PaypalCommerceSDK } from './paypal-commerce-sdk';
 import { getPaypalCommerceMock } from './paypal-commerce.mock';
 
 describe('PaypalCommerceScriptLoader', () => {
     let loader: ScriptLoader;
     let paypalLoader: PaypalCommerceScriptLoader;
     let paypal: PaypalCommerceSDK;
+    let paypalLoadScript: (options: PaypalCommerceScriptParams) => Promise<{ paypal: PaypalCommerceSDK }>;
 
     beforeEach(() => {
         loader = createScriptLoader();
         paypal = getPaypalCommerceMock();
+        paypalLoadScript = jest.fn(() => new Promise(resolve => {
+            (window as PaypalCommerceHostWindow).paypal = paypal;
+
+            return resolve({ paypal });
+        }));
 
         jest.spyOn(loader, 'loadScript')
             .mockImplementation(() => {
-                (window as PaypalCommerceHostWindow).paypal = paypal;
+                (window as PaypalCommerceHostWindow).paypalLoadScript = paypalLoadScript;
 
                 return Promise.resolve();
             });
@@ -27,29 +33,27 @@ describe('PaypalCommerceScriptLoader', () => {
     });
 
     describe('loads PayPalCommerce script with client Id, currency EUR, intent, disableFunding, commit', () => {
-        const params: { options: PaypalCommerceScriptOptions } = {
-            options: {
-                clientId: 'aaa',
-                merchantId: 'bbb',
-                currency: 'EUR',
-                disableFunding: ['credit', 'card'],
-                intent: 'capture',
-            },
+        const params: PaypalCommerceScriptParams = {
+            'client-id': 'aaa',
+            'merchant-id': 'bbb',
+            'disable-funding': ['credit', 'card'],
+            currency: 'EUR',
+            intent: 'capture',
         };
 
-        it('check params in script', async () => {
-            jest.spyOn(loader, 'loadScript')
-                .mockImplementation((url: string) => {
-                    (window as PaypalCommerceHostWindow).paypal = paypal;
-
-                    ['client-id=aaa', 'currency=EUR', 'disable-funding=credit,card', 'intent=capture'].forEach(str => {
-                        expect(url).toEqual(expect.stringContaining(str));
-                    });
-
-                    return Promise.resolve();
-                });
-
+        it('call loadScript', async () => {
             await paypalLoader.loadPaypalCommerce(params);
+
+            expect(loader.loadScript).toHaveBeenCalledWith(
+                'https://unpkg.com/@paypal/paypal-js@1.0.2/dist/paypal.browser.min.js',
+                { async: true, attributes: {} }
+            );
+        });
+
+        it('call paypalLoadScript with params', async () => {
+            await paypalLoader.loadPaypalCommerce(params);
+
+            expect(paypalLoadScript).toHaveBeenCalledWith(params);
         });
 
         it('check paypal in window', async () => {
@@ -60,27 +64,16 @@ describe('PaypalCommerceScriptLoader', () => {
     });
 
     describe('loads PayPalCommerce script with client Id and currency USD',  () => {
-        const params: { options: PaypalCommerceScriptOptions } = {
-            options: {
-                clientId: 'aaa',
-                merchantId: 'bbb',
-                currency: 'USD',
-            },
+        const params: PaypalCommerceScriptParams = {
+            'client-id': 'aaa',
+            'merchant-id': 'bbb',
+            currency: 'USD',
         };
 
         it('check params in script', async () => {
-            jest.spyOn(loader, 'loadScript')
-                .mockImplementation((url: string) => {
-                    (window as PaypalCommerceHostWindow).paypal = paypal;
-
-                    [ 'client-id=aaa', 'currency=USD' ].forEach(str => {
-                        expect(url).toEqual(expect.stringContaining(str));
-                    });
-
-                    return Promise.resolve();
-                });
-
             await paypalLoader.loadPaypalCommerce(params);
+
+            expect(paypalLoadScript).toHaveBeenCalledWith({ 'client-id': 'aaa', currency: 'USD', 'merchant-id': 'bbb' });
         });
 
         it('check paypal in window', async () => {
@@ -91,34 +84,26 @@ describe('PaypalCommerceScriptLoader', () => {
     });
 
     it('do not add merchant Id if it is null and enable progressive onboarding', async () => {
-        const params: { options: PaypalCommerceScriptOptions } = { options: { clientId: 'aaa', merchantId: undefined } };
-
-        jest.spyOn(loader, 'loadScript')
-            .mockImplementation((url: string) => {
-                (window as PaypalCommerceHostWindow).paypal = paypal;
-
-                expect(url).toEqual(expect.stringContaining('client-id=aaa'));
-                expect(url).not.toEqual(expect.stringContaining('merchant-id=undefined'));
-
-                return Promise.resolve();
-            });
+        const params: PaypalCommerceScriptParams = { 'client-id': 'aaa', 'merchant-id': undefined };
 
         await paypalLoader.loadPaypalCommerce(params, true);
+
+        expect(paypalLoadScript).toHaveBeenCalledWith({ 'client-id': 'aaa' });
     });
 
     it('throw error without merchant Id and disable progressive onboarding ', async () => {
         try {
-            await paypalLoader.loadPaypalCommerce({ options: { clientId: 'aaa', merchantId: '', currency: 'USD' } }, false);
+            await paypalLoader.loadPaypalCommerce({ 'client-id': 'aaa', 'merchant-id': '', currency: 'USD' }, false);
         } catch (error) {
-            expect(error).toEqual(new InvalidArgumentError(`Unable to proceed because "merchantId" argument in PayPal script is not provided.`));
+            expect(error).toEqual(new InvalidArgumentError(`Unable to proceed because "merchant-id" argument in PayPal script is not provided.`));
         }
     });
 
     it('throw error without client Id', async () => {
         try {
-            await paypalLoader.loadPaypalCommerce({ options: { clientId: '', merchantId: 'bbb', currency: 'USD' } });
+            await paypalLoader.loadPaypalCommerce({ 'client-id': '', 'merchant-id': 'bbb', currency: 'USD' });
         } catch (error) {
-            expect(error).toEqual(new InvalidArgumentError(`Unable to proceed because "clientId" argument in PayPal script is not provided.`));
+            expect(error).toEqual(new InvalidArgumentError(`Unable to proceed because "client-id" argument in PayPal script is not provided.`));
         }
     });
 
@@ -131,22 +116,22 @@ describe('PaypalCommerceScriptLoader', () => {
             });
 
         try {
-            await paypalLoader.loadPaypalCommerce({ options: { clientId: 'aaa', merchantId: 'bbb', currency: 'USD' } });
+            await paypalLoader.loadPaypalCommerce({ 'client-id': 'aaa', 'merchant-id': 'bbb', currency: 'USD' });
         } catch (error) {
             expect(error).toEqual(expectedError);
         }
     });
 
-    it('throw error if unable window.paypal', async () => {
+    it('throw error if unable window.paypalLoadScript', async () => {
         jest.spyOn(loader, 'loadScript')
             .mockImplementation(() => {
-                (window as PaypalCommerceHostWindow).paypal = undefined;
+                (window as PaypalCommerceHostWindow).paypalLoadScript = undefined;
 
                 return Promise.resolve();
             });
 
         try {
-            await paypalLoader.loadPaypalCommerce({ options: { clientId: 'aaa', merchantId: 'bbb', currency: 'EUR'} });
+            await paypalLoader.loadPaypalCommerce({ 'client-id': 'aaa', 'merchant-id': 'bbb', currency: 'EUR'});
         } catch (error) {
             expect(error).toEqual(new PaymentMethodClientUnavailableError());
         }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -155,6 +155,7 @@ export interface PaypalCommerceSDK {
 
 export interface PaypalCommerceHostWindow extends Window {
     paypal?: PaypalCommerceSDK;
+    paypalLoadScript?(options: PaypalCommerceScriptParams): Promise<{ paypal: PaypalCommerceSDK }>;
 }
 
 export interface PaypalCommerceInitializationData {
@@ -170,17 +171,14 @@ export type DisableFundingType = Array<'credit' | 'card'>;
 
 export type ComponentsScriptType = Array<'buttons' | 'messages' | 'hosted-fields'>;
 
-export interface PaypalCommerceScriptOptions {
-    clientId: string;
-    merchantId?: string;
+export interface PaypalCommerceScriptParams  {
+    'client-id': string;
+    'merchant-id'?: string;
+    'disable-funding'?: DisableFundingType;
+    'data-client-token'?: string;
+    'partner-attribution-id'?: string;
     currency?: string;
     commit?: boolean;
     intent?: 'capture' | 'authorize';
-    disableFunding?: DisableFundingType;
     components?: ComponentsScriptType;
-}
-
-export interface PaypalCommerceScriptAttribute {
-    clientToken?: string;
-    partnerAttributionId?: string;
 }


### PR DESCRIPTION
## What?
Fix bug, when buyer can't switch on the checkout between payment methods
Add one script for different methods (https://github.com/paypal/paypal-js)

## Why?
Script changed each time when buyer changed method
I call `createPaypalCommercePaymentProcessor` separately for each method, because in this case we can `close` PayPal buttons for the method that was closed. In previous case (one `createPaypalCommercePaymentProcessor` for all methods) I had errors, because `deinitialize` was called after `initialize` and close button

## Testing / Proof
https://www.loom.com/share/c54ef8c4859e48c1a201f6b5ef281836

@bigcommerce/checkout @bigcommerce/payments
