### PR TITLE
feat(payment): INT-4170 added hosted fields on Mollie verification field

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -652,6 +652,7 @@ export default function createPaymentStrategyRegistry(
 
     registry.register(PaymentStrategyType.MOLLIE, () =>
         new MolliePaymentStrategy(
+            hostedFormFactory,
             store,
             new MollieScriptLoader(scriptLoader),
             orderActionCreator,

--- a/src/payment/strategies/mollie/mollie-initialize-options.ts
+++ b/src/payment/strategies/mollie/mollie-initialize-options.ts
@@ -1,3 +1,5 @@
+import { HostedFormOptions } from '../../../hosted-form';
+
 /**
  * A set of options that are required to initialize the Mollie payment method.
  *
@@ -54,4 +56,9 @@ export default interface MolliePaymentInitializeOptions {
      * A set of styles required for the mollie components
      */
     styles: object;
+
+    /**
+     * Hosted Form Validation Options
+     */
+    form?: HostedFormOptions;
 }

--- a/src/payment/strategies/mollie/mollie.mock.ts
+++ b/src/payment/strategies/mollie/mollie.mock.ts
@@ -1,3 +1,4 @@
+import { HostedFieldType } from '../../../hosted-form';
 import { OrderRequestBody } from '../../../order';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 
@@ -6,6 +7,7 @@ import { MollieClient } from './mollie';
 export function getInitializeOptions(): PaymentInitializeOptions {
     return {
         methodId: 'credit_card',
+        gatewayId: 'mollie',
         mollie: {
             containerId: 'mollie-element',
             cardCvcId: 'mollie-card-cvc-component-field',
@@ -13,6 +15,28 @@ export function getInitializeOptions(): PaymentInitializeOptions {
             cardHolderId: 'mollie-card-holder-component-field',
             cardNumberId: 'mollie-card-number-component-field',
             styles: {valid: '#0f0'},
+        },
+    };
+}
+
+export function getHostedFormInitializeOptions(): PaymentInitializeOptions {
+    return {
+        methodId: 'credit_card',
+        gatewayId: 'mollie',
+        mollie: {
+            containerId: 'mollie-element',
+            cardCvcId: 'mollie-card-cvc-component-field',
+            cardExpiryId: 'mollie-card-expiry-component-field',
+            cardHolderId: 'mollie-card-holder-component-field',
+            cardNumberId: 'mollie-card-number-component-field',
+            styles: {valid: '#0f0'},
+            form: {
+                fields: {
+                    [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                    [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                    [HostedFieldType.CardName]: { containerId: 'card-name' },
+                },
+            },
         },
     };
 }
@@ -72,6 +96,35 @@ export function getOrderRequestBodyVaultAPMs(): OrderRequestBody {
             paymentData: {
                 shouldSaveInstrument: true,
                 shouldSetAsDefaultInstrument: false,
+            },
+        },
+    };
+}
+
+export function getOrderRequestBodyVaultCC(): OrderRequestBody {
+    return {
+        useStoreCredit: false,
+        payment: {
+            methodId: 'credit_card',
+            gatewayId: 'mollie',
+            paymentData: {
+                shouldSaveInstrument: true,
+                shouldSetAsDefaultInstrument: true,
+            },
+        },
+    };
+}
+
+export function getOrderRequestBodyVaultedCC(): OrderRequestBody {
+    return {
+        useStoreCredit: false,
+        payment: {
+            methodId: 'credit_card',
+            gatewayId: 'mollie',
+            paymentData: {
+                shouldSaveInstrument: true,
+                shouldSetAsDefaultInstrument: true,
+                instrumentId: '1234',
             },
         },
     };


### PR DESCRIPTION
What? INT-4170

Added hosted fields on verification fields on Mollie. 

Why?

Currently, we have some payment methods that are not using hosted credit card fields for stored instrument verifications (card number and CVV). This presents a security vulnerability as malicious JS can easily scrape credit card information.

## Testing / Proof

![Screen Shot 2021-05-20 at 16 07 38](https://user-images.githubusercontent.com/69221626/119048927-877f7c00-b985-11eb-997c-3f1d857be68b.png)

@bigcommerce/checkout @bigcommerce/payments
