### PR TITLE
feat(payments): PAYPAL-876 implement polling mechanism on front-end

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -46,7 +46,12 @@ import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
 import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy, PaypalScriptLoader } from './strategies/paypal';
-import { createPaypalCommercePaymentProcessor, PaypalCommerceCreditCardPaymentStrategy, PaypalCommerceFundingKeyResolver, PaypalCommerceHostedForm, PaypalCommercePaymentStrategy } from './strategies/paypal-commerce';
+import { createPaypalCommercePaymentProcessor,
+    PaypalCommerceCreditCardPaymentStrategy,
+    PaypalCommerceFundingKeyResolver,
+    PaypalCommerceHostedForm,
+    PaypalCommercePaymentStrategy,
+    PaypalCommerceRequestSender } from './strategies/paypal-commerce';
 import { SagePayPaymentStrategy } from './strategies/sage-pay';
 import { SquarePaymentStrategy, SquareScriptLoader } from './strategies/square';
 import { StripeScriptLoader, StripeV3PaymentStrategy } from './strategies/stripev3';
@@ -317,7 +322,8 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
-            new PaypalCommerceFundingKeyResolver()
+            new PaypalCommerceFundingKeyResolver(),
+            new PaypalCommerceRequestSender(requestSender)
         )
     );
 

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -43,3 +43,4 @@ export { default as paymentStrategyReducer } from './payment-strategy-reducer';
 export { default as PaymentStrategyRegistry } from './payment-strategy-registry';
 export { default as PaymentStrategySelector, PaymentStrategySelectorFactory, createPaymentStrategySelectorFactory } from './payment-strategy-selector';
 export { default as PaymentStrategyState } from './payment-strategy-state';
+export { default as PaymentStrategyType } from './payment-strategy-type';

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-initialize-options.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-initialize-options.ts
@@ -73,6 +73,10 @@ export interface PaypalCommercePaymentInitializeOptions {
      * Smart Payment Button is eligible. This callback can be used to hide the standard submit button.
      */
     onRenderButton?(): void;
+    /**
+     * A callback for displaying error popup. This callback requires error object as parameter.
+     */
+    onError?(error: Error): void;
 }
 
 /**

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -33,7 +33,8 @@ export default class PaypalCommercePaymentProcessor {
 
     constructor(
         private _paypalScriptLoader: PaypalCommerceScriptLoader,
-        private _paypalCommerceRequestSender: PaypalCommerceRequestSender
+        private _paypalCommerceRequestSender: PaypalCommerceRequestSender,
+        private _orderId?: string
     ) {}
 
     async initialize(paramsScript: PaypalCommerceScriptParams, isProgressiveOnboardingAvailable?: boolean): Promise<PaypalCommerceSDK> {
@@ -79,6 +80,10 @@ export default class PaypalCommercePaymentProcessor {
         this._paypalButtons.render(container);
 
         return this._paypalButtons;
+    }
+
+    getOrderId() {
+        return this._orderId;
     }
 
     renderMessages(cartTotal: number, container: string): PaypalCommerceMessages {
@@ -145,7 +150,6 @@ export default class PaypalCommercePaymentProcessor {
 
     deinitialize() {
         this._paypalButtons?.close?.();
-
         this._paypal = undefined;
         this._paypalButtons = undefined;
         this._fundingSource = undefined;
@@ -155,6 +159,7 @@ export default class PaypalCommercePaymentProcessor {
     private async _setupPayment(cartId: string, params: ParamsForProvider = {}): Promise<string> {
         const paramsForProvider = { ...params, isCredit: this._fundingSource === 'credit' || this._fundingSource === 'paylater' };
         const { orderId } = await this._paypalCommerceRequestSender.setupPayment(cartId, paramsForProvider);
+        this._orderId = orderId;
 
         return orderId;
     }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -30,11 +30,11 @@ export default class PaypalCommercePaymentProcessor {
     private _paypalMessages?: PaypalCommerceMessages;
     private _hostedFields?: PaypalCommerceHostedFields;
     private _fundingSource?: string;
+    private _orderId?: string;
 
     constructor(
         private _paypalScriptLoader: PaypalCommerceScriptLoader,
-        private _paypalCommerceRequestSender: PaypalCommerceRequestSender,
-        private _orderId?: string
+        private _paypalCommerceRequestSender: PaypalCommerceRequestSender
     ) {}
 
     async initialize(paramsScript: PaypalCommerceScriptParams, isProgressiveOnboardingAvailable?: boolean): Promise<PaypalCommerceSDK> {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -99,7 +99,8 @@ describe('PaypalCommercePaymentStrategy', () => {
             orderActionCreator,
             paymentActionCreator,
             paypalCommercePaymentProcessor,
-            paypalCommerceFundingKeyResolver
+            paypalCommerceFundingKeyResolver,
+            new PaypalCommerceRequestSender(requestSender)
         );
     });
 
@@ -169,11 +170,11 @@ describe('PaypalCommercePaymentStrategy', () => {
             await paypalCommercePaymentStrategy.initialize(options);
 
             const obj = {
-                    'client-id': 'abc',
-                    commit: true,
-                    currency: 'USD',
-                    intent: 'capture',
-                };
+                'client-id': 'abc',
+                commit: true,
+                currency: 'USD',
+                intent: 'capture',
+            };
 
             expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
         });
@@ -184,6 +185,7 @@ describe('PaypalCommercePaymentStrategy', () => {
             const buttonOption = {
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
+                onCancel: expect.any(Function),
             };
 
             const optionalParams = { fundingKey: 'PAYPAL', paramsForProvider: { isCheckout: true }, onRenderButton: expect.any(Function) };
@@ -207,6 +209,7 @@ describe('PaypalCommercePaymentStrategy', () => {
             const buttonOption = {
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
+                onCancel: expect.any(Function),
             };
 
             const optionalParams = { fundingKey: 'PAYLATER', paramsForProvider: { isCheckout: true }, onRenderButton: expect.any(Function) };
@@ -229,6 +232,7 @@ describe('PaypalCommercePaymentStrategy', () => {
                 .toHaveBeenCalledWith(cart.id, `${paypalcommerceOptions.container}`,
                     {   onApprove: expect.any(Function),
                         onClick: expect.any(Function),
+                        onCancel: expect.any(Function),
                         style: paymentMethod.initializationData.buttonStyle },
                     {   paramsForProvider: { isCheckout: true },
                         onRenderButton: expect.any(Function),

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -40,14 +40,14 @@ export default class PaypalCommerceRequestSender {
     }
 
     async getOrderStatus(): Promise<OrderStatus> {
-        const url = `/api/storefront/initialization/paypalcommerce`;
+        const url = '/api/storefront/initialization/paypalcommerce';
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
             'Content-Type': ContentType.Json,
         };
 
-        const res = await this._requestSender.get(url, {headers});
+        const res = await this._requestSender.get<OrderStatus>(url, {headers});
 
-        return res.body as OrderStatus;
+        return res.body;
     }
 }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -39,7 +39,7 @@ export default class PaypalCommerceRequestSender {
         return res.body as OrderData;
     }
 
-    async getOrderStatus(): Promise<OrderStatus> {
+    async getOrderStatus() {
         const url = '/api/storefront/initialization/paypalcommerce';
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender } from '@bigcommerce/request-sender';
 
 import { ContentType, INTERNAL_USE_ONLY } from '../../../common/http-request';
 
-import { OrderData } from './paypal-commerce-sdk';
+import { OrderData, OrderStatus } from './paypal-commerce-sdk';
 
 export interface ParamsForProvider {
     isCredit?: boolean;
@@ -37,5 +37,17 @@ export default class PaypalCommerceRequestSender {
         const res = await this._requestSender.post(url, { headers, body });
 
         return res.body as OrderData;
+    }
+
+    async getOrderStatus(): Promise<OrderStatus> {
+        const url = `/api/storefront/initialization/paypalcommerce`;
+        const headers = {
+            'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            'Content-Type': ContentType.Json,
+        };
+
+        const res = await this._requestSender.get(url, {headers});
+
+        return res.body as OrderStatus;
     }
 }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -1,6 +1,6 @@
 
 export interface ApproveDataOptions {
-    orderID: string;
+    orderID: string | undefined;
 }
 
 export interface ClickDataOptions {
@@ -15,6 +15,10 @@ export interface ClickActions {
 export interface OrderData {
     orderId: string;
     approveUrl: string;
+}
+
+export interface OrderStatus {
+    status: string;
 }
 
 export enum StyleButtonLabel {
@@ -58,6 +62,7 @@ export interface ButtonsOptions {
     createOrder?(): Promise<string>;
     onApprove?(data: ApproveDataOptions): void;
     onClick?(data: ClickDataOptions, actions: ClickActions): void;
+    onCancel?(): void;
 }
 
 export interface MessagesOptions {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -18,7 +18,7 @@ export interface OrderData {
 }
 
 export interface OrderStatus {
-    status: string;
+    status: 'APPROVED' | 'CREATED' | string;
 }
 
 export enum StyleButtonLabel {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -1,6 +1,6 @@
 
 export interface ApproveDataOptions {
-    orderID: string | undefined;
+    orderID?: string;
 }
 
 export interface ClickDataOptions {


### PR DESCRIPTION
## What?
Implement polling mechanism on front-end

## Why?
When we create order we can have drop off scenario, and we need to implement polling mechanism that sends request and ask for status and proceed with succeed flow if order status 'approved'

## Testing / Proof
Tested on Dev

@bigcommerce/checkout @bigcommerce/payments @davidchin 
