### PR TITLE
Support coupons & gift cards codes when the Drop-in component is already loaded for Digital River

### DIFF
--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -25,7 +25,7 @@ import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import { getClientMock, getDigitalRiverJSMock, getDigitalRiverPaymentMethodMock, getInitializeOptionsMock } from '../digitalriver/digitalriver.mock';
 
-import { DigitalRiverWindow, OnCancelOrErrorResponse, OnSuccessResponse } from './digitalriver';
+import { OnCancelOrErrorResponse, OnSuccessResponse } from './digitalriver';
 import DigitalRiverPaymentStrategy from './digitalriver-payment-strategy';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
 
@@ -117,15 +117,13 @@ describe('DigitalRiverPaymentStrategy', () => {
         let options: PaymentInitializeOptions;
         let onErrorCallback: (error: OnCancelOrErrorResponse) => {};
         let onSuccessCallback: (data?: OnSuccessResponse) => {};
-        const mockWindow = {} as DigitalRiverWindow;
 
         beforeEach(() => {
             jest.spyOn(store.getState().billingAddress, 'getBillingAddressOrThrow').mockReturnValue(getBillingAddress());
             jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(customer);
-            jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(mockWindow));
+            jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(digitalRiverLoadResponse));
             jest.spyOn(digitalRiverLoadResponse, 'createDropin').mockReturnValue(digitalRiverComponent);
             options = getInitializeOptionsMock();
-            mockWindow.DigitalRiver = jest.fn(() => digitalRiverLoadResponse);
         });
 
         it('loads DigitalRiver script', async () => {
@@ -198,9 +196,9 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when load response is empty or not provided', () => {
-            const error = 'Unable to proceed because the client library of a payment method is not loaded or ready to be used.';
-            mockWindow.DigitalRiver = undefined;
-            jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(mockWindow));
+            const error = 'Unable to proceed because the payment step of checkout has not been initialized.';
+
+            jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(undefined));
 
             const promise = strategy.initialize(options);
 
@@ -262,11 +260,9 @@ describe('DigitalRiverPaymentStrategy', () => {
         let onSuccessCallback: (data: OnSuccessResponse) => {};
         const digitalRiverLoadResponse = getDigitalRiverJSMock();
         const digitalRiverComponent = digitalRiverLoadResponse.createDropin(expect.any(Object));
-        const mockWindow = {} as DigitalRiverWindow;
-        mockWindow.DigitalRiver = jest.fn(() => digitalRiverLoadResponse);
 
         beforeEach(() => {
-            jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(mockWindow));
+            jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(digitalRiverLoadResponse));
             jest.spyOn(digitalRiverLoadResponse, 'createDropin').mockReturnValue(digitalRiverComponent);
             submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
             jest.spyOn(orderActionCreator, 'submitOrder')

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -3,19 +3,17 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitia
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { StoreCreditActionCreator } from '../../../store-credit';
-import { PaymentMethodClientUnavailableError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import DigitalRiverJS, { DigitalRiverDropIn, DigitalRiverInitializeToken, DigitalRiverInstance, DigitalRiverWindow, OnCancelOrErrorResponse, OnReadyResponse, OnSuccessResponse } from './digitalriver';
+import DigitalRiverJS, { DigitalRiverDropIn, DigitalRiverInitializeToken, OnCancelOrErrorResponse, OnReadyResponse, OnSuccessResponse } from './digitalriver';
 import DigitalRiverPaymentInitializeOptions from './digitalriver-payment-initialize-options';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
 
 export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
     private _digitalRiverJS?: DigitalRiverJS;
-    private _digitalRiverInstance?: DigitalRiverInstance;
     private _digitalRiverDropComponent?: DigitalRiverDropIn;
     private _submitFormEvent?: () => void;
     private _loadSuccessResponse?: OnSuccessResponse;
@@ -36,33 +34,22 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
         this._digitalRiverInitializeOptions = options.digitalriver;
         const paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(options.methodId);
         const { publicKey, paymentLanguage: locale } = paymentMethod.initializationData;
-        const digitalRiverWindow: DigitalRiverWindow = await this._digitalRiverScriptLoader.load();
         const { containerId } = this._getDigitalRiverInitializeOptions();
 
-        this._digitalRiverInstance = digitalRiverWindow.DigitalRiver;
-
-        if (!this._digitalRiverInstance) {
-            throw new PaymentMethodClientUnavailableError();
-        }
-
-        this._digitalRiverJS = new this._digitalRiverInstance(publicKey, { locale });
+        this._digitalRiverJS = await this._digitalRiverScriptLoader.load(publicKey, locale);
 
         this._unsubscribe = await this._store.subscribe(
-            state => {
+            async state => {
                 if (state.paymentStrategies.isInitialized(options.methodId)) {
                     const container = document.getElementById(containerId);
 
                     if (container) {
                         container.innerHTML = '';
 
-                        if (!this._digitalRiverInstance) {
-                            throw new PaymentMethodClientUnavailableError();
-                        }
-
-                        this._digitalRiverJS = new this._digitalRiverInstance(publicKey, { locale });
+                        this._digitalRiverJS = await this._digitalRiverScriptLoader.load(publicKey, locale);
                     }
 
-                    this._loadWidget(options);
+                    await this._loadWidget(options);
                 }
             },
             state => {
@@ -181,7 +168,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
         const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(options.methodId));
         const billing = state.billingAddress.getBillingAddressOrThrow();
         const customer = state.customer.getCustomerOrThrow();
-        const {paymentMethodConfiguration} = this._getDigitalRiverInitializeOptions().configuration;
+        const { paymentMethodConfiguration } = this._getDigitalRiverInitializeOptions().configuration;
         const { containerId, configuration } = this._getDigitalRiverInitializeOptions();
         const { clientToken } = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
 

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -3,21 +3,24 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitia
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { StoreCreditActionCreator } from '../../../store-credit';
+import { PaymentMethodClientUnavailableError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import DigitalRiverJS, { DigitalRiverDropIn, DigitalRiverInitializeToken, OnCancelOrErrorResponse, OnReadyResponse, OnSuccessResponse } from './digitalriver';
+import DigitalRiverJS, { DigitalRiverDropIn, DigitalRiverInitializeToken, DigitalRiverInstance, DigitalRiverWindow, OnCancelOrErrorResponse, OnReadyResponse, OnSuccessResponse } from './digitalriver';
 import DigitalRiverPaymentInitializeOptions from './digitalriver-payment-initialize-options';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
 
 export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
     private _digitalRiverJS?: DigitalRiverJS;
+    private _digitalRiverInstance?: DigitalRiverInstance;
     private _digitalRiverDropComponent?: DigitalRiverDropIn;
     private _submitFormEvent?: () => void;
     private _loadSuccessResponse?: OnSuccessResponse;
-    private _digitalRiverCheckoutId?: string;
+    private _digitalRiverCheckoutData?: DigitalRiverInitializeToken;
+    private _unsubscribe?: (() => void);
     private _digitalRiverInitializeOptions?: DigitalRiverPaymentInitializeOptions;
 
     constructor(
@@ -31,60 +34,57 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
 
     async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         this._digitalRiverInitializeOptions = options.digitalriver;
+        const paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(options.methodId);
+        const { publicKey, paymentLanguage: locale } = paymentMethod.initializationData;
+        const digitalRiverWindow: DigitalRiverWindow = await this._digitalRiverScriptLoader.load();
+        const { containerId } = this._getDigitalRiverInitializeOptions();
 
-        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(options.methodId));
-        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
-        let clientToken: DigitalRiverInitializeToken;
+        this._digitalRiverInstance = digitalRiverWindow.DigitalRiver;
 
-        if (!paymentMethod.clientToken) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        if (!this._digitalRiverInstance) {
+            throw new PaymentMethodClientUnavailableError();
         }
 
-        clientToken = JSON.parse(paymentMethod.clientToken);
+        this._digitalRiverJS = new this._digitalRiverInstance(publicKey, { locale });
 
-        const billing = state.billingAddress.getBillingAddressOrThrow();
-        const customer = state.customer.getCustomerOrThrow();
-        const { paymentMethodConfiguration } = this._getDigitalRiverInitializeOptions().configuration;
-        this._digitalRiverCheckoutId = clientToken.checkoutId;
-        this._submitFormEvent = this._getDigitalRiverInitializeOptions().onSubmitForm;
+        this._unsubscribe = await this._store.subscribe(
+            state => {
+                if (state.paymentStrategies.isInitialized(options.methodId)) {
+                    const container = document.getElementById(containerId);
 
-        const configuration = {
-            sessionId: clientToken.sessionId,
-            options: { ...this._getDigitalRiverInitializeOptions().configuration },
-            billingAddress: {
-                firstName: billing.firstName,
-                lastName: billing.lastName,
-                email: billing.email || customer.email,
-                phoneNumber: billing.phone,
-                address: {
-                    line1: billing.address1,
-                    line2: billing.address2,
-                    city: billing.city,
-                    state: billing.stateOrProvinceCode,
-                    postalCode: billing.postalCode,
-                    country: billing.countryCode,
-                },
-            },
-            paymentMethodConfiguration,
-            onSuccess: (data?: OnSuccessResponse) => {
-                this._onSuccessResponse(data);
-            },
-            onReady: (data?: OnReadyResponse) => {
-                this._onReadyResponse(data);
-            },
-            onError: (error: OnCancelOrErrorResponse) => {
-                this._getDigitalRiverInitializeOptions().onError?.(new Error(this._getErrorMessage(error)));
-            },
-        };
+                    if (container) {
+                        container.innerHTML = '';
 
-        this._digitalRiverJS = await this._digitalRiverScriptLoader.load(paymentMethod.initializationData.publicKey, paymentMethod.initializationData.paymentLanguage);
-        this._digitalRiverDropComponent = await this._getDigitalRiverJs().createDropin( configuration );
-        await this._digitalRiverDropComponent.mount(this._getDigitalRiverInitializeOptions().containerId);
+                        if (!this._digitalRiverInstance) {
+                            throw new PaymentMethodClientUnavailableError();
+                        }
 
-        return state;
+                        this._digitalRiverJS = new this._digitalRiverInstance(publicKey, { locale });
+                    }
+
+                    this._loadWidget(options);
+                }
+            },
+            state => {
+                const checkout = state.checkout.getCheckout();
+
+                return checkout && checkout.outstandingBalance;
+            },
+            state => {
+                const checkout = state.checkout.getCheckout();
+
+                return checkout && checkout.coupons;
+            }
+        );
+
+        return this._loadWidget(options);
     }
 
     deinitialize(): Promise<InternalCheckoutSelectors> {
+        if (this._unsubscribe) {
+            this._unsubscribe();
+        }
+
         return Promise.resolve(this._store.getState());
     }
 
@@ -98,7 +98,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
 
         await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
-        if (!payment || !this._loadSuccessResponse || !this._digitalRiverCheckoutId) {
+        if (!payment || !this._loadSuccessResponse || !this._digitalRiverCheckoutData) {
             throw new InvalidArgumentError('Unable to proceed because payload payment argument is not provided.');
         }
 
@@ -106,8 +106,9 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
             methodId: payment.methodId,
             paymentData: {
                 nonce: JSON.stringify({
-                    checkoutId: this._digitalRiverCheckoutId,
+                    checkoutId: this._digitalRiverCheckoutData.checkoutId,
                     source: this._loadSuccessResponse,
+                    sessionId: this._digitalRiverCheckoutData.sessionId,
                 }),
             },
         };
@@ -174,5 +175,59 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
         }
 
         return this._digitalRiverInitializeOptions;
+    }
+
+    private async _loadWidget(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(options.methodId));
+        const billing = state.billingAddress.getBillingAddressOrThrow();
+        const customer = state.customer.getCustomerOrThrow();
+        const {paymentMethodConfiguration} = this._getDigitalRiverInitializeOptions().configuration;
+        const { containerId, configuration } = this._getDigitalRiverInitializeOptions();
+        const { clientToken } = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
+
+        if (!clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        this._digitalRiverCheckoutData = JSON.parse(clientToken);
+
+        if (!this._digitalRiverCheckoutData) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        this._submitFormEvent = this._getDigitalRiverInitializeOptions().onSubmitForm;
+        const digitalRiverConfiguration = {
+            sessionId: this._digitalRiverCheckoutData.sessionId,
+            options: { ...configuration },
+            billingAddress: {
+                firstName: billing.firstName,
+                lastName: billing.lastName,
+                email: billing.email || customer.email,
+                phoneNumber: billing.phone,
+                address: {
+                    line1: billing.address1,
+                    line2: billing.address2,
+                    city: billing.city,
+                    state: billing.stateOrProvinceCode,
+                    postalCode: billing.postalCode,
+                    country: billing.countryCode,
+                },
+            },
+            paymentMethodConfiguration,
+            onSuccess: (data?: OnSuccessResponse) => {
+                this._onSuccessResponse(data);
+            },
+            onReady: (data?: OnReadyResponse) => {
+                this._onReadyResponse(data);
+            },
+            onError: (error: OnCancelOrErrorResponse) => {
+                const descriptiveError = new Error(this._getErrorMessage(error));
+                this._getDigitalRiverInitializeOptions().onError?.(descriptiveError);
+            },
+        };
+        this._digitalRiverDropComponent = await this._getDigitalRiverJs().createDropin(digitalRiverConfiguration);
+        this._digitalRiverDropComponent.mount(containerId);
+
+        return state;
     }
 }

--- a/src/payment/strategies/digitalriver/digitalriver-script-loader.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-script-loader.spec.ts
@@ -1,7 +1,5 @@
 import { ScriptLoader, StylesheetLoader } from '@bigcommerce/script-loader';
 
-import { PaymentMethodClientUnavailableError } from '../../errors';
-
 import { DigitalRiverWindow } from './digitalriver';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
 import { getDigitalRiverJSMock } from './digitalriver.mock';
@@ -41,24 +39,25 @@ describe('DigitalRiverScriptLoader', () => {
         });
 
         it('loads the JS and CSS', async () => {
-            await digitalRiverScriptLoader.load('pk_test1234', 'en-US');
+            await digitalRiverScriptLoader.load();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
             expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
         });
 
         it('it returns a DigitalRiverJS instance', async () => {
-            expect(await digitalRiverScriptLoader.load('pk_test1234', 'en-US')).toBe(digitalRiverJs);
+            expect(await digitalRiverScriptLoader.load()).toBe(windowMock);
         });
 
-        it('throws an error when window is not set', async () => {
+        it('it returns a DigitalRiver undefined instance', async () => {
             scriptLoader.loadScript = jest.fn(() => {
                 windowMock.DigitalRiver = undefined;
 
                 return Promise.resolve();
             });
+            const response = await digitalRiverScriptLoader.load();
 
-            return expect(digitalRiverScriptLoader.load('pk_test_fail', 'en-US')).rejects.toBeInstanceOf(PaymentMethodClientUnavailableError);
+            return expect(response.DigitalRiver).toEqual(undefined);
         });
     });
 });

--- a/src/payment/strategies/digitalriver/digitalriver-script-loader.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-script-loader.spec.ts
@@ -1,5 +1,7 @@
 import { ScriptLoader, StylesheetLoader } from '@bigcommerce/script-loader';
 
+import { PaymentMethodClientUnavailableError } from '../../errors';
+
 import { DigitalRiverWindow } from './digitalriver';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
 import { getDigitalRiverJSMock } from './digitalriver.mock';
@@ -39,14 +41,14 @@ describe('DigitalRiverScriptLoader', () => {
         });
 
         it('loads the JS and CSS', async () => {
-            await digitalRiverScriptLoader.load();
+            await digitalRiverScriptLoader.load('pk_test1234', 'en-US');
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
             expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
         });
 
         it('it returns a DigitalRiverJS instance', async () => {
-            expect(await digitalRiverScriptLoader.load()).toBe(windowMock);
+            expect(await digitalRiverScriptLoader.load('pk_test1234', 'en-US')).toBe(digitalRiverJs);
         });
 
         it('it returns a DigitalRiver undefined instance', async () => {
@@ -55,9 +57,8 @@ describe('DigitalRiverScriptLoader', () => {
 
                 return Promise.resolve();
             });
-            const response = await digitalRiverScriptLoader.load();
 
-            return expect(response.DigitalRiver).toEqual(undefined);
+            return expect(digitalRiverScriptLoader.load('pk_test1234', 'en-US')).rejects.toThrow(new PaymentMethodClientUnavailableError());
         });
     });
 });

--- a/src/payment/strategies/digitalriver/digitalriver-script-loader.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-script-loader.ts
@@ -1,6 +1,8 @@
 import { ScriptLoader, StylesheetLoader } from '@bigcommerce/script-loader';
 
-import { DigitalRiverWindow } from './digitalriver';
+import { PaymentMethodClientUnavailableError } from '../../errors';
+
+import DigitalRiverJS, { DigitalRiverWindow } from './digitalriver';
 
 export default class DigitalRiverScriptLoader {
     constructor(
@@ -9,12 +11,16 @@ export default class DigitalRiverScriptLoader {
         private _window: DigitalRiverWindow = window
     ) {}
 
-    async load(): Promise<DigitalRiverWindow> {
+    async load(publicKey: string, locale: string): Promise<DigitalRiverJS> {
         await Promise.all([
             this._stylesheetLoader.loadStylesheet(`https://js.digitalriverws.com/v1/css/DigitalRiver.css`),
             this._scriptLoader.loadScript(`https://js.digitalriverws.com/v1/DigitalRiver.js`),
         ]);
 
-        return Promise.resolve(this._window);
+        if (!this._window.DigitalRiver) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return Promise.resolve(new this._window.DigitalRiver(publicKey, { locale } ));
     }
 }

--- a/src/payment/strategies/digitalriver/digitalriver-script-loader.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-script-loader.ts
@@ -1,8 +1,6 @@
 import { ScriptLoader, StylesheetLoader } from '@bigcommerce/script-loader';
 
-import { PaymentMethodClientUnavailableError } from '../../errors';
-
-import DigitalRiverJS, { DigitalRiverWindow } from './digitalriver';
+import { DigitalRiverWindow } from './digitalriver';
 
 export default class DigitalRiverScriptLoader {
     constructor(
@@ -11,16 +9,12 @@ export default class DigitalRiverScriptLoader {
         private _window: DigitalRiverWindow = window
     ) {}
 
-    async load(digitalRiverPublicApiKey: string, locale: string): Promise<DigitalRiverJS> {
+    async load(): Promise<DigitalRiverWindow> {
         await Promise.all([
             this._stylesheetLoader.loadStylesheet(`https://js.digitalriverws.com/v1/css/DigitalRiver.css`),
             this._scriptLoader.loadScript(`https://js.digitalriverws.com/v1/DigitalRiver.js`),
         ]);
 
-        if (!this._window.DigitalRiver) {
-            throw new PaymentMethodClientUnavailableError();
-        }
-
-        return new this._window.DigitalRiver(digitalRiverPublicApiKey, { locale });
+        return Promise.resolve(this._window);
     }
 }

--- a/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.ts
@@ -4,14 +4,16 @@ export interface DigitalRiverWindow extends Window {
      * This function accepts an optional options object using the following format DigitalRiver(publishableApiKey{, options})
      * https://docs.digitalriver.com/digital-river-api/payment-integrations-1/digitalriver.js/reference/digital-river-publishable-api-key
      */
-    DigitalRiver?: new(apiKey: string, options?: DigitalRiverJSOptions) => DigitalRiverJS;
+    DigitalRiver?: DigitalRiverInstance;
 }
+
+export type DigitalRiverInstance = new(apiKey: string, options?: DigitalRiverJSOptions) => DigitalRiverJS;
 
 export default interface DigitalRiverJS {
     createDropin(configuration: DigitalRiverDropInConfiguration): DigitalRiverDropIn;
 }
 
-interface DigitalRiverJSOptions {
+export interface DigitalRiverJSOptions {
     /**
      * The locale used to localize the various display and error strings within DigitalRiver.js
      * Currently supported locales:

--- a/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.ts
@@ -4,10 +4,10 @@ export interface DigitalRiverWindow extends Window {
      * This function accepts an optional options object using the following format DigitalRiver(publishableApiKey{, options})
      * https://docs.digitalriver.com/digital-river-api/payment-integrations-1/digitalriver.js/reference/digital-river-publishable-api-key
      */
-    DigitalRiver?: DigitalRiverInstance;
+    DigitalRiver?: DigitalRiverClass;
 }
 
-export type DigitalRiverInstance = new(apiKey: string, options?: DigitalRiverJSOptions) => DigitalRiverJS;
+export type DigitalRiverClass = new(apiKey: string, options?: DigitalRiverJSOptions) => DigitalRiverJS;
 
 export default interface DigitalRiverJS {
     createDropin(configuration: DigitalRiverDropInConfiguration): DigitalRiverDropIn;


### PR DESCRIPTION
## What? [INT-4117](https://jira.bigcommerce.com/browse/INT-4117)
Add support to update drop-in component when coupons or card codes are changed

## Why?

Because when the Payment step and the drop in component is loaded in Checkout page, we need to reload the drop-in component and create the Digital River checkout object with the most recent cart data to support shoppers updates

## Testing / Proof


https://user-images.githubusercontent.com/42154828/114103626-17161300-988f-11eb-86bc-d977f4ae62fc.mov



@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
