### PR TITLE
fix(payment): PAYPAL-965 Check that there are no inventory underselli…

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
@@ -148,18 +148,14 @@ describe('PaypalCommerceCreditCardPaymentStrategy', () => {
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
         });
 
-        it('calls submit payment', async () => {
+        it('calls submit hosted form with payment data', async () => {
             await paymentStrategy.initialize(options);
             await paymentStrategy.execute(orderRequestBody, options);
 
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledTimes(2);
+            expect(paypalCommerceHostedForm.submit).toHaveBeenCalledTimes(1);
+            expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
             expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
-        });
-
-        it('calls submit hosted form', async () => {
-            await paymentStrategy.initialize(options);
-            await paymentStrategy.execute(orderRequestBody, options);
-
-            expect(paypalCommerceHostedForm.submit).toHaveBeenCalled();
         });
 
         it('throw error without payment data', async () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.ts
@@ -49,8 +49,10 @@ export default class PaypalCommerceCreditCardPaymentStrategy implements PaymentS
 
         this._paypalCommerceHostedForm.validate();
 
-        const { paymentMethods: { getPaymentMethodOrThrow } } = await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+        const { paymentMethods: { getPaymentMethodOrThrow } } = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(payment.methodId));
         const { orderId } = await this._paypalCommerceHostedForm.submit(getPaymentMethodOrThrow(payment.methodId).config.is3dsEnabled);
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
         const paymentData =  {
             formattedPayload: {


### PR DESCRIPTION
…ng or overselling issues in PayPal Commerce

## What?
We've got inventory count issue with ordered products during failing 3DS validation in PPC:
https://github.com/bigcommerce/checkout-sdk-js/blob/60d99061aaf321b216fed2288946d2ca8cb54c1a/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts#L63 
In this PR we've changed logic to submit hosted form first and don't create order in BCApp if any exception has been thrown during submission. This prevents decreasing product amount if 3DS fails and keeps inventory balance in a correct  state.

## Why?
^^

## Testing / Proof
Revert, manual testing

@bigcommerce/checkout @bigcommerce/payments
