### PR TITLE
fix(payment): INT-4481 GooglePay: Fix issue when attempting to pay without a last name provided in the billing address

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-get-first-and-last-name.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-get-first-and-last-name.spec.ts
@@ -1,0 +1,20 @@
+import { getFirstAndLastName } from './googlepay-get-first-and-last-name';
+
+describe('With a one part name', () => {
+    it('assigns the whole string as the first name', () => {
+        expect(getFirstAndLastName('Cher')).toEqual(['Cher', '']);
+    });
+});
+
+describe('With a two part name', () => {
+    it('splits the string into a first and a second name', () => {
+        expect(getFirstAndLastName('Lee Dunkley')).toEqual(['Lee', 'Dunkley']);
+    });
+});
+
+describe('With a three or more part name', () => {
+    it('assigns the final part as the last name and all others as the first name', () => {
+        expect(getFirstAndLastName('Neil deGrasse Tyson')).toEqual(['Neil deGrasse', 'Tyson']);
+        expect(getFirstAndLastName('Ignacio Arsenio Travieso Scull')).toEqual(['Ignacio Arsenio Travieso', 'Scull']);
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-get-first-and-last-name.ts
+++ b/src/payment/strategies/googlepay/googlepay-get-first-and-last-name.ts
@@ -1,0 +1,12 @@
+export function getFirstAndLastName(fullName: string): [string, string] {
+    const nameParts = fullName.split(' ');
+
+    if (nameParts.length === 1) {
+        return [fullName, ''];
+    }
+
+    const firstName = nameParts.slice(0, -1).join(' ');
+    const lastName = nameParts[nameParts.length - 1];
+
+    return [firstName, lastName];
+}

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
@@ -238,6 +238,18 @@ describe('GooglePayPaymentProcessor', () => {
             expect(googlePayInitializer.parseResponse).toHaveBeenCalled();
         });
 
+        it('throw response error without fullname', async () => {
+            jest.spyOn(googlePayInitializer, 'parseResponse').mockReturnValue(tokenizePayload);
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
+            jest.spyOn(store.getState().billingAddress, 'getBillingAddress').mockReturnValue(getGooglePayAddressMock());
+            const googlePaymentDataMock = getGooglePaymentDataMock();
+            googlePaymentDataMock.paymentMethodData.info.billingAddress.name = '';
+
+            await processor.initialize('googlepay');
+
+            expect(processor.handleSuccess(googlePaymentDataMock)).rejects.toThrow(MissingDataError);
+        });
+
         it('throws when methodId from state is missed', async () => {
             jest.spyOn(googlePayInitializer, 'parseResponse').mockReturnValue(Promise.resolve(tokenizePayload));
             jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -10,6 +10,7 @@ import { PaymentMethodInvalidError } from '../../errors';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 
 import { ButtonColor, ButtonType, EnvironmentType, GooglePaymentData, GooglePayAddress, GooglePayClient, GooglePayInitializer, GooglePayPaymentDataRequestV2, GooglePaySDK, TokenizePayload } from './googlepay';
+import { getFirstAndLastName } from './googlepay-get-first-and-last-name';
 import GooglePayScriptLoader from './googlepay-script-loader';
 
 export default class GooglePayPaymentProcessor {
@@ -156,7 +157,8 @@ export default class GooglePayPaymentProcessor {
     }
 
     private _mapGooglePayAddressToBillingAddress(paymentData: GooglePaymentData, id: string): BillingAddressUpdateRequestBody {
-        const firstName = paymentData.paymentMethodData.info.billingAddress.name.split(' ').slice(0, -1).join(' ');
+        const fullName = paymentData.paymentMethodData.info.billingAddress.name;
+        const [firstName, lastName] = getFirstAndLastName(fullName);
         const address1 =  paymentData.paymentMethodData.info.billingAddress.address1;
         const city =  paymentData.paymentMethodData.info.billingAddress.locality;
         const postalCode =  paymentData.paymentMethodData.info.billingAddress.postalCode;
@@ -169,7 +171,7 @@ export default class GooglePayPaymentProcessor {
         return {
             id,
             firstName,
-            lastName: paymentData.paymentMethodData.info.billingAddress.name.split(' ').slice(-1).join(' '),
+            lastName,
             company: paymentData.paymentMethodData.info.billingAddress.companyName,
             address1,
             address2: paymentData.paymentMethodData.info.billingAddress.address2 + paymentData.paymentMethodData.info.billingAddress.address3,
@@ -185,9 +187,11 @@ export default class GooglePayPaymentProcessor {
     }
 
     private _mapGooglePayAddressToShippingAddress(address: GooglePayAddress): AddressRequestBody {
+        const [firstName, lastName] = getFirstAndLastName(address.name);
+
         return {
-            firstName: address.name.split(' ').slice(0, -1).join(' '),
-            lastName: address.name.split(' ').slice(-1).join(' '),
+            firstName,
+            lastName,
             company: address.companyName,
             address1: address.address1,
             address2: address.address2 + address.address3,


### PR DESCRIPTION
## What?  [INT-4481](https://jira.bigcommerce.com/browse/INT-4481)
Changes the way to get the first name

## Why?
When the credit/debit card hasn't the last name the error was happening
![image](https://user-images.githubusercontent.com/4907027/124989072-5ece4700-e004-11eb-907f-7bd50f0a0537.png)


## Testing / Proof
**Before:** https://drive.google.com/file/d/1seY1J_tMoYWe6PA7AQYjZxiUu7bg44GA/view?usp=sharing
**After:** https://drive.google.com/file/d/1jiB8BW8eUM_20wDmuQ8KAPCGyw4ADMKX/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
