### PR TITLE
feat(payments): PAYPAL-847 Add PPCP to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,35 @@ await service.initializePayment({
 });
 ```
 
+Also, [PayPal](https://support.bigcommerce.com/s/article/Connecting-with-PayPal) (also known as PayPal Commerce Platform) requires specific options to initialize the PayPal Smart Payment Button on checkout page that substitutes a standard submit button
+
+```html
+<!-- This is where the PayPal button will be inserted -->
+<div id="container"></div>
+```
+
+```js
+service.initializePayment({
+    methodId: 'paypalcommerce',
+    paypalcommerce: {
+        container: '#container',
+        submitForm: () => {
+            service.submitOrder({ methodId: 'paypalcommerce', });
+        },
+        onValidate: (resolve, reject) => {
+            const isValid = service.validatePaymentForm();
+            if (isValid) {
+                return resolve();
+            }
+            return reject();
+        },
+        onRenderButton: () => {
+            service.hidePaymentSubmitButton();
+        }
+    },
+});
+```
+
 #### Submit order
 
 And then, you can ask the customer to provide payment details required by their chosen payment method. If the method is executed successfully, you will create an order and thereby complete the checkout process.

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-initialize-options.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-initialize-options.ts
@@ -17,7 +17,7 @@ export type PaypalCommerceInitializeOptions = PaypalCommercePaymentInitializeOpt
  * service.initializePayment({
  *     methodId: 'paypalcommerce',
  *     paypalcommerce: {
- *         container: 'container',
+ *         container: '#container',
  *         submitForm: () => {
  *             service.submitOrder({
  *                 methodId: 'paypalcommerce',


### PR DESCRIPTION
## What?
Add PPCP to README

## Why?
For the checkout-sdk readme file, we need to mention that Paypal Commerce has specific options for the initialization (as it is mentioned for Amazon)

## Testing / Proof
<img width="1278" alt="Screenshot 2020-11-18 at 12 38 30" src="https://user-images.githubusercontent.com/32959076/99519783-f827ea80-299a-11eb-9a85-0aedae54e5f1.png">

@bigcommerce/checkout @bigcommerce/payments
