### PR TITLE
fix(payment): INT-4598 handle vaulting Enable checkbox

### DIFF
--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -135,6 +135,65 @@ describe('DigitalRiverPaymentStrategy', () => {
             expect(digitalRiverLoadResponse.createDropin).toHaveBeenCalled();
         });
 
+        it('loads DigitalRiver script with vaulting enable and customer email', async () => {
+            jest.spyOn(store.getState().billingAddress, 'getBillingAddressOrThrow')
+                .mockReturnValue({...getBillingAddress(), email: undefined});
+            jest.spyOn(store.getState().customer, 'getCustomerOrThrow')
+                .mockReturnValue({ ...getCustomer(), email: 'customer@bigcommerce.com'});
+
+            if (options.digitalriver) {
+                options.digitalriver.configuration.showSavePaymentAgreement = true;
+            }
+
+            await strategy.initialize(options);
+
+            expect(digitalRiverScriptLoader.load).toHaveBeenCalled();
+            expect(digitalRiverLoadResponse.createDropin).toHaveBeenCalled();
+            expect(digitalRiverLoadResponse.createDropin).toBeCalledWith(
+                expect.objectContaining({
+                    options: expect.objectContaining({
+                        showSavePaymentAgreement: true,
+                    }),
+                })
+            );
+            expect(digitalRiverLoadResponse.createDropin).toBeCalledWith(
+                expect.objectContaining({
+                    billingAddress: expect.objectContaining({
+                        email: 'customer@bigcommerce.com',
+                    }),
+                })
+            );
+        });
+
+        it('loads DigitalRiver script without vaulting enable and customer email', async () => {
+            jest.spyOn(store.getState().billingAddress, 'getBillingAddressOrThrow')
+                .mockReturnValue({...getBillingAddress(), email: undefined});
+            jest.spyOn(store.getState().customer, 'getCustomerOrThrow')
+                .mockReturnValue({ ...getCustomer(), email: 'customer@bigcommerce.com'});
+
+            if (options.digitalriver) {
+                options.digitalriver.configuration.showSavePaymentAgreement = true;
+            }
+
+            await strategy.initialize(options);
+
+            expect(digitalRiverScriptLoader.load).toHaveBeenCalled();
+            expect(digitalRiverLoadResponse.createDropin).toBeCalledWith(
+                expect.objectContaining({
+                    options: expect.objectContaining({
+                        showSavePaymentAgreement: false,
+                    }),
+                })
+            );
+            expect(digitalRiverLoadResponse.createDropin).toBeCalledWith(
+                expect.objectContaining({
+                    billingAddress: expect.objectContaining({
+                        email: 'customer@bigcommerce.com',
+                    }),
+                })
+            );
+        });
+
         it('loads DigitalRiver when widget was updated ', async () => {
             jest.spyOn(store.getState().paymentStrategies, 'isInitialized').mockReturnValue(true);
             jest.spyOn(document, 'getElementById').mockReturnValue('mock');

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -227,7 +227,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
         this._submitFormEvent = this._getDigitalRiverInitializeOptions().onSubmitForm;
         const digitalRiverConfiguration = {
             sessionId: this._digitalRiverCheckoutData.sessionId,
-            options: { ...configuration, showSavePaymentAgreement: Boolean(customer.email) },
+            options: { ...configuration, showSavePaymentAgreement: Boolean(customer.email) && configuration.showSavePaymentAgreement },
             billingAddress: {
                 firstName: billing.firstName,
                 lastName: billing.lastName,


### PR DESCRIPTION
## What? [INT-4598](https://jira.bigcommerce.com/browse/INT-4598)
added showSavePaymentAgreement dynamically instead of hardcoded on JS then evaluated if It's true on SDK

## Why?
It's a bug that could affect future DigitalRiver users

## Testing / Proof
![image](https://user-images.githubusercontent.com/42154828/125129489-28a4cc00-e0c5-11eb-95d8-583f288e2603.png)

## Depends on
https://github.com/bigcommerce/checkout-js/pull/632
@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
