### PR TITLE
feat(payment): CHECKOUT-5906 Payment step "Name on Card" of checkout requires label for screen readers

### DIFF
--- a/src/payment/strategies/braintree/braintree-payment-options.ts
+++ b/src/payment/strategies/braintree/braintree-payment-options.ts
@@ -148,6 +148,7 @@ export interface BraintreeStoredCardFieldsMap {
 }
 
 export interface BraintreeFormFieldOptions {
+    accessibilityLabel?: string;
     containerId: string;
     placeholder?: string;
 }

--- a/src/payment/strategies/braintree/braintree-regular-field.ts
+++ b/src/payment/strategies/braintree/braintree-regular-field.ts
@@ -20,6 +20,8 @@ export default class BraintreeRegularField {
         this._input.style.width = '100%';
         this._input.placeholder = this._options.placeholder || '';
 
+        this._input.setAttribute('aria-label', this._options.accessibilityLabel || '');
+
         this._input.addEventListener('blur', this._handleBlur);
         this._input.addEventListener('focus', this._handleFocus);
 


### PR DESCRIPTION
## What?
Adding optional field "accessibilityLabel" to BraintreeFormField Options and setting aria-label attribute on card name input.
## Why?
Currently Braintree does not make use of the accessibility label made available [here](https://github.com/bigcommerce/checkout-js/pull/512)

This means that currently users relying on screen readers to checkout have a hard time understanding what part of the credit card form they are currently in.

## Testing / Proof
Before:
![Screen Shot 2021-08-05 at 5 59 13 PM](https://user-images.githubusercontent.com/20911717/128582246-4aeb7445-4db0-44db-af58-ea511234ad38.png)

After:
![Screen Shot 2021-08-05 at 5 58 31 PM](https://user-images.githubusercontent.com/20911717/128582256-ee91aa00-0ad6-43d3-a8b6-aa72abae5595.png)


@bigcommerce/checkout @bigcommerce/payments
