### PR TITLE
feat(payment): INT-4205 Add Moneris strategy

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -48,6 +48,7 @@ import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klar
 import { LegacyPaymentStrategy } from './strategies/legacy';
 import { MasterpassPaymentStrategy, MasterpassScriptLoader } from './strategies/masterpass';
 import { MolliePaymentStrategy, MollieScriptLoader } from './strategies/mollie';
+import { MonerisPaymentStrategy } from './strategies/moneris';
 import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
 import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
@@ -667,6 +668,15 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             hostedFormFactory
+        )
+    );
+
+    registry.register(PaymentStrategyType.MONERIS, () =>
+        new MonerisPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            storeCreditActionCreator
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -692,6 +692,24 @@ export function getMollie(): PaymentMethod {
     };
 }
 
+export function getMoneris(): PaymentMethod {
+    return {
+        id: 'moneris',
+        gateway: '',
+        logoUrl: '',
+        method: 'moneris',
+        supportedCards: [],
+        config: {
+            displayName: 'Moneris',
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        initializationData: {
+            profileId: 'ABC123',
+        },
+    };
+}
+
 export function getPaymentMethods(): PaymentMethod[] {
     return [
         getAdyenAmex(),
@@ -717,6 +735,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getPaypalCommerce(),
         getSquare(),
         getStripeV3(),
+        getMoneris(),
     ];
 }
 

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -14,6 +14,7 @@ import { KlarnaPaymentInitializeOptions } from './strategies/klarna';
 import { KlarnaV2PaymentInitializeOptions } from './strategies/klarnav2';
 import { MasterpassPaymentInitializeOptions } from './strategies/masterpass';
 import { MolliePaymentInitializeOptions } from './strategies/mollie';
+import { MonerisPaymentInitializeOptions } from './strategies/moneris';
 import { PaypalExpressPaymentInitializeOptions } from './strategies/paypal';
 import { PaypalCommerceInitializeOptions } from './strategies/paypal-commerce';
 import { SquarePaymentInitializeOptions } from './strategies/square';
@@ -116,6 +117,12 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support Masterpass.
      */
     masterpass?: MasterpassPaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the Moneris payment method.
+     * They can be omitted unless you need to support Moneris.
+     */
+    moneris?: MonerisPaymentInitializeOptions;
 
     /**
      * The options that are required to initialize the PayPal Express payment method.

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -27,6 +27,7 @@ enum PaymentStrategyType {
     LAYBUY = 'laybuy',
     LEGACY = 'legacy',
     MOLLIE = 'mollie',
+    MONERIS = 'moneris',
     NO_PAYMENT_DATA_REQUIRED = 'nopaymentdatarequired',
     OFFLINE = 'offline',
     OFFSITE = 'offsite',

--- a/src/payment/strategies/moneris/index.ts
+++ b/src/payment/strategies/moneris/index.ts
@@ -1,0 +1,3 @@
+export { default as MonerisPaymentInitializeOptions } from './moneris-payment-initialize-options';
+export { default as MonerisPaymentStrategy } from './moneris-payment-strategy';
+export { default as MonerisStylingProps } from './moneris';

--- a/src/payment/strategies/moneris/moneris-payment-initialize-options.ts
+++ b/src/payment/strategies/moneris/moneris-payment-initialize-options.ts
@@ -1,0 +1,10 @@
+import MonerisStylingProps from './moneris';
+
+export default interface MonerisaymentInitializeOptions {
+    /**
+     * The ID of a container which the Moneris iframe component should be mounted
+     */
+    containerId: string;
+
+    style?: MonerisStylingProps;
+}

--- a/src/payment/strategies/moneris/moneris-payment-initialize-options.ts
+++ b/src/payment/strategies/moneris/moneris-payment-initialize-options.ts
@@ -2,7 +2,7 @@ import MonerisStylingProps from './moneris';
 
 export default interface MonerisaymentInitializeOptions {
     /**
-     * The ID of a container which the Moneris iframe component should be mounted
+     * The ID of a container where the Moneris iframe component should be mounted
      */
     containerId: string;
 

--- a/src/payment/strategies/moneris/moneris-payment-strategy.spec.ts
+++ b/src/payment/strategies/moneris/moneris-payment-strategy.spec.ts
@@ -1,0 +1,245 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, Action } from '@bigcommerce/data-store';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+import { merge } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, Checkout, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { PaymentMethod, PaymentRequestSender } from '../../../payment';
+import { getMoneris } from '../../../payment/payment-methods.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import { StoreCreditActionCreator, StoreCreditActionType, StoreCreditRequestSender } from '../../../store-credit';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+
+import MonerisPaymentStrategy from './moneris-payment-strategy';
+
+describe('MonerisPaymentStrategy', () => {
+    const containerId = 'moneris_iframe_container';
+    const iframeId = 'moneris-payment-iframe';
+    let applyStoreCreditAction: Observable<Action>;
+    let checkoutMock: Checkout;
+    let container: HTMLDivElement;
+    let eventEmitter: EventEmitter;
+    let initializeOptions: PaymentInitializeOptions;
+    let options: PaymentRequestOptions;
+    let orderActionCreator: OrderActionCreator;
+    let payload: OrderRequestBody;
+    let paymentActionCreator: PaymentActionCreator;
+    let paymentHumanVerificationHandler: PaymentHumanVerificationHandler;
+    let paymentMethodMock: PaymentMethod;
+    let paymentRequestTransformer: PaymentRequestTransformer;
+    let paymentRequestSender: PaymentRequestSender;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let storeCreditActionCreator: StoreCreditActionCreator;
+    let strategy: MonerisPaymentStrategy;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+
+    let submitOrderAction: Observable<SubmitOrderAction>;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = createRequestSender();
+
+        orderActionCreator = new OrderActionCreator(
+            new OrderRequestSender(requestSender),
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+
+        paymentRequestTransformer = new PaymentRequestTransformer();
+        paymentRequestSender = new PaymentRequestSender(createPaymentClient());
+        paymentHumanVerificationHandler = new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()));
+        paymentActionCreator = new PaymentActionCreator(
+            paymentRequestSender,
+            orderActionCreator,
+            paymentRequestTransformer,
+            paymentHumanVerificationHandler
+        );
+
+        applyStoreCreditAction = of(createAction(StoreCreditActionType.ApplyStoreCreditRequested));
+        eventEmitter = new EventEmitter();
+        paymentMethodMock = getMoneris();
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        storeCreditActionCreator = new StoreCreditActionCreator(
+            new StoreCreditRequestSender(requestSender)
+        );
+
+        initializeOptions = {
+            methodId: 'moneris',
+            moneris: {
+                containerId,
+            },
+        };
+
+        checkoutMock = getCheckout();
+
+        options = { methodId: 'moneris' };
+        payload = merge(getOrderRequestBody(), {
+            payment: {
+                methodId: 'moneris',
+                paymentData: null,
+            },
+        });
+
+        container = document.createElement('div');
+        container.setAttribute('id', containerId);
+        document.body.appendChild(container);
+
+        jest.spyOn(document, 'getElementById');
+        jest.spyOn(document, 'createElement');
+        jest.spyOn(store, 'dispatch');
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        jest.spyOn(store.getState().checkout, 'getCheckoutOrThrow')
+            .mockReturnValue(checkoutMock);
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(paymentMethodMock);
+
+        jest.spyOn(storeCreditActionCreator, 'applyStoreCredit')
+            .mockReturnValue(applyStoreCreditAction);
+
+        jest.spyOn(window, 'addEventListener')
+            .mockImplementation((type, listener) => {
+                return eventEmitter.addListener(type, listener);
+            });
+
+        jest.spyOn(window, 'removeEventListener')
+            .mockImplementation((type, listener) => {
+                return eventEmitter.removeListener(type, listener);
+            });
+
+        strategy = new MonerisPaymentStrategy(store, orderActionCreator, paymentActionCreator, storeCreditActionCreator);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    describe('#initialize', () => {
+        it('successfully initializes moneris strategy and creates the iframe', async () => {
+            await expect(strategy.initialize(initializeOptions)).resolves.toEqual(store.getState());
+
+            expect(document.getElementById).toHaveBeenCalledWith(containerId);
+            expect(document.createElement).toHaveBeenCalledWith('iframe');
+        });
+
+        it('initializes moneris iframe and sets src to the live environment', async () => {
+            paymentMethodMock.config.testMode = false;
+            await expect(strategy.initialize(initializeOptions)).resolves.toEqual(store.getState());
+
+            const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
+            expect(iframe).toBeTruthy();
+            expect(iframe.src).toMatch(/www3.moneris.com/);
+        });
+
+        it('initializes moneris iframe and sets src to the test environment', async () => {
+            paymentMethodMock.config.testMode = true;
+            await expect(strategy.initialize(initializeOptions)).resolves.toEqual(store.getState());
+
+            const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
+            expect(iframe).toBeTruthy();
+            expect(iframe.src).toMatch(/esqa.moneris.com/);
+        });
+
+        it('fails to initialize moneris strategy when initialization options are not provided', () => {
+            initializeOptions.moneris = undefined;
+            expect(() => strategy.initialize(initializeOptions)).toThrow(InvalidArgumentError);
+
+            const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
+            expect(iframe).toBeFalsy();
+        });
+
+        it('fails to initialize moneris strategy when initialization data is missing', () => {
+            paymentMethodMock.initializationData = undefined;
+            expect(() => strategy.initialize(initializeOptions)).toThrow(MissingDataError);
+
+            const iframe = document.getElementById(iframeId) as HTMLIFrameElement;
+            expect(iframe).toBeFalsy();
+        });
+    });
+
+    describe('#execute', () => {
+        it('successfully executes moneris strategy and submits payment', async () => {
+            const expectedPayment = {
+                methodId: 'moneris',
+                paymentData: {
+                    nonce: 'ABC123',
+                },
+            };
+            checkoutMock.isStoreCreditApplied = true;
+
+            await strategy.initialize(initializeOptions);
+            const promise =  strategy.execute(payload, options);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('message', { data: '{\"responseCode\":[\"001\"],\"errorMessage\":null,\"dataKey\":\"ABC123\",\"bin\":\"1234\"}'});
+
+            await promise;
+
+            expect(storeCreditActionCreator.applyStoreCredit).toHaveBeenCalledWith(true);
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        });
+
+        it('throws error when moneris response is not successful', async () => {
+            await strategy.initialize(initializeOptions);
+            const promise =  strategy.execute(payload, options);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('message', { data: '{\"responseCode\":[\"400\"],\"errorMessage\":\"expected error message\",\"dataKey\":\"ABC123\",\"bin\":\"1234\"}'});
+
+            await expect(promise).rejects.toThrow(new Error('expected error message'));
+            expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
+        });
+
+        it('fails to executes moneris strategy when payment is not provided', async () => {
+            payload.payment = undefined;
+            await strategy.initialize(initializeOptions);
+            await expect(strategy.execute(payload)).rejects.toThrow(PaymentArgumentInvalidError);
+
+            expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy and removes event listener if set', async () => {
+            await strategy.initialize(initializeOptions);
+            const promise =  strategy.execute(payload, options);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('message', { data: '{\"responseCode\":[\"400\"],\"errorMessage\":\"expected error message\",\"dataKey\":\"ABC123\",\"bin\":\"1234\"}'});
+
+            await expect(promise).rejects.toThrow(new Error('expected error message'));
+
+            expect(await strategy.deinitialize()).toEqual(store.getState());
+            expect(window.removeEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+});

--- a/src/payment/strategies/moneris/moneris-payment-strategy.ts
+++ b/src/payment/strategies/moneris/moneris-payment-strategy.ts
@@ -1,0 +1,135 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { InvalidArgumentError , MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { StoreCreditActionCreator } from '../../../store-credit';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+import MonerisStylingProps,  { MonerisResponseData } from './moneris';
+
+const IFRAME_NAME = 'moneris-payment-iframe';
+const RESPONSE_SUCCESS_CODE = '001';
+
+export default class MonerisPaymentStrategy implements PaymentStrategy {
+    private _iframe?: HTMLIFrameElement;
+    private _monerisURL?: string;
+    private _windowEventListener?: (response: MessageEvent) => void;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _storeCreditActionCreator: StoreCreditActionCreator
+    ) {}
+
+    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+
+        const { moneris: monerisOptions } = options;
+        const { config, initializationData } = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
+
+        if (!monerisOptions) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.moneris" argument is not provided.');
+        }
+
+        if (!initializationData?.profileId) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        this._iframe = this._createIframe(monerisOptions.containerId, initializationData.profileId, !!config.testMode);
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        const { isStoreCreditApplied: useStoreCredit } = this._store.getState().checkout.getCheckoutOrThrow();
+
+        if (useStoreCredit !== undefined) {
+            await this._store.dispatch(this._storeCreditActionCreator.applyStoreCredit(useStoreCredit));
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+        const nonce = await new Promise<string | undefined>((resolve, reject) => {
+            const frameref = this._iframe?.contentWindow;
+
+            if (!this._monerisURL) {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+
+            frameref?.postMessage('tokenize', this._monerisURL);
+
+            this._windowEventListener = (response: MessageEvent) => this._handleMonerisResponse(response, resolve, reject);
+
+            window.addEventListener('message', this._windowEventListener);
+        });
+
+        if (nonce !== undefined) {
+            return this._store.dispatch(this._paymentActionCreator.submitPayment({
+                methodId: payment.methodId,
+                paymentData: { nonce },
+            }));
+        }
+
+        return this._store.getState();
+    }
+
+    finalize(): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        if (this._windowEventListener) {
+            window.removeEventListener('message', this._windowEventListener);
+            this._windowEventListener = undefined;
+        }
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _createIframe(containerId: string, profileId: string, testMode: boolean, style?: MonerisStylingProps): HTMLIFrameElement {
+        const container = document.getElementById(containerId);
+
+        if (!container) {
+            throw new InvalidArgumentError('Unable to create iframe without valid container ID.');
+        }
+
+        const iframe = document.createElement('iframe');
+        // Example CSS styling as provided by Moneris' documentation
+        const cssBody = style?.cssBody ?? 'background:white;';
+        const cssTextbox = style?.cssTextbox ?? 'border-width:2px;';
+        const csstextboxPan = style?.cssTextboxPan ?? 'width:140px;';
+        const cssTextboxExpiry = style?.cssTextboxExpiry ?? 'width:40px;';
+        const csstexboxCvd = style?.csstexboxCvd ?? 'width:40px';
+
+        iframe.name = IFRAME_NAME;
+        iframe.id = IFRAME_NAME;
+
+        this._monerisURL = `https://${ testMode ? 'esqa' : 'www3' }.moneris.com/HPPtoken/index.php`;
+
+        iframe.src = `${ this._monerisURL }?id=${profileId}&pmmsg=true&css_body=${cssBody}&css_textbox=${cssTextbox}&css_textbox_pan=${csstextboxPan}&enable_exp=1&css_textbox_exp=${cssTextboxExpiry}&enable_cvd=1&css_textbox_cvd=${csstexboxCvd}&display_labels=1`;
+
+        container.appendChild(iframe);
+
+        return iframe;
+    }
+
+    private _handleMonerisResponse(response: MessageEvent, resolve: (nonce: string) => void, reject: (reason: Error) => void): void {
+        const monerisResponse: MonerisResponseData = JSON.parse(response.data);
+
+        if (monerisResponse.responseCode[0] !== RESPONSE_SUCCESS_CODE) {
+            return reject(new Error(monerisResponse.errorMessage));
+        }
+
+        return resolve(monerisResponse.dataKey);
+    }
+}

--- a/src/payment/strategies/moneris/moneris.ts
+++ b/src/payment/strategies/moneris/moneris.ts
@@ -1,0 +1,14 @@
+export default interface MonerisStylingProps {
+    cssBody?: string;
+    cssTextbox?: string;
+    cssTextboxPan?: string;
+    cssTextboxExpiry?: string;
+    csstexboxCvd?: string;
+}
+
+export interface MonerisResponseData {
+    responseCode: string[];
+    dataKey: string;
+    errorMessage: string;
+    bin: string;
+}


### PR DESCRIPTION
## What? [INT-4205](https://jira.bigcommerce.com/browse/INT-4205)
Create Moneris payment strategy which mounts an iframe and sends events to the iframe and listens to evens sent from the iframe

## Why?
This is the way its implementation works and its based on [their documentation](https://developer.moneris.com/Documentation/NA/E-Commerce%20Solutions/Hosted%20Solutions/Hosted%20Tokenization) for the Hosted tokenization 

## Sibling PRs
https://github.com/bigcommerce/checkout-js/pull/563

## Testing / Proof
![image](https://user-images.githubusercontent.com/6343437/119568420-1cfa8180-bd73-11eb-9514-dee0c834f0dd.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
