### PR TITLE
INT-4087 Send the client token back to update the payment intent related for StripeV3

### DIFF
--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -360,6 +360,28 @@ describe('StripeV3PaymentStrategy', () => {
                     expect(response).toBe(store.getState());
                 });
 
+                it('submit payment with credit card and passes back the client token', async () => {
+                    await strategy.initialize(options);
+                    const response = await strategy.execute(getStripeV3OrderRequestBodyMock());
+
+                    expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            methodId: 'card',
+                            paymentData: expect.objectContaining({
+                                formattedPayload: {
+                                    credit_card_token: {
+                                        token: 'pm_1234',
+                                    },
+                                    confirm: false,
+                                    client_token: 'myToken',
+                                    vault_payment_instrument: false,
+                                },
+                            }),
+                        })
+                    );
+                    expect(response).toBe(store.getState());
+                });
+
                 it('with a signed user without phone number', async () => {
                     const customer = getCustomer();
                     customer.addresses[0].phone = '';

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -92,6 +92,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
             const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}?method=${methodId}`));
             const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
             const result = await this._confirmStripePayment(paymentMethod);
+            const { clientToken, method } = paymentMethod;
             const { id: token } = result.paymentIntent ?? result.paymentMethod ?? { id: '' };
             stripeError = result.error;
 
@@ -100,6 +101,10 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                 vault_payment_instrument: shouldSaveInstrument,
                 confirm: false,
             };
+
+            if (method === StripeElementType.CreditCard) {
+                formattedPayload.client_token = clientToken;
+            }
         }
 
         if (!shouldSubmitOrderBeforeLoadingAPM) {


### PR DESCRIPTION
[INT-4087](https://jira.bigcommerce.com/browse/INT-4087)

## What?
- Send back the client token to bigpay to update the related payment intent when place a order using a credit card

## Why?
- Update the payment intent instead to create a new one to prevent to left a incomplete payment intent

## Testing / Proof

<img width="285" alt="image" src="https://user-images.githubusercontent.com/45854000/123495253-9b537900-d5e8-11eb-824f-e4499554a3dd.png">

@bigcommerce/checkout @bigcommerce/payments
