### PR TITLE
feat(payment): INT-3947 Suppress PayPal and Klarna

### DIFF
--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -40,6 +40,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
 
         const billing = state.billingAddress.getBillingAddressOrThrow();
         const customer = state.customer.getCustomerOrThrow();
+        const { paymentMethodConfiguration } = this._getDigitalRiverInitializeOptions().configuration;
         this._digitalRiverCheckoutId = clientToken.checkoutId;
         this._submitFormEvent = this._getDigitalRiverInitializeOptions().onSubmitForm;
 
@@ -60,6 +61,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
                     country: billing.countryCode,
                 },
             },
+            paymentMethodConfiguration,
             onSuccess: (data?: OnSuccessResponse) => {
                 this._onSuccessResponse(data);
             },

--- a/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.ts
@@ -51,12 +51,12 @@ export interface DigitalRiverDropInConfiguration {
             postalCode: string;
             country: string;
         };
-
-        /**
-         * Additional configuration details for configuration structure (classes, styles etc..)
-         */
-        paymentMethodConfiguration?: BaseElementOptions;
     };
+
+    /**
+     * Additional configuration details for configuration structure (classes, styles etc..)
+     */
+    paymentMethodConfiguration?: BaseElementOptions;
 
     /**
      * The function called when the shopper has authorized payment and a payment source has been successfully created.
@@ -141,6 +141,11 @@ export interface OptionsResponse {
      * Use this option to show the required terms of sale disclosure. These localized terms automatically update if recurring products are purchased.
      */
     showTermsOfSaleDisclosure?: boolean;
+
+    /**
+     * Additional configuration details for drop-in.
+     */
+    paymentMethodConfiguration?: BaseElementOptions;
 }
 
 export interface ButtonResponse {
@@ -187,6 +192,11 @@ interface BaseElementOptions {
      * Set custom class names on the container DOM element when the Digital River element is in a particular state.
      */
     classes?: DigitalRiverElementClasses;
+
+    /**
+     * Remove specific payment methods when rendering drop-in.
+     */
+    disabledPaymentMethods?: string[];
 }
 
 /**


### PR DESCRIPTION
## What? [INT-3947](https://jira.bigcommerce.com/browse/INT-3947)
Suppress PayPal and Klarna for DigitalRiver from being renderer. Digital provides us a new param called `disabledPaymentMethods` to do that.

## Why?
Because Digital River needs to obtain permission from PayPal and Klarna before BigCommerce can support any of these payment methods within our Digital River integration

## Siblings Prs
https://github.com/bigcommerce/checkout-js/pull/537

## Testing / Proof
**Before:**
<img width="757" alt="Screen Shot 2021-03-03 at 1 56 23 PM" src="https://user-images.githubusercontent.com/42154828/111347738-1c43c180-8645-11eb-8746-1f42adba9fe7.png">
**After:**
<img width="1147" alt="Screen Shot 2021-03-08 at 12 03 26 PM" src="https://user-images.githubusercontent.com/42154828/111347769-249bfc80-8645-11eb-9546-c73a2c494c2a.png">

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
