### PR TITLE
fix(payment): INT-4489 cko add supported method 'card'

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -61,6 +61,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'checkoutcom',
         method: 'credit_card',
     },
+    'checkoutcom.card': {
+        provider: 'checkoutcom',
+        method: 'credit_card',
+    },
     stripe: {
         provider: 'stripe',
         method: 'credit_card',

--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -14,6 +14,7 @@ import { PaymentStrategy } from './strategies';
 const checkoutcomStrategies: {
     [key: string]: PaymentStrategyType;
 } = {
+    card: PaymentStrategyType.CHECKOUTCOM,
     credit_card: PaymentStrategyType.CHECKOUTCOM,
     sepa: PaymentStrategyType.CHECKOUTCOM_SEPA,
     ideal: PaymentStrategyType.CHECKOUTCOM_IDEAL,


### PR DESCRIPTION
## What? [INT-4489](https://jira.bigcommerce.com/browse/INT-4489)
Add alias mapping for credit_card as card

## Why?
Because method will change name from credit_card to card on Bigpay, both names will be keep to be able to merge without issues

## Testing / Proof
[Demo](https://drive.google.com/file/d/1EmTIw2wTqmYpYERm_a4GIWqjivYbNlt6/view?usp=sharing)

## Dependency of
https://github.com/bigcommerce/checkout-js/pull/656

## Depends on
https://github.com/bigcommerce/bigpay/pull/4109

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
