### PR TITLE
CHECKOUT-4941 Load form fields when loading order

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -269,7 +269,8 @@ describe('CheckoutService', () => {
             signInEmailActionCreator,
             spamProtectionActionCreator,
             new StoreCreditActionCreator(storeCreditRequestSender),
-            subscriptionsActionCreator
+            subscriptionsActionCreator,
+            formFieldsActionCreator
         );
     });
 
@@ -508,6 +509,7 @@ describe('CheckoutService', () => {
         beforeEach(() => {
             jest.spyOn(orderActionCreator, 'loadOrder');
             jest.spyOn(configActionCreator, 'loadConfig');
+            jest.spyOn(formFieldsActionCreator, 'loadFormFields');
         });
 
         it('loads order data', async () => {
@@ -522,6 +524,13 @@ describe('CheckoutService', () => {
 
             expect(configActionCreator.loadConfig).toHaveBeenCalled();
             expect(state.data.getConfig()).toEqual(getConfig().storeConfig);
+        });
+
+        it('loads form fields data', async () => {
+            const state = await checkoutService.loadOrder(295);
+
+            expect(formFieldsActionCreator.loadFormFields).toHaveBeenCalled();
+            expect(state.data.getCustomerAccountFields()).toEqual(getFormFields().customerAccount);
         });
     });
 

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -10,6 +10,7 @@ import { bindDecorator as bind } from '../common/utility';
 import { ConfigActionCreator } from '../config';
 import { CouponActionCreator, GiftCertificateActionCreator } from '../coupon';
 import { CustomerAccountRequestBody, CustomerActionCreator, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, CustomerStrategyActionCreator, GuestCredentials } from '../customer';
+import { FormFieldsActionCreator } from '../form';
 import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
 import { PaymentInitializeOptions, PaymentMethodActionCreator, PaymentRequestOptions, PaymentStrategyActionCreator } from '../payment';
@@ -65,7 +66,8 @@ export default class CheckoutService {
         private _signInEmailActionCreator: SignInEmailActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator,
         private _storeCreditActionCreator: StoreCreditActionCreator,
-        private _subscriptionsActionCreator: SubscriptionsActionCreator
+        private _subscriptionsActionCreator: SubscriptionsActionCreator,
+        private _formFieldsActionCreator: FormFieldsActionCreator
     ) {
         this._errorTransformer = createCheckoutServiceErrorTransformer();
         this._selectorsFactory = createCheckoutSelectorsFactory();
@@ -203,11 +205,13 @@ export default class CheckoutService {
      */
     loadOrder(orderId: number, options?: RequestOptions): Promise<CheckoutSelectors> {
         const loadCheckoutAction = this._orderActionCreator.loadOrder(orderId, options);
+        const formFieldsAction = this._formFieldsActionCreator.loadFormFields(options);
         const loadConfigAction = this._configActionCreator.loadConfig(options);
 
         return Promise.all([
             this._dispatch(loadCheckoutAction),
             this._dispatch(loadConfigAction, { queueId: 'config' }),
+            this._dispatch(formFieldsAction, { queueId: 'formFields' }),
         ])
             .then(() => this.getState());
     }

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -105,7 +105,8 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new SignInEmailActionCreator(new SignInEmailRequestSender(requestSender)),
         spamProtectionActionCreator,
         new StoreCreditActionCreator(new StoreCreditRequestSender(requestSender)),
-        subscriptionsActionCreator
+        subscriptionsActionCreator,
+        formFieldsActionCreator
     );
 }
 


### PR DESCRIPTION
## What?
Load form fields when loading order

## Why?
Because now the order confirmation page retrieves the form fields from the new endpoint, rather than from checkout-settings endpoint, causing an error.

## Testing / Proof
![Screen Shot 2020-12-16 at 9 45 03 am](https://user-images.githubusercontent.com/1621894/102282373-a1570600-3f84-11eb-9b9d-0c3c7700ac74.png)


@bigcommerce/checkout 