### PR TITLE
feat(payments): PAYPAL-800 PPCP: Pay-in-3

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -155,20 +155,28 @@ describe('PaypalCommerceButtonStrategy', () => {
         expect(paypalCommercePaymentProcessor.renderButtons).toHaveBeenCalledWith(cart.id, `#${options.containerId}`, buttonOption);
     });
 
-    it('render PayPal messaging with credit enabled', async () => {
-        paymentMethod.initializationData.isPayPalCreditAvailable = true;
+    it('do not render PayPal messaging without banner element', async () => {
+        const containerId = 'paypal-commerce-cart-messaging-banner';
+        expect(document.getElementById(containerId)).toBeNull();
+
+        await strategy.initialize(options);
+
+        expect(paypalCommercePaymentProcessor.renderMessages).not.toHaveBeenCalled();
+    });
+
+    it('render PayPal messaging with banner element', async () => {
+        const containerId = 'paypal-commerce-cart-messaging-banner';
+        let container: HTMLDivElement;
+        container = document.createElement('div');
+        container.setAttribute('id', containerId);
+        document.body.appendChild(container);
+        expect(document.getElementById(containerId)).not.toBeNull();
 
         await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
 
         await strategy.initialize(options);
 
         expect(paypalCommercePaymentProcessor.renderMessages).toHaveBeenCalledWith(cart.cartAmount, `#${paypalOptions.messagingContainer}`);
-    });
-
-    it('render PayPal messaging with credit disabled', async () => {
-        await strategy.initialize(options);
-
-        expect(paypalCommercePaymentProcessor.renderMessages).not.toHaveBeenCalled();
     });
 
     it('post payment details to server to set checkout data when PayPalCommerce payment details are tokenized', async () => {

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -39,8 +39,10 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         await this._paypalCommercePaymentProcessor.initialize(this._getParamsScript(initializationData, cart));
 
         this._paypalCommercePaymentProcessor.renderButtons(cart.id, `#${options.containerId}`, buttonParams);
-        if (initializationData.isPayPalCreditAvailable && options.paypalCommerce?.messagingContainer) {
-            this._paypalCommercePaymentProcessor.renderMessages(cart.cartAmount, `#${options.paypalCommerce?.messagingContainer}`);
+
+        const containerId = options.paypalCommerce?.messagingContainer;
+        if (containerId && document.getElementById(containerId)) {
+            this._paypalCommercePaymentProcessor.renderMessages(cart.cartAmount, `#${containerId}`);
         }
 
         return Promise.resolve();

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -36,13 +36,15 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             buttonParams.style = options.paypalCommerce.style;
         }
 
-        await this._paypalCommercePaymentProcessor.initialize(this._getParamsScript(initializationData, cart));
+        const messagingContainer = options.paypalCommerce?.messagingContainer;
+        const isMessagesAvailable = Boolean(messagingContainer && document.getElementById(messagingContainer));
+
+        await this._paypalCommercePaymentProcessor.initialize(this._getParamsScript(initializationData, cart, isMessagesAvailable));
 
         this._paypalCommercePaymentProcessor.renderButtons(cart.id, `#${options.containerId}`, buttonParams);
 
-        const containerId = options.paypalCommerce?.messagingContainer;
-        if (containerId && document.getElementById(containerId)) {
-            this._paypalCommercePaymentProcessor.renderMessages(cart.cartAmount, `#${containerId}`);
+        if (isMessagesAvailable) {
+            this._paypalCommercePaymentProcessor.renderMessages(cart.cartAmount, `#${messagingContainer}`);
         }
 
         return Promise.resolve();
@@ -71,14 +73,16 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         });
     }
 
-    private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart): PaypalCommerceScriptParams {
+    private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart, isMessagesAvailable: boolean): PaypalCommerceScriptParams {
         const { clientId, intent, isPayPalCreditAvailable, merchantId } = initializationData;
         const disableFunding: DisableFundingType = [ 'card' ];
         const components: ComponentsScriptType = ['buttons'];
 
         if (!isPayPalCreditAvailable) {
             disableFunding.push('credit');
-        } else {
+        }
+
+        if (isMessagesAvailable) {
             components.push('messages');
         }
 


### PR DESCRIPTION
## What?
As a GB sellers
I want to enable Pay-in-3 option
So that I can increase my sales volume

## Why?
We need to extend logic to enable Pay-in-3 banners on Card

## Testing / Proof
Tests updated
Manual testing
<img width="1307" alt="Screenshot 2020-11-10 at 11 02 37" src="https://user-images.githubusercontent.com/54856617/98652521-71dd2a00-2344-11eb-91d5-b4ae5b18178e.png">


@bigcommerce/checkout @bigcommerce/payments
