### PR TITLE
feat(checkout): INT-3700 Load Bolt Scripts from different environments

### DIFF
--- a/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -120,7 +120,13 @@ describe('BoltPaymentStrategy', () => {
     describe('#initialize', () => {
         it('successfully initializes the bolt strategy and loads the bolt client', async () => {
             await expect(strategy.initialize(boltClientScriptInitializationOptions)).resolves.toEqual(store.getState());
-            expect(boltScriptLoader.load).toHaveBeenCalledWith('publishableKey', true);
+            expect(boltScriptLoader.load).toHaveBeenCalledWith('publishableKey', true, undefined);
+        });
+
+        it('successfully initializes the bolt strategy and loads the bolt client with developer params', async () => {
+            paymentMethodMock.initializationData.developerConfig = { developerMode: 'bolt_sandbox', developerDomain: '' };
+            await expect(strategy.initialize(boltClientScriptInitializationOptions)).resolves.toEqual(store.getState());
+            expect(boltScriptLoader.load).toHaveBeenCalledWith('publishableKey', true, paymentMethodMock.initializationData.developerConfig);
         });
 
         it('fails to initialize the bolt strategy if publishableKey is not provided', async () => {

--- a/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -40,9 +40,9 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
                 throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
             }
 
-            const { publishableKey } = paymentMethod.initializationData;
+            const { developerConfig, publishableKey } = paymentMethod.initializationData;
 
-            this._boltClient = await this._boltScriptLoader.load(publishableKey, paymentMethod.config.testMode);
+            this._boltClient = await this._boltScriptLoader.load(publishableKey, paymentMethod.config.testMode, developerConfig);
         }
 
         return Promise.resolve(this._store.getState());

--- a/src/payment/strategies/bolt/bolt-script-loader.spec.ts
+++ b/src/payment/strategies/bolt/bolt-script-loader.spec.ts
@@ -2,7 +2,7 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
-import { BoltCheckout, BoltHostWindow } from './bolt';
+import { BoltCheckout, BoltDeveloperMode, BoltHostWindow } from './bolt';
 import BoltScriptLoader from './bolt-script-loader';
 import { getBoltScriptMock } from './bolt.mock';
 
@@ -38,11 +38,32 @@ describe('BoltScriptLoader', () => {
         });
 
         it('loads the bolt script in test mode', async () => {
-          await boltScriptLoader.load(publishableKey, true);
+            await boltScriptLoader.load(publishableKey, true);
 
-          expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-sandbox.bolt.com/connect-bigcommerce.js', expect.any(Object));
-          expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-sandbox.bolt.com/track.js');
-      });
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-sandbox.bolt.com/connect-bigcommerce.js', expect.any(Object));
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-sandbox.bolt.com/track.js');
+        });
+
+        it('loads the bolt script in staging mode', async () => {
+            await boltScriptLoader.load(publishableKey, true, { developerMode: BoltDeveloperMode.StagingMode, developerDomain: ''});
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-staging.bolt.com/connect-bigcommerce.js', expect.any(Object));
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-staging.bolt.com/track.js');
+        });
+
+        it('loads the bolt script in sandbox mode', async () => {
+            await boltScriptLoader.load(publishableKey, true, { developerMode: BoltDeveloperMode.SandboxMode, developerDomain: ''});
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-sandbox.bolt.com/connect-bigcommerce.js', expect.any(Object));
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect-sandbox.bolt.com/track.js');
+        });
+
+        it('loads the bolt script in development mode', async () => {
+            await boltScriptLoader.load(publishableKey, true, { developerMode: BoltDeveloperMode.DevelopmentMode, developerDomain: 'test.sample.com'});
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect.test.sample.com/connect-bigcommerce.js', expect.any(Object));
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//connect.test.sample.com/track.js');
+        });
 
         it('returns the Bolt Client from the window', async () => {
             const client = await boltScriptLoader.load(publishableKey);

--- a/src/payment/strategies/bolt/bolt-script-loader.ts
+++ b/src/payment/strategies/bolt/bolt-script-loader.ts
@@ -2,7 +2,7 @@ import { LoadScriptOptions, ScriptLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
-import { BoltCheckout, BoltHostWindow } from './bolt';
+import { BoltCheckout, BoltDeveloperMode, BoltDeveloperModeParams, BoltHostWindow } from './bolt';
 
 export default class BoltScriptLoader {
     constructor(
@@ -10,7 +10,7 @@ export default class BoltScriptLoader {
         public _window: BoltHostWindow = window
     ) {}
 
-    async load(publishableKey: string, testMode?: boolean): Promise<BoltCheckout> {
+    async load(publishableKey: string, testMode?: boolean, developerModeParams?: BoltDeveloperModeParams): Promise<BoltCheckout> {
         const options: LoadScriptOptions = {
             async: true,
             attributes: {
@@ -20,8 +20,8 @@ export default class BoltScriptLoader {
         };
 
         await Promise.all([
-            this._scriptLoader.loadScript(`//connect${testMode ? '-sandbox' : ''}.bolt.com/connect-bigcommerce.js`, options),
-            this._scriptLoader.loadScript(`//connect${testMode ? '-sandbox' : ''}.bolt.com/track.js`),
+            this._scriptLoader.loadScript(`//${this.getDomainURL(!!testMode, developerModeParams)}/connect-bigcommerce.js`, options),
+            this._scriptLoader.loadScript(`//${this.getDomainURL(!!testMode, developerModeParams)}/track.js`),
         ]);
 
         if (!this._window.BoltCheckout) {
@@ -29,5 +29,23 @@ export default class BoltScriptLoader {
         }
 
         return this._window.BoltCheckout;
+    }
+
+    private getDomainURL(testMode: boolean, developerModeParams?: BoltDeveloperModeParams): string {
+
+        if (!testMode) {
+            return 'connect.bolt.com';
+        }
+
+        if (developerModeParams) {
+            switch (developerModeParams.developerMode) {
+                case BoltDeveloperMode.StagingMode:
+                    return 'connect-staging.bolt.com';
+                case BoltDeveloperMode.DevelopmentMode:
+                    return `connect.${developerModeParams.developerDomain}`;
+            }
+        }
+
+        return 'connect-sandbox.bolt.com';
     }
 }

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -7,6 +7,17 @@ export interface BoltCheckout {
     setClientCustomCallbacks(callbacks: BoltCallbacks): void;
 }
 
+export interface BoltDeveloperModeParams {
+    developerMode: BoltDeveloperMode;
+    developerDomain: string;
+}
+
+export enum BoltDeveloperMode {
+    SandboxMode = 'bolt_sandbox',
+    StagingMode = 'bolt_staging',
+    DevelopmentMode = 'bolt_development',
+}
+
 export interface BoltClient {
     open(): void;
 }


### PR DESCRIPTION
## What? [INT-3700](https://jira.bigcommerce.com/browse/INT-3700)
Update Bolt's script loader to load scripts from different environments depending on the settings configured in the control panel.

## Why?
So Bolt's developers can configure their custom development URL on the store for testing purposes.

## Sibling PRs
https://github.com/bigcommerce/ng-payments/pull/1225
https://github.com/bigcommerce/bigcommerce/pull/39355
https://github.com/bigcommerce/bigpay/pull/3447

## Testing / Proof
[Demo Video](https://drive.google.com/file/d/154VVMjyYwEXNBZ_PbAhejZcDjIyXJIBP/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
