### PR TITLE
feat(payment): BOLT-49 removed unnecessary payment data nonce check f…

### DIFF
--- a/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -10,19 +10,19 @@ import { MissingDataError, NotInitializedError } from '../../../common/error/err
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentInitializeOptions, PaymentMethod, PaymentMethodRequestSender, PaymentRequestSender } from '../../../payment';
-import { getBolt } from '../../../payment/payment-methods.mock';
-import { getBoltScriptMock } from '../../../payment/strategies/bolt/bolt.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
 import { StoreCreditActionCreator, StoreCreditActionType, StoreCreditRequestSender } from '../../../store-credit';
 import { PaymentArgumentInvalidError, PaymentMethodCancelledError, PaymentMethodInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { getBolt } from '../../payment-methods.mock';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 
 import { BoltCheckout } from './bolt';
 import BoltPaymentStrategy from './bolt-payment-strategy';
 import BoltScriptLoader from './bolt-script-loader';
+import { getBoltScriptMock } from './bolt.mock';
 
 describe('BoltPaymentStrategy', () => {
     let applyStoreCreditAction: Observable<Action>;
@@ -273,18 +273,6 @@ describe('BoltPaymentStrategy', () => {
         it('fails to execute the strategy if no method id is provided with checkout takeover', async () => {
             payload.payment = {
                 methodId: '',
-            };
-
-            await strategy.initialize(boltTakeOverInitializationOptions);
-            await expect(strategy.execute(payload)).rejects.toThrow(MissingDataError);
-            expect(storeCreditActionCreator.applyStoreCredit).not.toHaveBeenCalled();
-            expect(boltClient.configure).not.toHaveBeenCalled();
-        });
-
-        it('fails to execute the strategy if no nonce is provided with checkout takeover', async () => {
-            payload.payment = {
-                methodId: 'bolt',
-                paymentData: { },
             };
 
             await strategy.initialize(boltTakeOverInitializationOptions);

--- a/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -1,4 +1,3 @@
-import { isNonceLike } from '../..';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
@@ -159,7 +158,7 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        if (!paymentData || !isNonceLike(paymentData)) {
+        if (!paymentData) {
             throw new MissingDataError(MissingDataErrorType.MissingPayment);
         }
 


### PR DESCRIPTION
…or Bolt Full Checkout

## What?
Removed unnecessary payment data nonce check

## Why?
During the task: https://jira.bigcommerce.com/browse/BOLT-49

## Testing / Proof
<img width="316" alt="Screenshot 2021-08-30 at 12 49 59" src="https://user-images.githubusercontent.com/25133454/131321247-0fc7d1bc-2cb5-4ec6-9217-65b8811c6de1.png">
