### PR TITLE
feat(checkout): PAYPAL-1100 added paylater to enable-funding field on paypalcommerce checkout and buttons

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -133,7 +133,7 @@ describe('PaypalCommerceButtonStrategy', () => {
             currency: 'USD',
             intent: 'capture',
             components: ['buttons', 'messages'],
-            'disable-funding': ['card', 'credit'],
+            'disable-funding': ['card', 'credit', 'paylater'],
         };
 
         expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
@@ -152,6 +152,10 @@ describe('PaypalCommerceButtonStrategy', () => {
                 intent: 'capture',
                 components: ['buttons', 'messages'],
                 'disable-funding': ['card'],
+                'enable-funding': [
+                    'credit',
+                    'paylater',
+                ],
         };
 
         expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);

--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -3,7 +3,7 @@ import { FormPoster } from '@bigcommerce/form-poster';
 import { Cart } from '../../../cart';
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { ApproveDataOptions, ButtonsOptions, ClickDataOptions, DisableFundingType, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceScriptParams } from '../../../payment/strategies/paypal-commerce';
+import { ApproveDataOptions, ButtonsOptions, ClickDataOptions, DisableFundingType, EnableFundingType, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceScriptParams } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
@@ -75,10 +75,18 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
 
     private _getParamsScript(initializationData: PaypalCommerceInitializationData, cart: Cart): PaypalCommerceScriptParams {
         const { clientId, intent, isPayPalCreditAvailable, merchantId, attributionId } = initializationData;
-        const disableFunding: DisableFundingType = [ 'card' ];
 
-        if (!isPayPalCreditAvailable) {
-            disableFunding.push('credit');
+        const disableFunding: DisableFundingType = [ 'card' ];
+        const enableFunding: EnableFundingType = [];
+
+        /**
+         *  The default value is different depending on the countries,
+         *  therefore there's a need to add credit, paylater to enable/disable funding explicitly
+         */
+        if (isPayPalCreditAvailable) {
+            enableFunding.push('credit', 'paylater');
+        } else {
+            disableFunding.push('credit', 'paylater');
         }
 
         return {
@@ -88,6 +96,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             currency: cart.currency.code,
             components: ['buttons', 'messages'],
             'disable-funding': disableFunding,
+            ...(enableFunding.length && {'enable-funding': enableFunding}),
             intent,
             'data-partner-attribution-id': attributionId,
         };

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -200,6 +200,29 @@ describe('PaypalCommercePaymentStrategy', () => {
             expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, 'paypalcommercealternativemethods');
         });
 
+        it('initializes paypalCommercePaymentProcessor with enable-funding field for enabling pay later', async () => {
+            jest.spyOn(paypalCommerceFundingKeyResolver, 'resolve')
+                .mockReturnValue('PAYLATER');
+
+            await paypalCommercePaymentStrategy.initialize({ ...options, gatewayId: undefined, methodId: PaymentStrategyType.PAYPAL_COMMERCE_CREDIT });
+
+            const obj = {
+                'client-id': 'abc',
+                commit: true,
+                currency: 'USD',
+                intent: 'capture',
+                components: [
+                    'buttons',
+                    'messages',
+                    'fields',
+                    'funding-eligibility',
+                ],
+                'enable-funding': 'paylater',
+            };
+
+            expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, undefined);
+        });
+
         it('renders PayPal button if orderId is undefined', async () => {
             await paypalCommercePaymentStrategy.initialize(options);
 

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -232,7 +232,8 @@ export interface PaypalCommerceInitializationData {
     attributionId?: string;
 }
 
-export type DisableFundingType = Array<'credit' | 'card'>;
+export type DisableFundingType = Array<'credit' | 'card' | 'paylater'>;
+export type EnableFundingType =  Array<'paypal' | 'credit' | 'paylater'> | string;
 
 export type ComponentsScriptType = Array<'buttons' | 'messages' | 'hosted-fields' | 'fields'>;
 
@@ -241,6 +242,7 @@ export interface PaypalCommerceScriptParams  {
     'merchant-id'?: string;
     'buyer-country'?: string;
     'disable-funding'?: DisableFundingType;
+    'enable-funding'?: EnableFundingType;
     'data-client-token'?: string;
     'data-partner-attribution-id'?: string;
     currency?: string;


### PR DESCRIPTION
## What?
Added paylater to enable-funding field on paypalcommerce checkout and buttons

## Why?
Due to https://jira.bigcommerce.com/browse/PAYPAL-1100
Previously Paylater didn't work outside US

## Testing / Proof
Units, manually
![image](https://user-images.githubusercontent.com/79574476/128870959-ee3300d5-713c-4430-bd13-4cb333288a3c.png)
![image](https://user-images.githubusercontent.com/79574476/128870977-1e627b60-b395-424f-97aa-feaec6ae0d08.png)


@bigcommerce/checkout @bigcommerce/payments
