### PR TITLE
feat(payment): INT-3896 [Zip] it returns the nonce value when it's a referred payment

### DIFF
--- a/src/payment/strategies/zip/zip-payment-strategy.ts
+++ b/src/payment/strategies/zip/zip-payment-strategy.ts
@@ -85,6 +85,10 @@ export default class ZipPaymentStrategy implements PaymentStrategy {
                     if (state === ZipModalEvent.CheckoutReferred && checkoutId) {
                         await this._prepareForReferredRegistration(payment.methodId, checkoutId);
 
+                        if (this._paymentMethod?.initializationData?.deferredFlowV2Enabled) {
+                            return resolve(checkoutId);
+                        }
+
                         return resolve();
                     }
 


### PR DESCRIPTION
## What?  [INT-3896](https://jira.bigcommerce.com/browse/INT-3896)
Return the checkouId as nonce value if it's referred payment

## Why?
we need bigpay save the transaction and the order as pending.

## Testing / Proof
<img width="1027" alt="Screen Shot 2021-02-19 at 11 08 16 AM" src="https://user-images.githubusercontent.com/4907027/108537096-d17f9580-72a2-11eb-80b0-6ad8de69e30e.png">

https://drive.google.com/file/d/1QPapnhi3-k68zEq1PyFlFvjpITU0qsJZ/view?usp=sharing

## Dependencies
This PR has dependency with [feat(payments): INT-3896 [Zip] getInitializationData indicates if deferred flow experiment is enabled](https://github.com/bigcommerce/bigcommerce/pull/39599)


## Merge order: 
1. [feat(payment): INT-3896 [Zip] getInitializationData indicates if deferred flow experiment is enabled](https://github.com/bigcommerce/bigcommerce/pull/39599) 
2. This PR

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
