### PR TITLE
fix(payment): INT-4672 Allow shoppers to change payment method when order finalization fails

### DIFF
--- a/src/order/errors/index.ts
+++ b/src/order/errors/index.ts
@@ -1,1 +1,2 @@
 export { default as OrderFinalizationNotRequiredError } from './order-finalization-not-required-error';
+export { default as OrderFinalizationNotCompletedError } from './order-finalization-not-completed-error';

--- a/src/order/errors/order-finalization-not-completed-error.spec.ts
+++ b/src/order/errors/order-finalization-not-completed-error.spec.ts
@@ -1,0 +1,23 @@
+import OrderFinalizationNotCompletedError from './order-finalization-not-completed-error';
+
+describe('OrderFinalizationNotCompletedError', () => {
+    let error = new OrderFinalizationNotCompletedError();
+
+    it('returns error name', () => {
+        expect(error.name).toEqual('OrderFinalizationNotCompletedError');
+    });
+
+    it('returns error type', () => {
+        expect(error.type).toEqual('order_finalization_not_completed');
+    });
+
+    it('returns default message', () => {
+        expect(error.message).toEqual('The current order could not be finalized successfully');
+    });
+
+    it('returns custom message', () => {
+        error = new OrderFinalizationNotCompletedError('Custom error message');
+
+        expect(error.message).toEqual('Custom error message');
+    });
+});

--- a/src/order/errors/order-finalization-not-completed-error.ts
+++ b/src/order/errors/order-finalization-not-completed-error.ts
@@ -1,0 +1,14 @@
+import { StandardError } from '../../common/error/errors';
+
+/**
+ * Throw this error if the order finalization request
+ * was not completed successfully.
+ */
+export default class OrderFinalizationNotCompletedError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'The current order could not be finalized successfully');
+
+        this.name = 'OrderFinalizationNotCompletedError';
+        this.type = 'order_finalization_not_completed';
+    }
+}

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -92,7 +92,8 @@ export default function createPaymentStrategyRegistry(
     const paymentHumanVerificationHandler = new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()));
     const paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator, paymentRequestTransformer, paymentHumanVerificationHandler);
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
-    const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(new RemoteCheckoutRequestSender(requestSender));
+    const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(requestSender);
+    const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender);
     const configActionCreator = new ConfigActionCreator(new ConfigRequestSender(requestSender));
     const formFieldsActionCreator = new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender));
     const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator, formFieldsActionCreator);
@@ -148,6 +149,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             paymentMethodActionCreator,
+            remoteCheckoutRequestSender,
             storeCreditActionCreator,
             new AfterpayScriptLoader(scriptLoader)
         )

--- a/src/remote-checkout/remote-checkout-request-sender.spec.ts
+++ b/src/remote-checkout/remote-checkout-request-sender.spec.ts
@@ -88,4 +88,16 @@ describe('RemoteCheckoutRequestSender', () => {
         expect(output).toEqual(response);
         expect(requestSender.post).toHaveBeenCalledWith('/remote-checkout/events/shopper-checkout-service-provider-authorization-requested', options);
     });
+
+    it('sends request to forget the remote checkout provider', async () => {
+        const response = getResponse({});
+        const options = { timeout: createTimeout() };
+
+        jest.spyOn(requestSender, 'post').mockReturnValue(response);
+
+        const output = await remoteCheckoutRequestSender.forgetCheckout(options);
+
+        expect(output).toEqual(response);
+        expect(requestSender.post).toHaveBeenCalledWith('/remote-checkout/forget-checkout', options);
+    });
 });

--- a/src/remote-checkout/remote-checkout-request-sender.ts
+++ b/src/remote-checkout/remote-checkout-request-sender.ts
@@ -51,6 +51,12 @@ export default class RemoteCheckoutRequestSender {
 
         return this._requestSender.post(url, { timeout });
     }
+
+    forgetCheckout({ timeout }: RequestOptions = {}): Promise<Response<any>> {
+        const url = `/remote-checkout/forget-checkout`;
+
+        return this._requestSender.post(url, { timeout });
+    }
 }
 
 export interface InitializePaymentOptions {


### PR DESCRIPTION
## What? [INT-4672](https://jira.bigcommerce.com/browse/INT-4672)
Add a new error type, **OrderFinalizationNotCompletedError** and modify the Afterpay strategy to catch any errors during the order finalization, within the **finalize** method, and reject the promise with an OrderFinalizationNotCompletedError.

Add support for the **forgetProvider** endpoint, and use it to forget the remote checkout provider which is applied when shoppers initialize a purchase by using an offsite provider.

Modify the Afterpay strategy to apply the necessary changes to fix the issue: catch the error from the order completion, forget the provider and refresh the state with all the supported payment methods.

## Why?
Currently if we get an error after calling the **finalize** method in the strategy and the error is other than **OrderFinalizationNotRequiredError** then shoppers see a modal informing them that their payment was declined but at this point the payment methods list do not load again and the "loading" animation spin indefinitely, so shoppers cannot select another payment method or retry the payment.

We found that the issue is shared with all the providers that implemented the offsite flow (like BluesnapV2, AdyenV1, Afterpay and others), the problem occurs when, for some reason, the **finalize** step of the strategy cannot be completed correctly, for example when the provider returns that the payment validation was not valid, if something like this happens then shoppers see the error informing them that their payment was declined but the payment methods do not load again and the "loading" animation spin indefinitely.

Here are some videos showing the issue (Bluesnap and Adyen):
https://drive.google.com/file/d/1bbtOiL3-3qxV1487k1v5iAxug9DT483E/view?usp=sharing
https://drive.google.com/file/d/1pBDl0t3Hh9pfcr5HnVq--C4fUivLO4oj/view?usp=sharing

By applying these changes we can make the **checkout-sdk** to catch the error and refresh the payment method lists to allow shoppers to select another payment method.

## Testing / Proof
https://drive.google.com/file/d/15aMngXeY-Rq1oA3iE4kh0hjxBz5g6BQF/view?usp=sharing

## Depends on
[bigpay](https://github.com/bigcommerce/bigpay/pull/4070)
[bcapp](https://github.com/bigcommerce/bigcommerce/pull/42144)

## Merge process
1. Merge this dependency https://github.com/bigcommerce/bigpay/pull/4070
2. Merge this PR

@bigcommerce/checkout @bigcommerce/payments
