### PR TITLE
feat(payment): PAYMENTS-6811 map failure codes to RequestError format

### DIFF
--- a/src/payment/strategies/ppsdk/step-handler/failed.spec.ts
+++ b/src/payment/strategies/ppsdk/step-handler/failed.spec.ts
@@ -15,6 +15,11 @@ describe('handleFailed', () => {
         };
 
         await expect(handleFailed(failedResponse)).rejects.toBeInstanceOf(RequestError);
+        await expect(handleFailed(failedResponse)).rejects.toStrictEqual(
+            expect.objectContaining({
+                body: { errors: [{ code: 'any-failure' }] },
+            })
+        );
     });
 });
 

--- a/src/payment/strategies/ppsdk/step-handler/failed.ts
+++ b/src/payment/strategies/ppsdk/step-handler/failed.ts
@@ -14,5 +14,14 @@ export const isFailed = (response: PaymentsAPIResponse): response is FailedRespo
     get(response.body, 'type') === 'failed' &&
     isString(get(response.body, 'code'));
 
+const toRequestErrorFormat = (failedResponse: FailedResponse) => ({
+    ...failedResponse,
+    body: {
+        errors: [
+            { code: failedResponse.body.code },
+        ],
+    },
+});
+
 export const handleFailed = (response: FailedResponse): Promise<void> =>
-    Promise.reject(new RequestError(response));
+    Promise.reject(new RequestError(toRequestErrorFormat(response)));


### PR DESCRIPTION
**N.B.** This work is protected behind a WIP feature toggle

## What?

- Map PPSDK payments API error responses into the format expected by `RequestError`

## Why?

- Consistency with current error reporting
- To enable specific translated error messages to be used in `checkout-js`'s current error modal (no changes required to `checkout-js`)


## Testing / Proof

- Extended test
![image](https://user-images.githubusercontent.com/56807262/124702212-5e19b000-df33-11eb-9d7c-0dd44a23ddac.png)


@bigcommerce/checkout @bigcommerce/payments
