### PR TITLE
feat(payment): PAYPAL-837 Submit cardholder name to PayPal

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
@@ -151,7 +151,10 @@ describe('PaypalCommerceHostedForm', () => {
         await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
         await hostedForm.submit(true);
 
-        expect(paypalCommercePaymentProcessor.submitHostedFields).toHaveBeenCalledWith(true);
+        expect(paypalCommercePaymentProcessor.submitHostedFields).toHaveBeenCalledWith({
+            cardholderName: '',
+            contingencies: ['3D_SECURE'],
+        });
     });
 
     it('throw error if 3ds is enabled and failed during sending', async () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
@@ -2,7 +2,7 @@ import { isNil, kebabCase, omitBy } from 'lodash';
 
 import { PaymentInvalidFormError, PaymentInvalidFormErrorDetails, PaymentMethodFailedError } from '../../errors';
 
-import { PaypalCommerceFormFieldStyles, PaypalCommerceFormFieldStylesMap, PaypalCommerceFormFieldType, PaypalCommerceFormFieldValidateErrorData, PaypalCommerceFormFieldValidateEventData, PaypalCommerceFormOptions, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommercePaymentProcessor, PaypalCommerceRegularField, PaypalCommerceScriptParams } from './index';
+import { PaypalCommerceFormFieldStyles, PaypalCommerceFormFieldStylesMap, PaypalCommerceFormFieldType, PaypalCommerceFormFieldValidateErrorData, PaypalCommerceFormFieldValidateEventData, PaypalCommerceFormOptions, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceHostedFieldsSubmitOptions, PaypalCommercePaymentProcessor, PaypalCommerceRegularField, PaypalCommerceScriptParams } from './index';
 import { PaypalCommerceFormFieldsMap, PaypalCommerceStoredCardFieldsMap } from './paypal-commerce-payment-initialize-options';
 
 enum PaypalCommerceHostedFormType {
@@ -52,8 +52,12 @@ export default class PaypalCommerceHostedForm {
 
     async submit(is3dsEnabled?: boolean): Promise<PaypalCommerceHostedFieldsApprove> {
         this.validate();
+        const options: PaypalCommerceHostedFieldsSubmitOptions = {
+            cardholderName: this._cardNameField?.getValue(),
+            contingencies: is3dsEnabled ? ['3D_SECURE'] : undefined,
+        };
 
-        const result = await this._paypalCommercePaymentProcessor.submitHostedFields(is3dsEnabled);
+        const result = await this._paypalCommercePaymentProcessor.submitHostedFields(options);
 
         if (is3dsEnabled && (result.liabilityShift === 'NO' || result.liabilityShift === 'UNKNOWN')) {
             throw new PaymentMethodFailedError('Failed authentication. Please try to authorize again.');

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
@@ -381,9 +381,12 @@ describe('PaypalCommercePaymentProcessor', () => {
         it('submit Hosted Fields when call submitHostedFields', async () => {
             await paypalCommercePaymentProcessor.initialize(initOptions);
             await paypalCommercePaymentProcessor.renderHostedFields(cart.id, hostedFormOptions);
-            await paypalCommercePaymentProcessor.submitHostedFields();
+            await paypalCommercePaymentProcessor.submitHostedFields({
+                cardholderName: 'cardholderName',
+                contingencies: undefined,
+            });
 
-            expect(submit).toHaveBeenCalled();
+            expect(submit).toHaveBeenCalledWith({ cardholderName: 'cardholderName' });
         });
 
         it('submitHostedFields should return orderId', async () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -1,3 +1,5 @@
+import { isNil, omitBy } from 'lodash';
+
 import { NotImplementedError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
@@ -120,17 +122,12 @@ export default class PaypalCommercePaymentProcessor {
         }
     }
 
-    async submitHostedFields(is3dsEnabled?: boolean): Promise<PaypalCommerceHostedFieldsApprove> {
+    async submitHostedFields(options?: PaypalCommerceHostedFieldsSubmitOptions): Promise<PaypalCommerceHostedFieldsApprove> {
         if (!this._hostedFields) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
-        const options: PaypalCommerceHostedFieldsSubmitOptions = {};
 
-        if (is3dsEnabled) {
-            options.contingencies = ['3D_SECURE'];
-        }
-
-        return this._hostedFields.submit(options);
+        return this._hostedFields.submit(omitBy(options, isNil));
     }
 
     getHostedFieldsValidationState(): { isValid: boolean; fields: PaypalCommerceHostedFieldsState['fields'] } {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -94,6 +94,7 @@ export interface PaypalCommerceHostedFieldsRenderOptions {
 
 export interface PaypalCommerceHostedFieldsSubmitOptions {
     contingencies?: Array<'3D_SECURE'>;
+    cardholderName?: string;
 }
 
 export interface PaypalCommerceHostedFieldsApprove {


### PR DESCRIPTION
## What?
Submit cardholder name to PayPal

## Why?
We need to send cardholder name to PayPal when the order is placed through the credit card method of PPCP.

## Testing / Proof
Manual, unit

@bigcommerce/checkout @bigcommerce/payments
