### PR TITLE
feat(payment): INT-3418 Added googlepay on cybersourcev2

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -55,25 +55,31 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
 
     /**
      * The options that are required to facilitate Braintree GooglePay. They can be
-     * omitted unles you need to support Braintree GooglePay.
+     * omitted unless you need to support Braintree GooglePay.
      */
     googlepaybraintree?: GooglePayButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate Checkout.com GooglePay. They can be
-     * omitted unles you need to support Checkout.com GooglePay.
+     * omitted unless you need to support Checkout.com GooglePay.
      */
     googlepaycheckoutcom?: GooglePayButtonInitializeOptions;
 
     /**
+     * The options that are required to facilitate CybersourceV2 GooglePay. They can be
+     * omitted unless you need to support CybersourceV2 GooglePay.
+     */
+    googlepaycybersourcev2?: GooglePayButtonInitializeOptions;
+
+    /**
      * The options that are required to facilitate Stripe GooglePay. They can be
-     * omitted unles you need to support Stripe GooglePay.
+     * omitted unless you need to support Stripe GooglePay.
      */
     googlepaystripe?: GooglePayButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate Authorize.Net GooglePay.
-     * They can be omitted unles you need to support Authorize.Net GooglePay.
+     * They can be omitted unless you need to support Authorize.Net GooglePay.
      */
     googlepayauthorizenet?: GooglePayButtonInitializeOptions;
 }

--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -37,6 +37,10 @@ describe('createCheckoutButtonRegistry', () => {
         expect(registry.get('googlepaybraintree')).toEqual(expect.any(GooglePayButtonStrategy));
     });
 
+    it('returns registry with GooglePay on CybersourceV2 Credit registered', () => {
+        expect(registry.get('googlepaycybersourcev2')).toEqual(expect.any(GooglePayButtonStrategy));
+    });
+
     it('returns registry with GooglePay on Stripe Credit registered', () => {
         expect(registry.get('googlepaystripe')).toEqual(expect.any(GooglePayButtonStrategy));
     });

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -8,7 +8,7 @@ import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
-import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 import { createPaypalCommercePaymentProcessor } from '../payment/strategies/paypal-commerce';
@@ -112,6 +112,18 @@ export default function createCheckoutButtonRegistry(
             createGooglePayPaymentProcessor(
                 store,
                 new GooglePayCheckoutcomInitializer(requestSender)
+            )
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2, () =>
+        new GooglePayButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayCybersourceV2Initializer()
             )
         )
     );

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -6,6 +6,7 @@ enum CheckoutButtonMethodType {
     GOOGLEPAY_AUTHORIZENET = 'googlepayauthorizenet',
     GOOGLEPAY_BRAINTREE = 'googlepaybraintree',
     GOOGLEPAY_CHECKOUTCOM = 'googlepaycheckoutcom',
+    GOOGLEPAY_CYBERSOURCEV2 = 'googlepaycybersourcev2',
     GOOGLEPAY_STRIPE = 'googlepaystripe',
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -22,6 +22,7 @@ export enum Mode {
     GooglePayAuthorizeNet,
     GooglePayBraintree,
     GooglePayCheckoutcom,
+    GooglePayCybersourceV2,
     GooglePayStripe,
 }
 
@@ -33,6 +34,7 @@ export function getCheckoutButtonOptions(methodId: CheckoutButtonMethodType, mod
     const googlepayauthorizenet = { googlepaybraintree: { buttonType: ButtonType.Short } };
     const googlepaybraintree = { googlepaybraintree: { buttonType: ButtonType.Short } };
     const googlepaycheckoutcom = { googlepaycheckoutcom: { buttonType: ButtonType.Short } };
+    const googlepaycybersourcev2 = { googlepaycybersourcev2: { buttonType: ButtonType.Short } };
     const googlepaystripe = { googlepaystripe: { buttonType: ButtonType.Short } };
 
     switch (mode) {
@@ -53,6 +55,9 @@ export function getCheckoutButtonOptions(methodId: CheckoutButtonMethodType, mod
         }
         case Mode.GooglePayCheckoutcom: {
             return { methodId, containerId, ...googlepaycheckoutcom };
+        }
+        case Mode.GooglePayCybersourceV2: {
+            return { methodId, containerId, ...googlepaycybersourcev2 };
         }
         case Mode.GooglePayStripe: {
             return { methodId, containerId, ...googlepaystripe };

--- a/src/checkout-buttons/strategies/googlepay/googlepay-cybersourcev2-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-cybersourcev2-button-strategy.spec.ts
@@ -1,0 +1,211 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { Cart } from '../../../cart';
+import { getCart, getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod } from '../../../payment';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { createGooglePayPaymentProcessor, GooglePayCybersourceV2Initializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+
+import GooglePayButtonStrategy from './googlepay-button-strategy';
+import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
+
+describe('GooglePayCheckoutButtonStrategy', () => {
+    let cart: Cart;
+    let container: HTMLDivElement;
+    let formPoster: FormPoster;
+    let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+    let paymentMethod: PaymentMethod;
+    let paymentProcessor: GooglePayPaymentProcessor;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: GooglePayButtonStrategy;
+    let walletButton: HTMLAnchorElement;
+
+    beforeEach(() => {
+        paymentMethod = getPaymentMethod();
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        cart = getCart();
+        requestSender = createRequestSender();
+
+        checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
+        paymentProcessor = createGooglePayPaymentProcessor(
+            store,
+            new GooglePayCybersourceV2Initializer()
+        );
+
+        formPoster = createFormPoster();
+
+        strategy = new GooglePayButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            paymentProcessor
+        );
+
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockReturnValue(Promise.resolve());
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethod);
+
+        jest.spyOn(store.getState().cart, 'getCartOrThrow')
+            .mockReturnValue(cart);
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockReturnValue(Promise.resolve());
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
+        walletButton = document.createElement('a');
+        walletButton.setAttribute('id', 'mockButton');
+
+        jest.spyOn(paymentProcessor, 'createButton')
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
+
+        jest.spyOn(paymentProcessor, 'deinitialize');
+
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    describe('#initialize()', () => {
+        it('Creates the button', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2);
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.createButton).toHaveBeenCalled();
+        });
+
+        it('initializes paymentProcessor only once', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2);
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
+        });
+
+        it('fails to initialize the strategy if no container id is supplied', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2, Mode.UndefinedContainer);
+
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('fails to initialize the strategy if no valid container id is supplied', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2, Mode.InvalidContainer);
+
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        beforeAll(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2, Mode.GooglePayCybersourceV2);
+        });
+
+        it('check if googlepay payment processor deinitialize is called', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize();
+
+            expect(paymentProcessor.deinitialize).toBeCalled();
+        });
+
+        it('succesfully deinitializes the strategy', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize();
+
+            // tslint:disable-next-line:no-non-null-assertion
+            const button = document.getElementById(checkoutButtonOptions.containerId!);
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+
+        it('Validates if strategy is loaded before call deinitialize', async () => {
+            await strategy.deinitialize();
+
+            // tslint:disable-next-line:no-non-null-assertion
+            const button = document.getElementById(checkoutButtonOptions.containerId!);
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2, Mode.GooglePayCybersourceV2);
+
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
+
+        it('handles wallet button event and updates shipping address', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('handles wallet button event and does not update shipping address if cart has digital products only', async () => {
+            cart.lineItems.physicalItems = [];
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -11,7 +11,7 @@ import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { createBraintreeVisaCheckoutPaymentProcessor, BraintreeScriptLoader, BraintreeSDKCreator, VisaCheckoutScriptLoader } from '../payment/strategies/braintree';
 import { ChasePayScriptLoader } from '../payment/strategies/chasepay';
-import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../spam-protection';
@@ -156,6 +156,18 @@ export default function createCustomerStrategyRegistry(
         )
     );
 
+    registry.register('googlepaycybersourcev2', () =>
+        new GooglePayCustomerStrategy(
+            store,
+            remoteCheckoutActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayCybersourceV2Initializer()
+            ),
+            formPoster
+        )
+    );
+
     registry.register('googlepaystripe', () =>
         new GooglePayCustomerStrategy(
             store,
@@ -165,8 +177,8 @@ export default function createCustomerStrategyRegistry(
                 new GooglePayStripeInitializer()
             ),
             formPoster
-    )
-);
+        )
+    );
 
     registry.register('default', () =>
         new DefaultCustomerStrategy(

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -87,5 +87,11 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      * The options that are required to initialize the GooglePay payment method.
      * They can be omitted unless you need to support GooglePay.
      */
+    googlepaycybersourcev2?: GooglePayCustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
     googlepaystripe?: GooglePayCustomerInitializeOptions;
 }

--- a/src/customer/strategies/googlepay/googlepay-customer-mock.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-mock.ts
@@ -107,6 +107,26 @@ export function getCheckoutcomCustomerInitializeOptions(mode: Mode = Mode.Full):
      }
 }
 
+export function getCybersourceV2CustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
+    const methodId = { methodId: 'googlepaycybersourcev2' };
+    const undefinedMethodId = { methodId: undefined };
+    const container = { container: 'googlePayCheckoutButton' };
+    const invalidContainer = { container: 'invalid_container' };
+    const googlepayCybersourceV2 = { googlepaycybersourcev2: { ...container } };
+    const googlepayCyberSourceV2WithInvalidContainer = { googlepaycybersourcev2: { ...invalidContainer } };
+
+    switch (mode) {
+        case Mode.Incomplete:
+            return { ...methodId };
+        case Mode.UndefinedMethodId:
+            return { ...undefinedMethodId, ...googlepayCybersourceV2 };
+        case Mode.InvalidContainer:
+            return { ...methodId, ...googlepayCyberSourceV2WithInvalidContainer };
+        default:
+            return { ...methodId, ...googlepayCybersourceV2 };
+     }
+}
+
 export function getStripeCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
     const methodId = { methodId: 'googlepaystripe' };
     const undefinedMethodId = { methodId: undefined };

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -97,6 +97,10 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             return options.googlepaycheckoutcom;
         }
 
+        if (options.methodId === 'googlepaycybersourcev2' && options.googlepaycybersourcev2) {
+            return options.googlepaycybersourcev2;
+        }
+
         if (options.methodId === 'googlepaystripe' && options.googlepaystripe) {
             return options.googlepaystripe;
         }

--- a/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
@@ -1,0 +1,244 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { getCart, getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { getConfigState } from '../../../config/configs.mock';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { createGooglePayPaymentProcessor, GooglePayCybersourceV2Initializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { CustomerInitializeOptions } from '../../customer-request-options';
+import { getCustomerState } from '../../customers.mock';
+import CustomerStrategy from '../customer-strategy';
+
+import { getCybersourceV2CustomerInitializeOptions, Mode } from './googlepay-customer-mock';
+import GooglePayCustomerStrategy from './googlepay-customer-strategy';
+
+describe('GooglePayCustomerStrategy', () => {
+    let container: HTMLDivElement;
+    let formPoster: FormPoster;
+    let customerInitializeOptions: CustomerInitializeOptions;
+    let paymentProcessor: GooglePayPaymentProcessor;
+    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: CustomerStrategy;
+    let walletButton: HTMLAnchorElement;
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        requestSender = createRequestSender();
+
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+            new RemoteCheckoutRequestSender(requestSender)
+        );
+
+        paymentProcessor = createGooglePayPaymentProcessor(
+            store,
+            new GooglePayCybersourceV2Initializer()
+        );
+
+        formPoster = createFormPoster();
+
+        strategy = new GooglePayCustomerStrategy(
+            store,
+            remoteCheckoutActionCreator,
+            paymentProcessor,
+            formPoster
+        );
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockReturnValue(Promise.resolve());
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockReturnValue(Promise.resolve());
+
+        walletButton = document.createElement('a');
+        walletButton.setAttribute('id', 'mockButton');
+        jest.spyOn(paymentProcessor, 'createButton')
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    describe('#initialize()', () => {
+        describe('Payment method exist', () => {
+            it('Creates the button', async () => {
+                customerInitializeOptions = getCybersourceV2CustomerInitializeOptions();
+
+                await strategy.initialize(customerInitializeOptions);
+
+                expect(paymentProcessor.createButton).toHaveBeenCalled();
+            });
+
+            it('fails to initialize the strategy if no GooglePayCustomerInitializeOptions is provided ', () => {
+                customerInitializeOptions = getCybersourceV2CustomerInitializeOptions(Mode.Incomplete);
+
+                expect(() => strategy.initialize(customerInitializeOptions)).toThrow(InvalidArgumentError);
+            });
+
+            it('fails to initialize the strategy if no methodid is supplied', () => {
+                customerInitializeOptions = getCybersourceV2CustomerInitializeOptions(Mode.UndefinedMethodId);
+
+                expect(() => strategy.initialize(customerInitializeOptions)).toThrow(InvalidArgumentError);
+            });
+
+            it('fails to initialize the strategy if no valid container id is supplied', async () => {
+                customerInitializeOptions = getCybersourceV2CustomerInitializeOptions(Mode.InvalidContainer);
+
+                await expect(strategy.initialize(customerInitializeOptions)).rejects.toThrow(InvalidArgumentError);
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        let containerId: string;
+
+        beforeAll(() => {
+            customerInitializeOptions = getCybersourceV2CustomerInitializeOptions();
+            containerId = customerInitializeOptions.googlepaycybersourcev2 ?
+                customerInitializeOptions.googlepaycybersourcev2.container : '';
+        });
+
+        it('successfully deinitializes the strategy', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            const button = document.getElementById(containerId);
+
+            expect(button).toHaveProperty('firstChild', walletButton);
+
+            await strategy.deinitialize();
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+
+        it('Validates if strategy is loaded before call deinitialize', async () => {
+            await strategy.deinitialize();
+
+            const button = document.getElementById(containerId);
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+    });
+
+    describe('#signIn()', () => {
+        it('throws error if trying to sign in programmatically', async () => {
+            customerInitializeOptions = getCybersourceV2CustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+
+            expect(() => strategy.signIn({ email: 'foo@bar.com', password: 'foobar' })).toThrowError();
+        });
+    });
+
+    describe('#signOut()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getCybersourceV2CustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('successfully signs out', async () => {
+            const paymentId = {
+                providerId: 'googlepaycybersourcev2',
+            };
+
+            jest.spyOn(store.getState().payment, 'getPaymentId')
+                .mockReturnValue(paymentId);
+
+            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+                .mockReturnValue('data');
+
+            const options = {
+                methodId: 'googlepaycybersourcev2',
+            };
+
+            await strategy.signOut(options);
+
+            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('googlepaycybersourcev2', options);
+            expect(store.dispatch).toHaveBeenCalled();
+        });
+
+        it('Returns state if no payment method exist', async () => {
+            const paymentId = undefined;
+            jest.spyOn(store, 'getState');
+
+            jest.spyOn(store.getState().payment, 'getPaymentId')
+                .mockReturnValue(paymentId);
+
+            const options = {
+                methodId: 'googlepaycybersourcev2',
+            };
+
+            expect(await strategy.signOut(options)).toEqual(store.getState());
+            expect(store.getState).toHaveBeenCalledTimes(4);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
+            customerInitializeOptions = {
+                methodId: 'googlepaycybersourcev2',
+                googlepaycybersourcev2: {
+                    container: 'googlePayCheckoutButton',
+                },
+            };
+
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
+
+        it('displays the wallet and updates the shipping address', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('displays the wallet and does not update the shipping address if cart has digital products only', async () => {
+            const cart = getCart();
+            cart.lineItems.physicalItems = [];
+            jest.spyOn(store.getState().cart, 'getCartOrThrow')
+                .mockReturnValue(cart);
+
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -147,6 +147,11 @@ describe('CreatePaymentStrategyRegistry', () => {
         expect(paymentStrategy).toBeInstanceOf(CyberSourceV2PaymentStrategy);
     });
 
+    it('can instantiate googlepaycybersourcev2', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CYBERSOURCEV2_GOOGLE_PAY);
+        expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+
     it('can instantiate klarna', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.KLARNA);
         expect(paymentStrategy).toBeInstanceOf(KlarnaPaymentStrategy);
@@ -199,6 +204,11 @@ describe('CreatePaymentStrategyRegistry', () => {
 
     it('can instantiate googlepaybraintree', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.BRAINTREE_GOOGLE_PAY);
+        expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+
+    it('can instantiate googlepaycybersourcev2', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CYBERSOURCEV2_GOOGLE_PAY);
         expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
     });
 

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -39,7 +39,7 @@ import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redi
 import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
 import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
 import { ExternalPaymentStrategy } from './strategies/external';
-import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
 import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
 import { LegacyPaymentStrategy } from './strategies/legacy';
@@ -491,6 +491,21 @@ export default function createPaymentStrategyRegistry(
             createGooglePayPaymentProcessor(
                 store,
                 new GooglePayStripeInitializer()
+            )
+        )
+    );
+
+    registry.register(PaymentStrategyType.CYBERSOURCEV2_GOOGLE_PAY, () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayCybersourceV2Initializer()
             )
         )
     );

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -509,6 +509,35 @@ export function getGooglePayAdyenV2(): PaymentMethod {
     };
 }
 
+export function getGooglePayCybersourceV2(): PaymentMethod {
+    return {
+        id: 'googlepaycybersourcev2',
+        logoUrl: '',
+        method: 'googlepay',
+        supportedCards: [
+            'VISA',
+            'MC',
+            'AMEX',
+        ],
+        config: {
+            displayName: 'Google Pay',
+            merchantId: '',
+            testMode: true,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'clientToken',
+        initializationData: {
+            originKey: 'YOUR_ORIGIN_KEY',
+            clientKey: 'YOUR_CLIENT_KEY',
+            nonce: 'nonce',
+            card_information: {
+                type: 'MasterCard',
+                number: '4111',
+            },
+        },
+    };
+}
+
 export function getZip(): PaymentMethod {
     return {
         id: 'zip',
@@ -623,6 +652,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getCheckoutcom(),
         getGooglePay(),
         getGooglePayAdyenV2(),
+        getGooglePayCybersourceV2(),
         getKlarna(),
         getPaypalExpress(),
         getPaypalCommerce(),

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -158,6 +158,12 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
     googlepaycheckoutcom?: GooglePayPaymentInitializeOptions;
 
     /**
+     * The options that are required to initialize the GooglePay CybersourceV2 payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
+    googlepaycybersourcev2?: GooglePayPaymentInitializeOptions;
+
+    /**
      * The options that are required to initialize the GooglePay Stripe payment method.
      * They can be omitted unless you need to support GooglePay.
      */

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -15,6 +15,7 @@ enum PaymentStrategyType {
     CHECKOUTCOM_GOOGLE_PAY = 'googlepaycheckoutcom',
     CYBERSOURCE = 'cybersource',
     CYBERSOURCEV2 = 'cybersourcev2',
+    CYBERSOURCEV2_GOOGLE_PAY = 'googlepaycybersourcev2',
     KLARNA = 'klarna',
     KLARNAV2 = 'klarnav2',
     LAYBUY = 'laybuy',

--- a/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.spec.ts
@@ -1,0 +1,40 @@
+import GooglePayCybersourceV2Initializer from './googlepay-cybersourcev2-initializer';
+import { getCheckoutMock, getCybersourceV2PaymentDataMock, getCybersourceV2PaymentDataRequest, getCybersourceV2PaymentMethodMock, getCybersourceV2TokenizedPayload  } from './googlepay.mock';
+
+describe('GooglePayCybersourceV2Initializer', () => {
+    let googlePayInitializer: GooglePayCybersourceV2Initializer;
+
+    beforeEach(() => {
+        googlePayInitializer = new GooglePayCybersourceV2Initializer();
+    });
+
+    it('creates an instance of GooglePayCybersourceV2Initializer', () => {
+        expect(googlePayInitializer).toBeInstanceOf(GooglePayCybersourceV2Initializer);
+    });
+
+    describe('#initialize', () => {
+        it('initializes the google pay configuration for Cybersourcev2', async () => {
+            const initialize = await googlePayInitializer.initialize(
+                getCheckoutMock(),
+                getCybersourceV2PaymentMethodMock(),
+                false
+            );
+
+            expect(initialize).toEqual(getCybersourceV2PaymentDataRequest());
+        });
+    });
+
+    describe('#teardown', () => {
+        it('teardown the initializer', () => {
+            expect(googlePayInitializer.teardown()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('#parseResponse', () => {
+        it('parses a response from google pay payload received', async () => {
+            const tokenizePayload = await googlePayInitializer.parseResponse(getCybersourceV2PaymentDataMock());
+
+            expect(tokenizePayload).toEqual(getCybersourceV2TokenizedPayload());
+        });
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.ts
@@ -1,0 +1,108 @@
+import { round } from 'lodash';
+
+import { Checkout } from '../../../checkout';
+import PaymentMethod from '../../payment-method';
+
+import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload, TokenizeType } from './googlepay';
+
+export default class GooglePayCybersourceV2Initializer implements GooglePayInitializer {
+    initialize(
+        checkout: Checkout,
+        paymentMethod: PaymentMethod,
+        hasShippingAddress: boolean
+    ): Promise<GooglePayPaymentDataRequestV2> {
+        return Promise.resolve(this._getGooglePayPaymentDataRequest(
+            checkout,
+            paymentMethod,
+            hasShippingAddress
+        ));
+    }
+
+    teardown(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    parseResponse(paymentData: GooglePaymentData): Promise<TokenizePayload> {
+        const {
+            paymentMethodData: {
+                type,
+                tokenizationData: { token },
+                info: {
+                    cardNetwork: cardType,
+                    cardDetails: lastFour,
+                },
+            },
+        } = paymentData;
+
+        return Promise.resolve({
+            nonce: btoa(token),
+            type: type as TokenizeType,
+            details: {
+                cardType,
+                lastFour,
+            },
+        });
+    }
+
+    private _getGooglePayPaymentDataRequest(
+        checkout: Checkout,
+        paymentMethod: PaymentMethod,
+        hasShippingAddress: boolean
+    ): GooglePayPaymentDataRequestV2 {
+        const {
+            outstandingBalance,
+            cart: {
+                currency: { code: currencyCode },
+            },
+        } = checkout;
+
+        const {
+            initializationData: {
+                gatewayMerchantId,
+                googleMerchantName: merchantName,
+                googleMerchantId: merchantId,
+                platformToken: authJwt,
+            },
+            supportedCards,
+        } = paymentMethod;
+
+        return {
+            apiVersion: 2,
+            apiVersionMinor: 0,
+            merchantInfo: {
+                authJwt,
+                merchantId,
+                merchantName,
+            },
+            allowedPaymentMethods: [{
+                type: 'CARD',
+                parameters: {
+                    allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                    allowedCardNetworks: supportedCards.map(card => card === 'MC' ? 'MASTERCARD' : card),
+                    billingAddressRequired: true,
+                    billingAddressParameters: {
+                        format: BillingAddressFormat.Full,
+                        phoneNumberRequired: true,
+                    },
+                },
+                tokenizationSpecification: {
+                    type: 'PAYMENT_GATEWAY',
+                    parameters: {
+                        gateway: 'cybersource',
+                        gatewayMerchantId,
+                    },
+                },
+            }],
+            transactionInfo: {
+                currencyCode,
+                totalPriceStatus: 'FINAL',
+                totalPrice: round(outstandingBalance, 2).toFixed(2),
+            },
+            emailRequired: true,
+            shippingAddressRequired: !hasShippingAddress,
+            shippingAddressParameters: {
+                phoneNumberRequired: true,
+            },
+        };
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -122,6 +122,10 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             return options.googlepaycheckoutcom;
         }
 
+        if (options.methodId === 'googlepaycybersourcev2' && options.googlepaycybersourcev2) {
+            return options.googlepaycybersourcev2;
+        }
+
         if (options.methodId === 'googlepaybraintree' && options.googlepaybraintree) {
             return options.googlepaybraintree;
         }

--- a/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -514,3 +514,69 @@ export function getGooglePayTokenizePayloadCheckoutcom(): TokenizePayload {
         },
     };
 }
+
+export function getCybersourceV2PaymentMethodMock(): PaymentMethod {
+    const paymentMethodMock = getPaymentMethodMock();
+    paymentMethodMock.initializationData.gatewayMerchantId = 'merchantId';
+
+    return paymentMethodMock;
+}
+
+export function getCybersourceV2PaymentDataMock(): GooglePaymentData {
+    const googlePaymentDataMock = getGooglePaymentDataMock();
+    googlePaymentDataMock.paymentMethodData.tokenizationData.token = '{"signature":"foo","protocolVersion":"ECv1","signedMessage":"{"encryptedMessage":"foo","ephemeralPublicKey":"foo"}"}';
+
+    return googlePaymentDataMock;
+}
+
+export function getCybersourceV2PaymentDataRequest(): GooglePayPaymentDataRequestV2 {
+    return {
+        apiVersion: 2,
+        apiVersionMinor: 0,
+        merchantInfo: {
+            authJwt: 'platformToken',
+            merchantId: '123',
+            merchantName: 'name',
+        },
+        allowedPaymentMethods: [{
+            type: 'CARD',
+            parameters: {
+                allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'],
+                billingAddressRequired: true,
+                billingAddressParameters: {
+                    format: BillingAddressFormat.Full,
+                    phoneNumberRequired: true,
+                },
+            },
+            tokenizationSpecification: {
+                type: 'PAYMENT_GATEWAY',
+                parameters: {
+                    gateway: 'cybersource',
+                    gatewayMerchantId: 'merchantId',
+                },
+            },
+        }],
+        transactionInfo: {
+            currencyCode: 'USD',
+            totalPriceStatus: 'FINAL',
+            totalPrice: '1.00',
+        },
+        emailRequired: true,
+        shippingAddressRequired: true,
+        shippingAddressParameters: {
+            phoneNumberRequired: true,
+        },
+    };
+}
+
+export function getCybersourceV2TokenizedPayload(): TokenizePayload {
+    return {
+        nonce: btoa('{"signature":"foo","protocolVersion":"ECv1","signedMessage":"{"encryptedMessage":"foo","ephemeralPublicKey":"foo"}"}'),
+        type: 'CARD',
+        details: {
+            cardType: 'MASTERCARD',
+            lastFour: '0304',
+        },
+    };
+}

--- a/src/payment/strategies/googlepay/index.ts
+++ b/src/payment/strategies/googlepay/index.ts
@@ -7,6 +7,7 @@ export { default as GooglePayAdyenV2Initializer } from './googlepay-adyenv2-init
 export { default as GooglePayAdyenV2PaymentProcessor } from './googlepay-adyenv2-payment-processor';
 export { default as GooglePayBraintreeInitializer } from './googlepay-braintree-initializer';
 export { default as GooglePayCheckoutcomInitializer } from './googlepay-checkoutcom-initializer';
+export { default as GooglePayCybersourceV2Initializer } from './googlepay-cybersourcev2-initializer';
 export { default as GooglePayStripeInitializer } from './googlepay-stripe-initializer';
 export { default as GooglePayAuthorizeNetInitializer } from './googlepay-authorizenet-initializer';
 export { default as GooglePayPaymentInitializeOptions } from './googlepay-initialize-options';


### PR DESCRIPTION
## What? [INT-3418](https://jira.bigcommerce.com/browse/INT-3418)
Added googlepay on cybersourcev2

## Why?
In order to show google pay like an option when cybersource is enabled on checkout.

## Dependent PR's
## [Checkout-js 495](https://github.com/bigcommerce/checkout-js/pull/495)

## Testing / Proof
![Screen Shot 2021-01-20 at 4 06 40 PM](https://user-images.githubusercontent.com/61981535/105376285-332ee000-5bcf-11eb-832b-30b2d46a4b10.png)
![Screen Shot 2021-01-20 at 4 07 38 PM](https://user-images.githubusercontent.com/61981535/105887443-5d1e4300-5fd1-11eb-9aca-15dc8c797133.png)
![Screen Shot 2021-01-20 at 4 07 03 PM](https://user-images.githubusercontent.com/61981535/105376215-23170080-5bcf-11eb-84ec-102d394024b3.png)
![Screen Shot 2021-01-26 at 12 09 05 PM](https://user-images.githubusercontent.com/61981535/105887457-61e2f700-5fd1-11eb-8677-c2a19442a071.png)
![Screen Shot 2021-01-26 at 12 13 57 PM](https://user-images.githubusercontent.com/61981535/105887462-63142400-5fd1-11eb-85d0-82e0734bd672.png)
![Screen Shot 2021-01-26 at 11 21 39 AM](https://user-images.githubusercontent.com/61981535/105887467-64455100-5fd1-11eb-90be-854549812c12.png)








