### PR TITLE
fix(payment): PAYPAL-766 Validate cc before submit order

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
@@ -22,7 +22,7 @@ import { PaymentInitializeOptions } from '../../payment-request-options';
 import { PaypalCommerceCreditCardPaymentStrategy, PaypalCommerceFormOptions, PaypalCommerceHostedForm, PaypalCommercePaymentProcessor, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK } from './index';
 import { getPaypalCommerceMock } from './paypal-commerce.mock';
 
-describe('PaypalCommercePaymentStrategy', () => {
+describe('PaypalCommerceCreditCardPaymentStrategy', () => {
     let orderActionCreator: OrderActionCreator;
     let paymentActionCreator: PaymentActionCreator;
     let paymentStrategy: PaypalCommerceCreditCardPaymentStrategy;
@@ -75,6 +75,7 @@ describe('PaypalCommercePaymentStrategy', () => {
 
         paypalCommerceHostedForm.initialize = jest.fn();
         paypalCommerceHostedForm.submit = jest.fn(() => ({ orderId }));
+        paypalCommerceHostedForm.validate = jest.fn();
 
         paymentStrategy = new PaypalCommerceCreditCardPaymentStrategy(
             store,

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.ts
@@ -47,7 +47,7 @@ export default class PaypalCommerceCreditCardPaymentStrategy implements PaymentS
             throw new PaymentArgumentInvalidError(['payment']);
         }
 
-        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+        this._paypalCommerceHostedForm.validate();
 
         const { paymentMethods: { getPaymentMethodOrThrow } } = await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
         const { orderId } = await this._paypalCommerceHostedForm.submit(getPaymentMethodOrThrow(payment.methodId).config.is3dsEnabled);

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
@@ -59,7 +59,7 @@ describe('PaypalCommerceHostedForm', () => {
         jest.spyOn(paypalCommercePaymentProcessor, 'submitHostedFields')
             .mockReturnValue(Promise.resolve({ orderId }));
 
-        jest.spyOn(paypalCommercePaymentProcessor, 'validateHostedForm')
+        jest.spyOn(paypalCommercePaymentProcessor, 'getValidationStateHostedFields')
             .mockReturnValue({ isValid: true });
 
         hostedForm = new PaypalCommerceHostedForm(paypalCommercePaymentProcessor);
@@ -164,7 +164,7 @@ describe('PaypalCommerceHostedForm', () => {
     });
 
     it('throw error if validate is failed during sending', async () => {
-        jest.spyOn(paypalCommercePaymentProcessor, 'validateHostedForm')
+        jest.spyOn(paypalCommercePaymentProcessor, 'getValidationStateHostedFields')
             .mockReturnValue({ isValid: false, fields: {} });
 
         await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
@@ -173,7 +173,7 @@ describe('PaypalCommerceHostedForm', () => {
     });
 
     it('call onValidate if validate is failed during sending', async () => {
-        jest.spyOn(paypalCommercePaymentProcessor, 'validateHostedForm')
+        jest.spyOn(paypalCommercePaymentProcessor, 'getValidationStateHostedFields')
             .mockReturnValue({
                 isValid: false,
                 fields: {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
@@ -59,7 +59,7 @@ describe('PaypalCommerceHostedForm', () => {
         jest.spyOn(paypalCommercePaymentProcessor, 'submitHostedFields')
             .mockReturnValue(Promise.resolve({ orderId }));
 
-        jest.spyOn(paypalCommercePaymentProcessor, 'getValidationStateHostedFields')
+        jest.spyOn(paypalCommercePaymentProcessor, 'getHostedFieldsValidationState')
             .mockReturnValue({ isValid: true });
 
         hostedForm = new PaypalCommerceHostedForm(paypalCommercePaymentProcessor);
@@ -164,7 +164,7 @@ describe('PaypalCommerceHostedForm', () => {
     });
 
     it('throw error if validate is failed during sending', async () => {
-        jest.spyOn(paypalCommercePaymentProcessor, 'getValidationStateHostedFields')
+        jest.spyOn(paypalCommercePaymentProcessor, 'getHostedFieldsValidationState')
             .mockReturnValue({ isValid: false, fields: {} });
 
         await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
@@ -173,7 +173,7 @@ describe('PaypalCommerceHostedForm', () => {
     });
 
     it('call onValidate if validate is failed during sending', async () => {
-        jest.spyOn(paypalCommercePaymentProcessor, 'getValidationStateHostedFields')
+        jest.spyOn(paypalCommercePaymentProcessor, 'getHostedFieldsValidationState')
             .mockReturnValue({
                 isValid: false,
                 fields: {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
@@ -63,7 +63,7 @@ export default class PaypalCommerceHostedForm {
     }
 
     validate(): void {
-        const { isValid, fields } = this._paypalCommercePaymentProcessor.getValidationStateHostedFields();
+        const { isValid, fields } = this._paypalCommercePaymentProcessor.getHostedFieldsValidationState();
 
         if (isValid) {
             return;

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
@@ -63,7 +63,7 @@ export default class PaypalCommerceHostedForm {
     }
 
     validate(): void {
-        const { isValid, fields } = this._paypalCommercePaymentProcessor.validateHostedForm();
+        const { isValid, fields } = this._paypalCommercePaymentProcessor.getValidationStateHostedFields();
 
         if (isValid) {
             return;

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
@@ -394,7 +394,7 @@ describe('PaypalCommercePaymentProcessor', () => {
             expect(result.orderId).toEqual(orderID);
         });
 
-        it('validateHostedForm should return isValid = false and fields', async () => {
+        it('getValidationStateHostedFields should return isValid = false and fields', async () => {
             const fields = {
                 cvv: { isValid: false },
                 expirationDate: { isValid: false },
@@ -408,14 +408,14 @@ describe('PaypalCommercePaymentProcessor', () => {
             await paypalCommercePaymentProcessor.initialize(initOptions);
             await paypalCommercePaymentProcessor.renderHostedFields(cart.id, hostedFormOptions);
 
-            expect(await paypalCommercePaymentProcessor.validateHostedForm()).toEqual({ isValid: false, fields });
+            expect(await paypalCommercePaymentProcessor.getValidationStateHostedFields()).toEqual({ isValid: false, fields });
         });
 
-        it('validateHostedForm should return isValid = true and fields', async () => {
+        it('getValidationStateHostedFields should return isValid = true and fields', async () => {
             await paypalCommercePaymentProcessor.initialize(initOptions);
             await paypalCommercePaymentProcessor.renderHostedFields(cart.id, hostedFormOptions);
 
-            expect(await paypalCommercePaymentProcessor.validateHostedForm()).toEqual({ isValid: true, fields: {} });
+            expect(await paypalCommercePaymentProcessor.getValidationStateHostedFields()).toEqual({ isValid: true, fields: {} });
         });
     });
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
@@ -393,6 +393,30 @@ describe('PaypalCommercePaymentProcessor', () => {
 
             expect(result.orderId).toEqual(orderID);
         });
+
+        it('validateHostedForm should return isValid = false and fields', async () => {
+            const fields = {
+                cvv: { isValid: false },
+                expirationDate: { isValid: false },
+                number: { isValid: false },
+            };
+            cardFields.getState = jest.fn(() => ({
+                cards: [],
+                emittedBy: '',
+                fields,
+            }));
+            await paypalCommercePaymentProcessor.initialize(initOptions);
+            await paypalCommercePaymentProcessor.renderHostedFields(cart.id, hostedFormOptions);
+
+            expect(await paypalCommercePaymentProcessor.validateHostedForm()).toEqual({ isValid: false, fields });
+        });
+
+        it('validateHostedForm should return isValid = true and fields', async () => {
+            await paypalCommercePaymentProcessor.initialize(initOptions);
+            await paypalCommercePaymentProcessor.renderHostedFields(cart.id, hostedFormOptions);
+
+            expect(await paypalCommercePaymentProcessor.validateHostedForm()).toEqual({ isValid: true, fields: {} });
+        });
     });
 
 });

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
@@ -394,7 +394,7 @@ describe('PaypalCommercePaymentProcessor', () => {
             expect(result.orderId).toEqual(orderID);
         });
 
-        it('getValidationStateHostedFields should return isValid = false and fields', async () => {
+        it('getHostedFieldsValidationState should return isValid = false and fields', async () => {
             const fields = {
                 cvv: { isValid: false },
                 expirationDate: { isValid: false },
@@ -408,14 +408,14 @@ describe('PaypalCommercePaymentProcessor', () => {
             await paypalCommercePaymentProcessor.initialize(initOptions);
             await paypalCommercePaymentProcessor.renderHostedFields(cart.id, hostedFormOptions);
 
-            expect(await paypalCommercePaymentProcessor.getValidationStateHostedFields()).toEqual({ isValid: false, fields });
+            expect(await paypalCommercePaymentProcessor.getHostedFieldsValidationState()).toEqual({ isValid: false, fields });
         });
 
-        it('getValidationStateHostedFields should return isValid = true and fields', async () => {
+        it('getHostedFieldsValidationState should return isValid = true and fields', async () => {
             await paypalCommercePaymentProcessor.initialize(initOptions);
             await paypalCommercePaymentProcessor.renderHostedFields(cart.id, hostedFormOptions);
 
-            expect(await paypalCommercePaymentProcessor.getValidationStateHostedFields()).toEqual({ isValid: true, fields: {} });
+            expect(await paypalCommercePaymentProcessor.getHostedFieldsValidationState()).toEqual({ isValid: true, fields: {} });
         });
     });
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -133,7 +133,7 @@ export default class PaypalCommercePaymentProcessor {
         return this._hostedFields.submit(options);
     }
 
-    getValidationStateHostedFields(): { isValid: boolean; fields: PaypalCommerceHostedFieldsState['fields'] } {
+    getHostedFieldsValidationState(): { isValid: boolean; fields: PaypalCommerceHostedFieldsState['fields'] } {
         if (!this._hostedFields) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -124,16 +124,6 @@ export default class PaypalCommercePaymentProcessor {
         if (!this._hostedFields) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
-
-        const { fields } = this._hostedFields.getState();
-
-        const formValid = (Object.keys(fields) as Array<keyof PaypalCommerceHostedFieldsState['fields']>)
-            .every(key => fields[key]?.isValid);
-
-        if (!formValid) {
-            throw { type: 'invalid_fields_before_submit', fields };
-        }
-
         const options: PaypalCommerceHostedFieldsSubmitOptions = {};
 
         if (is3dsEnabled) {
@@ -141,6 +131,19 @@ export default class PaypalCommercePaymentProcessor {
         }
 
         return this._hostedFields.submit(options);
+    }
+
+    validateHostedForm(): { isValid: boolean; fields: PaypalCommerceHostedFieldsState['fields'] } {
+        if (!this._hostedFields) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        const { fields } = this._hostedFields.getState();
+
+        const isValid = (Object.keys(fields) as Array<keyof PaypalCommerceHostedFieldsState['fields']>)
+            .every(key => fields[key]?.isValid);
+
+        return { isValid, fields };
     }
 
     deinitialize() {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -133,7 +133,7 @@ export default class PaypalCommercePaymentProcessor {
         return this._hostedFields.submit(options);
     }
 
-    validateHostedForm(): { isValid: boolean; fields: PaypalCommerceHostedFieldsState['fields'] } {
+    getValidationStateHostedFields(): { isValid: boolean; fields: PaypalCommerceHostedFieldsState['fields'] } {
         if (!this._hostedFields) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }


### PR DESCRIPTION
## What?
Validate credit cards before submit order

## Why?
Validation should be performed right after a buyer clicked place order (without allowing call for POST internalapi/v1/checkout/order)

## Testing / Proof
https://www.loom.com/share/2154e46c3f584fd3aaa7b8e27ba6690e

@bigcommerce/checkout @bigcommerce/payments
