### PR TITLE
fix(payment): INT-3717 Unformat cardNumber before notifying a bin num…

### DIFF
--- a/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
@@ -20,7 +20,7 @@ describe('HostedCardNumberInput', () => {
     let input: HostedInput;
     let inputAggregator: Pick<HostedInputAggregator, 'getInputValues'>;
     let inputValidator: Pick<HostedInputValidator, 'validate'>;
-    let numberFormatter: Pick<CardNumberFormatter, 'format'>;
+    let numberFormatter: Pick<CardNumberFormatter, 'format' | 'unformat'>;
     let paymentHandler: Pick<HostedInputPaymentHandler, 'handle'>;
     let styles: HostedInputStylesMap;
 
@@ -49,7 +49,7 @@ describe('HostedCardNumberInput', () => {
                 errors: {},
             })),
         };
-        numberFormatter = { format: jest.fn() };
+        numberFormatter = { format: jest.fn(), unformat: value => value.replace(/ /g, '') };
         paymentHandler = { handle: jest.fn() };
         styles = { default: { color: 'rgb(255, 255, 255)' } };
 
@@ -122,6 +122,17 @@ describe('HostedCardNumberInput', () => {
                 type: HostedInputEventType.BinChanged,
                 payload: {
                     bin: '411111',
+                },
+            });
+
+        element.value = '4987 6511 1111 1111';
+        element.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(eventPoster.post)
+            .toHaveBeenCalledWith({
+                type: HostedInputEventType.BinChanged,
+                payload: {
+                    bin: '498765',
                 },
             });
     });

--- a/src/hosted-form/iframe-content/hosted-card-number-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.ts
@@ -69,8 +69,11 @@ export default class HostedCardNumberInput extends HostedInput {
             });
         }
 
-        const bin = value.length >= 6 && number(value).isPotentiallyValid ? value.substr(0, 6) : '';
-        const prevBin = this._previousValue && this._previousValue.length >= 6 ? this._previousValue.substr(0, 6) : '';
+        const unformattedValue = this._formatter.unformat(value);
+        const unformattedPreviousValue = this._previousValue ? this._formatter.unformat(this._previousValue) : '';
+
+        const bin = unformattedValue.length >= 6 && number(unformattedValue).isPotentiallyValid ? unformattedValue.substr(0, 6) : '';
+        const prevBin = unformattedPreviousValue.length >= 6 ? unformattedPreviousValue.substr(0, 6) : '';
 
         if (bin !== prevBin) {
             this._eventPoster.post({


### PR DESCRIPTION
…ber change

## What? [INT-3717](https://jira.bigcommerce.com/browse/INT-3717)
Unformat the `cardNumber` field before notifying a bin number change.

## Why?
Cardinal 3DS' bin process is failing because the bin number contains spaces due to the card number formatter.

## Testing / Proof
CircleCI

Ping @bigcommerce/apex-integrations @bigcommerce/checkout @bigcommerce/payments
