### PR TITLE
feat(payment): INT-4170 added hosted field validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6910,8 +6910,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6932,14 +6931,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6954,20 +6951,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7084,14 +7078,12 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7106,7 +7098,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7114,14 +7105,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7140,7 +7129,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7221,8 +7209,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7234,7 +7221,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7320,8 +7306,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7357,7 +7342,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7377,7 +7361,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7421,14 +7404,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -646,6 +646,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             new StripeScriptLoader(scriptLoader),
             storeCreditActionCreator,
+            hostedFormFactory,
             locale
         )
     );

--- a/src/payment/strategies/stripev3/stripev3-initialize-options.ts
+++ b/src/payment/strategies/stripev3/stripev3-initialize-options.ts
@@ -1,3 +1,5 @@
+import { HostedFormOptions } from '../../../hosted-form';
+
 import { IndividualCardElementOptions, StripeElementOptions } from './stripev3';
 
 /**
@@ -52,4 +54,6 @@ export default interface StripeV3PaymentInitializeOptions {
     containerId: string;
 
     options?: StripeElementOptions | IndividualCardElementOptions;
+
+    form?: HostedFormOptions;
 }

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -6,6 +6,8 @@ import { isBillingAddressLike, BillingAddress } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
 import { Customer } from '../../../customer';
+import { HostedForm, HostedFormFactory, HostedFormOptions } from '../../../hosted-form';
+import { InvalidHostedFormError } from '../../../hosted-form/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getShippableItemsCount } from '../../../shipping';
@@ -32,7 +34,8 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
     private _stripeElement?: StripeElement;
     private _stripeCardElements?: StripeCardElements;
     private _useIndividualCardFields?: boolean;
-
+    private _hostedForm?: HostedForm;
+    private _shouldRenderHostedForm?: boolean;
     constructor(
         private _store: CheckoutStore,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
@@ -40,18 +43,24 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         private _orderActionCreator: OrderActionCreator,
         private _stripeScriptLoader: StripeV3ScriptLoader,
         private _storeCreditActionCreator: StoreCreditActionCreator,
+        private _hostedFormFactory: HostedFormFactory,
         private _locale: string
     ) {}
 
     async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         this._initializeOptions = options;
-
         const paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(this._getInitializeOptions().methodId);
         const { initializationData: { stripePublishableKey, stripeConnectedAccount, useIndividualCardFields } } = paymentMethod;
 
         this._useIndividualCardFields = useIndividualCardFields;
         this._stripeV3Client = await this._loadStripeJs(stripePublishableKey, stripeConnectedAccount);
         this._stripeElement = await this._mountElement(this._getInitializeOptions().methodId);
+
+        if (StripePaymentMethodType.CreditCard &&
+            this._isHostedPaymentFormEnabled(this._getInitializeOptions().methodId, this._getInitializeOptions().gatewayId) &&
+            this._isHostedFieldAvailable() && options.stripev3 && options.stripev3.form) {
+            await this._mountCardVerificationfields(options.stripev3.form);
+        }
 
         return Promise.resolve(this._store.getState());
     }
@@ -78,6 +87,24 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         if (isVaultedInstrument(paymentData)) {
             // tslint:disable-next-line: variable-name
             const { instrumentId: token, ccNumber: credit_card_number_confirmation, ccCvv: verification_value } = paymentData;
+
+            if (this._isHostedPaymentFormEnabled(methodId, gatewayId) && this._shouldRenderHostedForm) {
+                const form = this._hostedForm;
+
+                if (!form) {
+                    throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+                }
+
+                try {
+                    await form.validate();
+                } catch (error) {
+                    if (error instanceof InvalidHostedFormError) {
+                        return Promise.reject(error);
+                    }
+
+                    throw new Error(error.message);
+                }
+            }
 
             formattedPayload = {
                 bigpay_token: { token },
@@ -476,5 +503,33 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
             this._stripeElement.unmount();
             this._stripeElement = undefined;
         }
+    }
+
+    private async _mountCardVerificationfields(formOptions: HostedFormOptions) {
+
+        if (!formOptions) {
+            throw new InvalidArgumentError();
+        }
+
+        const { config } = this._store.getState();
+        const { paymentSettings: { bigpayBaseUrl: host = '' } = {} } = config.getStoreConfig() || {};
+
+        const form = this._hostedFormFactory.create(host, formOptions);
+        await form.attach();
+        this._shouldRenderHostedForm = true;
+        this._hostedForm = form;
+    }
+
+    private _isHostedPaymentFormEnabled(methodId: string, gatewayId?: string): boolean {
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(methodId, gatewayId);
+
+        return paymentMethod.config.isHostedFormEnabled === true;
+    }
+
+    private _isHostedFieldAvailable(): boolean {
+        const options = this._getInitializeOptions();
+
+        return (options.stripev3?.form && options.stripev3.form.fields) ? true : false;
     }
 }

--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -66,7 +66,7 @@ export function getStripeV3InitializeOptionsMock(stripeElementType: StripeElemen
     };
 }
 
-export function getStripeV3InitializeOptionsMockSingleElements(includeZipCode: boolean = false): PaymentInitializeOptions {
+export function getStripeV3InitializeOptionsMockSingleElements(includeZipCode: boolean = false, tsvFormActive: boolean = false): PaymentInitializeOptions {
     const paymentInitializeOptions: PaymentInitializeOptions = {
         methodId: 'card',
     };
@@ -108,6 +108,32 @@ export function getStripeV3InitializeOptionsMockSingleElements(includeZipCode: b
                 options: {
                     ...individualCardElementOptions,
                     zipCodeElementOptions: { containerId: 'stripe-postal-code-component-field' },
+                },
+            },
+        };
+    }
+
+    if (tsvFormActive) {
+        return {
+            ...paymentInitializeOptions,
+            stripev3: {
+                ...stripeV3PaymentInitializeOptions,
+                options: {
+                    ...individualCardElementOptions,
+                },
+                form: {
+                    fields: {
+                        cardCodeVerification: {
+                                accessibilityLabel: 'CVV',
+                                containerId: 'stripev3-ccCvv',
+                                instrumentId: '1234',
+                            },
+                        cardNumberVerification: {
+                            accessibilityLabel: 'Number',
+                            containerId: 'stripev3-ccNumber',
+                            instrumentId: '1234',
+                        },
+                    },
                 },
             },
         };


### PR DESCRIPTION
## What? [INT-4170](https://jira.bigcommerce.com/browse/INT-4170)
Added hosted fields on verification fields on Stripev3.

## Why?
Currently, we have some payment methods that are not using hosted credit card fields for stored instrument verifications (card number and CVV). This presents a security vulnerability as malicious JS can easily scrape credit card information.

## Dependencies
https://github.com/bigcommerce/checkout-js/pull/580

## Testing / Proof

[Testing proof Video INT-4170](https://drive.google.com/file/d/17K9KySwRmvx7p-AEId3N2fdN7-5bbn2V/view?usp=sharing)


@bigcommerce/checkout
