### PR TITLE
fix(checkout): INT-3571 Google Pay [StripeV3] - Billing address is missing

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -213,6 +213,8 @@ export default class GooglePayPaymentProcessor {
         const remoteBillingAddress = this._store.getState().billingAddress.getBillingAddress();
 
         if (!remoteBillingAddress) {
+            console.log('The billing address does not exist');
+
             throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
         }
 


### PR DESCRIPTION
## What?

The Billing address is missing when payment with google pay in Stripe V3

## Why?

We are showing in the logs when the billing address does not exist

## Testing / Proof

@bigcommerce/checkout @bigcommerce/payments
