### PR TITLE
fix(checkout): INT-2546 Add ideal to document supported apms

### DIFF
--- a/src/payment/strategies/checkoutcom-apm/checkoutcom-apm-payment-strategy.ts
+++ b/src/payment/strategies/checkoutcom-apm/checkoutcom-apm-payment-strategy.ts
@@ -89,7 +89,7 @@ export default class CheckoutcomAPMPaymentStrategy extends CreditCardPaymentStra
     }
 
     private _createFormattedPayload(methodId: string, paymentData: PaymentInstrument): WithDocumentInstrument {
-        const documentSupportedAPMs = ['boleto', 'oxxo', 'qpay'];
+        const documentSupportedAPMs = ['boleto', 'oxxo', 'qpay', 'ideal'];
         const formattedPayload: WithDocumentInstrument = { ccDocument: '' };
         const { ccDocument: document } = paymentData as WithDocumentInstrument;
 


### PR DESCRIPTION
## What?
Add Ideal as document supported APM

## Why?
Ideal requires an additional field to be sent for the payment to proceed

## Sibling PRs
https://github.com/bigcommerce/checkout-js/pull/519

## Testing / Proof
On Sibling PR

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
