### PR TITLE
fix(payment): BOLT-47 fixed an issue of throwing payment method error…

### DIFF
--- a/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -129,7 +129,23 @@ describe('BoltPaymentStrategy', () => {
             expect(boltScriptLoader.load).toHaveBeenCalledWith('publishableKey', true, paymentMethodMock.initializationData.developerConfig);
         });
 
-        it('fails to initialize the bolt strategy if publishableKey is not provided', async () => {
+        it('successfully initializes the bolt strategy without publishable key if BoltCheckout SDK was initialized before', async () => {
+            await boltScriptLoader.load('publishableKey', true, paymentMethodMock.initializationData.developerConfig);
+
+            const initializationOptions = {
+                ...boltTakeOverInitializationOptions,
+                bolt: {
+                    useBigCommerceCheckout: false,
+                },
+            };
+
+            paymentMethodMock.initializationData.publishableKey = null;
+
+            await expect(strategy.initialize(initializationOptions)).resolves.toEqual(store.getState());
+            expect(boltScriptLoader.load).toHaveBeenCalledWith();
+        });
+
+        it('fails to initialize the bolt strategy if publishableKey is not provided when using Bigcommerce Checkout', async () => {
             paymentMethodMock.initializationData.publishableKey = null;
             await expect(strategy.initialize(boltClientScriptInitializationOptions)).rejects.toThrow(MissingDataError);
             expect(boltScriptLoader.load).not.toHaveBeenCalled();

--- a/src/payment/strategies/bolt/bolt-script-loader.spec.ts
+++ b/src/payment/strategies/bolt/bolt-script-loader.spec.ts
@@ -71,7 +71,25 @@ describe('BoltScriptLoader', () => {
             expect(client).toBe(boltClient);
         });
 
+        it('returns the Bolt Client from the window if it is already exist without provided publishableKey', async () => {
+            await boltScriptLoader.load(publishableKey);
+
+            const client = await boltScriptLoader.load();
+
+            expect(client).toBe(boltClient);
+        });
+
         it('throws an error when window is not set', async () => {
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.BoltCheckout = undefined;
+
+                return Promise.resolve();
+            });
+
+            await expect(boltScriptLoader.load(publishableKey)).rejects.toThrow(PaymentMethodClientUnavailableError);
+        });
+
+        it('throws an error when window is not set and publishableKey is not provided', async () => {
             scriptLoader.loadScript = jest.fn(() => {
                 mockWindow.BoltCheckout = undefined;
 

--- a/src/payment/strategies/bolt/bolt-script-loader.ts
+++ b/src/payment/strategies/bolt/bolt-script-loader.ts
@@ -1,5 +1,6 @@
 import { LoadScriptOptions, ScriptLoader } from '@bigcommerce/script-loader';
 
+import { InvalidArgumentError } from '../../../common/error/errors';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
 import { BoltCheckout, BoltDeveloperMode, BoltDeveloperModeParams, BoltHostWindow } from './bolt';
@@ -10,9 +11,13 @@ export default class BoltScriptLoader {
         public _window: BoltHostWindow = window
     ) {}
 
-    async load(publishableKey: string, testMode?: boolean, developerModeParams?: BoltDeveloperModeParams): Promise<BoltCheckout> {
+    async load(publishableKey?: string, testMode?: boolean, developerModeParams?: BoltDeveloperModeParams): Promise<BoltCheckout> {
         if (this._window.BoltCheckout) {
             return this._window.BoltCheckout;
+        }
+
+        if (!publishableKey) {
+            throw new InvalidArgumentError('Unable to initialize payment because "publishableKey" argument is not provided.');
         }
 
         const options: LoadScriptOptions = {


### PR DESCRIPTION
… on initialization for Bolt Full Checkout flow

## What?
We should not throw an error on Bolt Payment Strategy initialisation if useBigcommerceCheckout is false and publishableKey is not provided.

## Why?
Because Bolt gets an error each time when they try to initialise Bolt Payment Strategy for Bolt Full Checkout flow

## Testing / Proof
Here is test result:
<img width="335" alt="Screenshot 2021-08-19 at 12 40 45" src="https://user-images.githubusercontent.com/25133454/130046596-a729c3f1-5912-4c29-a2d6-3767a7efa8f6.png">


@bigcommerce/checkout
