### PR TITLE
fix(provider): INT-3655 Avoid passing null nonce token to StripeV3

### DIFF
--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -87,6 +87,10 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
 
                 paymentIntent = await this._confirmVaultedPayment(clientSecret);
 
+                if (!paymentIntent.id) {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentToken);
+                }
+
                 paymentPayload = {
                     methodId,
                     paymentData: {
@@ -98,6 +102,10 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
             const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}?method=${methodId}`));
             const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
             paymentIntent = await this._confirmStripePayment(paymentMethod, shouldSaveInstrument);
+
+            if (!paymentIntent.id) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentToken);
+            }
 
             paymentPayload = {
                 methodId,

--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -149,6 +149,14 @@ export function getConfirmPaymentResponse(): unknown {
     };
 }
 
+export function getWrongPaymentResponse(): unknown {
+    return {
+        paymentIntent: {
+            otherKey: 'other_value',
+        },
+    };
+}
+
 export function getStripePaymentMethodOptionsWithGuestUserWithoutAddress(): PaymentMethodCreateParams {
     return {
         billing_details: {


### PR DESCRIPTION
## What?
[INT-3655](https://jira.bigcommerce.com/browse/INT-3655): Stripe V3 - Some customers unable to checkout with Stripe

This issue hasn't been reproduced, at least without forcing it to happen, it seems that sometimes the nonce token is not loaded and is sent as null to BigPay, the strategy should not allow this, so we are checking it before sending the payload to BigPay

## Why?
Customers are presenting issues that prevent them to finishing the payment when using Stripe as payment method, which end in bad user experience 

## Testing / Proof
Tests
![image](https://user-images.githubusercontent.com/64860381/104648740-324ef900-5679-11eb-8570-0fc971566565.png)

Message that the client will see
![image](https://user-images.githubusercontent.com/64860381/104648496-d3897f80-5678-11eb-9df7-8541f9493e04.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
