### PR TITLE
feat(payment): INT-4222 Add vaulting compatibility to Moneris

### DIFF
--- a/src/hosted-form/hosted-form-options.ts
+++ b/src/hosted-form/hosted-form-options.ts
@@ -1,3 +1,5 @@
+import { Omit } from '../common/types';
+
 import HostedFieldType from './hosted-field-type';
 import { HostedInputBlurEvent, HostedInputCardTypeChangeEvent, HostedInputEnterEvent, HostedInputFocusEvent, HostedInputStyles, HostedInputValidateEvent } from './iframe-content';
 
@@ -9,6 +11,9 @@ export default interface HostedFormOptions {
     onEnter?(data: HostedFieldEnterEventData): void;
     onFocus?(data: HostedFieldFocusEventData): void;
     onValidate?(data: HostedFieldValidateEventData): void;
+}
+export interface HostedFormValidationOptions extends Omit<HostedFormOptions, 'fields'> {
+    fields: HostedStoredCardFieldOptionsMap;
 }
 
 export type HostedFieldBlurEventData = HostedInputBlurEvent['payload'];

--- a/src/hosted-form/index.ts
+++ b/src/hosted-form/index.ts
@@ -1,6 +1,6 @@
 export { default as HostedFieldType } from './hosted-field-type';
 export { default as HostedForm } from './hosted-form';
 export { default as HostedFormFactory } from './hosted-form-factory';
-export { default as HostedFormOptions } from './hosted-form-options';
+export { default as HostedFormOptions, HostedFormValidationOptions } from './hosted-form-options';
 export { default as HostedFormOrderDataTransformer } from './hosted-form-order-data-transformer';
 export { default as HostedFormOrderData } from './hosted-form-order-data';

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -709,6 +709,7 @@ export default function createPaymentStrategyRegistry(
 
     registry.register(PaymentStrategyType.MONERIS, () =>
         new MonerisPaymentStrategy(
+            hostedFormFactory,
             store,
             orderActionCreator,
             paymentActionCreator,

--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -105,6 +105,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'digitalriver',
         method: 'credit_card',
     },
+    moneris: {
+        provider: 'moneris',
+        method: 'credit_card',
+    },
 };
 
 export default supportedInstruments;

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -736,6 +736,7 @@ export function getMoneris(): PaymentMethod {
         method: 'moneris',
         supportedCards: [],
         config: {
+            isHostedFormEnabled: false,
             displayName: 'Moneris',
             testMode: false,
         },

--- a/src/payment/strategies/moneris/moneris-payment-initialize-options.ts
+++ b/src/payment/strategies/moneris/moneris-payment-initialize-options.ts
@@ -1,10 +1,17 @@
+import { HostedFormValidationOptions } from '../../../hosted-form';
+
 import MonerisStylingProps from './moneris';
 
-export default interface MonerisaymentInitializeOptions {
+export default interface MonerisPaymentInitializeOptions {
     /**
      * The ID of a container where the Moneris iframe component should be mounted
      */
     containerId: string;
 
     style?: MonerisStylingProps;
+
+    /**
+     * Hosted Form Validation Options
+     */
+    form?: HostedFormValidationOptions;
 }

--- a/src/payment/strategies/moneris/moneris-payment-strategy.ts
+++ b/src/payment/strategies/moneris/moneris-payment-strategy.ts
@@ -2,42 +2,61 @@ import { map } from 'lodash';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError , MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
-import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { HostedForm, HostedFormFactory, HostedFormValidationOptions } from '../../../hosted-form';
+import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { StoreCreditActionCreator } from '../../../store-credit';
 import { PaymentArgumentInvalidError } from '../../errors';
+import isVaultedInstrument from '../../is-vaulted-instrument';
+import { HostedInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
 import MonerisStylingProps,  { MoneriesHostedFieldsQueryParams, MonerisInitializationData, MonerisResponseData } from './moneris';
+import MonerisPaymentInitializeOptions from './moneris-payment-initialize-options';
 
 const IFRAME_NAME = 'moneris-payment-iframe';
 const RESPONSE_SUCCESS_CODE = '001';
 
 export default class MonerisPaymentStrategy implements PaymentStrategy {
     private _iframe?: HTMLIFrameElement;
+    private _initializeOptions?: MonerisPaymentInitializeOptions;
     private _windowEventListener?: (response: MessageEvent) => void;
 
+    private _hostedForm?: HostedForm;
+
     constructor(
+        private _hostedFormFactory: HostedFormFactory,
         private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
         private _storeCreditActionCreator: StoreCreditActionCreator
     ) {}
 
-    initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const state = this._store.getState();
 
-        const { moneris: monerisOptions } = options;
-        const { config, initializationData } = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
+        const { moneris: monerisOptions, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "methodId" argument is not provided.');
+        }
 
         if (!monerisOptions) {
             throw new InvalidArgumentError('Unable to initialize payment because "options.moneris" argument is not provided.');
         }
 
+        this._initializeOptions = monerisOptions;
+
+        const { config, initializationData } = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
         if (!initializationData?.profileId) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        if (monerisOptions.form  && this._shouldShowTSVHostedForm(methodId)) {
+            this._hostedForm = await this._mountCardVerificationfields(monerisOptions.form);
         }
 
         if (!this._iframe) {
@@ -49,14 +68,10 @@ export default class MonerisPaymentStrategy implements PaymentStrategy {
 
     async execute(payload: OrderRequestBody, options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { payment , ...order } = payload;
-        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
 
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
         }
-
-        const paymentMethod = getPaymentMethodOrThrow(payment.methodId);
-        const testMode = paymentMethod.config.testMode;
 
         const { isStoreCreditApplied: useStoreCredit } = this._store.getState().checkout.getCheckoutOrThrow();
 
@@ -64,7 +79,44 @@ export default class MonerisPaymentStrategy implements PaymentStrategy {
             await this._store.dispatch(this._storeCreditActionCreator.applyStoreCredit(useStoreCredit));
         }
 
-        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+        try {
+            await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+            if (payment.paymentData && isVaultedInstrument(payment.paymentData)) {
+                return await this._executeWithVaulted(payment);
+            }
+
+            return await this._executeWithCC(payment);
+        } catch (error) {
+            return Promise.reject(error);
+        }
+    }
+
+    finalize(): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        if (this._windowEventListener) {
+            window.removeEventListener('message', this._windowEventListener);
+            this._windowEventListener = undefined;
+        }
+
+        if (this._iframe && this._iframe.parentNode) {
+            this._iframe.parentNode.removeChild(this._iframe);
+            this._iframe = undefined;
+        }
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private async _executeWithCC(payment: OrderPaymentRequestBody): Promise<InternalCheckoutSelectors> {
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(payment.methodId);
+
+        const testMode = paymentMethod.config.testMode;
+        const paymentData = payment.paymentData || {};
+        const { shouldSaveInstrument = false, shouldSetAsDefaultInstrument = false } = paymentData as HostedInstrument;
 
         const nonce = await new Promise<string | undefined>((resolve, reject) => {
             if (!this._iframe) {
@@ -89,29 +141,72 @@ export default class MonerisPaymentStrategy implements PaymentStrategy {
         if (nonce !== undefined) {
             return this._store.dispatch(this._paymentActionCreator.submitPayment({
                 methodId: payment.methodId,
-                paymentData: { nonce },
+                paymentData: { nonce, shouldSaveInstrument, shouldSetAsDefaultInstrument },
             }));
         }
 
         return this._store.getState();
     }
 
-    finalize(): Promise<InternalCheckoutSelectors> {
-        return Promise.reject(new OrderFinalizationNotRequiredError());
+    private async _executeWithVaulted(payment: OrderPaymentRequestBody): Promise<InternalCheckoutSelectors> {
+        if (this._isHostedPaymentFormEnabled(payment.methodId)) {
+            const form = this._hostedForm;
+
+            if (!form) {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+
+            await form.validate();
+            await form.submit(payment);
+
+            return await this._store.dispatch(this._orderActionCreator.loadCurrentOrder());
+        } else {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
+        }
     }
 
-    deinitialize(): Promise<InternalCheckoutSelectors> {
-        if (this._windowEventListener) {
-            window.removeEventListener('message', this._windowEventListener);
-            this._windowEventListener = undefined;
+    private _shouldShowTSVHostedForm(methodId: string): boolean {
+        return (this._isHostedPaymentFormEnabled(methodId) && this._isHostedFieldAvailable());
+    }
+
+    private _isHostedPaymentFormEnabled(methodId: string): boolean {
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(methodId);
+
+        return paymentMethod.config.isHostedFormEnabled === true;
+    }
+
+    private _isHostedFieldAvailable(): boolean {
+        const options = this._getInitializeOptions();
+
+        return !!options.form?.fields;
+    }
+
+    private _getInitializeOptions(): MonerisPaymentInitializeOptions {
+        if (!this._initializeOptions) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        if (this._iframe && this._iframe.parentNode) {
-            this._iframe.parentNode.removeChild(this._iframe);
-            this._iframe = undefined;
-        }
+        return this._initializeOptions;
+    }
 
-        return Promise.resolve(this._store.getState());
+    private async _mountCardVerificationfields(formOptions: HostedFormValidationOptions): Promise<HostedForm> {
+        try {
+            const { config } = this._store.getState();
+            const bigpayBaseUrl = config.getStoreConfig()?.paymentSettings.bigpayBaseUrl;
+
+            if (!bigpayBaseUrl) {
+                throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+            }
+
+            const form = this._hostedFormFactory.create(bigpayBaseUrl, formOptions);
+
+            await form.attach();
+
+            return form;
+        } catch (error) {
+            return error;
+        }
     }
 
     private _createIframe(containerId: string, initializationData: MonerisInitializationData, testMode: boolean, style?: MonerisStylingProps): HTMLIFrameElement {

--- a/src/payment/strategies/moneris/moneris.mock.ts
+++ b/src/payment/strategies/moneris/moneris.mock.ts
@@ -1,0 +1,32 @@
+import { HostedFieldType } from '../../../hosted-form';
+import { OrderRequestBody } from '../../../order';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+
+export function getHostedFormInitializeOptions(): PaymentInitializeOptions {
+    return {
+        methodId: 'moneris',
+        moneris: {
+            containerId: 'moneris_iframe_container',
+            form: {
+                fields: {
+                    [HostedFieldType.CardCodeVerification]: { containerId: 'card-code-veridifaction', instrumentId: 'instrument-id' },
+                    [HostedFieldType.CardNumberVerification]: { containerId: 'card-number-verification', instrumentId: 'instrument-id' },
+                },
+            },
+        },
+    };
+}
+
+export function getOrderRequestBodyVaultedCC(): OrderRequestBody {
+    return {
+        useStoreCredit: false,
+        payment: {
+            methodId: 'moneris',
+            paymentData: {
+                shouldSaveInstrument: true,
+                shouldSetAsDefaultInstrument: true,
+                instrumentId: '1234',
+            },
+        },
+    };
+}


### PR DESCRIPTION
## What? [(INT-4222)](https://jira.bigcommerce.com/browse/INT-4222)
Update strategy to support vaulted instruments and add Moneris to supported instruments.

## Why?
So vaulted instruments can be used with Moneris.

## Testing / Proof
UInit Testing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
