### PR TITLE
CHECKOUT-5418 Add support for recaptcha for customer account creation

### DIFF
--- a/src/checkout/checkout-reducer.ts
+++ b/src/checkout/checkout-reducer.ts
@@ -45,7 +45,7 @@ function dataReducer(
     case ConsignmentActionType.LoadShippingOptionsSucceeded:
     case GiftCertificateActionType.ApplyGiftCertificateSucceeded:
     case GiftCertificateActionType.RemoveGiftCertificateSucceeded:
-    case SpamProtectionActionType.ExecuteSucceeded:
+    case SpamProtectionActionType.VerifyCheckoutSucceeded:
         return objectMerge(data, omit(action.payload, [
             'billingAddress',
             'cart',

--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -253,7 +253,14 @@ describe('CheckoutService', () => {
             billingAddressActionCreator,
             checkoutActionCreator,
             configActionCreator,
-            new CustomerActionCreator(customerRequestSender, checkoutActionCreator),
+            new CustomerActionCreator(
+                customerRequestSender,
+                checkoutActionCreator,
+                new SpamProtectionActionCreator(
+                    createSpamProtection(createScriptLoader()),
+                    new SpamProtectionRequestSender(requestSender)
+                )
+            ),
             consignmentActionCreator,
             new CountryActionCreator(countryRequestSender),
             new CouponActionCreator(couponRequestSender),
@@ -1148,17 +1155,19 @@ describe('CheckoutService', () => {
             jest.spyOn(spamProtectionActionCreator, 'initialize')
                 .mockReturnValue(of(createAction(SpamProtectionActionType.InitializeSucceeded)));
 
-            jest.spyOn(spamProtectionActionCreator, 'execute')
+            jest.spyOn(spamProtectionActionCreator, 'verifyCheckoutSpamProtection')
                 .mockReturnValue(() => from([
+                    createAction(SpamProtectionActionType.VerifyCheckoutRequested),
                     createAction(SpamProtectionActionType.ExecuteRequested),
                     createAction(SpamProtectionActionType.ExecuteSucceeded),
+                    createAction(SpamProtectionActionType.VerifyCheckoutSucceeded),
                 ]));
         });
 
         it('executes spam check', async () => {
             await checkoutService.executeSpamCheck();
 
-            expect(spamProtectionActionCreator.execute)
+            expect(spamProtectionActionCreator.verifyCheckoutSpamProtection)
                 .toHaveBeenCalled();
         });
     });

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -560,13 +560,12 @@ export default class CheckoutService {
      * of development. Therefore the API is unstable and not ready for public
      * consumption.
      *
-     * @internal
      * @param customerAccount - The customer account data.
      * @param options - Options for creating customer account.
      * @returns A promise that resolves to the current state.
      */
     createCustomerAccount(customerAccount: CustomerAccountRequestBody, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._customerActionCreator.createAccount(customerAccount, options);
+        const action = this._customerActionCreator.createCustomer(customerAccount, options);
 
         return this._dispatch(action);
     }
@@ -1205,7 +1204,7 @@ export default class CheckoutService {
      * @returns A promise that resolves to the current state.
      */
     executeSpamCheck(): Promise<CheckoutSelectors> {
-        const action = this._spamProtectionActionCreator.execute();
+        const action = this._spamProtectionActionCreator.verifyCheckoutSpamProtection();
 
         return this._dispatch(action, { queueId: 'spamProtection' });
     }

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -85,7 +85,11 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         ),
         checkoutActionCreator,
         configActionCreator,
-        new CustomerActionCreator(new CustomerRequestSender(requestSender), checkoutActionCreator),
+        new CustomerActionCreator(
+            new CustomerRequestSender(requestSender),
+            checkoutActionCreator,
+            spamProtectionActionCreator
+        ),
         new ConsignmentActionCreator(new ConsignmentRequestSender(requestSender), checkoutRequestSender),
         new CountryActionCreator(new CountryRequestSender(requestSender, { locale })),
         new CouponActionCreator(new CouponRequestSender(requestSender)),

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -93,6 +93,7 @@ export interface CheckoutSettings {
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;
     googleRecaptchaSitekey: string;
+    isStorefrontSpamProtectionEnabled: boolean;
     guestCheckoutEnabled: boolean;
     hasMultiShippingEnabled: boolean;
     isAnalyticsEnabled: boolean;

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -28,6 +28,7 @@ export function getConfig(): Config {
                 googleRecaptchaSitekey: 'sitekey',
                 isAnalyticsEnabled: false,
                 isCardVaultingEnabled: true,
+                isStorefrontSpamProtectionEnabled: false,
                 isSignInEmailEnabled: false,
                 isPaymentRequestEnabled: false,
                 isPaymentRequestCanMakePaymentEnabled: false,

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -14,6 +14,7 @@ import { ChasePayScriptLoader } from '../payment/strategies/chasepay';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
+import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../spam-protection';
 
 import CustomerActionCreator from './customer-action-creator';
 import CustomerRequestSender from './customer-request-sender';
@@ -172,7 +173,11 @@ export default function createCustomerStrategyRegistry(
             store,
             new CustomerActionCreator(
                 new CustomerRequestSender(requestSender),
-                checkoutActionCreator
+                checkoutActionCreator,
+                new SpamProtectionActionCreator(
+                    createSpamProtection(scriptLoader),
+                    new SpamProtectionRequestSender(requestSender)
+                )
             )
         )
     );

--- a/src/customer/customer-account.ts
+++ b/src/customer/customer-account.ts
@@ -9,3 +9,7 @@ export default interface CustomerAccountRequestBody {
         fieldValue: string | number | string[];
     }>;
 }
+
+export interface CustomerAccountInternalRequestBody extends CustomerAccountRequestBody {
+    token?: string;
+}

--- a/src/customer/customer-actions.ts
+++ b/src/customer/customer-actions.ts
@@ -1,6 +1,7 @@
 import { Action } from '@bigcommerce/data-store';
 
 import { LoadCheckoutAction } from '../checkout';
+import { SpamProtectionAction } from '../spam-protection';
 
 import { InternalCustomerResponseData } from './internal-customer-responses';
 
@@ -27,6 +28,7 @@ export type CreateCustomerAction =
     CreateCustomerRequestedAction |
     CreateCustomerSucceededAction |
     CreateCustomerFailedAction |
+    SpamProtectionAction |
     LoadCheckoutAction;
 
 export type SignInCustomerAction =

--- a/src/customer/customer-request-sender.ts
+++ b/src/customer/customer-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
 
-import CustomerAccountRequestBody from './customer-account';
+import { CustomerAccountInternalRequestBody } from './customer-account';
 import CustomerCredentials from './customer-credentials';
 import { InternalCustomerResponseBody } from './internal-customer-responses';
 
@@ -11,7 +11,7 @@ export default class CustomerRequestSender {
         private _requestSender: RequestSender
     ) {}
 
-    createAccount(customerAccount: CustomerAccountRequestBody, { timeout }: RequestOptions = {}): Promise<Response<{}>> {
+    createAccount(customerAccount: CustomerAccountInternalRequestBody, { timeout }: RequestOptions = {}): Promise<Response<{}>> {
         const url = '/api/storefront/customer';
 
         return this._requestSender.post(url, { timeout, body: customerAccount });

--- a/src/spam-protection/create-spam-protection.ts
+++ b/src/spam-protection/create-spam-protection.ts
@@ -5,7 +5,7 @@ import { MutationObserverFactory } from '../common/dom';
 import GoogleRecaptcha from './google-recaptcha';
 import GoogleRecaptchaScriptLoader from './google-recaptcha-script-loader';
 
-export default function createSpamProtection(scriptLoader: ScriptLoader) {
+export default function createSpamProtection(scriptLoader: ScriptLoader): GoogleRecaptcha {
     return new GoogleRecaptcha(
         new GoogleRecaptchaScriptLoader(scriptLoader),
         new MutationObserverFactory()

--- a/src/spam-protection/index.ts
+++ b/src/spam-protection/index.ts
@@ -6,3 +6,5 @@ export { default as PaymentHumanVerificationHandler } from './payment-human-veri
 export { default as GoogleRecaptcha } from './google-recaptcha';
 export { default as SpamProtectionActionCreator } from './spam-protection-action-creator';
 export { default as SpamProtectionRequestSender } from './spam-protection-request-sender';
+export { default as isSpamProtectionExecuteSucceededAction } from './is-spam-protection-succeeded-action';
+export { default as GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow } from './google-recaptcha-script-loader';

--- a/src/spam-protection/is-spam-protection-succeeded-action.ts
+++ b/src/spam-protection/is-spam-protection-succeeded-action.ts
@@ -1,0 +1,9 @@
+import { ExecuteSucceededAction, SpamProtectionAction } from './spam-protection-actions';
+
+export default function isSpamProtectionExecuteSucceededAction(action: SpamProtectionAction): action is ExecuteSucceededAction {
+    const succeededAction = action as ExecuteSucceededAction;
+
+    return typeof succeededAction === 'object' &&
+        typeof succeededAction.payload === 'object' &&
+        typeof succeededAction.payload.token === 'string';
+}

--- a/src/spam-protection/spam-protection-actions.ts
+++ b/src/spam-protection/spam-protection-actions.ts
@@ -6,6 +6,9 @@ export enum SpamProtectionActionType {
     InitializeFailed = 'SPAM_PROTECTION_INITIALIZE_FAILED',
     InitializeSucceeded = 'SPAM_PROTECTION_INITIALIZE_SUCCEEDED',
     InitializeRequested = 'SPAM_PROTECTION_INITIALIZE_REQUESTED',
+    VerifyCheckoutRequested = 'SPAM_PROTECTION_CHECKOUT_VERIFY_REQUESTED',
+    VerifyCheckoutSucceeded = 'SPAM_PROTECTION_CHECKOUT_VERIFY_SUCCEEDED',
+    VerifyCheckoutFailed = 'SPAM_PROTECTION_CHECKOUT_VERIFY_FAILED',
     ExecuteRequested = 'SPAM_PROTECTION_EXECUTE_REQUESTED',
     ExecuteSucceeded = 'SPAM_PROTECTION_EXECUTE_SUCCEEDED',
     ExecuteFailed = 'SPAM_PROTECTION_EXECUTE_FAILED',
@@ -17,7 +20,10 @@ export type SpamProtectionAction =
     InitializeFailedAction |
     ExecuteRequestedAction |
     ExecuteSucceededAction |
-    ExecuteFailedAction;
+    ExecuteFailedAction |
+    CheckoutVerifyRequestedAction |
+    CheckoutVerifyFailedAction |
+    CheckoutVerifySucceededAction;
 
 export interface InitializeRequestedAction extends Action {
     type: SpamProtectionActionType.InitializeRequested;
@@ -35,10 +41,22 @@ export interface ExecuteRequestedAction extends Action {
     type: SpamProtectionActionType.ExecuteRequested;
 }
 
-export interface ExecuteSucceededAction extends Action<Checkout> {
+export interface ExecuteSucceededAction extends Action<{ token: string }> {
     type: SpamProtectionActionType.ExecuteSucceeded;
 }
 
 export interface ExecuteFailedAction extends Action {
     type: SpamProtectionActionType.ExecuteFailed;
+}
+
+export interface CheckoutVerifyRequestedAction extends Action {
+    type: SpamProtectionActionType.VerifyCheckoutRequested;
+}
+
+export interface CheckoutVerifyFailedAction extends Action<Error> {
+    type: SpamProtectionActionType.VerifyCheckoutFailed;
+}
+
+export interface CheckoutVerifySucceededAction extends Action<Checkout> {
+    type: SpamProtectionActionType.VerifyCheckoutSucceeded;
 }


### PR DESCRIPTION
## What?
Add support for recaptcha for customer account creation

## Why?
Because when Storefont recaptcha is enabled, it's required for customer account creation

## Testing / Proof
unit

@bigcommerce/checkout