### PR TITLE
CHECKOUT-4726 Allow creating customer address

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -186,6 +186,7 @@ describe('CheckoutService', () => {
         customerRequestSender = new CustomerRequestSender(requestSender);
 
         jest.spyOn(customerRequestSender, 'createAccount').mockResolvedValue(getResponse({}));
+        jest.spyOn(customerRequestSender, 'createAddress').mockResolvedValue(getResponse({}));
 
         paymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
 
@@ -440,6 +441,19 @@ describe('CheckoutService', () => {
                     lastName: 'last',
                     password: 'password',
                 }, undefined);
+
+            expect(state.data.getCheckout())
+                .toEqual(store.getState().checkout.getCheckout());
+        });
+    });
+
+    describe('#createCustomerAddress()', () => {
+        it('creates customer address', async () => {
+            const address = getShippingAddress();
+            const state = await checkoutService.createCustomerAddress(address);
+
+            expect(customerRequestSender.createAddress)
+                .toHaveBeenCalledWith(address, undefined);
 
             expect(state.data.getCheckout())
                 .toEqual(store.getState().checkout.getCheckout());

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -9,7 +9,7 @@ import { RequestOptions } from '../common/http-request';
 import { bindDecorator as bind } from '../common/utility';
 import { ConfigActionCreator } from '../config';
 import { CouponActionCreator, GiftCertificateActionCreator } from '../coupon';
-import { CustomerAccountRequestBody, CustomerActionCreator, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, CustomerStrategyActionCreator, GuestCredentials } from '../customer';
+import { CustomerAccountRequestBody, CustomerActionCreator, CustomerAddressRequestBody, CustomerCredentials, CustomerInitializeOptions, CustomerRequestOptions, CustomerStrategyActionCreator, GuestCredentials } from '../customer';
 import { FormFieldsActionCreator } from '../form';
 import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
@@ -564,12 +564,43 @@ export default class CheckoutService {
      * of development. Therefore the API is unstable and not ready for public
      * consumption.
      *
+     * @alpha
      * @param customerAccount - The customer account data.
      * @param options - Options for creating customer account.
      * @returns A promise that resolves to the current state.
      */
     createCustomerAccount(customerAccount: CustomerAccountRequestBody, options?: RequestOptions): Promise<CheckoutSelectors> {
         const action = this._customerActionCreator.createCustomer(customerAccount, options);
+
+        return this._dispatch(action);
+    }
+
+    /**
+     * Creates a customer account address.
+     *
+     * @remarks
+     * ```js
+     * checkoutService.createCustomerAddress({
+     *   firstName: 'Foo',
+     *   lastName: 'Bar',
+     *   address1: '55 Market St',
+     *   stateOrProvinceCode: 'CA',
+     *   countryCode: 'US',
+     *   postalCode: '90110'
+     *   customFields: [],
+     * });
+     * ```
+     * Please note that `createCustomerAccountAddress` is currently in an early stage
+     * of development. Therefore the API is unstable and not ready for public
+     * consumption.
+     *
+     * @alpha
+     * @param customerAddress - The customer account data.
+     * @param options - Options for creating customer account.
+     * @returns A promise that resolves to the current state.
+     */
+    createCustomerAddress(customerAddress: CustomerAddressRequestBody, options?: RequestOptions): Promise<CheckoutSelectors> {
+        const action = this._customerActionCreator.createAddress(customerAddress, options);
 
         return this._dispatch(action);
     }

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -284,6 +284,13 @@ export default interface CheckoutStoreErrorSelector {
      * @returns The error object if unable to create account, otherwise undefined.
      */
     getCreateCustomerAccountError(): Error | undefined;
+
+    /**
+     * Returns an error if unable to create customer address.
+     *
+     * @returns The error object if unable to create address, otherwise undefined.
+     */
+    getCreateCustomerAddressError(): Error | undefined;
 }
 
 export type CheckoutStoreErrorSelectorFactory = (state: InternalCheckoutSelectors) => CheckoutStoreErrorSelector;
@@ -351,6 +358,7 @@ export function createCheckoutStoreErrorSelectorFactory(): CheckoutStoreErrorSel
             getLoadConfigError: state.config.getLoadError,
             getSignInEmailError: state.signInEmail.getSendError,
             getCreateCustomerAccountError: state.customer.getCreateAccountError,
+            getCreateCustomerAddressError: state.customer.getCreateAddressError,
         };
 
         return {

--- a/src/checkout/checkout-store-status-selector.ts
+++ b/src/checkout/checkout-store-status-selector.ts
@@ -342,6 +342,13 @@ export default interface CheckoutStoreStatusSelector {
      * @returns True if creating, otherwise false.
      */
     isCreatingCustomerAccount(): boolean;
+
+    /**
+     * Checks whether a customer address is being created
+     *
+     * @returns True if creating, otherwise false.
+     */
+    isCreatingCustomerAddress(): boolean;
 }
 
 export type CheckoutStoreStatusSelectorFactory = (state: InternalCheckoutSelectors) => CheckoutStoreStatusSelector;
@@ -446,6 +453,7 @@ export function createCheckoutStoreStatusSelectorFactory(): CheckoutStoreStatusS
             isUpdatingBillingAddress: state.billingAddress.isUpdating,
             isUpdatingSubscriptions: state.subscriptions.isUpdating,
             isCreatingCustomerAccount: state.customer.isCreatingCustomerAccount,
+            isCreatingCustomerAddress: state.customer.isCreatingCustomerAddress,
             isContinuingAsGuest: state.billingAddress.isContinuingAsGuest,
             isUpdatingShippingAddress: state.shippingStrategies.isUpdatingAddress,
             isUpdatingConsignment: state.consignments.isUpdating,

--- a/src/customer/customer-account.ts
+++ b/src/customer/customer-account.ts
@@ -1,3 +1,5 @@
+import { AddressRequestBody } from '../address';
+
 export default interface CustomerAccountRequestBody {
     firstName: string;
     lastName: string;
@@ -13,3 +15,5 @@ export default interface CustomerAccountRequestBody {
 export interface CustomerAccountInternalRequestBody extends CustomerAccountRequestBody {
     token?: string;
 }
+
+export type CustomerAddressRequestBody = AddressRequestBody;

--- a/src/customer/customer-actions.ts
+++ b/src/customer/customer-actions.ts
@@ -3,6 +3,7 @@ import { Action } from '@bigcommerce/data-store';
 import { LoadCheckoutAction } from '../checkout';
 import { SpamProtectionAction } from '../spam-protection';
 
+import Customer from './customer';
 import { InternalCustomerResponseData } from './internal-customer-responses';
 
 export enum CustomerActionType {
@@ -17,11 +18,16 @@ export enum CustomerActionType {
     CreateCustomerRequested = 'CREATE_CUSTOMER_REQUESTED',
     CreateCustomerSucceeded = 'CREATE_CUSTOMER_SUCCEEDED',
     CreateCustomerFailed = 'CREATE_CUSTOMER_FAILED',
+
+    CreateCustomerAddressRequested = 'CREATE_CUSTOMER_ADDRESS_REQUESTED',
+    CreateCustomerAddressSucceeded = 'CREATE_CUSTOMER_ADDRESS_SUCCEEDED',
+    CreateCustomerAddressFailed = 'CREATE_CUSTOMER_ADDRESS_FAILED',
 }
 
 export type CustomerAction =
     SignInCustomerAction |
     SignOutCustomerAction |
+    CreateCustomerAddressAction |
     CreateCustomerAction;
 
 export type CreateCustomerAction =
@@ -29,6 +35,12 @@ export type CreateCustomerAction =
     CreateCustomerSucceededAction |
     CreateCustomerFailedAction |
     SpamProtectionAction |
+    LoadCheckoutAction;
+
+export type CreateCustomerAddressAction =
+    CreateCustomerAddressRequestedAction |
+    CreateCustomerAddressSucceededAction |
+    CreateCustomerAddressFailedAction |
     LoadCheckoutAction;
 
 export type SignInCustomerAction =
@@ -77,4 +89,16 @@ export interface CreateCustomerSucceededAction extends Action {
 
 export interface CreateCustomerFailedAction extends Action<Error> {
     type: CustomerActionType.CreateCustomerFailed;
+}
+
+export interface CreateCustomerAddressRequestedAction extends Action {
+    type: CustomerActionType.CreateCustomerAddressRequested;
+}
+
+export interface CreateCustomerAddressSucceededAction extends Action<Customer> {
+    type: CustomerActionType.CreateCustomerAddressSucceeded;
+}
+
+export interface CreateCustomerAddressFailedAction extends Action<Error> {
+    type: CustomerActionType.CreateCustomerAddressFailed;
 }

--- a/src/customer/customer-reducer.spec.ts
+++ b/src/customer/customer-reducer.spec.ts
@@ -1,6 +1,6 @@
 import { createErrorAction } from '@bigcommerce/data-store';
 
-import { CreateCustomerAction, CustomerActionType } from './customer-actions';
+import { CreateCustomerAction, CreateCustomerAddressAction, CustomerActionType } from './customer-actions';
 import customerReducer from './customer-reducer';
 import CustomerState, { DEFAULT_STATE } from './customer-state';
 
@@ -11,7 +11,7 @@ describe('customerReducer()', () => {
         initialState = DEFAULT_STATE;
     });
 
-    it('return is creating status', () => {
+    it('return is creating status true when requested', () => {
         const action: CreateCustomerAction = {
             type: CustomerActionType.CreateCustomerRequested,
         };
@@ -23,7 +23,7 @@ describe('customerReducer()', () => {
         }));
     });
 
-    it('returns new state with customer data when checkout is loaded successfully', () => {
+    it('returns is creating status false when succeeded', () => {
         const action: CreateCustomerAction = {
             type: CustomerActionType.CreateCustomerSucceeded,
         };
@@ -35,12 +35,45 @@ describe('customerReducer()', () => {
         }));
     });
 
-    it('returns new state with customer data when continue as guest is successful', () => {
+    it('returns is creating customer error', () => {
         const action = createErrorAction(CustomerActionType.CreateCustomerFailed, new Error());
 
         expect(customerReducer(initialState, action)).toEqual(expect.objectContaining({
             statuses: { isCreating: false },
             errors: { createError: action.payload },
+        }));
+    });
+
+    it('return is creating address status true when requested', () => {
+        const action: CreateCustomerAddressAction = {
+            type: CustomerActionType.CreateCustomerAddressRequested,
+        };
+
+        expect(customerReducer(initialState, action)).toEqual(expect.objectContaining({
+            statuses: {
+                isCreatingAddress: true,
+            },
+        }));
+    });
+
+    it('returns is creating address status false when succeeded', () => {
+        const action: CreateCustomerAddressAction = {
+            type: CustomerActionType.CreateCustomerAddressSucceeded,
+        };
+
+        expect(customerReducer(initialState, action)).toEqual(expect.objectContaining({
+            statuses: {
+                isCreatingAddress: false,
+            },
+        }));
+    });
+
+    it('returns is creating address error', () => {
+        const action = createErrorAction(CustomerActionType.CreateCustomerAddressFailed, new Error());
+
+        expect(customerReducer(initialState, action)).toEqual(expect.objectContaining({
+            statuses: { isCreatingAddress: false },
+            errors: { createAddressError: action.payload },
         }));
     });
 });

--- a/src/customer/customer-reducer.ts
+++ b/src/customer/customer-reducer.ts
@@ -6,14 +6,14 @@ import { clearErrorReducer } from '../common/error';
 import { objectMerge, objectSet } from '../common/utility';
 
 import Customer from './customer';
-import { CreateCustomerAction, CustomerActionType } from './customer-actions';
+import { CustomerAction, CustomerActionType } from './customer-actions';
 import CustomerState, { CustomerErrorsState, CustomerStatusesState, DEFAULT_STATE } from './customer-state';
 
 export default function customerReducer(
     state: CustomerState = DEFAULT_STATE,
-    action: CheckoutAction | ContinueAsGuestAction | CreateCustomerAction
+    action: CheckoutAction | ContinueAsGuestAction | CustomerAction
 ): CustomerState {
-    const reducer = combineReducers<CustomerState, CheckoutAction | CreateCustomerAction | ContinueAsGuestAction>({
+    const reducer = combineReducers<CustomerState, CheckoutAction | CustomerAction | ContinueAsGuestAction>({
         data: dataReducer,
         errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
@@ -24,12 +24,15 @@ export default function customerReducer(
 
 function dataReducer(
     data: Customer | undefined,
-    action: CheckoutAction | ContinueAsGuestAction | CreateCustomerAction
+    action: CheckoutAction | ContinueAsGuestAction | CustomerAction
 ): Customer | undefined {
     switch (action.type) {
     case BillingAddressActionType.ContinueAsGuestSucceeded:
     case CheckoutActionType.LoadCheckoutSucceeded:
         return objectMerge(data, action.payload && action.payload.customer);
+
+    case CustomerActionType.CreateCustomerAddressSucceeded:
+            return objectMerge(data, action.payload);
 
     default:
         return data;
@@ -38,7 +41,7 @@ function dataReducer(
 
 function errorsReducer(
     errors: CustomerErrorsState = DEFAULT_STATE.errors,
-    action: CheckoutAction | ContinueAsGuestAction | CreateCustomerAction
+    action: CheckoutAction | ContinueAsGuestAction | CustomerAction
 ): CustomerErrorsState {
     switch (action.type) {
     case CustomerActionType.CreateCustomerRequested:
@@ -48,6 +51,13 @@ function errorsReducer(
     case CustomerActionType.CreateCustomerFailed:
         return objectSet(errors, 'createError', action.payload);
 
+    case CustomerActionType.CreateCustomerAddressRequested:
+    case CustomerActionType.CreateCustomerAddressSucceeded:
+        return objectSet(errors, 'createAddressError', undefined);
+
+    case CustomerActionType.CreateCustomerAddressFailed:
+        return objectSet(errors, 'createAddressError', action.payload);
+
     default:
         return errors;
     }
@@ -55,7 +65,7 @@ function errorsReducer(
 
 function statusesReducer(
     statuses: CustomerStatusesState = DEFAULT_STATE.statuses,
-    action: CheckoutAction | ContinueAsGuestAction | CreateCustomerAction
+    action: CheckoutAction | ContinueAsGuestAction | CustomerAction
 ): CustomerStatusesState {
     switch (action.type) {
     case CustomerActionType.CreateCustomerRequested:
@@ -64,6 +74,13 @@ function statusesReducer(
     case CustomerActionType.CreateCustomerFailed:
     case CustomerActionType.CreateCustomerSucceeded:
         return objectSet(statuses, 'isCreating', false);
+
+    case CustomerActionType.CreateCustomerAddressRequested:
+        return objectSet(statuses, 'isCreatingAddress', true);
+
+    case CustomerActionType.CreateCustomerAddressFailed:
+    case CustomerActionType.CreateCustomerAddressSucceeded:
+        return objectSet(statuses, 'isCreatingAddress', false);
     default:
         return statuses;
     }

--- a/src/customer/customer-request-sender.spec.ts
+++ b/src/customer/customer-request-sender.spec.ts
@@ -1,8 +1,9 @@
 import { createRequestSender, createTimeout, RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { getResponse } from '../common/http-request/responses.mock';
+import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 
-import CustomerAccountRequestBody from './customer-account';
+import CustomerAccountRequestBody, { CustomerAddressRequestBody } from './customer-account';
 import CustomerCredentials from './customer-credentials';
 import CustomerRequestSender from './customer-request-sender';
 import { InternalCustomerResponseBody } from './internal-customer-responses';
@@ -55,6 +56,39 @@ describe('CustomerRequestSender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/customer', {
                 ...options,
                 body: customerAccount,
+            });
+        });
+    });
+
+    describe('#createAddress()', () => {
+        let customerAddress: CustomerAddressRequestBody;
+        let response: Response<InternalCustomerResponseBody>;
+
+        beforeEach(() => {
+            customerAddress = getShippingAddress();
+
+            response = getResponse(getCustomerResponseBody());
+
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve(response));
+        });
+
+        it('posts customer credentials', async () => {
+            const output = await customerRequestSender.createAddress(customerAddress);
+
+            expect(output).toEqual(response);
+            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/customer-address', {
+                body: customerAddress,
+            });
+        });
+
+        it('posts customer credentials with timeout', async () => {
+            const options = { timeout: createTimeout() };
+            const output = await customerRequestSender.createAddress(customerAddress, options);
+
+            expect(output).toEqual(response);
+            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/customer-address', {
+                ...options,
+                body: customerAddress,
             });
         });
     });

--- a/src/customer/customer-request-sender.ts
+++ b/src/customer/customer-request-sender.ts
@@ -2,7 +2,8 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { RequestOptions } from '../common/http-request';
 
-import { CustomerAccountInternalRequestBody } from './customer-account';
+import Customer from './customer';
+import { CustomerAccountInternalRequestBody, CustomerAddressRequestBody } from './customer-account';
 import CustomerCredentials from './customer-credentials';
 import { InternalCustomerResponseBody } from './internal-customer-responses';
 
@@ -15,6 +16,12 @@ export default class CustomerRequestSender {
         const url = '/api/storefront/customer';
 
         return this._requestSender.post(url, { timeout, body: customerAccount });
+    }
+
+    createAddress(customerAddress: CustomerAddressRequestBody, { timeout }: RequestOptions = {}): Promise<Response<Customer>> {
+        const url = `/api/storefront/customer-address`;
+
+        return this._requestSender.post<Customer>(url, { timeout, body: customerAddress });
     }
 
     signInCustomer(credentials: CustomerCredentials, { timeout }: RequestOptions = {}): Promise<Response<InternalCustomerResponseBody>> {

--- a/src/customer/customer-selector.spec.ts
+++ b/src/customer/customer-selector.spec.ts
@@ -64,4 +64,40 @@ describe('CustomerSelector', () => {
             expect(selector.isCreatingCustomerAccount()).toEqual(false);
         });
     });
+
+    describe('#getCreateAddressError()', () => {
+        it('returns current customer', () => {
+            const createAddressError = new Error();
+
+            selector = createCustomerSelector({
+                errors: { createAddressError },
+                statuses: {},
+            });
+
+            expect(selector.getCreateAddressError()).toEqual(createAddressError);
+        });
+
+        it('returns undefined if customer is unavailable', () => {
+            selector = createCustomerSelector(DEFAULT_STATE);
+
+            expect(selector.getCreateAddressError()).toEqual(undefined);
+        });
+    });
+
+    describe('#isCreatingCustomerAccount()', () => {
+        it('returns is creating address', () => {
+            selector = createCustomerSelector({
+                errors: { },
+                statuses: { isCreatingAddress: true },
+            });
+
+            expect(selector.isCreatingCustomerAddress()).toEqual(true);
+        });
+
+        it('returns undefined if customer is unavailable', () => {
+            selector = createCustomerSelector(DEFAULT_STATE);
+
+            expect(selector.isCreatingCustomerAddress()).toEqual(false);
+        });
+    });
 });

--- a/src/customer/customer-selector.ts
+++ b/src/customer/customer-selector.ts
@@ -9,6 +9,8 @@ export default interface CustomerSelector {
     getCustomer(): Customer | undefined;
     getCreateAccountError(): Error | undefined;
     isCreatingCustomerAccount(): boolean;
+    getCreateAddressError(): Error | undefined;
+    isCreatingCustomerAddress(): boolean;
 }
 
 export type CustomerSelectorFactory = (state: CustomerState) => CustomerSelector;
@@ -29,6 +31,16 @@ export function createCustomerSelectorFactory(): CustomerSelectorFactory {
         status => () => status
     );
 
+    const getCreateAddressError = createSelector(
+        (state: CustomerState) => state.errors.createAddressError,
+        error => () => error
+    );
+
+    const isCreatingCustomerAddress = createSelector(
+        (state: CustomerState) => !!state.statuses.isCreatingAddress,
+        status => () => status
+    );
+
     return memoizeOne((
         state: CustomerState = DEFAULT_STATE
     ): CustomerSelector => {
@@ -36,6 +48,8 @@ export function createCustomerSelectorFactory(): CustomerSelectorFactory {
             getCustomer: getCustomer(state),
             getCreateAccountError: getCreateAccountError(state),
             isCreatingCustomerAccount: isCreatingCustomerAccount(state),
+            getCreateAddressError: getCreateAddressError(state),
+            isCreatingCustomerAddress: isCreatingCustomerAddress(state),
         };
     });
 }

--- a/src/customer/customer-state.ts
+++ b/src/customer/customer-state.ts
@@ -8,10 +8,12 @@ export default interface CustomerState {
 
 export interface CustomerErrorsState {
     createError?: Error;
+    createAddressError?: Error;
 }
 
 export interface CustomerStatusesState {
     isCreating?: boolean;
+    isCreatingAddress?: boolean;
 }
 
 export const DEFAULT_STATE: CustomerState = {

--- a/src/customer/index.ts
+++ b/src/customer/index.ts
@@ -6,7 +6,7 @@ export { default as Customer, CustomerAddress } from './customer';
 export { default as createCustomerStrategyRegistry } from './create-customer-strategy-registry';
 export { CustomerAction, CustomerActionType } from './customer-actions';
 export { default as customerReducer } from './customer-reducer';
-export { default as CustomerAccountRequestBody } from './customer-account';
+export { default as CustomerAccountRequestBody, CustomerAddressRequestBody } from './customer-account';
 export { default as CustomerActionCreator } from './customer-action-creator';
 export { default as CustomerCredentials } from './customer-credentials';
 export { default as CustomerRequestSender } from './customer-request-sender';


### PR DESCRIPTION
## What?
Allow creating customer address. Alpha functionality.

## Why?
To allow creating customer addresses during checkout, which can be used for the multishipping UI.

## Testing / Proof
unit

@bigcommerce/checkout
