### PR TITLE
feat(payment): PAYMENTS-6813 extend Payment Method type to cover PPSDK variants

### DIFF
--- a/src/payment/payment-method.ts
+++ b/src/payment/payment-method.ts
@@ -1,5 +1,5 @@
 import PaymentMethodConfig from './payment-method-config';
-
+import InitialisationStrategies from './ppsdk-initialisation-strategies';
 export default interface PaymentMethod {
     id: string;
     config: PaymentMethodConfig;
@@ -12,4 +12,5 @@ export default interface PaymentMethod {
     nonce?: string;
     initializationData?: any;
     returnUrl?: string;
+    initializationStrategy?: InitialisationStrategies;
 }

--- a/src/payment/ppsdk-initialisation-strategies.ts
+++ b/src/payment/ppsdk-initialisation-strategies.ts
@@ -1,0 +1,11 @@
+interface BaseStrategy {
+    type: string;
+}
+
+interface None extends BaseStrategy {
+    type: 'NONE';
+}
+
+type InitialisationStrategies = None;
+
+export default InitialisationStrategies;


### PR DESCRIPTION
## What?

- Extend the SDK's notion of `PaymentMethod`s that will come over the wire to include a new, optional `initializationStrategy` attribute
- `initializationStrategy` will be a union of all future PPSDK 'initialisation strategies', each with their own schema

## Why?

- In future work these extra details can be used by the `PPSDKStrategy` for it to init correctly (https://github.com/bigcommerce/checkout-sdk-js/blob/d57e3ba074a16a8f4fed4aa3389ebcbcd374c5bb/src/payment/strategies/ppsdk/ppsdk-strategy.ts currently a wip, behind an experiment flag)
- So this new `PaymentMethod` shape is inherited by `checkout-js`, where it can be used to render the correct PPSDK UIs (https://github.com/bigcommerce/checkout-js/pull/586)

## Testing / Proof

- None: this is an additive, optional attribute on an existing type

@bigcommerce/checkout @bigcommerce/payments
