### PR TITLE
feat(payment): INT-3061 renamed mandate field to mandateUrl on order interface

### DIFF
--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -31,7 +31,7 @@ export default interface Order {
     status: string;
     taxes: Tax[];
     taxTotal: number;
-    mandate?: string;
+    mandateUrl?: string;
 }
 
 export type OrderPayments = Array<GatewayOrderPayment | GiftCertificateOrderPayment>;


### PR DESCRIPTION
## What? [INT-3061](https://jira.bigcommerce.com/browse/INT-3061)
Renamed mandate field to mandateUrl on order interface

## Why?
In order to match the persistence and communicate the intended usage.


## Sibling PR
[Checkout-JS #435](https://github.com/bigcommerce/checkout-js/pull/435)

## Testing / Proof

@bigcommerce/apex-integrations 
