### PR TITLE
feat(payment): PAYPAL-787 TypeError: Cannot read property 'orderId' of null

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -24,7 +24,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
     async initialize({ gatewayId, methodId, paypalcommerce }: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { paymentMethods: { getPaymentMethodOrThrow }, cart: { getCartOrThrow } } = this._store.getState();
         const { initializationData } = getPaymentMethodOrThrow(methodId, gatewayId);
-        const { orderId, buttonStyle } = initializationData;
+        const { orderId, buttonStyle } = initializationData ?? {};
 
         if (orderId) {
             this._orderId = orderId;


### PR DESCRIPTION
## What?
TypeError: Cannot read property 'orderId' of null

## Why?
According to task PAYPAL-787

## Testing / Proof
tested on dev
@bigcommerce/checkout @bigcommerce/payments @davidchin 
