### PR TITLE
feat(payments): INT-3538 Replaced browser language instead locale variable on Adyenv2

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -88,8 +88,7 @@ export default function createPaymentStrategyRegistry(
             store,
             paymentActionCreator,
             orderActionCreator,
-            new AdyenV2ScriptLoader(scriptLoader, getStylesheetLoader()),
-            locale
+            new AdyenV2ScriptLoader(scriptLoader, getStylesheetLoader())
         )
     );
 

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -73,8 +73,7 @@ describe('AdyenV2PaymentStrategy', () => {
             store,
             paymentActionCreator,
             orderActionCreator,
-            adyenV2ScriptLoader,
-            'en_US'
+            adyenV2ScriptLoader
         );
     });
 

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -29,8 +29,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         private _store: CheckoutStore,
         private _paymentActionCreator: PaymentActionCreator,
         private _orderActionCreator: OrderActionCreator,
-        private _scriptLoader: AdyenV2ScriptLoader,
-        private _locale: string
+        private _scriptLoader: AdyenV2ScriptLoader
     ) {}
 
     async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -58,7 +57,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
 
         this._adyenClient = await this._scriptLoader.load({
             environment:  paymentMethod.initializationData.environment,
-            locale: this._locale,
+            locale: navigator.language,
             [clientSideAuthentication.key]: clientSideAuthentication.value,
             paymentMethodsResponse: paymentMethod.initializationData.paymentMethodsResponse,
         });


### PR DESCRIPTION
## What? [INT-3538](url)
Replaced browser language instead locale variable on adyenv2

## Why?
In order to the merchant has the ability to translate adyenv2 components labels with browser language.

## Testing / Proof
![Screen Shot 2020-12-04 at 12 58 03 PM](https://user-images.githubusercontent.com/61981535/101203619-8d301200-3630-11eb-905d-90dc420e16ee.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations
