### PR TITLE
fix(payment): INT-4448 Braintree cardTypeChange event

### DIFF
--- a/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -219,18 +219,38 @@ describe('BraintreeHostedForm', () => {
             .toHaveBeenCalledWith({ fieldType: 'cardCode' });
     });
 
-    it('notifies when card number changes', async () => {
-        const handleCardTypeChange = jest.fn();
+    describe('#cardTypeChange', () => {
+        let handleCardTypeChange: jest.Mock;
 
-        await subject.initialize({
-            ...formOptions,
-            onCardTypeChange: handleCardTypeChange,
+        beforeEach(async () => {
+            handleCardTypeChange = jest.fn();
+
+            await subject.initialize({
+                ...formOptions,
+                onCardTypeChange: handleCardTypeChange,
+            });
         });
 
-        cardFieldsEventEmitter.emit('cardTypeChange', { cards: [{ type: 'Visa' }] });
+        it('notifies when card number changes', () => {
+            cardFieldsEventEmitter.emit('cardTypeChange', { cards: [{ type: 'visa' }] });
 
-        expect(handleCardTypeChange)
-            .toHaveBeenCalledWith({ cardType: 'Visa' });
+            expect(handleCardTypeChange)
+                .toHaveBeenCalledWith({ cardType: 'visa' });
+        });
+
+        it('notifies when card number changes and type is master-card', () => {
+            cardFieldsEventEmitter.emit('cardTypeChange', { cards: [{ type: 'master-card' }] });
+
+            expect(handleCardTypeChange)
+                .toHaveBeenCalledWith({ cardType: 'mastercard' });
+        });
+
+        it('notifies when card number changes and type of card is not yet known', () => {
+            cardFieldsEventEmitter.emit('cardTypeChange', { cards: [{ type: 'visa' }, { type: 'master-card' }] });
+
+            expect(handleCardTypeChange)
+                .toHaveBeenCalledWith({ cardType: undefined });
+        });
     });
 
     it('notifies when there are validation errors', async () => {

--- a/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -362,7 +362,9 @@ export default class BraintreeHostedForm {
 
     private _handleCardTypeChange: (event: BraintreeHostedFieldsState) => void = event => {
         this._formOptions?.onCardTypeChange?.({
-            cardType: event.cards[0]?.type,
+            cardType: event.cards.length === 1
+                ? event.cards[0].type.replace(/^master\-card$/, 'mastercard')
+                : undefined,
         });
     };
 


### PR DESCRIPTION
## What? [INT-4448](https://jira.bigcommerce.com/browse/INT-4448)
1. Validate event.cards length according to [the example](https://braintree.github.io/braintree-web/3.70.0/HostedFields.html#cardTypeChange-examples).
2. Replace `master-card` with `mastercard` in order to get MC logo highlighted.
-- [Braintree's card types](https://braintree.github.io/braintree-web/3.70.0/HostedFields.html#~hostedFieldsCard) vs [checkout supported card types](https://github.com/bigcommerce/checkout-js/blob/a17741168f05d11b6d8e6a773b999dde6bd0a123/src/app/payment/creditCard/CreditCardIconList.tsx#L6)
## Why?
1. To highlight all logos when the CC field is empty.
2. To support MC logo highlighting.

## Testing / Proof
![demo](https://user-images.githubusercontent.com/4843328/124039143-f1993100-d9c7-11eb-8b85-cc990fc0cd5b.gif)

@bigcommerce/checkout @bigcommerce/payments
