### PR TITLE
fix(payment): INT-4594 [Afterpay] display correct error message when amount is out of limits

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -269,6 +269,10 @@ export function getAfterpay(): PaymentMethod {
         },
         type: 'PAYMENT_TYPE_API',
         clientToken: 'foo',
+        initializationData: {
+            max: 1000,
+            min: 10,
+        },
     };
 }
 

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -7,7 +7,8 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckout, getCheckoutPayment, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { MissingDataError, NotInitializedError } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, NotInitializedError, RequestError } from '../../../common/error/errors';
+import { getErrorResponse } from '../../../common/http-request/responses.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
@@ -196,15 +197,59 @@ describe('AfterpayPaymentStrategy', () => {
         it('throws error if trying to execute before initialization', async () => {
             await strategy.deinitialize();
 
-            try {
-                await strategy.execute(payload);
-            } catch (error) {
-                expect(error).toBeInstanceOf(NotInitializedError);
-            }
+            await expect(strategy.execute(payload)).rejects.toThrow(NotInitializedError);
+        });
+
+        it('throws error if amount is outside the Afterpay limits', async () => {
+            store = createCheckoutStore(merge(getCheckoutStoreState(), {
+                checkout: { data: { outstandingBalance: 5 } },
+            }));
+
+            strategy = new AfterpayPaymentStrategy(
+                store,
+                checkoutValidator,
+                orderActionCreator,
+                paymentActionCreator,
+                paymentMethodActionCreator,
+                storeCreditActionCreator,
+                scriptLoader
+            );
+
+            await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway });
+
+            await expect(strategy.execute(payload)).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('throws InvalidArgumentError if payment method is not found', async () => {
+            const errorResponse = merge(
+                getErrorResponse(), {
+                    body: {
+                        status: 404,
+                    },
+                });
+
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(() => {
+                throw new RequestError(errorResponse);
+            });
+
+            expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
+
+            await expect(strategy.execute(payload)).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('throws RequestError if loadPaymentMethod fails', async () => {
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(() => {
+                throw new RequestError(getErrorResponse());
+            });
+
+            expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
+
+            await expect(strategy.execute(payload)).rejects.toThrow(RequestError);
         });
 
         it('loads payment client token', () => {
-            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(paymentMethod.gateway, undefined);
+            expect(paymentMethodActionCreator.loadPaymentMethod)
+                .toHaveBeenCalledWith(`${paymentMethod.gateway}?method=${paymentMethod.id}`, undefined);
             expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
         });
     });

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -7,8 +7,7 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckout, getCheckoutPayment, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { InvalidArgumentError, MissingDataError, NotInitializedError, RequestError } from '../../../common/error/errors';
-import { getErrorResponse } from '../../../common/http-request/responses.mock';
+import { MissingDataError, NotInitializedError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
@@ -198,33 +197,6 @@ describe('AfterpayPaymentStrategy', () => {
             await strategy.deinitialize();
 
             await expect(strategy.execute(payload)).rejects.toThrow(NotInitializedError);
-        });
-
-        it('throws InvalidArgumentError if payment method is not found', async () => {
-            const errorResponse = merge(
-                getErrorResponse(), {
-                    body: {
-                        status: 404,
-                    },
-                });
-
-            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(() => {
-                throw new RequestError(errorResponse);
-            });
-
-            expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
-
-            await expect(strategy.execute(payload)).rejects.toThrow(InvalidArgumentError);
-        });
-
-        it('throws RequestError if loadPaymentMethod fails', async () => {
-            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(() => {
-                throw new RequestError(getErrorResponse());
-            });
-
-            expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
-
-            await expect(strategy.execute(payload)).rejects.toThrow(RequestError);
         });
 
         it('loads payment client token', () => {

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -200,26 +200,6 @@ describe('AfterpayPaymentStrategy', () => {
             await expect(strategy.execute(payload)).rejects.toThrow(NotInitializedError);
         });
 
-        it('throws error if amount is outside the Afterpay limits', async () => {
-            store = createCheckoutStore(merge(getCheckoutStoreState(), {
-                checkout: { data: { outstandingBalance: 5 } },
-            }));
-
-            strategy = new AfterpayPaymentStrategy(
-                store,
-                checkoutValidator,
-                orderActionCreator,
-                paymentActionCreator,
-                paymentMethodActionCreator,
-                storeCreditActionCreator,
-                scriptLoader
-            );
-
-            await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway });
-
-            await expect(strategy.execute(payload)).rejects.toThrow(InvalidArgumentError);
-        });
-
         it('throws InvalidArgumentError if payment method is not found', async () => {
             const errorResponse = merge(
                 getErrorResponse(), {

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
@@ -1,5 +1,6 @@
 import { CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
-import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
+import { RequestOptions } from '../../../common/http-request';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { StoreCreditActionCreator } from '../../../store-credit';
 import { PaymentArgumentInvalidError } from '../../errors';
@@ -14,6 +15,7 @@ import AfterpaySdk from './afterpay-sdk';
 
 export default class AfterpayPaymentStrategy implements PaymentStrategy {
     private _afterpaySdk?: AfterpaySdk;
+    private _invalidAmountErrorMessage = 'The amount for your order is not supported by Afterpay, please select another payment method';
 
     constructor(
         private _store: CheckoutStore,
@@ -49,10 +51,13 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
     }
 
     async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        const paymentId = payload.payment && payload.payment.gatewayId;
+        if (!payload.payment) {
+            throw new PaymentArgumentInvalidError(['payment.gatewayId', 'payment.methodId']);
+        }
+        const { gatewayId, methodId } = payload.payment;
 
-        if (!paymentId) {
-            throw new PaymentArgumentInvalidError(['payment.gatewayId']);
+        if (!gatewayId || !methodId) {
+            throw new PaymentArgumentInvalidError(['payment.gatewayId', 'payment.methodId']);
         }
 
         let state = this._store.getState();
@@ -68,11 +73,17 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
 
         await this._checkoutValidator.validate(state.checkout.getCheckout(), options);
 
-        state = await this._store.dispatch(
-            this._paymentMethodActionCreator.loadPaymentMethod(paymentId, options)
-        );
+        state = await this._loadPaymentMethod(gatewayId, methodId, options);
 
-        await this._redirectToAfterpay(countryCode, state.paymentMethods.getPaymentMethod(paymentId));
+        const checkout = state.checkout.getCheckout();
+        const amount = checkout?.outstandingBalance || 0;
+        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId, gatewayId);
+
+        if (this._outsideLimits(amount, paymentMethod)) {
+            throw new InvalidArgumentError(this._invalidAmountErrorMessage);
+        }
+
+        await this._redirectToAfterpay(countryCode, paymentMethod);
 
         // Afterpay will handle the rest of the flow so return a promise that doesn't really resolve
         return new Promise<never>(() => {});
@@ -119,5 +130,25 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
         };
 
         return countryByCurrency[currencyCode] || 'AU';
+    }
+
+    private _outsideLimits(amount: number, paymentMethod?: PaymentMethod): boolean {
+        const $minimum = paymentMethod?.initializationData?.min || 0;
+
+        return amount < $minimum || amount > paymentMethod?.initializationData?.max;
+    }
+
+    private async _loadPaymentMethod(gatewayId: string, methodId: string, options?: RequestOptions): Promise<InternalCheckoutSelectors> {
+        try {
+            return await this._store.dispatch(
+                this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}?method=${methodId}`, options)
+            );
+        } catch (error) {
+            if (error instanceof RequestError && error?.body?.status === 404) {
+                throw new InvalidArgumentError(this._invalidAmountErrorMessage);
+            }
+
+            throw error;
+        }
     }
 }


### PR DESCRIPTION
## What? [INT-4594](https://jira.bigcommerce.com/browse/INT-4594)
Display the correct error message when trying to purchase with Afterpay and the amount is outside the limits provided by Afterpay (due to a Gift Certificate, Coupon code, Store credit)

## Why?
When the amount is outside limits Afterpay will respond with an error code when trying to fetch the client Token for the transaction, we are catching that error to display a custom error message

## Testing / Proof
Unit test
Video https://drive.google.com/file/d/15jMDT0uv4SsSrSgy62sfKWRMKyJt4lLb/view?usp=sharing

## Depends on
https://github.com/bigcommerce/bigcommerce/pull/41787
https://github.com/bigcommerce/bigpay/pull/4070

## How can this change be undone in case of failure?
Revert this PR

@bigcommerce/apex-integrations 