### PR TITLE
fix(payment): INT-4810 Forget checkout provider and reload payment methods - Clearpay

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -240,6 +240,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             paymentMethodActionCreator,
+            remoteCheckoutRequestSender,
             storeCreditActionCreator,
             new ClearpayScriptLoader(scriptLoader)
         )


### PR DESCRIPTION
## What? [INT-4810](https://jira.bigcommerce.com/browse/INT-4810)
Modify the Clearpay strategy to apply the necessary changes to fix the issue: catch the error from the order completion, forget the provider, and refresh the state with all the supported payment methods.
Related to https://github.com/bigcommerce/checkout-sdk-js/pull/1192

## Why?
By applying these changes we can make the checkout-sdk catch the error and refresh the payment method lists to allow shoppers to select another payment method.

## Testing / Proof
https://drive.google.com/file/d/1HK7VFfw1mTwT-NV4ieohCMfvsTVX7KBd/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
