### PR TITLE
feat(checkout): PAYPAL-1057 added Venmo APM to paypal commerce

### DIFF
--- a/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.spec.ts
@@ -47,5 +47,9 @@ describe('paypalCommerceFundingKeyResolver', () => {
         it('should return "TRUSTLY"', () => {
             expect(paypalCommerceFundingKeyResolver.resolve('trustly', 'paypalcommercealternativemethods')).toEqual('TRUSTLY');
         });
+
+        it('should return "VENMO"', () => {
+            expect(paypalCommerceFundingKeyResolver.resolve('venmo', 'paypalcommercealternativemethods')).toEqual('VENMO');
+        });
     });
 });

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.ts
@@ -32,6 +32,8 @@ export default class PaypalCommerceFundingKeyResolver {
                     return 'BLIK';
                 case 'trustly':
                     return 'TRUSTLY';
+                case 'venmo':
+                    return 'VENMO';
             }
         }
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -140,7 +140,7 @@ describe('PaypalCommercePaymentStrategy', () => {
     describe('#initialize()', () => {
         beforeEach(() => {
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
-                .mockReturnValue({ ...getPaypalCommerce(), initializationData: { ...getPaypalCommerce().initializationData, orderId: undefined } });
+                .mockReturnValue({ ...getPaypalCommerce(), initializationData: { ...getPaypalCommerce().initializationData, orderId: undefined, shouldRenderFields: true } });
         });
 
         it('returns checkout state', async () => {
@@ -279,6 +279,17 @@ describe('PaypalCommercePaymentStrategy', () => {
                     fullName: `${firstName} ${lastName}`,
                     email,
                 });
+        });
+
+        it('does not render APM fields when shouldRenderFields is false', async () => {
+            jest.spyOn(paypalCommerceFundingKeyResolver, 'resolve')
+                .mockReturnValue('P24');
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue({ ...getPaypalCommerce(), initializationData: { ...getPaypalCommerce().initializationData, orderId: undefined, shouldRenderFields: false } });
+
+            await paypalCommercePaymentStrategy.initialize({ ...options, gatewayId: PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS, methodId: 'p24' });
+
+            expect(paypalCommercePaymentProcessor.renderFields).not.toHaveBeenCalled();
         });
 
         it("throws an error if apmFieldsContainer wasn't provided when trying to initialize Przelewy24 method", async () => {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -51,7 +51,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
         } = this._store.getState();
 
         const { initializationData } = getPaymentMethodOrThrow(methodId, gatewayId);
-        const { orderId, buttonStyle } = initializationData ?? {};
+        const { orderId, buttonStyle, shouldRenderFields } = initializationData ?? {};
         this._isAPM = gatewayId === PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS;
 
         if (orderId) {
@@ -109,7 +109,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
 
         const fundingKey = this._paypalCommerceFundingKeyResolver.resolve(methodId, gatewayId);
 
-        if (this._isAPM)  {
+        if (this._isAPM && shouldRenderFields)  {
             const fullName = `${firstName} ${lastName}`;
             if (!apmFieldsContainer) {
                 throw new InvalidArgumentError('Unable to initialize payment because "options.paypalcommerce" argument should contain "apmFieldsContainer".');

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -201,6 +201,7 @@ export interface PaypalCommerceSDKFunding {
     BLIK: string;
     TRUSTLY: string;
     VERKKOPANKKI: string;
+    VENMO: string;
 }
 
 export interface PaypalCommerceSDK {

--- a/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
@@ -22,6 +22,7 @@ export function getPaypalCommerceMock(): PaypalCommerceSDK {
             SOFORT: 'sofort',
             TRUSTLY: 'trustly',
             VERKKOPANKKI: 'verkkopankki',
+            VENMO: 'venmo',
         },
         Buttons: () => ({
             render: jest.fn(),


### PR DESCRIPTION
## What?
Added Venmo payment method to paypal commerce integration. 
Added shouldRenderFields flag on APM initialization to prevent apm fields render for Venmo. It doesn't need apm fields.

connected PR: https://github.com/bigcommerce/checkout-js/pull/641
## Why?
Due to the https://jira.bigcommerce.com/browse/PAYPAL-1057

## Testing / Proof
tested manually, units
![image](https://user-images.githubusercontent.com/79574476/126478499-03c82210-c3aa-4b70-836d-eba72ea1fe9e.png)


@bigcommerce/checkout @bigcommerce/payments
