### PR TITLE
fix(payment): INT-3311 klarna can checkout with coupons

### DIFF
--- a/src/payment/strategies/klarna/klarna-payment-strategy.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.ts
@@ -42,6 +42,11 @@ export default class KlarnaPaymentStrategy implements PaymentStrategy {
                         const checkout = state.checkout.getCheckout();
 
                         return checkout && checkout.outstandingBalance;
+                    },
+                    state => {
+                        const checkout = state.checkout.getCheckout();
+
+                        return checkout && checkout.coupons;
                     }
                 );
 

--- a/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
+++ b/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
@@ -42,6 +42,11 @@ export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
                         const checkout = state.checkout.getCheckout();
 
                         return checkout && checkout.outstandingBalance;
+                    },
+                    state => {
+                        const checkout = state.checkout.getCheckout();
+
+                        return checkout && checkout.coupons;
                     }
                 );
 


### PR DESCRIPTION
## What?
[INT-3311](https://jira.bigcommerce.com/browse/INT-3311) Klarna Payments: Unable to checkout with a coupon
Fix an issue that prevents that a coupon is used when trying to checkout with Klarna and a coupon is added

## Why?
The issue don't let customers use coupon codes in the checkout with klarna

## Testing / Proof
https://drive.google.com/file/d/1ErQeEAaaqbQrnHZd1q5kDN49-mOFZOBG/view?usp=sharing

https://drive.google.com/file/d/1ZY9Tr93AgNr14kKZD_iE3sQQy1xYdhhG/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 