### PR TITLE
feat(payment): INT-3831 enable vaulting on cybersource v2

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -65,6 +65,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'cybersource',
         method: 'credit_card',
     },
+    cybersourcev2: {
+        provider: 'cybersourcev2',
+        method: 'credit_card',
+    },
     converge: {
         provider: 'converge',
         method: 'credit_card',


### PR DESCRIPTION
## What?
Added cybersourcev2 to supported payments instruments

## Why?
In order to show vaulted instruments on cybersource V2

## Testing / Proof
![Screen Shot 2021-01-29 at 7 21 02 PM](https://user-images.githubusercontent.com/61981535/106668986-983fe980-6570-11eb-83ba-ab0701074f1f.png)
![Screen Shot 2021-01-29 at 7 21 11 PM](https://user-images.githubusercontent.com/61981535/106668977-9544f900-6570-11eb-95cf-0cd5671f9af2.png)


@bigcommerce/checkout @bigcommerce/payments
