### PR TITLE
feat(payment): INT-4231 deleting spinner functionality in amazonpay

### DIFF
--- a/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
+++ b/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
@@ -225,8 +225,9 @@ describe('AmazonPayV2PaymentStrategy', () => {
             expect(amazonPayV2PaymentProcessor.createButton).not.toHaveBeenCalled();
         });
 
-        it('dispatches widgetInteraction when clicking previously binded edit method button', async () => {
+        it('dispatches widgetInteraction when clicking previously binded edit method button if region not US', async () => {
             paymentMethodMock.initializationData.paymentToken = paymentToken;
+            paymentMethodMock.initializationData.region = 'uk';
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                 .mockReturnValue(paymentMethodMock);
 
@@ -239,6 +240,22 @@ describe('AmazonPayV2PaymentStrategy', () => {
             }
 
             expect(paymentStrategyActionCreator.widgetInteraction).toHaveBeenCalled();
+        });
+
+        it('avoid dispatching widgetInteraction when clicking previously binded edit method button if region US', async () => {
+            paymentMethodMock.initializationData.paymentToken = paymentToken;
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(paymentMethodMock);
+
+            await strategy.initialize(initializeOptions);
+
+            const editButton = document.getElementById(changeMethodId);
+
+            if (editButton) {
+                editButton.click();
+            }
+
+            expect(paymentStrategyActionCreator.widgetInteraction).not.toHaveBeenCalled();
         });
 
         it('does not initialize the paymentProcessor if no options.amazonpayv2 are provided', () => {

--- a/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.spec.ts
+++ b/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.spec.ts
@@ -113,7 +113,8 @@ describe('AmazonPayV2ShippingStrategy', () => {
             };
         });
 
-        it('dispatches update shipping when clicking previously binded buttons', async () => {
+        it('dispatches update shipping when clicking previously binded buttons if region not US', async () => {
+            paymentMethodMock.initializationData.region = 'de';
             jest.spyOn(shippingStrategyActionCreator, 'widgetInteraction');
             paymentMethodMock.initializationData.paymentToken = paymentToken;
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
@@ -126,6 +127,21 @@ describe('AmazonPayV2ShippingStrategy', () => {
             }
 
             expect(shippingStrategyActionCreator.widgetInteraction).toHaveBeenCalled();
+        });
+
+        it('avoid dispatching update shipping when clicking previously binded buttons if US', async () => {
+            jest.spyOn(shippingStrategyActionCreator, 'widgetInteraction');
+            paymentMethodMock.initializationData.paymentToken = paymentToken;
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+
+            await strategy.initialize(initializeOptions);
+
+            const editButton = document.getElementById(shippingId);
+            if (editButton) {
+                editButton.click();
+            }
+
+            expect(shippingStrategyActionCreator.widgetInteraction).not.toHaveBeenCalled();
         });
 
         it('does not binds edit address button if no paymentToken is present on initializationData', async () => {


### PR DESCRIPTION
[INT-4231](https://jira.bigcommerce.com/browse/INT-4231)

## What?
I changed payment strategy to reject the promise that triggers the spinner in amazonpay payment step.

## Why?
Amazonpay team changed US region script to open a modal instead of performing a full redirect to their hosted page, this causes an infinite spinner running if shopper closes the modal.

The change covers US considering that is the only region using the modal, for the other regions (UK and EU) we will keep the same functionality as before.

## Testing / Proof
Demo issue to resolve:
https://drive.google.com/file/d/1nXrKE0YsvSFxsxjHED1CyFZSnE6vJC-q/view?usp=sharing

Demo US:
https://drive.google.com/file/d/1L8pXznmXBrfPZ6dTz91CWqSNij6O7HpY/view?usp=sharing

Demo UK:
https://drive.google.com/file/d/1Onur_lY6gkVD0oxFzWMbZ919c3XmnL9O/view?usp=sharing

Demo EU:
https://drive.google.com/file/d/1MEC2rPRouaxhJOsr4eyC3MmLo0SdBpXC/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
