### PR TITLE
feat(checkout): PAYPAL-1024 make APM work regardless of  geolocation

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -74,7 +74,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
 
         const loadingIndicatorContainerId = container.split('#')[1];
 
-        const paramsScript = this._getOptionsScript(initializationData, currencyCode);
+        const paramsScript = this._getOptionsScript(initializationData, currencyCode, this._isAPM ? methodId : undefined);
         const buttonParams: ButtonsOptions = {
             style: buttonStyle,
             onApprove: data => {
@@ -225,7 +225,11 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         submitForm();
     }
 
-    private _getOptionsScript(initializationData: PaypalCommerceInitializationData, currencyCode: Cart['currency']['code']): PaypalCommerceScriptParams {
+    private _getOptionsScript(
+        initializationData: PaypalCommerceInitializationData,
+        currencyCode: Cart['currency']['code'],
+        apmMehodId?: string
+    ): PaypalCommerceScriptParams {
         const { clientId, intent, merchantId, buyerCountry, isDeveloperModeApplicable } = initializationData;
 
         const returnObject = {
@@ -234,9 +238,11 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
             commit: true,
             currency: currencyCode,
             intent,
-            components: ['buttons', 'messages', 'fields'] as ComponentsScriptType,
+            components: ['buttons', 'messages', 'fields', 'funding-eligibility'] as ComponentsScriptType,
+            ...(apmMehodId && { 'enable-funding': apmMehodId}),
+            ...(isDeveloperModeApplicable && { 'buyer-country': buyerCountry }),
         };
 
-        return isDeveloperModeApplicable ? { ...returnObject, 'buyer-country': buyerCountry } : returnObject;
+        return returnObject;
     }
 }


### PR DESCRIPTION
## What?
Removed geolocation restrictions for PAYPAL APMs. Now we will check what APM is available on billing address

## Why?
Due to https://jira.bigcommerce.com/browse/PAYPAL-1024

## Testing / Proof
Tested manually.

Now on initialisation of Paypal we added funding-eligibility component and added enable-funding field where we're passing  APM id. this payment method will be eligible after these modifications.

![image](https://user-images.githubusercontent.com/79574476/118793801-9db40c00-b8a1-11eb-9580-fa18b5fefcb9.png)


@bigcommerce/checkout @bigcommerce/payments
