### PR TITLE
feat(payment): INT-3237 Prevent Cardinal downgrade to 3DSv1

### DIFF
--- a/src/payment/strategies/cardinal/cardinal-client.spec.ts
+++ b/src/payment/strategies/cardinal/cardinal-client.spec.ts
@@ -1,7 +1,6 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { MissingDataError, NotInitializedError, StandardError } from '../../../common/error/errors';
-import { PaymentMethodCancelledError } from '../../errors';
 
 import { getCardinalBinProcessResponse, getCardinalOrderData, getCardinalSDK, getCardinalThreeDSResult, getCardinalValidatedData } from './cardinal.mock';
 import { CardinalClient, CardinalEventType, CardinalInitializationType, CardinalPaymentType, CardinalScriptLoader, CardinalSignatureVerification, CardinalSDK, CardinalTriggerEvents, CardinalValidatedAction, CardinalValidatedData } from './index';
@@ -30,58 +29,81 @@ describe('CardinalClient', () => {
     });
 
     describe('#configure', () => {
-        it('throws an error if test mode is not defined', async () => {
-            try {
-                await client.configure('token');
-            } catch (error) {
-                expect(error).toBeInstanceOf(NotInitializedError);
-            }
-        });
+        let completed: () => {};
+        let validated: (data: CardinalValidatedData, jwt: string) => {};
 
-        it('completes the setup process successfully', async () => {
-            let call: () => {};
-
+        beforeEach(() => {
             sdk.on = jest.fn((type, callback) => {
                 if (type.toString() === CardinalEventType.SetupCompleted) {
-                    call = callback;
-                } else {
-                    jest.fn();
+                    completed = callback;
+                }
+
+                if (type.toString() === CardinalEventType.Validated) {
+                    validated = callback;
                 }
             });
+        });
 
-            jest.spyOn(sdk, 'setup').mockImplementation(() => {
-                call();
+        describe('#successfully', () => {
+            beforeEach(async () => {
+                jest.spyOn(sdk, 'setup').mockImplementation(() => {
+                    completed();
+                });
+
+                await client.load('provider', true);
             });
 
-            await client.load('provider', true);
-            await client.configure('token');
+            it('completes the setup process', async () => {
+                await client.configure('token');
 
-            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.SetupCompleted, expect.any(Function));
-            expect(sdk.setup).toHaveBeenCalledWith(CardinalInitializationType.Init, { jwt: 'token' });
+                expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.SetupCompleted, expect.any(Function));
+                expect(sdk.setup).toHaveBeenCalledWith(CardinalInitializationType.Init, { jwt: 'token' });
+            });
+
+            it('reconfigures the cardinal sdk', async () => {
+                await client.configure('firstToken');
+                await client.configure('secondToken');
+
+                expect(cardinalScriptLoader.load)
+                    .toHaveBeenNthCalledWith(2, expect.stringMatching(/^provider/), true);
+                expect(sdk.on)
+                    .toHaveBeenCalledTimes(4);
+                expect(sdk.setup)
+                    .toHaveBeenCalledTimes(2);
+            });
+
+            it('does not reconfigure the cardinal sdk if it\'s the same token', async () => {
+                await client.configure('sameToken');
+                await client.configure('sameToken');
+
+                expect(cardinalScriptLoader.load)
+                    .toHaveBeenNthCalledWith(1, 'provider', true);
+                expect(sdk.on)
+                    .toHaveBeenCalledTimes(2);
+                expect(sdk.setup)
+                    .toHaveBeenCalledTimes(1);
+            });
+        });
+
+        it('throws an error if cardinal sdk is not defined', () => {
+            expect(() => client.configure('token')).toThrow(NotInitializedError);
+
+            expect(cardinalScriptLoader.load)
+                .not.toHaveBeenCalled();
+            expect(sdk.on)
+                .not.toHaveBeenCalled();
+            expect(sdk.setup)
+                .not.toHaveBeenCalled();
         });
 
         it('completes the setup process with error', async () => {
-            let call: (data: CardinalValidatedData, jwt: string) => {};
-
-            sdk.on = jest.fn((type, callback) => {
-                if (type.toString() === CardinalEventType.Validated) {
-                    call = callback;
-                } else {
-                    jest.fn();
-                }
-            });
-
             jest.spyOn(sdk, 'setup').mockImplementation(() => {
-                call(getCardinalValidatedData(CardinalValidatedAction.Error, false, 1020), '');
+                validated(getCardinalValidatedData(CardinalValidatedAction.Error, false, 1020), '');
             });
 
             await client.load('provider', true);
 
-            try {
-                await client.configure('token');
-            } catch (error) {
-                expect(error).toBeInstanceOf(MissingDataError);
-            }
+            return expect(client.configure('token')).rejects.toThrow(MissingDataError);
         });
     });
 
@@ -251,29 +273,6 @@ describe('CardinalClient', () => {
 
             expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.Validated, expect.any(Function));
             expect(promise).toEqual({ token: 'token' });
-        });
-
-        it('throws an error if consumer cancels the challenge', async () => {
-            jest.spyOn(sdk, 'continue').mockImplementation(() => {
-                const data = {
-                    ErrorDescription: 'Success',
-                    ErrorNumber: 0,
-                    Payment: {
-                        ExtendedData: {
-                            ChallengeCancel: '01',
-                        },
-                        ProcessorTransactionId: 'qwerty123',
-                        Type: CardinalPaymentType.CCA,
-                    },
-                };
-                validatedCall(data, 'token');
-            });
-
-            const promise = client.getThreeDSecureData(getCardinalThreeDSResult(), getCardinalOrderData());
-
-            await expect(promise).rejects.toThrow(PaymentMethodCancelledError);
-
-            expect(sdk.on).toHaveBeenCalledWith(CardinalEventType.Validated, expect.any(Function));
         });
 
         it('returns an error without an action code', async () => {


### PR DESCRIPTION
## What? [INT-3237](https://jira.bigcommerce.com/browse/INT-3237)
Allow reconfiguration of the Cardinal SDK and avoid throwing an error if the consumer cancels the challenge.

## Why?
For cardinal flow v2 we need to be able to run the configuration step each time a new `ReferenceId` is generated (this happens each time the user is challenged). Otherwise, browser data won't be collected for the new `ReferenceId` and auth will downgrade to 3DS v1

## Testing / Proof
Manual, Unit / [Demo Video](https://drive.google.com/file/d/1sRMIcIOp9-cJcSElMic-EjtSktQanL_a/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments
