### PR TITLE
feat(payment): INT-3702 Add vaulted credit card support for Mollie

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -5,9 +5,9 @@ interface SupportedInstruments {
 }
 
 const supportedInstruments: SupportedInstruments = {
-    'mollie.creditcard': {
+    'mollie.credit_card': {
         provider: 'mollie',
-        method: 'creditcard',
+        method: 'credit_card',
     },
     'adyenv2.scheme': {
         provider: 'adyenv2',

--- a/src/payment/strategies/mollie/mollie-initialize-options.ts
+++ b/src/payment/strategies/mollie/mollie-initialize-options.ts
@@ -28,7 +28,7 @@ export default interface MolliePaymentInitializeOptions {
      * container, because when Mollie has Vaulted Instruments it gets hide,
      * and shows an error because can't mount Provider Components
      */
-    containerId: string;
+    containerId?: string;
 
     /**
      * The location to insert Mollie Component

--- a/src/payment/strategies/mollie/mollie-initialize-options.ts
+++ b/src/payment/strategies/mollie/mollie-initialize-options.ts
@@ -1,7 +1,57 @@
+/**
+ * A set of options that are required to initialize the Mollie payment method.
+ *
+ * Once Mollie payment is initialized, credit card form fields are provided by the
+ * payment provider as IFrames, these will be inserted into the current page. These
+ * options provide a location and styling for each of the form fields.
+ *
+ * ```js
+ * service.initializePayment({
+ *      methodId: 'mollie',
+ *      mollie: {
+ *          containerId: 'container',
+ *          cardNumberId: '',
+ *          cardHolderId: '',
+ *          cardCvcId: '',
+ *          cardExpiryId: '',
+ *          styles : {
+ *              base: {
+ *                  color: '#fff'
+ *              }
+ *          }
+ *      }
+ * });
+ */
 export default interface MolliePaymentInitializeOptions {
+    /**
+     * ContainerId is use in Mollie for determined either its showing or not the
+     * container, because when Mollie has Vaulted Instruments it gets hide,
+     * and shows an error because can't mount Provider Components
+     */
+    containerId: string;
+
+    /**
+     * The location to insert Mollie Component
+     */
     cardNumberId: string;
+
+    /**
+     * The location to insert Mollie Component
+     */
     cardHolderId: string;
+
+    /**
+     * The location to insert Mollie Component
+     */
     cardCvcId: string;
+
+    /**
+     * The location to insert Mollie Component
+     */
     cardExpiryId: string;
+
+    /**
+     * A set of styles required for the mollie components
+     */
     styles: object;
 }

--- a/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -120,6 +120,16 @@ describe('MolliePaymentStrategy', () => {
                 expect(mollieClient.createComponent).toBeCalledTimes(4);
                 expect(mollieElement.mount).toBeCalledTimes(4);
             });
+
+            it('does initialize without containerId', async () => {
+                delete options.mollie?.containerId;
+                await strategy.initialize(options);
+
+                expect(mollieScriptLoader.load).toBeCalledWith('test_T0k3n', 'en_US', true);
+                jest.runAllTimers();
+                expect(mollieClient.createComponent).toBeCalledTimes(4);
+                expect(mollieElement.mount).toBeCalledTimes(4);
+            });
         });
 
         describe('#execute', () => {

--- a/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -64,6 +64,8 @@ describe('MolliePaymentStrategy', () => {
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
+        jest.useFakeTimers();
+
         jest.spyOn(store, 'dispatch');
 
         jest.spyOn(orderActionCreator, 'finalizeOrder')
@@ -89,7 +91,7 @@ describe('MolliePaymentStrategy', () => {
         );
     });
 
-    describe('#Initialize & Executes', () => {
+    describe('#Initialize & #Execute', () => {
         let options: PaymentInitializeOptions;
 
         beforeEach(() => {
@@ -114,6 +116,7 @@ describe('MolliePaymentStrategy', () => {
                 await strategy.initialize(options);
 
                 expect(mollieScriptLoader.load).toBeCalledWith('test_T0k3n', 'en_US', true);
+                jest.runAllTimers();
                 expect(mollieClient.createComponent).toBeCalledTimes(4);
                 expect(mollieElement.mount).toBeCalledTimes(4);
             });
@@ -133,14 +136,15 @@ describe('MolliePaymentStrategy', () => {
                 }
             });
 
-            it('should call submitPayment when paying with creditcard', async () => {
+            it('should call submitPayment when paying with credit_card', async () => {
                 await strategy.initialize(options);
+                jest.runAllTimers();
                 await strategy.execute(getOrderRequestBodyWithCreditCard());
 
                 expect(mollieClient.createToken).toBeCalled();
                 expect(paymentActionCreator.submitPayment).toBeCalledWith({
                     gatewayId: 'mollie',
-                    methodId: 'creditcard',
+                    methodId: 'credit_card',
                     paymentData: {
                         formattedPayload: {
                             browser_info: {
@@ -149,11 +153,38 @@ describe('MolliePaymentStrategy', () => {
                                 language: 'en-US',
                                 screen_height: 0,
                                 screen_width: 0,
-                                time_zone_offset: '0',
+                                time_zone_offset: new Date().getTimezoneOffset().toString(),
                             },
                             credit_card_token : {
                                 token: 'tkn_test',
                             },
+                        },
+                    },
+                });
+            });
+
+            it('should call submitPayment when saving vaulted', async () => {
+                await strategy.initialize(options);
+                jest.runAllTimers();
+                const { payment } = getOrderRequestBodyWithCreditCard();
+                await strategy.execute({ ...payment, payment: { methodId: 'credit_card', paymentData: { shouldSaveInstrument: true, shouldSetAsDefaultInstrument: true } } });
+                expect(paymentActionCreator.submitPayment).toBeCalledWith({
+                    methodId: 'credit_card',
+                    paymentData: {
+                        formattedPayload: {
+                            browser_info: {
+                                color_depth: 24,
+                                java_enabled: false,
+                                language: 'en-US',
+                                screen_height: 0,
+                                screen_width: 0,
+                                time_zone_offset: new Date().getTimezoneOffset().toString(),
+                            },
+                            credit_card_token : {
+                                token: 'tkn_test',
+                            },
+                            set_as_default_stored_instrument: true,
+                            vault_payment_instrument: true,
                         },
                     },
                 });
@@ -170,16 +201,12 @@ describe('MolliePaymentStrategy', () => {
                 });
             });
         });
-
-        afterEach(() =>  {
-            jest.resetAllMocks();
-        });
     });
 
     describe('#finalize()', () => {
         it('finalize mollie', () => {
             const promise = strategy.finalize();
-            expect(promise).resolves.toBe({});
+            expect(promise).resolves.toBe(store.getState());
         });
     });
 
@@ -194,16 +221,22 @@ describe('MolliePaymentStrategy', () => {
 
             jest.spyOn(store.getState().config, 'getStoreConfig')
                 .mockReturnValue({ storeProfile: { storeLanguage:  'en_US' } });
+
+            jest.spyOn(document, 'querySelectorAll');
         });
 
         it('deinitialize mollie payment strategy', async () => {
             await strategy.initialize(options);
 
+            jest.runAllTimers();
+            expect(mollieClient.createComponent).toBeCalledTimes(4);
             expect(mollieElement.mount).toBeCalledTimes(4);
 
             const promise = strategy.deinitialize();
 
-            expect(mollieElement.unmount).toBeCalledTimes(4);
+            expect(document.querySelectorAll).toBeCalledTimes(2);
+            expect(document.querySelectorAll).toHaveBeenNthCalledWith(1, '.mollie-component');
+            expect(document.querySelectorAll).toHaveBeenNthCalledWith(2, '.mollie-components-controller');
 
             return expect(promise).resolves.toBe(store.getState());
         });

--- a/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -180,7 +180,11 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
      */
     private _mountElements() {
         const { containerId, cardNumberId, cardCvcId, cardExpiryId, cardHolderId, styles } = this._getInitializeOptions();
-        const container = document.getElementById(containerId);
+        let container: HTMLElement | null;
+
+        if (containerId) {
+            container = document.getElementById(containerId);
+        }
 
         setTimeout(() => {
             if (!containerId || container?.style.display !== 'none') {

--- a/src/payment/strategies/mollie/mollie.mock.ts
+++ b/src/payment/strategies/mollie/mollie.mock.ts
@@ -5,8 +5,9 @@ import { MollieClient } from './mollie';
 
 export function getInitializeOptions(): PaymentInitializeOptions {
     return {
-        methodId: 'creditcard',
+        methodId: 'credit_card',
         mollie: {
+            containerId: 'mollie-element',
             cardCvcId: 'mollie-card-cvc-component-field',
             cardExpiryId: 'mollie-card-expiry-component-field',
             cardHolderId: 'mollie-card-holder-component-field',
@@ -42,7 +43,7 @@ export function getOrderRequestBodyWithCreditCard(): OrderRequestBody {
     return {
         useStoreCredit: false,
         payment: {
-            methodId: 'creditcard',
+            methodId: 'credit_card',
             gatewayId: 'mollie',
             paymentData: undefined,
         },

--- a/src/payment/strategies/mollie/mollie.ts
+++ b/src/payment/strategies/mollie/mollie.ts
@@ -37,5 +37,5 @@ export interface MollieElement {
      * The callback receives an object with all the related information.
      * blur | focus | change
      */
-    addEventListener(event: 'blur' | 'focus' | 'change', callback: () => void): void;
+    addEventListener(event: 'blur' | 'focus' | 'change', callback: ( event: Event ) => void): void;
 }


### PR DESCRIPTION
## What? [INT-3702](https://jira.bigcommerce.com/browse/INT-3702)
added vaulted methods in order to save cc, added vault_payment_intrument variables, and create conditions to mount or not mount mollie components 

## Why?
We want the user to be able to save cc and use them later when logged in 

## Testing / Proof

![Screen Shot 2021-01-13 at 11 35 01](https://user-images.githubusercontent.com/69221626/104487990-6354fe00-5593-11eb-946b-8e62774c15b6.png)


@bigcommerce/checkout @bigcommerce/payments
