### PR TITLE
feat(checkout): PAYPAL-1111 Added APM check to paypalcommerce button integration and integrated SEPA

### DIFF
--- a/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -133,7 +133,11 @@ describe('PaypalCommerceButtonStrategy', () => {
             currency: 'USD',
             intent: 'capture',
             components: ['buttons', 'messages'],
-            'disable-funding': ['card', 'credit', 'paylater'],
+            'disable-funding': [
+                'card',
+                'credit',
+                'paylater',
+            ],
         };
 
         expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
@@ -151,8 +155,67 @@ describe('PaypalCommerceButtonStrategy', () => {
                 currency: 'USD',
                 intent: 'capture',
                 components: ['buttons', 'messages'],
-                'disable-funding': ['card'],
+                'disable-funding': [
+                    'card',
+                ],
                 'enable-funding': [
+                    'credit',
+                    'paylater',
+                ],
+        };
+
+        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
+    });
+
+    it('initializes PaypalCommerce with enabled APMs', async () => {
+
+        paymentMethod.initializationData.availableAlternativePaymentMethods = ['sepa', 'venmo', 'sofort', 'mybank'];
+        paymentMethod.initializationData.enabledAlternativePaymentMethods = ['sofort', 'mybank'];
+        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
+
+        await strategy.initialize(options);
+
+        const obj = {
+                'client-id': 'abc',
+                commit: false,
+                currency: 'USD',
+                intent: 'capture',
+                components: ['buttons', 'messages'],
+                'disable-funding': [
+                    'card',
+                    'sepa',
+                    'venmo',
+                    'credit',
+                    'paylater',
+                ],
+                'enable-funding': [
+                    'sofort',
+                    'mybank',
+                ],
+        };
+
+        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj);
+    });
+
+    it('initializes PaypalCommerce with disabled APMs', async () => {
+        paymentMethod.initializationData.availableAlternativePaymentMethods = ['sepa', 'venmo', 'sofort', 'mybank'];
+        paymentMethod.initializationData.enabledAlternativePaymentMethods = [];
+        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
+
+        await strategy.initialize(options);
+
+        const obj = {
+                'client-id': 'abc',
+                commit: false,
+                currency: 'USD',
+                intent: 'capture',
+                components: ['buttons', 'messages'],
+                'disable-funding': [
+                    'card',
+                    'sepa',
+                    'venmo',
+                    'sofort',
+                    'mybank',
                     'credit',
                     'paylater',
                 ],

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.spec.ts
@@ -48,6 +48,10 @@ describe('paypalCommerceFundingKeyResolver', () => {
             expect(paypalCommerceFundingKeyResolver.resolve('trustly', 'paypalcommercealternativemethods')).toEqual('TRUSTLY');
         });
 
+        it('should return "SEPA"', () => {
+            expect(paypalCommerceFundingKeyResolver.resolve('sepa', 'paypalcommercealternativemethods')).toEqual('SEPA');
+        });
+
         it('should return "VENMO"', () => {
             expect(paypalCommerceFundingKeyResolver.resolve('venmo', 'paypalcommercealternativemethods')).toEqual('VENMO');
         });

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.ts
@@ -32,6 +32,8 @@ export default class PaypalCommerceFundingKeyResolver {
                     return 'BLIK';
                 case 'trustly':
                     return 'TRUSTLY';
+                case 'sepa':
+                    return 'SEPA';
                 case 'venmo':
                     return 'VENMO';
             }

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -221,6 +221,9 @@ export interface PaypalCommerceHostWindow extends Window {
     paypalLoadScript?(options: PaypalCommerceScriptParams): Promise<{ paypal: PaypalCommerceSDK }>;
 }
 
+export type FundingType = string[];
+export type EnableFundingType =  FundingType | string;
+
 export interface PaypalCommerceInitializationData {
     clientId: string;
     merchantId?: string;
@@ -228,13 +231,12 @@ export interface PaypalCommerceInitializationData {
     isDeveloperModeApplicable?: boolean;
     intent?: 'capture' | 'authorize';
     isPayPalCreditAvailable?: boolean;
+    availableAlternativePaymentMethods: FundingType;
+    enabledAlternativePaymentMethods: FundingType;
     isProgressiveOnboardingAvailable?: boolean;
     clientToken?: string;
     attributionId?: string;
 }
-
-export type DisableFundingType = Array<'credit' | 'card' | 'paylater'>;
-export type EnableFundingType =  Array<'paypal' | 'credit' | 'paylater'> | string;
 
 export type ComponentsScriptType = Array<'buttons' | 'messages' | 'hosted-fields' | 'fields'>;
 
@@ -242,7 +244,7 @@ export interface PaypalCommerceScriptParams  {
     'client-id': string;
     'merchant-id'?: string;
     'buyer-country'?: string;
-    'disable-funding'?: DisableFundingType;
+    'disable-funding'?: FundingType;
     'enable-funding'?: EnableFundingType;
     'data-client-token'?: string;
     'data-partner-attribution-id'?: string;

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -198,6 +198,7 @@ export interface PaypalCommerceSDKFunding {
     IDEAL: string;
     MYBANK: string;
     SOFORT: string;
+    SEPA: string;
     BLIK: string;
     TRUSTLY: string;
     VERKKOPANKKI: string;

--- a/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
@@ -21,6 +21,7 @@ export function getPaypalCommerceMock(): PaypalCommerceSDK {
             MYBANK: 'mybank',
             SOFORT: 'sofort',
             TRUSTLY: 'trustly',
+            SEPA: 'sepa',
             VERKKOPANKKI: 'verkkopankki',
             VENMO: 'venmo',
         },


### PR DESCRIPTION
## What?
1) Added SEPA apm to paypalcommerce.
2) Implemented explicit passing of APMs to enable and disable fundings for Paypalcommerce button integration.
Thats is needed for showing smart buttons only for activated APMs and PayLater(Credit).

## Why?
Due to the https://jira.bigcommerce.com/browse/PAYPAL-1111

## Testing / Proof
Tested manually/units
This screenshot  shows that checkout passing explicitly enabled/disabled APMs and credit/paylater to disable/enable-funding params on paypal initialization.

![image](https://user-images.githubusercontent.com/79574476/130237600-032bb016-828d-44d6-80b6-ca2061e81613.png)



