### PR TITLE
feat(payment): INT-4342 added google pay on orbital

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -78,6 +78,12 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
     googlepaycybersourcev2?: GooglePayButtonInitializeOptions;
 
     /**
+     * The options that are required to facilitate Orbital GooglePay. They can be
+     * omitted unless you need to support Orbital GooglePay.
+     */
+     googlepayorbital?: GooglePayButtonInitializeOptions;
+
+    /**
      * The options that are required to facilitate Stripe GooglePay. They can be
      * omitted unless you need to support Stripe GooglePay.
      */

--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -41,6 +41,10 @@ describe('createCheckoutButtonRegistry', () => {
         expect(registry.get('googlepaycybersourcev2')).toEqual(expect.any(GooglePayButtonStrategy));
     });
 
+    it('returns registry with GooglePay on Orbital Credit registered', () => {
+        expect(registry.get('googlepayorbital')).toEqual(expect.any(GooglePayButtonStrategy));
+    });
+
     it('returns registry with GooglePay on Stripe Credit registered', () => {
         expect(registry.get('googlepaystripe')).toEqual(expect.any(GooglePayButtonStrategy));
     });

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -129,6 +129,18 @@ export default function createCheckoutButtonRegistry(
         )
     );
 
+    registry.register(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL, () =>
+        new GooglePayButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayCybersourceV2Initializer()
+            )
+        )
+    );
+
     registry.register(CheckoutButtonMethodType.GOOGLEPAY_STRIPE, () =>
         new GooglePayButtonStrategy(
             store,

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -7,6 +7,7 @@ enum CheckoutButtonMethodType {
     GOOGLEPAY_BRAINTREE = 'googlepaybraintree',
     GOOGLEPAY_CHECKOUTCOM = 'googlepaycheckoutcom',
     GOOGLEPAY_CYBERSOURCEV2 = 'googlepaycybersourcev2',
+    GOOGLEPAY_ORBITAL = 'googlepayorbital',
     GOOGLEPAY_STRIPE = 'googlepaystripe',
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -91,6 +91,10 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             return options.googlepaycybersourcev2;
         }
 
+        if (options.methodId === 'googlepayorbital' && options.googlepayorbital) {
+            return options.googlepayorbital;
+        }
+
         if (options.methodId === 'googlepaystripe' && options.googlepaystripe) {
             return options.googlepaystripe;
         }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -23,6 +23,7 @@ export enum Mode {
     GooglePayBraintree,
     GooglePayCheckoutcom,
     GooglePayCybersourceV2,
+    GooglePayOrbital,
     GooglePayStripe,
 }
 
@@ -35,6 +36,7 @@ export function getCheckoutButtonOptions(methodId: CheckoutButtonMethodType, mod
     const googlepaybraintree = { googlepaybraintree: { buttonType: ButtonType.Short } };
     const googlepaycheckoutcom = { googlepaycheckoutcom: { buttonType: ButtonType.Short } };
     const googlepaycybersourcev2 = { googlepaycybersourcev2: { buttonType: ButtonType.Short } };
+    const googlepayorbital = { googlepayorbital: { buttonType: ButtonType.Short } };
     const googlepaystripe = { googlepaystripe: { buttonType: ButtonType.Short } };
 
     switch (mode) {
@@ -58,6 +60,9 @@ export function getCheckoutButtonOptions(methodId: CheckoutButtonMethodType, mod
         }
         case Mode.GooglePayCybersourceV2: {
             return { methodId, containerId, ...googlepaycybersourcev2 };
+        }
+        case Mode.GooglePayOrbital: {
+            return { methodId, containerId, ...googlepayorbital };
         }
         case Mode.GooglePayStripe: {
             return { methodId, containerId, ...googlepaystripe };

--- a/src/checkout-buttons/strategies/googlepay/googlepay-orbital-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-orbital-button-strategy.spec.ts
@@ -1,0 +1,211 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { Cart } from '../../../cart';
+import { getCart, getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod } from '../../../payment';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { createGooglePayPaymentProcessor, GooglePayOrbitalInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+
+import GooglePayButtonStrategy from './googlepay-button-strategy';
+import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
+
+describe('GooglePayCheckoutButtonStrategy', () => {
+    let cart: Cart;
+    let container: HTMLDivElement;
+    let formPoster: FormPoster;
+    let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+    let paymentMethod: PaymentMethod;
+    let paymentProcessor: GooglePayPaymentProcessor;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: GooglePayButtonStrategy;
+    let walletButton: HTMLAnchorElement;
+
+    beforeEach(() => {
+        paymentMethod = getPaymentMethod();
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        cart = getCart();
+        requestSender = createRequestSender();
+
+        checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
+        paymentProcessor = createGooglePayPaymentProcessor(
+            store,
+            new GooglePayOrbitalInitializer()
+        );
+
+        formPoster = createFormPoster();
+
+        strategy = new GooglePayButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            paymentProcessor
+        );
+
+        jest.spyOn(store, 'dispatch')
+            .mockResolvedValue(store.getState());
+
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockResolvedValue(Promise.resolve());
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockResolvedValue(paymentMethod);
+
+        jest.spyOn(store.getState().cart, 'getCartOrThrow')
+            .mockReturnValue(cart);
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockResolvedValue(Promise.resolve());
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
+        walletButton = document.createElement('a');
+        walletButton.setAttribute('id', 'mockButton');
+
+        jest.spyOn(paymentProcessor, 'createButton')
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
+
+        jest.spyOn(paymentProcessor, 'deinitialize');
+
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    describe('#initialize()', () => {
+        it('Creates the button', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL, Mode.GooglePayOrbital);
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.createButton).toHaveBeenCalled();
+        });
+
+        it('initializes paymentProcessor only once', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL, Mode.GooglePayOrbital);
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
+        });
+
+        it('fails to initialize the strategy if no container id is supplied', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL, Mode.UndefinedContainer);
+
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('fails to initialize the strategy if no valid container id is supplied', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL, Mode.InvalidContainer);
+
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        beforeAll(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL, Mode.GooglePayOrbital);
+        });
+
+        it('check if googlepay payment processor deinitialize is called', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize();
+
+            expect(paymentProcessor.deinitialize).toBeCalled();
+        });
+
+        it('succesfully deinitializes the strategy', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize();
+
+            // tslint:disable-next-line:no-non-null-assertion
+            const button = document.getElementById(checkoutButtonOptions.containerId!);
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+
+        it('Validates if strategy is loaded before call deinitialize', async () => {
+            await strategy.deinitialize();
+
+            // tslint:disable-next-line:no-non-null-assertion
+            const button = document.getElementById(checkoutButtonOptions.containerId!);
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL, Mode.GooglePayOrbital);
+
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
+
+        it('handles wallet button event and updates shipping address', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('handles wallet button event and does not update shipping address if cart has digital products only', async () => {
+            cart.lineItems.physicalItems = [];
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(CheckoutButtonMethodType.GOOGLEPAY_ORBITAL);
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -11,7 +11,7 @@ import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { createBraintreeVisaCheckoutPaymentProcessor, BraintreeScriptLoader, BraintreeSDKCreator, VisaCheckoutScriptLoader } from '../payment/strategies/braintree';
 import { ChasePayScriptLoader } from '../payment/strategies/chasepay';
-import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayOrbitalInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
 import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../spam-protection';
@@ -163,6 +163,18 @@ export default function createCustomerStrategyRegistry(
             createGooglePayPaymentProcessor(
                 store,
                 new GooglePayCybersourceV2Initializer()
+            ),
+            formPoster
+        )
+    );
+
+    registry.register('googlepayorbital', () =>
+        new GooglePayCustomerStrategy(
+            store,
+            remoteCheckoutActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayOrbitalInitializer()
             ),
             formPoster
         )

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -93,5 +93,11 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      * The options that are required to initialize the GooglePay payment method.
      * They can be omitted unless you need to support GooglePay.
      */
+     googlepayorbital?: GooglePayCustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
     googlepaystripe?: GooglePayCustomerInitializeOptions;
 }

--- a/src/customer/strategies/googlepay/googlepay-customer-mock.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-mock.ts
@@ -127,6 +127,26 @@ export function getCybersourceV2CustomerInitializeOptions(mode: Mode = Mode.Full
      }
 }
 
+export function getOrbitalCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
+    const methodId = { methodId: 'googlepayorbital' };
+    const undefinedMethodId = { methodId: undefined };
+    const container = { container: 'googlePayCheckoutButton' };
+    const invalidContainer = { container: 'invalid_container' };
+    const googlepayOrbital = { googlepayorbital: { ...container } };
+    const googlepayOrbitalWithInvalidContainer = { googlepayorbital: { ...invalidContainer } };
+
+    switch (mode) {
+        case Mode.Incomplete:
+            return { ...methodId };
+        case Mode.UndefinedMethodId:
+            return { ...undefinedMethodId, ...googlepayOrbital };
+        case Mode.InvalidContainer:
+            return { ...methodId, ...googlepayOrbitalWithInvalidContainer };
+        default:
+            return { ...methodId, ...googlepayOrbital };
+     }
+}
+
 export function getStripeCustomerInitializeOptions(mode: Mode = Mode.Full): CustomerInitializeOptions {
     const methodId = { methodId: 'googlepaystripe' };
     const undefinedMethodId = { methodId: undefined };

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -102,6 +102,10 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             return options.googlepaycybersourcev2;
         }
 
+        if (options.methodId === 'googlepayorbital' && options.googlepayorbital) {
+            return options.googlepayorbital;
+        }
+
         if (options.methodId === 'googlepaystripe' && options.googlepaystripe) {
             return options.googlepaystripe;
         }

--- a/src/customer/strategies/googlepay/googlepay-orbital-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-orbital-customer-strategy.spec.ts
@@ -1,0 +1,244 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { getCart, getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { getConfigState } from '../../../config/configs.mock';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { createGooglePayPaymentProcessor, GooglePayOrbitalInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { CustomerInitializeOptions } from '../../customer-request-options';
+import { getCustomerState } from '../../customers.mock';
+import CustomerStrategy from '../customer-strategy';
+
+import { getOrbitalCustomerInitializeOptions, Mode } from './googlepay-customer-mock';
+import GooglePayCustomerStrategy from './googlepay-customer-strategy';
+
+describe('GooglePayCustomerStrategy', () => {
+    let container: HTMLDivElement;
+    let formPoster: FormPoster;
+    let customerInitializeOptions: CustomerInitializeOptions;
+    let paymentProcessor: GooglePayPaymentProcessor;
+    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: CustomerStrategy;
+    let walletButton: HTMLAnchorElement;
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        requestSender = createRequestSender();
+
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+            new RemoteCheckoutRequestSender(requestSender)
+        );
+
+        paymentProcessor = createGooglePayPaymentProcessor(
+            store,
+            new GooglePayOrbitalInitializer()
+        );
+
+        formPoster = createFormPoster();
+
+        strategy = new GooglePayCustomerStrategy(
+            store,
+            remoteCheckoutActionCreator,
+            paymentProcessor,
+            formPoster
+        );
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockReturnValue(Promise.resolve());
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockReturnValue(Promise.resolve());
+
+        walletButton = document.createElement('a');
+        walletButton.setAttribute('id', 'mockButton');
+        jest.spyOn(paymentProcessor, 'createButton')
+            .mockImplementation((onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            });
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    describe('#initialize()', () => {
+        describe('Payment method exist', () => {
+            it('Creates the button', async () => {
+                customerInitializeOptions = getOrbitalCustomerInitializeOptions();
+
+                await strategy.initialize(customerInitializeOptions);
+
+                expect(paymentProcessor.createButton).toHaveBeenCalled();
+            });
+
+            it('fails to initialize the strategy if no GooglePayCustomerInitializeOptions is provided ', () => {
+                customerInitializeOptions = getOrbitalCustomerInitializeOptions(Mode.Incomplete);
+
+                expect(() => strategy.initialize(customerInitializeOptions)).toThrow(InvalidArgumentError);
+            });
+
+            it('fails to initialize the strategy if no methodid is supplied', () => {
+                customerInitializeOptions = getOrbitalCustomerInitializeOptions(Mode.UndefinedMethodId);
+
+                expect(() => strategy.initialize(customerInitializeOptions)).toThrow(InvalidArgumentError);
+            });
+
+            it('fails to initialize the strategy if no valid container id is supplied', async () => {
+                customerInitializeOptions = getOrbitalCustomerInitializeOptions(Mode.InvalidContainer);
+
+                await expect(strategy.initialize(customerInitializeOptions)).rejects.toThrow(InvalidArgumentError);
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        let containerId: string;
+
+        beforeAll(() => {
+            customerInitializeOptions = getOrbitalCustomerInitializeOptions();
+            containerId = customerInitializeOptions.googlepayorbital ?
+                customerInitializeOptions.googlepayorbital.container : '';
+        });
+
+        it('successfully deinitializes the strategy', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            const button = document.getElementById(containerId);
+
+            expect(button).toHaveProperty('firstChild', walletButton);
+
+            await strategy.deinitialize();
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+
+        it('Validates if strategy is loaded before call deinitialize', async () => {
+            await strategy.deinitialize();
+
+            const button = document.getElementById(containerId);
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+    });
+
+    describe('#signIn()', () => {
+        it('throws error if trying to sign in programmatically', async () => {
+            customerInitializeOptions = getOrbitalCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+
+            expect(() => strategy.signIn({ email: 'foo@bar.com', password: 'foobar' })).toThrowError();
+        });
+    });
+
+    describe('#signOut()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getOrbitalCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('successfully signs out', async () => {
+            const paymentId = {
+                providerId: 'googlepayorbital',
+            };
+
+            jest.spyOn(store.getState().payment, 'getPaymentId')
+                .mockReturnValue(paymentId);
+
+            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+                .mockReturnValue('data');
+
+            const options = {
+                methodId: 'googlepayorbital',
+            };
+
+            await strategy.signOut(options);
+
+            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('googlepayorbital', options);
+            expect(store.dispatch).toHaveBeenCalled();
+        });
+
+        it('Returns state if no payment method exist', async () => {
+            const paymentId = undefined;
+            jest.spyOn(store, 'getState');
+
+            jest.spyOn(store.getState().payment, 'getPaymentId')
+                .mockReturnValue(paymentId);
+
+            const options = {
+                methodId: 'googlepayorbital',
+            };
+
+            expect(await strategy.signOut(options)).toEqual(store.getState());
+            expect(store.getState).toHaveBeenCalledTimes(4);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
+            customerInitializeOptions = {
+                methodId: 'googlepayorbital',
+                googlepayorbital: {
+                    container: 'googlePayCheckoutButton',
+                },
+            };
+
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(Promise.resolve());
+        });
+
+        it('displays the wallet and updates the shipping address', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(googlePaymentDataMock.shippingAddress);
+        });
+
+        it('displays the wallet and does not update the shipping address if cart has digital products only', async () => {
+            const cart = getCart();
+            cart.lineItems.physicalItems = [];
+            jest.spyOn(store.getState().cart, 'getCartOrThrow')
+                .mockReturnValue(cart);
+
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -172,6 +172,11 @@ describe('CreatePaymentStrategyRegistry', () => {
         expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
     });
 
+    it('can instantiate googlepayorbital', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.ORBITAL_GOOGLE_PAY);
+        expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+
     it('can instantiate klarna', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.KLARNA);
         expect(paymentStrategy).toBeInstanceOf(KlarnaPaymentStrategy);

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -43,7 +43,7 @@ import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
 import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
 import { DigitalRiverPaymentStrategy, DigitalRiverScriptLoader } from './strategies/digitalriver';
 import { ExternalPaymentStrategy } from './strategies/external';
-import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayOrbitalInitializer,  GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
 import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
 import { LegacyPaymentStrategy } from './strategies/legacy';
@@ -560,6 +560,21 @@ export default function createPaymentStrategyRegistry(
             createGooglePayPaymentProcessor(
                 store,
                 new GooglePayCybersourceV2Initializer()
+            )
+        )
+    );
+
+    registry.register(PaymentStrategyType.ORBITAL_GOOGLE_PAY, () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayOrbitalInitializer()
             )
         )
     );

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -557,6 +557,35 @@ export function getGooglePayCybersourceV2(): PaymentMethod {
     };
 }
 
+export function getGooglePayOrbital(): PaymentMethod {
+    return {
+        id: 'googlepayorbital',
+        logoUrl: '',
+        method: 'googlepay',
+        supportedCards: [
+            'VISA',
+            'MC',
+            'AMEX',
+        ],
+        config: {
+            displayName: 'Google Pay',
+            merchantId: '',
+            testMode: true,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'clientToken',
+        initializationData: {
+            originKey: 'YOUR_ORIGIN_KEY',
+            clientKey: 'YOUR_CLIENT_KEY',
+            nonce: 'nonce',
+            card_information: {
+                type: 'MasterCard',
+                number: '4111',
+            },
+        },
+    };
+}
+
 export function getZip(): PaymentMethod {
     return {
         id: 'zip',
@@ -736,6 +765,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getGooglePay(),
         getGooglePayAdyenV2(),
         getGooglePayCybersourceV2(),
+        getGooglePayOrbital(),
         getKlarna(),
         getMollie(),
         getPaypalExpress(),

--- a/src/payment/payment-request-options.ts
+++ b/src/payment/payment-request-options.ts
@@ -179,6 +179,12 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
     googlepaycybersourcev2?: GooglePayPaymentInitializeOptions;
 
     /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
+     googlepayorbital?: GooglePayPaymentInitializeOptions;
+
+    /**
      * The options that are required to initialize the GooglePay Stripe payment method.
      * They can be omitted unless you need to support GooglePay.
      */

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -31,6 +31,7 @@ enum PaymentStrategyType {
     NO_PAYMENT_DATA_REQUIRED = 'nopaymentdatarequired',
     OFFLINE = 'offline',
     OFFSITE = 'offsite',
+    ORBITAL_GOOGLE_PAY = 'googlepayorbital',
     PAYPAL = 'paypal',
     PAYPAL_EXPRESS = 'paypalexpress',
     PAYPAL_EXPRESS_CREDIT = 'paypalexpresscredit',

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
@@ -3,7 +3,7 @@ import { round } from 'lodash';
 import { Checkout } from '../../../checkout';
 import PaymentMethod from '../../payment-method';
 
-import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload, TokenizeType } from './googlepay';
+import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload } from './googlepay';
 
 export default class GooglePayAdyenV2Initializer implements GooglePayInitializer {
     initialize(
@@ -35,7 +35,7 @@ export default class GooglePayAdyenV2Initializer implements GooglePayInitializer
         } = paymentData;
 
         return Promise.resolve({
-            type: type as TokenizeType,
+            type,
             nonce: token,
             details: {
                 cardType,

--- a/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.ts
@@ -3,7 +3,7 @@ import { round } from 'lodash';
 import { PaymentMethod } from '../..';
 import { Checkout } from '../../../checkout';
 
-import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizationSpecification, TokenizePayload, TokenizeType } from './googlepay';
+import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizationSpecification, TokenizePayload } from './googlepay';
 
 const baseRequest = {
     apiVersion: 2,
@@ -38,7 +38,7 @@ export default class GooglePayAuthorizeNetInitializer implements GooglePayInitia
         } = paymentData;
 
         return Promise.resolve({
-            type: type as TokenizeType,
+            type,
             nonce: btoa(token),
             details: {
                 cardType,

--- a/src/payment/strategies/googlepay/googlepay-orbital-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-orbital-initializer.spec.ts
@@ -1,0 +1,40 @@
+import GooglePayOrbitalInitializer from './googlepay-orbital-initializer';
+import { getCheckoutMock, getOrbitalPaymentDataMock, getOrbitalPaymentDataRequest, getOrbitalPaymentMethodMock, getOrbitalTokenizedPayload  } from './googlepay.mock';
+
+describe('GooglePayCybersourceV2Initializer', () => {
+    let googlePayInitializer: GooglePayOrbitalInitializer;
+
+    beforeEach(() => {
+        googlePayInitializer = new GooglePayOrbitalInitializer();
+    });
+
+    it('creates an instance of GooglePayCybersourceV2Initializer', () => {
+        expect(googlePayInitializer).toBeInstanceOf(GooglePayOrbitalInitializer);
+    });
+
+    describe('#initialize', () => {
+        it('initializes the google pay configuration for Cybersourcev2', async () => {
+            const initialize = await googlePayInitializer.initialize(
+                getCheckoutMock(),
+                getOrbitalPaymentMethodMock(),
+                false
+            );
+
+            expect(initialize).toEqual(getOrbitalPaymentDataRequest());
+        });
+    });
+
+    describe('#teardown', () => {
+        it('teardown the initializer', () => {
+            expect(() => googlePayInitializer.teardown()).not.toThrow();
+        });
+    });
+
+    describe('#parseResponse', () => {
+        it('parses a response from google pay payload received', async () => {
+            const tokenizePayload = await googlePayInitializer.parseResponse(getOrbitalPaymentDataMock());
+
+            expect(tokenizePayload).toEqual(getOrbitalTokenizedPayload());
+        });
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-orbital-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-orbital-initializer.ts
@@ -5,7 +5,7 @@ import PaymentMethod from '../../payment-method';
 
 import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePayPaymentDataRequestV2, TokenizePayload } from './googlepay';
 
-export default class GooglePayCybersourceV2Initializer implements GooglePayInitializer {
+export default class GooglePayOrbitalInitializer implements GooglePayInitializer {
     initialize(
         checkout: Checkout,
         paymentMethod: PaymentMethod,
@@ -88,7 +88,7 @@ export default class GooglePayCybersourceV2Initializer implements GooglePayIniti
                 tokenizationSpecification: {
                     type: 'PAYMENT_GATEWAY',
                     parameters: {
-                        gateway: 'cybersource',
+                        gateway: 'chase',
                         gatewayMerchantId,
                     },
                 },

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -146,6 +146,10 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             return options.googlepaycybersourcev2;
         }
 
+        if (options.methodId === 'googlepayorbital' && options.googlepayorbital) {
+            return options.googlepayorbital;
+        }
+
         if (options.methodId === 'googlepaybraintree' && options.googlepaybraintree) {
             return options.googlepaybraintree;
         }

--- a/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -583,3 +583,69 @@ export function getCybersourceV2TokenizedPayload(): TokenizePayload {
         },
     };
 }
+
+export function getOrbitalPaymentMethodMock(): PaymentMethod {
+    const paymentMethodMock = getPaymentMethodMock();
+    paymentMethodMock.initializationData.gatewayMerchantId = 'merchantId';
+
+    return paymentMethodMock;
+}
+
+export function getOrbitalPaymentDataMock(): GooglePaymentData {
+    const googlePaymentDataMock = getGooglePaymentDataMock();
+    googlePaymentDataMock.paymentMethodData.tokenizationData.token = '{"signature":"foo","protocolVersion":"ECv1","signedMessage":"{"encryptedMessage":"foo","ephemeralPublicKey":"foo"}"}';
+
+    return googlePaymentDataMock;
+}
+
+export function getOrbitalPaymentDataRequest(): GooglePayPaymentDataRequestV2 {
+    return {
+        apiVersion: 2,
+        apiVersionMinor: 0,
+        merchantInfo: {
+            authJwt: 'platformToken',
+            merchantId: '123',
+            merchantName: 'name',
+        },
+        allowedPaymentMethods: [{
+            type: 'CARD',
+            parameters: {
+                allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'],
+                billingAddressRequired: true,
+                billingAddressParameters: {
+                    format: BillingAddressFormat.Full,
+                    phoneNumberRequired: true,
+                },
+            },
+            tokenizationSpecification: {
+                type: 'PAYMENT_GATEWAY',
+                parameters: {
+                    gateway: 'chase',
+                    gatewayMerchantId: 'merchantId',
+                },
+            },
+        }],
+        transactionInfo: {
+            currencyCode: 'USD',
+            totalPriceStatus: 'FINAL',
+            totalPrice: '1.00',
+        },
+        emailRequired: true,
+        shippingAddressRequired: true,
+        shippingAddressParameters: {
+            phoneNumberRequired: true,
+        },
+    };
+}
+
+export function getOrbitalTokenizedPayload(): TokenizePayload {
+    return {
+        nonce: btoa('{"signature":"foo","protocolVersion":"ECv1","signedMessage":"{"encryptedMessage":"foo","ephemeralPublicKey":"foo"}"}'),
+        type: 'CARD',
+        details: {
+            cardType: 'MASTERCARD',
+            lastFour: '0304',
+        },
+    };
+}

--- a/src/payment/strategies/googlepay/googlepay.ts
+++ b/src/payment/strategies/googlepay/googlepay.ts
@@ -76,7 +76,7 @@ export interface GooglePaymentData {
             token: string;
             type: string;
         };
-        type: string;
+        type: TokenizeType;
     };
     shippingAddress: GooglePayAddress;
     email: string;

--- a/src/payment/strategies/googlepay/index.ts
+++ b/src/payment/strategies/googlepay/index.ts
@@ -8,6 +8,7 @@ export { default as GooglePayAdyenV2PaymentProcessor } from './googlepay-adyenv2
 export { default as GooglePayBraintreeInitializer } from './googlepay-braintree-initializer';
 export { default as GooglePayCheckoutcomInitializer } from './googlepay-checkoutcom-initializer';
 export { default as GooglePayCybersourceV2Initializer } from './googlepay-cybersourcev2-initializer';
+export { default as GooglePayOrbitalInitializer } from './googlepay-orbital-initializer';
 export { default as GooglePayStripeInitializer } from './googlepay-stripe-initializer';
 export { default as GooglePayAuthorizeNetInitializer } from './googlepay-authorizenet-initializer';
 export { default as GooglePayPaymentInitializeOptions } from './googlepay-initialize-options';


### PR DESCRIPTION
## What? [INT-4342](https://jira.bigcommerce.com/browse/INT-4342)
Added Google Pay on Orbital

## Why?
So that merchants can offer Google Pay as Payment Method using Orbital (CMS) integration

## Testing / Proof
<img width="790" alt="INT-4342 Payment Step" src="https://user-images.githubusercontent.com/61981535/122312463-e202ee00-ced9-11eb-9759-716b8dbf30d9.png">

<img width="933" alt="INT-4342 Customer Step" src="https://user-images.githubusercontent.com/61981535/122312470-e3ccb180-ced9-11eb-9bcc-baa15d836c4a.png">

![Screen Shot 2021-06-18 at 1 39 01 PM](https://user-images.githubusercontent.com/61981535/122603971-d549db80-d03a-11eb-91c5-fe83c2452d28.png)

![Screen Shot 2021-06-18 at 1 39 44 PM](https://user-images.githubusercontent.com/61981535/122603985-da0e8f80-d03a-11eb-8ade-82a05eec35d7.png)



## Dependency of
[Checkout-JS 612](https://github.com/bigcommerce/checkout-js/pull/612)

bigcommerce/checkout 
bigcommerce/payments
