### PR TITLE
fix(payment): INT-4661 [Afterpay] get countryCode by shopperCurrency

### DIFF
--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -129,6 +129,27 @@ describe('AfterpayPaymentStrategy', () => {
 
             expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod, 'US');
         });
+
+        it('loads script when initializing strategy with NZD', async () => {
+            store = createCheckoutStore(merge(
+                getCheckoutStoreState(),
+                { cart: { data: { currency: { code: 'NZD' } } } }
+            ));
+
+            strategy = new AfterpayPaymentStrategy(
+                store,
+                checkoutValidator,
+                orderActionCreator,
+                paymentActionCreator,
+                paymentMethodActionCreator,
+                storeCreditActionCreator,
+                scriptLoader
+            );
+
+            await strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway });
+
+            expect(scriptLoader.load).toHaveBeenCalledWith(paymentMethod, 'NZ');
+        });
     });
 
     describe('#execute()', () => {


### PR DESCRIPTION
## What? [INT-4661](https://jira.bigcommerce.com/browse/INT-4661)
Get the countryCode from the  shopperCurrency instead from the store country, so Afterpay will redirect to the correct portal

## Why?
In the current state, Afterpay gets the countryCode from the storeCountry, which causes an error while using multicurrency, if the store was in NZ and the shopper was purchasing in CAD or USD, Afterpay would redirect this merchant to the NZ portal, which is not the intended behavior.

## Testing / Proof
https://drive.google.com/file/d/1lJr5NCaFU4HCipKyg7e6QEkOWwYR_85D/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
