### PR TITLE
feat(payment): INT-4170 added hosted fields on verification fields

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -166,6 +166,17 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
+    registry.register(PaymentStrategyType.AMAZONPAYV2, () =>
+        new AmazonPayV2PaymentStrategy(
+            store,
+            paymentStrategyActionCreator,
+            paymentMethodActionCreator,
+            orderActionCreator,
+            paymentActionCreator,
+            createAmazonPayV2PaymentProcessor()
+        )
+    );
+
     registry.register(PaymentStrategyType.AUTHORIZENET_GOOGLE_PAY, () =>
         new GooglePayPaymentStrategy(
             store,
@@ -178,17 +189,6 @@ export default function createPaymentStrategyRegistry(
                 store,
                 new GooglePayAuthorizeNetInitializer()
             )
-        )
-    );
-
-    registry.register(PaymentStrategyType.AMAZONPAYV2, () =>
-        new AmazonPayV2PaymentStrategy(
-            store,
-            paymentStrategyActionCreator,
-            paymentMethodActionCreator,
-            orderActionCreator,
-            paymentActionCreator,
-            createAmazonPayV2PaymentProcessor()
         )
     );
 
@@ -214,22 +214,96 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
+    registry.register(PaymentStrategyType.BRAINTREE, () =>
+        new BraintreeCreditCardPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            braintreePaymentProcessor
+        )
+    );
+
+    registry.register(PaymentStrategyType.BRAINTREE_GOOGLE_PAY, () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayBraintreeInitializer(
+                    new BraintreeSDKCreator(
+                        new BraintreeScriptLoader(scriptLoader)
+                    )
+                )
+            )
+        )
+    );
+
+    registry.register(PaymentStrategyType.BRAINTREE_PAYPAL, () =>
+        new BraintreePaypalPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            braintreePaymentProcessor
+        )
+    );
+
+    registry.register(PaymentStrategyType.BRAINTREE_PAYPAL_CREDIT, () =>
+        new BraintreePaypalPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            braintreePaymentProcessor,
+            true
+        )
+    );
+
+    registry.register(PaymentStrategyType.BRAINTREE_VISA_CHECKOUT, () =>
+        new BraintreeVisaCheckoutPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender),
+            new VisaCheckoutScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register(PaymentStrategyType.BOLT, () =>
+        new BoltPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            storeCreditActionCreator,
+            new BoltScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register(PaymentStrategyType.CONVERGE, () =>
+        new ConvergePaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory,
+            formPoster
+        )
+    );
+
     registry.register(PaymentStrategyType.CREDIT_CARD, () =>
         new CreditCardPaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,
             hostedFormFactory
-        )
-    );
-
-    registry.register(PaymentStrategyType.CHECKOUTCOM, () =>
-        new CreditCardRedirectPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            hostedFormFactory,
-            formPoster
         )
     );
 
@@ -275,6 +349,96 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
+    registry.register(PaymentStrategyType.CYBERSOURCEV2_GOOGLE_PAY, () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayCybersourceV2Initializer()
+            )
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM, () =>
+        new CreditCardRedirectPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory,
+            formPoster
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM_APM, () =>
+        new CheckoutcomAPMPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM_FAWRY, () =>
+        new CheckoutcomFawryPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM_GOOGLE_PAY, () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayCheckoutcomInitializer(requestSender)
+            )
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM_IDEAL, () =>
+        new CheckoutcomiDealPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHECKOUTCOM_SEPA, () =>
+        new CheckoutcomSEPAPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        )
+    );
+
+    registry.register(PaymentStrategyType.CHASE_PAY, () =>
+        new ChasePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            requestSender,
+            new ChasePayScriptLoader(scriptLoader),
+            new WepayRiskClient(scriptLoader)
+        )
+    );
+
     registry.register(PaymentStrategyType.DIGITALRIVER, () =>
         new DigitalRiverPaymentStrategy(
             store,
@@ -306,8 +470,54 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
+    registry.register(PaymentStrategyType.LAYBUY, () =>
+        new ExternalPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formPoster
+        )
+    );
+
     registry.register(PaymentStrategyType.LEGACY, () =>
         new LegacyPaymentStrategy(
+            store,
+            orderActionCreator
+        )
+    );
+
+    registry.register(PaymentStrategyType.MASTERPASS, () =>
+        new MasterpassPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            new MasterpassScriptLoader(scriptLoader),
+            locale
+        )
+    );
+
+    registry.register(PaymentStrategyType.MOLLIE, () =>
+        new MolliePaymentStrategy(
+            hostedFormFactory,
+            store,
+            new MollieScriptLoader(scriptLoader),
+            orderActionCreator,
+            paymentActionCreator
+        )
+    );
+
+    registry.register(PaymentStrategyType.MONERIS, () =>
+        new MonerisPaymentStrategy(
+            hostedFormFactory,
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            storeCreditActionCreator
+        )
+    );
+
+    registry.register(PaymentStrategyType.NO_PAYMENT_DATA_REQUIRED, () =>
+        new NoPaymentDataRequiredPaymentStrategy(
             store,
             orderActionCreator
         )
@@ -325,6 +535,21 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator
+        )
+    );
+
+    registry.register(PaymentStrategyType.ORBITAL_GOOGLE_PAY, () =>
+        new GooglePayPaymentStrategy(
+            store,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentStrategyActionCreator,
+            paymentActionCreator,
+            orderActionCreator,
+            createGooglePayPaymentProcessor(
+                store,
+                new GooglePayOrbitalInitializer()
+            )
         )
     );
 
@@ -351,24 +576,6 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
-    registry.register(PaymentStrategyType.PAYPAL_EXPRESS_CREDIT, () =>
-        new PaypalExpressPaymentStrategy(
-            store,
-            orderActionCreator,
-            new PaypalScriptLoader(scriptLoader)
-        )
-    );
-
-    registry.register(PaymentStrategyType.PAYPAL_COMMERCE_CREDIT_CARD, () =>
-        new PaypalCommerceCreditCardPaymentStrategy(
-            store,
-            paymentMethodActionCreator,
-            new PaypalCommerceHostedForm(createPaypalCommercePaymentProcessor(scriptLoader, requestSender)),
-            orderActionCreator,
-            paymentActionCreator
-        )
-    );
-
     registry.register(PaymentStrategyType.PAYPAL_COMMERCE, () =>
         new PaypalCommercePaymentStrategy(
             store,
@@ -390,6 +597,24 @@ export default function createPaymentStrategyRegistry(
             new PaypalCommerceFundingKeyResolver(),
             new PaypalCommerceRequestSender(requestSender),
             new LoadingIndicator({ styles: { backgroundColor: 'black' } })
+        )
+    );
+
+    registry.register(PaymentStrategyType.PAYPAL_COMMERCE_CREDIT_CARD, () =>
+        new PaypalCommerceCreditCardPaymentStrategy(
+            store,
+            paymentMethodActionCreator,
+            new PaypalCommerceHostedForm(createPaypalCommercePaymentProcessor(scriptLoader, requestSender)),
+            orderActionCreator,
+            paymentActionCreator
+        )
+    );
+
+    registry.register(PaymentStrategyType.PAYPAL_EXPRESS_CREDIT, () =>
+        new PaypalExpressPaymentStrategy(
+            store,
+            orderActionCreator,
+            new PaypalScriptLoader(scriptLoader)
         )
     );
 
@@ -437,110 +662,6 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
-    registry.register(PaymentStrategyType.NO_PAYMENT_DATA_REQUIRED, () =>
-        new NoPaymentDataRequiredPaymentStrategy(
-            store,
-            orderActionCreator
-        )
-    );
-
-    registry.register(PaymentStrategyType.BRAINTREE, () =>
-        new BraintreeCreditCardPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            paymentMethodActionCreator,
-            braintreePaymentProcessor
-        )
-    );
-
-    registry.register(PaymentStrategyType.BRAINTREE_PAYPAL, () =>
-        new BraintreePaypalPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            paymentMethodActionCreator,
-            braintreePaymentProcessor
-        )
-    );
-
-    registry.register(PaymentStrategyType.BRAINTREE_PAYPAL_CREDIT, () =>
-        new BraintreePaypalPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            paymentMethodActionCreator,
-            braintreePaymentProcessor,
-            true
-        )
-    );
-
-    registry.register(PaymentStrategyType.BRAINTREE_VISA_CHECKOUT, () =>
-        new BraintreeVisaCheckoutPaymentStrategy(
-            store,
-            checkoutActionCreator,
-            paymentMethodActionCreator,
-            paymentStrategyActionCreator,
-            paymentActionCreator,
-            orderActionCreator,
-            createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender),
-            new VisaCheckoutScriptLoader(scriptLoader)
-        )
-    );
-
-    registry.register(PaymentStrategyType.CHASE_PAY, () =>
-        new ChasePayPaymentStrategy(
-            store,
-            checkoutActionCreator,
-            orderActionCreator,
-            paymentActionCreator,
-            paymentMethodActionCreator,
-            paymentStrategyActionCreator,
-            requestSender,
-            new ChasePayScriptLoader(scriptLoader),
-            new WepayRiskClient(scriptLoader)
-        )
-    );
-
-    registry.register(PaymentStrategyType.BRAINTREE_GOOGLE_PAY, () =>
-        new GooglePayPaymentStrategy(
-            store,
-            checkoutActionCreator,
-            paymentMethodActionCreator,
-            paymentStrategyActionCreator,
-            paymentActionCreator,
-            orderActionCreator,
-            createGooglePayPaymentProcessor(
-                store,
-                new GooglePayBraintreeInitializer(
-                    new BraintreeSDKCreator(
-                        new BraintreeScriptLoader(scriptLoader)
-                    )
-                )
-            )
-        )
-    );
-
-    registry.register(PaymentStrategyType.WE_PAY, () =>
-        new WepayPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            hostedFormFactory,
-            new WepayRiskClient(scriptLoader)
-        )
-    );
-
-    registry.register(PaymentStrategyType.MASTERPASS, () =>
-        new MasterpassPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            new MasterpassScriptLoader(scriptLoader),
-            locale
-        )
-    );
-
     registry.register(PaymentStrategyType.STRIPE_GOOGLE_PAY, () =>
         new GooglePayPaymentStrategy(
             store,
@@ -556,48 +677,35 @@ export default function createPaymentStrategyRegistry(
         )
     );
 
-    registry.register(PaymentStrategyType.CYBERSOURCEV2_GOOGLE_PAY, () =>
-        new GooglePayPaymentStrategy(
+    registry.register(PaymentStrategyType.STRIPEV3, () =>
+        new StripeV3PaymentStrategy(
             store,
-            checkoutActionCreator,
             paymentMethodActionCreator,
-            paymentStrategyActionCreator,
             paymentActionCreator,
             orderActionCreator,
-            createGooglePayPaymentProcessor(
-                store,
-                new GooglePayCybersourceV2Initializer()
-            )
+            new StripeScriptLoader(scriptLoader),
+            storeCreditActionCreator,
+            hostedFormFactory,
+            locale
         )
     );
 
-    registry.register(PaymentStrategyType.ORBITAL_GOOGLE_PAY, () =>
-        new GooglePayPaymentStrategy(
+    registry.register(PaymentStrategyType.WE_PAY, () =>
+        new WepayPaymentStrategy(
             store,
-            checkoutActionCreator,
-            paymentMethodActionCreator,
-            paymentStrategyActionCreator,
-            paymentActionCreator,
             orderActionCreator,
-            createGooglePayPaymentProcessor(
-                store,
-                new GooglePayOrbitalInitializer()
-            )
+            paymentActionCreator,
+            hostedFormFactory,
+            new WepayRiskClient(scriptLoader)
         )
     );
 
-    registry.register(PaymentStrategyType.CHECKOUTCOM_GOOGLE_PAY, () =>
-        new GooglePayPaymentStrategy(
+    registry.register(PaymentStrategyType.SEZZLE, () =>
+        new ExternalPaymentStrategy(
             store,
-            checkoutActionCreator,
-            paymentMethodActionCreator,
-            paymentStrategyActionCreator,
-            paymentActionCreator,
             orderActionCreator,
-            createGooglePayPaymentProcessor(
-                store,
-                new GooglePayCheckoutcomInitializer(requestSender)
-            )
+            paymentActionCreator,
+            formPoster
         )
     );
 
@@ -611,113 +719,6 @@ export default function createPaymentStrategyRegistry(
             remoteCheckoutActionCreator,
             new ZipScriptLoader(scriptLoader),
             storefrontPaymentRequestSender
-        )
-    );
-
-    registry.register(PaymentStrategyType.CONVERGE, () =>
-        new ConvergePaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            hostedFormFactory,
-            formPoster
-        )
-    );
-
-    registry.register(PaymentStrategyType.LAYBUY, () =>
-        new ExternalPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            formPoster
-        )
-    );
-
-    registry.register(PaymentStrategyType.SEZZLE, () =>
-        new ExternalPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            formPoster
-        )
-    );
-
-    registry.register(PaymentStrategyType.STRIPEV3, () =>
-        new StripeV3PaymentStrategy(
-            store,
-            paymentMethodActionCreator,
-            paymentActionCreator,
-            orderActionCreator,
-            new StripeScriptLoader(scriptLoader),
-            storeCreditActionCreator,
-            locale
-        )
-    );
-
-    registry.register(PaymentStrategyType.BOLT, () =>
-        new BoltPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            paymentMethodActionCreator,
-            storeCreditActionCreator,
-            new BoltScriptLoader(scriptLoader)
-        )
-    );
-
-    registry.register(PaymentStrategyType.CHECKOUTCOM_APM, () =>
-        new CheckoutcomAPMPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            hostedFormFactory
-        )
-    );
-
-    registry.register(PaymentStrategyType.MOLLIE, () =>
-        new MolliePaymentStrategy(
-            hostedFormFactory,
-            store,
-            new MollieScriptLoader(scriptLoader),
-            orderActionCreator,
-            paymentActionCreator
-        )
-    );
-
-    registry.register(PaymentStrategyType.CHECKOUTCOM_SEPA, () =>
-        new CheckoutcomSEPAPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            hostedFormFactory
-        )
-    );
-
-    registry.register(PaymentStrategyType.CHECKOUTCOM_IDEAL, () =>
-        new CheckoutcomiDealPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            hostedFormFactory
-        )
-    );
-
-    registry.register(PaymentStrategyType.CHECKOUTCOM_FAWRY, () =>
-        new CheckoutcomFawryPaymentStrategy(
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            hostedFormFactory
-        )
-    );
-
-    registry.register(PaymentStrategyType.MONERIS, () =>
-        new MonerisPaymentStrategy(
-            hostedFormFactory,
-            store,
-            orderActionCreator,
-            paymentActionCreator,
-            storeCreditActionCreator
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -619,7 +619,7 @@ export function getQuadpay(): PaymentMethod {
     };
 }
 
-export function getStripeV3(method: string = 'card', shouldUseIndividualCardFields: boolean = false): PaymentMethod {
+export function getStripeV3(method: string = 'card', shouldUseIndividualCardFields: boolean = false, isHostedFormEnabled: boolean = false): PaymentMethod {
     return {
         id: method,
         logoUrl: '',
@@ -629,6 +629,7 @@ export function getStripeV3(method: string = 'card', shouldUseIndividualCardFiel
             displayName: 'Stripe',
             merchantId: '',
             testMode: true,
+            isHostedFormEnabled,
         },
         initializationData: {
             stripePublishableKey: 'key',

--- a/src/payment/strategies/stripev3/stripev3-initialize-options.ts
+++ b/src/payment/strategies/stripev3/stripev3-initialize-options.ts
@@ -1,3 +1,5 @@
+import { HostedFormOptions } from '../../../hosted-form';
+
 import { IndividualCardElementOptions, StripeElementOptions } from './stripev3';
 
 /**
@@ -52,4 +54,9 @@ export default interface StripeV3PaymentInitializeOptions {
     containerId: string;
 
     options?: StripeElementOptions | IndividualCardElementOptions;
+
+    /**
+     * Hosted Form Validation Options
+     */
+    form?: HostedFormOptions;
 }

--- a/src/payment/strategies/stripev3/stripev3.mock.ts
+++ b/src/payment/strategies/stripev3/stripev3.mock.ts
@@ -1,10 +1,13 @@
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
+import { HostedFieldType } from '../../../hosted-form';
 import { OrderRequestBody } from '../../../order';
 import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 
 import { IndividualCardElementOptions, StripeV3PaymentInitializeOptions } from './index';
 import { PaymentMethodCreateParams, StripeBillingDetails, StripeConfirmCardPaymentData, StripeElementType, StripeShippingAddress, StripeV3Client } from './stripev3';
+
+const gatewayId = 'stripev3';
 
 export function getStripeV3JsMock(): StripeV3Client {
     return {
@@ -55,6 +58,7 @@ export function getFailingStripeV3JsMock(): StripeV3Client {
 export function getStripeV3InitializeOptionsMock(stripeElementType: StripeElementType = StripeElementType.CreditCard): PaymentInitializeOptions {
     return {
         methodId: stripeElementType,
+        gatewayId,
         stripev3: {
             containerId: `stripe-${stripeElementType}-component-field`,
             options: {
@@ -68,7 +72,8 @@ export function getStripeV3InitializeOptionsMock(stripeElementType: StripeElemen
 
 export function getStripeV3InitializeOptionsMockSingleElements(includeZipCode: boolean = false): PaymentInitializeOptions {
     const paymentInitializeOptions: PaymentInitializeOptions = {
-        methodId: 'card',
+        methodId: StripeElementType.CreditCard,
+        gatewayId,
     };
 
     const stripeV3PaymentInitializeOptions: StripeV3PaymentInitializeOptions = {
@@ -145,6 +150,38 @@ export function getStripeV3OrderRequestBodyVaultMock(stripeElementType: StripeEl
     };
 }
 
+export function getHostedFormInitializeOptions(): PaymentInitializeOptions {
+    return {
+        methodId: StripeElementType.CreditCard,
+        gatewayId,
+        stripev3: {
+            containerId: 'stripe-element',
+            form: {
+                fields: {
+                    [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                    [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                    [HostedFieldType.CardName]: { containerId: 'card-name' },
+                },
+            },
+        },
+    };
+}
+
+export function getOrderRequestBodyVaultedCC(): OrderRequestBody {
+    return {
+        useStoreCredit: false,
+        payment: {
+            methodId: StripeElementType.CreditCard,
+            gatewayId,
+            paymentData: {
+                shouldSaveInstrument: true,
+                shouldSetAsDefaultInstrument: true,
+                instrumentId: '1234',
+            },
+        },
+    };
+}
+
 export function getConfirmPaymentResponse(): unknown {
     return {
         paymentIntent: {
@@ -206,20 +243,10 @@ export function getStripeBillingAddress(): StripeBillingDetails {
 }
 
 export function getStripeBillingAddressWithoutPhone(): StripeBillingDetails {
-    const billingAddress = getBillingAddress();
+    const billingAddress = getStripeBillingAddress();
+    delete billingAddress.phone;
 
-    return {
-        address: {
-            city: billingAddress.city,
-            country: billingAddress.countryCode,
-            line1: billingAddress.address1,
-            line2: billingAddress.address2,
-            postal_code: billingAddress.postalCode,
-            state: billingAddress.stateOrProvinceCode,
-        },
-        name: `${billingAddress.firstName} ${billingAddress.lastName}`,
-        email: billingAddress.email,
-    };
+    return billingAddress;
 }
 
 export function getStripeShippingAddressGuestUserWithoutAddress(): StripeConfirmCardPaymentData {


### PR DESCRIPTION
## What? [INT-4170](https://jira.bigcommerce.com/browse/INT-4170)
Added hosted fields on verification fields on StripeV3

## Why?
Currently, we have some payment methods that are not using hosted credit card fields for stored instrument verifications (card number and CVV). This presents a security vulnerability as malicious JS can easily scrape credit card information.

## Siblings
[Checkout #637](https://github.com/bigcommerce/checkout-js/pull/637)

## Testing / Proof
- Manual
- Unit
https://www.loom.com/share/3cdac217e2b14282a3e7af6373e5ee01

@bigcommerce/apex-integrations @bigcommerce/checkout 
