### PR TITLE
fix(payments): INT-3611 fixing where nonce value is going to be reloaded

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -37,16 +37,12 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { methodId } = options;
 
-        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+        const state = this._store.getState();
         this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
 
         this._googlePayOptions = this._getGooglePayOptions(options);
 
         this._buttonClickEventHandler = this._handleButtlonClickedEvent(methodId);
-
-        if (this._paymentMethod.initializationData.nonce) {
-            return Promise.resolve(this._store.getState());
-        }
 
         await this._googlePayPaymentProcessor.initialize(methodId);
 
@@ -89,6 +85,11 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         const { methodId } = payload.payment;
 
+        if (!this._paymentMethod?.initializationData.nonce) {
+            const state = this._store.getState();
+            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        }
+
         let payment = await this._getPayment(methodId);
 
         if (!payment.paymentData.nonce || !payment.paymentData.cardInformation) {
@@ -97,6 +98,10 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 onPaymentSelect = () => {},
             } = this._googlePayOptions;
             await this._displayWallet(methodId, onPaymentSelect, onError);
+
+            const state = this._store.getState();
+            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
             payment = await this._getPayment(methodId);
 
             if (!payment.paymentData.nonce) {
@@ -153,32 +158,31 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     }
 
     private async _getPayment(methodId: string): Promise<PaymentMethodData> {
-        if (!methodId) {
+        if (!methodId || !this._paymentMethod) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
-
-        let state = this._store.getState();
-        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-
-        const { nonce } = this._paymentMethod.initializationData;
-        if (nonce) {
-            state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
-            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        }
-
-        const { card_information: cardInformation } = this._paymentMethod.initializationData;
 
         return {
             methodId,
             paymentData: {
                 method: methodId,
-                cardInformation,
-                nonce: this._getNonce(methodId, this._paymentMethod),
+                cardInformation: this._paymentMethod.initializationData.card_information,
+                nonce: await this._getNonce(methodId),
             },
         };
     }
 
-    private _getNonce(methodId: string, { initializationData: { nonce }}: PaymentMethod) {
+    private async _getNonce(methodId: string) {
+        if (!this._paymentMethod) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+        const nonce = this._paymentMethod.initializationData.nonce;
+
+        if (nonce) {
+            const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        }
+
         if (methodId === 'googlepayadyenv2') {
             return JSON.stringify({
                 type: AdyenPaymentMethodType.GooglePay,
@@ -197,6 +201,16 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         // TODO: Revisit how we deal with GooglePaymentData after receiving it from Google
         await this._googlePayPaymentProcessor.handleSuccess(paymentData);
+
+        const state = this._store.getState();
+        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        if (this._paymentMethod.initializationData.nonce) {
+            return await Promise.all([
+                this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
+                this._store.getState(),
+            ]);
+        }
 
         return await Promise.all([
             this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),


### PR DESCRIPTION
## What? [INT-4266](https://jira.bigcommerce.com/browse/INT-4266)
change where the nonce value is going to be reloaded

## Why?
the nonce value was being reloaded before be used then the value was empty, triggering one more time the popup to select the credit card
this happens because the backend delete the nonce value after be used: [Link](https://github.com/bigcommerce/bigcommerce/pull/39827/files#diff-ec498346f9c15c814cc5db89dd9abe81d9509baad8b0085124ed355238e145c8R438)

the function `loadPaymentMethod` calls the backend (deleting the nonce value) then I have to be careful where is called


## Testing / Proof
Happy path, it works form checkout and the cart section
https://drive.google.com/file/d/1vfEomqIo-Y_Ob0FYEMbXvl0yrTcZEh8x/view?usp=sharing

the original issue with the nonce value is fixed: [INT-3611](https://jira.bigcommerce.com/browse/INT-3611)
https://drive.google.com/file/d/1jF8xMUZkK_sInv_W2G5QNRELB-CtUaTB/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
