### PR TITLE
fix(analytics): DATA-7883 Fix Segment + GAEE issue

### DIFF
--- a/src/analytics/analytics-tracker-ga.spec.ts
+++ b/src/analytics/analytics-tracker-ga.spec.ts
@@ -1,0 +1,104 @@
+import { LineItemMap } from '../cart';
+import { getGiftCertificateItem } from '../cart/line-items.mock';
+import { getPhysicalItem } from '../order/line-items.mock';
+import { getOrder } from '../order/orders.mock';
+
+import { AnalyticsProduct, ExtraItemsData } from './analytics-step-tracker';
+import { isPayloadSizeLimitReached } from './analytics-tracker-ga';
+
+describe('analytics step tracker helpers',  () => {
+    test('should return false on small order', () => {
+        const order = getOrder();
+
+        const result = isPayloadSizeLimitReached({
+            orderId: order.orderId,
+            affiliation: 'storeName',
+            revenue: order.orderAmount,
+            shipping: order.shippingCostTotal,
+            tax: order.taxTotal,
+            discount: order.discountAmount,
+            coupon: (order.coupons || []).map(coupon => coupon.code.toUpperCase()).join(','),
+            currency: 'USD',
+            products: getPayloadProducts({}, order.lineItems),
+        });
+
+        expect(result).toBe(false);
+    });
+
+    test('should return true on large order', () => {
+
+        const order = getOrder();
+
+        const lineItems = {
+            physicalItems: Array.from(new Array(100)).map(() => getPhysicalItem()),
+            digitalItems: [],
+            giftCertificates: [
+                getGiftCertificateItem(),
+            ],
+            customItems: [],
+        };
+
+        const result = isPayloadSizeLimitReached({
+            orderId: order.orderId,
+            affiliation: 'storeName',
+            revenue: order.orderAmount,
+            shipping: order.shippingCostTotal,
+            tax: order.taxTotal,
+            discount: order.discountAmount,
+            coupon: (order.coupons || []).map(coupon => coupon.code.toUpperCase()).join(','),
+            currency: 'USD',
+            products: getPayloadProducts({}, lineItems),
+        });
+
+        expect(result).toBe(true);
+    });
+});
+
+function getPayloadProducts(itemsData: ExtraItemsData, lineItems: LineItemMap): AnalyticsProduct[] {
+    const customItems: AnalyticsProduct[] = (lineItems.customItems || []).map(item => ({
+        product_id: item.id,
+        sku: item.sku,
+        price: item.listPrice,
+        quantity: item.quantity,
+        name: item.name,
+    }));
+
+    const giftCertificateItems: AnalyticsProduct[] = lineItems.giftCertificates.map(item => {
+        return {
+            product_id: item.id,
+            price: item.amount,
+            name: item.name,
+            quantity: 1,
+        };
+    });
+
+    const physicalAndDigitalItems: AnalyticsProduct[] = [
+        ...lineItems.physicalItems,
+        ...lineItems.digitalItems,
+    ].map(item => {
+        let itemAttributes;
+
+        if (item.options && item.options.length) {
+            itemAttributes = item.options.map(option => `${option.name}:${option.value}`);
+            itemAttributes.sort();
+        }
+
+        return {
+            product_id: item.productId,
+            sku: item.sku,
+            price: item.salePrice,
+            image_url: item.imageUrl,
+            name: item.name,
+            quantity: item.quantity,
+            brand: itemsData[item.productId] ? itemsData[item.productId].brand : '',
+            category: itemsData[item.productId] ? itemsData[item.productId].category : '',
+            variant: (itemAttributes || []).join(', '),
+        };
+    });
+
+    return [
+        ...customItems,
+        ...physicalAndDigitalItems,
+        ...giftCertificateItems,
+    ];
+}

--- a/src/analytics/analytics-tracker-ga.ts
+++ b/src/analytics/analytics-tracker-ga.ts
@@ -1,0 +1,60 @@
+import AnalyticsTrackerWindow from './analytics-tracker-window';
+import { isAnalyticsTrackerWindow } from './is-analytics-step-tracker-window';
+
+interface AnalyticsTrackerWindowGA extends AnalyticsTrackerWindow {
+    ga(command: string, eventName: string, payload: AnalyticPayload): void;
+}
+
+function isAnalyticsTrackerWindowGA(window: Window | AnalyticsTrackerWindowGA): window is AnalyticsTrackerWindowGA {
+    return window && 'ga' in window && typeof window.ga === 'function';
+}
+
+export function isGoogleAnalyticsAvailable(): boolean {
+    return isAnalyticsTrackerWindow(window) && isAnalyticsTrackerWindowGA(window);
+}
+
+export function sendGoogleAnalytics(type: string, payload: AnalyticPayload): void {
+    if (isAnalyticsTrackerWindowGA(window)) {
+        window.ga('send', type, {
+            ...payload,
+            nonInteraction: false,
+        });
+    }
+}
+
+/**
+ * Max size of the payload for the Google Analytics module
+ * if the limit will be succeeded, the GA throwing a silent error,
+ * and only in debug mode you can see it
+ */
+export function isPayloadSizeLimitReached(obj: AnalyticPayload): boolean {
+    const ANALYTICS_MAX_URI_LENGTH = 8096;
+
+    return serializeAnalyticsEventPayload(obj).length >= ANALYTICS_MAX_URI_LENGTH;
+}
+
+function serializeAnalyticsEventPayload(obj: AnalyticPayload): string {
+    return Object.keys(obj).reduce((acc: string[], key) => {
+        const type = typeof obj[key];
+
+        if (type === 'string' || type === 'number') {
+            return [
+                ...acc,
+                `${key}=${obj[key]}`,
+            ];
+        }
+
+        if (type === 'object' && obj[key] !== null) {
+            return [
+                ...acc,
+                serializeAnalyticsEventPayload(obj[key] as AnalyticPayload),
+            ];
+        }
+
+        return acc;
+    }, []).join('&');
+}
+
+interface AnalyticPayload {
+    [key: string]: unknown;
+}

--- a/src/analytics/analytics-tracker-window.ts
+++ b/src/analytics/analytics-tracker-window.ts
@@ -1,7 +1,5 @@
 export interface AnalyticsTracker {
     track(step: string, data: any): void;
-    hit(hitName: string, data: any): void;
-    hasPayloadLimit(data: any): boolean;
 }
 
 export default interface AnalyticsTrackerWindow extends Window {


### PR DESCRIPTION
## What? [DATA-7883](https://jira.bigcommerce.com/browse/DATA-7883)
Fix bug with Segment + GAEE.

## Why?
When the experiment `DATA-6891.missing_orders_within_GA` is ON there are issues with data being sent to Google Analytics when a merchant is using Segment.com to setup Google Analytics.

## Testing / Proof
Manually / Unit tests 

1) 34 items in the Cart, $850 total
![image](https://user-images.githubusercontent.com/75369099/127508207-6aacf91b-e0fc-44a0-a8ba-9c07775fa26f.png)

2) now we send large orders in a transaction mode (each line_item per request)
![image](https://user-images.githubusercontent.com/75369099/127511673-350100b4-3372-4864-abcb-96aa7cc0d028.png)

3) proof from Google Analytics
![image](https://user-images.githubusercontent.com/75369099/127512375-b10b541f-f857-42ce-889d-57d169cc02bf.png)

@bigcommerce/checkout @bigcommerce/payments 