### PR TITLE
CHECKOUT-5324: Set nonce in memory instead of local storage

### DIFF
--- a/src/hosted-form/iframe-content/get-hosted-input-storage.ts
+++ b/src/hosted-form/iframe-content/get-hosted-input-storage.ts
@@ -1,15 +1,9 @@
-import { BrowserStorage } from '../../common/storage';
-
 import HostedInputStorage from './hosted-input-storage';
-
-const STORAGE_NAMESPACE = 'BigCommerce.HostedInput';
 
 let storage: HostedInputStorage | null;
 
 export default function getHostedInputStorage(): HostedInputStorage {
-    storage = storage || new HostedInputStorage(
-        new BrowserStorage(STORAGE_NAMESPACE)
-    );
+    storage = storage || new HostedInputStorage();
 
     return storage;
 }

--- a/src/hosted-form/iframe-content/hosted-input-storage.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-storage.spec.ts
@@ -1,34 +1,16 @@
-import { BrowserStorage } from '../../common/storage';
-
 import HostedInputStorage from './hosted-input-storage';
 
 describe('HostedInputStorage', () => {
-    let storage: Pick<BrowserStorage, 'getItem' | 'setItem'>;
     let subject: HostedInputStorage;
 
     beforeEach(() => {
-        storage = {
-            getItem: jest.fn(),
-            setItem: jest.fn(),
-        };
-        subject = new HostedInputStorage(storage as BrowserStorage);
+        subject = new HostedInputStorage();
     });
 
-    it('sets nonce in browser storage', () => {
+    it('sets nonce for later retrieval', () => {
         subject.setNonce('abc');
-
-        expect(storage.setItem)
-            .toHaveBeenCalledWith('nonce', 'abc');
-    });
-
-    it('retrieves nonce in browser storage', () => {
-        jest.spyOn(storage, 'getItem')
-            .mockReturnValue('abc');
 
         expect(subject.getNonce())
             .toEqual('abc');
-
-        expect(storage.getItem)
-            .toHaveBeenCalledWith('nonce');
     });
 });

--- a/src/hosted-form/iframe-content/hosted-input-storage.ts
+++ b/src/hosted-form/iframe-content/hosted-input-storage.ts
@@ -1,15 +1,11 @@
-import { BrowserStorage } from '../../common/storage';
-
 export default class HostedInputStorage {
-    constructor(
-        private _storage: BrowserStorage
-    ) {}
+    private _nonce?: string;
 
     setNonce(nonce: string): void {
-        this._storage.setItem('nonce', nonce);
+        this._nonce = nonce;
     }
 
-    getNonce(): string | null {
-        return this._storage.getItem('nonce');
+    getNonce(): string | undefined {
+        return this._nonce;
     }
 }


### PR DESCRIPTION
## What?
Set the nonce of a hosted form in memory instead of local storage.

## Why?
We don't need to set it in local storage anymore with the changes proposed in https://github.com/bigcommerce/bigpay/pull/3415.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/security 
