### PR TITLE
CHECKOUT-5740: Post to and receive messages from `www` subdomain

### DIFF
--- a/src/common/iframe/iframe-event-listener.spec.ts
+++ b/src/common/iframe/iframe-event-listener.spec.ts
@@ -50,6 +50,16 @@ describe('IframeEventListener', () => {
         expect(handleComplete).not.toHaveBeenCalled();
     });
 
+    it('responds to event with www subdomain', () => {
+        eventEmitter.emit('message', {
+            origin: origin.replace('http://', 'http://www.'),
+            data: { type: TestEventType.Loaded },
+        });
+
+        expect(handleLoaded).toHaveBeenCalled();
+        expect(handleComplete).not.toHaveBeenCalled();
+    });
+
     it('does not respond to event with unrecognized origin', () => {
         eventEmitter.emit('message', {
             origin: 'https://foobar.com',

--- a/src/common/iframe/iframe-event-listener.ts
+++ b/src/common/iframe/iframe-event-listener.ts
@@ -1,4 +1,4 @@
-import { parseUrl } from '../url';
+import { appendWww, parseUrl } from '../url';
 import { bindDecorator as bind } from '../utility';
 
 import { IframeEventMap } from './iframe-event';
@@ -7,12 +7,15 @@ import isIframeEvent from './is-iframe-event';
 export default class IframeEventListener<TEventMap extends IframeEventMap<keyof TEventMap>> {
     private _isListening: boolean;
     private _listeners: EventListeners<TEventMap>;
-    private _sourceOrigin: string;
+    private _sourceOrigins: string[];
 
     constructor(
         sourceOrigin: string
     ) {
-        this._sourceOrigin = parseUrl(sourceOrigin).origin;
+        this._sourceOrigins = [
+            parseUrl(sourceOrigin).origin,
+            appendWww(parseUrl(sourceOrigin)).origin,
+        ];
         this._isListening = false;
         this._listeners = {};
     }
@@ -75,7 +78,7 @@ export default class IframeEventListener<TEventMap extends IframeEventMap<keyof 
 
     @bind
     private _handleMessage(event: MessageEvent): void {
-        if ((event.origin !== this._sourceOrigin) ||
+        if ((this._sourceOrigins.indexOf(event.origin) === -1) ||
             !isIframeEvent(event.data as TEventMap[keyof TEventMap], event.data.type)
         ) {
             return;

--- a/src/common/iframe/iframe-event-poster.ts
+++ b/src/common/iframe/iframe-event-poster.ts
@@ -30,11 +30,13 @@ export default class IframeEventPoster<TEvent> {
         event: TEvent,
         options?: IframeEventPostOptions<TSuccessEvent, TErrorEvent>
     ): Promise<TSuccessEvent> | void {
-        if (window === this._targetWindow) {
+        const targetWindow = this._targetWindow;
+
+        if (window === targetWindow) {
             return;
         }
 
-        if (!this._targetWindow) {
+        if (!targetWindow) {
             throw new Error('Unable to post message because target window is not set.');
         }
 
@@ -56,7 +58,7 @@ export default class IframeEventPoster<TEvent> {
             )
             .toPromise();
 
-        this._targetWindow.postMessage(event, this._targetOrigin);
+        targetWindow.postMessage(event, this._targetOrigin);
 
         return result;
     }

--- a/src/common/url/append-www.spec.ts
+++ b/src/common/url/append-www.spec.ts
@@ -1,0 +1,40 @@
+import appendWww from './append-www';
+
+describe('appendWww', () => {
+    it('appends www to URL', () => {
+        const url = {
+            hash: '',
+            hostname: 'foobar.com',
+            href: 'https://foobar.com:8080/bar?foo=foo',
+            origin: 'https://foobar.com:8080',
+            pathname: '/bar',
+            port: '8080',
+            protocol: 'https:',
+            search: '?foo=foo',
+        };
+
+        expect(appendWww(url))
+            .toEqual({
+                ...url,
+                origin: 'https://www.foobar.com:8080',
+                hostname: 'www.foobar.com',
+                href: 'https://www.foobar.com:8080/bar?foo=foo',
+            });
+    });
+
+    it('does not www to URL if already has www', () => {
+        const url = {
+            hash: '',
+            hostname: 'www.foobar.com',
+            href: 'https://www.foobar.com:8080/bar?foo=foo',
+            origin: 'https://www.foobar.com:8080',
+            pathname: '/bar',
+            port: '8080',
+            protocol: 'https:',
+            search: '?foo=foo',
+        };
+
+        expect(appendWww(url))
+            .toEqual(url);
+    });
+});

--- a/src/common/url/append-www.ts
+++ b/src/common/url/append-www.ts
@@ -1,0 +1,10 @@
+import parseUrl from './parse-url';
+import Url from './url';
+
+export default function appendWww(url: Url): Url {
+    return parseUrl(
+        url.hostname.indexOf('www') === 0 ?
+            url.href :
+            url.href.replace(url.hostname, `www.${url.hostname}`)
+    );
+}

--- a/src/common/url/index.ts
+++ b/src/common/url/index.ts
@@ -1,2 +1,3 @@
+export { default as appendWww } from './append-www';
 export { default as parseUrl } from './parse-url';
 export { default as Url } from './url';

--- a/src/hosted-form/hosted-field-events.ts
+++ b/src/hosted-form/hosted-field-events.ts
@@ -30,6 +30,7 @@ export interface HostedFieldAttachEvent {
         fontUrls?: string[];
         placeholder?: string;
         styles?: HostedFieldStylesMap;
+        origin?: string;
         type: HostedFieldType;
     };
 }

--- a/src/hosted-form/hosted-field.spec.ts
+++ b/src/hosted-form/hosted-field.spec.ts
@@ -109,6 +109,7 @@ describe('HostedField', () => {
                     fontUrls: [],
                     placeholder: 'Enter your card number here',
                     styles: { default: { color: 'rgb(0, 0, 0)', fontFamily: 'Open Sans, Arial' } },
+                    origin: document.location.origin,
                     type: HostedFieldType.CardNumber,
                 },
             }, {

--- a/src/hosted-form/hosted-field.ts
+++ b/src/hosted-form/hosted-field.ts
@@ -74,6 +74,7 @@ export default class HostedField {
                             fontUrls: this._getFontUrls(),
                             placeholder: this._placeholder,
                             styles: this._styles,
+                            origin: document.location.origin,
                             type: this._type,
                         },
                     }, {

--- a/src/hosted-form/iframe-content/hosted-input-factory.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.spec.ts
@@ -38,4 +38,18 @@ describe('HostedInputFactory', () => {
         expect(factory.create(document.createElement('form'), HostedFieldType.CardName))
             .toBeInstanceOf(HostedInput);
     });
+
+    it('normalises parent origin if origin contains www', () => {
+        factory.normalizeParentOrigin('https://www.store.foobar.com');
+
+        expect(factory.getParentOrigin())
+            .toEqual('https://www.store.foobar.com');
+    });
+
+    it('does not normalise parent origin if origin is completely different', () => {
+        factory.normalizeParentOrigin('https://www.xyz.com');
+
+        expect(factory.getParentOrigin())
+            .toEqual('https://store.foobar.com');
+    });
 });

--- a/src/hosted-form/iframe-content/hosted-input-factory.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.ts
@@ -1,6 +1,7 @@
 import { createClient as createBigpayClient } from '@bigcommerce/bigpay-client';
 
 import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
+import { appendWww, parseUrl } from '../../common/url';
 import { PaymentRequestSender, PaymentRequestTransformer } from '../../payment';
 import { CardInstrument } from '../../payment/instrument';
 import HostedFieldType from '../hosted-field-type';
@@ -52,6 +53,23 @@ export default class HostedInputFactory {
         }
 
         return this._createInput(type, form, styles, fontUrls, placeholder, accessibilityLabel, autocomplete);
+    }
+
+    normalizeParentOrigin(origin: string): void {
+        if (this._parentOrigin === origin) {
+            return;
+        }
+
+        if (this._parentOrigin !== appendWww(parseUrl(origin)).origin &&
+            origin !== appendWww(parseUrl(this._parentOrigin)).origin) {
+            return;
+        }
+
+        this._parentOrigin = origin;
+    }
+
+    getParentOrigin(): string {
+        return this._parentOrigin;
     }
 
     private _createExpiryInput(

--- a/src/hosted-form/iframe-content/hosted-input-initializer.ts
+++ b/src/hosted-form/iframe-content/hosted-input-initializer.ts
@@ -19,7 +19,7 @@ export default class HostedInputInitializer {
         private _factory: HostedInputFactory,
         private _storage: HostedInputStorage,
         private _eventListener: IframeEventListener<HostedFieldEventMap>
-    ) {}
+    ) { }
 
     initialize(containerId: string, nonce?: string): Promise<HostedInput> {
         if (nonce) {
@@ -37,7 +37,12 @@ export default class HostedInputInitializer {
         )
             .pipe(
                 map(({ payload }) => {
-                    const { accessibilityLabel, cardInstrument, fontUrls, placeholder, styles, type } = payload;
+                    const { accessibilityLabel, cardInstrument, fontUrls, placeholder, styles, origin, type } = payload;
+
+                    if (origin) {
+                        this._factory.normalizeParentOrigin(origin);
+                    }
+
                     const field = this._factory.create(form, type, styles, fontUrls, placeholder, accessibilityLabel, cardInstrument);
 
                     field.attach();


### PR DESCRIPTION
## What?
Post to and receive messages from `www` subdomain.

## Why?
Before this change, hosted payment forms do not load for stores that have WWW redirect setting set as "no preference" (meaning it doesn't do any kind of redirect to force shoppers to be on the `ShopPath` domain).

## Testing / Proof
Unit + manual

The test store is set up with WWW redirect setting as "no preference"

![www_test](https://user-images.githubusercontent.com/667603/113967188-d65cd080-9873-11eb-8cd8-85f272dd2d7d.gif)

@bigcommerce/checkout @bigcommerce/payments
