### PR TITLE
fix(common): CHECKOUT-5612 Add isAccountCreationEnabled prop to Store…

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -93,6 +93,7 @@ export interface CheckoutSettings {
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;
     googleRecaptchaSitekey: string;
+    isAccountCreationEnabled: boolean;
     isStorefrontSpamProtectionEnabled: boolean;
     guestCheckoutEnabled: boolean;
     hasMultiShippingEnabled: boolean;

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -26,6 +26,7 @@ export function getConfig(): Config {
                 hasMultiShippingEnabled: true,
                 googleMapsApiKey: '',
                 googleRecaptchaSitekey: 'sitekey',
+                isAccountCreationEnabled: true,
                 isAnalyticsEnabled: false,
                 isCardVaultingEnabled: true,
                 isStorefrontSpamProtectionEnabled: false,


### PR DESCRIPTION
## What?
Add `isAccountCreationEnabled` prop to StoreConfig

## Why?
Because it has been added to the API

## Testing / Proof
unit

@bigcommerce/checkout