### PR TITLE
fix(payment): INT-4438 update SDK documentation for Digital River

### DIFF
--- a/src/payment/strategies/digitalriver/digitalriver-payment-initialize-options.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-initialize-options.ts
@@ -1,5 +1,77 @@
 import { OptionsResponse } from './digitalriver';
 
+/**
+ * A set of options that are required to initialize the DigitalRiver payment method.
+ *
+ * When DigitalRiver is initialized, a widget will be inserted into the DOM. The widget has a list of payment options for the customer to choose from.
+ *
+ * ```html
+ * <!-- This is where the widget will be inserted -->
+ * <div id="container"></div>
+ * ```
+ *
+ * ```js
+ * service.initializePayment({
+ *   methodId: 'digitalriver',
+ *   digitalriver: {
+ *       containerId: 'digitalriver-component-field',
+ *       // Callback for submitting payment form that gets called when a buyer approves DR payment
+ *       onSubmitForm: () => {
+ *           // Example function
+ *           this.submitOrder(
+ *               {
+ *                   payment: {methodId: 'digitalriver',}
+ *               }
+ *           );
+ *       },
+ *       onError: (error) => {
+ *           console.log(error);
+ *       },
+ *   }
+ * });
+ * ```
+ *
+ * Additional options can be passed in to customize the components and register
+ * event callbacks.
+ *
+ * ```js
+ * service.initializePayment({
+ *   methodId: 'digitalriver',
+ *   digitalriver: {
+ *       containerId: 'digitalriver-component-field',
+ *       configuration: {
+ *           flow: 'checkout',
+ *           showSavePaymentAgreement: false,
+ *           showComplianceSection: true,
+ *           button: {
+ *               type: 'submitOrder',
+ *           },
+ *           usage: 'unscheduled',
+ *           showTermsOfSaleDisclosure: true,
+ *           paymentMethodConfiguration: {
+ *               classes: {
+ *                   // these classes are to control styles on BC side
+ *                   base: 'form-input optimizedCheckout-form-input'
+ *               },
+ *           },
+ *       },
+ *       // Callback for submitting payment form that gets called when a buyer approves DR payment
+ *      onSubmitForm: () => {
+ *           // Example function
+ *           this.submitOrder(
+ *               {
+ *                   payment: {methodId: 'digitalriver',}
+ *               }
+ *           );
+ *       },
+ *       onError: (error) => {
+ *           console.log(error);
+ *       },
+ *   }
+ * });
+ * ```
+ */
+
 export default interface DigitalRiverPaymentInitializeOptions {
     /**
      * The ID of a container which the Digital River drop in component should be mounted


### PR DESCRIPTION
## What? [INT-4438](https://jira.bigcommerce.com/browse/INT-4438)
updated Digital River documentation

## Why?
As a Third-party developer, I want to be able to use the Checkout SDK within the context of Digital River so that I can build my own checkout and understand how Digital River payment integration will work.

## Testing / Proof
<img width="1353" alt="Screen Shot 2021-06-29 at 4 48 27 PM" src="https://user-images.githubusercontent.com/42154828/123871910-f0013780-d8f9-11eb-89bd-ebe7e6fb4926.png">
<img width="1351" alt="Screen Shot 2021-06-29 at 4 48 37 PM" src="https://user-images.githubusercontent.com/42154828/123871915-f1326480-d8f9-11eb-9fc1-9f185e3df98a.png">

@bigcommerce/checkout @bigcommerce/payments
