### PR TITLE
fix(payment): INT-4266 Googlepay - fixing where nonce value is going …

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -152,6 +152,14 @@ describe('GooglePayPaymentStrategy', () => {
             expect(googlePayPaymentProcessor.initialize).toHaveBeenCalled();
         });
 
+        it('does not reload the state', async () => {
+            paymentMethodMock.config.testMode = true;
+
+            await strategy.initialize(googlePayOptions);
+
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledTimes(0);
+        });
+
         it('does not load googlepay if initialization options are not provided', async () => {
             googlePayOptions = { methodId: 'googlepaybraintree'};
 
@@ -227,7 +235,7 @@ describe('GooglePayPaymentStrategy', () => {
             };
         });
 
-        it('creates the order and submit payment', async () => {
+        it('creates the order and submit payment form cart', async () => {
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
                 initializationData: {
                     nonce: 'nonce',
@@ -244,6 +252,77 @@ describe('GooglePayPaymentStrategy', () => {
 
             await strategy.execute(getGoogleOrderRequestBody());
 
+            expect(store.getState().paymentMethods.getPaymentMethodOrThrow).toHaveBeenCalledTimes(2);
+            expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+        });
+
+        it('creates the order and submit payment form checkout page', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue({
+                initializationData: {
+                    nonce: 'nonce',
+                    card_information: {
+                        type: 'type',
+                        number: 'number',
+                    },
+                },
+            }).mockReturnValueOnce({
+                initializationData: {
+                    nonce: '',
+                    card_information: {
+                        type: 'type',
+                        number: 'number',
+                    },
+                },
+            });
+            await strategy.initialize(googlePayOptions);
+
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+
+            await strategy.execute(getGoogleOrderRequestBody());
+
+            expect(store.getState().paymentMethods.getPaymentMethodOrThrow).toHaveBeenCalledTimes(3);
+            expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+        });
+
+        it('creates the order and submit payment form checkout page with declined card', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue({
+                initializationData: {
+                    nonce: 'nonce',
+                    card_information: {
+                        type: 'type',
+                        number: 'number',
+                    },
+                },
+            }).mockReturnValueOnce({
+                initializationData: {
+                    nonce: '',
+                    card_information: {
+                        type: 'type',
+                        number: 'number',
+                    },
+                },
+            }).mockReturnValueOnce({
+                initializationData: {
+                    nonce: '',
+                    card_information: {
+                        type: 'type',
+                        number: 'number',
+                    },
+                },
+            });
+            await strategy.initialize(googlePayOptions);
+
+            jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(Promise.resolve());
+
+            await strategy.execute(getGoogleOrderRequestBody());
+
+            expect(store.getState().paymentMethods.getPaymentMethodOrThrow).toHaveBeenCalledTimes(4);
             expect(orderActionCreator.submitOrder).toHaveBeenCalled();
             expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
         });

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -37,16 +37,12 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { methodId } = options;
 
-        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+        const state = this._store.getState();
         this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
 
         this._googlePayOptions = this._getGooglePayOptions(options);
 
         this._buttonClickEventHandler = this._handleButtlonClickedEvent(methodId);
-
-        if (this._paymentMethod.initializationData.nonce) {
-            return Promise.resolve(this._store.getState());
-        }
 
         await this._googlePayPaymentProcessor.initialize(methodId);
 
@@ -89,6 +85,10 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         const { methodId } = payload.payment;
 
+        if (!this._paymentMethod?.initializationData.nonce) {
+            this._paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(methodId);
+        }
+
         let payment = await this._getPayment(methodId);
 
         if (!payment.paymentData.nonce || !payment.paymentData.cardInformation) {
@@ -97,6 +97,9 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 onPaymentSelect = () => {},
             } = this._googlePayOptions;
             await this._displayWallet(methodId, onPaymentSelect, onError);
+
+            this._paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(methodId);
+
             payment = await this._getPayment(methodId);
 
             if (!payment.paymentData.nonce) {
@@ -153,41 +156,39 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     }
 
     private async _getPayment(methodId: string): Promise<PaymentMethodData> {
-        if (!methodId) {
+        if (!methodId || !this._paymentMethod) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
-
-        let state = this._store.getState();
-        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-
-        const { nonce } = this._paymentMethod.initializationData;
-        if (nonce) {
-            state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
-            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        }
-
-        const { card_information: cardInformation } = this._paymentMethod.initializationData;
 
         return {
             methodId,
             paymentData: {
                 method: methodId,
-                cardInformation,
-                nonce: this._getNonce(methodId, this._paymentMethod),
+                cardInformation: this._paymentMethod.initializationData.card_information,
+                nonce: await this._getNonce(methodId),
             },
         };
     }
 
-    private _getNonce(methodId: string, { initializationData: { nonce }}: PaymentMethod) {
+    private async _getNonce(methodId: string): Promise<string> {
+        if (!this._paymentMethod) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (this._paymentMethod.initializationData.nonce) {
+            const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        }
+
         if (methodId === 'googlepayadyenv2') {
             return JSON.stringify({
                 type: AdyenPaymentMethodType.GooglePay,
-                googlePayToken: nonce,
+                googlePayToken: this._paymentMethod.initializationData.nonce,
                 browser_info: getBrowserInfo(),
             });
         }
 
-        return nonce;
+        return this._paymentMethod.initializationData.nonce;
     }
 
     private async _paymentInstrumentSelected(paymentData: GooglePaymentData, methodId: string) {
@@ -197,6 +198,15 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         // TODO: Revisit how we deal with GooglePaymentData after receiving it from Google
         await this._googlePayPaymentProcessor.handleSuccess(paymentData);
+
+        this._paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        if (this._paymentMethod.initializationData.nonce) {
+            return await Promise.all([
+                this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
+                this._store.getState(),
+            ]);
+        }
 
         return await Promise.all([
             this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),


### PR DESCRIPTION
…to be reloaded

## What? [INT-4266](https://jira.bigcommerce.com/browse/INT-4266)
change where the nonce value is going to be reloaded

## Why?
the nonce value was being reloaded before be used then the value was empty, triggering one more time the popup to select the credit card
this happens because the backend delete the nonce value after be used: [Link](https://github.com/bigcommerce/bigcommerce/pull/39827/files#diff-ec498346f9c15c814cc5db89dd9abe81d9509baad8b0085124ed355238e145c8R438)

the function `loadPaymentMethod` calls the backend (deleting the nonce value) then I have to be careful where is called


## Testing / Proof
Happy path, it works form checkout and the cart section
https://drive.google.com/file/d/1vfEomqIo-Y_Ob0FYEMbXvl0yrTcZEh8x/view?usp=sharing

the original issue with the nonce value is fixed: [INT-3611](https://jira.bigcommerce.com/browse/INT-3611)
https://drive.google.com/file/d/1jF8xMUZkK_sInv_W2G5QNRELB-CtUaTB/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
