### PR TITLE
feat(payment): INT-2503 Add strategy for checkout.com with Fawry

### DIFF
--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -1,4 +1,4 @@
-import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithCheckoutcomiDealInstrument, WithCheckoutcomSEPAInstrument, WithDocumentInstrument } from '../payment';
+import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithCheckoutcomiDealInstrument, WithCheckoutcomFawryInstrument, WithCheckoutcomSEPAInstrument, WithDocumentInstrument } from '../payment';
 
 /**
  * An object that contains the information required for submitting an order.
@@ -39,5 +39,5 @@ export interface OrderPaymentRequestBody {
      * An object that contains the details of a credit card, vaulted payment
      * instrument or nonce instrument.
      */
-    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument | CreditCardInstrument & WithCheckoutcomSEPAInstrument | CreditCardInstrument & WithCheckoutcomiDealInstrument;
+    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument | CreditCardInstrument & WithCheckoutcomFawryInstrument | CreditCardInstrument & WithCheckoutcomSEPAInstrument | CreditCardInstrument & WithCheckoutcomiDealInstrument;
 }

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -33,7 +33,7 @@ import { BoltPaymentStrategy, BoltScriptLoader } from './strategies/bolt';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVisaCheckoutPaymentStrategy, VisaCheckoutScriptLoader } from './strategies/braintree';
 import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow, CardinalThreeDSecureFlowV2 } from './strategies/cardinal';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
-import { CheckoutcomiDealPaymentStrategy, CheckoutcomAPMPaymentStrategy, CheckoutcomSEPAPaymentStrategy } from './strategies/checkoutcom-custom';
+import { CheckoutcomiDealPaymentStrategy, CheckoutcomAPMPaymentStrategy, CheckoutcomFawryPaymentStrategy, CheckoutcomSEPAPaymentStrategy } from './strategies/checkoutcom-custom';
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
@@ -634,6 +634,15 @@ export default function createPaymentStrategyRegistry(
 
     registry.register(PaymentStrategyType.CHECKOUTCOM_IDEAL, () =>
         new CheckoutcomiDealPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM_FAWRY, () =>
+        new CheckoutcomFawryPaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -13,6 +13,7 @@ export {
     default as Payment,
     CreditCardInstrument,
     WithCheckoutcomiDealInstrument,
+    WithCheckoutcomFawryInstrument,
     WithCheckoutcomSEPAInstrument,
     HostedCreditCardInstrument,
     HostedInstrument,

--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -16,6 +16,7 @@ const checkoutcomStrategies: {
     credit_card: PaymentStrategyType.CHECKOUTCOM,
     sepa: PaymentStrategyType.CHECKOUTCOM_SEPA,
     ideal: PaymentStrategyType.CHECKOUTCOM_IDEAL,
+    fawry: PaymentStrategyType.CHECKOUTCOM_FAWRY,
 };
 export default class PaymentStrategyRegistry extends Registry<PaymentStrategy, PaymentStrategyType> {
     constructor(

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -11,6 +11,7 @@ enum PaymentStrategyType {
     BOLT = 'bolt',
     CHECKOUTCOM = 'checkoutcom',
     CHECKOUTCOM_APM = 'checkoutcomapm',
+    CHECKOUTCOM_FAWRY = 'checkoutcomfawry',
     CHECKOUTCOM_SEPA = 'checkoutcomsepa',
     CHECKOUTCOM_IDEAL = 'checkoutcomideal',
     CREDIT_CARD = 'creditcard',

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -15,9 +15,10 @@ export type PaymentInstrument = (
     CreditCardInstrument & WithHostedFormNonce |
     CreditCardInstrument & WithDocumentInstrument |
     CreditCardInstrument & WithCheckoutcomiDealInstrument |
+    CreditCardInstrument & WithCheckoutcomFawryInstrument |
     CreditCardInstrument & WithCheckoutcomSEPAInstrument |
     CryptogramInstrument |
-    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | WithCheckoutcomiDealInstrument | WithCheckoutcomSEPAInstrument | StripeV3Intent> |
+    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | WithCheckoutcomiDealInstrument | WithCheckoutcomFawryInstrument | WithCheckoutcomSEPAInstrument | StripeV3Intent> |
     HostedInstrument |
     NonceInstrument |
     ThreeDSVaultedInstrument |
@@ -56,6 +57,11 @@ export interface WithCheckoutcomSEPAInstrument {
 
 export interface WithCheckoutcomiDealInstrument {
     bic: string;
+}
+
+export interface WithCheckoutcomFawryInstrument {
+    customerMobile: string;
+    customerEmail: string;
 }
 
 export interface WithHostedFormNonce {

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-fawry-payment-strategy.spec.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-fawry-payment-strategy.spec.ts
@@ -1,0 +1,136 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { merge } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../../checkout';
+import { getCheckoutStoreState } from '../../../../checkout/checkouts.mock';
+import { HostedFormFactory } from '../../../../hosted-form';
+import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../../order';
+import { getOrderRequestBody } from '../../../../order/internal-orders.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../../spam-protection';
+import PaymentActionCreator from '../../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../../payment-actions';
+import { getPaymentMethod } from '../../../payment-methods.mock';
+import PaymentRequestSender from '../../../payment-request-sender';
+import PaymentRequestTransformer from '../../../payment-request-transformer';
+
+import CheckoutcomFawryPaymentStrategy from './checkoutcom-fawry-payment-strategy';
+
+describe('CheckoutcomFawryPaymentStrategy', () => {
+    let formFactory: HostedFormFactory;
+    let finalizeOrderAction: Observable<FinalizeOrderAction>;
+    let formPoster: FormPoster;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let orderRequestSender: OrderRequestSender;
+    let strategy: CheckoutcomFawryPaymentStrategy;
+    let submitOrderAction: Observable<SubmitOrderAction>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+    let state: InternalCheckoutSelectors;
+
+    beforeEach(() => {
+        formFactory = new HostedFormFactory(store);
+        requestSender = createRequestSender();
+        orderRequestSender = new OrderRequestSender(requestSender);
+        orderActionCreator = new OrderActionCreator(
+            orderRequestSender,
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        formPoster = createFormPoster();
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(store, 'dispatch');
+
+        state = store.getState();
+
+        jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(getPaymentMethod());
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockImplementation((_url, _data, callback = () => {}) => callback());
+
+        jest.spyOn(orderActionCreator, 'finalizeOrder')
+            .mockReturnValue(finalizeOrderAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        strategy = new CheckoutcomFawryPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formFactory
+        );
+    });
+
+    it('returns checkout state', async () => {
+        const output = await strategy.execute(getOrderRequestBody());
+
+        expect(output).toEqual(store.getState());
+    });
+
+    it('submits customer fields when methodId is supported', async () => {
+        const paymentWithDocument = {
+            payment: {
+                methodId: 'fawry',
+                gatewayId: 'checkoutcom',
+                paymentData: {
+                    customerMobile: '1234567890',
+                    customerEmail: 'test@test.com',
+                },
+            },
+        };
+        const payload = merge(getOrderRequestBody(), paymentWithDocument);
+        const options = { methodId: 'fawry' };
+
+        const expectedPayment = merge(payload.payment, { paymentData: { formattedPayload: { customerMobile: '1234567890', customerEmail: 'test@test.com' }}});
+
+        await strategy.execute(payload, options);
+
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+    });
+
+    it('doees not submit customer fields when methodId is unsupported', async () => {
+        const paymentWithDocument = {
+            payment: {
+                methodId: 'notfawry',
+                gatewayId: 'checkoutcom',
+                paymentData: {
+                    customerMobile: '1234567890',
+                    customerEmail: 'test@test.com',
+                },
+            },
+        };
+        const payload = merge(getOrderRequestBody(), paymentWithDocument);
+        const options = { methodId: 'fawry' };
+
+        const expectedPayment = merge(payload.payment, { paymentData: { formattedPayload: undefined}});
+
+        await strategy.execute(payload, options);
+
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+    });
+});

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-fawry-payment-strategy.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-fawry-payment-strategy.ts
@@ -1,0 +1,41 @@
+import { InternalCheckoutSelectors } from '../../../../checkout';
+import { OrderRequestBody } from '../../../../order';
+import { PaymentArgumentInvalidError } from '../../../errors';
+import { PaymentInstrument, WithCheckoutcomFawryInstrument } from '../../../payment';
+import { PaymentRequestOptions } from '../../../payment-request-options';
+import CheckoutcomCustomPaymentStrategy from '../checkoutcom-custom-payment-strategy';
+
+const CHECKOUTCOM_FAWRY_PAYMENT_METHOD = 'fawry';
+export default class CheckoutcomFawryPaymentStrategy extends CheckoutcomCustomPaymentStrategy {
+
+    protected async _executeWithoutHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+        const paymentData = payment && payment.paymentData;
+
+        if (!payment || !paymentData) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+        try {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({
+                ...payment,
+                paymentData: {
+                    ...paymentData,
+                    formattedPayload: this._createFormattedPayload(payment.methodId, paymentData),
+                },
+            }));
+        } catch (error) {
+            return this._processResponse(error);
+        }
+    }
+
+    private _createFormattedPayload(methodId: string, paymentData: PaymentInstrument): WithCheckoutcomFawryInstrument | undefined {
+        if (CHECKOUTCOM_FAWRY_PAYMENT_METHOD === methodId && 'customerMobile' in paymentData && 'customerEmail' in paymentData) {
+            return { customerMobile: paymentData.customerMobile, customerEmail: paymentData.customerEmail };
+        }
+
+        return;
+    }
+}

--- a/src/payment/strategies/checkoutcom-custom/index.ts
+++ b/src/payment/strategies/checkoutcom-custom/index.ts
@@ -1,3 +1,4 @@
 export { default as CheckoutcomAPMPaymentStrategy } from './checkoutcom-apm/checkoutcom-apm-payment-strategy';
+export { default as CheckoutcomFawryPaymentStrategy } from './checkoutcom-sepa/checkoutcom-fawry-payment-strategy';
 export { default as CheckoutcomSEPAPaymentStrategy } from './checkoutcom-sepa/checkoutcom-sepa-payment-strategy';
 export { default as CheckoutcomiDealPaymentStrategy } from './checkoutcom-ideal/checkoutcom-ideal-payment-strategy';


### PR DESCRIPTION
## What?
Create a payment strategy for fawry that sends the mobile number and email to the backend.

## Why?
These two fields are required for Fawry in order to process a payment.

## Sibling PR
https://github.com/bigcommerce/checkout-js/pull/528

## Merge after
https://github.com/bigcommerce/checkout-sdk-js/pull/1079

## Testing / Proof
Pending...

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
 