### PR TITLE
feat(checkout): INT-2544 Create strategy For redirect flow on checkout.com APMs

### DIFF
--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -1,4 +1,4 @@
-import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument } from '../payment';
+import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithDocumentInstrument } from '../payment';
 
 /**
  * An object that contains the information required for submitting an order.
@@ -39,5 +39,5 @@ export interface OrderPaymentRequestBody {
      * An object that contains the details of a credit card, vaulted payment
      * instrument or nonce instrument.
      */
-    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument;
+    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument;
 }

--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -16,8 +16,10 @@ import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy } from './strategies/braintree';
 import { ChasepayPaymentStrategy } from './strategies/chasepay';
+import { CheckoutcomAPMPaymentStrategy } from './strategies/checkoutcom-apm';
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
+import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource';
 import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
 import { GooglePayPaymentStrategy } from './strategies/googlepay';
@@ -113,6 +115,16 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate chasepay', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.CHASE_PAY);
         expect(paymentStrategy).toBeInstanceOf(ChasepayPaymentStrategy);
+    });
+
+    it('can instantiate checkout.com', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CHECKOUTCOM);
+        expect(paymentStrategy).toBeInstanceOf(CreditCardRedirectPaymentStrategy);
+    });
+
+    it('can instantiate checkout.com apms', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CHECKOUTCOM_APM);
+        expect(paymentStrategy).toBeInstanceOf(CheckoutcomAPMPaymentStrategy);
     });
 
     it('can instantiate converge', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -32,6 +32,7 @@ import { BoltPaymentStrategy, BoltScriptLoader } from './strategies/bolt';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVisaCheckoutPaymentStrategy, VisaCheckoutScriptLoader } from './strategies/braintree';
 import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow, CardinalThreeDSecureFlowV2 } from './strategies/cardinal';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
+import { CheckoutcomAPMPaymentStrategy } from './strategies/checkoutcom-apm';
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
@@ -570,6 +571,15 @@ export default function createPaymentStrategyRegistry(
             paymentMethodActionCreator,
             storeCreditActionCreator,
             new BoltScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM_APM, () =>
+        new CheckoutcomAPMPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
         )
     );
 

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -20,7 +20,8 @@ export {
     PaymentInstrumentMeta,
     NonceInstrument,
     ThreeDSecure,
-    ThreeDSecureToken
+    ThreeDSecureToken,
+    WithDocumentInstrument
 } from './payment';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';

--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -53,6 +53,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'checkoutcom',
         method: 'credit_card',
     },
+    'checkoutcom.credit_card': {
+        provider: 'checkoutcom',
+        method: 'credit_card',
+    },
     stripe: {
         provider: 'stripe',
         method: 'credit_card',

--- a/src/payment/payment-response-body.ts
+++ b/src/payment/payment-response-body.ts
@@ -6,6 +6,7 @@ export default interface PaymentResponseBody {
     three_ds_result: ThreeDsResult | {};
     fraud_review: boolean;
     transaction_type: string;
+    additional_action_required?: AdditionalActionRequired;
     errors?: Array<{
         code: string;
         message: string;
@@ -29,4 +30,17 @@ export interface ThreeDsResult {
     payer_auth_request: string;
     merchant_data: string;
     callback_url: string;
+}
+
+export interface AdditionalActionRequired {
+    type: AdditionalActionType;
+    data: AdditionalRedirectData;
+}
+
+export interface AdditionalRedirectData {
+    redirect_url: string;
+}
+
+export enum AdditionalActionType {
+    OffsiteRedirect = 'offsite_redirect',
 }

--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -45,6 +45,15 @@ export default class PaymentStrategyRegistry extends Registry<PaymentStrategy, P
             return PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS;
         }
 
+        if (paymentMethod.gateway === PaymentStrategyType.CHECKOUTCOM) {
+            switch (paymentMethod.id) {
+                case 'credit_card':
+                    return PaymentStrategyType.CHECKOUTCOM;
+                default:
+                    return PaymentStrategyType.CHECKOUTCOM_APM;
+            }
+        }
+
         const methodId = paymentMethod.gateway || paymentMethod.id;
 
         if (this._hasFactoryForMethod(methodId)) {

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -10,6 +10,7 @@ enum PaymentStrategyType {
     BLUESNAPV2 = 'bluesnapv2',
     BOLT = 'bolt',
     CHECKOUTCOM = 'checkoutcom',
+    CHECKOUTCOM_APM = 'checkoutcomapm',
     CREDIT_CARD = 'creditcard',
     CHECKOUTCOM_GOOGLE_PAY = 'googlepaycheckoutcom',
     CYBERSOURCE = 'cybersource',

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -13,8 +13,9 @@ export default interface Payment {
 export type PaymentInstrument = (
     CreditCardInstrument |
     CreditCardInstrument & WithHostedFormNonce |
+    CreditCardInstrument & WithDocumentInstrument |
     CryptogramInstrument |
-    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument> |
+    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument> |
     HostedInstrument |
     NonceInstrument |
     ThreeDSVaultedInstrument |
@@ -40,6 +41,10 @@ export interface CreditCardInstrument {
     shouldSetAsDefaultInstrument?: boolean;
     extraData?: any;
     threeDSecure?: ThreeDSecure | ThreeDSecureToken;
+}
+
+export interface WithDocumentInstrument {
+    ccDocument: string;
 }
 
 export interface WithHostedFormNonce {

--- a/src/payment/strategies/checkoutcom-apm/checkoutcom-apm-payment-strategy.spec.ts
+++ b/src/payment/strategies/checkoutcom-apm/checkoutcom-apm-payment-strategy.spec.ts
@@ -1,0 +1,341 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { merge, omit } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../hosted-form';
+import { FinalizeOrderAction, LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getOrder } from '../../../order/orders.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import { getPaymentMethod } from '../../payment-methods.mock';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+import * as paymentStatusTypes from '../../payment-status-types';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+
+import CheckoutcomAPMPaymentStrategy from './checkoutcom-apm-payment-strategy';
+
+describe('CheckoutcomAPMPaymentStrategy', () => {
+    let formFactory: HostedFormFactory;
+    let finalizeOrderAction: Observable<FinalizeOrderAction>;
+    let formPoster: FormPoster;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let orderRequestSender: OrderRequestSender;
+    let strategy: CheckoutcomAPMPaymentStrategy;
+    let submitOrderAction: Observable<SubmitOrderAction>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+    let state: InternalCheckoutSelectors;
+
+    beforeEach(() => {
+        formFactory = new HostedFormFactory(store);
+        requestSender = createRequestSender();
+        orderRequestSender = new OrderRequestSender(requestSender);
+        orderActionCreator = new OrderActionCreator(
+            orderRequestSender,
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        formPoster = createFormPoster();
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(store, 'dispatch');
+
+        state = store.getState();
+
+        jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(getPaymentMethod());
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockImplementation((_url, _data, callback = () => {}) => callback());
+
+        jest.spyOn(orderActionCreator, 'finalizeOrder')
+            .mockReturnValue(finalizeOrderAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        strategy = new CheckoutcomAPMPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formFactory
+        );
+    });
+
+    it('submits order without payment data', async () => {
+        const payload = getOrderRequestBody();
+        const options = { methodId: 'methodId' };
+
+        await strategy.execute(payload, options);
+
+        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), options);
+        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    });
+
+    it('submits document field when methodId is supported', async () => {
+        const paymentWithDocument = {
+            payment: {
+                methodId: 'oxxo',
+                gatewayId: 'checkoutcom',
+                paymentData: {
+                    ccDocument: 'card-document',
+                },
+            },
+        };
+        const payload = merge(getOrderRequestBody(), paymentWithDocument);
+        const options = { methodId: 'oxxo' };
+
+        const expectedPayment = merge(payload.payment, { paymentData: { formattedPayload: { ccDocument: 'card-document' }}});
+
+        await strategy.execute(payload, options);
+
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+    });
+
+    it('returns checkout state', async () => {
+        const output = await strategy.execute(getOrderRequestBody());
+
+        expect(output).toEqual(store.getState());
+    });
+
+    it('redirects to target url when additional action redirect is provided', async () => {
+        const error = new RequestError(getResponse({
+            ...getErrorPaymentResponseBody(),
+            errors: [],
+            additional_action_required: {
+                data: {
+                    redirect_url: 'http://redirect-url.com',
+                },
+                type: 'offsite_redirect',
+            },
+            three_ds_result: {},
+            status: 'error',
+        }));
+
+        window.location.replace = jest.fn();
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+        strategy.execute(getOrderRequestBody());
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(window.location.replace).toBeCalledWith('http://redirect-url.com');
+    });
+
+    it('does not redirect to target url if additional action is not provided', async () => {
+        const response = new RequestError(getResponse(getErrorPaymentResponseBody()));
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, response)));
+
+        await expect(strategy.execute(getOrderRequestBody())).rejects.toThrow(RequestError);
+        expect(formPoster.postForm).not.toHaveBeenCalled();
+    });
+
+    it('finalizes order if order is created and payment is finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(getOrder());
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.FINALIZE);
+
+        await strategy.finalize();
+
+        expect(orderActionCreator.finalizeOrder).toHaveBeenCalled();
+        expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not created', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.INITIALIZE);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('throws error if order is missing', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+    });
+
+    describe('when hosted form is enabled', () => {
+        let form: Pick<HostedForm, 'attach' | 'submit' | 'validate'>;
+        let initializeOptions: PaymentInitializeOptions;
+        let loadOrderAction: Observable<LoadOrderSucceededAction>;
+        let state: InternalCheckoutSelectors;
+
+        beforeEach(() => {
+            form = {
+                attach: jest.fn(() => Promise.resolve()),
+                submit: jest.fn(() => Promise.resolve()),
+                validate: jest.fn(() => Promise.resolve()),
+            };
+            initializeOptions = {
+                creditCard: {
+                    form: {
+                        fields: {
+                            [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                            [HostedFieldType.CardName]: { containerId: 'card-name' },
+                            [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                        },
+                    },
+                },
+                methodId: 'checkoutcom',
+            };
+            loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
+            state = store.getState();
+
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(merge(
+                    getPaymentMethod(),
+                    { config: { isHostedFormEnabled: true } }
+                ));
+
+            jest.spyOn(orderActionCreator, 'loadCurrentOrder')
+                .mockReturnValue(loadOrderAction);
+
+            jest.spyOn(formFactory, 'create')
+                .mockReturnValue(form);
+        });
+
+        it('creates hosted form', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(formFactory.create)
+                .toHaveBeenCalledWith(
+                    'https://bigpay.integration.zone',
+                    // tslint:disable-next-line:no-non-null-assertion
+                    initializeOptions.creditCard!.form!
+                );
+        });
+
+        it('attaches hosted form to container', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(form.attach)
+                .toHaveBeenCalled();
+        });
+
+        it('submits payment data with hosted form', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(form.submit)
+                .toHaveBeenCalledWith(payload.payment);
+        });
+
+        it('validates user input before submitting data', async () => {
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(getOrderRequestBody());
+
+            expect(form.validate)
+                .toHaveBeenCalled();
+        });
+
+        it('does not submit payment data with hosted form if validation fails', async () => {
+            jest.spyOn(form, 'validate')
+                .mockRejectedValue(new Error());
+
+            try {
+                await strategy.initialize(initializeOptions);
+                await strategy.execute(getOrderRequestBody());
+            } catch (error) {
+                expect(form.submit)
+                    .not.toHaveBeenCalled();
+            }
+        });
+
+        it('loads current order after payment submission', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(loadOrderAction);
+        });
+
+        it('redirects to target url when additional action redirect is provided', async () => {
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [],
+                additional_action_required: {
+                    data: {
+                        redirect_url: 'http://redirect-url.com',
+                    },
+                    type: 'offsite_redirect',
+                },
+                three_ds_result: {},
+                status: 'error',
+            }));
+
+            window.location.replace = jest.fn();
+
+            jest.spyOn(form, 'submit')
+                .mockRejectedValue(error);
+
+            await strategy.initialize(initializeOptions);
+            strategy.execute(getOrderRequestBody());
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(window.location.replace).toBeCalledWith('http://redirect-url.com');
+            expect(orderActionCreator.loadCurrentOrder)
+                .not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/payment/strategies/checkoutcom-apm/checkoutcom-apm-payment-strategy.ts
+++ b/src/payment/strategies/checkoutcom-apm/checkoutcom-apm-payment-strategy.ts
@@ -1,0 +1,102 @@
+import { InternalCheckoutSelectors } from '../../../checkout';
+import { NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
+import { OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import { PaymentInstrument, WithDocumentInstrument } from '../../payment';
+import { PaymentRequestOptions } from '../../payment-request-options';
+import { AdditionalActionRequired, AdditionalActionType } from '../../payment-response-body';
+import * as paymentStatusTypes from '../../payment-status-types';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+export default class CheckoutcomAPMPaymentStrategy extends CreditCardPaymentStrategy {
+
+    finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const order = state.order.getOrder();
+
+        if (order && state.payment.getPaymentStatus() === paymentStatusTypes.FINALIZE) {
+            return this._store.dispatch(this._orderActionCreator.finalizeOrder(order.orderId, options));
+        }
+
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    protected async _executeWithoutHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+        const paymentData = payment && payment.paymentData;
+
+        if (!payment || !paymentData) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+        const _paymentData = {
+            ...paymentData,
+            formattedPayload: this._createFormattedPayload(payment.methodId, paymentData),
+        };
+
+        try {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData: _paymentData }));
+        } catch (error) {
+            return this._processResponse(error);
+        }
+    }
+
+    protected async _executeWithHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors>  {
+        const { payment, ...order } = payload;
+        const form = this._hostedForm;
+
+        if (!form) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (!payment || !payment.methodId) {
+            throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+
+        try {
+            await form.validate();
+            await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+            await form.submit(payment);
+        } catch (error) {
+            return this._processResponse(error);
+        }
+
+        return await this._store.dispatch(this._orderActionCreator.loadCurrentOrder());
+    }
+
+    private _processResponse(error: RequestError): Promise<InternalCheckoutSelectors> {
+        if (!(error instanceof RequestError)) {
+            return Promise.reject(error);
+        }
+
+        const additionalActionRequired: AdditionalActionRequired = error.body.additional_action_required;
+
+        // TODO validate all possible responses and perform respective additional actions
+        if (additionalActionRequired && additionalActionRequired.type === AdditionalActionType.OffsiteRedirect) {
+            return this._performRedirect(additionalActionRequired);
+        }
+
+        return Promise.reject(error);
+    }
+
+    private _performRedirect(additionalActionRequired: AdditionalActionRequired): Promise<InternalCheckoutSelectors> {
+        return new Promise(() => {
+            window.location.replace(additionalActionRequired.data.redirect_url);
+        });
+    }
+
+    private _createFormattedPayload(methodId: string, paymentData: PaymentInstrument): WithDocumentInstrument {
+        const documentSupportedAPMs = ['boleto', 'oxxo', 'qpay'];
+        const formattedPayload: WithDocumentInstrument = { ccDocument: '' };
+        const { ccDocument: document } = paymentData as WithDocumentInstrument;
+
+        if (documentSupportedAPMs.indexOf(methodId) !== -1 && document) {
+            formattedPayload.ccDocument = document;
+        }
+
+        return formattedPayload;
+    }
+}

--- a/src/payment/strategies/checkoutcom-apm/index.ts
+++ b/src/payment/strategies/checkoutcom-apm/index.ts
@@ -1,0 +1,1 @@
+export { default as CheckoutcomAPMPaymentStrategy } from './checkoutcom-apm-payment-strategy';


### PR DESCRIPTION
## What? [INT-2544](https://jira.bigcommerce.com/browse/INT-2544)
Create a payment strategy that will handle the APMs on checkout.com.
This strategy will handle `additional actions` when submitting payment  such as a redirect and submit special fields as part of the formatted payload such as `document`.

## Why?
This PR establishes the base for the future APM implementation.

## Testing / Proof
This PR has only been tested on development environment to work as expected, and on integrations to keep checkout.com working as is until the new functionality is developed and tested

@bigcommerce/checkout @bigcommerce/payments
