### PR TITLE
feat(payment): INT-3408 migrate masterpass to SRC

### DIFF
--- a/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/masterpass/masterpass-button-strategy.spec.ts
@@ -7,6 +7,7 @@ import { createCheckoutStore, Checkout, CheckoutActionCreator, CheckoutRequestSe
 import { getCheckout, getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfig } from '../../../config/configs.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getMasterpass, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
@@ -17,7 +18,7 @@ import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 import MasterpassButtonStrategy from './masterpass-button-strategy';
 
-describe('MasterpassCustomerStrategy', () => {
+describe('MasterpassButtonStrategy', () => {
     let container: HTMLDivElement;
     let containerFoo: HTMLDivElement;
     let masterpass: Masterpass;
@@ -51,6 +52,9 @@ describe('MasterpassCustomerStrategy', () => {
 
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
             .mockReturnValue(paymentMethodMock);
+
+        jest.spyOn(store.getState().config, 'getStoreConfig')
+        .mockReturnValue(getConfig().storeConfig);
 
         jest.spyOn(store.getState().checkout, 'getCheckout')
             .mockReturnValue(checkoutMock);
@@ -103,7 +107,7 @@ describe('MasterpassCustomerStrategy', () => {
 
             await strategy.initialize(masterpassOptions);
 
-            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(true);
+            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(true, 'en_US', 'checkoutId');
         });
 
         it('loads masterpass without test mode if disabled', async () => {
@@ -111,7 +115,7 @@ describe('MasterpassCustomerStrategy', () => {
 
             await strategy.initialize(masterpassOptions);
 
-            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(false);
+            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(false, 'en_US', 'checkoutId');
         });
 
         it('fails to initialize the strategy if no container is supplied', async () => {

--- a/src/customer/strategies/masterpass/masterpass-customer-strategy.spec.ts
+++ b/src/customer/strategies/masterpass/masterpass-customer-strategy.spec.ts
@@ -5,7 +5,7 @@ import { getCartState } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
-import { getConfigState } from '../../../config/configs.mock';
+import { getConfig, getConfigState } from '../../../config/configs.mock';
 import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getMasterpass, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { Masterpass, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
@@ -50,6 +50,9 @@ describe('MasterpassCustomerStrategy', () => {
 
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
             .mockReturnValue(paymentMethodMock);
+
+        jest.spyOn(store.getState().config, 'getStoreConfig')
+        .mockReturnValue(getConfig().storeConfig);
 
         requestSender = createRequestSender();
 
@@ -99,7 +102,7 @@ describe('MasterpassCustomerStrategy', () => {
 
             await strategy.initialize(masterpassOptions);
 
-            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(true);
+            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(true, 'en_US', 'checkoutId');
         });
 
         it('loads masterpass without test mode if disabled', async () => {
@@ -107,7 +110,7 @@ describe('MasterpassCustomerStrategy', () => {
 
             await strategy.initialize(masterpassOptions);
 
-            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(false);
+            expect(masterpassScriptLoader.load).toHaveBeenLastCalledWith(false, 'en_US', 'checkoutId');
         });
 
         it('fails to initialize the strategy if no methodId is supplied', async () => {

--- a/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
+++ b/src/payment/strategies/masterpass/masterpass-payment-strategy.spec.ts
@@ -91,6 +91,9 @@ describe('MasterpassPaymentStrategy', () => {
 
         it('throws an exception if masterpass options is not passed', () => {
             initOptions.masterpass = undefined;
+            paymentMethodMock.initializationData = {
+                checkoutId: 'checkout-id',
+            };
             const error = 'Unable to initialize payment because "options.masterpass" argument is not provided.';
 
             return expect(strategy.initialize(initOptions)).rejects.toThrow(error);
@@ -102,7 +105,7 @@ describe('MasterpassPaymentStrategy', () => {
 
             beforeEach(() => {
                 paymentMethodMock.initializationData = {
-                    allowedCardTypes: ['visa', 'amex', 'mastercard'],
+                    allowedCardTypes: ['visa', 'amex', 'master'],
                     checkoutId: 'checkout-id',
                 };
 
@@ -110,13 +113,12 @@ describe('MasterpassPaymentStrategy', () => {
                     allowedCardTypes: [
                         'visa',
                         'amex',
-                        'mastercard',
+                        'master',
                     ],
                     amount: '190.00',
                     cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                     checkoutId: 'checkout-id',
                     currency: 'USD',
-                    suppressShippingAddress: false,
                     callbackUrl: getCallbackUrlMock(),
                 };
 
@@ -126,7 +128,7 @@ describe('MasterpassPaymentStrategy', () => {
 
             it('loads the script and calls the checkout when the wallet button is clicked', async () => {
                 await strategy.initialize(initOptions);
-                expect(scriptLoader.load).toHaveBeenLastCalledWith(false);
+                expect(scriptLoader.load).toHaveBeenLastCalledWith(false, 'en_US', 'checkout-id');
                 walletButton.click();
                 expect(masterpassScript.checkout).toHaveBeenCalledWith(payload);
             });
@@ -134,7 +136,7 @@ describe('MasterpassPaymentStrategy', () => {
             it('loads the script in test mode, and calls the checkout when the wallet button is clicked', async () => {
                 paymentMethodMock.config.testMode = true;
                 await strategy.initialize(initOptions);
-                expect(scriptLoader.load).toHaveBeenLastCalledWith(true);
+                expect(scriptLoader.load).toHaveBeenLastCalledWith(true, 'en_US', 'checkout-id');
                 walletButton.click();
                 expect(masterpassScript.checkout).toHaveBeenCalled();
             });
@@ -143,7 +145,7 @@ describe('MasterpassPaymentStrategy', () => {
                 paymentMethodMock.config.testMode = true;
                 initOptions.masterpass = {};
                 await strategy.initialize(initOptions);
-                expect(scriptLoader.load).toHaveBeenLastCalledWith(true);
+                expect(scriptLoader.load).toHaveBeenLastCalledWith(true, 'en_US', 'checkout-id');
                 walletButton.click();
                 expect(masterpassScript.checkout).not.toHaveBeenCalled();
             });

--- a/src/payment/strategies/masterpass/masterpass-script-loader.ts
+++ b/src/payment/strategies/masterpass/masterpass-script-loader.ts
@@ -10,9 +10,9 @@ export default class MasterpassScriptLoader {
         public _window: MasterpassHostWindow = window
     ) {}
 
-    load(testMode?: boolean): Promise<Masterpass> {
+    load(testMode?: boolean, locale?: string, checkoutId?: string): Promise<Masterpass> {
         return this._scriptLoader
-            .loadScript(`//${testMode ? 'sandbox.' : ''}masterpass.com/integration/merchant.js`)
+            .loadScript(`https://${testMode ? 'sandbox.' : ''}src.mastercard.com/srci/integration/merchant.js?locale=${locale}&checkoutid=${checkoutId}`)
             .then(() => {
                 if (!this._window.masterpass) {
                     throw new PaymentMethodClientUnavailableError();


### PR DESCRIPTION
## What?[INT-3408](https://jira.bigcommerce.com/browse/INT-3408)
Added new URL script and source button on masterpass

## Why?
In order to be able to continue using Masterpass (now "SRC") when shoppers checkout
So that they can continue accepting payment via Masterpass (SRC).

## Depends on
1# [BIGCOMMERCE #39508](https://github.com/bigcommerce/bigcommerce/pull/39508)
2#[CHECKOUT-SDK-JS #1072](https://github.com/bigcommerce/checkout-sdk-js/pull/1072)
3#[CHECKOUT-JS #1072](https://github.com/bigcommerce/checkout-js/pull/515)

## Testing / Proof

[TESTING PROOF VIDEO](https://drive.google.com/file/d/13DRZY92NnGDP1q-_t9hHnetXGfgZmVak/view?usp=sharing)

![CART INT-3408](https://user-images.githubusercontent.com/61981535/108116174-c89f8180-7060-11eb-8210-3ccf0483c7fe.png)
![CUSTOMER INT-3408](https://user-images.githubusercontent.com/61981535/108116190-d05f2600-7060-11eb-8c0f-e4b474f59afb.png)
![Payment Step INT-3408](https://user-images.githubusercontent.com/61981535/108116196-d2c18000-7060-11eb-88ac-bb31146b21e4.png)
![QUICK CART INT-3408 2](https://user-images.githubusercontent.com/61981535/108116198-d3f2ad00-7060-11eb-914d-4ce909460d03.png)
![QUICK CART INT-3408](https://user-images.githubusercontent.com/61981535/108116213-d7863400-7060-11eb-9a19-0253b1050e1c.png)

@bigcommerce/apex-integrations  @bigcommerce/payments


