### PR TITLE
feat(payments): PAYPAL-883 Implement logic for APM to always work in Authorize and Capture transaction type on frontend part

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -28,6 +28,7 @@ import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
 import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy } from './strategies/paypal';
+import { PaypalCommercePaymentStrategy } from './strategies/paypal-commerce';
 import { SagePayPaymentStrategy } from './strategies/sage-pay';
 import { SquarePaymentStrategy } from './strategies/square';
 import { StripeV3PaymentStrategy } from './strategies/stripev3';
@@ -82,6 +83,11 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate braintree', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.BRAINTREE);
         expect(paymentStrategy).toBeInstanceOf(BraintreeCreditCardPaymentStrategy);
+    });
+
+    it('can instantiate APM', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS);
+        expect(paymentStrategy).toBeInstanceOf(PaypalCommercePaymentStrategy);
     });
 
     it('can instantiate bluesnapv2', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -342,6 +342,17 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
+    registry.register(PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS, () =>
+        new PaypalCommercePaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
+            new PaypalCommerceFundingKeyResolver(),
+            new PaypalCommerceRequestSender(requestSender)
+        )
+    );
+
     registry.register(PaymentStrategyType.SAGE_PAY, () =>
         new SagePayPaymentStrategy(
             store,
@@ -560,7 +571,7 @@ export default function createPaymentStrategyRegistry(
             storeCreditActionCreator,
             new BoltScriptLoader(scriptLoader)
         )
-);
+    );
 
     return registry;
 }

--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -37,9 +37,12 @@ export default class PaymentStrategyRegistry extends Registry<PaymentStrategy, P
             return PaymentStrategyType.KLARNAV2;
         }
 
-        if (paymentMethod.id === PaymentStrategyType.PAYPAL_COMMERCE_CREDIT ||
-            paymentMethod.gateway === PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS) {
+        if (paymentMethod.id === PaymentStrategyType.PAYPAL_COMMERCE_CREDIT) {
             return PaymentStrategyType.PAYPAL_COMMERCE;
+        }
+
+        if ( paymentMethod.gateway === PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS) {
+            return PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS;
         }
 
         const methodId = paymentMethod.gateway || paymentMethod.id;

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
@@ -204,7 +204,7 @@ describe('PaypalCommercePaymentProcessor', () => {
             await new Promise(resolve => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.setupPayment)
-                .toHaveBeenCalledWith(cart.id, { isCredit: false });
+                .toHaveBeenCalledWith(cart.id, { isCredit: false, isAPM: false });
         });
 
         it('create order with credit (post request to server) when PayPalCommerce payment details are setup payment', async () => {
@@ -220,7 +220,7 @@ describe('PaypalCommercePaymentProcessor', () => {
             await new Promise(resolve => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.setupPayment)
-                .toHaveBeenCalledWith(cart.id, { isCredit: true });
+                .toHaveBeenCalledWith(cart.id, { isCredit: true, isAPM: false });
         });
 
         it('call onApprove when PayPalCommerce payment details are tokenized', async () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -121,7 +121,7 @@ describe('PaypalCommercePaymentStrategy', () => {
                 'buyer-country': 'IT',
             };
 
-            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
+            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, undefined);
         });
     });
 
@@ -141,7 +141,7 @@ describe('PaypalCommercePaymentStrategy', () => {
                 intent: 'capture',
             };
 
-            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
+            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, undefined);
         });
     });
 
@@ -176,7 +176,7 @@ describe('PaypalCommercePaymentStrategy', () => {
                 intent: 'capture',
             };
 
-            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
+            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, undefined);
         });
 
         it('render PayPal button if orderId is undefined', async () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -77,7 +77,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
             },
         };
 
-        await this._paypalCommercePaymentProcessor.initialize(paramsScript);
+        await this._paypalCommercePaymentProcessor.initialize(paramsScript, undefined, gatewayId);
 
         this._paypalCommercePaymentProcessor.renderButtons(cartId, container, buttonParams, {
             onRenderButton,

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.spec.ts
@@ -93,5 +93,19 @@ describe('PaypalCommerceRequestSender', () => {
                 headers,
             }));
         });
+        it('create order from checkout page for APM', async () => {
+            paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
+            await paypalCommerceRequestSender.setupPayment('abc', { isCheckout: true, isAPM: true });
+
+            const headers = {
+                'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                'Content-Type': ContentType.Json,
+            };
+
+            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommercealternativemethods', expect.objectContaining({
+                body: {cartId: 'abc'},
+                headers,
+            }));
+        });
     });
 });

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -8,6 +8,7 @@ export interface ParamsForProvider {
     isCredit?: boolean;
     isCheckout?: boolean;
     isCreditCard?: boolean;
+    isAPM?: boolean;
 }
 
 export default class PaypalCommerceRequestSender {
@@ -16,7 +17,7 @@ export default class PaypalCommerceRequestSender {
     ) {}
 
     async setupPayment(cartId: string, params: ParamsForProvider = {}): Promise<OrderData> {
-        const { isCredit, isCheckout, isCreditCard } = params;
+        const { isCredit, isCheckout, isCreditCard, isAPM } = params;
         let provider = 'paypalcommerce';
 
         if (isCreditCard) {
@@ -25,6 +26,10 @@ export default class PaypalCommerceRequestSender {
             provider = isCredit ? 'paypalcommercecreditcheckout' : 'paypalcommercecheckout';
         } else if (isCredit) {
             provider = 'paypalcommercecredit';
+        }
+
+        if (isAPM) {
+            provider = 'paypalcommercealternativemethods';
         }
 
         const url = `/api/storefront/payment/${provider}`;


### PR DESCRIPTION
## What?
Implement logic for APM to always work in Authorize and Capture transaction type on frontend part

## Why?
According to task PAYPAL-883

## Testing / Proof
Tested on dev

@bigcommerce/checkout @bigcommerce/payments @davidchin 
