### PR TITLE
fix(payment): INT-4761 Improvements to the Afterpay strategy

### DIFF
--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -204,7 +204,8 @@ describe('AfterpayPaymentStrategy', () => {
         });
 
         it('loads payment client token', () => {
-            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(paymentMethod.gateway, undefined);
+            expect(paymentMethodActionCreator.loadPaymentMethod)
+                .toHaveBeenCalledWith(`${paymentMethod.gateway}?method=${paymentMethod.id}`, undefined);
             expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
         });
     });

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
@@ -61,7 +61,8 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
         let state = this._store.getState();
         const currencyCode = state.cart.getCart()?.currency.code || '';
         const countryCode = this._mapCurrencyToISO2(currencyCode);
-        const { isStoreCreditApplied: useStoreCredit } = this._store.getState().checkout.getCheckoutOrThrow();
+        let { useStoreCredit } = payload;
+        useStoreCredit = typeof useStoreCredit === 'undefined' ? this._store.getState().checkout.getCheckoutOrThrow().isStoreCreditApplied : useStoreCredit;
 
         if (useStoreCredit !== undefined) {
             state = await this._store.dispatch(


### PR DESCRIPTION
## What? [INT-4761](https://jira.bigcommerce.com/browse/INT-4761)
Modify the strategy to load the payment method correctly and specify the store credit if necessary

## Why?
Afterpay is a multi-option provider but currently the strategy is loading the payment method as a unique method so it's causing a bad user experience

## Testing / Proof
**BEFORE**
![image](https://user-images.githubusercontent.com/36899206/129389299-20b295c1-b890-451e-8a70-e868a7ef8419.png)
**AFTER**
![image](https://user-images.githubusercontent.com/36899206/129389401-fec65538-cf04-46c1-8155-3fddc14acd53.png)

@bigcommerce/checkout @bigcommerce/payments
