### PR TITLE
feat(payment): BOLT-19 added BoltCheckout implementation for customer…

### DIFF
--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -569,10 +569,10 @@ export default class CheckoutService {
      * @param options - Options for creating customer account.
      * @returns A promise that resolves to the current state.
      */
-    createCustomerAccount(customerAccount: CustomerAccountRequestBody, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._customerActionCreator.createCustomer(customerAccount, options);
+    createCustomerAccount(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<CheckoutSelectors> {
+        const action = this._customerStrategyActionCreator.signUp(customerAccount, options);
 
-        return this._dispatch(action);
+        return this._dispatch(action, { queueId: 'customerStrategy' });
     }
 
     /**
@@ -632,10 +632,10 @@ export default class CheckoutService {
      * @param options - Options for continuing as a guest.
      * @returns A promise that resolves to the current state.
      */
-    continueAsGuest(credentials: GuestCredentials, options?: RequestOptions): Promise<CheckoutSelectors> {
-        const action = this._billingAddressActionCreator.continueAsGuest(credentials, options);
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<CheckoutSelectors> {
+        const action = this._customerStrategyActionCreator.continueAsGuest(credentials, options);
 
-        return this._dispatch(action);
+        return this._dispatch(action, { queueId: 'customerStrategy' });
     }
 
     /**

--- a/src/common/error/errors/index.ts
+++ b/src/common/error/errors/index.ts
@@ -11,6 +11,7 @@ export { default as StorefrontRequestError } from './map-from-storefront-error-r
 export { default as TimeoutError } from './timeout-error';
 export { default as UnrecoverableError } from './unrecoverable-error';
 export { default as UnsupportedBrowserError } from './unsupported-browser-error';
+export { default as UnhandledExternalError } from './unhandeled_external_error';
 
 export { default as mapFromInternalErrorResponse } from './map-from-internal-error-response';
 export { default as mapFromPaymentErrorResponse } from './map-from-payment-error-response';

--- a/src/common/error/errors/unhandeled_external_error.spec.ts
+++ b/src/common/error/errors/unhandeled_external_error.spec.ts
@@ -1,0 +1,9 @@
+import UnhandledExternalError from './unhandeled_external_error';
+
+describe('UnhandledExternalError', () => {
+    it('returns error name', () => {
+        const error = new UnhandledExternalError();
+
+        expect(error.name).toEqual('UnhandledExternalError');
+    });
+});

--- a/src/common/error/errors/unhandeled_external_error.ts
+++ b/src/common/error/errors/unhandeled_external_error.ts
@@ -1,0 +1,13 @@
+import StandardError from './standard-error';
+
+/**
+ * Throw this error if we get an error from external services/partners.
+ */
+export default class UnhandledExternalError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unhandled external error.');
+
+        this.name = 'UnhandledExternalError';
+        this.type = 'unhandled_external';
+    }
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -88,6 +88,7 @@ export interface StoreCurrency {
 }
 
 export interface CheckoutSettings {
+    customContinueFlowProviderId: string;
     features: { [featureName: string]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -19,6 +19,7 @@ export function getConfig(): Config {
         storeConfig: {
             cdnPath: 'https://cdn.bcapp.dev/rHEAD',
             checkoutSettings: {
+                customContinueFlowProviderId: '',
                 features: {},
                 enableOrderComments: true,
                 enableTermsAndConditions: false,

--- a/src/customer/customer-strategy-actions.ts
+++ b/src/customer/customer-strategy-actions.ts
@@ -7,6 +7,12 @@ export enum CustomerStrategyActionType {
     SignOutFailed = 'CUSTOMER_STRATEGY_SIGN_OUT_FAILED',
     SignOutRequested = 'CUSTOMER_STRATEGY_SIGN_OUT_REQUESTED',
     SignOutSucceeded = 'CUSTOMER_STRATEGY_SIGN_OUT_SUCCEEDED',
+    SignUpFailed = 'CUSTOMER_STRATEGY_SIGN_UP_FAILED',
+    SignUpRequested = 'CUSTOMER_STRATEGY_SIGN_UP_REQUESTED',
+    SignUpSucceeded = 'CUSTOMER_STRATEGY_SIGN_UP_SUCCEEDED',
+    ContinueAsGuestFailed = 'CUSTOMER_STRATEGY_CONTINUE_AS_GUEST_FAILED',
+    ContinueAsGuestRequested = 'CUSTOMER_STRATEGY_CONTINUE_AS_GUEST_REQUESTED',
+    ContinueAsGuestSucceeded = 'CUSTOMER_STRATEGY_CONTINUE_AS_GUEST_SUCCEEDED',
     InitializeFailed = 'CUSTOMER_STRATEGY_INITIALIZE_FAILED',
     InitializeRequested = 'CUSTOMER_STRATEGY_INITIALIZE_REQUESTED',
     InitializeSucceeded = 'CUSTOMER_STRATEGY_INITIALIZE_SUCCEEDED',
@@ -21,6 +27,8 @@ export enum CustomerStrategyActionType {
 export type CustomerStrategyAction =
     CustomerStrategySignInAction |
     CustomerStrategySignOutAction |
+    CustomerStrategySignUpAction |
+    CustomerStrategyContinueAsGuestAction |
     CustomerStrategyInitializeAction |
     CustomerStrategyDeinitializeAction |
     CustomerStrategyWidgetAction;
@@ -34,6 +42,16 @@ export type CustomerStrategySignOutAction =
     SignOutRequestedAction |
     SignOutSucceededAction |
     SignOutFailedAction;
+
+export type CustomerStrategySignUpAction =
+    SignUpRequestedAction |
+    SignUpSucceededAction |
+    SignUpFailedAction;
+
+export type CustomerStrategyContinueAsGuestAction =
+    ContinueAsGuestRequestedAction |
+    ContinueAsGuestSucceededAction |
+    ContinueAsGuestFailedAction;
 
 export type CustomerStrategyInitializeAction =
     InitializeRequestedAction |
@@ -72,6 +90,30 @@ export interface SignOutSucceededAction extends Action {
 
 export interface SignOutFailedAction extends Action<Error> {
     type: CustomerStrategyActionType.SignOutFailed;
+}
+
+export interface SignUpRequestedAction extends Action {
+    type: CustomerStrategyActionType.SignUpRequested;
+}
+
+export interface SignUpSucceededAction extends Action {
+    type: CustomerStrategyActionType.SignUpSucceeded;
+}
+
+export interface SignUpFailedAction extends Action<Error> {
+    type: CustomerStrategyActionType.SignUpFailed;
+}
+
+export interface ContinueAsGuestRequestedAction extends Action {
+    type: CustomerStrategyActionType.ContinueAsGuestRequested;
+}
+
+export interface ContinueAsGuestSucceededAction extends Action {
+    type: CustomerStrategyActionType.ContinueAsGuestSucceeded;
+}
+
+export interface ContinueAsGuestFailedAction extends Action<Error> {
+    type: CustomerStrategyActionType.ContinueAsGuestFailed;
 }
 
 export interface InitializeRequestedAction extends Action {

--- a/src/customer/customer-strategy-reducer.spec.ts
+++ b/src/customer/customer-strategy-reducer.spec.ts
@@ -125,6 +125,49 @@ describe('customerStrategyReducer()', () => {
         });
     });
 
+    it('returns the pending flag as true if the customer continues as a guest', () => {
+        const action = createAction(
+            CustomerStrategyActionType.ContinueAsGuestRequested,
+            undefined,
+            { methodId: 'foobar' }
+        );
+
+        expect(customerStrategyReducer(initialState, action).statuses).toEqual({
+            continueAsGuestMethodId: 'foobar',
+            isContinuingAsGuest: true,
+        });
+    });
+
+    it('returns the pending flag as false if the customer has continued as guest successfully', () => {
+        const action = createAction(
+            CustomerStrategyActionType.ContinueAsGuestSucceeded,
+            undefined,
+            { methodId: 'foobar' }
+        );
+
+        expect(customerStrategyReducer(initialState, action).statuses).toEqual({
+            continueAsGuestMethodId: undefined,
+            isContinuingAsGuest: false,
+        });
+
+        expect(customerStrategyReducer(initialState, action).statuses).toEqual({
+            isContinuingAsGuest: false,
+        });
+    });
+
+    it('returns error if customer has failed to continue as guest', () => {
+        const action = createErrorAction(
+            CustomerStrategyActionType.ContinueAsGuestFailed,
+            new Error(),
+            { methodId: 'foobar' }
+        );
+
+        expect(customerStrategyReducer(initialState, action).errors).toEqual({
+            continueAsGuestMethodId: 'foobar',
+            continueAsGuestError: action.payload,
+        });
+    });
+
     it('returns pending flag as true if signing in customer', () => {
         const action = createAction(
             CustomerStrategyActionType.SignInRequested,
@@ -208,6 +251,49 @@ describe('customerStrategyReducer()', () => {
 
         expect(customerStrategyReducer(initialState, action).statuses).toEqual({
             isSigningOut: false,
+        });
+    });
+
+    it('returns pending flag as true if signing up customer', () => {
+        const action = createAction(
+            CustomerStrategyActionType.SignUpRequested,
+            undefined,
+            { methodId: 'foobar' }
+        );
+
+        expect(customerStrategyReducer(initialState, action).statuses).toEqual({
+            signUpMethodId: 'foobar',
+            isSigningUp: true,
+        });
+    });
+
+    it('returns pending flag as false if customer has signed up successfully', () => {
+        const action = createAction(
+            CustomerStrategyActionType.SignUpSucceeded,
+            undefined,
+            { methodId: 'foobar' }
+        );
+
+        expect(customerStrategyReducer(initialState, action).statuses).toEqual({
+            signUpMethodId: undefined,
+            isSigningUp: false,
+        });
+
+        expect(customerStrategyReducer(initialState, action).statuses).toEqual({
+            isSigningUp: false,
+        });
+    });
+
+    it('returns error if customer has failed to sign up', () => {
+        const action = createErrorAction(
+            CustomerStrategyActionType.SignUpFailed,
+            new Error(),
+            { methodId: 'foobar' }
+        );
+
+        expect(customerStrategyReducer(initialState, action).errors).toEqual({
+            signUpMethodId: 'foobar',
+            signUpError: action.payload,
         });
     });
 

--- a/src/customer/customer-strategy-reducer.ts
+++ b/src/customer/customer-strategy-reducer.ts
@@ -42,6 +42,7 @@ function dataReducer(
     return data;
 }
 
+// tslint:disable-next-line cyclomatic-complexity
 function errorsReducer(
     errors: CustomerStrategyErrorsState = DEFAULT_STATE.errors,
     action: CustomerStrategyAction
@@ -73,6 +74,19 @@ function errorsReducer(
             deinitializeMethodId: action.meta && action.meta.methodId,
         });
 
+    case CustomerStrategyActionType.ContinueAsGuestRequested:
+    case CustomerStrategyActionType.ContinueAsGuestSucceeded:
+        return objectMerge(errors, {
+            continueAsGuestError: undefined,
+            continueAsGuestMethodId: undefined,
+        });
+
+    case CustomerStrategyActionType.ContinueAsGuestFailed:
+        return objectMerge(errors, {
+            continueAsGuestError: action.payload,
+            continueAsGuestMethodId: action.meta && action.meta.methodId,
+        });
+
     case CustomerStrategyActionType.SignInRequested:
     case CustomerStrategyActionType.SignInSucceeded:
         return objectMerge(errors, {
@@ -99,6 +113,19 @@ function errorsReducer(
             signOutMethodId: action.meta && action.meta.methodId,
         });
 
+    case CustomerStrategyActionType.SignUpRequested:
+    case CustomerStrategyActionType.SignUpSucceeded:
+        return objectMerge(errors, {
+            signUpError: undefined,
+            signUpMethodId: undefined,
+        });
+
+    case CustomerStrategyActionType.SignUpFailed:
+        return objectMerge(errors, {
+            signUpError: action.payload,
+            signUpMethodId: action.meta && action.meta.methodId,
+        });
+
     case CustomerStrategyActionType.WidgetInteractionStarted:
     case CustomerStrategyActionType.WidgetInteractionFinished:
         return objectMerge(errors, {
@@ -117,6 +144,7 @@ function errorsReducer(
     }
 }
 
+// tslint:disable-next-line cyclomatic-complexity
 function statusesReducer(
     statuses: CustomerStrategyStatusesState = DEFAULT_STATE.statuses,
     action: CustomerStrategyAction
@@ -148,6 +176,19 @@ function statusesReducer(
             deinitializeMethodId: undefined,
         });
 
+    case CustomerStrategyActionType.ContinueAsGuestRequested:
+        return objectMerge(statuses, {
+            isContinuingAsGuest: true,
+            continueAsGuestMethodId: action.meta && action.meta.methodId,
+        });
+
+    case CustomerStrategyActionType.ContinueAsGuestFailed:
+    case CustomerStrategyActionType.ContinueAsGuestSucceeded:
+        return objectMerge(statuses, {
+            isContinuingAsGuest: false,
+            continueAsGuestMethodId: undefined,
+        });
+
     case CustomerStrategyActionType.SignInRequested:
         return objectMerge(statuses, {
             isSigningIn: true,
@@ -172,6 +213,19 @@ function statusesReducer(
         return objectMerge(statuses, {
             isSigningOut: false,
             signOutMethodId: undefined,
+        });
+
+    case CustomerStrategyActionType.SignUpRequested:
+        return objectMerge(statuses, {
+            isSigningUp: true,
+            signUpMethodId: action.meta && action.meta.methodId,
+        });
+
+    case CustomerStrategyActionType.SignUpFailed:
+    case CustomerStrategyActionType.SignUpSucceeded:
+        return objectMerge(statuses, {
+            isSigningUp: false,
+            signUpMethodId: undefined,
         });
 
     case CustomerStrategyActionType.WidgetInteractionStarted:

--- a/src/customer/customer-strategy-selector.spec.ts
+++ b/src/customer/customer-strategy-selector.spec.ts
@@ -15,6 +15,25 @@ describe('CustomerStrategySelector', () => {
         };
     });
 
+    describe('#getContinueAsGuestError()', () => {
+        it('returns error if unable to continue as guest', () => {
+            const continueAsGuestError = getErrorResponse();
+
+            selector = createCustomerStrategySelector({
+                ...state.customerStrategy,
+                errors: { continueAsGuestError },
+            });
+
+            expect(selector.getContinueAsGuestError()).toEqual(continueAsGuestError);
+        });
+
+        it('does not returns error if able to continue as guest', () => {
+            selector = createCustomerStrategySelector(state.customerStrategy);
+
+            expect(selector.getContinueAsGuestError()).toBeUndefined();
+        });
+    });
+
     describe('#getSignInError()', () => {
         it('returns error if unable to sign in', () => {
             const signInError = getErrorResponse();
@@ -50,6 +69,25 @@ describe('CustomerStrategySelector', () => {
             selector = createCustomerStrategySelector(state.customerStrategy);
 
             expect(selector.getSignOutError()).toBeUndefined();
+        });
+    });
+
+    describe('#getSignUpError()', () => {
+        it('returns error if unable to sign up', () => {
+            const signUpError = getErrorResponse();
+
+            selector = createCustomerStrategySelector({
+                ...state.customerStrategy,
+                errors: { signUpError },
+            });
+
+            expect(selector.getSignUpError()).toEqual(signUpError);
+        });
+
+        it('does not return error if able to sign up', () => {
+            selector = createCustomerStrategySelector(state.customerStrategy);
+
+            expect(selector.getSignUpError()).toBeUndefined();
         });
     });
 
@@ -113,6 +151,23 @@ describe('CustomerStrategySelector', () => {
         });
     });
 
+    describe('#isContinuingAsGuest()', () => {
+        it('returns true if shopper continues as guest', () => {
+            selector = createCustomerStrategySelector({
+                ...state.customerStrategy,
+                statuses: { isContinuingAsGuest: true },
+            });
+
+            expect(selector.isContinuingAsGuest()).toEqual(true);
+        });
+
+        it('returns false if shopper has not signed in', () => {
+            selector = createCustomerStrategySelector(state.customerStrategy);
+
+            expect(selector.isContinuingAsGuest()).toEqual(false);
+        });
+    });
+
     describe('#isSigningIn()', () => {
         it('returns true if signing in', () => {
             selector = createCustomerStrategySelector({
@@ -144,6 +199,23 @@ describe('CustomerStrategySelector', () => {
             selector = createCustomerStrategySelector(state.customerStrategy);
 
             expect(selector.isSigningOut()).toEqual(false);
+        });
+    });
+
+    describe('#isSigningUp()', () => {
+        it('returns true if signing up', () => {
+            selector = createCustomerStrategySelector({
+                ...state.customerStrategy,
+                statuses: { isSigningUp: true },
+            });
+
+            expect(selector.isSigningUp()).toEqual(true);
+        });
+
+        it('returns false if not signing up', () => {
+            selector = createCustomerStrategySelector(state.customerStrategy);
+
+            expect(selector.isSigningUp()).toEqual(false);
         });
     });
 

--- a/src/customer/customer-strategy-selector.ts
+++ b/src/customer/customer-strategy-selector.ts
@@ -5,12 +5,16 @@ import { createSelector } from '../common/selector';
 import CustomerStrategyState, { DEFAULT_STATE } from './customer-strategy-state';
 
 export default interface CustomerStrategySelector {
+    getContinueAsGuestError(methodId?: string): Error | undefined;
     getSignInError(methodId?: string): Error | undefined;
     getSignOutError(methodId?: string): Error | undefined;
+    getSignUpError(methodId?: string): Error | undefined;
     getInitializeError(methodId?: string): Error | undefined;
     getWidgetInteractionError(methodId?: string): Error | undefined;
+    isContinuingAsGuest(methodId?: string): boolean;
     isSigningIn(methodId?: string): boolean;
     isSigningOut(methodId?: string): boolean;
+    isSigningUp(methodId?: string): boolean;
     isInitializing(methodId?: string): boolean;
     isInitialized(methodId: string): boolean;
     isWidgetInteracting(methodId?: string): boolean;
@@ -19,6 +23,18 @@ export default interface CustomerStrategySelector {
 export type CustomerStrategySelectorFactory = (state: CustomerStrategyState) => CustomerStrategySelector;
 
 export function createCustomerStrategySelectorFactory(): CustomerStrategySelectorFactory {
+    const getContinueAsGuestError = createSelector(
+        (state: CustomerStrategyState) => state.errors.continueAsGuestMethodId,
+        (state: CustomerStrategyState) => state.errors.continueAsGuestError,
+        (continueAsGuestMethodId, continueAsGuestError) => (methodId?: string) => {
+            if (methodId && continueAsGuestMethodId !== methodId) {
+                return;
+            }
+
+            return continueAsGuestError;
+        }
+    );
+
     const getSignInError = createSelector(
         (state: CustomerStrategyState) => state.errors.signInMethodId,
         (state: CustomerStrategyState) => state.errors.signInError,
@@ -40,6 +56,18 @@ export function createCustomerStrategySelectorFactory(): CustomerStrategySelecto
             }
 
             return signOutError;
+        }
+    );
+
+    const getSignUpError = createSelector(
+        (state: CustomerStrategyState) => state.errors.signUpMethodId,
+        (state: CustomerStrategyState) => state.errors.signUpError,
+        (signUpMethodId, signUpError) => (methodId?: string) => {
+            if (methodId && signUpMethodId !== methodId) {
+                return;
+            }
+
+            return signUpError;
         }
     );
 
@@ -67,6 +95,18 @@ export function createCustomerStrategySelectorFactory(): CustomerStrategySelecto
         }
     );
 
+    const isContinuingAsGuest = createSelector(
+        (state: CustomerStrategyState) => state.statuses.continueAsGuestMethodId,
+        (state: CustomerStrategyState) => state.statuses.isContinuingAsGuest,
+        (continueAsGuestMethodId, isContinuingAsGuest) => (methodId?: string) => {
+            if (methodId && continueAsGuestMethodId !== methodId) {
+                return false;
+            }
+
+            return !!isContinuingAsGuest;
+        }
+    );
+
     const isSigningIn = createSelector(
         (state: CustomerStrategyState) => state.statuses.signInMethodId,
         (state: CustomerStrategyState) => state.statuses.isSigningIn,
@@ -88,6 +128,18 @@ export function createCustomerStrategySelectorFactory(): CustomerStrategySelecto
             }
 
             return !!isSigningOut;
+        }
+    );
+
+    const isSigningUp = createSelector(
+        (state: CustomerStrategyState) => state.statuses.signUpMethodId,
+        (state: CustomerStrategyState) => state.statuses.isSigningUp,
+        (signUpMethodId, isSigningUp) => (methodId?: string) => {
+            if (methodId && signUpMethodId !== methodId) {
+                return false;
+            }
+
+            return !!isSigningUp;
         }
     );
 
@@ -131,10 +183,14 @@ export function createCustomerStrategySelectorFactory(): CustomerStrategySelecto
         return {
             getSignInError: getSignInError(state),
             getSignOutError: getSignOutError(state),
+            getSignUpError: getSignUpError(state),
+            getContinueAsGuestError: getContinueAsGuestError(state),
             getInitializeError: getInitializeError(state),
             getWidgetInteractionError: getWidgetInteractionError(state),
+            isContinuingAsGuest: isContinuingAsGuest(state),
             isSigningIn: isSigningIn(state),
             isSigningOut: isSigningOut(state),
+            isSigningUp: isSigningUp(state),
             isInitializing: isInitializing(state),
             isInitialized: isInitialized(state),
             isWidgetInteracting: isWidgetInteracting(state),

--- a/src/customer/customer-strategy-state.ts
+++ b/src/customer/customer-strategy-state.ts
@@ -19,19 +19,27 @@ export interface CustomerStrategyErrorsState {
     signInMethodId?: string;
     signOutError?: Error;
     signOutMethodId?: string;
+    signUpError?: Error;
+    signUpMethodId?: string;
+    continueAsGuestError?: Error;
+    continueAsGuestMethodId?: string;
     widgetInteractionError?: Error;
     widgetInteractionMethodId?: string;
 }
 
 export interface CustomerStrategyStatusesState {
+    continueAsGuestMethodId?: string;
     deinitializeMethodId?: string;
     initializeMethodId?: string;
+    isContinuingAsGuest?: boolean;
     isDeinitializing?: boolean;
     isInitializing?: boolean;
     isSigningIn?: boolean;
     isSigningOut?: boolean;
+    isSigningUp?: boolean;
     signInMethodId?: string;
     signOutMethodId?: string;
+    signUpMethodId?: string;
     isWidgetInteracting?: boolean;
     widgetInteractionMethodId?: string;
 }

--- a/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
@@ -1,17 +1,30 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getFormFieldsState } from '../../../form/form.mock';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor } from '../../../payment/strategies/amazon-pay-v2';
 import { getPaymentMethodMockUndefinedMerchant } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
@@ -20,8 +33,13 @@ import AmazonPayV2CustomerStrategy from './amazon-pay-v2-customer-strategy';
 import { getAmazonPayV2CustomerInitializeOptions, Mode } from './amazon-pay-v2-customer.mock';
 
 describe('AmazonPayV2CustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
+    let customerActionCreator: CustomerActionCreator;
     let customerInitializeOptions: CustomerInitializeOptions;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
     let paymentProcessor: AmazonPayV2PaymentProcessor;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
@@ -50,13 +68,39 @@ describe('AmazonPayV2CustomerStrategy', () => {
             new RemoteCheckoutRequestSender(requestSender)
         );
 
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
         paymentProcessor = createAmazonPayV2PaymentProcessor();
 
         strategy = new AmazonPayV2CustomerStrategy(
             store,
             paymentMethodActionCreator,
             remoteCheckoutActionCreator,
-            paymentProcessor
+            paymentProcessor,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         jest.spyOn(store, 'dispatch')
@@ -164,6 +208,31 @@ describe('AmazonPayV2CustomerStrategy', () => {
         });
     });
 
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getAmazonPayV2CustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('Runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'amazonpay' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         it('throws error if trying to sign in programmatically', async () => {
             customerInitializeOptions = getAmazonPayV2CustomerInitializeOptions();
@@ -217,6 +286,31 @@ describe('AmazonPayV2CustomerStrategy', () => {
             await strategy.signOut(options);
 
             expect(store.getState).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getAmazonPayV2CustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('Runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'amazonpay' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 });

--- a/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
+++ b/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
@@ -1,10 +1,14 @@
+import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from '../../../common/error/errors';
 import { PaymentMethodActionCreator } from '../../../payment';
 import { AmazonPayV2PaymentProcessor, AmazonPayV2PayOptions, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
 import { getShippableItemsCount } from '../../../shipping';
+import CustomerAccountRequestBody from '../../customer-account';
+import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
+import { GuestCredentials } from '../../guest-credentials';
 import CustomerStrategy from '../customer-strategy';
 
 export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
@@ -14,7 +18,9 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
         private _store: CheckoutStore,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
-        private _amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor
+        private _amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _customerActionCreator: CustomerActionCreator
     ) {}
 
     async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -60,6 +66,18 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
 
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.createCustomer(customerAccount, options)
+        );
+    }
+
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._billingAddressActionCreator.continueAsGuest(credentials, options)
         );
     }
 

--- a/src/customer/strategies/amazon/amazon-pay-customer-strategy.ts
+++ b/src/customer/strategies/amazon/amazon-pay-customer-strategy.ts
@@ -1,9 +1,13 @@
+import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { AmazonPayLoginButton, AmazonPayScriptLoader, AmazonPayWindow } from '../../../payment/strategies/amazon-pay';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import CustomerAccountRequestBody from '../../customer-account';
+import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
+import { GuestCredentials } from '../../guest-credentials';
 import CustomerStrategy from '../customer-strategy';
 
 import AmazonPayCustomerInitializeOptions from './amazon-pay-customer-initialize-options';
@@ -17,7 +21,9 @@ export default class AmazonPayCustomerStrategy implements CustomerStrategy {
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _remoteCheckoutRequestSender: RemoteCheckoutRequestSender,
-        private _scriptLoader: AmazonPayScriptLoader
+        private _scriptLoader: AmazonPayScriptLoader,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _customerActionCreator: CustomerActionCreator
     ) {
         this._window = window;
     }
@@ -78,6 +84,18 @@ export default class AmazonPayCustomerStrategy implements CustomerStrategy {
 
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.createCustomer(customerAccount, options)
+        );
+    }
+
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._billingAddressActionCreator.continueAsGuest(credentials, options)
         );
     }
 

--- a/src/customer/strategies/bolt/bolt-customer-strategy.spec.ts
+++ b/src/customer/strategies/bolt/bolt-customer-strategy.spec.ts
@@ -1,0 +1,304 @@
+import { createAction } from '@bigcommerce/data-store';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
+
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
+import { getBolt } from '../../../payment/payment-methods.mock';
+import { BoltCheckout, BoltScriptLoader } from '../../../payment/strategies/bolt';
+import { getQuote } from '../../../quote/internal-quotes.mock';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
+import CustomerRequestSender from '../../customer-request-sender';
+import CustomerStrategy from '../customer-strategy';
+
+import BoltCustomerStrategy from './bolt-customer-strategy';
+
+describe('BoltCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
+    let boltScriptLoader: BoltScriptLoader;
+    let boltCheckout: BoltCheckout;
+    let customerActionCreator: CustomerActionCreator;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let store: CheckoutStore;
+    let strategy: CustomerStrategy;
+
+    beforeEach(() => {
+        const scriptLoader = createScriptLoader();
+        paymentMethodMock = getBolt();
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
+        boltCheckout = {} as BoltCheckout;
+        boltCheckout.configure = jest.fn();
+        boltCheckout.setClientCustomCallbacks = jest.fn();
+        boltCheckout.openCheckout = jest.fn();
+        boltCheckout.hasBoltAccount = jest.fn();
+
+        boltScriptLoader = new BoltScriptLoader(scriptLoader);
+        boltScriptLoader.load = jest.fn(() => Promise.resolve(boltCheckout));
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethodMock);
+
+        strategy = new BoltCustomerStrategy(
+            store,
+            boltScriptLoader,
+            paymentMethodActionCreator,
+            billingAddressActionCreator,
+            customerActionCreator
+        );
+    });
+
+    it('creates an instance of BoltCustomerStrategy', () => {
+        expect(strategy).toBeInstanceOf(BoltCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('fails to initialize the strategy if methodId is not provided', async () => {
+            try {
+                await strategy.initialize({ methodId: undefined });
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('fails to initialize the strategy if publishableKey option is not provided', async () => {
+            paymentMethodMock.initializationData.publishableKey = undefined;
+
+            try {
+                await strategy.initialize({ methodId: 'bolt' });
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('loads bolt script loader', async () => {
+            await strategy.initialize({ methodId: 'bolt' });
+
+            expect(boltScriptLoader.load).toHaveBeenCalled();
+        });
+    });
+
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(undefined);
+
+            await strategy.initialize({ methodId: 'bolt' });
+        });
+
+        it('fails to continueAsGuest if methodId is not provided', async () => {
+            const credentials = { email: 'test@test.com' };
+            const options = { methodId: undefined };
+
+            try {
+                await strategy.continueAsGuest(credentials, options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('should pass default `continue as guest` flow if provider customContinueFlowEnabled is false', async () => {
+            paymentMethodMock.initializationData.customContinueFlowEnabled = false;
+
+            const credentials = { email: 'test@test.com' };
+            const options = { methodId: 'bolt' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest').mockReturnValue(action);
+            jest.spyOn(boltCheckout, 'hasBoltAccount');
+            jest.spyOn(boltCheckout, 'openCheckout');
+            jest.spyOn(store, 'dispatch');
+
+            await strategy.continueAsGuest(credentials, options);
+
+            expect(boltCheckout.hasBoltAccount).not.toHaveBeenCalled();
+            expect(boltCheckout.openCheckout).not.toHaveBeenCalled();
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+        });
+
+        it('should check is shopper has bolt account when provider customContinueFlowEnabled', async () => {
+            paymentMethodMock.initializationData.customContinueFlowEnabled = true;
+
+            const credentials = { email: 'test@test.com' };
+            const options = { methodId: 'bolt' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest').mockReturnValue(action);
+            jest.spyOn(boltCheckout, 'hasBoltAccount');
+            jest.spyOn(store, 'dispatch');
+
+            await strategy.continueAsGuest(credentials, options);
+
+            expect(boltCheckout.hasBoltAccount).toHaveBeenCalledWith(credentials.email);
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+        });
+    });
+
+    describe('#signIn()', () => {
+        beforeEach(async () => {
+            jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(undefined);
+
+            await strategy.initialize({ methodId: 'bolt' });
+        });
+
+        it('fails to signIn if methodId is not provided', async () => {
+            const credentials = { email: 'test@test.com', password: 'password' };
+            const options = { methodId: undefined };
+
+            try {
+                await strategy.signIn(credentials, options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('should be checked if user has bolt account after successfully signIn', async () => {
+            paymentMethodMock.initializationData.customContinueFlowEnabled = true;
+
+            const credentials = { email: 'test@test.com', password: 'password' };
+            const options = { methodId: 'bolt' };
+            const action = of(createAction(CustomerActionType.SignInCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'signInCustomer').mockReturnValue(action);
+            jest.spyOn(boltCheckout, 'hasBoltAccount');
+            jest.spyOn(store, 'dispatch');
+
+            await strategy.signIn(credentials, options);
+
+            expect(customerActionCreator.signInCustomer).toHaveBeenCalledWith(credentials, options);
+            expect(boltCheckout.hasBoltAccount).toHaveBeenCalledWith(credentials.email);
+        });
+
+        it('should not be opened Bolt checkout modal after signIn if customContinueFlowEnabled is false', async () => {
+            paymentMethodMock.initializationData.customContinueFlowEnabled = false;
+
+            const credentials = { email: 'test@test.com', password: 'password' };
+            const options = { methodId: 'bolt' };
+            const action = of(createAction(CustomerActionType.SignInCustomerFailed, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'signInCustomer').mockReturnValue(action);
+            jest.spyOn(boltCheckout, 'hasBoltAccount');
+            jest.spyOn(boltCheckout, 'openCheckout');
+            jest.spyOn(store, 'dispatch');
+
+            await strategy.signIn(credentials, options);
+
+            expect(customerActionCreator.signInCustomer).toHaveBeenCalledWith(credentials, options);
+            expect(boltCheckout.hasBoltAccount).not.toHaveBeenCalled();
+            expect(boltCheckout.openCheckout).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#signOut()', () => {
+        it('runs default signOut flow', async () => {
+            const options = { methodId: 'bolt' };
+            const action = of(createAction(CustomerActionType.SignOutCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'signOutCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            await strategy.signOut(options);
+
+            expect(customerActionCreator.signOutCustomer).toHaveBeenCalledWith(options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(undefined);
+
+            await strategy.initialize({ methodId: 'bolt' });
+        });
+
+        it('fails to signUp if methodId is not provided', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: undefined };
+
+            try {
+                await strategy.signUp(customerAccount, options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('should be checked if shopper has bolt account after successfully signUp', async () => {
+            paymentMethodMock.initializationData.customContinueFlowEnabled = true;
+
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'bolt' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer').mockReturnValue(action);
+            jest.spyOn(boltCheckout, 'hasBoltAccount');
+            jest.spyOn(store, 'dispatch');
+
+            await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(boltCheckout.hasBoltAccount).toHaveBeenCalledWith(customerAccount.email);
+        });
+
+        it('should not open Bolt checkout modal after signUp if customContinueFlowEnabled is false', done => {
+            paymentMethodMock.initializationData.customContinueFlowEnabled = false;
+
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'bolt' };
+            const action = of(createAction(CustomerActionType.SignInCustomerFailed, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer').mockReturnValue(action);
+            jest.spyOn(boltCheckout, 'hasBoltAccount');
+            jest.spyOn(boltCheckout, 'openCheckout');
+            jest.spyOn(store, 'dispatch');
+
+            strategy.signUp(customerAccount, options)
+                .then(() => {
+                    expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+                    expect(boltCheckout.hasBoltAccount).not.toHaveBeenCalled();
+                    expect(boltCheckout.openCheckout).not.toHaveBeenCalled();
+                    done();
+                });
+        });
+    });
+});

--- a/src/customer/strategies/bolt/bolt-customer-strategy.ts
+++ b/src/customer/strategies/bolt/bolt-customer-strategy.ts
@@ -1,0 +1,129 @@
+import { BillingAddressActionCreator } from '../../../billing';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, UnhandledExternalError } from '../../../common/error/errors';
+import { PaymentMethodActionCreator } from '../../../payment';
+import { BoltCheckout, BoltScriptLoader } from '../../../payment/strategies/bolt';
+import CustomerAccountRequestBody from '../../customer-account';
+import CustomerActionCreator from '../../customer-action-creator';
+import CustomerCredentials from '../../customer-credentials';
+import { CustomerRequestOptions } from '../../customer-request-options';
+import { GuestCredentials } from '../../guest-credentials';
+import CustomerStrategy from '../customer-strategy';
+
+export default class BoltCustomerStrategy implements CustomerStrategy {
+    private _boltClient?: BoltCheckout;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _boltScriptLoader: BoltScriptLoader,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _customerActionCreator: CustomerActionCreator
+    ) {}
+
+    async initialize(options: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to proceed because "methodId" argument is not provided.');
+        }
+
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethods());
+
+        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+        if (!paymentMethod || !paymentMethod.initializationData.publishableKey) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const { developerConfig, publishableKey } = paymentMethod.initializationData;
+
+        this._boltClient = await this._boltScriptLoader.load(publishableKey, paymentMethod.config.testMode, developerConfig);
+
+        return this._store.getState();
+    }
+
+    async deinitialize(): Promise<InternalCheckoutSelectors> {
+        this._boltClient = undefined;
+
+        return this._store.getState();
+    }
+
+    async continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to proceed because "methodId" argument is not provided.');
+        }
+
+        await this._openCustomBoltCheckoutWidget(credentials.email, methodId);
+
+        return this._store.dispatch(this._billingAddressActionCreator.continueAsGuest(credentials, options));
+    }
+
+    async signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to proceed because "methodId" argument is not provided.');
+        }
+
+        await this._store.dispatch(this._customerActionCreator.signInCustomer(credentials, options));
+
+        return this._openCustomBoltCheckoutWidget(credentials.email, methodId);
+    }
+
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(this._customerActionCreator.signOutCustomer(options));
+    }
+
+    async signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to proceed because "methodId" argument is not provided.');
+        }
+
+        await this._store.dispatch(this._customerActionCreator.createCustomer(customerAccount, options));
+
+        return this._openCustomBoltCheckoutWidget(customerAccount.email, methodId);
+    }
+
+    private async _openCustomBoltCheckoutWidget(email: string, methodId: string): Promise<InternalCheckoutSelectors> {
+        const boltCheckout = this._boltClient;
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+        try {
+            if (!boltCheckout) {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+
+            if (!paymentMethod) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            if (paymentMethod.initializationData?.customContinueFlowEnabled) {
+                const hasBoltAccount = await boltCheckout.hasBoltAccount(email);
+
+                if (hasBoltAccount) {
+                    await new Promise(resolve => {
+                        const callbacks = {
+                            close: resolve,
+                        };
+
+                        boltCheckout.openCheckout(email, callbacks);
+                    }).catch(error => error);
+                }
+            }
+        } catch (error) {
+            if (error.name !== 'MissingDataError' && error.name !== 'NotInitializedError') {
+                throw new UnhandledExternalError(error.message);
+            }
+
+            throw error;
+        }
+
+        return this._store.getState();
+    }
+}

--- a/src/customer/strategies/bolt/index.ts
+++ b/src/customer/strategies/bolt/index.ts
@@ -1,0 +1,1 @@
+export { default as BoltCustomerStrategy } from './bolt-customer-strategy';

--- a/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
+++ b/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
@@ -1,10 +1,14 @@
+import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from '../../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { BraintreeVisaCheckoutPaymentProcessor, VisaCheckoutPaymentSuccessPayload, VisaCheckoutScriptLoader } from '../../../payment/strategies/braintree';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
+import CustomerAccountRequestBody from '../../customer-account';
+import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
 import CustomerStrategyActionCreator from '../../customer-strategy-action-creator';
+import { GuestCredentials } from '../../guest-credentials';
 import CustomerStrategy from '../customer-strategy';
 
 export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerStrategy {
@@ -18,7 +22,9 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
         private _customerStrategyActionCreator: CustomerStrategyActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _braintreeVisaCheckoutPaymentProcessor: BraintreeVisaCheckoutPaymentProcessor,
-        private _visaCheckoutScriptLoader: VisaCheckoutScriptLoader
+        private _visaCheckoutScriptLoader: VisaCheckoutScriptLoader,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _customerActionCreator: CustomerActionCreator
     ) {}
 
     initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -89,6 +95,18 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
     signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut('braintreevisacheckout', options)
+        );
+    }
+
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.createCustomer(customerAccount, options)
+        );
+    }
+
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._billingAddressActionCreator.continueAsGuest(credentials, options)
         );
     }
 

--- a/src/customer/strategies/chasepay/chasepay-customer-strategy.spec.ts
+++ b/src/customer/strategies/chasepay/chasepay-customer-strategy.spec.ts
@@ -1,26 +1,43 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getFormFieldsState } from '../../../form/form.mock';
 import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getChasePay, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { ChasePayEventType, ChasePayScriptLoader, JPMC } from '../../../payment/strategies/chasepay';
 import { getChasePayScriptMock } from '../../../payment/strategies/chasepay/chasepay.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
 import ChasePayCustomerStrategy from './chasepay-customer-strategy';
 
 describe('ChasePayCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
+    let customerActionCreator: CustomerActionCreator;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
     let paymentMethodMock: PaymentMethod;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
@@ -60,6 +77,30 @@ describe('ChasePayCustomerStrategy', () => {
         jest.spyOn(chasePayScriptLoader, 'load')
             .mockReturnValue(Promise.resolve(JPMC));
 
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         requestSender = createRequestSender();
         formPoster = createFormPoster();
@@ -69,7 +110,9 @@ describe('ChasePayCustomerStrategy', () => {
             remoteCheckoutActionCreator,
             chasePayScriptLoader,
             requestSender,
-            formPoster
+            formPoster,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         container = document.createElement('div');
@@ -214,6 +257,29 @@ describe('ChasePayCustomerStrategy', () => {
         });
     });
 
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            await strategy.initialize({ methodId: 'chasepay', chasepay: { container: 'login' } });
+        });
+
+        it('runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'chasepay' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         beforeEach(async () => {
             await strategy.initialize({ methodId: 'chasepay', chasepay: { container: 'login' } });
@@ -247,6 +313,29 @@ describe('ChasePayCustomerStrategy', () => {
 
             expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('chasepay', options);
             expect(store.dispatch).toHaveBeenCalled();
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            await strategy.initialize({ methodId: 'chasepay', chasepay: { container: 'login' } });
+        });
+
+        it('runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'chasepay' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 });

--- a/src/customer/strategies/chasepay/chasepay-customer-strategy.ts
+++ b/src/customer/strategies/chasepay/chasepay-customer-strategy.ts
@@ -1,12 +1,16 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
+import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { ChasePayScriptLoader, ChasePaySuccessPayload } from '../../../payment/strategies/chasepay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
+import CustomerAccountRequestBody from '../../customer-account';
+import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
+import { GuestCredentials } from '../../guest-credentials';
 import CustomerStrategy from '../customer-strategy';
 
 export default class ChasePayCustomerStrategy implements CustomerStrategy {
@@ -18,7 +22,9 @@ export default class ChasePayCustomerStrategy implements CustomerStrategy {
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _chasePayScriptLoader: ChasePayScriptLoader,
         private _requestSender: RequestSender,
-        private _formPoster: FormPoster
+        private _formPoster: FormPoster,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _customerActionCreator: CustomerActionCreator
     ) {}
 
     initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -113,6 +119,18 @@ export default class ChasePayCustomerStrategy implements CustomerStrategy {
 
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.createCustomer(customerAccount, options)
+        );
+    }
+
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._billingAddressActionCreator.continueAsGuest(credentials, options)
         );
     }
 

--- a/src/customer/strategies/customer-strategy.ts
+++ b/src/customer/strategies/customer-strategy.ts
@@ -1,11 +1,17 @@
 import { InternalCheckoutSelectors } from '../../checkout';
+import CustomerAccountRequestBody from '../customer-account';
 import CustomerCredentials from '../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../customer-request-options';
+import { GuestCredentials } from '../guest-credentials';
 
 export default interface CustomerStrategy {
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
+
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
 
     signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
+
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors>;
 
     initialize(options?: CustomerInitializeOptions): Promise<InternalCheckoutSelectors>;
 

--- a/src/customer/strategies/default/default-customer-strategy.spec.ts
+++ b/src/customer/strategies/default/default-customer-strategy.spec.ts
@@ -3,12 +3,14 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { ScriptLoader } from '@bigcommerce/script-loader';
 import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { MutationObserverFactory } from '../../../common/dom';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getQuote } from '../../../quote/internal-quotes.mock';
 import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
 import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerActionType } from '../../customer-actions';
 import CustomerRequestSender from '../../customer-request-sender';
@@ -16,15 +18,16 @@ import CustomerRequestSender from '../../customer-request-sender';
 import DefaultCustomerStrategy from './default-customer-strategy';
 
 describe('DefaultCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let customerActionCreator: CustomerActionCreator;
     let store: CheckoutStore;
 
     beforeEach(() => {
         store = createCheckoutStore();
         const requestSender = createRequestSender();
-        const mockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
         const scriptLoader = new ScriptLoader();
-        const googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(scriptLoader, mockWindow);
+        const googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        const googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(scriptLoader, googleRecaptchaMockWindow);
         const mutationObserverFactory = new MutationObserverFactory();
         const googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, mutationObserverFactory);
 
@@ -40,10 +43,35 @@ describe('DefaultCustomerStrategy', () => {
                 new SpamProtectionRequestSender(requestSender)
             )
         );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(requestSender),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(requestSender)
+            )
+        );
+    });
+
+    it('dispatches action to continue as guest', async () => {
+        const strategy = new DefaultCustomerStrategy(store, billingAddressActionCreator, customerActionCreator);
+        const credentials = { email: 'foo@bar.com' };
+        const options = {};
+        const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+        jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+            .mockReturnValue(action);
+
+        jest.spyOn(store, 'dispatch');
+
+        const output = await strategy.continueAsGuest(credentials, options);
+
+        expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+        expect(store.dispatch).toHaveBeenCalledWith(action);
+        expect(output).toEqual(store.getState());
     });
 
     it('dispatches action to sign in customer', async () => {
-        const strategy = new DefaultCustomerStrategy(store, customerActionCreator);
+        const strategy = new DefaultCustomerStrategy(store, billingAddressActionCreator, customerActionCreator);
         const credentials = { email: 'foo@bar.com', password: 'foobar' };
         const options = {};
         const action = of(createAction(CustomerActionType.SignInCustomerRequested, getQuote()));
@@ -61,7 +89,7 @@ describe('DefaultCustomerStrategy', () => {
     });
 
     it('dispatches action to sign out customer', async () => {
-        const strategy = new DefaultCustomerStrategy(store, customerActionCreator);
+        const strategy = new DefaultCustomerStrategy(store, billingAddressActionCreator, customerActionCreator);
         const options = {};
         const action = of(createAction(CustomerActionType.SignOutCustomerRequested, getQuote()));
 
@@ -73,6 +101,24 @@ describe('DefaultCustomerStrategy', () => {
         const output = await strategy.signOut(options);
 
         expect(customerActionCreator.signOutCustomer).toHaveBeenCalledWith(options);
+        expect(store.dispatch).toHaveBeenCalledWith(action);
+        expect(output).toEqual(store.getState());
+    });
+
+    it('dispatches action to sign up customer', async () => {
+        const strategy = new DefaultCustomerStrategy(store, billingAddressActionCreator, customerActionCreator);
+        const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+        const options = {};
+        const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+        jest.spyOn(customerActionCreator, 'createCustomer')
+            .mockReturnValue(action);
+
+        jest.spyOn(store, 'dispatch');
+
+        const output = await strategy.signUp(customerAccount, options);
+
+        expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
         expect(store.dispatch).toHaveBeenCalledWith(action);
         expect(output).toEqual(store.getState());
     });

--- a/src/customer/strategies/default/default-customer-strategy.ts
+++ b/src/customer/strategies/default/default-customer-strategy.ts
@@ -1,14 +1,26 @@
+import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import CustomerAccountRequestBody from '../../customer-account';
 import CustomerActionCreator from '../../customer-action-creator';
 import CustomerCredentials from '../../customer-credentials';
 import { CustomerRequestOptions } from '../../customer-request-options';
+import { GuestCredentials } from '../../guest-credentials';
 import CustomerStrategy from '../customer-strategy';
 
 export default class DefaultCustomerStrategy implements CustomerStrategy {
     constructor(
         private _store: CheckoutStore,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
         private _customerActionCreator: CustomerActionCreator
     ) {}
+
+    initialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
         return this._store.dispatch(
@@ -22,11 +34,15 @@ export default class DefaultCustomerStrategy implements CustomerStrategy {
         );
     }
 
-    initialize(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.createCustomer(customerAccount, options)
+        );
     }
 
-    deinitialize(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._billingAddressActionCreator.continueAsGuest(credentials, options)
+        );
     }
 }

--- a/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
@@ -1,16 +1,29 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
@@ -18,9 +31,14 @@ import { getAuthNetCustomerInitializeOptions, Mode } from './googlepay-customer-
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
-    let formPoster: FormPoster;
+    let customerActionCreator: CustomerActionCreator;
     let customerInitializeOptions: CustomerInitializeOptions;
+    let formPoster: FormPoster;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
     let paymentProcessor: GooglePayPaymentProcessor;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
@@ -50,11 +68,37 @@ describe('GooglePayCustomerStrategy', () => {
 
         formPoster = createFormPoster();
 
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
         strategy = new GooglePayCustomerStrategy(
             store,
             remoteCheckoutActionCreator,
             paymentProcessor,
-            formPoster
+            formPoster,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         jest.spyOn(formPoster, 'postForm')
@@ -142,6 +186,31 @@ describe('GooglePayCustomerStrategy', () => {
         });
     });
 
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getAuthNetCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'googlepayauthorizenet' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         it('throws error if trying to sign in programmatically', async () => {
             customerInitializeOptions = getAuthNetCustomerInitializeOptions();
@@ -193,6 +262,31 @@ describe('GooglePayCustomerStrategy', () => {
 
             expect(await strategy.signOut(options)).toEqual(store.getState());
             expect(store.getState).toHaveBeenCalledTimes(4);
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getAuthNetCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'googlepayauthorizenet' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 

--- a/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
@@ -1,18 +1,30 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
 import { createGooglePayPaymentProcessor, GooglePayBraintreeInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
@@ -20,9 +32,14 @@ import { getBraintreeCustomerInitializeOptions,  Mode } from './googlepay-custom
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
-    let formPoster: FormPoster;
+    let customerActionCreator: CustomerActionCreator;
     let customerInitializeOptions: CustomerInitializeOptions;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
+    let formPoster: FormPoster;
     let paymentProcessor: GooglePayPaymentProcessor;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
@@ -53,13 +70,40 @@ describe('GooglePayCustomerStrategy', () => {
                 )
             )
         );
+
         formPoster = createFormPoster();
+
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
 
         strategy = new GooglePayCustomerStrategy(
             store,
             remoteCheckoutActionCreator,
             paymentProcessor,
-            formPoster
+            formPoster,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         jest.spyOn(formPoster, 'postForm')
@@ -147,6 +191,31 @@ describe('GooglePayCustomerStrategy', () => {
         });
     });
 
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getBraintreeCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'googlepaybraintree' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         it('throws error if trying to sign in programmatically', async () => {
             customerInitializeOptions = getBraintreeCustomerInitializeOptions();
@@ -198,6 +267,31 @@ describe('GooglePayCustomerStrategy', () => {
 
             expect(await strategy.signOut(options)).toEqual(store.getState());
             expect(store.getState).toHaveBeenCalledTimes(4);
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getBraintreeCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'googlepaybraintree' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 

--- a/src/customer/strategies/googlepay/googlepay-checkoutcom-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-checkoutcom-customer-strategy.spec.ts
@@ -1,16 +1,29 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayCheckoutcomInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
@@ -18,9 +31,14 @@ import { getCheckoutcomCustomerInitializeOptions, Mode } from './googlepay-custo
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
-    let formPoster: FormPoster;
+    let customerActionCreator: CustomerActionCreator;
     let customerInitializeOptions: CustomerInitializeOptions;
+    let formPoster: FormPoster;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
     let paymentProcessor: GooglePayPaymentProcessor;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
@@ -50,11 +68,37 @@ describe('GooglePayCustomerStrategy', () => {
 
         formPoster = createFormPoster();
 
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
         strategy = new GooglePayCustomerStrategy(
             store,
             remoteCheckoutActionCreator,
             paymentProcessor,
-            formPoster
+            formPoster,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         jest.spyOn(formPoster, 'postForm')
@@ -142,6 +186,31 @@ describe('GooglePayCustomerStrategy', () => {
         });
     });
 
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getCheckoutcomCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'googlepaycheckoutcom' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         it('throws error if trying to sign in programmatically', async () => {
             customerInitializeOptions = getCheckoutcomCustomerInitializeOptions();
@@ -193,6 +262,31 @@ describe('GooglePayCustomerStrategy', () => {
 
             expect(await strategy.signOut(options)).toEqual(store.getState());
             expect(store.getState).toHaveBeenCalledTimes(4);
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getCheckoutcomCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'googlepaycheckoutcom' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -1,12 +1,16 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 
+import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from '../../../common/error/errors';
 import { bindDecorator as bind } from '../../../common/utility';
 import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
 import { getShippableItemsCount } from '../../../shipping';
+import CustomerAccountRequestBody from '../../customer-account';
+import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
+import { GuestCredentials } from '../../guest-credentials';
 import CustomerStrategy from '../customer-strategy';
 
 import GooglePayCustomerInitializeOptions from './googlepay-customer-initialize-options';
@@ -18,7 +22,9 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         private _store: CheckoutStore,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _googlePayPaymentProcessor: GooglePayPaymentProcessor,
-        private _formPoster: FormPoster
+        private _formPoster: FormPoster,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _customerActionCreator: CustomerActionCreator
     ) {}
 
     initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -63,6 +69,18 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
 
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.createCustomer(customerAccount, options)
+        );
+    }
+
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._billingAddressActionCreator.continueAsGuest(credentials, options)
         );
     }
 

--- a/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
@@ -1,16 +1,29 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayCybersourceV2Initializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
@@ -18,9 +31,14 @@ import { getCybersourceV2CustomerInitializeOptions, Mode } from './googlepay-cus
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
-    let formPoster: FormPoster;
+    let customerActionCreator: CustomerActionCreator;
     let customerInitializeOptions: CustomerInitializeOptions;
+    let formPoster: FormPoster;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
     let paymentProcessor: GooglePayPaymentProcessor;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
@@ -50,11 +68,37 @@ describe('GooglePayCustomerStrategy', () => {
 
         formPoster = createFormPoster();
 
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
         strategy = new GooglePayCustomerStrategy(
             store,
             remoteCheckoutActionCreator,
             paymentProcessor,
-            formPoster
+            formPoster,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         jest.spyOn(formPoster, 'postForm')
@@ -142,6 +186,31 @@ describe('GooglePayCustomerStrategy', () => {
         });
     });
 
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getCybersourceV2CustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'googlepaycybersourcev2' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         it('throws error if trying to sign in programmatically', async () => {
             customerInitializeOptions = getCybersourceV2CustomerInitializeOptions();
@@ -193,6 +262,31 @@ describe('GooglePayCustomerStrategy', () => {
 
             expect(await strategy.signOut(options)).toEqual(store.getState());
             expect(store.getState).toHaveBeenCalledTimes(4);
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getCybersourceV2CustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'googlepaycybersourcev2' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 

--- a/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
@@ -1,16 +1,29 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayPaymentProcessor, GooglePayStripeInitializer } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
@@ -18,9 +31,14 @@ import { getStripeCustomerInitializeOptions, Mode } from './googlepay-customer-m
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
-    let formPoster: FormPoster;
+    let customerActionCreator: CustomerActionCreator;
     let customerInitializeOptions: CustomerInitializeOptions;
+    let formPoster: FormPoster;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
     let paymentProcessor: GooglePayPaymentProcessor;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
@@ -50,11 +68,37 @@ describe('GooglePayCustomerStrategy', () => {
 
         formPoster = createFormPoster();
 
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
         strategy = new GooglePayCustomerStrategy(
             store,
             remoteCheckoutActionCreator,
             paymentProcessor,
-            formPoster
+            formPoster,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         jest.spyOn(formPoster, 'postForm')
@@ -142,6 +186,31 @@ describe('GooglePayCustomerStrategy', () => {
         });
     });
 
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getStripeCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'googlepaystripe' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         it('throws error if trying to sign in programmatically', async () => {
             customerInitializeOptions = getStripeCustomerInitializeOptions();
@@ -193,6 +262,31 @@ describe('GooglePayCustomerStrategy', () => {
 
             expect(await strategy.signOut(options)).toEqual(store.getState());
             expect(store.getState).toHaveBeenCalledTimes(4);
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            customerInitializeOptions = getStripeCustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+        });
+
+        it('runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'googlepaystripe' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 

--- a/src/customer/strategies/masterpass/masterpass-customer-strategy.spec.ts
+++ b/src/customer/strategies/masterpass/masterpass-customer-strategy.spec.ts
@@ -1,24 +1,41 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfig, getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getMasterpass, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { Masterpass, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
 import { getMasterpassScriptMock } from '../../../payment/strategies/masterpass/masterpass.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
 import MasterpassCustomerStrategy from './masterpass-customer-strategy';
 
 describe('MasterpassCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
+    let customerActionCreator: CustomerActionCreator;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
     let masterpass: Masterpass;
     let masterpassScriptLoader: MasterpassScriptLoader;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
@@ -53,7 +70,7 @@ describe('MasterpassCustomerStrategy', () => {
             .mockReturnValue(paymentMethodMock);
 
         jest.spyOn(store.getState().config, 'getStoreConfig')
-        .mockReturnValue(getConfig().storeConfig);
+            .mockReturnValue(getConfig().storeConfig);
 
         requestSender = createRequestSender();
 
@@ -71,11 +88,38 @@ describe('MasterpassCustomerStrategy', () => {
         paymentMethodActionCreator = new PaymentMethodActionCreator(
             new PaymentMethodRequestSender(requestSender)
         );
+
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
         strategy = new MasterpassCustomerStrategy(
             store,
             paymentMethodActionCreator,
             remoteCheckoutActionCreator,
-            masterpassScriptLoader
+            masterpassScriptLoader,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         container = document.createElement('div');
@@ -188,6 +232,29 @@ describe('MasterpassCustomerStrategy', () => {
         });
     });
 
+    describe('#continueAsGuest()', () => {
+        beforeEach(async () => {
+            await strategy.initialize({ methodId: 'masterpass', masterpass: { container: 'login' } });
+        });
+
+        it('runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'masterpass' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         beforeEach(async () => {
             await strategy.initialize({ methodId: 'masterpass', masterpass: { container: 'login' } });
@@ -222,6 +289,29 @@ describe('MasterpassCustomerStrategy', () => {
 
             expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('masterpass', options);
             expect(store.dispatch).toHaveBeenCalled();
+        });
+    });
+
+    describe('#signUp()', () => {
+        beforeEach(async () => {
+            await strategy.initialize({ methodId: 'masterpass', masterpass: { container: 'login' } });
+        });
+
+        it('runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'masterpass' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 });

--- a/src/customer/strategies/masterpass/masterpass-customer-strategy.ts
+++ b/src/customer/strategies/masterpass/masterpass-customer-strategy.ts
@@ -1,9 +1,13 @@
+import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from '../../../common/error/errors';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { getCallbackUrl, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
+import CustomerAccountRequestBody from '../../customer-account';
+import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerInitializeOptions, CustomerRequestOptions } from '../../customer-request-options';
+import { GuestCredentials } from '../../guest-credentials';
 import CustomerStrategy from '../customer-strategy';
 
 export default class MasterpassCustomerStrategy implements CustomerStrategy {
@@ -14,7 +18,9 @@ export default class MasterpassCustomerStrategy implements CustomerStrategy {
         private _store: CheckoutStore,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
-        private _masterpassScriptLoader: MasterpassScriptLoader
+        private _masterpassScriptLoader: MasterpassScriptLoader,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _customerActionCreator: CustomerActionCreator
     ) {}
 
     initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -100,6 +106,18 @@ export default class MasterpassCustomerStrategy implements CustomerStrategy {
 
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.createCustomer(customerAccount, options)
+        );
+    }
+
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._billingAddressActionCreator.continueAsGuest(credentials, options)
         );
     }
 

--- a/src/customer/strategies/square/square-customer-strategy.spec.ts
+++ b/src/customer/strategies/square/square-customer-strategy.spec.ts
@@ -1,19 +1,37 @@
+import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { of } from 'rxjs';
 
+import { BillingAddressActionCreator, BillingAddressActionType, BillingAddressRequestSender } from '../../../billing';
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState, getSquare } from '../../../payment/payment-methods.mock';
+import { getQuote } from '../../../quote/internal-quotes.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { GoogleRecaptcha, GoogleRecaptchaScriptLoader, GoogleRecaptchaWindow, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
+import CustomerRequestSender from '../../customer-request-sender';
 import { getCustomerState } from '../../customers.mock';
 import CustomerStrategy from '../customer-strategy';
 
 import SquareCustomerStrategy from './square-customer-strategy';
 
 describe('SquareCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
     let container: HTMLDivElement;
+    let customerActionCreator: CustomerActionCreator;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
     let paymentMethodMock: PaymentMethod;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let store: CheckoutStore;
@@ -40,9 +58,35 @@ describe('SquareCustomerStrategy', () => {
             new RemoteCheckoutRequestSender(createRequestSender())
         );
 
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(createScriptLoader(), googleRecaptchaMockWindow);
+        googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, new MutationObserverFactory());
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender())
+            )
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(createRequestSender()),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(createRequestSender())
+            )
+        );
+
         strategy = new SquareCustomerStrategy(
             store,
-            remoteCheckoutActionCreator
+            remoteCheckoutActionCreator,
+            billingAddressActionCreator,
+            customerActionCreator
         );
 
         container = document.createElement('div');
@@ -58,6 +102,25 @@ describe('SquareCustomerStrategy', () => {
         expect(strategy).toBeInstanceOf(SquareCustomerStrategy);
     });
 
+    describe('#continueAsGuest()', () => {
+        it('runs default continue as guest flow', async () => {
+            const credentials = { email: 'foo@bar.com' };
+            const options = { methodId: 'squarev2' };
+            const action = of(createAction(BillingAddressActionType.ContinueAsGuestRequested, getQuote()));
+
+            jest.spyOn(billingAddressActionCreator, 'continueAsGuest')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.continueAsGuest(credentials, options);
+
+            expect(billingAddressActionCreator.continueAsGuest).toHaveBeenCalledWith(credentials, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
+        });
+    });
+
     describe('#signIn()', () => {
         it('throws error if trying to sign in programmatically', () => {
             expect(() => strategy.signIn({ email: 'foo@bar.com', password: 'foobar' })).toThrowError();
@@ -66,9 +129,7 @@ describe('SquareCustomerStrategy', () => {
 
     describe('#signOut()', () => {
         beforeEach(() => {
-            const paymentId = {
-                providerId: 'squarev2',
-            };
+            const paymentId = { providerId: 'squarev2' };
 
             jest.spyOn(store.getState().payment, 'getPaymentId').mockReturnValue(paymentId);
 
@@ -77,14 +138,31 @@ describe('SquareCustomerStrategy', () => {
         });
 
         it('throws error if trying to sign out programmatically', async () => {
-            const options = {
-                methodId: 'squarev2',
-            };
+            const options = { methodId: 'squarev2' };
 
             await strategy.signOut(options);
 
             expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('squarev2', options);
             expect(store.dispatch).toHaveBeenCalled();
+        });
+    });
+
+    describe('#signUp()', () => {
+        it('runs default sign up customer flow', async () => {
+            const customerAccount = { firstName: 'foo', lastName: 'bar', email: 'foo@bar.com', password: 'foobar' };
+            const options = { methodId: 'squarev2' };
+            const action = of(createAction(CustomerActionType.CreateCustomerRequested, getQuote()));
+
+            jest.spyOn(customerActionCreator, 'createCustomer')
+                .mockReturnValue(action);
+
+            jest.spyOn(store, 'dispatch');
+
+            const output = await strategy.signUp(customerAccount, options);
+
+            expect(customerActionCreator.createCustomer).toHaveBeenCalledWith(customerAccount, options);
+            expect(store.dispatch).toHaveBeenCalledWith(action);
+            expect(output).toEqual(store.getState());
         });
     });
 });

--- a/src/customer/strategies/square/square-customer-strategy.ts
+++ b/src/customer/strategies/square/square-customer-strategy.ts
@@ -1,14 +1,20 @@
+import { BillingAddressActionCreator } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { NotImplementedError } from '../../../common/error/errors';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
+import CustomerAccountRequestBody from '../../customer-account';
+import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerRequestOptions } from '../../customer-request-options';
+import { GuestCredentials } from '../../guest-credentials';
 import CustomerStrategy from '../customer-strategy';
 
 export default class SquareCustomerStrategy implements CustomerStrategy {
 
     constructor(
         private _store: CheckoutStore,
-        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator
+        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _customerActionCreator: CustomerActionCreator
     ) {}
 
     signIn(): Promise<InternalCheckoutSelectors> {
@@ -27,6 +33,18 @@ export default class SquareCustomerStrategy implements CustomerStrategy {
 
         return this._store.dispatch(
             this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
+        );
+    }
+
+    signUp(customerAccount: CustomerAccountRequestBody, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.createCustomer(customerAccount, options)
+        );
+    }
+
+    continueAsGuest(credentials: GuestCredentials, options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._billingAddressActionCreator.continueAsGuest(credentials, options)
         );
     }
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -670,6 +670,7 @@ export function getBolt(): PaymentMethod {
         type: 'PAYMENT_TYPE_API',
         initializationData: {
             publishableKey: 'publishableKey',
+            customContinueFlowEnabled: false,
         },
         clientToken: 'clientToken',
     };

--- a/src/payment/strategies/bolt/bolt.mock.ts
+++ b/src/payment/strategies/bolt/bolt.mock.ts
@@ -6,6 +6,8 @@ export function getBoltScriptMock(shouldSucced: boolean = false): BoltCheckout {
             return getConfiguredBoltMock(shouldSucced, callbacks || { success: () => {}, close: () => {}});
         }),
         setClientCustomCallbacks: jest.fn(),
+        openCheckout: jest.fn(),
+        hasBoltAccount: jest.fn(),
     };
 }
 

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -5,6 +5,12 @@ export interface BoltHostWindow extends Window {
 export interface BoltCheckout {
     configure(cart: BoltCart, hints: {}, callbacks?: BoltCallbacks): BoltClient;
     setClientCustomCallbacks(callbacks: BoltCallbacks): void;
+    openCheckout(email: string, callbacks?: BoltOpenCheckoutCallbacks): void;
+    hasBoltAccount(email: string): boolean;
+}
+
+export interface BoltOpenCheckoutCallbacks {
+    close?(): void;
 }
 
 export interface BoltDeveloperModeParams {


### PR DESCRIPTION
…s with bolt account

## What?
Added BoltCheckout implementation for customers with bolt account.

## Why?
We need to add custom flow for _continue as guest_, _sign in_ and  _sign up_ events, to show BoltCheckout modal if the customer has BoltAccount

Task: https://jira.bigcommerce.com/browse/BOLT-19

## Sibling pull-request
checkout-js: https://github.com/bigcommerce/checkout-js/pull/619

## Testing / Proof
Some gifs to figure out how it looks like:
![continue_as_customer](https://user-images.githubusercontent.com/25133454/122948894-eb7dd180-d383-11eb-81bf-6e1be142deaf.gif)
![sign_in](https://user-images.githubusercontent.com/25133454/122948927-f0db1c00-d383-11eb-92cd-faa159989147.gif)
![sign_up](https://user-images.githubusercontent.com/25133454/122948951-f59fd000-d383-11eb-9a3a-0da28878f1b4.gif)

There how it will looks like if the user have default flow or customer hasn't bolt account:
![continue_as_guest_without_bolt_account](https://user-images.githubusercontent.com/25133454/124246107-4b653c80-db29-11eb-8501-3405fd6f4e36.gif)


@bigcommerce/checkout @bigcommerce/payments
