### PR TITLE
feat(provider): INT-3659 Add payment method flow to Stripe v3

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -15,7 +15,7 @@ export type PaymentInstrument = (
     CreditCardInstrument & WithHostedFormNonce |
     CreditCardInstrument & WithDocumentInstrument |
     CryptogramInstrument |
-    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument> |
+    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | StripeV3Intent> |
     HostedInstrument |
     NonceInstrument |
     ThreeDSVaultedInstrument |
@@ -132,6 +132,13 @@ interface AdyenV2Card {
         token: string;
     };
     bigpay_token?: void;
+}
+
+interface StripeV3Intent {
+    credit_card_token: {
+        token: string;
+    };
+    confirm: boolean;
 }
 
 export interface FormattedHostedInstrument {

--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -23,6 +23,8 @@ export function getStripeV3JsMock(): StripeV3Client {
         confirmCardPayment: jest.fn(),
         confirmIdealPayment: jest.fn(),
         confirmSepaDebitPayment: jest.fn(),
+        createPaymentMethod: jest.fn(),
+        handleCardAction: jest.fn(),
     };
 }
 
@@ -45,6 +47,8 @@ export function getFailingStripeV3JsMock(): StripeV3Client {
         confirmCardPayment: jest.fn(),
         confirmIdealPayment: jest.fn(),
         confirmSepaDebitPayment: jest.fn(),
+        createPaymentMethod: jest.fn(),
+        handleCardAction: jest.fn(),
     };
 }
 
@@ -153,6 +157,22 @@ export function getWrongPaymentResponse(): unknown {
     return {
         paymentIntent: {
             otherKey: 'other_value',
+        },
+    };
+}
+
+export function getWrongPaymentMethodResponse(): unknown {
+    return {
+        paymentMethod: {
+            otherKey: 'other_value',
+        },
+    };
+}
+
+export function getPaymentMethodResponse(): unknown {
+    return {
+        paymentMethod: {
+            id: 'pm_1234',
         },
     };
 }

--- a/src/payment/strategies/stripev3/stripev3.ts
+++ b/src/payment/strategies/stripev3/stripev3.ts
@@ -43,6 +43,22 @@ export interface PaymentIntent {
     status: 'succeeded' | string;
 }
 
+/**
+ * The PaymentMethod object
+ */
+export interface PaymentMethod {
+    /**
+     * Unique identifier for the object.
+     */
+    id: string;
+
+    /**
+     * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value.
+     * It contains additional information specific to the PaymentMethod type.
+     */
+    type: string;
+}
+
 export interface PaymentMethodCreateParams {
     /**
      * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
@@ -767,6 +783,37 @@ export interface StripeV3Client {
          */
         data?: StripeConfirmSepaPaymentData
     ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+
+    /**
+     * Use stripe.createPaymentMethod to convert payment information collected by elements into a PaymentMethod
+     * object that you safely pass to your server to use in an API call.
+     * @docs https://stripe.com/docs/js/payment_methods/create_payment_method
+     *
+     * @param type: String, The type of the PaymentMethod to create. Refer to the PaymentMethod API for all possible values.
+     * @param card: StripeElement, A card or cardNumber Element.
+     * @param billing_details: StripeBillingDetails, Billing information associated with the PaymentMethod that
+     * may be used or required by particular types of payment methods.
+     */
+    createPaymentMethod(
+        params: CreatePaymentMethodParams
+    ): Promise<{paymentMethod?: PaymentMethod; error?: StripeError}>;
+
+    /**
+     * Use stripe.handleCardAction in the Payment Intents API manual confirmation flow to handle a PaymentIntent
+     * with the requires_action status. It will throw an error if the PaymentIntent has a different status.
+     * @docs https://stripe.com/docs/js/payment_intents/handle_card_action
+     *
+     * @param paymentIntentClientSecret: String, The client secret of the PaymentIntent to handle.
+     */
+    handleCardAction(
+        paymentIntentClientSecret: string
+    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+}
+
+export interface CreatePaymentMethodParams {
+    type: StripePaymentMethodType;
+    card: StripeElement;
+    billing_details?: StripeBillingDetails;
 }
 
 export interface StripeHostWindow extends Window {
@@ -818,7 +865,8 @@ export interface StripeConfigurationOptions {
 }
 
 export interface StripeAdditionalActionData {
-    redirect_url: string;
+    redirect_url?: string;
+    intent?: string;
 }
 
 export interface StripeAdditionalAction {
@@ -830,6 +878,7 @@ export interface StripeAdditionalActionError {
     body: {
         errors?: Array<{ code: string; message?: string }>;
         additional_action_required: StripeAdditionalAction;
+        three_ds_result: { token: string };
     };
 }
 


### PR DESCRIPTION
## What?
I changed the code of PaymentIntent confirmation in the frontend with the creation of a paymentMethod with credit card details. This change is to create and process the PaymentIntent in BigPay and only keep the credit card details actions in checkout-sdk.

## Why?
Multiple paymentIntents are created with the current approach and kept as incomplete, and with this approach we also help to avoid different order amounts when the paymentIntent is created and when the transaction is processed in BigPay.

## Testing / Proof
Manual testing along with this PR: [INT-3660](https://github.com/bigcommerce/bigpay/pull/3339)
Unit testing: 
![image](https://user-images.githubusercontent.com/35146660/105537951-55505d00-5cb8-11eb-9c4d-b47f5ff42e93.png)

**Note**: We need to merge first https://github.com/bigcommerce/bigpay/pull/3339 to won't affect any merchant

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
