### PR TITLE
Don't cache loader.js

### DIFF
--- a/.metadata_rules.yml
+++ b/.metadata_rules.yml
@@ -1,0 +1,3 @@
+- '**/loader.js': {
+  cache_control: 'no-cache, max-age=0'
+}


### PR DESCRIPTION
Work in Progress
## What?
Add loader.js to .metadata_rules.yml with `cache_control: 'no-cache, max-age=0'`

## Why?
Allow CDNs to respect origin headers for loader.js.

## Testing / Proof
Pending

@bigcommerce/checkout @bigcommerce/payments
