### PR TITLE
CHECKOUT-5873: Fix path to copy previous releases from

### DIFF
--- a/scripts/circleci/copy-previous-releases.sh
+++ b/scripts/circleci/copy-previous-releases.sh
@@ -6,7 +6,7 @@ set -u
 git clone --depth 1 git@github.com:bigcommerce/checkout-sdk-js-server.git /tmp/repo-server
 
 # Copy previous releases into a folder for further modification
-cp -rf /tmp/repo-server/public ~/repo/dist-cdn
+cp -rf /tmp/repo-server/public/* ~/repo/dist-cdn
 
 # Rewrite the placeholder text contained in those releases with the production URL
 for file in ~/repo/dist-cdn/*/loader-v*.js; do


### PR DESCRIPTION
## What?
Don't copy the `public` folder itself, instead copy its content.

## Why?
Otherwise we'll end up with the wrong destination path.

## Testing / Proof
Manual (here listing all the files that are copied over as a part of the CircleCI job)

<img width="522" alt="Screen Shot 2021-06-23 at 3 57 35 pm" src="https://user-images.githubusercontent.com/667603/123043558-d1072f00-d43b-11eb-9de1-95bfcecfdc6e.png">


@bigcommerce/checkout @bigcommerce/payments
