### PR TITLE
CHECKOUT-4941 Expose customer account fields

### DIFF
--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -5,6 +5,7 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
@@ -30,7 +31,8 @@ export default function createCheckoutButtonRegistry(
     const scriptLoader = getScriptLoader();
     const checkoutActionCreator = new CheckoutActionCreator(
         new CheckoutRequestSender(requestSender),
-        new ConfigActionCreator(new ConfigRequestSender(requestSender))
+        new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+        new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
     );
     const paypalCommercePaymentProcessor = createPaypalCommercePaymentProcessor(scriptLoader, requestSender);
 

--- a/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -6,6 +6,7 @@ import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfig, getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getAmazonPayV2, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
 import { getAmazonPayV2ButtonParamsMock, getPaymentMethodMockUndefinedMerchant } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
@@ -32,7 +33,8 @@ describe('AmazonPayV2ButtonStrategy', () => {
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
         paymentProcessor = createAmazonPayV2PaymentProcessor();

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -10,6 +10,7 @@ import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, Checkou
 import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getBraintreePaypal } from '../../../payment/payment-methods.mock';
 import { BraintreeDataCollector, BraintreePaypalCheckout, BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
 import { getDataCollectorMock, getPaypalCheckoutMock } from '../../../payment/strategies/braintree/braintree.mock';
@@ -40,7 +41,8 @@ describe('BraintreePaypalButtonStrategy', () => {
         store = createCheckoutStore(getCheckoutStoreState());
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(createRequestSender()),
-            new ConfigActionCreator(new ConfigRequestSender(createRequestSender()))
+            new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
         );
         braintreeSDKCreator = new BraintreeSDKCreator(new BraintreeScriptLoader(getScriptLoader()));
         formPoster = createFormPoster();

--- a/src/checkout-buttons/strategies/googlepay/googlepay-adyenv2-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-adyenv2-button-strategy.spec.ts
@@ -9,6 +9,7 @@ import { InvalidArgumentError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
@@ -48,7 +49,8 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
         checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(

--- a/src/checkout-buttons/strategies/googlepay/googlepay-authorizenet-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-authorizenet-button-strategy.spec.ts
@@ -9,6 +9,7 @@ import { InvalidArgumentError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
@@ -48,7 +49,8 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
         checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -10,6 +10,7 @@ import { InvalidArgumentError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
@@ -50,7 +51,8 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
         checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(

--- a/src/checkout-buttons/strategies/googlepay/googlepay-checkoutcom-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-checkoutcom-button-strategy.spec.ts
@@ -9,6 +9,7 @@ import { InvalidArgumentError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayCheckoutcomInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
@@ -48,7 +49,8 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
         checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(

--- a/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
@@ -9,6 +9,7 @@ import { InvalidArgumentError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayPaymentProcessor, GooglePayStripeInitializer } from '../../../payment/strategies/googlepay';
@@ -48,7 +49,8 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
         checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(

--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
@@ -7,6 +7,7 @@ import { createCheckoutStore, Checkout, CheckoutActionCreator, CheckoutRequestSe
 import { getCheckout, getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getMasterpass, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { Masterpass, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
@@ -65,7 +66,8 @@ describe('MasterpassCustomerStrategy', () => {
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
         strategy = new MasterpassButtonStrategy(

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -11,6 +11,7 @@ import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, Checkou
 import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod, PaymentMethodActionType } from '../../../payment';
 import { getPaypalCommerce } from '../../../payment/payment-methods.mock';
 import { PaypalCommercePaymentProcessor, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, StyleButtonColor, StyleButtonLabel } from '../../../payment/strategies/paypal-commerce';
@@ -45,7 +46,8 @@ describe('PaypalCommerceButtonStrategy', () => {
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(new ConfigRequestSender(createRequestSender()))
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
         paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor(new PaypalCommerceScriptLoader(getScriptLoader()), new PaypalCommerceRequestSender(requestSender));
         eventEmitter = new EventEmitter();

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -10,6 +10,7 @@ import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, Checkou
 import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaypalExpress } from '../../../payment/payment-methods.mock';
 import { PaypalActions, PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../../payment/strategies/paypal';
 import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
@@ -35,7 +36,8 @@ describe('PaypalButtonStrategy', () => {
         store = createCheckoutStore(getCheckoutStoreState());
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(createRequestSender()),
-            new ConfigActionCreator(new ConfigRequestSender(createRequestSender()))
+            new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
         );
         formPoster = createFormPoster();
         paypalScriptLoader = new PaypalScriptLoader(getScriptLoader());

--- a/src/checkout/checkout-actions.ts
+++ b/src/checkout/checkout-actions.ts
@@ -1,6 +1,7 @@
 import { Action } from '@bigcommerce/data-store';
 
 import { LoadConfigAction } from '../config';
+import { LoadFormFieldsAction } from '../form';
 
 import Checkout from './checkout';
 
@@ -20,6 +21,7 @@ export type LoadCheckoutAction =
     LoadCheckoutRequestedAction |
     LoadCheckoutSucceededAction |
     LoadCheckoutFailedAction |
+    LoadFormFieldsAction |
     LoadConfigAction;
 
 export type UpdateCheckoutAction =

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -12,7 +12,8 @@ import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { getConfig } from '../config/configs.mock';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
 import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '../customer';
-import { getFormFields } from '../form/form.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
+import { getAddressFormFields, getFormFields } from '../form/form.mock';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { getCountriesResponseBody } from '../geography/countries.mock';
 import { OrderActionCreator, OrderRequestSender } from '../order';
@@ -54,6 +55,8 @@ describe('CheckoutService', () => {
     let checkoutValidator: CheckoutValidator;
     let configActionCreator: ConfigActionCreator;
     let configRequestSender: ConfigRequestSender;
+    let formFieldsActionCreator: FormFieldsActionCreator;
+    let formFieldsRequestSender: FormFieldsRequestSender;
     let couponRequestSender: CouponRequestSender;
     let customerStrategyActionCreator: CustomerStrategyActionCreator;
     let errorActionCreator: ErrorActionCreator;
@@ -199,9 +202,16 @@ describe('CheckoutService', () => {
 
         configActionCreator = new ConfigActionCreator(configRequestSender);
 
+        formFieldsRequestSender = new FormFieldsRequestSender(requestSender);
+
+        jest.spyOn(formFieldsRequestSender, 'loadFields').mockResolvedValue(getResponse(getFormFields()));
+
+        formFieldsActionCreator = new FormFieldsActionCreator(formFieldsRequestSender);
+
         checkoutActionCreator = new CheckoutActionCreator(
             checkoutRequestSender,
-            configActionCreator
+            configActionCreator,
+            formFieldsActionCreator
         );
 
         consignmentActionCreator = new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender);
@@ -438,7 +448,7 @@ describe('CheckoutService', () => {
         it('loads config data', async () => {
             const state = await checkoutService.loadShippingAddressFields();
             const result = state.data.getShippingAddressFields('');
-            const expected = getFormFields();
+            const expected = getAddressFormFields();
 
             expect(map(result, 'id')).toEqual(map(expected, 'id'));
         });
@@ -454,7 +464,7 @@ describe('CheckoutService', () => {
         it('loads config data', async () => {
             const state = await checkoutService.loadBillingAddressFields();
             const result = state.data.getBillingAddressFields('');
-            const expected = getFormFields();
+            const expected = getAddressFormFields();
 
             expect(map(result, 'id')).toEqual(map(expected, 'id'));
         });

--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -1,7 +1,7 @@
 import { find, reject } from 'lodash';
 
 import { FormField } from '../form';
-import { getFormFields } from '../form/form.mock';
+import { getAddressFormFields } from '../form/form.mock';
 import { getUnitedStates } from '../geography/countries.mock';
 import { getBraintree } from '../payment/payment-methods.mock';
 import { getAustralia } from '../shipping/shipping-countries.mock';
@@ -224,7 +224,7 @@ describe('CheckoutStoreSelector', () => {
         const predicate = ({ name }: FormField) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
         const field = find(results, { name: 'stateOrProvinceCode' });
 
-        expect(reject(results, predicate)).toEqual(reject(getFormFields(), predicate));
+        expect(reject(results, predicate)).toEqual(reject(getAddressFormFields(), predicate));
         expect(field && field.options && field.options.items)
             .toEqual(getAustralia().subdivisions.map(({ code, name }) => ({ label: name, value: code })));
     });
@@ -234,7 +234,7 @@ describe('CheckoutStoreSelector', () => {
         const predicate = ({ name }: FormField) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
         const field = find(results, { name: 'stateOrProvinceCode' });
 
-        expect(reject(results, predicate)).toEqual(reject(getFormFields(), predicate));
+        expect(reject(results, predicate)).toEqual(reject(getAddressFormFields(), predicate));
         expect(field && field.options && field.options.items)
             .toEqual(getUnitedStates().subdivisions.map(({ code, name }) => ({ label: name, value: code })));
     });

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -229,6 +229,14 @@ export default interface CheckoutStoreSelector {
     getInstruments(paymentMethod: PaymentMethod): PaymentInstrument[] | undefined;
 
     /**
+     * Gets a set of form fields that should be presented in order to create a customer.
+     *
+     * @returns The set of customer account form fields if it is loaded,
+     * otherwise undefined.
+     */
+    getCustomerAccountFields(): FormField[];
+
+    /**
      * Gets a set of form fields that should be presented to customers in order
      * to capture their billing address for a specific country.
      *
@@ -449,6 +457,11 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         }
     );
 
+    const getCustomerAccountFields = createSelector(
+        ({ form }: InternalCheckoutSelectors) => form.getCustomerAccountFields,
+        getCustomerAccountFields => clone(getCustomerAccountFields)
+    );
+
     const getBillingAddressFields = createSelector(
         ({ form }: InternalCheckoutSelectors) => form.getBillingAddressFields,
         ({ countries }: InternalCheckoutSelectors) => countries.getCountries,
@@ -496,6 +509,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             isPaymentDataSubmitted: isPaymentDataSubmitted(state),
             getSignInEmail: getSignInEmail(state),
             getInstruments: getInstruments(state),
+            getCustomerAccountFields: getCustomerAccountFields(state),
             getBillingAddressFields: getBillingAddressFields(state),
             getShippingAddressFields: getShippingAddressFields(state),
         };

--- a/src/checkout/checkout-store-state.ts
+++ b/src/checkout/checkout-store-state.ts
@@ -4,6 +4,7 @@ import { CheckoutButtonState } from '../checkout-buttons';
 import { ConfigState } from '../config';
 import { CouponState, GiftCertificateState } from '../coupon';
 import { CustomerState, CustomerStrategyState } from '../customer';
+import { FormFieldsState } from '../form';
 import { CountryState } from '../geography';
 import { OrderState } from '../order';
 import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
@@ -27,6 +28,7 @@ export default interface CheckoutStoreState {
     consignments: ConsignmentState;
     customer: CustomerState;
     customerStrategies: CustomerStrategyState;
+    formFields: FormFieldsState;
     giftCertificates: GiftCertificateState;
     instruments: InstrumentState;
     order: OrderState;

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -6,6 +6,7 @@ import { getCoupon, getCouponsState, getShippingCoupon } from '../coupon/coupons
 import { getGiftCertificate, getGiftCertificatesState } from '../coupon/gift-certificates.mock';
 import { getCustomer, getCustomerState } from '../customer/customers.mock';
 import { getCustomerStrategyState } from '../customer/internal-customers.mock';
+import { getFormFieldsState } from '../form/form.mock';
 import { getCountriesState } from '../geography/countries.mock';
 import { getOrderState } from '../order/orders.mock';
 import { ACKNOWLEDGE, HOSTED } from '../payment';
@@ -125,6 +126,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         coupons: getCouponsState(),
         customer: getCustomerState(),
         customerStrategies: getCustomerStrategyState(),
+        formFields: getFormFieldsState(),
         giftCertificates: getGiftCertificatesState(),
         instruments: getInstrumentsState(),
         order: { errors: {}, statuses: {} },

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -8,6 +8,7 @@ import { getEnvironment } from '../common/utility';
 import { ConfigActionCreator, ConfigRequestSender, ConfigState, ConfigWindow } from '../config';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
 import { createCustomerStrategyRegistry, CustomerStrategyActionCreator } from '../customer';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { createPaymentClient, createPaymentStrategyRegistry, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentStrategyActionCreator } from '../payment';
@@ -73,6 +74,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new CheckoutValidator(checkoutRequestSender)
     );
     const subscriptionsActionCreator = new SubscriptionsActionCreator(new SubscriptionsRequestSender(requestSender));
+    const formFieldsActionCreator = new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender));
 
     return new CheckoutService(
         store,
@@ -80,7 +82,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
             new BillingAddressRequestSender(requestSender),
             subscriptionsActionCreator
         ),
-        new CheckoutActionCreator(checkoutRequestSender, configActionCreator),
+        new CheckoutActionCreator(checkoutRequestSender, configActionCreator, formFieldsActionCreator),
         configActionCreator,
         new ConsignmentActionCreator(new ConsignmentRequestSender(requestSender), checkoutRequestSender),
         new CountryActionCreator(new CountryRequestSender(requestSender, { locale })),

--- a/src/checkout/create-checkout-store-reducer.ts
+++ b/src/checkout/create-checkout-store-reducer.ts
@@ -6,6 +6,7 @@ import { checkoutButtonReducer } from '../checkout-buttons';
 import { configReducer } from '../config';
 import { couponReducer, giftCertificateReducer } from '../coupon';
 import { customerReducer, customerStrategyReducer } from '../customer';
+import { formFieldsReducer } from '../form';
 import { countryReducer } from '../geography';
 import { orderReducer } from '../order';
 import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
@@ -31,6 +32,7 @@ export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState
         coupons: couponReducer,
         customer: customerReducer,
         customerStrategies: customerStrategyReducer,
+        formFields: formFieldsReducer,
         giftCertificates: giftCertificateReducer,
         instruments: instrumentReducer,
         order: orderReducer,

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -56,12 +56,11 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = createCartSelector(state.cart);
         const checkoutButton = createCheckoutButtonSelector(state.checkoutButton);
-        const config = createConfigSelector(state.config);
         const countries = createCountrySelector(state.countries);
         const coupons = createCouponSelector(state.coupons);
         const customer = createCustomerSelector(state.customer);
         const customerStrategies = createCustomerStrategySelector(state.customerStrategies);
-        const form = createFormSelector(state.config);
+        const form = createFormSelector(state.formFields);
         const giftCertificates = createGiftCertificateSelector(state.giftCertificates);
         const instruments = createInstrumentSelector(state.instruments);
         const paymentMethods = createPaymentMethodSelector(state.paymentMethods);
@@ -79,6 +78,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const checkout = createCheckoutSelector(state.checkout, billingAddress, cart, consignments, coupons, customer, giftCertificates);
         const order = createOrderSelector(state.order, billingAddress, coupons);
         const payment = createPaymentSelector(checkout, order);
+        const config = createConfigSelector(state.config, state.formFields);
 
         const selectors = {
             billingAddress,

--- a/src/config/config-selector.spec.ts
+++ b/src/config/config-selector.spec.ts
@@ -18,20 +18,27 @@ describe('ConfigSelector', () => {
 
     describe('#getConfig()', () => {
         it('returns the current config', () => {
-            configSelector = createConfigSelector(state.config);
+            configSelector = createConfigSelector(state.config, state.formFields);
 
             expect(configSelector.getConfig()).toEqual(state.config.data);
         });
 
         it('returns the store config', () => {
-            configSelector = createConfigSelector(state.config);
+            configSelector = createConfigSelector(state.config, state.formFields);
 
-            // tslint:disable-next-line:no-non-null-assertion
-            expect(configSelector.getStoreConfig()).toEqual(state.config.data!.storeConfig);
+            expect(configSelector.getStoreConfig()).toEqual({
+                // tslint:disable-next-line:no-non-null-assertion
+                ...state.config.data!.storeConfig,
+                formFields: {
+                    customerAccount: state.formFields.data?.customerAccount,
+                    shippingAddress: state.formFields.data?.shippingAddress,
+                    billingAddress: state.formFields.data?.billingAddress,
+                },
+            });
         });
 
         it('returns the context config', () => {
-            configSelector = createConfigSelector(state.config);
+            configSelector = createConfigSelector(state.config, state.formFields);
 
             // tslint:disable-next-line:no-non-null-assertion
             expect(configSelector.getContextConfig()).toEqual(state.config.data!.context);
@@ -62,21 +69,21 @@ describe('ConfigSelector', () => {
         });
 
         it('returns all the flash messages', () => {
-            configSelector = createConfigSelector(configStateWithMessages);
+            configSelector = createConfigSelector(configStateWithMessages, state.formFields);
 
             expect(configSelector.getFlashMessages())
                 .toEqual(flashMessages);
         });
 
         it('returns the flash message matching the provided filter', () => {
-            configSelector = createConfigSelector(configStateWithMessages);
+            configSelector = createConfigSelector(configStateWithMessages, state.formFields);
 
             expect(configSelector.getFlashMessages('error'))
                 .toEqual([flashMessages[1]]);
         });
 
         it('returns empty array when no messages available', () => {
-            configSelector = createConfigSelector(state.config);
+            configSelector = createConfigSelector(state.config, state.formFields);
 
             expect(configSelector.getFlashMessages())
                 .toEqual([]);
@@ -90,7 +97,7 @@ describe('ConfigSelector', () => {
             configSelector = createConfigSelector({
                 ...state.config,
                 meta: { externalSource },
-            });
+            }, state.formFields);
 
             expect(configSelector.getExternalSource()).toEqual(externalSource);
         });
@@ -103,13 +110,13 @@ describe('ConfigSelector', () => {
             configSelector = createConfigSelector({
                 ...state.config,
                 errors: { loadError },
-            });
+            }, state.formFields);
 
             expect(configSelector.getLoadError()).toEqual(loadError);
         });
 
         it('does not returns error if able to load config', () => {
-            configSelector = createConfigSelector(state.config);
+            configSelector = createConfigSelector(state.config, state.formFields);
 
             expect(configSelector.getLoadError()).toBeUndefined();
         });
@@ -120,13 +127,13 @@ describe('ConfigSelector', () => {
             configSelector = createConfigSelector({
                 ...state.config,
                 statuses: { isLoading: true },
-            });
+            }, state.formFields);
 
             expect(configSelector.isLoading()).toEqual(true);
         });
 
         it('returns false if not loading config', () => {
-            configSelector = createConfigSelector(state.config);
+            configSelector = createConfigSelector(state.config, state.formFields);
 
             expect(configSelector.isLoading()).toEqual(false);
         });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,4 @@
-import { FormField } from '../form';
+import { FormFields } from '../form';
 
 export default interface Config {
     context: ContextConfig;
@@ -12,7 +12,19 @@ export interface StoreConfig {
     currency: StoreCurrency;
     displayDateFormat: string;
     inputDateFormat: string;
+
+    /**
+     * @deprecated Please use instead the data selectors
+     * @remarks
+     * ```js
+     * const data = CheckoutService.getState().data;
+     * const shippingAddressFields = data.getShippingAddressFields('US');
+     * const billingAddressFields = data.getBillingAddressFields('US');
+     * const customerAccountFields = data.getCustomerAccountFields();
+     * ```
+     */
     formFields: FormFields;
+
     links: StoreLinks;
     paymentSettings: PaymentSettings;
     shopperConfig: ShopperConfig;
@@ -66,11 +78,6 @@ export interface StoreLinks {
     orderConfirmationLink: string;
 }
 
-export interface FormFields {
-    shippingAddressFields: FormField[];
-    billingAddressFields: FormField[];
-}
-
 export interface StoreCurrency {
     code: string;
     decimalPlaces: string;
@@ -91,6 +98,7 @@ export interface CheckoutSettings {
     isAnalyticsEnabled: boolean;
     isCardVaultingEnabled: boolean;
     isCouponCodeCollapsed: boolean;
+    isSignInEmailEnabled: boolean;
     isPaymentRequestEnabled: boolean;
     isPaymentRequestCanMakePaymentEnabled: boolean;
     isSpamProtectionEnabled: boolean;

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -28,6 +28,7 @@ export function getConfig(): Config {
                 googleRecaptchaSitekey: 'sitekey',
                 isAnalyticsEnabled: false,
                 isCardVaultingEnabled: true,
+                isSignInEmailEnabled: false,
                 isPaymentRequestEnabled: false,
                 isPaymentRequestCanMakePaymentEnabled: false,
                 isCouponCodeCollapsed: true,
@@ -55,11 +56,8 @@ export function getConfig(): Config {
                 thousandsSeparator: ',',
             },
             displayDateFormat: 'dd/MM/yyyy',
-            formFields: {
-                shippingAddressFields: getFormFields(),
-                billingAddressFields: getFormFields(),
-            },
             inputDateFormat: 'dd/MM/yyyy',
+            formFields: getFormFields(),
             links: {
                 cartLink: 'https://store-k1drp8k8.bcapp.dev/cart.php',
                 checkoutLink: 'https://store-k1drp8k8.bcapp.dev/checkout',

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -5,6 +5,7 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
@@ -36,7 +37,8 @@ export default function createCustomerStrategyRegistry(
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const checkoutActionCreator = new CheckoutActionCreator(
         checkoutRequestSender,
-        new ConfigActionCreator(new ConfigRequestSender(requestSender))
+        new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+        new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
     );
     const formPoster = createFormPoster();
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));

--- a/src/customer/customer-action-creator.spec.ts
+++ b/src/customer/customer-action-creator.spec.ts
@@ -8,6 +8,7 @@ import { getCheckout } from '../checkout/checkouts.mock';
 import { ErrorResponseBody } from '../common/error';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 
 import CustomerActionCreator from './customer-action-creator';
 import { CustomerActionType } from './customer-actions';
@@ -35,7 +36,8 @@ describe('CustomerActionCreator', () => {
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(createRequestSender()),
-            new ConfigActionCreator(new ConfigRequestSender(createRequestSender()))
+            new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
         );
 
         jest.spyOn(checkoutActionCreator, 'loadCurrentCheckout')

--- a/src/customer/customer-strategy-action-creator.spec.ts
+++ b/src/customer/customer-strategy-action-creator.spec.ts
@@ -7,6 +7,7 @@ import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, Chec
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 
 import createCustomerStrategyRegistry from './create-customer-strategy-registry';
 import CustomerActionCreator from './customer-action-creator';
@@ -26,9 +27,8 @@ describe('CustomerStrategyActionCreator', () => {
         const requestSender = createRequestSender();
         const checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
-            new ConfigActionCreator(
-                new ConfigRequestSender(requestSender)
-            )
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
         state = getCheckoutStoreState();

--- a/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
@@ -5,6 +5,7 @@ import { createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { getConfigState } from '../../../config/configs.mock';
+import { getFormFieldsState } from '../../../form/form.mock';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor } from '../../../payment/strategies/amazon-pay-v2';
@@ -35,6 +36,7 @@ describe('AmazonPayV2CustomerStrategy', () => {
             customer: getCustomerState(),
             config: getConfigState(),
             cart: getCartState(),
+            formFields: getFormFieldsState(),
             paymentMethods: getPaymentMethodsState(),
         });
 

--- a/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
@@ -8,6 +8,7 @@ import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getBraintreeVisaCheckout } from '../../../payment/payment-methods.mock';
 import { createBraintreeVisaCheckoutPaymentProcessor, BraintreeVisaCheckoutPaymentProcessor, VisaCheckoutScriptLoader, VisaCheckoutSDK } from '../../../payment/strategies/braintree';
@@ -60,11 +61,13 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         visaCheckoutScriptLoader.load = jest.fn(() => Promise.resolve(visaCheckoutSDK));
 
         const registry = createCustomerStrategyRegistry(store, createRequestSender());
-        const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
-        const configRequestSender = new ConfigRequestSender(createRequestSender());
-        const configActionCreator = new ConfigActionCreator(configRequestSender);
 
-        checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         customerStrategyActionCreator = new CustomerStrategyActionCreator(registry);
 

--- a/src/customer/strategies/chasepay/chasepay-customer-strategy.spec.ts
+++ b/src/customer/strategies/chasepay/chasepay-customer-strategy.spec.ts
@@ -7,6 +7,7 @@ import { createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../../common/error/errors';
 import { getConfigState } from '../../../config/configs.mock';
+import { getFormFieldsState } from '../../../form/form.mock';
 import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getChasePay, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { ChasePayEventType, ChasePayScriptLoader, JPMC } from '../../../payment/strategies/chasepay';
@@ -38,6 +39,7 @@ describe('ChasePayCustomerStrategy', () => {
             customer: getCustomerState(),
             config: getConfigState(),
             cart: getCartState(),
+            formFields: getFormFieldsState(),
             paymentMethods: getPaymentMethodsState(),
         });
 

--- a/src/customer/strategies/default/default-customer-strategy.spec.ts
+++ b/src/customer/strategies/default/default-customer-strategy.spec.ts
@@ -4,6 +4,7 @@ import { of } from 'rxjs';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getQuote } from '../../../quote/internal-quotes.mock';
 import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerActionType } from '../../customer-actions';
@@ -18,15 +19,13 @@ describe('DefaultCustomerStrategy', () => {
     beforeEach(() => {
         store = createCheckoutStore();
         const requestSender = createRequestSender();
-        const configActionCreator = new ConfigActionCreator(
-            new ConfigRequestSender(requestSender)
-        );
 
         customerActionCreator = new CustomerActionCreator(
             new CustomerRequestSender(requestSender),
             new CheckoutActionCreator(
                 new CheckoutRequestSender(requestSender),
-                configActionCreator
+                new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
             )
         );
     });

--- a/src/form/form-field.ts
+++ b/src/form/form-field.ts
@@ -5,6 +5,7 @@ export type FormFieldFieldType =
     'date' |
     'text' |
     'dropdown' |
+    'password' |
     'radio' |
     'multiline';
 
@@ -13,6 +14,13 @@ export type FormFieldType =
     'date' |
     'integer' |
     'string';
+
+export interface CustomerPasswordRequirements {
+    alpha: string;
+    numeric: string;
+    minlength: number;
+    description: string;
+}
 
 export default interface FormField {
     name: string | AddressKey;
@@ -29,6 +37,13 @@ export default interface FormField {
     min?: string | number;
     max?: string | number;
     options?: FormFieldOptions;
+    requirements?: CustomerPasswordRequirements;
+}
+
+export interface FormFields {
+    customerAccount: FormField[];
+    shippingAddress: FormField[];
+    billingAddress: FormField[];
 }
 
 export interface FormFieldOptions {

--- a/src/form/form-fields-action-creator.spec.ts
+++ b/src/form/form-fields-action-creator.spec.ts
@@ -1,0 +1,80 @@
+import { createRequestSender, RequestSender, Response } from '@bigcommerce/request-sender';
+import { merge, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+
+import { FormFields } from './form-field';
+import FormFieldsActionCreator from './form-fields-action-creator';
+import { FormFieldsActionType } from './form-fields-actions';
+import FormFieldsRequestSender from './form-fields-request-sender';
+import { getFormFields } from './form.mock';
+
+describe('FormFieldsActionCreator', () => {
+    let requestSender: RequestSender;
+    let formFieldsRequestSender: FormFieldsRequestSender;
+    let formFieldsActionCreator: FormFieldsActionCreator;
+    let errorResponse: Response<any>;
+    let response: Response<FormFields>;
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+        formFieldsRequestSender = new FormFieldsRequestSender(requestSender);
+        formFieldsActionCreator = new FormFieldsActionCreator(formFieldsRequestSender);
+
+        response = getResponse(getFormFields());
+        errorResponse = getErrorResponse();
+
+        jest.spyOn(formFieldsRequestSender, 'loadFields')
+            .mockReturnValue(Promise.resolve(response));
+    });
+
+    describe('#loadConfig()', () => {
+        it('emits actions if able to load config', async () => {
+            const actions = await formFieldsActionCreator.loadFormFields()
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: FormFieldsActionType.LoadFormFieldsRequested },
+                { type: FormFieldsActionType.LoadFormFieldsSucceeded, payload: response.body },
+            ]);
+        });
+
+        it('emits error actions if unable to load config', async () => {
+            jest.spyOn(formFieldsRequestSender, 'loadFields').mockReturnValue(Promise.reject(errorResponse));
+
+            const errorHandler = jest.fn(action => of(action));
+            const actions = await formFieldsActionCreator.loadFormFields()
+                .pipe(
+                    catchError(errorHandler),
+                    toArray()
+                )
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: FormFieldsActionType.LoadFormFieldsRequested },
+                { type: FormFieldsActionType.LoadFormFieldsFailed, payload: errorResponse, error: true },
+            ]);
+        });
+
+        it('dispatches actions using cached responses if available', async () => {
+            const actions = await merge(
+                formFieldsActionCreator.loadFormFields({ useCache: true }),
+                formFieldsActionCreator.loadFormFields({ useCache: true })
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: FormFieldsActionType.LoadFormFieldsRequested },
+                { type: FormFieldsActionType.LoadFormFieldsRequested },
+                { type: FormFieldsActionType.LoadFormFieldsSucceeded, payload: response.body },
+                { type: FormFieldsActionType.LoadFormFieldsSucceeded, payload: response.body },
+            ]);
+
+            expect(formFieldsRequestSender.loadFields).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/form/form-fields-action-creator.ts
+++ b/src/form/form-fields-action-creator.ts
@@ -1,0 +1,30 @@
+import { createAction } from '@bigcommerce/data-store';
+import { concat, defer, of, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { cachableAction, ActionOptions } from '../common/data-store';
+import { throwErrorAction } from '../common/error';
+import { RequestOptions } from '../common/http-request';
+
+import { FormFieldsActionType, LoadFormFieldsAction } from './form-fields-actions';
+import FormFieldsRequestSender from './form-fields-request-sender';
+
+export default class FormFieldsActionCreator {
+    constructor(
+        private _formFieldsRequestSender: FormFieldsRequestSender
+    ) {}
+
+    @cachableAction
+    loadFormFields(options?: RequestOptions & ActionOptions): Observable<LoadFormFieldsAction> {
+        return concat(
+            of(createAction(FormFieldsActionType.LoadFormFieldsRequested)),
+            defer(async () => {
+                const { body } = await this._formFieldsRequestSender.loadFields(options);
+
+                return createAction(FormFieldsActionType.LoadFormFieldsSucceeded, body);
+            })
+        ).pipe(
+            catchError(response => throwErrorAction(FormFieldsActionType.LoadFormFieldsFailed, response))
+        );
+    }
+}

--- a/src/form/form-fields-actions.ts
+++ b/src/form/form-fields-actions.ts
@@ -1,0 +1,26 @@
+import { Action } from '@bigcommerce/data-store';
+
+import { FormFields } from './form-field';
+
+export enum FormFieldsActionType {
+    LoadFormFieldsRequested = 'LOAD_FORM_FIELDS_REQUESTED',
+    LoadFormFieldsSucceeded = 'LOAD_FORM_FIELDS_SUCCEEDED',
+    LoadFormFieldsFailed = 'LOAD_FORM_FIELDS_FAILED',
+}
+
+export type LoadFormFieldsAction =
+    LoadFormFieldsRequestedAction |
+    LoadFormFieldsSucceededAction |
+    LoadFormFieldsFailedAction;
+
+export interface LoadFormFieldsRequestedAction extends Action {
+    type: FormFieldsActionType.LoadFormFieldsRequested;
+}
+
+export interface LoadFormFieldsSucceededAction extends Action<FormFields> {
+    type: FormFieldsActionType.LoadFormFieldsSucceeded;
+}
+
+export interface LoadFormFieldsFailedAction extends Action<Error> {
+    type: FormFieldsActionType.LoadFormFieldsFailed;
+}

--- a/src/form/form-fields-reducer.spec.ts
+++ b/src/form/form-fields-reducer.spec.ts
@@ -1,0 +1,42 @@
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+
+import { FormFieldsActionType } from './form-fields-actions';
+import { getFormFields } from './form.mock';
+import { formFieldsReducer, FormFieldsState } from './index';
+
+describe('formFieldsReducer()', () => {
+    let initialState: FormFieldsState;
+
+    beforeEach(() => {
+        initialState = {
+            errors: {},
+            statuses: {},
+        };
+    });
+
+    it('loads the config', () => {
+        const action = createAction(FormFieldsActionType.LoadFormFieldsRequested);
+
+        expect(formFieldsReducer(initialState, action)).toMatchObject({
+            statuses: { isLoading: true },
+        });
+    });
+
+    it('returns config data if it was load successfully', () => {
+        const action = createAction(FormFieldsActionType.LoadFormFieldsSucceeded, getFormFields());
+
+        expect(formFieldsReducer(initialState, action)).toMatchObject({
+            data: action.payload,
+            statuses: { isLoading: false },
+        });
+    });
+
+    it('returns an error if loading fails', () => {
+        const action = createErrorAction(FormFieldsActionType.LoadFormFieldsFailed, new Error());
+
+        expect(formFieldsReducer(initialState, action)).toMatchObject({
+            errors: { loadError: action.payload },
+            statuses: { isLoading: false },
+        });
+    });
+});

--- a/src/form/form-fields-reducer.ts
+++ b/src/form/form-fields-reducer.ts
@@ -1,0 +1,67 @@
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
+import { objectMerge, objectSet } from '../common/utility';
+
+import { FormFields } from './form-field';
+import { FormFieldsActionType, LoadFormFieldsAction } from './form-fields-actions';
+import FormFieldsState, { DEFAULT_STATE, FormFieldsErrorState, FormFieldsStatusesState } from './form-fields-state';
+
+export default function formFieldsReducer(
+    state: FormFieldsState = DEFAULT_STATE,
+    action: Action
+): FormFieldsState {
+    const reducer = combineReducers<FormFieldsState>({
+        data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
+        statuses: statusesReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: FormFields | undefined,
+    action: LoadFormFieldsAction
+): FormFields | undefined {
+    switch (action.type) {
+    case FormFieldsActionType.LoadFormFieldsSucceeded:
+        return objectMerge(data, action.payload);
+
+    default:
+        return data;
+    }
+}
+
+function errorsReducer(
+    errors: FormFieldsErrorState = DEFAULT_STATE.errors,
+    action: LoadFormFieldsAction
+): FormFieldsErrorState {
+    switch (action.type) {
+    case FormFieldsActionType.LoadFormFieldsSucceeded:
+        return objectSet(errors, 'loadError', undefined);
+
+    case FormFieldsActionType.LoadFormFieldsFailed:
+        return objectSet(errors, 'loadError', action.payload);
+
+    default:
+        return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: FormFieldsStatusesState = DEFAULT_STATE.statuses,
+    action: LoadFormFieldsAction
+): FormFieldsStatusesState {
+    switch (action.type) {
+    case FormFieldsActionType.LoadFormFieldsRequested:
+        return objectSet(statuses, 'isLoading', true);
+
+    case FormFieldsActionType.LoadFormFieldsSucceeded:
+    case FormFieldsActionType.LoadFormFieldsFailed:
+        return objectSet(statuses, 'isLoading', false);
+
+    default:
+        return statuses;
+    }
+}

--- a/src/form/form-fields-request-sender.spec.ts
+++ b/src/form/form-fields-request-sender.spec.ts
@@ -1,0 +1,54 @@
+import { createRequestSender, createTimeout, Response } from '@bigcommerce/request-sender';
+
+import { ContentType, INTERNAL_USE_ONLY } from '../common/http-request';
+import { getResponse } from '../common/http-request/responses.mock';
+
+import { FormFields } from './form-field';
+import FormFieldsRequestSender from './form-fields-request-sender';
+import { getFormFields } from './form.mock';
+
+describe('FormFieldsRequestSender', () => {
+    const requestSender = createRequestSender();
+    let formFieldsRequestSender: FormFieldsRequestSender;
+
+    beforeEach(() => {
+        formFieldsRequestSender = new FormFieldsRequestSender(requestSender);
+    });
+
+    describe('#loadFormFields()', () => {
+        let response: Response<FormFields>;
+
+        beforeEach(() => {
+            response = getResponse(getFormFields());
+
+            jest.spyOn(requestSender, 'get')
+                .mockReturnValue(Promise.resolve(response));
+        });
+
+        it('loads fields', async () => {
+            const output = await formFieldsRequestSender.loadFields();
+
+            expect(output).toEqual(response);
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/form-fields', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                    'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                },
+            });
+        });
+
+        it('loads config with timeout', async () => {
+            const options = { timeout: createTimeout() };
+            const output = await formFieldsRequestSender.loadFields(options);
+
+            expect(output).toEqual(response);
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/form-fields', {
+                ...options,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                    'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                },
+            });
+        });
+    });
+});

--- a/src/form/form-fields-request-sender.ts
+++ b/src/form/form-fields-request-sender.ts
@@ -1,0 +1,23 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { ContentType, INTERNAL_USE_ONLY, RequestOptions } from '../common/http-request';
+
+import { FormFields } from './form-field';
+
+export default class FormFieldsRequestSender {
+    constructor(
+        private _requestSender: RequestSender
+    ) {}
+
+    loadFields({ timeout }: RequestOptions = {}): Promise<Response<FormFields>> {
+        const url = '/api/storefront/form-fields';
+
+        return this._requestSender.get(url, {
+            timeout,
+            headers: {
+                Accept: ContentType.JsonV1,
+                'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            },
+        });
+    }
+}

--- a/src/form/form-fields-state.ts
+++ b/src/form/form-fields-state.ts
@@ -1,0 +1,20 @@
+import { FormFields } from './form-field';
+
+export default interface FormFieldsState {
+    data?: FormFields;
+    errors: FormFieldsErrorState;
+    statuses: FormFieldsStatusesState;
+}
+
+export interface FormFieldsErrorState {
+    loadError?: Error;
+}
+
+export interface FormFieldsStatusesState {
+    isLoading?: boolean;
+}
+
+export const DEFAULT_STATE: FormFieldsState = {
+    errors: {},
+    statuses: {},
+};

--- a/src/form/form-selector.spec.ts
+++ b/src/form/form-selector.spec.ts
@@ -7,7 +7,7 @@ import { getCountries } from '../geography/countries.mock';
 import { getShippingCountries } from '../shipping/shipping-countries.mock';
 
 import FormSelector, { createFormSelectorFactory, FormSelectorFactory } from './form-selector';
-import { getFormFields } from './form.mock';
+import { getAddressFormFields, getFormFields } from './form.mock';
 
 // tslint:disable:no-non-null-assertion
 
@@ -25,12 +25,12 @@ describe('FormSelector', () => {
         let countries: Country[];
 
         beforeEach(() => {
-            formSelector = createFormSelector(state.config);
+            formSelector = createFormSelector(state.formFields);
             countries = getShippingCountries();
         });
 
         it('returns the shipping address form fields', () => {
-            const expected = getFormFields();
+            const expected = getAddressFormFields();
             const result = formSelector.getShippingAddressFields([], '');
 
             expect(map(result, 'id')).toEqual(map(expected, 'id'));
@@ -103,12 +103,12 @@ describe('FormSelector', () => {
         let countries: Country[];
 
         beforeEach(() => {
-            formSelector = createFormSelector(state.config);
+            formSelector = createFormSelector(state.formFields);
             countries = getCountries();
         });
 
         it('returns the billing address form fields', () => {
-            const expected = getFormFields();
+            const expected = getAddressFormFields();
             const result = formSelector.getBillingAddressFields([], '');
 
             expect(map(result, 'id')).toEqual(map(expected, 'id'));
@@ -176,6 +176,20 @@ describe('FormSelector', () => {
             const postCode = find(forms, { name: 'postalCode' });
 
             expect(postCode!.required).toBe(false);
+        });
+    });
+
+    describe('#getCustomerAccountFields()', () => {
+        let formSelector: FormSelector;
+
+        beforeEach(() => {
+            formSelector = createFormSelector(state.formFields);
+        });
+
+        it('returns the customer account fields', () => {
+            const { customerAccount } = getFormFields();
+
+            expect(formSelector.getCustomerAccountFields()).toEqual(customerAccount);
         });
     });
 });

--- a/src/form/form.mock.ts
+++ b/src/form/form.mock.ts
@@ -1,6 +1,41 @@
-import FormField from './form-field';
+import FormField, { FormFields } from './form-field';
+import FormFieldsState from './form-fields-state';
 
-export function getFormFields(): FormField[] {
+export function getFormFieldsState(): FormFieldsState {
+    return {
+        data: getFormFields(),
+        errors: {},
+        statuses: {},
+    };
+}
+
+export function getFormFields(): FormFields {
+    return {
+        customerAccount: getAccountFormFields(),
+        billingAddress: getAddressFormFields(),
+        shippingAddress: getAddressFormFields(),
+    };
+}
+
+export function getAccountFormFields(): FormField[] {
+    return [{
+        id: 'field_4',
+        name: 'firstName',
+        custom: false,
+        label: 'First Name',
+        required: true,
+        default: '',
+    }, {
+        id: 'field_5',
+        name: 'lastName',
+        custom: false,
+        label: 'Last Name',
+        required: true,
+        default: '',
+    }];
+}
+
+export function getAddressFormFields(): FormField[] {
     return [{
         id: 'field_4',
         name: 'firstName',

--- a/src/form/index.ts
+++ b/src/form/index.ts
@@ -1,2 +1,9 @@
+export * from './form-fields-actions';
+
 export { default as FormSelector, FormSelectorFactory, createFormSelectorFactory } from './form-selector';
-export { default as FormField } from './form-field';
+export { default as FormField, FormFields } from './form-field';
+export { default as FormFieldsRequestSender } from './form-fields-request-sender';
+
+export { default as FormFieldsActionCreator } from './form-fields-action-creator';
+export { default as formFieldsReducer } from './form-fields-reducer';
+export { default as FormFieldsState, DEFAULT_STATE } from './form-fields-state';

--- a/src/payment/create-payment-client.spec.ts
+++ b/src/payment/create-payment-client.spec.ts
@@ -2,6 +2,7 @@ import { createClient } from '@bigcommerce/bigpay-client';
 
 import { createCheckoutStore, CheckoutStore } from '../checkout';
 import { getConfigState } from '../config/configs.mock';
+import { getFormFieldsState } from '../form/form.mock';
 
 import createPaymentClient from './create-payment-client';
 
@@ -12,6 +13,7 @@ describe('createPaymentClient()', () => {
     beforeEach(() => {
         store = createCheckoutStore({
             config: getConfigState(),
+            formFields: getFormFieldsState(),
         });
 
         jest.spyOn(store, 'subscribe');

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -5,6 +5,7 @@ import { createScriptLoader, getScriptLoader, getStylesheetLoader } from '@bigco
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
@@ -78,7 +79,8 @@ export default function createPaymentStrategyRegistry(
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(new RemoteCheckoutRequestSender(requestSender));
     const configActionCreator = new ConfigActionCreator(new ConfigRequestSender(requestSender));
-    const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
+    const formFieldsActionCreator = new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender));
+    const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator, formFieldsActionCreator);
     const paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator, spamProtectionActionCreator);
     const formPoster = createFormPoster();
     const hostedFormFactory = new HostedFormFactory(store);

--- a/src/payment/payment-strategy-registry.spec.ts
+++ b/src/payment/payment-strategy-registry.spec.ts
@@ -1,5 +1,6 @@
 import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../checkout';
 import { getConfigState } from '../config/configs.mock';
+import { getFormFieldsState } from '../form/form.mock';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 
 import { getAdyenAmex, getAmazonPay, getBankDeposit, getBraintree, getBraintreePaypal, getCybersource } from './payment-methods.mock';
@@ -51,6 +52,7 @@ describe('PaymentStrategyRegistry', () => {
     beforeEach(() => {
         store = createCheckoutStore({
             config: getConfigState(),
+            formFields: getFormFieldsState(),
         });
 
         registry = new PaymentStrategyRegistry(store);

--- a/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
+++ b/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
@@ -11,6 +11,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutVali
 import { MissingDataError } from '../../../common/error/errors';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { getFormFieldsState } from '../../../form/form.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
@@ -62,6 +63,7 @@ describe('AffirmPaymentStrategy', () => {
             paymentMethods: getPaymentMethodsState(),
             consignments: getConsignmentsState(),
             billingAddress: getBillingAddressState(),
+            formFields: getFormFieldsState(),
             order: getOrderState(),
         });
         checkoutRequestSender = new CheckoutRequestSender(requestSender);

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -8,6 +8,7 @@ import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, Chec
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
@@ -72,11 +73,13 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
         const spamProtection = createSpamProtection(createScriptLoader());
         const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, 'en_US');
         const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
-        const configRequestSender = new ConfigRequestSender(createRequestSender());
-        const configActionCreator = new ConfigActionCreator(configRequestSender);
         const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
 
-        checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
         orderActionCreator = new OrderActionCreator(
             new OrderRequestSender(createRequestSender()),
             checkoutValidator

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -8,6 +8,7 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '..
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { OrderActionCreator } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { createPaymentClient, createPaymentStrategyRegistry, PaymentActionCreator, PaymentInitializeOptions, PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentStrategyActionCreator } from '../../../payment';
@@ -45,16 +46,17 @@ describe('GooglePayPaymentStrategy', () => {
         });
 
         const requestSender = createRequestSender();
-        const checkoutRequestSender = new CheckoutRequestSender(requestSender);
-        const configRequestSender = new ConfigRequestSender(requestSender);
-        const configActionCreator = new ConfigActionCreator(configRequestSender);
         const paymentMethodRequestSender: PaymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
         const scriptLoader = createScriptLoader();
         const paymentClient = createPaymentClient(store);
         const spamProtection = createSpamProtection(scriptLoader);
         const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, 'en_US');
 
-        checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator);
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
         paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             registry,

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
@@ -9,6 +9,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutVali
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { getFormFieldsState } from '../../../form/form.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentActionCreator, PaymentInitializeOptions, PaymentMethod, PaymentRequestSender } from '../../../payment';
@@ -47,6 +48,7 @@ describe('MasterpassPaymentStrategy', () => {
             config: getConfigState(),
             customer: getCustomerState(),
             cart: getCartState(),
+            formFields: getFormFieldsState(),
             paymentMethods: getPaymentMethodsState(),
         });
 


### PR DESCRIPTION
## What?
Expose customer account fields

## Why?
So they can be used to render customer creation

## Testing / Proof
API is not returning the right form fields names.
https://launchbay.bigcommerce.net/deployments/193438

<img width="920" alt="Screen Shot 2020-11-24 at 4 55 44 pm" src="https://user-images.githubusercontent.com/1621894/100054337-f320da80-2e75-11eb-8a5a-3e0ee9972db7.png">


@bigcommerce/checkout 