### PR TITLE
fix(payment): INT-4802 Moneris Validate response before resolve

### DIFF
--- a/src/payment/strategies/moneris/moneris-payment-strategy.spec.ts
+++ b/src/payment/strategies/moneris/moneris-payment-strategy.spec.ts
@@ -277,6 +277,62 @@ describe('MonerisPaymentStrategy', () => {
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
         });
 
+        it('submits payment with vaulted card', async () => {
+            const expectedPayment = {
+                methodId: 'moneris',
+                paymentData: {
+                    instrumentId: '1234',
+                    shouldSaveInstrument: true,
+                    shouldSetAsDefaultInstrument: true,
+                },
+            };
+
+            await strategy.initialize(initializeOptions);
+
+            const pendingExecution = strategy.execute(getOrderRequestBodyVaultedCC(), options);
+
+            const mockMonerisIframeMessage = {
+                responseCode: ['001'],
+                errorMessage: null,
+                dataKey: 'ABC123',
+                bin: '1234',
+            };
+
+            window.postMessage(JSON.stringify(mockMonerisIframeMessage), '*');
+
+            await pendingExecution;
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        });
+
+        it('Moneris returns an object instead of a stringify JSON', async () => {
+            const expectedPayment = {
+                methodId: 'moneris',
+                paymentData: {
+                    instrumentId: '1234',
+                    shouldSaveInstrument: true,
+                    shouldSetAsDefaultInstrument: true,
+                },
+            };
+
+            await strategy.initialize(initializeOptions);
+
+            const pendingExecution = strategy.execute(getOrderRequestBodyVaultedCC(), options);
+
+            const mockMonerisIframeMessage = {
+                responseCode: ['001'],
+                errorMessage: null,
+                dataKey: 'ABC123',
+                bin: '1234',
+            };
+
+            window.postMessage(mockMonerisIframeMessage, '*');
+
+            await pendingExecution;
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        });
+
         it('submits payment and sends shouldSaveInstrument and shouldSetAsDefaultInstrument if provided', async () => {
             const expectedPayment = {
                 methodId: 'moneris',

--- a/src/payment/strategies/moneris/moneris-payment-strategy.ts
+++ b/src/payment/strategies/moneris/moneris-payment-strategy.ts
@@ -126,6 +126,10 @@ export default class MonerisPaymentStrategy implements PaymentStrategy {
             frameref?.postMessage('tokenize', this._monerisURL(!!testMode));
 
             this._windowEventListener = (response: MessageEvent) => {
+                if (typeof response.data !== 'string') {
+                    return;
+                }
+
                 try {
                     resolve(this._handleMonerisResponse(response));
                 } catch (error) {


### PR DESCRIPTION
[INT-4802](https://jira.bigcommerce.com/browse/INT-4802)
## What?
Validate if the response is formatted as expected 

## Why?
The handler can be triggered before the response is send by Moneris 

## Testing / Proof
![image](https://user-images.githubusercontent.com/6343437/131579402-f55c52e5-9d51-4690-b227-9ec6a2ad1c27.png)


@bigcommerce/checkout @bigcommerce/payments
