### PR TITLE
fix(payment): INT-4761 Improvements to the Afterpay strategy

### DIFF
--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -335,6 +335,7 @@ describe('AfterpayPaymentStrategy', () => {
 
             expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
             expect(store.dispatch).toHaveBeenCalledWith(paymentFailedErrorAction);
+            expect(storeCreditActionCreator.applyStoreCredit).toHaveBeenCalledWith(false);
 
             expect(remoteCheckoutRequestSender.forgetCheckout).toHaveBeenCalled();
             expect(paymentMethodActionCreator.loadPaymentMethods).toHaveBeenCalled();

--- a/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
+++ b/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
@@ -108,6 +108,10 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
         } catch (error) {
             await this._remoteCheckoutRequestSender.forgetCheckout();
             await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethods());
+            // Applying the status of store credit after the order was created and the payment was declined
+            const useStoreCredit = this._store.getState().checkout.getCheckoutOrThrow().isStoreCreditApplied;
+
+            await this._store.dispatch(this._storeCreditActionCreator.applyStoreCredit(useStoreCredit));
 
             throw new OrderFinalizationNotCompletedError(error.body?.errors?.[0]?.message);
         }


### PR DESCRIPTION
## What?
Ensure `useStoreCredit` value is correct when Afterpay fails to process a payment (invalid card or similar) and the shopper wants to retry their payment using the correct data.

## Why?
Afterpay is having issues after it fails to process a payment (invalid card or similar) and the shopper wants to retry their payment, store credit was being applied even if the checkbox was not selected, which caused an error in Bigpay because the amounts were not matching.

## Testing / Proof
Before the changes https://drive.google.com/file/d/1y45TcAlyN5xqrJytDrWQ6hO0xSBQYQFe/view?usp=sharing
After the changes https://drive.google.com/file/d/166jI99wasflw8F14Ncx6ExISSRK9GH9F/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
