### PR TITLE
feat(payment): INT-4021 Add strategy for iDeal APM

### DIFF
--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -1,4 +1,4 @@
-import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithCheckoutcomSEPAInstrument, WithDocumentInstrument } from '../payment';
+import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithCheckoutcomiDealInstrument, WithCheckoutcomSEPAInstrument, WithDocumentInstrument } from '../payment';
 
 /**
  * An object that contains the information required for submitting an order.
@@ -39,5 +39,5 @@ export interface OrderPaymentRequestBody {
      * An object that contains the details of a credit card, vaulted payment
      * instrument or nonce instrument.
      */
-    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument | CreditCardInstrument & WithCheckoutcomSEPAInstrument;
+    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument | CreditCardInstrument & WithCheckoutcomSEPAInstrument | CreditCardInstrument & WithCheckoutcomiDealInstrument;
 }

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -32,7 +32,7 @@ import { BoltPaymentStrategy, BoltScriptLoader } from './strategies/bolt';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVisaCheckoutPaymentStrategy, VisaCheckoutScriptLoader } from './strategies/braintree';
 import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow, CardinalThreeDSecureFlowV2 } from './strategies/cardinal';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
-import { CheckoutcomAPMPaymentStrategy, CheckoutcomSEPAPaymentStrategy } from './strategies/checkoutcom-custom';
+import { CheckoutcomiDealPaymentStrategy, CheckoutcomAPMPaymentStrategy, CheckoutcomSEPAPaymentStrategy } from './strategies/checkoutcom-custom';
 import { ConvergePaymentStrategy } from './strategies/converge';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
@@ -622,6 +622,15 @@ export default function createPaymentStrategyRegistry(
 
     registry.register(PaymentStrategyType.CHECKOUTCOM_SEPA, () =>
         new CheckoutcomSEPAPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM_IDEAL, () =>
+        new CheckoutcomiDealPaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -12,6 +12,7 @@ export { default as PaymentActionCreator } from './payment-action-creator';
 export {
     default as Payment,
     CreditCardInstrument,
+    WithCheckoutcomiDealInstrument,
     WithCheckoutcomSEPAInstrument,
     HostedCreditCardInstrument,
     HostedInstrument,

--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -15,6 +15,7 @@ const checkoutcomStrategies: {
 } = {
     credit_card: PaymentStrategyType.CHECKOUTCOM,
     sepa: PaymentStrategyType.CHECKOUTCOM_SEPA,
+    ideal: PaymentStrategyType.CHECKOUTCOM_IDEAL,
 };
 export default class PaymentStrategyRegistry extends Registry<PaymentStrategy, PaymentStrategyType> {
     constructor(

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -12,6 +12,7 @@ enum PaymentStrategyType {
     CHECKOUTCOM = 'checkoutcom',
     CHECKOUTCOM_APM = 'checkoutcomapm',
     CHECKOUTCOM_SEPA = 'checkoutcomsepa',
+    CHECKOUTCOM_IDEAL = 'checkoutcomideal',
     CREDIT_CARD = 'creditcard',
     CHECKOUTCOM_GOOGLE_PAY = 'googlepaycheckoutcom',
     CONVERGE = 'converge',

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -14,9 +14,10 @@ export type PaymentInstrument = (
     CreditCardInstrument |
     CreditCardInstrument & WithHostedFormNonce |
     CreditCardInstrument & WithDocumentInstrument |
+    CreditCardInstrument & WithCheckoutcomiDealInstrument |
     CreditCardInstrument & WithCheckoutcomSEPAInstrument |
     CryptogramInstrument |
-    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | WithCheckoutcomSEPAInstrument | StripeV3Intent> |
+    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | WithCheckoutcomiDealInstrument | WithCheckoutcomSEPAInstrument | StripeV3Intent> |
     HostedInstrument |
     NonceInstrument |
     ThreeDSVaultedInstrument |
@@ -50,6 +51,10 @@ export interface WithDocumentInstrument {
 
 export interface WithCheckoutcomSEPAInstrument {
     iban: string;
+    bic: string;
+}
+
+export interface WithCheckoutcomiDealInstrument {
     bic: string;
 }
 

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.spec.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.spec.ts
@@ -1,0 +1,341 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { merge, omit } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../../checkout';
+import { getCheckoutStoreState } from '../../../../checkout/checkouts.mock';
+import { RequestError } from '../../../../common/error/errors';
+import { getResponse } from '../../../../common/http-request/responses.mock';
+import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../../hosted-form';
+import { FinalizeOrderAction, LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../../order/errors';
+import { getOrderRequestBody } from '../../../../order/internal-orders.mock';
+import { getOrder } from '../../../../order/orders.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../../spam-protection';
+import PaymentActionCreator from '../../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../../payment-actions';
+import { getPaymentMethod } from '../../../payment-methods.mock';
+import { PaymentInitializeOptions } from '../../../payment-request-options';
+import PaymentRequestSender from '../../../payment-request-sender';
+import PaymentRequestTransformer from '../../../payment-request-transformer';
+import * as paymentStatusTypes from '../../../payment-status-types';
+import { getErrorPaymentResponseBody } from '../../../payments.mock';
+
+import CheckoutcomiDealPaymentStrategy from './checkoutcom-ideal-payment-strategy';
+
+describe('CheckoutcomiDealPaymentStrategy', () => {
+    let formFactory: HostedFormFactory;
+    let finalizeOrderAction: Observable<FinalizeOrderAction>;
+    let formPoster: FormPoster;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let orderRequestSender: OrderRequestSender;
+    let strategy: CheckoutcomiDealPaymentStrategy;
+    let submitOrderAction: Observable<SubmitOrderAction>;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+    let state: InternalCheckoutSelectors;
+
+    beforeEach(() => {
+        formFactory = new HostedFormFactory(store);
+        requestSender = createRequestSender();
+        orderRequestSender = new OrderRequestSender(requestSender);
+        orderActionCreator = new OrderActionCreator(
+            orderRequestSender,
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        formPoster = createFormPoster();
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(store, 'dispatch');
+
+        state = store.getState();
+
+        jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(getPaymentMethod());
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockImplementation((_url, _data, callback = () => {}) => callback());
+
+        jest.spyOn(orderActionCreator, 'finalizeOrder')
+            .mockReturnValue(finalizeOrderAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        strategy = new CheckoutcomiDealPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formFactory
+        );
+    });
+
+    it('submits order without payment data', async () => {
+        const payload = getOrderRequestBody();
+        const options = { methodId: 'methodId' };
+
+        await strategy.execute(payload, options);
+
+        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), options);
+        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    });
+
+    it('submits document field when methodId is supported', async () => {
+        const paymentWithDocument = {
+            payment: {
+                methodId: 'ideal',
+                gatewayId: 'checkoutcom',
+                paymentData: {
+                    bic: 'TESTCODE',
+                },
+            },
+        };
+        const payload = merge(getOrderRequestBody(), paymentWithDocument);
+        const options = { methodId: 'ideal' };
+
+        const expectedPayment = merge(payload.payment, { paymentData: { formattedPayload: { bic: 'TESTCODE' }}});
+
+        await strategy.execute(payload, options);
+
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+    });
+
+    it('returns checkout state', async () => {
+        const output = await strategy.execute(getOrderRequestBody());
+
+        expect(output).toEqual(store.getState());
+    });
+
+    it('redirects to target url when additional action redirect is provided', async () => {
+        const error = new RequestError(getResponse({
+            ...getErrorPaymentResponseBody(),
+            errors: [],
+            additional_action_required: {
+                data: {
+                    redirect_url: 'http://redirect-url.com',
+                },
+                type: 'offsite_redirect',
+            },
+            three_ds_result: {},
+            status: 'error',
+        }));
+
+        window.location.replace = jest.fn();
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+        strategy.execute(getOrderRequestBody());
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(window.location.replace).toBeCalledWith('http://redirect-url.com');
+    });
+
+    it('does not redirect to target url if additional action is not provided', async () => {
+        const response = new RequestError(getResponse(getErrorPaymentResponseBody()));
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, response)));
+
+        await expect(strategy.execute(getOrderRequestBody())).rejects.toThrow(RequestError);
+        expect(formPoster.postForm).not.toHaveBeenCalled();
+    });
+
+    it('finalizes order if order is created and payment is finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(getOrder());
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.FINALIZE);
+
+        await strategy.finalize();
+
+        expect(orderActionCreator.finalizeOrder).toHaveBeenCalled();
+        expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not created', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('does not finalize order if order is not finalized', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.payment, 'getPaymentStatus')
+            .mockReturnValue(paymentStatusTypes.INITIALIZE);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+    });
+
+    it('throws error if order is missing', async () => {
+        const state = store.getState();
+
+        jest.spyOn(state.order, 'getOrder')
+            .mockReturnValue(null);
+
+        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+    });
+
+    describe('when hosted form is enabled', () => {
+        let form: Pick<HostedForm, 'attach' | 'submit' | 'validate'>;
+        let initializeOptions: PaymentInitializeOptions;
+        let loadOrderAction: Observable<LoadOrderSucceededAction>;
+        let state: InternalCheckoutSelectors;
+
+        beforeEach(() => {
+            form = {
+                attach: jest.fn(() => Promise.resolve()),
+                submit: jest.fn(() => Promise.resolve()),
+                validate: jest.fn(() => Promise.resolve()),
+            };
+            initializeOptions = {
+                creditCard: {
+                    form: {
+                        fields: {
+                            [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                            [HostedFieldType.CardName]: { containerId: 'card-name' },
+                            [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                        },
+                    },
+                },
+                methodId: 'checkoutcom',
+            };
+            loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
+            state = store.getState();
+
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(merge(
+                    getPaymentMethod(),
+                    { config: { isHostedFormEnabled: true } }
+                ));
+
+            jest.spyOn(orderActionCreator, 'loadCurrentOrder')
+                .mockReturnValue(loadOrderAction);
+
+            jest.spyOn(formFactory, 'create')
+                .mockReturnValue(form);
+        });
+
+        it('creates hosted form', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(formFactory.create)
+                .toHaveBeenCalledWith(
+                    'https://bigpay.integration.zone',
+                    // tslint:disable-next-line:no-non-null-assertion
+                    initializeOptions.creditCard!.form!
+                );
+        });
+
+        it('attaches hosted form to container', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(form.attach)
+                .toHaveBeenCalled();
+        });
+
+        it('submits payment data with hosted form', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(form.submit)
+                .toHaveBeenCalledWith(payload.payment);
+        });
+
+        it('validates user input before submitting data', async () => {
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(getOrderRequestBody());
+
+            expect(form.validate)
+                .toHaveBeenCalled();
+        });
+
+        it('does not submit payment data with hosted form if validation fails', async () => {
+            jest.spyOn(form, 'validate')
+                .mockRejectedValue(new Error());
+
+            try {
+                await strategy.initialize(initializeOptions);
+                await strategy.execute(getOrderRequestBody());
+            } catch (error) {
+                expect(form.submit)
+                    .not.toHaveBeenCalled();
+            }
+        });
+
+        it('loads current order after payment submission', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(loadOrderAction);
+        });
+
+        it('redirects to target url when additional action redirect is provided', async () => {
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [],
+                additional_action_required: {
+                    data: {
+                        redirect_url: 'http://redirect-url.com',
+                    },
+                    type: 'offsite_redirect',
+                },
+                three_ds_result: {},
+                status: 'error',
+            }));
+
+            window.location.replace = jest.fn();
+
+            jest.spyOn(form, 'submit')
+                .mockRejectedValue(error);
+
+            await strategy.initialize(initializeOptions);
+            strategy.execute(getOrderRequestBody());
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(window.location.replace).toBeCalledWith('http://redirect-url.com');
+            expect(orderActionCreator.loadCurrentOrder)
+                .not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.spec.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.spec.ts
@@ -1,29 +1,22 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
-import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { merge, omit } from 'lodash';
+import { merge } from 'lodash';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../../checkout';
 import { getCheckoutStoreState } from '../../../../checkout/checkouts.mock';
-import { RequestError } from '../../../../common/error/errors';
-import { getResponse } from '../../../../common/http-request/responses.mock';
-import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../../hosted-form';
-import { FinalizeOrderAction, LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../../order';
-import { OrderFinalizationNotRequiredError } from '../../../../order/errors';
+import { HostedFormFactory } from '../../../../hosted-form';
+import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestSender, SubmitOrderAction } from '../../../../order';
 import { getOrderRequestBody } from '../../../../order/internal-orders.mock';
-import { getOrder } from '../../../../order/orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../../spam-protection';
 import PaymentActionCreator from '../../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../../payment-actions';
 import { getPaymentMethod } from '../../../payment-methods.mock';
-import { PaymentInitializeOptions } from '../../../payment-request-options';
 import PaymentRequestSender from '../../../payment-request-sender';
 import PaymentRequestTransformer from '../../../payment-request-transformer';
-import * as paymentStatusTypes from '../../../payment-status-types';
-import { getErrorPaymentResponseBody } from '../../../payments.mock';
 
 import CheckoutcomiDealPaymentStrategy from './checkoutcom-ideal-payment-strategy';
 
@@ -91,17 +84,13 @@ describe('CheckoutcomiDealPaymentStrategy', () => {
         );
     });
 
-    it('submits order without payment data', async () => {
-        const payload = getOrderRequestBody();
-        const options = { methodId: 'methodId' };
+    it('returns checkout state', async () => {
+        const output = await strategy.execute(getOrderRequestBody());
 
-        await strategy.execute(payload, options);
-
-        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), options);
-        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+        expect(output).toEqual(store.getState());
     });
 
-    it('submits document field when methodId is supported', async () => {
+    it('submits bic field when methodId is supported', async () => {
         const paymentWithDocument = {
             payment: {
                 methodId: 'ideal',
@@ -122,220 +111,24 @@ describe('CheckoutcomiDealPaymentStrategy', () => {
         expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
     });
 
-    it('returns checkout state', async () => {
-        const output = await strategy.execute(getOrderRequestBody());
-
-        expect(output).toEqual(store.getState());
-    });
-
-    it('redirects to target url when additional action redirect is provided', async () => {
-        const error = new RequestError(getResponse({
-            ...getErrorPaymentResponseBody(),
-            errors: [],
-            additional_action_required: {
-                data: {
-                    redirect_url: 'http://redirect-url.com',
+    it('doees not submit bic field when methodId is unsupported', async () => {
+        const paymentWithDocument = {
+            payment: {
+                methodId: 'notideal',
+                gatewayId: 'checkoutcom',
+                paymentData: {
+                    bic: 'TESTCODE',
                 },
-                type: 'offsite_redirect',
             },
-            three_ds_result: {},
-            status: 'error',
-        }));
+        };
+        const payload = merge(getOrderRequestBody(), paymentWithDocument);
+        const options = { methodId: 'ideal' };
 
-        window.location.replace = jest.fn();
+        const expectedPayment = merge(payload.payment, { paymentData: { formattedPayload: undefined}});
 
-        jest.spyOn(paymentActionCreator, 'submitPayment')
-            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+        await strategy.execute(payload, options);
 
-        strategy.execute(getOrderRequestBody());
-
-        await new Promise(resolve => process.nextTick(resolve));
-
-        expect(window.location.replace).toBeCalledWith('http://redirect-url.com');
-    });
-
-    it('does not redirect to target url if additional action is not provided', async () => {
-        const response = new RequestError(getResponse(getErrorPaymentResponseBody()));
-
-        jest.spyOn(paymentActionCreator, 'submitPayment')
-            .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, response)));
-
-        await expect(strategy.execute(getOrderRequestBody())).rejects.toThrow(RequestError);
-        expect(formPoster.postForm).not.toHaveBeenCalled();
-    });
-
-    it('finalizes order if order is created and payment is finalized', async () => {
-        const state = store.getState();
-
-        jest.spyOn(state.order, 'getOrder')
-            .mockReturnValue(getOrder());
-
-        jest.spyOn(state.payment, 'getPaymentStatus')
-            .mockReturnValue(paymentStatusTypes.FINALIZE);
-
-        await strategy.finalize();
-
-        expect(orderActionCreator.finalizeOrder).toHaveBeenCalled();
-        expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
-    });
-
-    it('does not finalize order if order is not created', async () => {
-        const state = store.getState();
-
-        jest.spyOn(state.order, 'getOrder')
-            .mockReturnValue(null);
-
-        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
-        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
-        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
-    });
-
-    it('does not finalize order if order is not finalized', async () => {
-        const state = store.getState();
-
-        jest.spyOn(state.payment, 'getPaymentStatus')
-            .mockReturnValue(paymentStatusTypes.INITIALIZE);
-
-        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
-        expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
-        expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
-    });
-
-    it('throws error if order is missing', async () => {
-        const state = store.getState();
-
-        jest.spyOn(state.order, 'getOrder')
-            .mockReturnValue(null);
-
-        await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
-    });
-
-    describe('when hosted form is enabled', () => {
-        let form: Pick<HostedForm, 'attach' | 'submit' | 'validate'>;
-        let initializeOptions: PaymentInitializeOptions;
-        let loadOrderAction: Observable<LoadOrderSucceededAction>;
-        let state: InternalCheckoutSelectors;
-
-        beforeEach(() => {
-            form = {
-                attach: jest.fn(() => Promise.resolve()),
-                submit: jest.fn(() => Promise.resolve()),
-                validate: jest.fn(() => Promise.resolve()),
-            };
-            initializeOptions = {
-                creditCard: {
-                    form: {
-                        fields: {
-                            [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
-                            [HostedFieldType.CardName]: { containerId: 'card-name' },
-                            [HostedFieldType.CardNumber]: { containerId: 'card-number' },
-                        },
-                    },
-                },
-                methodId: 'checkoutcom',
-            };
-            loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
-            state = store.getState();
-
-            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
-                .mockReturnValue(merge(
-                    getPaymentMethod(),
-                    { config: { isHostedFormEnabled: true } }
-                ));
-
-            jest.spyOn(orderActionCreator, 'loadCurrentOrder')
-                .mockReturnValue(loadOrderAction);
-
-            jest.spyOn(formFactory, 'create')
-                .mockReturnValue(form);
-        });
-
-        it('creates hosted form', async () => {
-            await strategy.initialize(initializeOptions);
-
-            expect(formFactory.create)
-                .toHaveBeenCalledWith(
-                    'https://bigpay.integration.zone',
-                    // tslint:disable-next-line:no-non-null-assertion
-                    initializeOptions.creditCard!.form!
-                );
-        });
-
-        it('attaches hosted form to container', async () => {
-            await strategy.initialize(initializeOptions);
-
-            expect(form.attach)
-                .toHaveBeenCalled();
-        });
-
-        it('submits payment data with hosted form', async () => {
-            const payload = getOrderRequestBody();
-
-            await strategy.initialize(initializeOptions);
-            await strategy.execute(payload);
-
-            expect(form.submit)
-                .toHaveBeenCalledWith(payload.payment);
-        });
-
-        it('validates user input before submitting data', async () => {
-            await strategy.initialize(initializeOptions);
-            await strategy.execute(getOrderRequestBody());
-
-            expect(form.validate)
-                .toHaveBeenCalled();
-        });
-
-        it('does not submit payment data with hosted form if validation fails', async () => {
-            jest.spyOn(form, 'validate')
-                .mockRejectedValue(new Error());
-
-            try {
-                await strategy.initialize(initializeOptions);
-                await strategy.execute(getOrderRequestBody());
-            } catch (error) {
-                expect(form.submit)
-                    .not.toHaveBeenCalled();
-            }
-        });
-
-        it('loads current order after payment submission', async () => {
-            const payload = getOrderRequestBody();
-
-            await strategy.initialize(initializeOptions);
-            await strategy.execute(payload);
-
-            expect(store.dispatch)
-                .toHaveBeenCalledWith(loadOrderAction);
-        });
-
-        it('redirects to target url when additional action redirect is provided', async () => {
-            const error = new RequestError(getResponse({
-                ...getErrorPaymentResponseBody(),
-                errors: [],
-                additional_action_required: {
-                    data: {
-                        redirect_url: 'http://redirect-url.com',
-                    },
-                    type: 'offsite_redirect',
-                },
-                three_ds_result: {},
-                status: 'error',
-            }));
-
-            window.location.replace = jest.fn();
-
-            jest.spyOn(form, 'submit')
-                .mockRejectedValue(error);
-
-            await strategy.initialize(initializeOptions);
-            strategy.execute(getOrderRequestBody());
-
-            await new Promise(resolve => process.nextTick(resolve));
-
-            expect(window.location.replace).toBeCalledWith('http://redirect-url.com');
-            expect(orderActionCreator.loadCurrentOrder)
-                .not.toHaveBeenCalled();
-        });
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
     });
 });

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.ts
@@ -1,0 +1,46 @@
+import { InternalCheckoutSelectors } from '../../../../checkout';
+import { OrderRequestBody } from '../../../../order';
+import { PaymentArgumentInvalidError } from '../../../errors';
+import { PaymentInstrument, WithCheckoutcomiDealInstrument } from '../../../payment';
+import { PaymentRequestOptions } from '../../../payment-request-options';
+import CheckoutcomCustomPaymentStrategy from '../checkoutcom-custom-payment-strategy';
+
+const CHECKOUTCOM_IDEAL_PAYMENT_METHOD = 'ideal';
+export default class CheckoutcomiDealPaymentStrategy extends CheckoutcomCustomPaymentStrategy {
+
+    protected async _executeWithoutHostedForm(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+        const paymentData = payment?.paymentData;
+
+        if (!payment || !paymentData) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+        try {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({
+                ...payment,
+                paymentData: {
+                    ...paymentData,
+                    formattedPayload: this._createFormattedPayload(payment.methodId, paymentData),
+                },
+            }));
+        } catch (error) {
+            return this._processResponse(error);
+        }
+    }
+
+    private _createFormattedPayload(methodId: string, paymentData: PaymentInstrument): WithCheckoutcomiDealInstrument {
+        const formattedPayload: WithCheckoutcomiDealInstrument = { bic: '' };
+        const bic = 'bic' in paymentData
+            ? paymentData.bic
+            : '';
+
+        if (CHECKOUTCOM_IDEAL_PAYMENT_METHOD === methodId && bic) {
+            formattedPayload.bic = bic;
+        }
+
+        return formattedPayload;
+    }
+}

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.ts
@@ -31,16 +31,11 @@ export default class CheckoutcomiDealPaymentStrategy extends CheckoutcomCustomPa
         }
     }
 
-    private _createFormattedPayload(methodId: string, paymentData: PaymentInstrument): WithCheckoutcomiDealInstrument {
-        const formattedPayload: WithCheckoutcomiDealInstrument = { bic: '' };
-        const bic = 'bic' in paymentData
-            ? paymentData.bic
-            : '';
-
-        if (CHECKOUTCOM_IDEAL_PAYMENT_METHOD === methodId && bic) {
-            formattedPayload.bic = bic;
+    private _createFormattedPayload(methodId: string, paymentData: PaymentInstrument): WithCheckoutcomiDealInstrument | undefined {
+        if (CHECKOUTCOM_IDEAL_PAYMENT_METHOD === methodId && 'bic' in paymentData) {
+            return { bic: paymentData.bic };
         }
 
-        return formattedPayload;
+        return;
     }
 }

--- a/src/payment/strategies/checkoutcom-custom/index.ts
+++ b/src/payment/strategies/checkoutcom-custom/index.ts
@@ -1,2 +1,3 @@
 export { default as CheckoutcomAPMPaymentStrategy } from './checkoutcom-apm/checkoutcom-apm-payment-strategy';
 export { default as CheckoutcomSEPAPaymentStrategy } from './checkoutcom-sepa/checkoutcom-sepa-payment-strategy';
+export { default as CheckoutcomiDealPaymentStrategy } from './checkoutcom-ideal/checkoutcom-ideal-payment-strategy';


### PR DESCRIPTION
## What?
Create a payment strategy for ideal that sends the bic to the backend.


## Why?
This field is mandatory for Ideal payment to be processed

## Sibling PR
https://github.com/bigcommerce/checkout-js/pull/541

## Testing / Proof
Pending

@bigcommerce/checkout @bigcommerce/payments
