### PR TITLE
feat(payment): INT-3438 Integrate Barclays strategy

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -12,6 +12,7 @@ import { AdyenV2PaymentStrategy } from './strategies/adyenv2';
 import { AffirmPaymentStrategy } from './strategies/affirm';
 import { AfterpayPaymentStrategy } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy } from './strategies/amazon-pay';
+import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy } from './strategies/braintree';
 import { ChasepayPaymentStrategy } from './strategies/chasepay';
@@ -70,6 +71,11 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate afterpay', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.AFTERPAY);
         expect(paymentStrategy).toBeInstanceOf(AfterpayPaymentStrategy);
+    });
+
+    it('can instantiate barclays', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.BARCLAYS);
+        expect(paymentStrategy).toBeInstanceOf(BarclaysPaymentStrategy);
     });
 
     it('can instantiate braintree', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -25,10 +25,11 @@ import { AffirmPaymentStrategy, AffirmScriptLoader } from './strategies/affirm';
 import { AfterpayPaymentStrategy, AfterpayScriptLoader } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy, AmazonPayScriptLoader } from './strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentStrategy } from './strategies/amazon-pay-v2';
+import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BoltPaymentStrategy, BoltScriptLoader } from './strategies/bolt';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVisaCheckoutPaymentStrategy, VisaCheckoutScriptLoader } from './strategies/braintree';
-import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow } from './strategies/cardinal';
+import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow, CardinalThreeDSecureFlowV2 } from './strategies/cardinal';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
@@ -162,6 +163,20 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             createAmazonPayV2PaymentProcessor()
+        )
+    );
+
+    registry.register(PaymentStrategyType.BARCLAYS, () =>
+        new BarclaysPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory,
+            new CardinalThreeDSecureFlowV2(
+                store,
+                paymentActionCreator,
+                new CardinalClient(new CardinalScriptLoader(scriptLoader))
+            )
         )
     );
 

--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -29,6 +29,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'adyenv2',
         method: 'giropay',
     },
+    barclays: {
+        provider: 'barclays',
+        method: 'credit_card',
+    },
     braintree: {
         provider: 'braintree',
         method: 'credit_card',

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -182,6 +182,22 @@ export function getCybersource(): PaymentMethod {
     };
 }
 
+export function getBarclays(): PaymentMethod {
+    return {
+        id: 'barclays',
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: [],
+        config: {
+            displayName: 'Barclaycard Smartpay',
+            is3dsEnabled: true,
+            testMode: true,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'barclaysToken',
+    };
+}
+
 export function getBankDeposit(): PaymentMethod {
     return {
         id: 'bankdeposit',

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -6,6 +6,7 @@ enum PaymentStrategyType {
     AMAZON = 'amazon',
     AUTHORIZENET_GOOGLE_PAY = 'googlepayauthorizenet',
     AMAZONPAYV2 = 'amazonpay',
+    BARCLAYS = 'barclays',
     BLUESNAPV2 = 'bluesnapv2',
     BOLT = 'bolt',
     CHECKOUTCOM = 'checkoutcom',

--- a/src/payment/strategies/barclays/barclays-payment-strategy.spec.ts
+++ b/src/payment/strategies/barclays/barclays-payment-strategy.spec.ts
@@ -1,0 +1,157 @@
+import { merge } from 'lodash';
+import { of } from 'rxjs';
+
+import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethod from '../../payment-method';
+import { getBarclays } from '../../payment-methods.mock';
+import { CardinalClient, CardinalThreeDSecureFlowV2 } from '../cardinal';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+import BarclaysPaymentStrategy from './barclays-payment-strategy';
+
+describe('BarclaysPaymentStrategy', () => {
+    let hostedFormFactory: HostedFormFactory;
+    let orderActionCreator: Pick<OrderActionCreator, 'submitOrder'>;
+    let paymentActionCreator: Pick<PaymentActionCreator, 'submitPayment'>;
+    let paymentMethod: PaymentMethod;
+    let state: InternalCheckoutSelectors;
+    let store: CheckoutStore;
+    let strategy: BarclaysPaymentStrategy;
+    let cardinalClient: CardinalClient;
+    let threeDSecureFlow: Pick<CardinalThreeDSecureFlowV2, 'prepare' | 'start'>;
+
+    beforeEach(() => {
+        paymentMethod = getBarclays();
+
+        store = createCheckoutStore();
+
+        orderActionCreator = {
+            submitOrder: jest.fn(() => of()),
+        };
+
+        paymentActionCreator = {
+            submitPayment: jest.fn(() => of()),
+        };
+
+        hostedFormFactory = {} as HostedFormFactory;
+
+        cardinalClient = {} as CardinalClient;
+
+        threeDSecureFlow = new CardinalThreeDSecureFlowV2(
+            store,
+            paymentActionCreator as PaymentActionCreator,
+            cardinalClient
+        );
+
+        jest.spyOn(threeDSecureFlow, 'prepare')
+            .mockReturnValue(Promise.resolve());
+        jest.spyOn(threeDSecureFlow, 'start');
+
+        state = store.getState();
+
+        jest.spyOn(store, 'dispatch')
+            .mockResolvedValue(state);
+
+        jest.spyOn(store, 'getState')
+            .mockReturnValue(state);
+
+        jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(paymentMethod);
+
+        strategy = new BarclaysPaymentStrategy(
+            store,
+            orderActionCreator as OrderActionCreator,
+            paymentActionCreator as PaymentActionCreator,
+            hostedFormFactory,
+            threeDSecureFlow as CardinalThreeDSecureFlowV2
+        );
+    });
+
+    it('is special type of credit card strategy', () => {
+        expect(strategy)
+            .toBeInstanceOf(CreditCardPaymentStrategy);
+    });
+
+    describe('#initialize', () => {
+        it('throws error if payment method is not defined', async () => {
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockImplementation(() => { throw new Error(); });
+
+            await expect(strategy.initialize({ methodId: paymentMethod.id })).rejects.toThrow(Error);
+        });
+
+        describe('#threeDSecureFlow', () => {
+            it('does not prepare 3DS flow if not enabled', async () => {
+                paymentMethod.config.is3dsEnabled = false;
+
+                await strategy.initialize({ methodId: paymentMethod.id });
+
+                expect(threeDSecureFlow.prepare)
+                    .not.toHaveBeenCalled();
+            });
+
+            it('prepares 3DS flow if enabled', async () => {
+                paymentMethod.config.is3dsEnabled = true;
+
+                await strategy.initialize({ methodId: paymentMethod.id });
+
+                expect(threeDSecureFlow.prepare)
+                    .toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('#execute', () => {
+        let payload: OrderRequestBody;
+
+        beforeEach(() => {
+            payload = merge({}, getOrderRequestBody(), {
+                payment: {
+                    methodId: paymentMethod.id,
+                    gatewayId: paymentMethod.gateway,
+                },
+            });
+        });
+
+        it('throws error if payment method is not defined', async () => {
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockImplementation(() => { throw new Error(); });
+
+            await expect(strategy.execute(payload)).rejects.toThrow(Error);
+        });
+
+        describe('#threeDSecureFlow', () => {
+            let parentExecute: jest.SpyInstance<CreditCardPaymentStrategy['execute']>;
+
+            beforeEach(() => {
+                parentExecute = jest.spyOn(CreditCardPaymentStrategy.prototype, 'execute');
+            });
+
+            it('does not start 3DS flow if not enabled', async () => {
+                paymentMethod.config.is3dsEnabled = false;
+
+                await strategy.execute(payload);
+
+                expect(threeDSecureFlow.start)
+                    .not.toHaveBeenCalled();
+                expect(parentExecute)
+                    .toHaveBeenCalled();
+            });
+
+            it('starts 3DS flow if enabled', async () => {
+                paymentMethod.config.is3dsEnabled = true;
+
+                await strategy.execute(payload);
+
+                expect(threeDSecureFlow.start)
+                    .toHaveBeenCalled();
+                expect(parentExecute)
+                    .toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/src/payment/strategies/barclays/barclays-payment-strategy.ts
+++ b/src/payment/strategies/barclays/barclays-payment-strategy.ts
@@ -1,0 +1,53 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { CardinalThreeDSecureFlowV2 } from '../cardinal';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+export default class BarclaysPaymentStrategy extends CreditCardPaymentStrategy {
+    constructor(
+        store: CheckoutStore,
+        orderActionCreator: OrderActionCreator,
+        paymentActionCreator: PaymentActionCreator,
+        hostedFormFactory: HostedFormFactory,
+        private _threeDSecureFlow: CardinalThreeDSecureFlowV2
+    ) {
+        super(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        );
+    }
+
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        await super.initialize(options);
+
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(options.methodId);
+
+        if (paymentMethod.config.is3dsEnabled) {
+            await this._threeDSecureFlow.prepare(paymentMethod);
+        }
+
+        return this._store.getState();
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment: { methodId = '' } = {} } = payload;
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+
+        if (getPaymentMethodOrThrow(methodId).config.is3dsEnabled) {
+            return this._threeDSecureFlow.start(
+                super.execute.bind(this),
+                payload,
+                options,
+                this._hostedForm
+            );
+        }
+
+        return super.execute(payload, options);
+    }
+}

--- a/src/payment/strategies/barclays/index.ts
+++ b/src/payment/strategies/barclays/index.ts
@@ -1,0 +1,1 @@
+export { default as BarclaysPaymentStrategy } from './barclays-payment-strategy';

--- a/src/payment/strategies/cardinal/cardinal-client.ts
+++ b/src/payment/strategies/cardinal/cardinal-client.ts
@@ -3,7 +3,7 @@ import { includes } from 'lodash';
 import { Address } from '../../../address';
 import { BillingAddress } from '../../../billing';
 import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
-import { PaymentMethodFailedError } from '../../errors';
+import { PaymentMethodCancelledError, PaymentMethodFailedError } from '../../errors';
 import { CreditCardInstrument, ThreeDSecureToken, VaultedInstrument } from '../../payment';
 import { ThreeDsResult } from '../../payment-response-body';
 
@@ -94,6 +94,10 @@ export default class CardinalClient {
                         }
 
                         if (!data.ActionCode) {
+                            if (data.Payment?.ExtendedData?.ChallengeCancel) {
+                                reject(new PaymentMethodCancelledError());
+                            }
+
                             return resolve({ token: jwt });
                         }
 

--- a/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.spec.ts
+++ b/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.spec.ts
@@ -1,0 +1,196 @@
+import { Response } from '@bigcommerce/request-sender';
+import { merge } from 'lodash';
+import { of } from 'rxjs';
+
+import { getBillingAddress } from '../../../billing/billing-addresses.mock';
+import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { getCheckout, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
+import { RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { HostedForm } from '../../../hosted-form';
+import { OrderRequestBody } from '../../../order';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getOrder } from '../../../order/orders.mock';
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethod from '../../payment-method';
+import { getBarclays } from '../../payment-methods.mock';
+import { PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+import CardinalClient from './cardinal-client';
+import CardinalThreeDSecureFlowV2 from './cardinal-three-d-secure-flow-v2';
+
+describe('CardinalBarclaysThreeDSecureFlow', () => {
+    let state: InternalCheckoutSelectors;
+    let store: CheckoutStore;
+    let cardinalClient: Pick<CardinalClient, 'configure' | 'getThreeDSecureData' | 'load' | 'runBinProcess'>;
+    let threeDSecureFlow: CardinalThreeDSecureFlowV2;
+    let paymentMethod: PaymentMethod;
+    let paymentActionCreator: Pick<PaymentActionCreator, 'submitPayment'>;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreStateWithOrder());
+
+        paymentMethod = getBarclays();
+
+        cardinalClient = {
+            configure: jest.fn(() => Promise.resolve()),
+            getThreeDSecureData: jest.fn(() => Promise.resolve()),
+            load: jest.fn(() => Promise.resolve()),
+            runBinProcess: jest.fn(() => Promise.resolve()),
+        };
+
+        paymentActionCreator = {
+            submitPayment: jest.fn(() => of()),
+        };
+
+        state = store.getState();
+
+        jest.spyOn(store, 'getState')
+            .mockReturnValue(state);
+
+        threeDSecureFlow = new CardinalThreeDSecureFlowV2(
+            store,
+            paymentActionCreator as PaymentActionCreator,
+            cardinalClient as CardinalClient
+        );
+    });
+
+    describe('#prepare', () => {
+        it('loads Cardinal client', async () => {
+            await threeDSecureFlow.prepare(paymentMethod);
+
+            expect(cardinalClient.load)
+                .toHaveBeenCalledWith(paymentMethod.id, paymentMethod.config.testMode);
+        });
+    });
+
+    describe('#start', () => {
+        let execute: PaymentStrategy['execute'];
+        let form: Pick<HostedForm, 'getBin' | 'submit'>;
+        let options: PaymentRequestOptions;
+        let payload: OrderRequestBody;
+
+        beforeEach(() => {
+            execute = jest.fn(() => Promise.resolve(state));
+            options = { methodId: paymentMethod.id };
+
+            form = {
+                getBin: jest.fn(() => '411111'),
+                submit: jest.fn(),
+            };
+
+            payload = merge({}, getOrderRequestBody(), {
+                payment: {
+                    methodId: paymentMethod.id,
+                    gatewayId: paymentMethod.gateway,
+                },
+            });
+        });
+
+        it('executes order submission', async () => {
+            await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+            expect(execute).toHaveBeenCalledWith(payload, options);
+        });
+
+        describe('if additional action is required', () => {
+            let additionalActionRequired: Response<any>;
+
+            beforeEach(() => {
+                additionalActionRequired = getResponse({
+                    status: 'additional_action_required',
+                    additional_action_required: { data: { token: 'JWT123' } },
+                    three_ds_result: { payer_auth_request: 'TOKEN123' },
+                });
+
+                execute = jest.fn(() => Promise.reject(new RequestError(additionalActionRequired)));
+            });
+
+            it('configures Cardinal client', async () => {
+                await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                expect(cardinalClient.configure)
+                    .toHaveBeenCalledWith('JWT123');
+            });
+
+            it('runs BIN detection process if defined', async () => {
+                await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                expect(cardinalClient.runBinProcess)
+                    .toHaveBeenCalledWith(form.getBin());
+            });
+
+            it('submits XID token using hosted form if provided', async () => {
+                await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                expect(form.submit)
+                    .toHaveBeenCalledWith(merge({}, payload.payment, {
+                        paymentData: { threeDSecure: { xid: 'TOKEN123' } },
+                    }));
+            });
+
+            it('submits XID token directly if hosted form is not provided', async () => {
+                await threeDSecureFlow.start(execute, payload, options);
+
+                expect(paymentActionCreator.submitPayment)
+                    .toHaveBeenCalledWith(merge({}, payload.payment, {
+                        paymentData: { threeDSecure: { xid: 'TOKEN123' } },
+                    }));
+            });
+
+            describe('if 3DS is required', () => {
+                let threeDSecureRequired: Response<any>;
+
+                beforeEach(() => {
+                    threeDSecureRequired = getResponse({
+                        errors: [{ code: 'three_d_secure_required' }],
+                        three_ds_result: {
+                            acs_url: 'https://foo.com',
+                            payer_auth_request: 'TOKEN345',
+                            merchant_data: 'qwerty123...',
+                            callback_url: null,
+                        },
+                    });
+
+                    jest.spyOn(form, 'submit')
+                        .mockRejectedValueOnce(new RequestError(threeDSecureRequired));
+                    jest.spyOn(paymentActionCreator, 'submitPayment')
+                        .mockRejectedValueOnce(new RequestError(threeDSecureRequired));
+                });
+
+                it('handles 3DS error and prompts shopper to authenticate', async () => {
+                    await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                    expect(cardinalClient.getThreeDSecureData)
+                        .toHaveBeenCalledWith(threeDSecureRequired.body.three_ds_result, {
+                            billingAddress: getBillingAddress(),
+                            shippingAddress: getShippingAddress(),
+                            currencyCode: getCheckout().cart.currency.code,
+                            id: getOrder().orderId.toString(),
+                            amount: getCheckout().cart.cartAmount,
+                        });
+                });
+
+                it('submits 3DS token using hosted form if provided', async () => {
+                    await threeDSecureFlow.start(execute, payload, options, form as HostedForm);
+
+                    expect(form.submit)
+                        .toHaveBeenCalledWith(merge({}, payload.payment, {
+                            paymentData: { threeDSecure: { token: 'TOKEN345' } },
+                        }));
+                });
+
+                it('submits 3DS token directly if hosted form is not provided', async () => {
+                    await threeDSecureFlow.start(execute, payload, options);
+
+                    expect(paymentActionCreator.submitPayment)
+                        .toHaveBeenCalledWith(merge({}, payload.payment, {
+                            paymentData: { threeDSecure: { token: 'TOKEN345' } },
+                        }));
+                });
+            });
+        });
+    });
+});

--- a/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.ts
+++ b/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.ts
@@ -1,0 +1,115 @@
+import { merge, some } from 'lodash';
+
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { RequestError } from '../../../common/error/errors';
+import { HostedForm } from '../../../hosted-form';
+import { OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
+import { InstrumentSelector } from '../../instrument';
+import isCreditCardLike from '../../is-credit-card-like';
+import isVaultedInstrument from '../../is-vaulted-instrument';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethod from '../../payment-method';
+import { PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+import { CardinalThreeDSecureToken } from './cardinal';
+import CardinalClient, { CardinalOrderData } from './cardinal-client';
+
+export default class CardinalThreeDSecureFlowV2 {
+    constructor(
+        private _store: CheckoutStore,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _cardinalClient: CardinalClient
+    ) {}
+
+    async prepare(method: PaymentMethod): Promise<void> {
+        await this._cardinalClient.load(method.id, method.config.testMode);
+    }
+
+    async start(
+        execute: PaymentStrategy['execute'],
+        payload: OrderRequestBody,
+        options?: PaymentRequestOptions,
+        hostedForm?: HostedForm
+    ): Promise<InternalCheckoutSelectors> {
+        const { instruments: { getCardInstrument } } = this._store.getState();
+        const { payment = { methodId: '' } } = payload;
+        const { paymentData = {} } = payment;
+
+        try {
+            return await execute(payload, options);
+        } catch (error) {
+            if (error instanceof RequestError && error.body.status === 'additional_action_required') {
+                const token = error.body.additional_action_required?.data?.token;
+                const xid = error.body.three_ds_result?.payer_auth_request;
+
+                await this._cardinalClient.configure(token);
+
+                const bin = this._getBin(paymentData, getCardInstrument, hostedForm);
+
+                if (bin) {
+                    await this._cardinalClient.runBinProcess(bin);
+                }
+
+                try {
+                    return await this._submitPayment(payment, { xid }, hostedForm);
+                } catch (error) {
+                    if (error instanceof RequestError && some(error.body.errors, {code: 'three_d_secure_required'})) {
+                        const threeDsResult = error.body.three_ds_result;
+                        const token = threeDsResult?.payer_auth_request;
+
+                        await this._cardinalClient.getThreeDSecureData(threeDsResult, this._getOrderData());
+
+                        return await this._submitPayment(payment, { token }, hostedForm);
+                    }
+
+                    throw error;
+                }
+            }
+
+            throw error;
+        }
+    }
+
+    private _getOrderData(): CardinalOrderData {
+        const store = this._store.getState();
+        const billingAddress = store.billingAddress.getBillingAddressOrThrow();
+        const shippingAddress = store.shippingAddress.getShippingAddress();
+        const { cart: { currency: { code: currencyCode }, cartAmount: amount } } = store.checkout.getCheckoutOrThrow();
+        const id = store.order.getOrderOrThrow().orderId.toString();
+
+        return { billingAddress, shippingAddress, currencyCode, id, amount };
+    }
+
+    private async _submitPayment(
+        payment: OrderPaymentRequestBody,
+        threeDSecure: CardinalThreeDSecureToken,
+        hostedForm?: HostedForm
+    ): Promise<InternalCheckoutSelectors> {
+        const paymentPayload = merge({}, payment, { paymentData: { threeDSecure } });
+
+        if (!hostedForm) {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload));
+        }
+
+        await hostedForm.submit(paymentPayload);
+
+        return this._store.getState();
+    }
+
+    private _getBin(
+        paymentData: NonNullable<OrderPaymentRequestBody['paymentData']>,
+        getCardInstrument: InstrumentSelector['getCardInstrument'],
+        hostedForm?: HostedForm
+    ): string {
+        const instrument = isVaultedInstrument(paymentData) && getCardInstrument(paymentData.instrumentId);
+        const ccNumber = isCreditCardLike(paymentData) && paymentData.ccNumber;
+        const bin = instrument ?
+            instrument.iin :
+            hostedForm ?
+                hostedForm?.getBin() :
+                ccNumber;
+
+        return bin || '';
+    }
+}

--- a/src/payment/strategies/cardinal/cardinal.ts
+++ b/src/payment/strategies/cardinal/cardinal.ts
@@ -1,3 +1,5 @@
+import { ThreeDSecure, ThreeDSecureToken } from '../../payment';
+
 export const CardinalSignatureValidationErrors = [100004, 1010, 1011, 1020];
 
 export interface CardinalSDK {
@@ -69,7 +71,7 @@ export interface CardinalValidatedData {
     ActionCode?: CardinalValidatedAction;
     ErrorDescription: string;
     ErrorNumber: number;
-    Validated: boolean;
+    Validated?: boolean;
     Payment?: CardinalPayment;
 }
 
@@ -141,6 +143,7 @@ export type CardinalCCAExtendedData = Partial<{
     SignatureVerification: string;
     XID: string;
     UCAFIndicator: string;
+    ChallengeCancel: string;
 }>;
 
 export enum CardinalEventType {
@@ -176,3 +179,5 @@ export enum CardinalSignatureVerification {
     Yes = 'Y',
     No = 'N',
 }
+
+export type CardinalThreeDSecureToken = Pick<ThreeDSecure, 'xid'> | ThreeDSecureToken;

--- a/src/payment/strategies/cardinal/index.ts
+++ b/src/payment/strategies/cardinal/index.ts
@@ -1,5 +1,6 @@
 export * from './cardinal';
 
 export { default as CardinalThreeDSecureFlow } from './cardinal-three-d-secure-flow';
+export { default as CardinalThreeDSecureFlowV2 } from './cardinal-three-d-secure-flow-v2';
 export { default as CardinalScriptLoader } from './cardinal-script-loader';
 export { default as CardinalClient, CardinalOrderData, CardinalSupportedPaymentInstrument } from './cardinal-client';


### PR DESCRIPTION
## What? [INT-3438](https://jira.bigcommerce.com/browse/INT-3438)
1. Creates 'Barclays' payment strategy and makes it available in checkout.
2. Creates a new version of Cardinal 3DS Flow to be used in this integration and planned to be used in future ones.

## Why?
A new payment strategy is required to support Barclays with Cardinal 3DS v2

## Testing / Proof
CircleCI

Ping @bigcommerce/apex-integrations @bigcommerce/checkout @bigcommerce/payments