### PR TITLE
feat(payments): INT-3537 Add CYBS One Platform Payment Strategy

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -19,6 +19,7 @@ import { ChasepayPaymentStrategy } from './strategies/chasepay';
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource';
+import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
 import { GooglePayPaymentStrategy } from './strategies/googlepay';
 import { KlarnaPaymentStrategy } from './strategies/klarna';
 import { LegacyPaymentStrategy } from './strategies/legacy';
@@ -121,6 +122,11 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate cybersource', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.CYBERSOURCE);
         expect(paymentStrategy).toBeInstanceOf(CyberSourcePaymentStrategy);
+    });
+
+    it('can instantiate cybersourcev2', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CYBERSOURCEV2);
+        expect(paymentStrategy).toBeInstanceOf(CyberSourceV2PaymentStrategy);
     });
 
     it('can instantiate klarna', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -36,6 +36,7 @@ import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
+import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
 import { ExternalPaymentStrategy } from './strategies/external';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
@@ -223,6 +224,20 @@ export default function createPaymentStrategyRegistry(
                 store,
                 paymentActionCreator,
                 paymentMethodActionCreator,
+                new CardinalClient(new CardinalScriptLoader(scriptLoader))
+            )
+        )
+    );
+
+    registry.register(PaymentStrategyType.CYBERSOURCEV2, () =>
+        new CyberSourceV2PaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory,
+            new CardinalThreeDSecureFlowV2(
+                store,
+                paymentActionCreator,
                 new CardinalClient(new CardinalScriptLoader(scriptLoader))
             )
         )

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -13,6 +13,7 @@ enum PaymentStrategyType {
     CREDIT_CARD = 'creditcard',
     CHECKOUTCOM_GOOGLE_PAY = 'googlepaycheckoutcom',
     CYBERSOURCE = 'cybersource',
+    CYBERSOURCEV2 = 'cybersourcev2',
     KLARNA = 'klarna',
     KLARNAV2 = 'klarnav2',
     LAYBUY = 'laybuy',

--- a/src/payment/strategies/cybersourcev2/cybersourcev2-payment-strategy.spec.ts
+++ b/src/payment/strategies/cybersourcev2/cybersourcev2-payment-strategy.spec.ts
@@ -1,0 +1,148 @@
+import { merge } from 'lodash';
+import { of } from 'rxjs';
+
+import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethod from '../../payment-method';
+import { getCybersource } from '../../payment-methods.mock';
+import { CardinalThreeDSecureFlowV2 } from '../cardinal';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+import CyberSourceV2PaymentStrategy from './cybersourcev2-payment-strategy';
+
+describe('CyberSourceV2PaymentStrategy', () => {
+    let hostedFormFactory: HostedFormFactory;
+    let orderActionCreator: Pick<OrderActionCreator, 'submitOrder'>;
+    let paymentActionCreator: Pick<PaymentActionCreator, 'submitPayment'>;
+    let paymentMethod: PaymentMethod;
+    let state: InternalCheckoutSelectors;
+    let store: CheckoutStore;
+    let strategy: CyberSourceV2PaymentStrategy;
+    let threeDSecureFlow: Pick<CardinalThreeDSecureFlowV2, 'prepare' | 'start'>;
+
+    beforeEach(() => {
+        paymentMethod = {
+            ...getCybersource(),
+            clientToken: 'foo',
+        };
+
+        store = createCheckoutStore();
+
+        orderActionCreator = {
+            submitOrder: jest.fn(() => of()),
+        };
+
+        paymentActionCreator = {
+            submitPayment: jest.fn(() => of()),
+        };
+
+        hostedFormFactory = {} as HostedFormFactory;
+
+        threeDSecureFlow = {
+            prepare: jest.fn(() => Promise.resolve()),
+            start: jest.fn(() => Promise.resolve()),
+        };
+
+        state = store.getState();
+
+        jest.spyOn(store, 'dispatch')
+            .mockResolvedValue(state);
+
+        jest.spyOn(store, 'getState')
+            .mockReturnValue(state);
+
+        jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(paymentMethod);
+
+        strategy = new CyberSourceV2PaymentStrategy(
+            store,
+            orderActionCreator as OrderActionCreator,
+            paymentActionCreator as PaymentActionCreator,
+            hostedFormFactory,
+            threeDSecureFlow as CardinalThreeDSecureFlowV2
+        );
+    });
+
+    it('is special type of credit card strategy', () => {
+        expect(strategy)
+            .toBeInstanceOf(CreditCardPaymentStrategy);
+    });
+
+    describe('#initialize', () => {
+        it('throws error if payment method is not defined', async () => {
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockImplementation(() => { throw new Error(); });
+
+            try {
+                await strategy.initialize({ methodId: paymentMethod.id });
+            } catch (error) {
+                expect(error)
+                    .toBeInstanceOf(Error);
+            }
+        });
+
+        it('does not prepare 3DS flow if not enabled', async () => {
+            paymentMethod.config.is3dsEnabled = false;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(threeDSecureFlow.prepare)
+                .not.toHaveBeenCalled();
+        });
+
+        it('prepares 3DS flow if enabled', async () => {
+            paymentMethod.config.is3dsEnabled = true;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(threeDSecureFlow.prepare)
+                .toHaveBeenCalled();
+        });
+    });
+
+    describe('#execute', () => {
+        let payload: OrderRequestBody;
+
+        beforeEach(() => {
+            payload = merge({}, getOrderRequestBody(), {
+                payment: {
+                    methodId: paymentMethod.id,
+                    gatewayId: paymentMethod.gateway,
+                },
+            });
+        });
+
+        it('throws error if payment method is not defined', async () => {
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockImplementation(() => { throw new Error(); });
+
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error)
+                    .toBeInstanceOf(Error);
+            }
+        });
+
+        it('does not start 3DS flow if not enabled', async () => {
+            paymentMethod.config.is3dsEnabled = false;
+
+            await strategy.execute(payload);
+
+            expect(threeDSecureFlow.start)
+                .not.toHaveBeenCalled();
+        });
+
+        it('starts 3DS flow if enabled', async () => {
+            paymentMethod.config.is3dsEnabled = true;
+
+            await strategy.execute(payload);
+
+            expect(threeDSecureFlow.start)
+                .toHaveBeenCalled();
+        });
+    });
+});

--- a/src/payment/strategies/cybersourcev2/cybersourcev2-payment-strategy.ts
+++ b/src/payment/strategies/cybersourcev2/cybersourcev2-payment-strategy.ts
@@ -1,0 +1,53 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { CardinalThreeDSecureFlowV2 } from '../cardinal';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+export default class CyberSourceV2PaymentStrategy extends CreditCardPaymentStrategy {
+    constructor(
+        store: CheckoutStore,
+        orderActionCreator: OrderActionCreator,
+        paymentActionCreator: PaymentActionCreator,
+        hostedFormFactory: HostedFormFactory,
+        private _threeDSecureFlow: CardinalThreeDSecureFlowV2
+    ) {
+        super(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        );
+    }
+
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        await super.initialize(options);
+
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(options.methodId);
+
+        if (paymentMethod.config.is3dsEnabled) {
+            await this._threeDSecureFlow.prepare(paymentMethod);
+        }
+
+        return this._store.getState();
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment: { methodId = '' } = {} } = payload;
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+
+        if (getPaymentMethodOrThrow(methodId).config.is3dsEnabled) {
+            return this._threeDSecureFlow.start(
+                super.execute.bind(this),
+                payload,
+                options,
+                this._hostedForm
+            );
+        }
+
+        return super.execute(payload, options);
+    }
+}

--- a/src/payment/strategies/cybersourcev2/index.ts
+++ b/src/payment/strategies/cybersourcev2/index.ts
@@ -1,0 +1,1 @@
+export { default as CyberSourceV2PaymentStrategy } from './cybersourcev2-payment-strategy';


### PR DESCRIPTION
## What? [INT-3537](https://jira.bigcommerce.com/browse/INT-3537)


## Why?
I want to offer merchants the possibility to migrate from previous Cybersource integration reducing friction while configuring and adding features not existing on previous.  

## Testing / Proof
![image](https://user-images.githubusercontent.com/8570490/99977388-2c6c2400-2d6a-11eb-9ef1-ed9634deeb7f.png)
 
Ping @bigcommerce/apex-integrations 
