### PR TITLE
feat(payment): INT-4686 remove disabledPaymentMethod interface for DR

### DIFF
--- a/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/src/payment/strategies/digitalriver/digitalriver.ts
@@ -216,11 +216,6 @@ interface BaseElementOptions {
      * Set custom class names on the container DOM element when the Digital River element is in a particular state.
      */
     classes?: DigitalRiverElementClasses;
-
-    /**
-     * Remove specific payment methods when rendering drop-in.
-     */
-    disabledPaymentMethods?: string[];
 }
 
 /**


### PR DESCRIPTION
## What? [INT-4686](https://jira.bigcommerce.com/browse/INT-4686)
remove disabledPaymentMethod interface for DR

## Why?
This functionality will be managed from the DigitalRiver dashboard and we will not send this anymore 

## Testing / Proof
![image](https://user-images.githubusercontent.com/42154828/127232305-7b88937c-9b41-41d4-8ce3-3e322e9e8e3d.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
