### PR TITLE
fix(payments): Renew the nonce for Google Payment when the payment fails.

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -297,6 +297,34 @@ describe('GooglePayPaymentStrategy', () => {
             expect(googlePayPaymentProcessor.displayWallet).toBeCalled();
         });
 
+        it('gets again the payment information and get a new nonce', async () => {
+            jest.spyOn(googlePayPaymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(getGooglePaymentDataMock());
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValueOnce({
+                initializationData: {
+                    nonce: '',
+                    card_information: {
+                        type: 'type',
+                        number: 'number',
+                    },
+                },
+            }).mockReturnValue({
+                initializationData: {
+                    nonce: 'newNonce',
+                    card_information: {
+                        type: 'type',
+                        number: 'number',
+                    },
+                },
+            });
+
+            await strategy.initialize(googlePayOptions);
+            await strategy.execute(getGoogleOrderRequestBody());
+
+            expect(store.getState().paymentMethods.getPaymentMethodOrThrow).toHaveBeenCalledTimes(3);
+            expect(googlePayPaymentProcessor.displayWallet).toBeCalled();
+        });
+
         it('gets again the payment information and user closes widget', async () => {
             jest.spyOn(googlePayPaymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -42,7 +42,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         this._googlePayOptions = this._getGooglePayOptions(options);
 
-        this._buttonClickEventHandler = this._handleButtlonClickedEvent(methodId);
+        this._buttonClickEventHandler = this._handleButtonClickedEvent(methodId);
 
         if (this._paymentMethod.initializationData.nonce) {
             return Promise.resolve(this._store.getState());
@@ -89,6 +89,11 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         const { methodId } = payload.payment;
 
+        if (this._paymentMethod?.initializationData.nonce !== '') {
+            const state = this._store.getState();
+            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        }
+
         let payment = await this._getPayment(methodId);
 
         if (!payment.paymentData.nonce || !payment.paymentData.cardInformation) {
@@ -97,11 +102,11 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 onPaymentSelect = () => {},
             } = this._googlePayOptions;
             await this._displayWallet(methodId, onPaymentSelect, onError);
-            payment = await this._getPayment(methodId);
+            payment = await this._getPayment(methodId, true);
+        }
 
-            if (!payment.paymentData.nonce) {
-                throw new MissingDataError(MissingDataErrorType.MissingPayment);
-            }
+        if (!payment.paymentData.nonce) {
+            throw new MissingDataError(MissingDataErrorType.MissingPayment);
         }
 
         try {
@@ -152,33 +157,35 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         throw new InvalidArgumentError('Unable to initialize payment because "options.googlepay" argument is not provided.');
     }
 
-    private async _getPayment(methodId: string): Promise<PaymentMethodData> {
-        if (!methodId) {
+    private async _getPayment(methodId: string, requireRenewNonce = false): Promise<PaymentMethodData> {
+        if (!methodId || !this._paymentMethod) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        let state = this._store.getState();
-        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const card_information = this._paymentMethod?.initializationData.card_information;
+        let nonce = this._paymentMethod?.initializationData.nonce;
 
-        const { nonce } = this._paymentMethod.initializationData;
         if (nonce) {
-            state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
-            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+            this._paymentMethod = { ...this._paymentMethod,  initializationData: { nonce: ''} };
         }
 
-        const { card_information: cardInformation } = this._paymentMethod.initializationData;
+        if (requireRenewNonce) {
+            const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+            this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+            nonce = this._paymentMethod?.initializationData.nonce;
+        }
 
         return {
             methodId,
             paymentData: {
                 method: methodId,
-                cardInformation,
-                nonce: this._getNonce(methodId, this._paymentMethod),
+                cardInformation: card_information,
+                nonce: await this._encodeNonce(methodId, nonce),
             },
         };
     }
 
-    private _getNonce(methodId: string, { initializationData: { nonce }}: PaymentMethod) {
+    private async _encodeNonce(methodId: string, nonce: string) {
         if (methodId === 'googlepayadyenv2') {
             return JSON.stringify({
                 type: AdyenPaymentMethodType.GooglePay,
@@ -198,13 +205,23 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         // TODO: Revisit how we deal with GooglePaymentData after receiving it from Google
         await this._googlePayPaymentProcessor.handleSuccess(paymentData);
 
+        const state = this._store.getState();
+        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        if (this._paymentMethod.initializationData.nonce) {
+            return await Promise.all([
+                this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
+                this._store.getState(),
+            ]);
+        }
+
         return await Promise.all([
             this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
             this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId)),
         ]);
     }
 
-    private _handleButtlonClickedEvent(methodId: string): (event?: Event) => Promise<InternalCheckoutSelectors> {
+    private _handleButtonClickedEvent(methodId: string): (event?: Event) => Promise<InternalCheckoutSelectors> {
 
         return (event?: Event) => {
             event?.preventDefault();


### PR DESCRIPTION
## What? [INT-4266](https://jira.bigcommerce.com/browse/INT-4266)
Renew the nonce when the payment fails for GooglePay

## Why?
If the payment fails we don't renew the nonce so the user used the same nonce to pay and never can pay again until the user delete his order and create a new one with a new nonce.

## Testing / Proof
- [x] Manual Verification () => [VIDEO](https://drive.google.com/file/d/1ofP_cVPm2424YeDXjpAaQQDFLjOAp5zU/view?usp=sharing)
- [x] Unit Test.
![image](https://user-images.githubusercontent.com/13474826/120230778-a7c8f980-c215-11eb-9e3a-c94a8610778a.png)


@bigcommerce/apex-integrations  @bigcommerce/checkout @bigcommerce/payments