### PR TITLE
feat(payment): PAYPAL-876 fixed paypalcommerce initialization endpoint

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.spec.ts
@@ -102,7 +102,7 @@ describe('PaypalCommerceRequestSender', () => {
                 'Content-Type': ContentType.Json,
             };
 
-            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommercealternativemethods', expect.objectContaining({
+            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommercealternativemethodscheckout', expect.objectContaining({
                 body: {cartId: 'abc'},
                 headers,
             }));

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -29,7 +29,7 @@ export default class PaypalCommerceRequestSender {
         }
 
         if (isAPM) {
-            provider = 'paypalcommercealternativemethods';
+            provider = 'paypalcommercealternativemethodscheckout';
         }
 
         const url = `/api/storefront/payment/${provider}`;


### PR DESCRIPTION
## What?
Fixed endpoint from paypalcommercealternativemethods to paypalcommercealternativemethodscheckout
## Why?
To fix polling mechanism

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments
