### PR TITLE
feat(payment): BOLT-30 updated finalize method for Bolt payment strategy

### DIFF
--- a/src/payment/strategies/bolt/bolt-script-loader.ts
+++ b/src/payment/strategies/bolt/bolt-script-loader.ts
@@ -11,6 +11,10 @@ export default class BoltScriptLoader {
     ) {}
 
     async load(publishableKey: string, testMode?: boolean, developerModeParams?: BoltDeveloperModeParams): Promise<BoltCheckout> {
+        if (this._window.BoltCheckout) {
+            return this._window.BoltCheckout;
+        }
+
         const options: LoadScriptOptions = {
             async: true,
             attributes: {

--- a/src/payment/strategies/bolt/bolt.mock.ts
+++ b/src/payment/strategies/bolt/bolt.mock.ts
@@ -6,6 +6,7 @@ export function getBoltScriptMock(shouldSucced: boolean = false): BoltCheckout {
             return getConfiguredBoltMock(shouldSucced, callbacks || { success: () => {}, close: () => {}});
         }),
         setClientCustomCallbacks: jest.fn(),
+        getTransactionReference: jest.fn(),
     };
 }
 

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -5,6 +5,7 @@ export interface BoltHostWindow extends Window {
 export interface BoltCheckout {
     configure(cart: BoltCart, hints: {}, callbacks?: BoltCallbacks): BoltClient;
     setClientCustomCallbacks(callbacks: BoltCallbacks): void;
+    getTransactionReference(): Promise<string | undefined>;
 }
 
 export interface BoltDeveloperModeParams {


### PR DESCRIPTION
## What?
Updated executeBoltFullCheckout method for Bolt payment strategy.

## Why?
From current implementation the fact that an order is created after the Bolt Payment happens in some cases (issue on Bolt side or slow connection) cause of the issues with orphan orders on Bolt side. For minimising this issues we some changes to executeBoltFullCheckout method more useful and Bolt will send us transaction reference. When Bolt creates transaction reference the are understand that we have an order created and I they will have some troubles on their side, we will throw an error to let user know, that something went wrong.

## Testing / Proof
All unit tests passed locally:
<img width="325" alt="Screenshot 2021-07-02 at 10 09 15" src="https://user-images.githubusercontent.com/25133454/124237588-57003580-db20-11eb-8640-9c6676077743.png">

@bigcommerce/checkout @bigcommerce/payments
