### PR TITLE
feat(payment): INT-4584 - Refactor Quadpay uri data for redirect

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -613,6 +613,9 @@ export function getQuadpay(): PaymentMethod {
         },
         type: 'PAYMENT_TYPE_API',
         clientToken: '{"id":"checkout_id"}',
+        initializationData: {
+            redirectUrl: 'http://some-url',
+        },
     };
 }
 

--- a/src/payment/strategies/quadpay/quadpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/quadpay/quadpay-payment-strategy.spec.ts
@@ -183,12 +183,6 @@ describe('QuadpayPaymentStrategy', () => {
             const additionalActionRequiredError = new RequestError(getResponse({
                 ...getErrorPaymentResponseBody(),
                 status: 'additional_action_required',
-                additional_action_required: {
-                    type: 'external_redirect',
-                    data: {
-                        redirect_url: 'http://some-url',
-                    },
-                } ,
             }));
             const paymentFailedErrorAction = of(createErrorAction(
                 PaymentActionType.SubmitPaymentFailed,
@@ -229,6 +223,13 @@ describe('QuadpayPaymentStrategy', () => {
         it('fails to execute if nonce is empty', async () => {
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                 .mockReturnValue({ ...getQuadpay(), clientToken: JSON.stringify({ id: '' }) });
+
+            await expect(strategy.execute(orderRequestBody, quadpayOptions)).rejects.toThrow(MissingDataError);
+        });
+
+        it('fails to execute if redirectUrl is empty', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue({ ...getQuadpay(), initializationData: { redirectUrl: ''} });
 
             await expect(strategy.execute(orderRequestBody, quadpayOptions)).rejects.toThrow(MissingDataError);
         });


### PR DESCRIPTION
## What? [INT-4584](https://jira.bigcommerce.com/browse/INT-4584)
Refactor in the `quadpay-payment-strategy` to get the `redirect_url `from the `initializePayment` instead of the `additional_action_required.data` response.

## Why?
to avoid getting the `uri` data from the get calls because the endpoint will not longer send the `uri` data 
ticket:
[INT-4584](https://jira.bigcommerce.com/browse/INT-4584)

## Testing / Proof
![image](https://user-images.githubusercontent.com/3879353/127381752-13292284-b912-49df-a54d-2616c8c15aee.png)
[Video](https://drive.google.com/file/d/10V1UoQlnsgGCSyk8Md6hQyNDEud9yGXi/view?usp=sharing)

## Depends on
https://github.com/bigcommerce/bigcommerce/pull/42068

## Dependency of
[bigpay: INT-4584](https://github.com/bigcommerce/bigpay/pull/4097)
@bigcommerce/checkout @bigcommerce/payments
