### PR TITLE
feat(payment): PAYPAL-863 Braintree: PayPal JS SDK Smart Buttons

### DIFF
--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -41,8 +41,9 @@ export default function createCheckoutButtonRegistry(
             store,
             checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
-            new PaypalScriptLoader(scriptLoader),
-            formPoster
+            formPoster,
+            undefined,
+            window
         )
     );
 
@@ -51,9 +52,9 @@ export default function createCheckoutButtonRegistry(
             store,
             checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
-            new PaypalScriptLoader(scriptLoader),
             formPoster,
-            true
+            true,
+            window
         )
     );
 

--- a/src/checkout-buttons/index.ts
+++ b/src/checkout-buttons/index.ts
@@ -2,5 +2,5 @@ export { default as createCheckoutButtonInitializer } from './create-checkout-bu
 export { default as checkoutButtonReducer } from './checkout-button-reducer';
 export { default as CheckoutButtonSelector, CheckoutButtonSelectorFactory, createCheckoutButtonSelectorFactory } from './checkout-button-selector';
 export { default as CheckoutButtonState } from './checkout-button-state';
-
+export { CheckoutButtonStrategy } from './strategies/';
 export { CheckoutButtonOptions, CheckoutButtonInitializeOptions } from './checkout-button-options';

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -67,11 +67,11 @@ describe('BraintreePaypalButtonStrategy', () => {
         jest.spyOn(paypal.Button, 'render')
             .mockImplementation((options: PaypalButtonOptions) => {
                 eventEmitter.on('payment', () => {
-                    options.createOrder().catch(() => {});
+                    options.payment().catch(() => {});
                 });
 
                 eventEmitter.on('authorize', () => {
-                    options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {});
+                    options.onAuthorize({ payerId: 'PAYER_ID' }).catch(() => {});
                 });
             });
 

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -102,6 +102,7 @@ describe('BraintreePaypalButtonStrategy', () => {
 
                 return {
                     render: jest.fn(),
+                    isEligible: jest.fn(),
                 };
             });
 
@@ -112,7 +113,7 @@ describe('BraintreePaypalButtonStrategy', () => {
             ]));
 
         jest.spyOn(braintreeSDKCreator, 'getPaypalCheckout')
-            .mockImplementation(callback => {
+            .mockImplementation(({}, callback) => {
                 callback(paypalCheckout);
 
                 return Promise.resolve(paypalCheckout);
@@ -196,10 +197,7 @@ describe('BraintreePaypalButtonStrategy', () => {
                 label: undefined,
                 shape: 'rect',
             },
-            funding: {
-                allowed: [],
-                disallowed: [paypal.FUNDING.CREDIT],
-            },
+            fundingSource: paypal.FUNDING.PAYPAL,
         });
     });
 
@@ -535,10 +533,7 @@ describe('BraintreePaypalButtonStrategy', () => {
                     label: 'credit',
                     shape: 'rect',
                 },
-                funding: {
-                    allowed: [paypal.FUNDING.CREDIT],
-                    disallowed: [],
-                },
+                fundingSource: paypal.FUNDING.PAYPAL,
             });
         });
 

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -5,8 +5,8 @@ import { Address, LegacyAddress } from '../../../address';
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../../common/error/errors';
 import { PaymentMethod } from '../../../payment';
-import { BraintreeError, BraintreePaypalCheckout, BraintreeShippingAddressOverride, BraintreeSDKCreator, BraintreeTokenizePayload } from '../../../payment/strategies/braintree';
-import { PaypalAuthorizeData, PaypalScriptLoader } from '../../../payment/strategies/paypal';
+import { BraintreeError, BraintreePaypalCheckout, BraintreeShippingAddressOverride, BraintreeSDKCreator, BraintreeTokenizePayload, RenderButtonsData } from '../../../payment/strategies/braintree';
+import { PaypalAuthorizeData, PaypalHostWindow } from '../../../payment/strategies/paypal';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
@@ -18,9 +18,10 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         private _store: CheckoutStore,
         private _checkoutActionCreator: CheckoutActionCreator,
         private _braintreeSDKCreator: BraintreeSDKCreator,
-        private _paypalScriptLoader: PaypalScriptLoader,
         private _formPoster: FormPoster,
-        private _offerCredit: boolean = false
+        private _offerCredit: boolean = false,
+        private _window: PaypalHostWindow,
+        private _renderButtonsData?: RenderButtonsData
     ) {}
 
     initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
@@ -33,39 +34,52 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         }
 
         this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        const container = `#${options.containerId}`;
+
+        this._renderButtonsData = {
+            paymentMethod,
+            paypalOptions,
+            container,
+        };
+
+        const that = this;
 
         return Promise.all([
-            this._braintreeSDKCreator.getPaypalCheckout(),
-            this._paypalScriptLoader.loadPaypal(),
+            this._braintreeSDKCreator.getPaypalCheckout(this.renderButtons, that),
+            this._braintreeSDKCreator.getPaypal(),
         ])
-            .then(([paypalCheckout, paypal]) => {
+            .then(([paypalCheckout]) => {
                 this._paypalCheckout = paypalCheckout;
-
-                const allowedSources = [];
-                const disallowedSources = [];
-
-                if (paypalOptions.allowCredit) {
-                    allowedSources.push(paypal.FUNDING.CREDIT);
-                } else {
-                    disallowedSources.push(paypal.FUNDING.CREDIT);
-                }
-
-                return paypal.Button.render({
-                    env: paymentMethod.config.testMode ? 'sandbox' : 'production',
-                    commit: paypalOptions.shouldProcessPayment ? true : false,
-                    funding: {
-                        allowed: allowedSources,
-                        disallowed: disallowedSources,
-                    },
-                    style: {
-                        shape: 'rect',
-                        label: this._offerCredit ? 'credit' : undefined,
-                        ...pick(paypalOptions.style, 'layout', 'size', 'color', 'label', 'shape', 'tagline', 'fundingicons'),
-                    },
-                    payment: () => this._setupPayment(paypalOptions.shippingAddress, paypalOptions.onPaymentError),
-                    onAuthorize: data => this._tokenizePayment(data, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
-                }, options.containerId);
             });
+    }
+
+    renderButtons() {
+        const allowedSources = [];
+        const disallowedSources = [];
+        const { paypalOptions, paymentMethod, container } = this._renderButtonsData as RenderButtonsData;
+
+        if (paypalOptions.allowCredit) {
+            allowedSources.push((this._window && this._window.paypal) && this._window.paypal.FUNDING.CREDIT);
+        } else {
+            disallowedSources.push((this._window && this._window.paypal) && this._window.paypal.FUNDING.CREDIT);
+        }
+        if (this._window && this._window.paypal) {
+            this._window.paypal.Buttons({
+                env: paymentMethod.config.testMode ? 'sandbox' : 'production',
+                commit: paypalOptions.shouldProcessPayment ? true : false,
+                funding: {
+                    allowed: allowedSources as string[],
+                    disallowed: disallowedSources as string[],
+                },
+                style: {
+                    shape: 'rect',
+                    label: this._offerCredit ? 'credit' : undefined,
+                    ...pick(paypalOptions.style, 'layout', 'size', 'color', 'tagline', 'fundingicons'),
+                },
+                createOrder: () => this._setupPayment(paypalOptions.shippingAddress, paypalOptions.onPaymentError),
+                onApprove: (data: PaypalAuthorizeData) => this._tokenizePayment(data, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
+            }).render(container);
+        }
     }
 
     deinitialize(): Promise<void> {

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -76,8 +76,8 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
                     label: this._offerCredit ? 'credit' : undefined,
                     ...pick(paypalOptions.style, 'layout', 'size', 'color', 'tagline', 'fundingicons'),
                 },
-                createOrder: () => this._setupPayment(paypalOptions.shippingAddress, paypalOptions.onPaymentError),
-                onApprove: (data: PaypalAuthorizeData) => this._tokenizePayment(data, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
+                payment: () => this._setupPayment(paypalOptions.shippingAddress, paypalOptions.onPaymentError),
+                onAuthorize: (data: PaypalAuthorizeData) => this._tokenizePayment(data, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
             }).render(container);
         }
     }

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -74,19 +74,25 @@ describe('PaypalButtonStrategy', () => {
         jest.spyOn(paypal.Button, 'render')
             .mockImplementation((options: PaypalButtonOptions) => {
                 eventEmitter.on('payment', () => {
-                    options.payment({
-                        payerId: 'PAYER_ID',
-                        paymentID: 'PAYMENT_ID',
-                        payerID: 'PAYER_ID',
-                    }, actionsMock).catch(() => {});
+                    if (options.payment) {
+                        options.payment({
+                            payerId: 'PAYER_ID',
+                            paymentID: 'PAYMENT_ID',
+                            payerID: 'PAYER_ID',
+                        }, actionsMock).catch(() => {
+                        });
+                    }
                 });
 
                 eventEmitter.on('authorize', () => {
-                    options.onAuthorize({
-                        payerId: 'PAYER_ID',
-                        paymentID: 'PAYMENT_ID',
-                        payerID: 'PAYER_ID',
-                    }, actionsMock).catch(() => {});
+                    if (options.onAuthorize) {
+                        options.onAuthorize({
+                            payerId: 'PAYER_ID',
+                            paymentID: 'PAYMENT_ID',
+                            payerID: 'PAYER_ID',
+                        }, actionsMock).catch(() => {
+                        });
+                    }
                 });
             });
 

--- a/src/payment/strategies/braintree/braintree-script-loader.spec.ts
+++ b/src/payment/strategies/braintree/braintree-script-loader.spec.ts
@@ -33,7 +33,7 @@ describe('BraintreeScriptLoader', () => {
 
         it('loads the client', async () => {
             await braintreeScriptLoader.loadClient();
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.59.0/js/client.min.js');
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.70.0/js/client.min.js');
         });
 
         it('returns the client from the window', async () => {
@@ -58,7 +58,7 @@ describe('BraintreeScriptLoader', () => {
 
         it('loads the ThreeDSecure library', async () => {
             await braintreeScriptLoader.load3DS();
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.59.0/js/three-d-secure.min.js');
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.70.0/js/three-d-secure.min.js');
         });
 
         it('returns the ThreeDSecure from the window', async () => {
@@ -83,7 +83,7 @@ describe('BraintreeScriptLoader', () => {
 
         it('loads the data collector library', async () => {
             await braintreeScriptLoader.loadDataCollector();
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.59.0/js/data-collector.min.js');
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.70.0/js/data-collector.min.js');
         });
 
         it('returns the data collector from the window', async () => {
@@ -108,7 +108,7 @@ describe('BraintreeScriptLoader', () => {
 
         it('loads the VisaCheckout library', async () => {
             await braintreeScriptLoader.loadVisaCheckout();
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.59.0/js/visa-checkout.min.js');
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.70.0/js/visa-checkout.min.js');
         });
 
         it('returns the VisaCheckout from the window', async () => {
@@ -133,7 +133,7 @@ describe('BraintreeScriptLoader', () => {
 
         it('loads the GooglePay library', async () => {
             await braintreeScriptLoader.loadGooglePayment();
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.59.0/js/google-payment.min.js');
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//js.braintreegateway.com/web/3.70.0/js/google-payment.min.js');
         });
 
         it('returns the GooglePay from the window', async () => {
@@ -177,7 +177,7 @@ describe('BraintreeScriptLoader', () => {
             await braintreeScriptLoader.loadHostedFields();
 
             expect(scriptLoader.loadScript)
-                .toHaveBeenCalledWith('//js.braintreegateway.com/web/3.59.0/js/hosted-fields.min.js');
+                .toHaveBeenCalledWith('//js.braintreegateway.com/web/3.70.0/js/hosted-fields.min.js');
         });
 
         it('returns hosted fields from window', async () => {

--- a/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -13,7 +13,7 @@ export default class BraintreeScriptLoader {
 
     loadClient(): Promise<BraintreeClientCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.59.0/js/client.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.70.0/js/client.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.client) {
                     throw new PaymentMethodClientUnavailableError();
@@ -25,7 +25,7 @@ export default class BraintreeScriptLoader {
 
     load3DS(): Promise<BraintreeThreeDSecureCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.59.0/js/three-d-secure.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.70.0/js/three-d-secure.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.threeDSecure) {
                     throw new PaymentMethodClientUnavailableError();
@@ -37,7 +37,7 @@ export default class BraintreeScriptLoader {
 
     loadDataCollector(): Promise<BraintreeDataCollectorCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.59.0/js/data-collector.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.70.0/js/data-collector.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.dataCollector) {
                     throw new PaymentMethodClientUnavailableError();
@@ -48,8 +48,9 @@ export default class BraintreeScriptLoader {
     }
 
     loadPaypal(): Promise<BraintreePaypalCreator> {
+
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.59.0/js/paypal.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.70.0/js/paypal.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.paypal) {
                     throw new PaymentMethodClientUnavailableError();
@@ -60,8 +61,9 @@ export default class BraintreeScriptLoader {
     }
 
     loadPaypalCheckout(): Promise<BraintreePaypalCheckoutCreator> {
+
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.59.0/js/paypal-checkout.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.70.0/js/paypal-checkout.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.paypalCheckout) {
                     throw new PaymentMethodClientUnavailableError();
@@ -73,7 +75,7 @@ export default class BraintreeScriptLoader {
 
     loadVisaCheckout(): Promise<BraintreeVisaCheckoutCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.59.0/js/visa-checkout.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.70.0/js/visa-checkout.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.visaCheckout) {
                     throw new PaymentMethodClientUnavailableError();
@@ -85,7 +87,7 @@ export default class BraintreeScriptLoader {
 
     loadGooglePayment(): Promise<GooglePayCreator> {
         return this._scriptLoader
-            .loadScript('//js.braintreegateway.com/web/3.59.0/js/google-payment.min.js')
+            .loadScript('//js.braintreegateway.com/web/3.70.0/js/google-payment.min.js')
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.googlePayment) {
                     throw new PaymentMethodClientUnavailableError();
@@ -96,7 +98,7 @@ export default class BraintreeScriptLoader {
     }
 
     async loadHostedFields(): Promise<BraintreeHostedFieldsCreator> {
-        await this._scriptLoader.loadScript('//js.braintreegateway.com/web/3.59.0/js/hosted-fields.min.js');
+        await this._scriptLoader.loadScript('//js.braintreegateway.com/web/3.70.0/js/hosted-fields.min.js');
 
         if (!this._window.braintree || !this._window.braintree.hostedFields) {
             throw new PaymentMethodClientUnavailableError();

--- a/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -1,4 +1,4 @@
-import CheckoutButtonStrategy from '../../../checkout-buttons/strategies/checkout-button-strategy';
+import { CheckoutButtonStrategy } from '../../../checkout-buttons/strategies';
 import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 
 import { BraintreeClient,

--- a/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -1,4 +1,3 @@
-import { CheckoutButtonStrategy } from '../../../checkout-buttons/strategies';
 import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 
 import { BraintreeClient,
@@ -11,6 +10,7 @@ import { BraintreeClient,
     BraintreeThreeDSecure,
     BraintreeVisaCheckout,
     GooglePayBraintreeSDK,
+    PaypalClientInstance,
     RenderButtons } from './braintree';
 import BraintreeScriptLoader from './braintree-script-loader';
 
@@ -60,17 +60,20 @@ export default class BraintreeSDKCreator {
         return this._paypal;
     }
 
-    getPaypalCheckout(renderButtonCallback: RenderButtons, context: CheckoutButtonStrategy): Promise<BraintreePaypalCheckout> {
+    getPaypalCheckout(renderButtonCallback: RenderButtons): Promise<BraintreePaypalCheckout> {
         if (!this._paypalCheckout) {
             this._paypalCheckout = Promise.all([
                 this.getClient(),
                 this._braintreeScriptLoader.loadPaypalCheckout(),
             ])
-                .then(([client, paypalCheckout]) => paypalCheckout.create({ client }, (_error: string, instance: any) =>  {
-                     instance.loadPayPalSDK(() => {
-                         renderButtonCallback.bind(context)();
-                   });
-                }));
+                .then(([client, paypalCheckout]) => paypalCheckout.create({ client }, (_error: string, instance: PaypalClientInstance) =>  {
+                    instance.loadPayPalSDK(() => {
+                        renderButtonCallback(instance);
+                    });
+                }))
+                .catch(error => {
+                    throw error;
+                });
         }
 
         return this._paypalCheckout;

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -1,5 +1,7 @@
+import { BraintreePaypalButtonInitializeOptions } from '../../../checkout-buttons/strategies/braintree';
+import { PaymentMethod } from '../../index';
 import { GooglePaymentData, GooglePayBraintreeDataRequest, GooglePayBraintreePaymentDataRequestV1, GooglePayCreator, TokenizePayload } from '../googlepay';
-import { PaypalAuthorizeData, PaypalSDK } from '../paypal';
+import { PaypalAuthorizeData, PaypalButtonOptions, PaypalButtonRender, PaypalSDK } from '../paypal';
 
 import { VisaCheckoutInitOptions, VisaCheckoutPaymentSuccessPayload, VisaCheckoutTokenizedPayload } from './visacheckout';
 
@@ -15,7 +17,7 @@ export interface BraintreeSDK {
 }
 
 export interface BraintreeModuleCreator<TInstance, TOptions = BraintreeModuleCreatorConfig> {
-    create(config: TOptions): Promise<TInstance>;
+    create(config: TOptions, callback?: (error: string, instance: any) => void): Promise<TInstance>;
 }
 
 export interface BraintreeModuleCreatorConfig {
@@ -189,6 +191,7 @@ export interface BraintreePaypal {
     closeWindow(): void;
     focusWindow(): void;
     tokenize(options: BraintreePaypalRequest): Promise<BraintreeTokenizePayload>;
+    Buttons?(options: PaypalButtonOptions): PaypalButtonRender;
 }
 
 export interface BraintreePaypalCheckout {
@@ -350,3 +353,11 @@ interface BraintreeThreeDSecureVerificationData {
         liabilityShifted: boolean;
     };
 }
+
+export interface RenderButtonsData {
+    paymentMethod: PaymentMethod;
+    paypalOptions: BraintreePaypalButtonInitializeOptions;
+    container: string;
+}
+
+export type RenderButtons = () => void;

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -360,4 +360,10 @@ export interface RenderButtonsData {
     container: string;
 }
 
-export type RenderButtons = () => void;
+export type RenderButtons = (instance: PaypalClientInstance) => void;
+
+export interface PaypalClientInstance {
+    loadPayPalSDK(callback: RenderButtons): void;
+    tokenizePayment(data: PaypalAuthorizeData): BraintreeTokenizePayload;
+    createPayment(): void;
+}

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -363,7 +363,11 @@ export interface RenderButtonsData {
 export type RenderButtons = (instance: PaypalClientInstance) => void;
 
 export interface PaypalClientInstance {
-    loadPayPalSDK(callback: RenderButtons): void;
+    loadPayPalSDK(config: Config, callback: RenderButtons): void;
     tokenizePayment(data: PaypalAuthorizeData): BraintreeTokenizePayload;
-    createPayment(): void;
+    createPayment(data: BraintreePaypalRequest): Promise<string>;
+}
+
+export interface Config {
+    currency?: string ;
 }

--- a/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
@@ -51,6 +51,7 @@ describe('PaypalExpressPaymentStrategy', () => {
                 CARD: 'card',
                 CREDIT: 'credit',
             },
+            Buttons: jest.fn(),
         };
 
         scriptLoader = new PaypalScriptLoader(createScriptLoader());

--- a/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal/paypal-express-payment-strategy.spec.ts
@@ -50,6 +50,7 @@ describe('PaypalExpressPaymentStrategy', () => {
             FUNDING: {
                 CARD: 'card',
                 CREDIT: 'credit',
+                PAYPAL: 'paypal',
             },
             Buttons: jest.fn(),
         };

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -2,6 +2,7 @@ export interface PaypalSDK {
     Button: PaypalButton;
     checkout: PaypalExpressCheckout;
     FUNDING: PaypalFundingTypeList;
+    Buttons(options: PaypalButtonOptions): PaypalButtonRender;
 }
 
 export interface PaypalFundingTypeList {
@@ -13,14 +14,18 @@ export interface PaypalButton {
     render(options: PaypalButtonOptions, container: string): void;
 }
 
+export interface PaypalButtonRender {
+    render(container: string): void;
+}
+
 export interface PaypalButtonOptions {
     env?: string;
     commit?: boolean;
     style?: PaypalButtonStyleOptions;
     funding?: PaypalFundingType;
     client?: PaypalClientToken;
-    payment(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
-    onAuthorize(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    createOrder(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    onApprove(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
 }
 
 export interface PaypalClientToken {
@@ -133,4 +138,5 @@ export interface PaypalExpressCheckoutOptions {
 
 export interface PaypalHostWindow extends Window {
     paypal?: PaypalSDK;
+    flag?: boolean;
 }

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -24,8 +24,11 @@ export interface PaypalButtonOptions {
     style?: PaypalButtonStyleOptions;
     funding?: PaypalFundingType;
     client?: PaypalClientToken;
-    payment(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
-    onAuthorize(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    payment?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    onAuthorize?(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    createOrder?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    onApprove?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+
 }
 
 export interface PaypalClientToken {
@@ -138,5 +141,4 @@ export interface PaypalExpressCheckoutOptions {
 
 export interface PaypalHostWindow extends Window {
     paypal?: PaypalSDK;
-    flag?: boolean;
 }

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -8,6 +8,7 @@ export interface PaypalSDK {
 export interface PaypalFundingTypeList {
     CARD: string;
     CREDIT: string;
+    PAYPAL: string;
 }
 
 export interface PaypalButton {
@@ -16,6 +17,7 @@ export interface PaypalButton {
 
 export interface PaypalButtonRender {
     render(container: string): void;
+    isEligible(): boolean;
 }
 
 export interface PaypalButtonOptions {
@@ -23,6 +25,7 @@ export interface PaypalButtonOptions {
     commit?: boolean;
     style?: PaypalButtonStyleOptions;
     funding?: PaypalFundingType;
+    fundingSource?: string;
     client?: PaypalClientToken;
     payment?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
     onAuthorize?(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -24,8 +24,8 @@ export interface PaypalButtonOptions {
     style?: PaypalButtonStyleOptions;
     funding?: PaypalFundingType;
     client?: PaypalClientToken;
-    createOrder(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
-    onApprove(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    payment(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    onAuthorize(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
 }
 
 export interface PaypalClientToken {

--- a/src/payment/strategies/paypal/paypal.mock.ts
+++ b/src/payment/strategies/paypal/paypal.mock.ts
@@ -5,6 +5,7 @@ export function getPaypalMock(): PaypalSDK {
         FUNDING: {
             CARD: 'card',
             CREDIT: 'credit',
+            PAYPAL: 'paypal',
         },
         Button: {
             render: jest.fn(),

--- a/src/payment/strategies/paypal/paypal.mock.ts
+++ b/src/payment/strategies/paypal/paypal.mock.ts
@@ -15,5 +15,6 @@ export function getPaypalMock(): PaypalSDK {
             closeFlow: jest.fn(),
             setup: jest.fn(),
         },
+        Buttons: jest.fn(),
     };
 }


### PR DESCRIPTION
## What?
Upgrading Braintree version SDK 3.59.0 => 3.70.0
Documentation for migration : https://developers.braintreepayments.com/guides/paypal/paypal-sdk-migration-guide/javascript/v3
## Why?
According to task PAYPAL-863.  To show Pay Later smart button and to be consistent with PPC integration.

## Testing / Proof
Tested on dev
Before
<img width="476" alt="Screenshot 2021-05-27 at 19 09 11" src="https://user-images.githubusercontent.com/54856617/119950218-5285b180-bfa3-11eb-88db-fdf0e2a057d2.png">
After
![Screenshot 2021-04-30 at 15 48 09](https://user-images.githubusercontent.com/54856617/119950294-60d3cd80-bfa3-11eb-8f61-13825a808f05.png)

@bigcommerce/checkout @bigcommerce/payments @davidchin @vneutrino @capsula4 
