### PR TITLE
feat(payment): INT-4197 added type and color parameters on googlepay checkout button

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -54,6 +54,12 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
     containerId: string;
 
     /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support adyenv2 GooglePay.
+     */
+     googlepayadyenv2?: GooglePayButtonInitializeOptions;
+
+    /**
      * The options that are required to facilitate Braintree GooglePay. They can be
      * omitted unless you need to support Braintree GooglePay.
      */

--- a/src/checkout-buttons/strategies/googlepay/googlepay-adyenv2-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-adyenv2-button-strategy.spec.ts
@@ -99,7 +99,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
     describe('#initialize()', () => {
         it('Creates the button', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2, Mode.GooglePayAdyenV2);
 
             await strategy.initialize(checkoutButtonOptions);
 
@@ -107,7 +107,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         });
 
         it('Validates if strategy has been initialized', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ADYENV2, Mode.GooglePayAdyenV2);
 
             await strategy.initialize(checkoutButtonOptions);
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-authorizenet-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-authorizenet-button-strategy.spec.ts
@@ -99,7 +99,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
     describe('#initialize()', () => {
         it('Creates the button', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.GooglePayAuthorizeNet);
 
             await strategy.initialize(checkoutButtonOptions);
 
@@ -107,7 +107,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         });
 
         it('Validates if strategy has been initialized', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_AUTHORIZENET, Mode.GooglePayAuthorizeNet);
 
             await strategy.initialize(checkoutButtonOptions);
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -105,7 +105,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
     describe('#initialize()', () => {
         it('Creates the button', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, Mode.GooglePayBraintree);
 
             await strategy.initialize(checkoutButtonOptions);
 
@@ -113,7 +113,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         });
 
         it('Validates if strategy has been initialized', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE, Mode.GooglePayBraintree);
 
             await strategy.initialize(checkoutButtonOptions);
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -8,6 +8,7 @@ import { getShippableItemsCount } from '../../../shipping';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
+import { GooglePayButtonInitializeOptions } from './googlepay-button-options';
 export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
     private _methodId?: string;
     private _walletButton?: HTMLElement;
@@ -22,6 +23,8 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
     async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
         const { containerId, methodId } = options;
 
+        const googlePayOptions = this._getGooglePayOptions(options);
+
         if (!containerId || !methodId) {
             throw new InvalidArgumentError('Unable to proceed because "containerId" argument is not provided.');
         }
@@ -31,7 +34,7 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
         await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         await this._googlePayPaymentProcessor.initialize(this._getMethodId());
 
-        this._walletButton = this._createSignInButton(containerId);
+        this._walletButton = this._createSignInButton(containerId, googlePayOptions);
     }
 
     deinitialize(): Promise<void> {
@@ -43,14 +46,15 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
         return this._googlePayPaymentProcessor.deinitialize();
     }
 
-    private _createSignInButton(containerId: string): HTMLElement {
+    private _createSignInButton(containerId: string, buttonOptions: GooglePayButtonInitializeOptions): HTMLElement {
         const container = document.getElementById(containerId);
+        const { buttonType, buttonColor } = buttonOptions;
 
         if (!container) {
             throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
         }
 
-        const googlePayButton = this._googlePayPaymentProcessor.createButton(this._handleWalletButtonClick);
+        const googlePayButton = this._googlePayPaymentProcessor.createButton(this._handleWalletButtonClick, buttonType, buttonColor);
 
         container.appendChild(googlePayButton);
 
@@ -63,6 +67,35 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
         }
 
         return this._methodId;
+    }
+
+    private _getGooglePayOptions(options: CheckoutButtonInitializeOptions): GooglePayButtonInitializeOptions {
+
+        if (options.methodId === 'googlepayadyenv2' && options.googlepayadyenv2) {
+            return options.googlepayadyenv2;
+        }
+
+        if (options.methodId === 'googlepayauthorizenet' && options.googlepayauthorizenet) {
+            return options.googlepayauthorizenet;
+        }
+
+        if (options.methodId === 'googlepaybraintree' && options.googlepaybraintree) {
+            return options.googlepaybraintree;
+        }
+
+        if (options.methodId === 'googlepaycheckoutcom' && options.googlepaycheckoutcom) {
+            return options.googlepaycheckoutcom;
+        }
+
+        if (options.methodId === 'googlepaycybersourcev2' && options.googlepaycybersourcev2) {
+            return options.googlepaycybersourcev2;
+        }
+
+        if (options.methodId === 'googlepaystripe' && options.googlepaystripe) {
+            return options.googlepaystripe;
+        }
+
+        throw new InvalidArgumentError();
     }
 
     @bind

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -31,7 +31,7 @@ export function getCheckoutButtonOptions(methodId: CheckoutButtonMethodType, mod
     const undefinedContainerId = { containerId: '' };
     const invalidContainerId = { containerId: 'invalid_container' };
     const googlepayadyenv2 = { googlepayadyenv2: { buttonType: ButtonType.Short } };
-    const googlepayauthorizenet = { googlepaybraintree: { buttonType: ButtonType.Short } };
+    const googlepayauthorizenet = { googlepayauthorizenet: { buttonType: ButtonType.Short } };
     const googlepaybraintree = { googlepaybraintree: { buttonType: ButtonType.Short } };
     const googlepaycheckoutcom = { googlepaycheckoutcom: { buttonType: ButtonType.Short } };
     const googlepaycybersourcev2 = { googlepaycybersourcev2: { buttonType: ButtonType.Short } };

--- a/src/checkout-buttons/strategies/googlepay/googlepay-checkoutcom-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-checkoutcom-button-strategy.spec.ts
@@ -105,7 +105,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
     describe('#initialize()', () => {
         it('Creates the button', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM, Mode.GooglePayCheckoutcom);
 
             await strategy.initialize(checkoutButtonOptions);
 
@@ -113,7 +113,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         });
 
         it('initializes paymentProcessor only once', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CHECKOUTCOM, Mode.GooglePayCheckoutcom);
 
             await strategy.initialize(checkoutButtonOptions);
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-cybersourcev2-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-cybersourcev2-button-strategy.spec.ts
@@ -105,7 +105,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
     describe('#initialize()', () => {
         it('Creates the button', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2, Mode.GooglePayCybersourceV2);
 
             await strategy.initialize(checkoutButtonOptions);
 
@@ -113,7 +113,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         });
 
         it('initializes paymentProcessor only once', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_CYBERSOURCEV2, Mode.GooglePayCybersourceV2);
 
             await strategy.initialize(checkoutButtonOptions);
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
@@ -99,15 +99,14 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
     describe('#initialize()', () => {
         it('Creates the button', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_STRIPE);
-
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_STRIPE, Mode.GooglePayStripe);
             await strategy.initialize(checkoutButtonOptions);
 
             expect(paymentProcessor.createButton).toHaveBeenCalled();
         });
 
         it('Validates if strategy has been initialized', async () => {
-            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_STRIPE);
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_STRIPE, Mode.GooglePayStripe);
 
             await strategy.initialize(checkoutButtonOptions);
 

--- a/src/customer/strategies/googlepay/googlepay-customer-initialize-options.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-initialize-options.ts
@@ -1,3 +1,4 @@
+import { ButtonColor, ButtonType } from '../../../payment/strategies/googlepay';
 export default interface GooglePayCustomerInitializeOptions {
     /**
      * This container is used to set an event listener, provide an element ID if you want
@@ -5,4 +6,19 @@ export default interface GooglePayCustomerInitializeOptions {
      * It should be an HTML element.
      */
     container: string;
+
+    /**
+     * The color of the GooglePay button that will be inserted.
+     *  black (default): a black button suitable for use on white or light backgrounds.
+     *  white: a white button suitable for use on colorful backgrounds.
+     */
+     buttonColor?: ButtonColor;
+
+     /**
+      * The size of the GooglePay button that will be inserted.
+      *  long: "Buy with Google Pay" button (default). A translated button label may appear
+      *         if a language specified in the viewer's browser matches an available language.
+      *  short: Google Pay payment button without the "Buy with" text.
+      */
+     buttonType?: ButtonType;
 }

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -32,7 +32,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
 
         return this._googlePayPaymentProcessor.initialize(methodId)
             .then(() => {
-                this._walletButton = this._createSignInButton(googlePayOptions.container);
+                this._walletButton = this._createSignInButton(googlePayOptions.container, googlePayOptions);
             })
             .then(() => this._store.getState());
     }
@@ -66,14 +66,15 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         );
     }
 
-    private _createSignInButton(containerId: string): HTMLElement {
+    private _createSignInButton(containerId: string, buttonOptions: GooglePayCustomerInitializeOptions): HTMLElement {
         const container = document.querySelector(`#${containerId}`);
+        const { buttonType, buttonColor } = buttonOptions;
 
         if (!container) {
             throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
         }
 
-        const button = this._googlePayPaymentProcessor.createButton(this._handleWalletButtonClick);
+        const button = this._googlePayPaymentProcessor.createButton(this._handleWalletButtonClick, buttonType, buttonColor);
 
         container.appendChild(button);
 


### PR DESCRIPTION
## What? [INT-4197](https://jira.bigcommerce.com/browse/INT-4197)

## Why? 
In order to change UI button experience it was  passed type an color parameters to createbutton method

## Testing / Proof
[TESTING PROOF VIDEO](https://drive.google.com/file/d/1MO5iRPADbiICc1qyWlI_RbYnHjIOmcFG/view?usp=sharing)

![Screen Shot 2021-05-18 at 5 40 34 PM](https://user-images.githubusercontent.com/61981535/118732540-28dcc580-b800-11eb-9ee2-a4b1c387067f.png)
![Screen Shot 2021-05-19 at 5 19 54 PM](https://user-images.githubusercontent.com/61981535/118892537-a7039f80-b8c6-11eb-9d90-b3e57bf4782e.png)
![Screen Shot 2021-05-19 at 5 20 12 PM](https://user-images.githubusercontent.com/61981535/118892559-aec34400-b8c6-11eb-9a8e-215097afe720.png)
![Screen Shot 2021-05-19 at 5 19 14 PM](https://user-images.githubusercontent.com/61981535/118892580-b71b7f00-b8c6-11eb-867e-45a04dd69887.png)



@bigcommerce/checkout @bigcommerce/payments
