### PR TITLE
fix(payments): INT-2816 fix unit test for googlepay adyenv2 payment processor

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -474,6 +474,8 @@ export function getGooglePayAdyenV2(): PaymentMethod {
         type: 'PAYMENT_TYPE_API',
         clientToken: 'clientToken',
         initializationData: {
+            originKey: 'YOUR_ORIGIN_KEY',
+            clientKey: 'YOUR_CLIENT_KEY',
             nonce: 'nonce',
             card_information: {
                 type: 'MasterCard',

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.spec.ts
@@ -6,14 +6,14 @@ import { getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { RequestError } from '../../../common/error/errors';
-import { getConfigState } from '../../../config/configs.mock';
+import { getConfig, getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { OrderActionCreator } from '../../../order';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
 import { getGooglePayAdyenV2, getPaymentMethodsState } from '../../payment-methods.mock';
 import { AdyenV2ScriptLoader } from '../adyenv2';
 
-import GooglePayAdyenV2PaymentProcessor from './googlepay-adyenv2-payment-processor';
+import { GooglePayAdyenV2PaymentProcessor } from './index';
 
 describe('GooglePayAdyenV2PaymentProcessor', () => {
     let processor: GooglePayAdyenV2PaymentProcessor;
@@ -54,6 +54,7 @@ describe('GooglePayAdyenV2PaymentProcessor', () => {
 
         jest.spyOn(adyenV2ScriptLoader, 'load').mockReturnValue({createFromAction});
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(getGooglePayAdyenV2());
+        jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue(getConfig().storeConfig);
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
     });
 


### PR DESCRIPTION
## What? [INT-2816](https://jira.bigcommerce.com/browse/INT-2816)
mockReturn to getStoreConfig in order to make the processor work

## Why?
Unit test were broken

## Testing / Proof
<img width="974" alt="Screen Shot 2020-12-09 at 13 32 36" src="https://user-images.githubusercontent.com/69221626/101678040-02ca2280-3a23-11eb-8dd1-674309b1a0db.png">


@bigcommerce/checkout @bigcommerce/payments
