### PR TITLE
fix(provider): PAYPAL-767 Fix device data collection for Braintree stored credit cards

### DIFF
--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -45,7 +45,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
     beforeEach(() => {
         braintreePaymentProcessorMock = {} as BraintreePaymentProcessor;
         braintreePaymentProcessorMock.initialize = jest.fn();
-        braintreePaymentProcessorMock.initializeHostedForm = jest.fn(() => Promise.resolve());
+        braintreePaymentProcessorMock.initializeHostedForm = jest.fn(() => Promise.resolve(true));
         braintreePaymentProcessorMock.tokenizeCard = jest.fn(() => Promise.resolve({ nonce: 'my_tokenized_card' }));
         braintreePaymentProcessorMock.tokenizeHostedForm = jest.fn(() => Promise.resolve({ nonce: 'my_tokenized_card_with_hosted_form' }));
         braintreePaymentProcessorMock.tokenizeHostedFormForStoredCardVerification = jest.fn(() => Promise.resolve({ nonce: 'my_tokenized_card_verification_with_hosted_form' }));

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -40,9 +40,7 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
             this._braintreePaymentProcessor.initialize(paymentMethod.clientToken, options.braintree);
 
             if (this._isHostedPaymentFormEnabled(options.methodId, options.gatewayId) && options.braintree?.form) {
-                await this._braintreePaymentProcessor.initializeHostedForm(options.braintree.form);
-
-                this._isHostedFormInitialized = true;
+                this._isHostedFormInitialized = await this._braintreePaymentProcessor.initializeHostedForm(options.braintree.form);
             }
 
             this._is3dsEnabled = paymentMethod.config.is3dsEnabled;

--- a/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -168,6 +168,15 @@ describe('BraintreeHostedForm', () => {
             });
     });
 
+    it('returns true', async () => {
+        expect(await subject.initialize(formOptions)).toBe(true);
+    });
+
+    it('returns false when no fields specified in form options', async () => {
+        const options = { ...formOptions, fields: {} };
+        expect(await subject.initialize(options)).toBe(false);
+    });
+
     it('notifies when field receives focus', async () => {
         const handleFocus = jest.fn();
 

--- a/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -1,4 +1,4 @@
-import { isNil, omitBy, Dictionary } from 'lodash';
+import { isEmpty, isNil, omitBy, Dictionary } from 'lodash';
 
 import { Address } from '../../../address';
 import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
@@ -26,15 +26,21 @@ export default class BraintreeHostedForm {
         private _braintreeSDKCreator: BraintreeSDKCreator
     ) {}
 
-    async initialize(options: BraintreeFormOptions): Promise<void> {
+    async initialize(options: BraintreeFormOptions): Promise<boolean> {
         this._formOptions = options;
 
         this._type = isBraintreeFormFieldsMap(options.fields) ?
             BraintreeHostedFormType.CreditCard :
             BraintreeHostedFormType.StoredCardVerification;
 
+        const fields = this._mapFieldOptions(options.fields);
+
+        if (isEmpty(fields)) {
+            return Promise.resolve(false);
+        }
+
         this._cardFields = await this._braintreeSDKCreator.createHostedFields({
-            fields: this._mapFieldOptions(options.fields),
+            fields,
             styles: options.styles && this._mapStyleOptions(options.styles),
         });
 
@@ -53,6 +59,8 @@ export default class BraintreeHostedForm {
             this._cardNameField.on('focus', this._handleNameFocus);
             this._cardNameField.attach();
         }
+
+        return Promise.resolve(true);
     }
 
     async deinitialize(): Promise<void> {

--- a/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -36,7 +36,7 @@ export default class BraintreeHostedForm {
         const fields = this._mapFieldOptions(options.fields);
 
         if (isEmpty(fields)) {
-            return Promise.resolve(false);
+            return false;
         }
 
         this._cardFields = await this._braintreeSDKCreator.createHostedFields({
@@ -60,7 +60,7 @@ export default class BraintreeHostedForm {
             this._cardNameField.attach();
         }
 
-        return Promise.resolve(true);
+        return true;
     }
 
     async deinitialize(): Promise<void> {

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -99,8 +99,8 @@ export default class BraintreePaymentProcessor {
         return this._braintreeSDKCreator.teardown();
     }
 
-    async initializeHostedForm(options: BraintreeFormOptions): Promise<void> {
-        await this._braintreeHostedForm.initialize(options);
+    async initializeHostedForm(options: BraintreeFormOptions): Promise<boolean> {
+        return await this._braintreeHostedForm.initialize(options);
     }
 
     async deinitializeHostedForm(): Promise<void> {


### PR DESCRIPTION
## What?

Fixed the issue with collection device data and sending it to Braintree when buyer uses credit cards vaulting.

Changes:
- don't initialize Braintree Hosted Fields SDK when there are no fields on the credit card form

## Why?

When buyer uses stored credit cards device data isn't sent to Braintree and transactions are rejected by anti-fraud mechanisms.

<img width="685" alt="Screen Shot 2020-12-11 at 8 34 48 PM" src="https://user-images.githubusercontent.com/732181/102077166-8b750400-3e11-11eb-9c1a-4a39af9d0d20.png">

The issue is that Hosted Fields Braintree JS SDK requires non empty `fields` option to initialize Hosted Fields ([documentation](https://braintree.github.io/braintree-web/current/module-braintree-web_hosted-fields.html#.create), [source](https://github.com/braintree/braintree-web/blob/3.59.0/src/hosted-fields/external/hosted-fields.js#L418)) and to declare credit card fields which are precent on the form. But there are some cases when there is no any field - e.g. when stored credit card chosen - and checkout-sdk-js passes empty `fields`.

It leads to exception raising and interrupting initialization process:

```json
{
  "code": "INSTANTIATION_OPTION_REQUIRED",
  "message": "options.fields is required when instantiating Hosted Fields.",
  "name": "BraintreeError",
  "type": "MERCHANT",
}
```

As a consequence the device data collector isn't initialized and device data aren't sent to Braintree.

## Testing / Proof

Device data is sending correctly to the BigPay backend

<img width="1383" alt="Screen Shot 2020-12-11 at 3 48 22 PM" src="https://user-images.githubusercontent.com/732181/102077516-1a821c00-3e12-11eb-8407-2aba46613510.png">

Device data successfully stored on the Braintree side.

<img width="517" alt="Screen Shot 2020-12-11 at 2 28 43 PM" src="https://user-images.githubusercontent.com/732181/102078503-b4969400-3e13-11eb-9a3f-ccc0aff1b04b.png">

@bigcommerce/checkout @bigcommerce/payments
