### PR TITLE
fix(payment): PAYMENTS-6642 Make Paypal overlay modal/new window aware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2023,6 +2023,11 @@
       "integrity": "sha512-bt9zfk7wHtTcht4ZYBqNkpogTQyjr9gnUMn0OueJNlRqzOWaYY/vpIGGFCnqnGRxdXi1a2R/p2RQE8ITChen1g==",
       "dev": true
     },
+    "@braintree/browser-detection": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@braintree/browser-detection/-/browser-detection-1.11.0.tgz",
+      "integrity": "sha512-A6G4DDygjLskhJkQvb6sURWSqL2sCkjKgnL6Pi2ZhiqOffiyyETmUpUSquCGthD8BKLGqVPpwHT4t883B9iZxw=="
+    },
     "@cnakazawa/watch": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@bigcommerce/memoize": "^1.0.0",
     "@bigcommerce/request-sender": "^1.0.3",
     "@bigcommerce/script-loader": "^2.2.1",
+    "@braintree/browser-detection": "^1.11.0",
     "@types/card-validator": "^4.1.0",
     "@types/iframe-resizer": "^3.5.6",
     "@types/lodash": "^4.14.139",

--- a/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -1,3 +1,5 @@
+import { supportsPopups } from '@braintree/browser-detection';
+
 import { Address } from '../../../address';
 import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { Overlay } from '../../../common/overlay';
@@ -56,11 +58,15 @@ export default class BraintreePaymentProcessor {
     }
 
     paypal({ shouldSaveInstrument, ...config }: PaypalConfig): Promise<BraintreeTokenizePayload> {
+        const newWindowFlow = supportsPopups();
+
         return this._braintreeSDKCreator.getPaypal()
             .then(paypal => {
-                this._overlay.show({
-                    onClick: () => paypal.focusWindow(),
-                });
+                if (newWindowFlow) {
+                    this._overlay.show({
+                        onClick: () => paypal.focusWindow(),
+                    });
+                }
 
                 return paypal.tokenize({
                     enableShippingAddress: true,


### PR DESCRIPTION
## What?

- Use Braintree's own `supportsPopups` method to determine if or not to add a dark overlay to our checkout page 

## Why?

- Without it we are adding our dark overlay on top of the PayPal modal. Braintree/PayPal chooses to use a modal when the current browser does not support a new window (or popup) journey.

## Testing / Proof

Extended unit tests now covering this scenario, plus:

1. Emulated mobile experience where the browser supports new windows (unchanged)

https://user-images.githubusercontent.com/56807262/111715736-9a53d280-88a8-11eb-8c87-05587889f4bd.mov


2. Emulated mobile experience where the browser does **not support** new windows (now without dark overlay obscuring the PayPal form)

https://user-images.githubusercontent.com/56807262/111715754-a50e6780-88a8-11eb-9efa-3cb08a3e29f7.mov





@bigcommerce/checkout @bigcommerce/payments
