### PR TITLE
feat(payment): PAYMENTS-6806 add dummy PPSDK strategy

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -32,6 +32,7 @@ import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy } from './strategies/paypal';
 import { PaypalCommercePaymentStrategy } from './strategies/paypal-commerce';
+import { PPSDKStrategy } from './strategies/ppsdk';
 import { SagePayPaymentStrategy } from './strategies/sage-pay';
 import { SquarePaymentStrategy } from './strategies/square';
 import { StripeV3PaymentStrategy } from './strategies/stripev3';
@@ -247,5 +248,10 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate zip', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.ZIP);
         expect(paymentStrategy).toBeInstanceOf(ZipPaymentStrategy);
+    });
+
+    it('can instantiate ppsdk', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.PPSDK);
+        expect(paymentStrategy).toBeInstanceOf(PPSDKStrategy);
     });
 });

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -57,6 +57,7 @@ import { createPaypalCommercePaymentProcessor,
     PaypalCommerceHostedForm,
     PaypalCommercePaymentStrategy,
     PaypalCommerceRequestSender } from './strategies/paypal-commerce';
+import { PPSDKStrategy } from './strategies/ppsdk';
 import { SagePayPaymentStrategy } from './strategies/sage-pay';
 import { SquarePaymentStrategy, SquareScriptLoader } from './strategies/square';
 import { StripeScriptLoader, StripeV3PaymentStrategy } from './strategies/stripev3';
@@ -367,6 +368,12 @@ export default function createPaymentStrategyRegistry(
             new PaypalCommerceFundingKeyResolver(),
             new PaypalCommerceRequestSender(requestSender),
             new LoadingIndicator({ styles: { backgroundColor: 'black' } })
+        )
+    );
+
+    registry.register(PaymentStrategyType.PPSDK, () =>
+        new PPSDKStrategy(
+            store
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -146,6 +146,16 @@ export function getPaypal(): PaymentMethod {
     };
 }
 
+export function getPPSDK(): PaymentMethod {
+    return {
+        id: 'cabbagepay',
+        method: 'credit-card',
+        supportedCards: [],
+        config: {},
+        type: 'PAYMENT_TYPE_SDK',
+    };
+}
+
 export function getAdyenAmex(): PaymentMethod {
     return {
         id: 'amex',

--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -41,6 +41,15 @@ export default class PaymentStrategyRegistry extends Registry<PaymentStrategy, P
     }
 
     private _getToken(paymentMethod: PaymentMethod): PaymentStrategyType {
+        const ppsdkFeatureOn =
+            this._store.getState()
+                .config.getStoreConfig()
+                ?.checkoutSettings.features['PAYMENTS-6806.enable_ppsdk_strategy'];
+
+        if (ppsdkFeatureOn && paymentMethod.type === PaymentStrategyType.PPSDK) {
+            return PaymentStrategyType.PPSDK;
+        }
+
         if (paymentMethod.gateway === 'klarna') {
             return PaymentStrategyType.KLARNAV2;
         }

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -36,6 +36,7 @@ enum PaymentStrategyType {
     PAYPAL_COMMERCE_CREDIT = 'paypalcommercecredit',
     PAYPAL_COMMERCE_CREDIT_CARD = 'paypalcommercecreditcards',
     PAYPAL_COMMERCE_ALTERNATIVE_METHODS = 'paypalcommercealternativemethods',
+    PPSDK = 'PAYMENT_TYPE_SDK',
     SAGE_PAY = 'sagepay',
     SQUARE = 'squarev2',
     STRIPEV3 = 'stripev3',

--- a/src/payment/strategies/ppsdk/index.ts
+++ b/src/payment/strategies/ppsdk/index.ts
@@ -1,0 +1,1 @@
+export { PPSDKStrategy } from './ppsdk-strategy';

--- a/src/payment/strategies/ppsdk/ppsdk-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.ts
@@ -1,0 +1,27 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { OrderRequestBody } from '../../../order';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+export class PPSDKStrategy implements PaymentStrategy {
+
+    constructor(
+        protected _store: CheckoutStore
+    ) {}
+
+    execute(_payload: OrderRequestBody, _options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    finalize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    initialize(_options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+}


### PR DESCRIPTION
https://jira.bigcommerce.com/browse/PAYMENTS-6806

BCApp Experiment PR: https://github.com/bigcommerce/bigcommerce/pull/40715

## What?
- Add the start of a PPSDK Strategy behind an experiment flag: `PAYMENTS-6806.enable_ppsdk_strategy`
- The initial strategy is just a dummy class with no functionality

## Why?
- To safely begin building out the ability to consume PPSDK payment methods

## Testing / Proof
- Passing tests
- No outward changes - due to work in progress being gated behind flag

@bigcommerce/checkout @bigcommerce/payments
