### PR TITLE
fix(provider): INT-4480 Throws stripe error when user closes the auth modal on Stripe V3

### DIFF
--- a/src/payment/strategies/stripev3/stripev3.ts
+++ b/src/payment/strategies/stripev3/stripev3.ts
@@ -41,6 +41,21 @@ export interface PaymentIntent {
      * Status of this PaymentIntent. Read more about each PaymentIntent [status](https://stripe.com/docs/payments/intents#intent-statuses).
      */
     status: 'succeeded' | string;
+
+     /**
+      * The payment error encountered in the previous PaymentIntent confirmation. It will be cleared if the PaymentIntent is later updated for any reason.
+      */
+     last_payment_error: LastPaymentError | null;
+}
+
+/**
+ * The payment error encountered in the previous PaymentIntent confirmation. It will be cleared if the PaymentIntent is later updated for any reason.
+ */
+export interface LastPaymentError {
+    /**
+     * A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
+     */
+     message?: string;
 }
 
 /**
@@ -71,6 +86,11 @@ export interface StripeError {
      * A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
      */
     message?: string;
+
+    /**
+     * The PaymentIntent object.
+     */
+    payment_intent: PaymentIntent;
 }
 
 /**


### PR DESCRIPTION
## What? [INT-4480](https://jira.bigcommerce.com/browse/INT-4480)

Throws stripe error when user closes the auth modal on Stripe V3

## Why?
Sentry reported a lot number of errors at checkout using Stripe V3.  “_We are unable to authenticate your payment method. Please choose a different payment method and try again._” [CHECKOUT-JS-4AG](https://sentry.io/organizations/bigcommerce/issues/2392691077/?referrer=jira_integration)

This error is caused by some authentication failure in 3Ds or because the user canceled the purchase. 

![imagen](https://user-images.githubusercontent.com/69487174/126795414-404fafe1-898c-40ae-9d2c-f5218c7b3d51.png)


This PR handles the cancellation exception separately from the one generated by authentication failure. 
## Testing / Proof
<img width="902" alt="Screen Shot 2021-07-23 at 4 01 42 PM" src="https://user-images.githubusercontent.com/69487174/126841247-2af6076b-7246-41b0-8790-c09938cf93fd.png">

- [Video](https://drive.google.com/file/d/1BDiUc-AxKf4Jyq2hf-fMayzCRFSrVVWc/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations
