### PR TITLE
feat(payment): INT-4237 Add issuer for Mollie APMs

### DIFF
--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -1,4 +1,4 @@
-import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithCheckoutcomiDealInstrument, WithCheckoutcomFawryInstrument, WithCheckoutcomSEPAInstrument, WithDocumentInstrument } from '../payment';
+import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithCheckoutcomiDealInstrument, WithCheckoutcomFawryInstrument, WithCheckoutcomSEPAInstrument, WithDocumentInstrument, WithMollieIssuerInstrument } from '../payment';
 
 /**
  * An object that contains the information required for submitting an order.
@@ -39,5 +39,5 @@ export interface OrderPaymentRequestBody {
      * An object that contains the details of a credit card, vaulted payment
      * instrument or nonce instrument.
      */
-    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument | CreditCardInstrument & WithCheckoutcomFawryInstrument | CreditCardInstrument & WithCheckoutcomSEPAInstrument | CreditCardInstrument & WithCheckoutcomiDealInstrument;
+    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument | CreditCardInstrument & WithCheckoutcomFawryInstrument | CreditCardInstrument & WithCheckoutcomSEPAInstrument | CreditCardInstrument & WithCheckoutcomiDealInstrument | HostedInstrument & WithMollieIssuerInstrument;
 }

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -24,7 +24,8 @@ export {
     NonceInstrument,
     ThreeDSecure,
     ThreeDSecureToken,
-    WithDocumentInstrument
+    WithDocumentInstrument,
+    WithMollieIssuerInstrument
 } from './payment';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -18,7 +18,7 @@ export type PaymentInstrument = (
     CreditCardInstrument & WithCheckoutcomFawryInstrument |
     CreditCardInstrument & WithCheckoutcomSEPAInstrument |
     CryptogramInstrument |
-    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | WithCheckoutcomiDealInstrument | WithCheckoutcomFawryInstrument | WithCheckoutcomSEPAInstrument | StripeV3Intent> |
+    FormattedPayload<AdyenV2Instrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | WithCheckoutcomiDealInstrument | WithCheckoutcomFawryInstrument | WithCheckoutcomSEPAInstrument | StripeV3Intent | WithMollieIssuerInstrument> |
     HostedInstrument |
     NonceInstrument |
     ThreeDSVaultedInstrument |
@@ -48,6 +48,10 @@ export interface CreditCardInstrument {
 
 export interface WithDocumentInstrument {
     ccDocument: string;
+}
+
+export interface WithMollieIssuerInstrument {
+    issuer: string;
 }
 
 export interface WithCheckoutcomSEPAInstrument {

--- a/src/payment/strategies/klarnav2/klarna-supported-countries.ts
+++ b/src/payment/strategies/klarnav2/klarna-supported-countries.ts
@@ -1,2 +1,2 @@
-export const supportedCountries = ['AT', 'CH', 'DE', 'DK', 'ES', 'FI', 'GB', 'NL', 'NO', 'NZ', 'SE'];
+export const supportedCountries = ['AT', 'BE', 'CH', 'DE', 'DK', 'ES', 'FI', 'GB', 'IT', 'NL', 'NO', 'NZ', 'SE'];
 export const supportedCountriesRequiringStates = ['AU'];

--- a/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -20,7 +20,7 @@ import PaymentRequestTransformer from '../../payment-request-transformer';
 import {  MollieClient, MollieElement, MollieHostWindow } from './mollie';
 import MolliePaymentStrategy from './mollie-payment-strategy';
 import MollieScriptLoader from './mollie-script-loader';
-import { getInitializeOptions, getMollieClient, getOrderRequestBodyAPMs, getOrderRequestBodyWithoutPayment, getOrderRequestBodyWithCreditCard } from './mollie.mock';
+import { getInitializeOptions, getMollieClient, getOrderRequestBodyAPMs,  getOrderRequestBodyVaultAPMs, getOrderRequestBodyWithoutPayment, getOrderRequestBodyWithCreditCard } from './mollie.mock';
 
 describe('MolliePaymentStrategy', () => {
     let orderRequestSender: OrderRequestSender;
@@ -207,7 +207,29 @@ describe('MolliePaymentStrategy', () => {
                 expect(paymentActionCreator.submitPayment).toBeCalledWith({
                     gatewayId: 'mollie',
                     methodId: 'belfius',
-                    paymentData: undefined,
+                    paymentData: {
+                        formattedPayload: {
+                            issuer: 'foo',
+                        },
+                        issuer: 'foo',
+                    },
+                });
+            });
+
+            it('should save vault_payment_instrument on APMs', async () => {
+                await strategy.initialize(options);
+                await strategy.execute(getOrderRequestBodyVaultAPMs());
+
+                expect(paymentActionCreator.submitPayment).toBeCalledWith({
+                    gatewayId: 'mollie',
+                    methodId: 'belfius',
+                    paymentData: {
+                        formattedPayload: {
+                            issuer: '',
+                        },
+                        shouldSaveInstrument: true,
+                        shouldSetAsDefaultInstrument: false,
+                    },
                 });
             });
         });

--- a/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -71,7 +71,7 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         const shouldSaveInstrument = (paymentData as HostedInstrument)?.shouldSaveInstrument;
         const shouldSetAsDefaultInstrument = (paymentData as HostedInstrument)?.shouldSetAsDefaultInstrument;
 
-        if (!payment) {
+        if (!payment || !paymentData) {
             throw new PaymentArgumentInvalidError([ 'payment' ]);
         }
 
@@ -105,7 +105,17 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             } else {
                 await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
-                return await this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
+                const issuer = 'issuer' in paymentData ? paymentData.issuer : '';
+
+                return await this._store.dispatch(this._paymentActionCreator.submitPayment({
+                    ...payment,
+                    paymentData: {
+                        ...paymentData,
+                        formattedPayload: {
+                            issuer,
+                        },
+                    },
+                }));
             }
         } catch (error) {
 

--- a/src/payment/strategies/mollie/mollie.mock.ts
+++ b/src/payment/strategies/mollie/mollie.mock.ts
@@ -45,7 +45,7 @@ export function getOrderRequestBodyWithCreditCard(): OrderRequestBody {
         payment: {
             methodId: 'credit_card',
             gatewayId: 'mollie',
-            paymentData: undefined,
+            paymentData: {},
         },
     };
 }
@@ -56,7 +56,23 @@ export function getOrderRequestBodyAPMs(): OrderRequestBody {
         payment: {
             methodId: 'belfius',
             gatewayId: 'mollie',
-            paymentData: undefined,
+            paymentData: {
+                issuer: 'foo',
+            },
+        },
+    };
+}
+
+export function getOrderRequestBodyVaultAPMs(): OrderRequestBody {
+    return {
+        useStoreCredit: false,
+        payment: {
+            methodId: 'belfius',
+            gatewayId: 'mollie',
+            paymentData: {
+                shouldSaveInstrument: true,
+                shouldSetAsDefaultInstrument: false,
+            },
         },
     };
 }


### PR DESCRIPTION
## What? [INT-4237](https://jira.bigcommerce.com/browse/INT-4237), [INT-3772](https://jira.bigcommerce.com/browse/INT-3772)
 List Issuing Banks In Dropdown on Payment Step, adding  IssuerInstrument to Mollie on strategy and payment

Adding BE and IT to the `klarna-supported-countries.ts` in order for Klarna to Suppport these countries


## Why?
Some APMs such as Ideal have bank from where to choose, 

## Testing / Proof
![Screen Shot 2021-04-28 at 15 17 34](https://user-images.githubusercontent.com/69221626/116467058-e04f6f00-a834-11eb-91a2-f1a7ad56b553.png)

## Siblings 
[JS](https://github.com/bigcommerce/checkout-js/pull/566)
[BCAPP](https://github.com/bigcommerce/bigcommerce/pull/40630)
[BIGPAY](https://github.com/bigcommerce/bigpay/pull/3748)

@bigcommerce/checkout @bigcommerce/payments
