### PR TITLE
fix(checkout): INT-3665 3D Secure is declining the transaction in Braintree without any reason in some stores

### DIFF
--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -129,7 +129,7 @@ export default class BraintreePaymentProcessor {
         amount: number,
         nonce: string
     ): Promise<BraintreeVerifyPayload> {
-        if (!this._threeDSecureOptions) {
+        if (!this._threeDSecureOptions || !nonce) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
@@ -171,6 +171,8 @@ export default class BraintreePaymentProcessor {
                         validate: false,
                     },
                     billingAddress: billingAddress && {
+                        countryCodeAlpha2: billingAddress.countryCode,
+                        locality: billingAddress.city,
                         countryName: billingAddress.country,
                         postalCode: billingAddress.postalCode,
                         streetAddress: billingAddress.address2 ?

--- a/src/payment/strategies/braintree/braintree.mock.ts
+++ b/src/payment/strategies/braintree/braintree.mock.ts
@@ -131,6 +131,8 @@ export function getBraintreeRequestData(): BraintreeRequestData {
         data: {
             creditCard: {
                 billingAddress: {
+                    countryCodeAlpha2: 'US',
+                    locality: 'Some City',
                     countryName: 'United States',
                     postalCode: '95555',
                     streetAddress: '12345 Testing Way',

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -225,6 +225,8 @@ export interface BraintreeRequestData {
     data: {
         creditCard: {
             billingAddress?: {
+                countryCodeAlpha2: string;
+                locality: string;
                 countryName: string;
                 postalCode: string;
                 streetAddress: string;


### PR DESCRIPTION
## What? [INT-3665](https://jira.bigcommerce.com/browse/INT-3665)

Fix the 3D Secure in Braintree because sometimes the nonce is not created correctly and the flow process must be break to doesn't show 3D Secure dialog.

## Why?

Because the transaction is declined after the 3D Secure dialog is showed without any kind of message that what was wrong

## Testing / Proof

[Video](https://drive.google.com/file/d/1rwQ6O5C0JrSHkeAqrndgE3z4gtGgVRXu/view?usp=sharing)

The issue can't be reproduced locally, but we know that the creation of the nonce is the problem, so if the nonce is not created we break the flow of the payment process to doesn't show 3D Secure dialog.

Ping @bigcommerce/payments @bigcommerce/apex-integrations