### PR TITLE
fix(checkout): INT-3941 Updated remote-checkout path on button initialization

### DIFF
--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
@@ -191,7 +191,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
                 AmazonPayV2PayOptions.PayAndShip,
             createCheckoutSession: {
                 method: checkoutSessionMethod,
-                url: `${config.links.siteLink}/remote-checkout/${paymentMethod.id}/payment-session`,
+                url: `${config.storeProfile.shopPath}/remote-checkout/${paymentMethod.id}/payment-session`,
                 extractAmazonCheckoutSessionId,
             },
             placement: AmazonPayV2Placement.Checkout,


### PR DESCRIPTION
[INT-3941](https://jira.bigcommerce.com/browse/INT-3941)

## What?
- When you create a cart that contains a channel id, the amazon pay button in the checkout takes from bcapp a path that brings null, So if that channel id does not have a linked site, it comes with null. But that shouldn't affect the remote-checkout button so the path was changed to redirect to the correct domain of the store.

## Why?
- It uses a path that should not use because it would be a different domain than the BigCommerce Store and it is a requirement of Amazon Pay. (Only one BigCommerce store can be linked to a single Seller Central account).

There are 3 ways to initialize the payment button of amazon pay and only one of them did not work, so we changed the path like the others and now it works.
 
1) createCheckoutSession: {
                url: `${shopPath}/remote-checkout/${paymentMethod.id}/payment-session`,
                method: checkoutSessionMethod,
                extractAmazonCheckoutSessionId,
            },
 This is the amazon pay button v1 in cart. file: amazon-pay-v2-button-strategy.ts 

2) createCheckoutSession: {
                method: checkoutSessionMethod,
                url: `${config.storeProfile.shopPath}/remote-checkout/${methodId}/payment-session`,
                extractAmazonCheckoutSessionId,
            },
This is the amazon pay button v1 in customer section on checkout. file: amazon-pay-v2-customer-strategy.ts

3) Before this commit
     createCheckoutSession: {
                method: checkoutSessionMethod,
                url: `${config.links.siteLink}/remote-checkout/${paymentMethod.id}/payment-session`,
                extractAmazonCheckoutSessionId,
            },
 This is the amazon pay button in the payment section on checout. file: amazon-pay-v2-payment-strategy.ts 

## Testing / Proof
Create a cart with channel ID other than the native BigCommerce store. It does not occur when the channel ID is omitted or set to the native BigCommerce store.
Example:
POST https://api.integration.zone/stores/ukrzatksj0/v3/carts
{
"line_items":[
{ "quantity":3, "product_id":77 ,"variant_id": 2}
],
"channel_id": 1478064,
"customer_id":1
}

Returns Cart ID

POST https://api.integration.zone/stores/ukrzatksj0/v3/carts/d7e2b472-c791-49b8-8138-12855c6a2aae/redirect_urls

Returns Checkout URL

Then click on the check-out url.  Go to checkout area, complete customer, shipping, billing and click on amazon pay on payment section. You must go to amazon pay login.  



@bigcommerce/checkout @bigcommerce/payments