### PR TITLE
feat(payment): PAYMENTS-6814 add NonePaymentProcessor test

### DIFF
--- a/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.spec.ts
+++ b/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.spec.ts
@@ -1,0 +1,57 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import { PaymentStrategyType } from '../../..';
+import { PPSDKPaymentMethod } from '../../../ppsdk-payment-method';
+import { StepHandler } from '../step-handler';
+import { ContinueHandler } from '../step-handler/continue-handler';
+
+import { NonePaymentProcessor } from './none-payment-processor';
+
+describe('NonePaymentProcessor', () => {
+    const paymentMethod: PPSDKPaymentMethod = {
+        id: 'some-id',
+        method: 'some-method',
+        type: PaymentStrategyType.PPSDK,
+        config: {},
+        supportedCards: [],
+        initializationStrategy: {
+            type: 'some-strategy',
+        },
+    };
+
+    const requestSender = createRequestSender();
+    const stepHandler = new StepHandler(new ContinueHandler(new FormPoster()));
+    const nonePaymentProcessor = new NonePaymentProcessor(requestSender, stepHandler);
+
+    describe('#process', () => {
+        it('posts the Payment Method ID to the BigPay Payments endpoint', async () => {
+            const requestSenderSpy = jest.spyOn(requestSender, 'post').mockResolvedValue({});
+            jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
+
+            await nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com' });
+
+            expect(requestSenderSpy).toBeCalledWith(
+                'https://some-domain.com/payments',
+                { body: { payment_method_id: 'some-id.some-method' } }
+            );
+        });
+
+        it('passes the Payments endpoint response to the stepHandler', async () => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue({ body: 'some-api-response' });
+            const stepHandlerSpy = jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
+
+            await nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com' });
+
+            expect(stepHandlerSpy).toBeCalledWith({ body: 'some-api-response' });
+        });
+
+        it('returns the final value from the stepHandler', async () => {
+            jest.spyOn(requestSender, 'post').mockResolvedValue({});
+            jest.spyOn(stepHandler, 'handle').mockResolvedValue({ someValue: 12345 });
+
+            await expect(nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com' }))
+                .resolves.toStrictEqual({ someValue: 12345 });
+        });
+    });
+});

--- a/src/payment/strategies/ppsdk/ppsdk-payment-processor.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-processor.ts
@@ -3,7 +3,7 @@ import { PPSDKPaymentMethod } from '../../ppsdk-payment-method';
 
 export interface ProcessorSettings {
     paymentMethod: PPSDKPaymentMethod;
-    payment: OrderPaymentRequestBody | undefined;
+    payment?: OrderPaymentRequestBody;
     bigpayBaseUrl: string;
 }
 


### PR DESCRIPTION
## What?

- Add missing test to the `NonePaymentProcessor`

## Why?

- Ensures the payments endpoint it called correctly
- Ensures that the result of that result is passed to the `stepHandler`
- Ensures that the `stepHandler`'s result is returned from the processor's `process` method

## Testing / Proof

- New test


@bigcommerce/checkout @bigcommerce/payments
