### PR TITLE
fix(payment): PAYPAL-1026 fixed button height

### DIFF
--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
@@ -13,7 +13,7 @@ export interface BraintreePaypalButtonInitializeOptions {
     /**
      * A set of styling options for the checkout button.
      */
-    style?: Pick<PaypalButtonStyleOptions, 'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons'>;
+    style?: Pick<PaypalButtonStyleOptions, 'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons' | 'height'>;
 
     /**
      * Whether or not to show a credit button.

--- a/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -54,6 +54,9 @@ describe('BraintreePaypalButtonStrategy', () => {
         paypalOptions = {
             onAuthorizeError: jest.fn(),
             onPaymentError: jest.fn(),
+            style: {
+                height: 45,
+            },
         };
 
         options = {
@@ -196,6 +199,7 @@ describe('BraintreePaypalButtonStrategy', () => {
             style: {
                 label: undefined,
                 shape: 'rect',
+                height: 45,
             },
             fundingSource: paypal.FUNDING.PAYPAL,
         });
@@ -214,6 +218,7 @@ describe('BraintreePaypalButtonStrategy', () => {
                     label: 'paypal',
                     tagline: true,
                     fundingicons: false,
+                    height: 45,
                 },
             },
         };
@@ -229,6 +234,7 @@ describe('BraintreePaypalButtonStrategy', () => {
                 label: 'paypal',
                 tagline: true,
                 fundingicons: false,
+                height: 45,
             },
         }));
     });
@@ -507,6 +513,7 @@ describe('BraintreePaypalButtonStrategy', () => {
                     allowCredit: true,
                     style: {
                         label: 'credit',
+                        height: 45,
                     },
                 },
             };
@@ -532,6 +539,7 @@ describe('BraintreePaypalButtonStrategy', () => {
                 style: {
                     label: 'credit',
                     shape: 'rect',
+                    height: 45,
                 },
                 fundingSource: paypal.FUNDING.PAYPAL,
             });

--- a/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/src/payment/strategies/paypal/paypal-sdk.ts
@@ -52,6 +52,7 @@ export interface PaypalButtonStyleOptions {
     shape?: 'pill' | 'rect';
     tagline?: boolean;
     fundingicons?: boolean;
+    height?: number;
 }
 
 export interface PaypalActions {


### PR DESCRIPTION
## What?
Fixed button height for Braintree payment provider

## Why?
According to task https://jira.bigcommerce.com/browse/PAYPAL-1026
## Testing / Proof
Tested on dev and integration

@bigcommerce/checkout @bigcommerce/payments @davidchin 
