### PR TITLE
fix(payment): INT-4063 Avoid holding inventory if a payment intent co…

### DIFF
--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -153,22 +153,6 @@ export function getConfirmPaymentResponse(): unknown {
     };
 }
 
-export function getWrongPaymentResponse(): unknown {
-    return {
-        paymentIntent: {
-            otherKey: 'other_value',
-        },
-    };
-}
-
-export function getWrongPaymentMethodResponse(): unknown {
-    return {
-        paymentMethod: {
-            otherKey: 'other_value',
-        },
-    };
-}
-
 export function getPaymentMethodResponse(): unknown {
     return {
         paymentMethod: {


### PR DESCRIPTION
…nfirmation fails for StripeV3

## What? [INT-4063](https://jira.bigcommerce.com/browse/INT-4063)
Allow reaching the backend when a payment intent confirmation fails. Allowing inventory to be returned to stock immediately.

## Why?
To avoid inventory be held for several minutes due to a failed payment.

## Testing / Proof
Watch the video >>[here](https://drive.google.com/file/d/14KQHRTmkRlvRHCNYJplAfcaLVNzelY9b/view?usp=sharing)<<

## Sibling PR
https://github.com/bigcommerce/bigpay/pull/3674

@bigcommerce/apex-integrations  @bigcommerce/checkout @bigcommerce/payments
