### PR TITLE
CHECKOUT-4871 Add documentation for CheckoutService#signOut

### DIFF
--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -614,6 +614,19 @@ export default class CheckoutService {
      * console.log(state.data.getCustomer());
      * ```
      *
+     * When a store has "Allow customers to access their cart across multiple devices" enabled, signing out
+     * will remove the cart/checkout data from the current session. An error with type="checkout_not_available" will be thrown.
+     *
+     * ```js
+     * try {
+     *   await service.signOutCustomer();
+     * } catch (error) {
+     *   if (error.type === 'checkout_not_available') {
+     *     window.top.location.assign('/');
+     *   }
+     * }
+     * ```
+     *
      * @param options - Options for signing out the customer.
      * @returns A promise that resolves to the current state.
      */


### PR DESCRIPTION
## What?
Add documentation for CheckoutService#signOut, when "cross cart retrieval" is enabled

## Why?
It seems to be a common issue across a few merchants, not handling this error properly.

## Testing / Proof
ci

@bigcommerce/checkout 