### PR TITLE
feat(checkout): INT-3675 Add Bolt's tracking script to checkout

### DIFF
--- a/src/payment/strategies/bolt/bolt-script-loader.spec.ts
+++ b/src/payment/strategies/bolt/bolt-script-loader.spec.ts
@@ -34,12 +34,14 @@ describe('BoltScriptLoader', () => {
             await boltScriptLoader.load(publishableKey);
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect.bolt.com/connect-bigcommerce.js', expect.any(Object));
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect.bolt.com/track.js');
         });
 
         it('loads the bolt script in test mode', async () => {
           await boltScriptLoader.load(publishableKey, true);
 
           expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-sandbox.bolt.com/connect-bigcommerce.js', expect.any(Object));
+          expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-sandbox.bolt.com/track.js');
       });
 
         it('returns the Bolt Client from the window', async () => {

--- a/src/payment/strategies/bolt/bolt-script-loader.ts
+++ b/src/payment/strategies/bolt/bolt-script-loader.ts
@@ -19,7 +19,11 @@ export default class BoltScriptLoader {
             },
         };
 
-        await this._scriptLoader.loadScript(`//connect${testMode ? '-sandbox' : ''}.bolt.com/connect-bigcommerce.js`, options);
+        await Promise.all([
+            this._scriptLoader.loadScript(`//connect${testMode ? '-sandbox' : ''}.bolt.com/connect-bigcommerce.js`, options),
+            this._scriptLoader.loadScript(`//connect${testMode ? '-sandbox' : ''}.bolt.com/track.js`),
+        ]);
+
         if (!this._window.BoltCheckout) {
             throw new PaymentMethodClientUnavailableError();
         }


### PR DESCRIPTION
## What? [INT-3675](https://jira.bigcommerce.com/browse/INT-3675)
Load Bolt's `track.js` when using Bolt's Fraud option along with lightbox's script.

## Why?
To make Bolt able to collect data for the best checkout experience.

## Testing / Proof
QA review

@bigcommerce/checkout @bigcommerce/payments
