### PR TITLE
feat(payment): INT-3702 added vaulted cc

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -5,9 +5,9 @@ interface SupportedInstruments {
 }
 
 const supportedInstruments: SupportedInstruments = {
-    'mollie.creditcard': {
+    'mollie.credit_card': {
         provider: 'mollie',
-        method: 'creditcard',
+        method: 'credit_card',
     },
     'adyenv2.scheme': {
         provider: 'adyenv2',

--- a/src/payment/strategies/mollie/mollie-initialize-options.ts
+++ b/src/payment/strategies/mollie/mollie-initialize-options.ts
@@ -1,7 +1,57 @@
+/**
+ * A set of options that are required to initialize the Mollie payment method.
+ *
+ * Once Mollie payment is initialized, credit card form fields are provided by the
+ * payment provider as IFrames, these will be inserted into the current page. These
+ * options provide a location and styling for each of the form fields.
+ *
+ * ```js
+ * service.initializePayment({
+ *      methodId: 'mollie',
+ *      mollie: {
+ *          containerId: 'container',
+ *          cardNumberId: '',
+ *          cardHolderId: '',
+ *          cardCvcId: '',
+ *          cardExpiryId: '',
+ *          styles : {
+ *              base: {
+ *                  color: '#fff'
+ *              }
+ *          }
+ *      }
+ * });
+ */
 export default interface MolliePaymentInitializeOptions {
+    /**
+     * ContainerId is use in Mollie for determined either its showing or not the
+     * container, because when Mollie has Vaulted Instruments it gets hide,
+     * and shows an error because can't mount Provider Components
+     */
+    containerId: string;
+
+    /**
+     * The location to insert Mollie Component
+     */
     cardNumberId: string;
+
+    /**
+     * The location to insert Mollie Component
+     */
     cardHolderId: string;
+
+    /**
+     * The location to insert Mollie Component
+     */
     cardCvcId: string;
+
+    /**
+     * The location to insert Mollie Component
+     */
     cardExpiryId: string;
+
+    /**
+     * A set of styles required for the mollie components
+     */
     styles: object;
 }

--- a/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -64,6 +64,8 @@ describe('MolliePaymentStrategy', () => {
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
+        jest.useFakeTimers();
+
         jest.spyOn(store, 'dispatch');
 
         jest.spyOn(orderActionCreator, 'finalizeOrder')
@@ -89,7 +91,7 @@ describe('MolliePaymentStrategy', () => {
         );
     });
 
-    describe('#Initialize & Executes', () => {
+    describe('#Initialize & #Execute', () => {
         let options: PaymentInitializeOptions;
 
         beforeEach(() => {
@@ -114,6 +116,7 @@ describe('MolliePaymentStrategy', () => {
                 await strategy.initialize(options);
 
                 expect(mollieScriptLoader.load).toBeCalledWith('test_T0k3n', 'en_US', true);
+                jest.runAllTimers();
                 expect(mollieClient.createComponent).toBeCalledTimes(4);
                 expect(mollieElement.mount).toBeCalledTimes(4);
             });
@@ -133,14 +136,15 @@ describe('MolliePaymentStrategy', () => {
                 }
             });
 
-            it('should call submitPayment when paying with creditcard', async () => {
+            it('should call submitPayment when paying with credit_card', async () => {
                 await strategy.initialize(options);
+                jest.runAllTimers();
                 await strategy.execute(getOrderRequestBodyWithCreditCard());
 
                 expect(mollieClient.createToken).toBeCalled();
                 expect(paymentActionCreator.submitPayment).toBeCalledWith({
                     gatewayId: 'mollie',
-                    methodId: 'creditcard',
+                    methodId: 'credit_card',
                     paymentData: {
                         formattedPayload: {
                             browser_info: {
@@ -149,11 +153,38 @@ describe('MolliePaymentStrategy', () => {
                                 language: 'en-US',
                                 screen_height: 0,
                                 screen_width: 0,
-                                time_zone_offset: '0',
+                                time_zone_offset: new Date().getTimezoneOffset().toString(),
                             },
                             credit_card_token : {
                                 token: 'tkn_test',
                             },
+                        },
+                    },
+                });
+            });
+
+            it('should call submitPayment when saving vaulted', async () => {
+                await strategy.initialize(options);
+                jest.runAllTimers();
+                const { payment } = getOrderRequestBodyWithCreditCard();
+                await strategy.execute({ ...payment, payment: { methodId: 'credit_card', paymentData: { shouldSaveInstrument: true, shouldSetAsDefaultInstrument: true } } });
+                expect(paymentActionCreator.submitPayment).toBeCalledWith({
+                    methodId: 'credit_card',
+                    paymentData: {
+                        formattedPayload: {
+                            browser_info: {
+                                color_depth: 24,
+                                java_enabled: false,
+                                language: 'en-US',
+                                screen_height: 0,
+                                screen_width: 0,
+                                time_zone_offset: new Date().getTimezoneOffset().toString(),
+                            },
+                            credit_card_token : {
+                                token: 'tkn_test',
+                            },
+                            set_as_default_stored_instrument: true,
+                            vault_payment_instrument: true,
                         },
                     },
                 });
@@ -170,16 +201,12 @@ describe('MolliePaymentStrategy', () => {
                 });
             });
         });
-
-        afterEach(() =>  {
-            jest.resetAllMocks();
-        });
     });
 
     describe('#finalize()', () => {
         it('finalize mollie', () => {
             const promise = strategy.finalize();
-            expect(promise).resolves.toBe({});
+            expect(promise).resolves.toBe(store.getState());
         });
     });
 
@@ -194,16 +221,22 @@ describe('MolliePaymentStrategy', () => {
 
             jest.spyOn(store.getState().config, 'getStoreConfig')
                 .mockReturnValue({ storeProfile: { storeLanguage:  'en_US' } });
+
+            jest.spyOn(document, 'querySelectorAll');
         });
 
         it('deinitialize mollie payment strategy', async () => {
             await strategy.initialize(options);
 
+            jest.runAllTimers();
+            expect(mollieClient.createComponent).toBeCalledTimes(4);
             expect(mollieElement.mount).toBeCalledTimes(4);
 
             const promise = strategy.deinitialize();
 
-            expect(mollieElement.unmount).toBeCalledTimes(4);
+            expect(document.querySelectorAll).toBeCalledTimes(2);
+            expect(document.querySelectorAll).toHaveBeenNthCalledWith(1, '.mollie-component');
+            expect(document.querySelectorAll).toHaveBeenNthCalledWith(2, '.mollie-components-controller');
 
             return expect(promise).resolves.toBe(store.getState());
         });

--- a/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -1,4 +1,4 @@
-import { some } from 'lodash';
+import { each, some } from 'lodash';
 
 import { PaymentActionCreator } from '../..';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
@@ -6,12 +6,18 @@ import { getBrowserInfo } from '../../../common/browser-info';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { PaymentArgumentInvalidError } from '../../errors';
+import isVaultedInstrument from '../../is-vaulted-instrument';
+import { HostedInstrument } from '../../payment';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
 import { MollieClient, MollieElement } from './mollie';
 import MolliePaymentInitializeOptions from './mollie-initialize-options';
 import MollieScriptLoader from './mollie-script-loader';
+
+export enum MolliePaymentMethodType {
+    creditcard = 'credit_card',
+}
 
 export default class MolliePaymentStrategy implements PaymentStrategy {
     private _initializeOptions?: MolliePaymentInitializeOptions;
@@ -51,7 +57,7 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to initialize payment because "merchantId" argument is not provided.');
         }
 
-        if (methodId === 'creditcard') {
+        if (methodId === MolliePaymentMethodType.creditcard) {
             this._mollieClient = await this._loadMollieJs(merchantId, storeConfig.storeProfile.storeLanguage, testMode);
             this._mountElements();
         }
@@ -61,14 +67,21 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
 
     async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         const { payment , ...order} = payload;
+        const paymentData = payment?.paymentData;
+        const shouldSaveInstrument = (paymentData as HostedInstrument)?.shouldSaveInstrument;
+        const shouldSetAsDefaultInstrument = (paymentData as HostedInstrument)?.shouldSetAsDefaultInstrument;
 
         if (!payment) {
             throw new PaymentArgumentInvalidError([ 'payment' ]);
         }
 
         try {
-            if (payment.methodId === 'creditcard') {
+            if (payment.methodId === MolliePaymentMethodType.creditcard) {
                 await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+                if (paymentData && isVaultedInstrument(paymentData)) {
+                    return this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
+                }
 
                 const { token, error } = await this._getMollieClient().createToken();
 
@@ -83,6 +96,8 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
                             credit_card_token: {
                                 token,
                             },
+                            vault_payment_instrument: shouldSaveInstrument,
+                            set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
                             browser_info: getBrowserInfo(),
                         },
                     },
@@ -90,9 +105,7 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             } else {
                 await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
-                return await this._store.dispatch(this._paymentActionCreator.submitPayment({
-                    ...payment,
-                }));
+                return await this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
             }
         } catch (error) {
 
@@ -105,19 +118,27 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
     }
 
     deinitialize(): Promise<InternalCheckoutSelectors> {
-        this._cardNumberElement?.unmount();
-        this._expiryDateElement?.unmount();
-        this._verificationCodeElement?.unmount();
-        this._cardHolderElement?.unmount();
+        this._mollieClient = undefined;
+
+        this.removeMollieComponents();
 
         return Promise.resolve(this._store.getState());
+    }
+
+    private removeMollieComponents(): void {
+        const mollieComponents = document.querySelectorAll('.mollie-component');
+
+        each(mollieComponents, component => component.remove());
+
+        const controllers = document.querySelectorAll('.mollie-components-controller');
+
+        each(controllers, controller => controller.remove());
     }
 
     private _processAdditionalAction(error: any): Promise<InternalCheckoutSelectors> {
         if (!(error instanceof RequestError) || !some(error.body.errors, {code: 'additional_action_required'})) {
             return Promise.reject(error);
         }
-
         const { additional_action_required: { data : { redirect_url } } } = error.body;
 
         return new Promise(() => window.location.replace(redirect_url));
@@ -131,12 +152,12 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         return this._initializeOptions;
     }
 
-    private async _loadMollieJs(merchantId: string, locale: string, testmode: boolean = false) {
+    private _loadMollieJs(merchantId: string, locale: string, testmode: boolean = false): Promise<MollieClient> {
         if (this._mollieClient) {
             return Promise.resolve(this._mollieClient);
         }
 
-        return await this._mollieScriptLoader
+        return this._mollieScriptLoader
             .load(merchantId, locale, testmode);
     }
 
@@ -148,18 +169,35 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         return this._mollieClient;
     }
 
+    /**
+     * ContainerId is use in Mollie for determined either its showing or not the
+     * container, because when Mollie has Vaulted Instruments it gets hide,
+     * and shows an error because can't mount Provider Components
+     *
+     * We had to add a settimeout because Mollie sets de tab index after mounting
+     * each component, but without a setTimeOut Mollie is not able to find the
+     * components as they are hidden so we need to wait until they are shown
+     */
     private _mountElements() {
-        const mollieClient = this._getMollieClient();
-        const { cardNumberId, cardCvcId, cardExpiryId, cardHolderId, styles } = this._getInitializeOptions();
+        const { containerId, cardNumberId, cardCvcId, cardExpiryId, cardHolderId, styles } = this._getInitializeOptions();
+        const container = document.getElementById(containerId);
 
-        this._cardHolderElement = mollieClient.createComponent('cardHolder', { styles });
-        this._cardNumberElement = mollieClient.createComponent('cardNumber', { styles });
-        this._verificationCodeElement = mollieClient.createComponent('verificationCode', { styles });
-        this._expiryDateElement = mollieClient.createComponent('expiryDate', { styles });
+        setTimeout(() => {
+            if (container?.style.display !== 'none') {
+                const mollieClient = this._getMollieClient();
 
-        this._cardNumberElement.mount(`#${cardNumberId}`);
-        this._expiryDateElement.mount(`#${cardExpiryId}`);
-        this._verificationCodeElement.mount(`#${cardCvcId}`);
-        this._cardHolderElement.mount(`#${cardHolderId}`);
+                this._cardHolderElement = mollieClient.createComponent('cardHolder', { styles });
+                this._cardHolderElement.mount(`#${cardHolderId}`);
+
+                this._cardNumberElement = mollieClient.createComponent('cardNumber', { styles });
+                this._cardNumberElement.mount(`#${cardNumberId}`);
+
+                this._verificationCodeElement = mollieClient.createComponent('verificationCode', { styles });
+                this._verificationCodeElement.mount(`#${cardCvcId}`);
+
+                this._expiryDateElement = mollieClient.createComponent('expiryDate', { styles });
+                this._expiryDateElement.mount(`#${cardExpiryId}`);
+            }
+        }, 0);
     }
 }

--- a/src/payment/strategies/mollie/mollie.mock.ts
+++ b/src/payment/strategies/mollie/mollie.mock.ts
@@ -5,8 +5,9 @@ import { MollieClient } from './mollie';
 
 export function getInitializeOptions(): PaymentInitializeOptions {
     return {
-        methodId: 'creditcard',
+        methodId: 'credit_card',
         mollie: {
+            containerId: 'mollie-element',
             cardCvcId: 'mollie-card-cvc-component-field',
             cardExpiryId: 'mollie-card-expiry-component-field',
             cardHolderId: 'mollie-card-holder-component-field',
@@ -42,7 +43,7 @@ export function getOrderRequestBodyWithCreditCard(): OrderRequestBody {
     return {
         useStoreCredit: false,
         payment: {
-            methodId: 'creditcard',
+            methodId: 'credit_card',
             gatewayId: 'mollie',
             paymentData: undefined,
         },

--- a/src/payment/strategies/mollie/mollie.ts
+++ b/src/payment/strategies/mollie/mollie.ts
@@ -37,5 +37,5 @@ export interface MollieElement {
      * The callback receives an object with all the related information.
      * blur | focus | change
      */
-    addEventListener(event: 'blur' | 'focus' | 'change', callback: () => void): void;
+    addEventListener(event: 'blur' | 'focus' | 'change', callback: ( event: Event ) => void): void;
 }


### PR DESCRIPTION
## What? [INT-3702](https://jira.bigcommerce.com/browse/INT-3702)
added vaulted methods in order to save cc, added vault_payment_intrument variables, and create conditions to mount or not mount mollie components 

## Why?
We want the user to be able to save cc and use them later when logged in 

## Testing / Proof

![Screen Shot 2021-01-13 at 11 35 01](https://user-images.githubusercontent.com/69221626/104487990-6354fe00-5593-11eb-946b-8e62774c15b6.png)


@bigcommerce/checkout @bigcommerce/payments
