### PR TITLE
fix(payment): PAYMENTS-7214 fix PPSDK initialisation strategy casing

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -130,7 +130,7 @@ export function getPPSDK(): PaymentMethod {
         config: {},
         type: 'PAYMENT_TYPE_SDK',
         initializationStrategy: {
-            type: 'NONE',
+            type: 'none',
         },
     };
 }

--- a/src/payment/strategies/ppsdk/initialization-strategies/none.ts
+++ b/src/payment/strategies/ppsdk/initialization-strategies/none.ts
@@ -1,7 +1,7 @@
 import { InitializationStrategy } from '../../../';
 interface None {
-    type: 'NONE';
+    type: 'none';
 }
 
 export const isNone = (strategy: Pick<InitializationStrategy, 'type'>): strategy is None =>
-    strategy.type === 'NONE';
+    strategy.type === 'none';


### PR DESCRIPTION
**N.B.** The PPSDK is behind a work in progress feature toggle

## What?

- Fix casing of expected PPSDK initialisation strategy value from BE

## Why?

- BE will be sending lowercase rather than all caps

## Testing / Proof

- Passing tests

@bigcommerce/checkout @bigcommerce/payments
