### PR TITLE
feat(payment): PAYPAL-876 stop polling mechanism when error occurs

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -186,6 +186,7 @@ describe('PaypalCommercePaymentStrategy', () => {
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
                 onCancel: expect.any(Function),
+                onError: expect.any(Function),
             };
 
             const optionalParams = { fundingKey: 'PAYPAL', paramsForProvider: { isCheckout: true }, onRenderButton: expect.any(Function) };
@@ -210,6 +211,7 @@ describe('PaypalCommercePaymentStrategy', () => {
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
                 onCancel: expect.any(Function),
+                onError: expect.any(Function),
             };
 
             const optionalParams = { fundingKey: 'PAYLATER', paramsForProvider: { isCheckout: true }, onRenderButton: expect.any(Function) };
@@ -233,6 +235,7 @@ describe('PaypalCommercePaymentStrategy', () => {
                     {   onApprove: expect.any(Function),
                         onClick: expect.any(Function),
                         onCancel: expect.any(Function),
+                        onError: expect.any(Function),
                         style: paymentMethod.initializationData.buttonStyle },
                     {   paramsForProvider: { isCheckout: true },
                         onRenderButton: expect.any(Function),

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -75,6 +75,9 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
             onCancel: () => {
                 this._deinitializePollingTimer(gatewayId);
             },
+            onError: () => {
+                this._deinitializePollingTimer(gatewayId);
+            },
         };
 
         await this._paypalCommercePaymentProcessor.initialize(paramsScript, undefined, gatewayId);

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -63,6 +63,7 @@ export interface ButtonsOptions {
     onApprove?(data: ApproveDataOptions): void;
     onClick?(data: ClickDataOptions, actions: ClickActions): void;
     onCancel?(): void;
+    onError?(): void;
 }
 
 export interface MessagesOptions {


### PR DESCRIPTION
## What?
Stop polling mechanism when error occurs
## Why?
According to task PAYPAL-876
## Testing / Proof
Tested on dev

@bigcommerce/checkout @bigcommerce/payments @davidchin 
