### PR TITLE
CHECKOUT-5892: Specify locale for default and fallback translations

### DIFF
--- a/src/locale/language-config.ts
+++ b/src/locale/language-config.ts
@@ -1,5 +1,8 @@
 export default interface LanguageConfig {
     defaultTranslations: Translations;
+    defaultLocale?: string;
+    fallbackTranslations?: Translations;
+    fallbackLocale?: string;
     locale: string;
     locales: Locales;
     translations: Translations;

--- a/src/locale/language-service.ts
+++ b/src/locale/language-service.ts
@@ -117,15 +117,23 @@ export default class LanguageService {
         const locales = config.locales || {};
         const translations = this._flattenObject(config.translations || {});
         const defaultTranslations = this._flattenObject(config.defaultTranslations || {});
-        const translationKeys = union(Object.keys(defaultTranslations), Object.keys(translations));
+        const fallbackTranslations = this._flattenObject(config.fallbackTranslations || {});
+        const translationKeys = union(
+            Object.keys(fallbackTranslations),
+            Object.keys(defaultTranslations),
+            Object.keys(translations)
+        );
 
         translationKeys.forEach(key => {
             if (translations && translations[key]) {
                 output.translations[key] = translations[key];
                 output.locales[key] = locales[key] || output.locale;
-            } else {
+            } else if (defaultTranslations[key]) {
                 output.translations[key] = defaultTranslations[key];
-                output.locales[key] = DEFAULT_LOCALE;
+                output.locales[key] = config.defaultLocale ?? DEFAULT_LOCALE;
+            } else {
+                output.translations[key] = fallbackTranslations[key];
+                output.locales[key] = config.fallbackLocale ?? DEFAULT_LOCALE;
             }
         });
 


### PR DESCRIPTION
## What?
Specify a locale for default and fallback translations.

## Why?
At the moment, it is defaulted as `en`. But default translations can be in a language other than English. We can't just default to English because that'd break locale-aware formatting (i.e.: pluralisation)

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments
