### PR TITLE
fix(payment): disable withCredentials on PPSDK xhr requests to BigPay

### DIFF
--- a/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.spec.ts
+++ b/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.spec.ts
@@ -33,7 +33,10 @@ describe('NonePaymentProcessor', () => {
 
             expect(requestSenderSpy).toBeCalledWith(
                 'https://some-domain.com/payments',
-                { body: { payment_method_id: 'some-id.some-method' } }
+                {
+                    body: { payment_method_id: 'some-id.some-method' },
+                    credentials: false,
+                }
             );
         });
 

--- a/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.ts
+++ b/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.ts
@@ -14,7 +14,7 @@ export class NonePaymentProcessor implements PaymentProcessor {
         const paymentMethodId = `${paymentMethod.id}.${paymentMethod.method}`;
         const body = { payment_method_id: paymentMethodId };
 
-        return this._requestSender.post<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments`, { body })
+        return this._requestSender.post<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments`, { credentials: false, body })
             .then(response => this._stepHandler.handle(response));
     }
 }

--- a/src/payment/strategies/ppsdk/ppsdk-payment-resumer.spec.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-resumer.spec.ts
@@ -17,7 +17,7 @@ describe('PaymentResumer', () => {
 
             await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com' });
 
-            expect(requestSenderSpy).toBeCalledWith('https://some-domain.com/payments/some-id');
+            expect(requestSenderSpy).toBeCalledWith('https://some-domain.com/payments/some-id', { credentials: false});
         });
 
         it('passes the Payments endpoint response to the stepHandler', async () => {

--- a/src/payment/strategies/ppsdk/ppsdk-payment-resumer.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-resumer.ts
@@ -15,7 +15,7 @@ export class PaymentResumer {
     ) {}
 
     resume({ paymentId, bigpayBaseUrl }: ResumeSettings): Promise<void> {
-        return this._requestSender.get<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments/${paymentId}`)
+        return this._requestSender.get<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments/${paymentId}`, { credentials: false })
             .then(response => this._stepHandler.handle(response));
     }
 }


### PR DESCRIPTION
**N.B.** The PPSDK is behind a work in progress feature toggle

## What?

- Disable `withCredentials` setting when posting/getting to the BigPay payments endpoints

## Why?

- Cookies are not required
- The default value of `true` conflicts with the `Access-Control-Allow-Origin` value of `*` returned by BigPay, creating a CORS issues

## Testing / Proof
- Passing tests

@bigcommerce/checkout @bigcommerce/payments
