### PR TITLE
feat(payment): PAYPAL-848 Add messages to script

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -155,25 +155,6 @@ describe('PaypalCommerceButtonStrategy', () => {
         expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
     });
 
-    it('initializes PaypalCommerce and PayPal credit enabled & messaging disabled', async () => {
-        paymentMethod.initializationData.isPayPalCreditAvailable = true;
-        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
-        document.body.removeChild(messageContainer);
-
-        await strategy.initialize(options);
-
-        const obj = {
-            'client-id': 'abc',
-            commit: false,
-            currency: 'USD',
-            intent: 'capture',
-            components: ['buttons'],
-            'disable-funding': ['card'],
-        };
-
-        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
-    });
-
     it('render PayPal buttons', async () => {
         await strategy.initialize(options);
 

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -3,7 +3,7 @@ import { FormPoster } from '@bigcommerce/form-poster';
 import { Cart } from '../../../cart';
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { ApproveDataOptions, ButtonsOptions, ClickDataOptions, ComponentsScriptType, DisableFundingType, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceScriptParams } from '../../../payment/strategies/paypal-commerce';
+import { ApproveDataOptions, ButtonsOptions, ClickDataOptions, DisableFundingType, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceScriptParams } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
@@ -39,7 +39,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         const messagingContainer = options.paypalCommerce?.messagingContainer;
         const isMessagesAvailable = Boolean(messagingContainer && document.getElementById(messagingContainer));
 
-        await this._paypalCommercePaymentProcessor.initialize(this._getParamsScript(initializationData, cart, isMessagesAvailable));
+        await this._paypalCommercePaymentProcessor.initialize(this._getParamsScript(initializationData, cart));
 
         this._paypalCommercePaymentProcessor.renderButtons(cart.id, `#${options.containerId}`, buttonParams);
 
@@ -73,17 +73,12 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         });
     }
 
-    private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart, isMessagesAvailable: boolean): PaypalCommerceScriptParams {
+    private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart): PaypalCommerceScriptParams {
         const { clientId, intent, isPayPalCreditAvailable, merchantId } = initializationData;
         const disableFunding: DisableFundingType = [ 'card' ];
-        const components: ComponentsScriptType = ['buttons'];
 
         if (!isPayPalCreditAvailable) {
             disableFunding.push('credit');
-        }
-
-        if (isMessagesAvailable) {
-            components.push('messages');
         }
 
         return {
@@ -91,7 +86,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             'merchant-id': merchantId,
             commit: false,
             currency: cart.currency.code,
-            components,
+            components: ['buttons', 'messages'],
             'disable-funding': disableFunding,
             intent,
         };

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -32,6 +32,10 @@ describe('PaypalCommerceScriptLoader', () => {
         paypalLoader = new PaypalCommerceScriptLoader(loader);
     });
 
+    afterEach(() => {
+        (window as PaypalCommerceHostWindow).paypalLoadScript = undefined;
+    });
+
     describe('loads PayPalCommerce script with client Id, currency EUR, intent, disableFunding, commit', () => {
         const params: PaypalCommerceScriptParams = {
             'client-id': 'aaa',

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -17,12 +17,14 @@ export default class PaypalCommerceScriptLoader {
     async loadPaypalCommerce(params: PaypalCommerceScriptParams, isProgressiveOnboardingAvailable?: boolean): Promise<PaypalCommerceSDK> {
         this._validateParams(params, isProgressiveOnboardingAvailable);
 
-        const scriptSrc = 'https://unpkg.com/@paypal/paypal-js@1.0.2/dist/paypal.browser.min.js';
-
-        await this._scriptLoader.loadScript(scriptSrc, { async: true, attributes: {} });
-
         if (!this._window.paypalLoadScript) {
-            throw new PaymentMethodClientUnavailableError();
+            const scriptSrc = 'https://unpkg.com/@paypal/paypal-js@1.0.2/dist/paypal.browser.min.js';
+
+            await this._scriptLoader.loadScript(scriptSrc, {async: true, attributes: {}});
+
+            if (!this._window.paypalLoadScript) {
+                throw new PaymentMethodClientUnavailableError();
+            }
         }
 
         await this._window.paypalLoadScript(params);


### PR DESCRIPTION
## What?
Add `messages` to `components` in PayPal script always in the PaypalCommerceButtonStrategy

## Why?
It needs for credit banners. PayPal recommends us to use SDK for banners in the way it is implemented on the cart page

Related task https://github.com/bigcommerce/content/pull/615

## Testing / Proof
https://www.loom.com/share/252298feb82047f388deb0f55a9a95d6

@bigcommerce/checkout @bigcommerce/payments
