### PR TITLE
feat(payment): INT-2816 Added 3DS to googlepay adyenv2

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -36,7 +36,7 @@ import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
 import { ExternalPaymentStrategy } from './strategies/external';
-import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
 import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
 import { LegacyPaymentStrategy } from './strategies/legacy';
@@ -104,6 +104,11 @@ export default function createPaymentStrategyRegistry(
             createGooglePayPaymentProcessor(
                 store,
                 new GooglePayAdyenV2Initializer()
+            ),
+            new GooglePayAdyenV2PaymentProcessor(
+                store,
+                paymentActionCreator,
+                new AdyenV2ScriptLoader(scriptLoader, getStylesheetLoader())
             )
         )
     );

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -456,6 +456,33 @@ export function getGooglePay(): PaymentMethod {
     };
 }
 
+export function getGooglePayAdyenV2(): PaymentMethod {
+    return {
+        id: 'googlepayadyenv2',
+        logoUrl: '',
+        method: 'googlepay',
+        supportedCards: [
+            'VISA',
+            'MC',
+            'AMEX',
+        ],
+        config: {
+            displayName: 'Google Pay',
+            merchantId: '',
+            testMode: true,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'clientToken',
+        initializationData: {
+            nonce: 'nonce',
+            card_information: {
+                type: 'MasterCard',
+                number: '4111',
+            },
+        },
+    };
+}
+
 export function getZip(): PaymentMethod {
     return {
         id: 'zip',
@@ -569,6 +596,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getBraintreeVisaCheckout(),
         getCheckoutcom(),
         getGooglePay(),
+        getGooglePayAdyenV2(),
         getKlarna(),
         getPaypalExpress(),
         getPaypalCommerce(),

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
@@ -59,6 +59,7 @@ export default class GooglePayAdyenV2Initializer implements GooglePayInitializer
         const {
             initializationData: {
                 gatewayMerchantId,
+                storeCountry: countryCode,
                 googleMerchantName: merchantName,
                 googleMerchantId: merchantId,
                 platformToken: authJwt,
@@ -94,6 +95,7 @@ export default class GooglePayAdyenV2Initializer implements GooglePayInitializer
                 },
             }],
             transactionInfo: {
+                countryCode,
                 currencyCode,
                 totalPriceStatus: 'FINAL',
                 totalPrice: round(outstandingBalance, 2).toFixed(2),

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.spec.ts
@@ -1,0 +1,97 @@
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
+
+import { createPaymentClient, PaymentActionCreator, PaymentRequestSender, PaymentRequestTransformer } from '../..';
+import { getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { RequestError } from '../../../common/error/errors';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { OrderActionCreator } from '../../../order';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import { getGooglePayAdyenV2, getPaymentMethodsState } from '../../payment-methods.mock';
+import { AdyenV2ScriptLoader } from '../adyenv2';
+
+import GooglePayAdyenV2PaymentProcessor from './googlepay-adyenv2-payment-processor';
+
+describe('GooglePayAdyenV2PaymentProcessor', () => {
+    let processor: GooglePayAdyenV2PaymentProcessor;
+    let store: CheckoutStore;
+    let requestSender: RequestSender;
+    let paymentActionCreator: PaymentActionCreator;
+    let orderActionCreator: OrderActionCreator;
+    let adyenV2ScriptLoader: AdyenV2ScriptLoader;
+    const createFromAction = jest.fn((action, {onAdditionalDetails}) => {
+        onAdditionalDetails({action});
+    });
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+        const scriptLoader = createScriptLoader();
+        const paymentClient = createPaymentClient(store);
+
+        orderActionCreator = new OrderActionCreator(
+            paymentClient,
+            new CheckoutValidator(
+                new CheckoutRequestSender(requestSender)
+            )
+        );
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(paymentClient),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(scriptLoader))
+        );
+        requestSender = createRequestSender();
+        adyenV2ScriptLoader = new AdyenV2ScriptLoader(scriptLoader, getStylesheetLoader());
+
+        jest.spyOn(adyenV2ScriptLoader, 'load').mockReturnValue({createFromAction});
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(getGooglePayAdyenV2());
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+    });
+
+    it('#initialize()', () => {
+        processor = new GooglePayAdyenV2PaymentProcessor(
+            store,
+            paymentActionCreator,
+            adyenV2ScriptLoader
+        );
+        processor.initialize({methodId: 'googlepayadyenv2'});
+        expect(adyenV2ScriptLoader.load).toBeCalled();
+    });
+
+    it('#processAdditionalAction', async () => {
+        processor.initialize({methodId: 'googlepayadyenv2'});
+        const err: RequestError = new RequestError({
+            body: {
+                errors: [{ code: 'additional_action_required' }],
+                provider_data: {
+                    action: '{}',
+                },
+            },
+            headers: {},
+            status: 400,
+            statusText: 'Please continue with additional actions.',
+        });
+
+        await processor.processAdditionalAction(err);
+        expect(createFromAction).toBeCalledTimes(1);
+    });
+
+    it('#processAdditionalAction failed', async () => {
+        processor.initialize({methodId: 'googlepayadyenv2'});
+
+        try {
+            await processor.processAdditionalAction({code: 'processAdditionalAction'});
+        } catch (error) {
+            expect(error).toStrictEqual({code: 'processAdditionalAction'});
+        }
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.ts
@@ -1,0 +1,95 @@
+import { some } from 'lodash';
+
+import { Payment, PaymentActionCreator, PaymentInitializeOptions } from '../..';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
+import { PaymentMethodCancelledError } from '../../errors';
+import { AdyenAction, AdyenAdditionalAction, AdyenAdditionalActionState, AdyenClient, AdyenError, AdyenV2ScriptLoader } from '../adyenv2';
+
+export default class GooglePayAdyenV2PaymentProcessor {
+    private _adyenClient?: AdyenClient;
+
+    constructor(private _store: CheckoutStore, private _paymentActionCreator: PaymentActionCreator, private _scriptLoader: AdyenV2ScriptLoader) {}
+
+    async initialize(options: PaymentInitializeOptions) {
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
+        const storeConfig = state.config.getStoreConfig();
+
+        if (!storeConfig) {
+            throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+        }
+
+        const clientSideAuthentication = {
+            key: '',
+            value: '',
+        };
+
+        if (paymentMethod.initializationData.originKey) {
+            clientSideAuthentication.key = 'originKey';
+            clientSideAuthentication.value = paymentMethod.initializationData.originKey;
+        } else {
+            clientSideAuthentication.key = 'clientKey';
+            clientSideAuthentication.value = paymentMethod.initializationData.clientKey;
+        }
+
+        this._adyenClient = await this._scriptLoader.load({
+            environment: paymentMethod.config.testMode ? 'TEST' : ' PRODUCTION',
+            locale: storeConfig.storeProfile.storeLanguage,
+            [clientSideAuthentication.key]: clientSideAuthentication.value,
+            paymentMethodsResponse: paymentMethod.initializationData.paymentMethodsResponse,
+        });
+    }
+
+    async processAdditionalAction(error: unknown): Promise<InternalCheckoutSelectors> {
+        if (!(error instanceof RequestError) || !some(error.body.errors, {code: 'additional_action_required'})) {
+            return Promise.reject(error);
+        }
+
+        const payment = await this._handleAction(error.body.provider_data);
+
+        try {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({
+                ...payment,
+                paymentData: {
+                    ...payment.paymentData,
+                },
+            }));
+        } catch (error) {
+            return this.processAdditionalAction(error);
+        }
+    }
+
+    private _handleAction(additionalAction: AdyenAdditionalAction): Promise<Payment> {
+        return new Promise((resolve, reject) => {
+            const adyenAction: AdyenAction = JSON.parse(additionalAction.action);
+
+            const additionalActionComponent = this._getAdyenClient().createFromAction(adyenAction, {
+                onAdditionalDetails: (additionalActionState: AdyenAdditionalActionState) => {
+                    const paymentPayload = {
+                        methodId: adyenAction.paymentMethodType,
+                        paymentData: {
+                            nonce: JSON.stringify(additionalActionState.data),
+                        },
+                    };
+
+                    resolve(paymentPayload);
+                },
+                size: '05',
+                onError: (error: AdyenError) => reject(error),
+            });
+
+            additionalActionComponent.mount('body');
+
+            reject(new PaymentMethodCancelledError());
+        });
+    }
+
+    private _getAdyenClient(): AdyenClient {
+        if (!this._adyenClient) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this._adyenClient;
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -1,5 +1,5 @@
-
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { getBrowserInfo } from '../../../common/browser-info';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { bindDecorator as bind } from '../../../common/utility';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
@@ -12,6 +12,7 @@ import { AdyenPaymentMethodType } from '../adyenv2';
 import PaymentStrategy from '../payment-strategy';
 
 import { GooglePaymentData, PaymentMethodData } from './googlepay';
+import GooglePayAdyenV2PaymentProcessor from './googlepay-adyenv2-payment-processor';
 import GooglePayPaymentInitializeOptions from './googlepay-initialize-options';
 import GooglePayPaymentProcessor from './googlepay-payment-processor';
 
@@ -27,7 +28,8 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         private _paymentStrategyActionCreator: PaymentStrategyActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
         private _orderActionCreator: OrderActionCreator,
-        private _googlePayPaymentProcessor: GooglePayPaymentProcessor
+        private _googlePayPaymentProcessor: GooglePayPaymentProcessor,
+        private _googlePayAdyenV2PaymentProcessor?: GooglePayAdyenV2PaymentProcessor
     ) {}
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -93,6 +95,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             .then(() =>
                 this._store.dispatch(this._orderActionCreator.submitOrder({ useStoreCredit: payload.useStoreCredit }, options))
                     .then(() => this._store.dispatch(this._paymentActionCreator.submitPayment(this._getPayment())))
+                    .catch(error => this._googlePayAdyenV2PaymentProcessor?.processAdditionalAction(error) || Promise.reject(error))
             );
     }
 
@@ -102,6 +105,12 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
     private _getGooglePayOptions(options: PaymentInitializeOptions): GooglePayPaymentInitializeOptions {
         if (options.methodId === 'googlepayadyenv2' && options.googlepayadyenv2) {
+            if (!this._googlePayAdyenV2PaymentProcessor) {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+
+            this._googlePayAdyenV2PaymentProcessor.initialize(options);
+
             return options.googlepayadyenv2;
         }
 
@@ -146,6 +155,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             nonce = JSON.stringify({
                 type: AdyenPaymentMethodType.GooglePay,
                 googlePayToken: paymentMethod.initializationData.nonce,
+                browser_info: getBrowserInfo(),
             });
         } else {
             nonce = paymentMethod.initializationData.nonce;

--- a/src/payment/strategies/googlepay/index.ts
+++ b/src/payment/strategies/googlepay/index.ts
@@ -4,6 +4,7 @@ export * from './googlepay-braintree';
 export { default as GooglePayScriptLoader } from './googlepay-script-loader';
 export { default as GooglePayPaymentStrategy } from './googlepay-payment-strategy';
 export { default as GooglePayAdyenV2Initializer } from './googlepay-adyenv2-initializer';
+export { default as GooglePayAdyenV2PaymentProcessor } from './googlepay-adyenv2-payment-processor';
 export { default as GooglePayBraintreeInitializer } from './googlepay-braintree-initializer';
 export { default as GooglePayCheckoutcomInitializer } from './googlepay-checkoutcom-initializer';
 export { default as GooglePayStripeInitializer } from './googlepay-stripe-initializer';


### PR DESCRIPTION
## What? [INT-2816](https://jira.bigcommerce.com/browse/INT-2816)
Create a new strategy for googlepay Adyen where 3DS could be handle


## Why?
In order to have 3DS working for google pay on AdyenV2

## Siblings

[BigCommerce PR](https://github.com/bigcommerce/bigcommerce/pull/38152)
[BigPay PR](https://github.com/bigcommerce/bigpay/pull/3190)
[Checkout-JS](https://github.com/bigcommerce/checkout-js/pull/470)

## Testing / Proof
![googlepay-3ds](https://user-images.githubusercontent.com/69221626/100132188-abd12480-2e4a-11eb-8275-35f944ec3a27.gif)

@bigcommerce/checkout @bigcommerce/payments
