### PR TITLE
fix(payment): INT-4674 Using  forgetCheckout instead of signOut on Google Pay

### DIFF
--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -47,7 +47,7 @@ export default function createCustomerStrategyRegistry(
     const formPoster = createFormPoster();
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(requestSender);
-    const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender);
+    const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender, checkoutActionCreator);
     const spamProtectionActionCreator = new SpamProtectionActionCreator(
         createSpamProtection(scriptLoader),
         new SpamProtectionRequestSender(requestSender)
@@ -124,7 +124,7 @@ export default function createCustomerStrategyRegistry(
     registry.register('squarev2', () =>
         new SquareCustomerStrategy(
             store,
-            new RemoteCheckoutActionCreator(remoteCheckoutRequestSender)
+            new RemoteCheckoutActionCreator(remoteCheckoutRequestSender, checkoutActionCreator)
         )
     );
 

--- a/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
+++ b/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
@@ -1,10 +1,12 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getFormFieldsState } from '../../../form/form.mock';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
@@ -20,6 +22,7 @@ import AmazonPayV2CustomerStrategy from './amazon-pay-v2-customer-strategy';
 import { getAmazonPayV2CustomerInitializeOptions, Mode } from './amazon-pay-v2-customer.mock';
 
 describe('AmazonPayV2CustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
     let customerInitializeOptions: CustomerInitializeOptions;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
@@ -41,13 +44,19 @@ describe('AmazonPayV2CustomerStrategy', () => {
         });
 
         requestSender = createRequestSender();
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
 
         paymentMethodActionCreator = new PaymentMethodActionCreator(
             new PaymentMethodRequestSender(requestSender)
         );
 
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(requestSender)
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
 
         paymentProcessor = createAmazonPayV2PaymentProcessor();

--- a/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
@@ -50,8 +50,8 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethodMock);
 
-        const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(createRequestSender());
-        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender);
+        const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(requestSender);
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender, checkoutActionCreator);
 
         visaCheckoutSDK = {} as VisaCheckoutSDK;
         visaCheckoutSDK.init = jest.fn();
@@ -60,7 +60,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         visaCheckoutScriptLoader = new VisaCheckoutScriptLoader(scriptLoader);
         visaCheckoutScriptLoader.load = jest.fn(() => Promise.resolve(visaCheckoutSDK));
 
-        const registry = createCustomerStrategyRegistry(store, createRequestSender(), '');
+        const registry = createCustomerStrategyRegistry(store, requestSender, '');
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
@@ -68,7 +68,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
             new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
-        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
         customerStrategyActionCreator = new CustomerStrategyActionCreator(registry);
 
         strategy = new BraintreeVisaCheckoutCustomerStrategy(

--- a/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
@@ -2,10 +2,12 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
@@ -18,6 +20,7 @@ import { getAuthNetCustomerInitializeOptions, Mode } from './googlepay-customer-
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let customerInitializeOptions: CustomerInitializeOptions;
@@ -39,8 +42,15 @@ describe('GooglePayCustomerStrategy', () => {
 
         requestSender = createRequestSender();
 
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(requestSender)
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(
@@ -167,7 +177,7 @@ describe('GooglePayCustomerStrategy', () => {
             jest.spyOn(store.getState().payment, 'getPaymentId')
                 .mockReturnValue(paymentId);
 
-            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+            jest.spyOn(remoteCheckoutActionCreator, 'forgetCheckout')
                 .mockReturnValue('data');
 
             const options = {
@@ -176,7 +186,7 @@ describe('GooglePayCustomerStrategy', () => {
 
             await strategy.signOut(options);
 
-            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('googlepayauthorizenet', options);
+            expect(remoteCheckoutActionCreator.forgetCheckout).toHaveBeenCalledWith('googlepayauthorizenet', options);
             expect(store.dispatch).toHaveBeenCalled();
         });
 

--- a/src/customer/strategies/googlepay/googlepay-checkoutcom-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-checkoutcom-customer-strategy.spec.ts
@@ -2,10 +2,12 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayCheckoutcomInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
@@ -18,6 +20,7 @@ import { getCheckoutcomCustomerInitializeOptions, Mode } from './googlepay-custo
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let customerInitializeOptions: CustomerInitializeOptions;
@@ -39,8 +42,15 @@ describe('GooglePayCustomerStrategy', () => {
 
         requestSender = createRequestSender();
 
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(requestSender)
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(
@@ -167,7 +177,7 @@ describe('GooglePayCustomerStrategy', () => {
             jest.spyOn(store.getState().payment, 'getPaymentId')
                 .mockReturnValue(paymentId);
 
-            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+            jest.spyOn(remoteCheckoutActionCreator, 'forgetCheckout')
                 .mockReturnValue('data');
 
             const options = {
@@ -176,7 +186,7 @@ describe('GooglePayCustomerStrategy', () => {
 
             await strategy.signOut(options);
 
-            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('googlepaycheckoutcom', options);
+            expect(remoteCheckoutActionCreator.forgetCheckout).toHaveBeenCalledWith('googlepaycheckoutcom', options);
             expect(store.dispatch).toHaveBeenCalled();
         });
 

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -61,9 +61,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             return Promise.resolve(this._store.getState());
         }
 
-        return this._store.dispatch(
-            this._remoteCheckoutActionCreator.signOut(payment.providerId, options)
-        );
+        return this._store.dispatch(this._remoteCheckoutActionCreator.forgetCheckout(payment.providerId, options));
     }
 
     executePaymentMethodCheckout(options?: ExecutePaymentMethodCheckoutOptions): Promise<InternalCheckoutSelectors> {

--- a/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
@@ -2,10 +2,12 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayCybersourceV2Initializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
@@ -18,6 +20,7 @@ import { getCybersourceV2CustomerInitializeOptions, Mode } from './googlepay-cus
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let customerInitializeOptions: CustomerInitializeOptions;
@@ -39,8 +42,15 @@ describe('GooglePayCustomerStrategy', () => {
 
         requestSender = createRequestSender();
 
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(requestSender)
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(
@@ -167,7 +177,7 @@ describe('GooglePayCustomerStrategy', () => {
             jest.spyOn(store.getState().payment, 'getPaymentId')
                 .mockReturnValue(paymentId);
 
-            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+            jest.spyOn(remoteCheckoutActionCreator, 'forgetCheckout')
                 .mockReturnValue('data');
 
             const options = {
@@ -176,7 +186,7 @@ describe('GooglePayCustomerStrategy', () => {
 
             await strategy.signOut(options);
 
-            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('googlepaycybersourcev2', options);
+            expect(remoteCheckoutActionCreator.forgetCheckout).toHaveBeenCalledWith('googlepaycybersourcev2', options);
             expect(store.dispatch).toHaveBeenCalled();
         });
 

--- a/src/customer/strategies/googlepay/googlepay-orbital-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-orbital-customer-strategy.spec.ts
@@ -2,10 +2,12 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayOrbitalInitializer, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
@@ -18,6 +20,7 @@ import { getOrbitalCustomerInitializeOptions, Mode } from './googlepay-customer-
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let customerInitializeOptions: CustomerInitializeOptions;
@@ -39,8 +42,15 @@ describe('GooglePayCustomerStrategy', () => {
 
         requestSender = createRequestSender();
 
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(requestSender)
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(
@@ -167,7 +177,7 @@ describe('GooglePayCustomerStrategy', () => {
             jest.spyOn(store.getState().payment, 'getPaymentId')
                 .mockReturnValue(paymentId);
 
-            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+            jest.spyOn(remoteCheckoutActionCreator, 'forgetCheckout')
                 .mockReturnValue('data');
 
             const options = {
@@ -176,7 +186,7 @@ describe('GooglePayCustomerStrategy', () => {
 
             await strategy.signOut(options);
 
-            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('googlepayorbital', options);
+            expect(remoteCheckoutActionCreator.forgetCheckout).toHaveBeenCalledWith('googlepayorbital', options);
             expect(store.dispatch).toHaveBeenCalled();
         });
 

--- a/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
+++ b/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
@@ -2,10 +2,12 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster/';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCart, getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createGooglePayPaymentProcessor, GooglePayPaymentProcessor, GooglePayStripeInitializer } from '../../../payment/strategies/googlepay';
 import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
@@ -18,6 +20,7 @@ import { getStripeCustomerInitializeOptions, Mode } from './googlepay-customer-m
 import GooglePayCustomerStrategy from './googlepay-customer-strategy';
 
 describe('GooglePayCustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
     let formPoster: FormPoster;
     let customerInitializeOptions: CustomerInitializeOptions;
@@ -39,8 +42,15 @@ describe('GooglePayCustomerStrategy', () => {
 
         requestSender = createRequestSender();
 
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(requestSender)
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
 
         paymentProcessor = createGooglePayPaymentProcessor(
@@ -167,7 +177,7 @@ describe('GooglePayCustomerStrategy', () => {
             jest.spyOn(store.getState().payment, 'getPaymentId')
                 .mockReturnValue(paymentId);
 
-            jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+            jest.spyOn(remoteCheckoutActionCreator, 'forgetCheckout')
                 .mockReturnValue('data');
 
             const options = {
@@ -176,7 +186,7 @@ describe('GooglePayCustomerStrategy', () => {
 
             await strategy.signOut(options);
 
-            expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalledWith('googlepaystripe', options);
+            expect(remoteCheckoutActionCreator.forgetCheckout).toHaveBeenCalledWith('googlepaystripe', options);
             expect(store.dispatch).toHaveBeenCalled();
         });
 

--- a/src/customer/strategies/masterpass/masterpass-customer-strategy.spec.ts
+++ b/src/customer/strategies/masterpass/masterpass-customer-strategy.spec.ts
@@ -2,10 +2,12 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfig, getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getMasterpass, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { Masterpass, MasterpassScriptLoader } from '../../../payment/strategies/masterpass';
@@ -18,6 +20,7 @@ import CustomerStrategy from '../customer-strategy';
 import MasterpassCustomerStrategy from './masterpass-customer-strategy';
 
 describe('MasterpassCustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
     let masterpass: Masterpass;
     let masterpassScriptLoader: MasterpassScriptLoader;
@@ -57,8 +60,15 @@ describe('MasterpassCustomerStrategy', () => {
 
         requestSender = createRequestSender();
 
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(requestSender)
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
 
         masterpass = getMasterpassScriptMock();

--- a/src/customer/strategies/square/square-customer-strategy.spec.ts
+++ b/src/customer/strategies/square/square-customer-strategy.spec.ts
@@ -1,9 +1,11 @@
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState, getSquare } from '../../../payment/payment-methods.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
@@ -13,9 +15,11 @@ import CustomerStrategy from '../customer-strategy';
 import SquareCustomerStrategy from './square-customer-strategy';
 
 describe('SquareCustomerStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
     let paymentMethodMock: PaymentMethod;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let requestSender: RequestSender;
     let store: CheckoutStore;
     let strategy: CustomerStrategy;
 
@@ -36,8 +40,16 @@ describe('SquareCustomerStrategy', () => {
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
             .mockReturnValue(paymentMethodMock);
 
+        requestSender = createRequestSender();
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(createRequestSender())
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
 
         strategy = new SquareCustomerStrategy(

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -93,10 +93,10 @@ export default function createPaymentStrategyRegistry(
     const paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator, paymentRequestTransformer, paymentHumanVerificationHandler);
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(requestSender);
-    const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender);
     const configActionCreator = new ConfigActionCreator(new ConfigRequestSender(requestSender));
     const formFieldsActionCreator = new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender));
     const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator, formFieldsActionCreator);
+    const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender, checkoutActionCreator);
     const paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator, spamProtectionActionCreator);
     const formPoster = createFormPoster();
     const hostedFormFactory = new HostedFormFactory(store);

--- a/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
+++ b/src/payment/strategies/klarna/klarna-payment-strategy.spec.ts
@@ -1,12 +1,14 @@
 import { createAction, Action } from '@bigcommerce/data-store';
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge, omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
-import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
@@ -24,6 +26,7 @@ import KlarnaScriptLoader from './klarna-script-loader';
 import { getEUBillingAddress, getEUBillingAddressWithNoPhone, getKlarnaUpdateSessionParams, getKlarnaUpdateSessionParamsForOC, getKlarnaUpdateSessionParamsPhone, getOCBillingAddress } from './klarna.mock';
 
 describe('KlarnaPaymentStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let initializePaymentAction: Observable<Action>;
     let klarnaCredit: KlarnaCredit;
     let loadPaymentMethodAction: Observable<Action>;
@@ -32,6 +35,7 @@ describe('KlarnaPaymentStrategy', () => {
     let orderActionCreator: OrderActionCreator;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let requestSender: RequestSender;
     let scriptLoader: KlarnaScriptLoader;
     let submitOrderAction: Observable<Action>;
     let store: CheckoutStore;
@@ -45,13 +49,22 @@ describe('KlarnaPaymentStrategy', () => {
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(paymentMethodMock);
 
+        requestSender = createRequestSender();
+
         orderActionCreator = new OrderActionCreator(
-            new OrderRequestSender(createRequestSender()),
-            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+            new OrderRequestSender(requestSender),
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
         );
-        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
+
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(createRequestSender())
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
         scriptLoader = new KlarnaScriptLoader(createScriptLoader());
         strategy = new KlarnaPaymentStrategy(

--- a/src/payment/strategies/quadpay/quadpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/quadpay/quadpay-payment-strategy.spec.ts
@@ -6,12 +6,14 @@ import { omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, Checkout, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { createCheckoutStore, Checkout, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckout, getCheckoutState } from '../../../checkout/checkouts.mock';
 import { MissingDataError, RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
@@ -31,6 +33,7 @@ import { getErrorPaymentResponseBody } from '../../payments.mock';
 import QuadpayPaymentStrategy from './quadpay-payment-strategy';
 
 describe('QuadpayPaymentStrategy', () => {
+    let checkoutActionCreator: CheckoutActionCreator;
     let store: CheckoutStore;
     let requestSender: RequestSender;
     let orderActionCreator: OrderActionCreator;
@@ -73,8 +76,14 @@ describe('QuadpayPaymentStrategy', () => {
         storeCreditActionCreator = new StoreCreditActionCreator(
             new StoreCreditRequestSender(requestSender)
         );
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
-            new RemoteCheckoutRequestSender(requestSender)
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
         );
         storefrontPaymentRequestSender = new StorefrontPaymentRequestSender(requestSender);
 

--- a/src/remote-checkout/remote-checkout-actions.ts
+++ b/src/remote-checkout/remote-checkout-actions.ts
@@ -3,6 +3,10 @@ import { Action } from '@bigcommerce/data-store';
 import { AmazonPayRemoteCheckout } from './methods';
 
 export enum RemoteCheckoutActionType {
+    ForgetCheckoutRemoteCustomerRequested = 'FORGET_CHECKOUT_REMOTE_CUSTOMER_REQUESTED',
+    ForgetCheckoutRemoteCustomerSucceeded = 'FORGET_CHECKOUT_REMOTE_CUSTOMER_SUCCEEDED',
+    ForgetCheckoutRemoteCustomerFailed = 'FORGET_CHECKOUT_REMOTE_CUSTOMER_FAILED',
+
     InitializeRemoteBillingRequested = 'INITIALIZE_REMOTE_BILLING_REQUESTED',
     InitializeRemoteBillingSucceeded = 'INITIALIZE_REMOTE_BILLING_SUCCEEDED',
     InitializeRemoteBillingFailed = 'INITIALIZE_REMOTE_BILLING_FAILED',
@@ -26,12 +30,29 @@ export enum RemoteCheckoutActionType {
     UpdateRemoteCheckout = 'UPDATE_REMOTE_CHECKOUT',
 }
 
-export type RemoteCheckoutAction = InitializeRemoteBillingAction |
+export type RemoteCheckoutAction = ForgetCheckoutRemoteCustomerAction |
+    InitializeRemoteBillingAction |
     InitializeRemoteShippingAction |
     InitializeRemotePaymentAction |
     SignOutRemoteCustomerAction |
     LoadRemoteSettingsAction |
     UpdateRemoteCheckoutAction;
+
+export type ForgetCheckoutRemoteCustomerAction = ForgetCheckoutRemoteCustomerRequestedAction |
+    ForgetCheckoutRemoteCustomerSucceededAction |
+    ForgetCheckoutRemoteCustomerFailedAction;
+
+export interface ForgetCheckoutRemoteCustomerRequestedAction extends Action {
+    type: RemoteCheckoutActionType.ForgetCheckoutRemoteCustomerRequested;
+}
+
+export interface ForgetCheckoutRemoteCustomerSucceededAction extends Action {
+    type: RemoteCheckoutActionType.ForgetCheckoutRemoteCustomerSucceeded;
+}
+
+export interface ForgetCheckoutRemoteCustomerFailedAction extends Action {
+    type: RemoteCheckoutActionType.ForgetCheckoutRemoteCustomerFailed;
+}
 
 export type InitializeRemoteBillingAction = InitializeRemoteBillingSucceededAction |
     InitializeRemoteBillingFailedAction |

--- a/src/shipping/create-shipping-strategy-registry.ts
+++ b/src/shipping/create-shipping-strategy-registry.ts
@@ -1,8 +1,10 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
-import { CheckoutRequestSender, CheckoutStore } from '../checkout';
+import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
+import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
@@ -30,7 +32,13 @@ export default function createShippingStrategyRegistry(
             store,
             consignmentActionCreator,
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
-            new RemoteCheckoutActionCreator(new RemoteCheckoutRequestSender(requestSender)),
+            new RemoteCheckoutActionCreator(
+                new RemoteCheckoutRequestSender(requestSender),
+                new CheckoutActionCreator(
+                    new CheckoutRequestSender(requestSender),
+                    new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+                    new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+                )),
             new AmazonPayScriptLoader(getScriptLoader())
         )
     );


### PR DESCRIPTION
## What? [INT-4674](https://jira.bigcommerce.com/browse/INT-4674)
Using the forgetCheckout action instead of the signOut action when clicking sign out on Google Pay

## Why?
Using the signOut action was deleting all the checkout data

## Testing / Proof
![image](https://user-images.githubusercontent.com/87149598/129791441-5b9263e4-8c19-4502-ab7e-e5746027139f.png)
After signing out
![image](https://user-images.githubusercontent.com/87149598/129791523-4b16090d-cf3b-4e69-958a-cbafd7041c6f.png)


@bigcommerce/checkout @bigcommerce/payments
