### PR TITLE
fix(provider): INT-3571 Google Pay [StripeV3] - Billing address is missing

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -156,18 +156,28 @@ export default class GooglePayPaymentProcessor {
     }
 
     private _mapGooglePayAddressToBillingAddress(paymentData: GooglePaymentData, id: string): BillingAddressUpdateRequestBody {
+        const firstName = paymentData.paymentMethodData.info.billingAddress.name.split(' ').slice(0, -1).join(' ');
+        const address1 =  paymentData.paymentMethodData.info.billingAddress.address1;
+        const city =  paymentData.paymentMethodData.info.billingAddress.locality;
+        const postalCode =  paymentData.paymentMethodData.info.billingAddress.postalCode;
+        const countryCode =  paymentData.paymentMethodData.info.billingAddress.countryCode;
+
+        if (!firstName || !address1 || !city || !postalCode || !countryCode) {
+            throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
+        }
+
         return {
             id,
-            firstName: paymentData.paymentMethodData.info.billingAddress.name.split(' ').slice(0, -1).join(' '),
+            firstName,
             lastName: paymentData.paymentMethodData.info.billingAddress.name.split(' ').slice(-1).join(' '),
             company: paymentData.paymentMethodData.info.billingAddress.companyName,
-            address1: paymentData.paymentMethodData.info.billingAddress.address1,
+            address1,
             address2: paymentData.paymentMethodData.info.billingAddress.address2 + paymentData.paymentMethodData.info.billingAddress.address3,
-            city: paymentData.paymentMethodData.info.billingAddress.locality,
+            city,
             stateOrProvince: paymentData.paymentMethodData.info.billingAddress.administrativeArea,
             stateOrProvinceCode: paymentData.paymentMethodData.info.billingAddress.administrativeArea,
-            postalCode: paymentData.paymentMethodData.info.billingAddress.postalCode,
-            countryCode: paymentData.paymentMethodData.info.billingAddress.countryCode,
+            postalCode,
+            countryCode,
             phone: paymentData.paymentMethodData.info.billingAddress.phoneNumber,
             customFields: [],
             email: paymentData.email,

--- a/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -109,7 +109,7 @@ export function getGooglePayAddressMock(): GooglePayAddress {
         companyName: 'mock',
         countryCode: 'mock',
         locality: 'mock',
-        name: 'mock',
+        name: 'mock mock',
         postalCode: 'mock',
         sortingCode: 'mock',
         phoneNumber: 'mock',


### PR DESCRIPTION
## What?

The Billing address is missing when payment with google pay in Stripe V3

## Why?

We are validating the billing address when is retrieving for first time and throw a exception if does not exist

## Testing / Proof

![Screen Shot 2021-03-12 at 5 53 49 p m](https://user-images.githubusercontent.com/69822466/111012717-984aba80-8362-11eb-92f3-bea27e3e74a9.png)


Ping @bigcommerce/payments
