### PR TITLE
feat(order): INT-4776 Create a new field for the mandate reference ID

### DIFF
--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -32,7 +32,6 @@ export default interface Order {
     status: string;
     taxes: Tax[];
     taxTotal: number;
-    mandateUrl?: string;
 }
 
 export type OrderPayments = Array<GatewayOrderPayment | GiftCertificateOrderPayment>;
@@ -42,6 +41,7 @@ export type OrderMeta = OrderMetaState;
 export interface OrderPayment {
     providerId: string;
     gatewayId?: string;
+    methodId?: string;
     paymentId?: string;
     description: string;
     amount: number;
@@ -51,6 +51,10 @@ export interface GatewayOrderPayment extends OrderPayment {
     detail: {
         step: string;
         instructions: string;
+    };
+    mandate?: {
+        id: string;
+        url?: string;
     };
 }
 


### PR DESCRIPTION
## What?
Add mandate and methodId  property to the gateway Order Payments.

## Why?
So they can be accessed in the Order Status page.

## Testing / Proof
[Demo Videos](https://drive.google.com/drive/folders/1VcyX_5nMpL3Ri0nMPOcgDqWWBq0Kmzvx?usp=sharing)
<img width="716" alt="Screen Shot 2021-08-23 at 3 41 02 PM" src="https://user-images.githubusercontent.com/35502707/130525745-6da0cbf3-2921-4ac5-9996-e929745fcd13.png">


## Sibling PRs
https://github.com/bigcommerce/bigcommerce/pull/42364
https://github.com/bigcommerce/bigpay/pull/4234
https://github.com/bigcommerce/checkout-js/pull/674

## Merge Order
1) https://github.com/bigcommerce/checkout-sdk-js/pull/1220

2) https://github.com/bigcommerce/bigcommerce/pull/42364
https://github.com/bigcommerce/bigpay/pull/4234
https://github.com/bigcommerce/checkout-js/pull/674

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
