### PR TITLE
fix(payment): PAYMENTS-7221 fix the PPSDK BigPay Payments request headers

### DIFF
--- a/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.spec.ts
+++ b/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.spec.ts
@@ -29,13 +29,17 @@ describe('NonePaymentProcessor', () => {
             const requestSenderSpy = jest.spyOn(requestSender, 'post').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com' });
+            await nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(requestSenderSpy).toBeCalledWith(
                 'https://some-domain.com/payments',
                 {
                     body: { payment_method_id: 'some-id.some-method' },
                     credentials: false,
+                    headers: {
+                        authorization: 'some-token',
+                        'X-XSRF-TOKEN': null,
+                    },
                 }
             );
         });
@@ -44,7 +48,7 @@ describe('NonePaymentProcessor', () => {
             jest.spyOn(requestSender, 'post').mockResolvedValue({ body: 'some-api-response' });
             const stepHandlerSpy = jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com' });
+            await nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(stepHandlerSpy).toBeCalledWith({ body: 'some-api-response' });
         });
@@ -53,7 +57,7 @@ describe('NonePaymentProcessor', () => {
             jest.spyOn(requestSender, 'post').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({ someValue: 12345 });
 
-            await expect(nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com' }))
+            await expect(nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' }))
                 .resolves.toStrictEqual({ someValue: 12345 });
         });
     });

--- a/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.ts
+++ b/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.ts
@@ -10,11 +10,19 @@ export class NonePaymentProcessor implements PaymentProcessor {
         private _stepHandler: StepHandler
     ) {}
 
-    process({ paymentMethod, bigpayBaseUrl }: ProcessorSettings) {
+    process({ paymentMethod, bigpayBaseUrl, token }: ProcessorSettings) {
         const paymentMethodId = `${paymentMethod.id}.${paymentMethod.method}`;
         const body = { payment_method_id: paymentMethodId };
+        const options = {
+            credentials: false,
+            body,
+            headers: {
+                authorization: token,
+                'X-XSRF-TOKEN': null,
+            },
+        };
 
-        return this._requestSender.post<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments`, { credentials: false, body })
+        return this._requestSender.post<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments`, options)
             .then(response => this._stepHandler.handle(response));
     }
 }

--- a/src/payment/strategies/ppsdk/ppsdk-payment-processor.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-processor.ts
@@ -2,6 +2,7 @@ import { OrderPaymentRequestBody } from '../../../order';
 import { PPSDKPaymentMethod } from '../../ppsdk-payment-method';
 
 export interface ProcessorSettings {
+    token: string;
     paymentMethod: PPSDKPaymentMethod;
     payment?: OrderPaymentRequestBody;
     bigpayBaseUrl: string;

--- a/src/payment/strategies/ppsdk/ppsdk-payment-resumer.spec.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-resumer.spec.ts
@@ -15,16 +15,24 @@ describe('PaymentResumer', () => {
             const requestSenderSpy = jest.spyOn(requestSender, 'get').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com' });
+            await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
-            expect(requestSenderSpy).toBeCalledWith('https://some-domain.com/payments/some-id', { credentials: false});
+            expect(requestSenderSpy).toBeCalledWith(
+                'https://some-domain.com/payments/some-id',
+                {
+                    credentials: false,
+                    headers: {
+                        authorization: 'some-token',
+                        'X-XSRF-TOKEN': null,
+                    },
+                });
         });
 
         it('passes the Payments endpoint response to the stepHandler', async () => {
             jest.spyOn(requestSender, 'get').mockResolvedValue({ body: 'some-api-response' });
             const stepHandlerSpy = jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com' });
+            await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(stepHandlerSpy).toBeCalledWith({ body: 'some-api-response' });
         });
@@ -33,7 +41,7 @@ describe('PaymentResumer', () => {
             jest.spyOn(requestSender, 'get').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({ someValue: 12345 });
 
-            await expect(paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com' }))
+            await expect(paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' }))
                 .resolves.toStrictEqual({ someValue: 12345 });
         });
     });

--- a/src/payment/strategies/ppsdk/ppsdk-payment-resumer.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-resumer.ts
@@ -4,6 +4,7 @@ import { PaymentsAPIResponse } from './ppsdk-payments-api-response';
 import { StepHandler } from './step-handler';
 
 interface ResumeSettings {
+    token: string;
     paymentId: string;
     bigpayBaseUrl: string;
 }
@@ -14,8 +15,16 @@ export class PaymentResumer {
         private _stepHandler: StepHandler
     ) {}
 
-    resume({ paymentId, bigpayBaseUrl }: ResumeSettings): Promise<void> {
-        return this._requestSender.get<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments/${paymentId}`, { credentials: false })
+    resume({ paymentId, bigpayBaseUrl, token }: ResumeSettings): Promise<void> {
+        const options = {
+            credentials: false,
+            headers: {
+                authorization: token,
+                'X-XSRF-TOKEN': null,
+            },
+        };
+
+        return this._requestSender.get<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments/${paymentId}`, options)
             .then(response => this._stepHandler.handle(response));
     }
 }


### PR DESCRIPTION
**N.B.** The PPSDK is behind a work in progress feature toggle

## What?

- For PPSDK requests to the BigPay `/payments` endpoint: 
  - Add `AUTHORIZATION` header populated by the order token
  - Null out `X-XSRF-TOKEN` header (as not to have its value set by default: https://github.com/bigcommerce/request-sender-js/pull/27)

## Why?

- BigPay need the `AUTHORIZATION` JWT value to work with the order
- The endpoint is not designed to use `X-XSRF-TOKEN` value, so its default inclusion is unnecessary and potentially misleading

## Testing / Proof

- Updated tests

@bigcommerce/checkout @bigcommerce/payments
