### PR TITLE
feat(cart): CHECKOUT-5747 Add cart changed error data

### DIFF
--- a/src/cart/errors/cart-changed-error.spec.ts
+++ b/src/cart/errors/cart-changed-error.spec.ts
@@ -1,9 +1,19 @@
+import { getCheckout } from '../../checkout/checkouts.mock';
+
 import CartChangedError from './cart-changed-error';
 
 describe('CartChangedError', () => {
     it('returns error name', () => {
-        const error = new CartChangedError();
+        const error = new CartChangedError(getCheckout(), {
+            ...getCheckout(),
+            outstandingBalance: 0,
+        });
 
         expect(error.name).toEqual('CartChangedError');
+        expect(error.data.previous).toEqual(getCheckout());
+        expect(error.data.updated).toEqual({
+            ...getCheckout(),
+            outstandingBalance: 0,
+        });
     });
 });

--- a/src/cart/errors/cart-changed-error.ts
+++ b/src/cart/errors/cart-changed-error.ts
@@ -1,10 +1,26 @@
+import { ComparableCheckout } from '../../checkout';
 import { StandardError } from '../../common/error/errors';
 
 export default class CartChangedError extends StandardError {
-    constructor() {
+    /**
+     * @alpha
+     * Please note that this option is currently in an early stage of
+     * development. Therefore the API is unstable and not ready for public
+     * consumption.
+     */
+    data: { previous: ComparableCheckout; updated: ComparableCheckout };
+
+    constructor(
+        previous: ComparableCheckout,
+        updated: ComparableCheckout
+    ) {
         super('An update to your shopping cart has been detected and your available shipping costs have been updated.');
 
         this.name = 'CartChangedError';
         this.type = 'cart_changed';
+        this.data = {
+            previous,
+            updated,
+        };
     }
 }

--- a/src/checkout/checkout-store-error-selector.ts
+++ b/src/checkout/checkout-store-error-selector.ts
@@ -1,5 +1,6 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 
+import { CartChangedError } from '../cart/errors';
 import { RequestError } from '../common/error/errors';
 import { createSelector, createShallowEqualSelector } from '../common/selector';
 import { Omit } from '../common/types';
@@ -36,7 +37,7 @@ export default interface CheckoutStoreErrorSelector {
      *
      * @returns The error object if unable to submit, otherwise undefined.
      */
-    getSubmitOrderError(): Error | undefined;
+    getSubmitOrderError(): Error | CartChangedError | undefined;
 
     /**
      * Returns an error if unable to finalize the current order.

--- a/src/checkout/checkout-validator.spec.ts
+++ b/src/checkout/checkout-validator.spec.ts
@@ -79,7 +79,10 @@ describe('CheckoutValidator', () => {
                 })
                     .catch(errorHandler);
 
-                expect(errorHandler).toHaveBeenCalledWith(new CartChangedError());
+                expect(errorHandler).toHaveBeenCalledWith(new CartChangedError(
+                    getCheckout(),
+                    getCheckout()
+                ));
             });
 
             it('rejects with "cart changed error" if outstandingBalance are different', async () => {

--- a/src/checkout/index.ts
+++ b/src/checkout/index.ts
@@ -15,7 +15,7 @@ export { default as CheckoutStoreSelector, CheckoutStoreSelectorFactory, createC
 export { default as CheckoutStoreState } from './checkout-store-state';
 export { default as CheckoutStoreStatusSelector, CheckoutStoreStatusSelectorFactory, createCheckoutStoreStatusSelectorFactory } from './checkout-store-status-selector';
 export { default as CheckoutStore, CheckoutStoreOptions, ReadableCheckoutStore } from './checkout-store';
-export { default as CheckoutValidator } from './checkout-validator';
+export { default as CheckoutValidator, ComparableCheckout } from './checkout-validator';
 export { default as InternalCheckoutSelectors } from './internal-checkout-selectors';
 
 export { default as createActionTransformer } from './create-action-transformer';

--- a/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
+++ b/src/embedded-checkout/iframe-content/iframe-embedded-checkout-messenger.spec.ts
@@ -1,4 +1,5 @@
 import { CartChangedError } from '../../cart/errors';
+import { getCheckout } from '../../checkout/checkouts.mock';
 import { IframeEventListener, IframeEventPoster } from '../../common/iframe';
 import { EmbeddedCheckoutEvent, EmbeddedCheckoutEventType } from '../embedded-checkout-events';
 
@@ -40,7 +41,10 @@ describe('EmbeddedCheckoutMessenger', () => {
     });
 
     it('posts `complete` event to parent window', () => {
-        const error = new CartChangedError();
+        const error = new CartChangedError(
+            getCheckout(),
+            getCheckout()
+        );
 
         messenger.postError(error);
 


### PR DESCRIPTION
## What?
Provide the previous and updated cart as part of `CartChangedError`

## Why?
So that we can log the contents in case of issues to related to this error.

## Testing / Proof
unit

Tested also in combination with Checkout JS changes
<img width="1676" alt="Screen Shot 2021-04-15 at 3 09 48 pm" src="https://user-images.githubusercontent.com/1621894/114817073-b477c680-9dfc-11eb-8e0e-6197991dd94f.png">


@bigcommerce/checkout @bigcommerce/payments
