### PR TITLE
feat(payments): PAYPAL-839 Move method_id in execute

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -246,9 +246,9 @@ describe('PaypalCommercePaymentStrategy', () => {
                         vault_payment_instrument: null,
                         set_as_default_stored_instrument: null,
                         device_info: null,
+                        method_id: 'paypalcommerce',
                         paypal_account: {
                             order_id: paymentMethod.initializationData.orderId,
-                            method_id: 'paypal',
                         },
                     },
                 },
@@ -278,9 +278,9 @@ describe('PaypalCommercePaymentStrategy', () => {
                         vault_payment_instrument: null,
                         set_as_default_stored_instrument: null,
                         device_info: null,
+                        method_id: 'przelewy24',
                         paypal_account: {
                             order_id: paymentMethod.initializationData.orderId,
-                            method_id: 'przelewy24',
                         },
                     },
                 },


### PR DESCRIPTION
## What?
Move method_id in execute

## Why?
During the implementation of APMs, we implemented it they it reflects the name of the provider for each order PayPal commerce.
However, in order to calculate GMV per each particular APM we have to reflect each APM name in the order in the way like - payment method - PayPal (Sofort).

We need to pass `method_id` in request to bigpay for purchase

## Testing / Proof
Manual, unit

@bigcommerce/checkout @bigcommerce/payments
