### PR TITLE
feat(payments): PAYPAL-830 Add mechanism for testing of the APMs for different countries

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -107,6 +107,30 @@ export function getPaypalCommerce(): PaymentMethod {
     };
 }
 
+export function getPaypalCommerceTestModeOn(): PaymentMethod {
+    return {
+      ...getPaypalCommerce(),
+        initializationData: {
+          ...getPaypalCommerce().initializationData,
+            isDeveloperModeApplicable: true,
+            buyerCountry: 'IT',
+
+        },
+    };
+}
+
+export function getPaypalCommerceTestModeOff(): PaymentMethod {
+    return {
+        ...getPaypalCommerce(),
+        initializationData: {
+            ...getPaypalCommerce().initializationData,
+            isDeveloperModeApplicable: false,
+            buyerCountry: 'IT',
+
+        },
+    };
+}
+
 export function getPaypal(): PaymentMethod {
     return {
         id: 'paypal',

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -15,7 +15,9 @@ import { PaymentArgumentInvalidError, PaymentMethodInvalidError } from '../../er
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
-import { getPaypalCommerce } from '../../payment-methods.mock';
+import { getPaypalCommerce,
+    getPaypalCommerceTestModeOff,
+    getPaypalCommerceTestModeOn } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentStrategyType from '../../payment-strategy-type';
 import PaymentStrategy from '../payment-strategy';
@@ -99,6 +101,47 @@ describe('PaypalCommercePaymentStrategy', () => {
             paypalCommercePaymentProcessor,
             paypalCommerceFundingKeyResolver
         );
+    });
+
+    describe('Country test mode on', () => {
+        beforeEach(() => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue({ ...getPaypalCommerceTestModeOn(), initializationData: { ...getPaypalCommerceTestModeOn().initializationData, orderId: undefined } });
+        });
+
+        it('returns country if test mode on', async () => {
+            await paypalCommercePaymentStrategy.initialize(options);
+
+            const obj = {
+                'client-id': 'abc',
+                commit: true,
+                currency: 'USD',
+                intent: 'capture',
+                'buyer-country': 'IT',
+            };
+
+            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
+        });
+    });
+
+    describe('Country test mode off', () => {
+        beforeEach(() => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue({ ...getPaypalCommerceTestModeOff(), initializationData: { ...getPaypalCommerceTestModeOff().initializationData, orderId: undefined } });
+        });
+
+        it('returns country if test mode off', async () => {
+            await paypalCommercePaymentStrategy.initialize(options);
+
+            const obj = {
+                'client-id': 'abc',
+                commit: true,
+                currency: 'USD',
+                intent: 'capture',
+            };
+
+            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
+        });
     });
 
     describe('#initialize()', () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -109,14 +109,15 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
     }
 
     private _getOptionsScript(initializationData: PaypalCommerceInitializationData, currencyCode: Cart['currency']['code']): PaypalCommerceScriptParams {
-        const { clientId, intent, merchantId } = initializationData;
-
-        return {
+        const { clientId, intent, merchantId, buyerCountry, isDeveloperModeApplicable } = initializationData;
+        const returnObject = {
             'client-id': clientId,
             'merchant-id': merchantId,
             commit: true,
             currency: currencyCode,
             intent,
         };
+
+        return isDeveloperModeApplicable ? { ...returnObject, 'buyer-country': buyerCountry } : returnObject;
     }
 }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -179,6 +179,8 @@ export interface PaypalCommerceHostWindow extends Window {
 export interface PaypalCommerceInitializationData {
     clientId: string;
     merchantId?: string;
+    buyerCountry?: string;
+    isDeveloperModeApplicable?: boolean;
     intent?: 'capture' | 'authorize';
     isPayPalCreditAvailable?: boolean;
     isProgressiveOnboardingAvailable?: boolean;
@@ -192,6 +194,7 @@ export type ComponentsScriptType = Array<'buttons' | 'messages' | 'hosted-fields
 export interface PaypalCommerceScriptParams  {
     'client-id': string;
     'merchant-id'?: string;
+    'buyer-country'?: string;
     'disable-funding'?: DisableFundingType;
     'data-client-token'?: string;
     'partner-attribution-id'?: string;


### PR DESCRIPTION
## What?
Add mechanism for testing of the APMs for different countries

## Why?
By default Paypal connect appropriate APMs, depending on the country of the buyer, which Paypal determine by location and other factors, however, to check any APM in the test mode without using VPN, we force-pushed the country if the test mode is enabled.

## Testing / Proof
Tested on dev

@bigcommerce/checkout @bigcommerce/payments
