### PR TITLE
fix(payment): INT-4705 [Clearpay] display correct error message when amount is out of limits

### DIFF
--- a/src/payment/strategies/clearpay/clearpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/clearpay/clearpay-payment-strategy.spec.ts
@@ -7,7 +7,8 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckout, getCheckoutPayment, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, NotInitializedError, RequestError } from '../../../common/error/errors';
+import { getErrorResponse } from '../../../common/http-request/responses.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
@@ -185,8 +186,36 @@ describe('ClearpayPaymentStrategy', () => {
             }
         });
 
+        it('throws InvalidArgumentError if loadPaymentMethod fails', async () => {
+            const errorResponse = merge(
+                getErrorResponse(), {
+                    body: {
+                        status: 422,
+                    },
+                });
+
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(() => {
+                throw new RequestError(errorResponse);
+            });
+
+            expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
+
+            await expect(strategy.execute(payload)).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('throws RequestError if loadPaymentMethod fails', async () => {
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(() => {
+                throw new RequestError(getErrorResponse());
+            });
+
+            expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
+
+            await expect(strategy.execute(payload)).rejects.toThrow(RequestError);
+        });
+
         it('loads payment client token', () => {
-            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(`${paymentMethod.gateway}?method=${paymentMethod.id}`);
+            expect(paymentMethodActionCreator.loadPaymentMethod)
+                .toHaveBeenCalledWith(`${paymentMethod.gateway}?method=${paymentMethod.id}`, undefined);
             expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
         });
 


### PR DESCRIPTION
## What? [INT-4705](https://jira.bigcommerce.com/browse/INT-4705)
Display the correct error message when trying to purchase with Clearpay and the amount is outside the limits provided by Afterpay (due to a Coupon code)

## Why?
When the amount is outside limits Clearpay will respond with an error code when trying to fetch the client Token for the transaction, we are catching that error to display a custom error message

## Testing / Proof
Unit test
Video https://drive.google.com/file/d/15jMDT0uv4SsSrSgy62sfKWRMKyJt4lLb/view?usp=sharing

## Depends on
BCAPP
[#42128](https://github.com/bigcommerce/bigcommerce/pull/42128)

## How can this change be undone in case of failure?
Revert this PR

@bigcommerce/apex-integrations 