### PR TITLE
feat(payment): BOLT-24 added account creation flag for Bolt Embedded One Click execution

### DIFF
--- a/src/customer/strategies/bolt/bolt-customer-strategy.ts
+++ b/src/customer/strategies/bolt/bolt-customer-strategy.ts
@@ -3,7 +3,7 @@ import { noop } from 'rxjs';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { PaymentMethodActionCreator } from '../../../payment';
-import { PaymentMethodFailedError } from '../../../payment/errors';
+import { PaymentMethodFailedError, PaymentMethodInvalidError } from '../../../payment/errors';
 import { BoltCheckout, BoltScriptLoader } from '../../../payment/strategies/bolt';
 import CustomerActionCreator from '../../customer-action-creator';
 import CustomerCredentials from '../../customer-credentials';
@@ -136,7 +136,11 @@ export default class BoltCustomerStrategy implements CustomerStrategy {
     private async _hasBoltAccount(email: string) {
         const boltClient = this._getBoltClient();
 
-        return boltClient.hasBoltAccount(email);
+        try {
+            return await boltClient.hasBoltAccount(email);
+        } catch {
+            throw new PaymentMethodInvalidError();
+        }
     }
 
     private _getCustomerEmail() {

--- a/src/order/order-request-body.ts
+++ b/src/order/order-request-body.ts
@@ -1,4 +1,4 @@
-import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithCheckoutcomiDealInstrument, WithCheckoutcomFawryInstrument, WithCheckoutcomSEPAInstrument, WithDocumentInstrument, WithMollieIssuerInstrument } from '../payment';
+import { CreditCardInstrument, HostedCreditCardInstrument, HostedInstrument, HostedVaultedInstrument, NonceInstrument, VaultedInstrument, WithAccountCreation, WithCheckoutcomiDealInstrument, WithCheckoutcomFawryInstrument, WithCheckoutcomSEPAInstrument, WithDocumentInstrument, WithMollieIssuerInstrument } from '../payment';
 
 /**
  * An object that contains the information required for submitting an order.
@@ -39,5 +39,5 @@ export interface OrderPaymentRequestBody {
      * An object that contains the details of a credit card, vaulted payment
      * instrument or nonce instrument.
      */
-    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument | CreditCardInstrument & WithCheckoutcomFawryInstrument | CreditCardInstrument & WithCheckoutcomSEPAInstrument | CreditCardInstrument & WithCheckoutcomiDealInstrument | HostedInstrument & WithMollieIssuerInstrument;
+    paymentData?: CreditCardInstrument | HostedInstrument | HostedCreditCardInstrument | HostedVaultedInstrument | NonceInstrument | VaultedInstrument | CreditCardInstrument & WithDocumentInstrument | CreditCardInstrument & WithCheckoutcomFawryInstrument | CreditCardInstrument & WithCheckoutcomSEPAInstrument | CreditCardInstrument & WithCheckoutcomiDealInstrument | HostedInstrument & WithMollieIssuerInstrument | WithAccountCreation;
 }

--- a/src/payment/index.ts
+++ b/src/payment/index.ts
@@ -9,6 +9,7 @@ export { default as createPaymentStrategyRegistry } from './create-payment-strat
 export { default as isHostedInstrumentLike } from './is-hosted-intrument-like';
 export { default as isNonceLike } from './is-nonce-like';
 export { default as isVaultedInstrument } from './is-vaulted-instrument';
+export { default as withAccountCreation } from './with-account-creation';
 export { default as PaymentActionCreator } from './payment-action-creator';
 export {
     default as Payment,
@@ -25,8 +26,9 @@ export {
     NonceInstrument,
     ThreeDSecure,
     ThreeDSecureToken,
+    WithAccountCreation,
     WithDocumentInstrument,
-    WithMollieIssuerInstrument
+    WithMollieIssuerInstrument,
 } from './payment';
 export { default as PaymentMethod } from './payment-method';
 export { default as PaymentMethodMeta } from './payment-method-meta';

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -24,11 +24,16 @@ export type PaymentInstrument = (
     ThreeDSVaultedInstrument |
     VaultedInstrument |
     VaultedInstrument & WithHostedFormNonce |
-    VaultedInstrumentWithNonceVerification
+    VaultedInstrumentWithNonceVerification |
+    WithAccountCreation
 );
 
 export interface PaymentInstrumentMeta {
     deviceSessionId?: string;
+}
+
+export interface WithAccountCreation {
+    shouldCreateAccount?: boolean;
 }
 
 export interface CreditCardInstrument {

--- a/src/payment/strategies/bolt/bolt-payment-initialize-options.ts
+++ b/src/payment/strategies/bolt/bolt-payment-initialize-options.ts
@@ -54,4 +54,9 @@ export default interface BoltPaymentInitializeOptions {
      * The CSS selector of a container where the Bolt Embedded payment field should be inserted into.
      */
     containerId?: string;
+
+    /**
+     * A callback that gets called when the customer selects Bolt as payment option.
+     */
+    onPaymentSelect?(hasBoltAccount: boolean): void;
 }

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -5,7 +5,7 @@ export interface BoltHostWindow extends Window {
 
 export interface BoltCheckout {
     configure(cart: BoltCart, hints: {}, callbacks?: BoltCallbacks): BoltClient;
-    hasBoltAccount(email: string): boolean;
+    hasBoltAccount(email: string): Promise<boolean>;
     getTransactionReference(): Promise<string | undefined>;
     openCheckout(email: string, callbacks?: BoltOpenCheckoutCallbacks): void;
     setClientCustomCallbacks(callbacks: BoltCallbacks): void;

--- a/src/payment/with-account-creation.ts
+++ b/src/payment/with-account-creation.ts
@@ -1,0 +1,7 @@
+import { WithAccountCreation } from './payment';
+
+export default function withAccountCreation(paymentData: unknown): paymentData is WithAccountCreation {
+    return typeof paymentData === 'object'
+        && paymentData !== null
+        && 'shouldCreateAccount' in paymentData;
+}


### PR DESCRIPTION
## What?
Added account creation flag to Bolt Embedded One Click execution payment payload.

## Why?
Because of the task: https://jira.bigcommerce.com/browse/BOLT-24

## Testing / Proof
Unit tests
Manual test

Here is a screenshot of the checkbox:
<img width="1300" alt="4 14 15 32" src="https://user-images.githubusercontent.com/25133454/132622550-2b5f649f-3867-4ac0-9290-a9b598d3a2d4.png">

## Sibling pull-request
checkout-js: https://github.com/bigcommerce/checkout-js/pull/690

@bigcommerce/checkout
