### PR TITLE
fix(payment): INT-4087 Catch stripe exception to process 3ds when payment intent is updated on the backend - StripeV3

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -619,7 +619,7 @@ export function getQuadpay(): PaymentMethod {
     };
 }
 
-export function getStripeV3(method: string = 'card', shouldUseIndividualCardFields: boolean = false, isHostedFormEnabled: boolean = false): PaymentMethod {
+export function getStripeV3(method: string = 'card', shouldUseIndividualCardFields: boolean = false, isHostedFormEnabled: boolean = false, shouldReusePaymentIntent: boolean = false): PaymentMethod {
     return {
         id: method,
         logoUrl: '',
@@ -634,6 +634,7 @@ export function getStripeV3(method: string = 'card', shouldUseIndividualCardFiel
         initializationData: {
             stripePublishableKey: 'key',
             useIndividualCardFields: shouldUseIndividualCardFields,
+            reusePaymentIntent: shouldReusePaymentIntent,
         },
         type: 'PAYMENT_TYPE_API',
         clientToken: 'clientToken',


### PR DESCRIPTION
[INT-4087](https://jira.bigcommerce.com/browse/INT-4087)

## What?
- Catch exception when try to  execute the handle card action to execute the confirm card peyment when 3ds auth is required on stripev3

## Why?
 To prevent duplicate payment intent entries, we reuse the payment intent created on the initialization step and update its data and confirm on the backend.
When use a 3ds card the response of that confirmation tell us that need a 3ds auth and send that action to the front  where we use the  handleCardAction to process it, but it will try a exception with the its message say that use confirmCardPayment  instead.

This is the two case that covers this changes:

1.- With new payment Intent: 
 - Use handleCardAction to resolve 3ds
 - Send to the back confirm=true
 
2.- With payment intent udpated and confirmed:
- Use handleCardAction to resolve 3ds, it will throw a exception
- Catch the exception and use confirmCardPayment
- Send to the back confirm=false (confirmation is not need it)
 
## Testing / Proof
.
![image](https://user-images.githubusercontent.com/45854000/127030579-180a7bb6-0632-435b-9d09-ed8808529d34.png)
![image](https://user-images.githubusercontent.com/45854000/127030616-6e831cd9-3026-4421-9553-16297c79fd76.png)

## Depends on
https://github.com/bigcommerce/bigcommerce/pull/42559

@bigcommerce/checkout @bigcommerce/payments
