### PR TITLE
fix(payment): INT-4685 Orbital initializer added properly

### DIFF
--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -8,7 +8,7 @@ import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
-import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayOrbitalInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 import { createPaypalCommercePaymentProcessor } from '../payment/strategies/paypal-commerce';
@@ -136,7 +136,7 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             createGooglePayPaymentProcessor(
                 store,
-                new GooglePayCybersourceV2Initializer()
+                new GooglePayOrbitalInitializer()
             )
         )
     );


### PR DESCRIPTION
## What? [INT-4685](https://jira.bigcommerce.com/browse/INT-4685)
create-checkout-button-registry.ts fixed to reference the correct Orbital initializer.


## Why?
GooglePay in Orbital was not sending the proper google pay token due to a wrong reference.


## Testing / Proof
![orbital cart google pay](https://user-images.githubusercontent.com/40832991/127534568-67190c13-f6b1-4c11-bfb3-c5a619e9bb1e.gif)

Ping @bigcommerce/checkout  @bigcommerce/payments @bigcommerce/apex-integrations 
