### PR TITLE
fix(payment): PAYPAL-970 don't show loading indicator if checkout form hasn't passed validation

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -4,6 +4,7 @@ import { createScriptLoader, getScriptLoader, getStylesheetLoader } from '@bigco
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
+import { LoadingIndicator } from '../common/loading-indicator';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { HostedFormFactory } from '../hosted-form';
@@ -345,6 +346,10 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
+    const LOADING_INDICATOR_STYLES = {
+        backgroundColor: 'black',
+    };
+
     registry.register(PaymentStrategyType.PAYPAL_COMMERCE, () =>
         new PaypalCommercePaymentStrategy(
             store,
@@ -352,7 +357,8 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
             new PaypalCommerceFundingKeyResolver(),
-            new PaypalCommerceRequestSender(requestSender)
+            new PaypalCommerceRequestSender(requestSender),
+            new LoadingIndicator({styles: LOADING_INDICATOR_STYLES})
         )
     );
 
@@ -363,7 +369,8 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
             new PaypalCommerceFundingKeyResolver(),
-            new PaypalCommerceRequestSender(requestSender)
+            new PaypalCommerceRequestSender(requestSender),
+            new LoadingIndicator({styles: LOADING_INDICATOR_STYLES})
         )
     );
 

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -346,10 +346,6 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
-    const LOADING_INDICATOR_STYLES = {
-        backgroundColor: 'black',
-    };
-
     registry.register(PaymentStrategyType.PAYPAL_COMMERCE, () =>
         new PaypalCommercePaymentStrategy(
             store,
@@ -358,7 +354,7 @@ export default function createPaymentStrategyRegistry(
             createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
             new PaypalCommerceFundingKeyResolver(),
             new PaypalCommerceRequestSender(requestSender),
-            new LoadingIndicator({styles: LOADING_INDICATOR_STYLES})
+            new LoadingIndicator({ styles: { backgroundColor: 'black' } })
         )
     );
 
@@ -370,7 +366,7 @@ export default function createPaymentStrategyRegistry(
             createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
             new PaypalCommerceFundingKeyResolver(),
             new PaypalCommerceRequestSender(requestSender),
-            new LoadingIndicator({styles: LOADING_INDICATOR_STYLES})
+            new LoadingIndicator({ styles: { backgroundColor: 'black' } })
         )
     );
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -22,7 +22,7 @@ import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentStrategyType from '../../payment-strategy-type';
 import PaymentStrategy from '../payment-strategy';
 
-import { PaypalCommerceFundingKeyResolver, PaypalCommercePaymentInitializeOptions, PaypalCommercePaymentProcessor, PaypalCommercePaymentStrategy, PaypalCommerceRequestSender, PaypalCommerceScriptLoader } from './index';
+import { PaypalCommerceFundingKeyResolver, PaypalCommercePaymentInitializeOptions, PaypalCommercePaymentProcessor, PaypalCommercePaymentStrategy, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, ClickActions } from './index';
 
 describe('PaypalCommercePaymentStrategy', () => {
     let orderActionCreator: OrderActionCreator;
@@ -40,6 +40,7 @@ describe('PaypalCommercePaymentStrategy', () => {
     let eventEmitter: EventEmitter;
     let cart: Cart;
     let orderID: string;
+    let onClickActions: ClickActions;
     let submitForm: () => void;
 
     beforeEach(() => {
@@ -87,6 +88,17 @@ describe('PaypalCommercePaymentStrategy', () => {
                 eventEmitter.on('onApprove', () => {
                     if (options.onApprove) {
                         options.onApprove({ orderID });
+                    }
+                });
+
+                onClickActions = {
+                    resolve: jest.fn(),
+                    reject: jest.fn(),
+                };
+
+                eventEmitter.on('onClick', () => {
+                    if (options.onClick) {
+                        options.onClick(null, onClickActions);
                     }
                 });
             });
@@ -251,6 +263,13 @@ describe('PaypalCommercePaymentStrategy', () => {
             await new Promise(resolve => process.nextTick(resolve));
 
             expect(submitForm).toHaveBeenCalled();
+        });
+
+        it('call onValidate onclick', async () => {
+            await paypalCommercePaymentStrategy.initialize(options);
+            eventEmitter.emit('onClick');
+
+            expect(paypalcommerceOptions.onValidate).toHaveBeenCalled();
         });
 
         it('throw error if paypalcommerce is undefined', async () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -22,7 +22,7 @@ import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentStrategyType from '../../payment-strategy-type';
 import PaymentStrategy from '../payment-strategy';
 
-import { PaypalCommerceFundingKeyResolver, PaypalCommercePaymentInitializeOptions, PaypalCommercePaymentProcessor, PaypalCommercePaymentStrategy, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, ClickActions } from './index';
+import { ClickActions, PaypalCommerceFundingKeyResolver, PaypalCommercePaymentInitializeOptions, PaypalCommercePaymentProcessor, PaypalCommercePaymentStrategy, PaypalCommerceRequestSender, PaypalCommerceScriptLoader } from './index';
 
 describe('PaypalCommercePaymentStrategy', () => {
     let orderActionCreator: OrderActionCreator;

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -35,7 +35,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         private _paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor,
         private _paypalCommerceFundingKeyResolver: PaypalCommerceFundingKeyResolver,
         private _paypalCommerceRequestSender: PaypalCommerceRequestSender,
-        private _loadingIndicator?: LoadingIndicator,
+        private _loadingIndicator: LoadingIndicator,
         private _pollingInterval?: number,
         private _pollingTimer = 0
     ) {}

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -77,9 +77,14 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
             },
             onClick: async (_, actions) => {
                 this._initializePollingMechanism(submitForm, gatewayId, methodId, paypalcommerce);
-                this._loadingIndicator?.show(loadingIndicatorContainerId);
 
-                return onValidate(actions.resolve, actions.reject);
+                const onValidationPassed = () => {
+                    this._loadingIndicator?.show(loadingIndicatorContainerId);
+
+                    return actions.resolve();
+                };
+
+                return onValidate(onValidationPassed, actions.reject);
             },
             onCancel: () => {
                 this._deinitializePollingTimer(gatewayId);

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -24,13 +24,9 @@ const ORDER_STATUS_APPROVED = 'APPROVED';
 const ORDER_STATUS_CREATED = 'CREATED';
 const POLLING_INTERVAL = 3000;
 const POLLING_MAX_TIME = 600000;
-const LOADING_INDICATOR_STYLES = {
-    backgroundColor: 'black',
-};
 
 export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
     private _orderId?: string;
-    private _loadingIndicator?: LoadingIndicator;
 
     constructor(
         private _store: CheckoutStore,
@@ -39,6 +35,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         private _paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor,
         private _paypalCommerceFundingKeyResolver: PaypalCommerceFundingKeyResolver,
         private _paypalCommerceRequestSender: PaypalCommerceRequestSender,
+        private _loadingIndicator?: LoadingIndicator,
         private _pollingInterval?: number,
         private _pollingTimer = 0
     ) {}
@@ -47,7 +44,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         const { paymentMethods: { getPaymentMethodOrThrow }, cart: { getCartOrThrow } } = this._store.getState();
         const { initializationData } = getPaymentMethodOrThrow(methodId, gatewayId);
         const { orderId, buttonStyle } = initializationData ?? {};
-        this._loadingIndicator = new LoadingIndicator({styles: LOADING_INDICATOR_STYLES});
+
         if (orderId) {
             this._orderId = orderId;
 


### PR DESCRIPTION
## What?
Don't show loading indicator if checkout form hasn't passed validation

## Why?
Due to [PAYPAL-970](https://jira.bigcommerce.com/browse/PAYPAL-970)

## Testing / Proof
Tested manually

@bigcommerce/checkout @bigcommerce/payments
