### PR TITLE
fix(payment): PAYMENTS-7252 pass methodIds on to PPSDK endpoint without transformation

### DIFF
--- a/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.spec.ts
+++ b/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.spec.ts
@@ -1,25 +1,12 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 
-import { PaymentStrategyType } from '../../..';
-import { PPSDKPaymentMethod } from '../../../ppsdk-payment-method';
 import { StepHandler } from '../step-handler';
 import { ContinueHandler } from '../step-handler/continue-handler';
 
 import { NonePaymentProcessor } from './none-payment-processor';
 
 describe('NonePaymentProcessor', () => {
-    const paymentMethod: PPSDKPaymentMethod = {
-        id: 'some-id',
-        method: 'some-method',
-        type: PaymentStrategyType.PPSDK,
-        config: {},
-        supportedCards: [],
-        initializationStrategy: {
-            type: 'some-strategy',
-        },
-    };
-
     const requestSender = createRequestSender();
     const stepHandler = new StepHandler(new ContinueHandler(new FormPoster()));
     const nonePaymentProcessor = new NonePaymentProcessor(requestSender, stepHandler);
@@ -29,7 +16,7 @@ describe('NonePaymentProcessor', () => {
             const requestSenderSpy = jest.spyOn(requestSender, 'post').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
+            await nonePaymentProcessor.process({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(requestSenderSpy).toBeCalledWith(
                 'https://some-domain.com/payments',
@@ -48,7 +35,7 @@ describe('NonePaymentProcessor', () => {
             jest.spyOn(requestSender, 'post').mockResolvedValue({ body: 'some-api-response' });
             const stepHandlerSpy = jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
+            await nonePaymentProcessor.process({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(stepHandlerSpy).toBeCalledWith({ body: 'some-api-response' });
         });
@@ -57,7 +44,7 @@ describe('NonePaymentProcessor', () => {
             jest.spyOn(requestSender, 'post').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({ someValue: 12345 });
 
-            await expect(nonePaymentProcessor.process({ paymentMethod, bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' }))
+            await expect(nonePaymentProcessor.process({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' }))
                 .resolves.toStrictEqual({ someValue: 12345 });
         });
     });

--- a/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.ts
+++ b/src/payment/strategies/ppsdk/payment-processors/none-payment-processor.ts
@@ -10,9 +10,8 @@ export class NonePaymentProcessor implements PaymentProcessor {
         private _stepHandler: StepHandler
     ) {}
 
-    process({ paymentMethod, bigpayBaseUrl, token }: ProcessorSettings) {
-        const paymentMethodId = `${paymentMethod.id}.${paymentMethod.method}`;
-        const body = { payment_method_id: paymentMethodId };
+    process({ methodId, bigpayBaseUrl, token }: ProcessorSettings) {
+        const body = { payment_method_id: methodId };
         const options = {
             credentials: false,
             body,

--- a/src/payment/strategies/ppsdk/ppsdk-payment-processor.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-processor.ts
@@ -1,9 +1,8 @@
 import { OrderPaymentRequestBody } from '../../../order';
-import { PPSDKPaymentMethod } from '../../ppsdk-payment-method';
 
 export interface ProcessorSettings {
     token: string;
-    paymentMethod: PPSDKPaymentMethod;
+    methodId: string;
     payment?: OrderPaymentRequestBody;
     bigpayBaseUrl: string;
 }

--- a/src/payment/strategies/ppsdk/ppsdk-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.ts
@@ -27,12 +27,11 @@ export class PPSDKStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to submit payment because "options.methodId" argument is not provided.');
         }
 
-        const paymentMethod = getPPSDKMethod(this._store, options.methodId);
-
+        const { methodId } = options;
         const { payment, ...order } = payload;
         const { _paymentProcessor: paymentProcessor } = this;
 
-        if (!paymentProcessor || !paymentMethod) {
+        if (!paymentProcessor) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
@@ -44,7 +43,7 @@ export class PPSDKStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingOrder);
         }
 
-        await paymentProcessor.process({ paymentMethod, payment, bigpayBaseUrl, token });
+        await paymentProcessor.process({ methodId, payment, bigpayBaseUrl, token });
 
         return this._store.getState();
     }


### PR DESCRIPTION
**N.B. this work is protected by a WIP feature toggle**

## What?

- Transparently pass on `methodId` to PPSDK, rather than constructing it out of `${paymentMethod.id}.${paymentMethod.method}`

## Why?

- The BE is now sending the id value in the `this.that` format, so the client no longer needs to assemble it

## Testing / Proof

- Passing unit tests
- Manual test of WIP PPSDK functionality 

@bigcommerce/checkout @bigcommerce/payments
