### PR TITLE
INT 4309 Adding support to Vaulted Cards that requires 3DS and 3DS2 in Digital River

### DIFF
--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -427,14 +427,13 @@ describe('DigitalRiverPaymentStrategy', () => {
                             bigpay_token: {
                                 token: getVaultedInstrument().instrumentId,
                             },
-                            verification_value: '000',
                             credit_card_token: {
                                 token: JSON.stringify({
                                     checkoutId: '12345676543',
                                 }),
                             },
+                            set_as_default_stored_instrument: null,
                         },
-                        set_as_default_stored_instrument: false,
                     },
                 };
 

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -407,7 +407,7 @@ describe('DigitalRiverPaymentStrategy', () => {
                 expect(digitalRiverLoadResponse.authenticateSource).toHaveBeenCalled();
             });
 
-            it('calls authenticateSource and authentication fails', async () => {
+            it('calls authenticateSource method, authentication fails and execute method fails', async () => {
                 jest.spyOn(paymentActionCreator, 'submitPayment')
                     .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, getAdditionalActionError())));
                 jest.spyOn(digitalRiverLoadResponse, 'authenticateSource').mockReturnValue(Promise.resolve({status: AuthenticationSourceStatus.failed}));
@@ -432,6 +432,7 @@ describe('DigitalRiverPaymentStrategy', () => {
                                     checkoutId: '12345676543',
                                 }),
                             },
+                            confirm: false,
                             set_as_default_stored_instrument: null,
                         },
                     },

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -115,14 +115,13 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
                         bigpay_token: {
                             token: paymentData.instrumentId,
                         },
-                        verification_value: '000',
                         credit_card_token: {
                             token: JSON.stringify({
                                 checkoutId: this._digitalRiverCheckoutData.checkoutId,
                             }),
                         },
+                        set_as_default_stored_instrument: shouldSetAsDefaultInstrument || null,
                     },
-                    set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
                 },
             };
 
@@ -297,15 +296,14 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
                             bigpay_token: {
                                 token: instrumentId,
                             },
-                            verification_value: '000',
                             credit_card_token: {
                                 token: JSON.stringify({
                                     checkoutId: this._digitalRiverCheckoutData.checkoutId,
                                 }),
                             },
                             confirm: true,
+                            set_as_default_stored_instrument: shouldSetAsDefaultInstrument || null,
                         },
-                        set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
                     },
                 };
 

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -12,15 +12,7 @@ import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import DigitalRiverJS, {
-    DigitalRiverAdditionalProviderData,
-    DigitalRiverAuthenticateSourceResponse,
-    DigitalRiverDropIn,
-    DigitalRiverInitializeToken,
-    OnCancelOrErrorResponse,
-    OnReadyResponse,
-    OnSuccessResponse
-} from './digitalriver';
+import DigitalRiverJS, { AuthenticationSourceStatus, DigitalRiverAdditionalProviderData, DigitalRiverAuthenticateSourceResponse, DigitalRiverDropIn, DigitalRiverInitializeToken, OnCancelOrErrorResponse, OnReadyResponse, OnSuccessResponse } from './digitalriver';
 import DigitalRiverPaymentInitializeOptions from './digitalriver-payment-initialize-options';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
 
@@ -293,7 +285,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
             sourceId: additionalAction.source_id,
             sourceClientSecret: additionalAction.source_client_secret,
         }).then((data: DigitalRiverAuthenticateSourceResponse) => {
-            if (data.status === 'complete' || data.status === 'authentication_not_required') {
+            if (data.status === AuthenticationSourceStatus.complete || data.status === AuthenticationSourceStatus.authentication_not_required) {
                 if (!this._digitalRiverCheckoutData) {
                     throw new InvalidArgumentError('Unable to proceed because payload payment argument is not provided.');
                 }

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -115,7 +115,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
                     throw error;
                 }
 
-                const confirm: boolean = await this._authenticateSource(error.body.provider_data);
+                const confirm = await this._authenticateSource(error.body.provider_data);
 
                 return await this._submitVaultedInstrument(methodId, paymentData.instrumentId, this._digitalRiverCheckoutData.checkoutId, shouldSetAsDefaultInstrument, confirm);
             }

--- a/src/payment/strategies/digitalriver/digitalriver.mock.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.mock.ts
@@ -10,6 +10,7 @@ export function getDigitalRiverJSMock(): DigitalRiverJS {
                 mount: jest.fn(),
             };
         }),
+        authenticateSource: jest.fn(),
     };
 }
 

--- a/src/payment/strategies/digitalriver/digitalriver.mock.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.mock.ts
@@ -91,13 +91,11 @@ function getAdditionalActionErrorResponse(): DigitalRiverAdditionalProviderData 
 export function getAdditionalActionError(): RequestError {
     return new RequestError(getResponse({
         ...getErrorPaymentResponseBody(),
-        ...{
-            provider_data: getAdditionalActionErrorResponse(),
+        provider_data: getAdditionalActionErrorResponse(),
             errors: [
                 {
                     code: 'additional_action_required',
                 },
             ],
-        },
     }));
 }

--- a/src/payment/strategies/digitalriver/digitalriver.mock.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.mock.ts
@@ -1,7 +1,11 @@
+import { RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { OrderRequestBody } from '../../../order';
 import PaymentMethod from '../../payment-method';
 import { PaymentInitializeOptions } from '../../payment-request-options';
+import { getErrorPaymentResponseBody, getVaultedInstrument } from '../../payments.mock';
 
-import DigitalRiverJS, { DigitalRiverInitializeToken } from './digitalriver';
+import DigitalRiverJS, { DigitalRiverAdditionalProviderData, DigitalRiverInitializeToken } from './digitalriver';
 
 export function getDigitalRiverJSMock(): DigitalRiverJS {
     return {
@@ -37,6 +41,16 @@ export function getInitializeOptionsMock(): PaymentInitializeOptions {
     };
 }
 
+export function getOrderRequestBodyWithVaultedInstrument(): OrderRequestBody {
+    return {
+        useStoreCredit: false,
+        payment: {
+            methodId: 'digitalriver',
+            paymentData: getVaultedInstrument(),
+        },
+    };
+}
+
 export function getClientMock(): DigitalRiverInitializeToken {
     return {
         sessionId: '1234',
@@ -65,4 +79,25 @@ export function getDigitalRiverPaymentMethodMock(): PaymentMethod {
         type: 'PAYMENT_TYPE_API',
         clientToken: 'clientToken',
     };
+}
+
+function getAdditionalActionErrorResponse(): DigitalRiverAdditionalProviderData {
+    return {
+        source_id: 'sourceId',
+        source_client_secret: 'sourceClientSecret',
+    };
+}
+
+export function getAdditionalActionError(): RequestError {
+    return new RequestError(getResponse({
+        ...getErrorPaymentResponseBody(),
+        ...{
+            provider_data: getAdditionalActionErrorResponse(),
+            errors: [
+                {
+                    code: 'additional_action_required',
+                },
+            ],
+        },
+    }));
 }

--- a/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.ts
@@ -11,6 +11,22 @@ export type DigitalRiverClass = new(apiKey: string, options?: DigitalRiverJSOpti
 
 export default interface DigitalRiverJS {
     createDropin(configuration: DigitalRiverDropInConfiguration): DigitalRiverDropIn;
+    authenticateSource(data: DigitalRiverAuthenticateSourceRequest): Promise<DigitalRiverAuthenticateSourceResponse>;
+}
+
+interface DigitalRiverAuthenticateSourceRequest {
+    sessionId: string;
+    sourceId: string;
+    sourceClientSecret: string;
+}
+
+export interface DigitalRiverAdditionalProviderData {
+    source_id: string;
+    source_client_secret: string;
+}
+
+export interface DigitalRiverAuthenticateSourceResponse {
+    status: string;
 }
 
 export interface DigitalRiverJSOptions {

--- a/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.ts
@@ -26,7 +26,13 @@ export interface DigitalRiverAdditionalProviderData {
 }
 
 export interface DigitalRiverAuthenticateSourceResponse {
-    status: string;
+    status: AuthenticationSourceStatus;
+}
+
+export enum AuthenticationSourceStatus {
+    complete = 'complete',
+    authentication_not_required = 'authentication_not_required',
+    failed = 'failed',
 }
 
 export interface DigitalRiverJSOptions {


### PR DESCRIPTION
## What?
I update the payment strategy to support additional actions from BigPay and to call the authenticationSource method from Digital River JS.

## Why?
Digital River requires to call AuthenticateSource method from the DR.js when a vaulted card is in use, this since it invokes SCA which is PSD2 compliancy

## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/122823415-f281e280-d2a4-11eb-8e3a-d7e9098ff39b.png)

[Demo](https://drive.google.com/file/d/1BDHaRsnnbJk-urR_lP1x1TAuPYdu4i5f/view?usp=sharing)


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
