### PR TITLE
feat(payment): INT-4646 Add Openpay payment strategy

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -31,6 +31,7 @@ import { MasterpassPaymentStrategy } from './strategies/masterpass';
 import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
 import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
+import { OpyPaymentStrategy } from './strategies/opy';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy } from './strategies/paypal';
 import { PaypalCommercePaymentStrategy } from './strategies/paypal-commerce';
 import { PPSDKStrategy } from './strategies/ppsdk';
@@ -195,6 +196,11 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate offsite', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.OFFSITE);
         expect(paymentStrategy).toBeInstanceOf(OffsitePaymentStrategy);
+    });
+
+    it('can instantiate openpay', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.OPY);
+        expect(paymentStrategy).toBeInstanceOf(OpyPaymentStrategy);
     });
 
     it('can instantiate paypal', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -53,6 +53,7 @@ import { MonerisPaymentStrategy } from './strategies/moneris';
 import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
 import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
+import { OpyPaymentStrategy } from './strategies/opy';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy, PaypalScriptLoader } from './strategies/paypal';
 import { createPaypalCommercePaymentProcessor,
     PaypalCommerceCreditCardPaymentStrategy,
@@ -537,6 +538,12 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator
+        )
+    );
+
+    registry.register(PaymentStrategyType.OPY, () =>
+        new OpyPaymentStrategy(
+            store
         )
     );
 

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -543,7 +543,11 @@ export default function createPaymentStrategyRegistry(
 
     registry.register(PaymentStrategyType.OPY, () =>
         new OpyPaymentStrategy(
-            store
+            store,
+            orderActionCreator,
+            paymentMethodActionCreator,
+            storefrontPaymentRequestSender,
+            paymentActionCreator
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -756,6 +756,39 @@ export function getMoneris(): PaymentMethod {
     };
 }
 
+export function getOpy(): PaymentMethod {
+    return {
+        clientToken: '3000000091451',
+        config: {
+            displayName: 'Openpay',
+            testMode: false,
+        },
+        id: 'opy',
+        initializationData: {
+            nextAction: {
+                formPost: {
+                    formFields: [
+                        {
+                            fieldName: 'TransactionToken',
+                            fieldValue: 'Al5dE65...%3D',
+                        },
+                        {
+                            fieldName: 'JamPlanID',
+                            fieldValue: '3000000091451',
+                        },
+                    ],
+                    formPostUrl: 'https://retailer.myopenpay.com.au/websalestraining/',
+                },
+                type: 'FormPost',
+            },
+        },
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: ['VISA', 'MC'],
+        type: 'PAYMENT_TYPE_API',
+    };
+}
+
 export function getPaymentMethods(): PaymentMethod[] {
     return [
         getAdyenAmex(),
@@ -778,13 +811,14 @@ export function getPaymentMethods(): PaymentMethod[] {
         getGooglePayOrbital(),
         getKlarna(),
         getMollie(),
-        getPaypalExpress(),
+        getMoneris(),
+        getOpy(),
         getPaypalCommerce(),
+        getPaypalExpress(),
+        getPPSDK(),
         getQuadpay(),
         getSquare(),
         getStripeV3(),
-        getMoneris(),
-        getPPSDK(),
         getUnsupportedPPSDK(),
         getApplePay(),
     ];

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -31,6 +31,7 @@ enum PaymentStrategyType {
     NO_PAYMENT_DATA_REQUIRED = 'nopaymentdatarequired',
     OFFLINE = 'offline',
     OFFSITE = 'offsite',
+    OPY = 'opy',
     ORBITAL_GOOGLE_PAY = 'googlepayorbital',
     PAYPAL = 'paypal',
     PAYPAL_EXPRESS = 'paypalexpress',

--- a/src/payment/strategies/opy/index.ts
+++ b/src/payment/strategies/opy/index.ts
@@ -1,0 +1,1 @@
+export { default as OpyPaymentStrategy } from './opy-payment-strategy';

--- a/src/payment/strategies/opy/index.ts
+++ b/src/payment/strategies/opy/index.ts
@@ -1,1 +1,3 @@
+export * from './opy';
+
 export { default as OpyPaymentStrategy } from './opy-payment-strategy';

--- a/src/payment/strategies/opy/opy-payment-strategy.spec.ts
+++ b/src/payment/strategies/opy/opy-payment-strategy.spec.ts
@@ -1,0 +1,67 @@
+import { getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getPaymentMethodsState } from '../../payment-methods.mock';
+
+import OpyPaymentStrategy from './opy-payment-strategy';
+
+describe('OpyPaymentStrategy', () => {
+    let store: CheckoutStore;
+    let strategy: OpyPaymentStrategy;
+
+    beforeEach(() => {
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        strategy = new OpyPaymentStrategy(
+            store
+        );
+    });
+
+    describe('#initialize()', () => {
+        it('initializes the strategy successfully', async () => {
+            await expect(strategy.initialize()).resolves.toEqual(store.getState());
+        });
+    });
+
+    describe('#execute()', () => {
+        let orderRequestBody: OrderRequestBody;
+
+        beforeEach(async () => {
+            orderRequestBody = {
+                ...getOrderRequestBody(),
+                payment: {
+                    methodId: 'opy',
+                },
+            };
+
+            await strategy.initialize();
+        });
+
+        it('executes the strategy successfully', async () => {
+            await expect(strategy.execute(orderRequestBody)).resolves.toEqual(store.getState());
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            await expect(strategy.deinitialize()).resolves.toEqual(store.getState());
+        });
+    });
+});

--- a/src/payment/strategies/opy/opy-payment-strategy.spec.ts
+++ b/src/payment/strategies/opy/opy-payment-strategy.spec.ts
@@ -1,17 +1,44 @@
+import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { omit } from 'lodash';
+import { of } from 'rxjs';
+
 import { getCartState } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { MissingDataError, NotImplementedError, RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
 import { getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
-import { OrderRequestBody } from '../../../order';
+import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
-import { getPaymentMethodsState } from '../../payment-methods.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import createPaymentClient from '../../create-payment-client';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType } from '../../payment-actions';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
+import { getOpy, getPaymentMethodsState } from '../../payment-methods.mock';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+import StorefrontPaymentRequestSender from '../../storefront-payment-request-sender';
 
+import { ActionTypes, OpyPaymentMethod } from './opy';
 import OpyPaymentStrategy from './opy-payment-strategy';
 
 describe('OpyPaymentStrategy', () => {
     let store: CheckoutStore;
+    let requestSender: RequestSender;
+    let paymentClient: OrderRequestSender;
+    let orderActionCreator: OrderActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let storefrontPaymentRequestSender: StorefrontPaymentRequestSender;
+    let paymentActionCreator: PaymentActionCreator;
     let strategy: OpyPaymentStrategy;
 
     beforeEach(() => {
@@ -23,8 +50,46 @@ describe('OpyPaymentStrategy', () => {
             paymentMethods: getPaymentMethodsState(),
         });
 
+        requestSender = createRequestSender();
+
+        paymentClient = createPaymentClient(store);
+
+        orderActionCreator = new OrderActionCreator(
+            paymentClient,
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(requestSender)
+        );
+
+        storefrontPaymentRequestSender = new StorefrontPaymentRequestSender(requestSender);
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(paymentClient),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(of(createAction(OrderActionType.SubmitOrderRequested)));
+
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+            .mockResolvedValue(store.getState());
+
+        jest.spyOn(storefrontPaymentRequestSender, 'saveExternalId')
+            .mockResolvedValue(undefined);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(of(createAction(PaymentActionType.SubmitPaymentRequested)));
+
         strategy = new OpyPaymentStrategy(
-            store
+            store,
+            orderActionCreator,
+            paymentMethodActionCreator,
+            storefrontPaymentRequestSender,
+            paymentActionCreator
         );
     });
 
@@ -35,21 +100,114 @@ describe('OpyPaymentStrategy', () => {
     });
 
     describe('#execute()', () => {
-        let orderRequestBody: OrderRequestBody;
+        let payload: OrderRequestBody;
+        let options: PaymentInitializeOptions;
+        let order: Omit<OrderRequestBody, 'payment'>;
 
         beforeEach(async () => {
-            orderRequestBody = {
+            payload = {
                 ...getOrderRequestBody(),
                 payment: {
                     methodId: 'opy',
                 },
             };
+            options = { methodId: 'opy' };
+            order = omit(payload, 'payment');
 
             await strategy.initialize();
         });
 
         it('executes the strategy successfully', async () => {
-            await expect(strategy.execute(orderRequestBody)).resolves.toEqual(store.getState());
+            await strategy.execute(payload, options);
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(order, options);
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith('opy', options);
+            expect(storefrontPaymentRequestSender.saveExternalId).toHaveBeenCalledWith('opy', '3000000091451');
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({ methodId: 'opy', paymentData: { nonce: '3000000091451' }});
+        });
+
+        it('redirects to Openpay URL', async () => {
+            const paymentFailedErrorAction = of(createErrorAction(
+                PaymentActionType.SubmitPaymentFailed,
+                new RequestError(getResponse({
+                    ...getErrorPaymentResponseBody(),
+                    status: 'additional_action_required',
+                }))
+            ));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(paymentFailedErrorAction);
+
+            window.location.assign = jest.fn();
+
+            strategy.execute(payload, options);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(window.location.assign).toBeCalledWith(
+                'https://retailer.myopenpay.com.au/websalestraining?TransactionToken=Al5dE65...%3D&JamPlanID=3000000091451'
+            );
+        });
+
+        describe('fails to execute if:', () => {
+            it('payment argument is invalid', async () => {
+                payload.payment = undefined;
+
+                await expect(strategy.execute(payload, options)).rejects.toThrow(PaymentArgumentInvalidError);
+            });
+
+            it('payment method is not found', async () => {
+                payload.payment = { methodId: 'unkwnown' };
+
+                await expect(strategy.execute(payload, options)).rejects.toThrow(MissingDataError);
+            });
+
+            it('payment method is not an OpyPaymentMethod', async () => {
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValueOnce({ ...getOpy(), initializationData: undefined });
+
+                await expect(strategy.execute(payload, options)).rejects.toThrow(MissingDataError);
+            });
+
+            it('nonce is empty', async () => {
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValueOnce({ ...getOpy(), clientToken: '' });
+
+                await expect(strategy.execute(payload, options)).rejects.toThrow(MissingDataError);
+            });
+
+            it('nextAction type is not supported', async () => {
+                const initializationData = (getOpy() as OpyPaymentMethod).initializationData;
+                initializationData.nextAction.type = ActionTypes.WAIT_FOR_CUSTOMER;
+
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValueOnce({ ...getOpy(), initializationData });
+
+                const paymentFailedErrorAction = of(createErrorAction(
+                    PaymentActionType.SubmitPaymentFailed,
+                    new RequestError(getResponse({
+                        ...getErrorPaymentResponseBody(),
+                        status: 'additional_action_required',
+                    }))
+                ));
+
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(paymentFailedErrorAction);
+
+                await expect(strategy.execute(payload, options)).rejects.toThrow(NotImplementedError);
+            });
+
+            it('RequestError status is not additional_action_required', async () => {
+                const paymentFailedErrorAction = of(createErrorAction(
+                    PaymentActionType.SubmitPaymentFailed,
+                    new RequestError(getResponse(getErrorPaymentResponseBody()))
+                ));
+
+                jest.spyOn(paymentActionCreator, 'submitPayment')
+                    .mockReturnValueOnce(paymentFailedErrorAction);
+
+                await expect(strategy.execute(payload, options)).rejects.toThrow(RequestError);
+            });
         });
     });
 

--- a/src/payment/strategies/opy/opy-payment-strategy.ts
+++ b/src/payment/strategies/opy/opy-payment-strategy.ts
@@ -1,0 +1,27 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+export default class OpyPaymentStrategy implements PaymentStrategy {
+    constructor(
+        private _store: CheckoutStore
+    ) { }
+
+    initialize(_options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    execute(_payload: OrderRequestBody, _options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    finalize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+}

--- a/src/payment/strategies/opy/opy-payment-strategy.ts
+++ b/src/payment/strategies/opy/opy-payment-strategy.ts
@@ -1,20 +1,81 @@
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { OrderRequestBody } from '../../../order';
+import { MissingDataError, MissingDataErrorType, NotImplementedError, RequestError } from '../../../common/error/errors';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import StorefrontPaymentRequestSender from '../../storefront-payment-request-sender';
 import PaymentStrategy from '../payment-strategy';
+
+import { isOpyPaymentMethod, ActionTypes } from './opy';
 
 export default class OpyPaymentStrategy implements PaymentStrategy {
     constructor(
-        private _store: CheckoutStore
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _storefrontPaymentRequestSender: StorefrontPaymentRequestSender,
+        private _paymentActionCreator: PaymentActionCreator
     ) { }
 
     initialize(_options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         return Promise.resolve(this._store.getState());
     }
 
-    execute(_payload: OrderRequestBody, _options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        const { methodId } = payment;
+        const {
+            paymentMethods: { getPaymentMethodOrThrow },
+        } = await this._store.dispatch(
+            this._paymentMethodActionCreator.loadPaymentMethod(methodId, options)
+        );
+        const paymentMethod = getPaymentMethodOrThrow(methodId);
+
+        if (!isOpyPaymentMethod(paymentMethod)) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const {
+            clientToken: nonce,
+            initializationData: { nextAction, nextAction: { type } },
+        } = paymentMethod;
+
+        if (!nonce) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentToken);
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+        await this._storefrontPaymentRequestSender.saveExternalId(methodId, nonce);
+
+        try {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({ methodId, paymentData: { nonce } }));
+        } catch (error) {
+            if (error instanceof RequestError && error.body.status === 'additional_action_required') {
+                if (nextAction.type === ActionTypes.FORM_POST) {
+                    const { formPost: { formPostUrl, formFields } } = nextAction;
+
+                    const url = new URL(formPostUrl.replace(/\/$/, ''));
+
+                    formFields.forEach(({ fieldName, fieldValue }) => {
+                        url.searchParams.append(fieldName, fieldValue);
+                    });
+
+                    return new Promise(() => window.location.assign(decodeURI(url.href)));
+                }
+
+                throw new NotImplementedError(`Unsupported action type: ${type}`);
+            }
+
+            throw error;
+        }
     }
 
     finalize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {

--- a/src/payment/strategies/opy/opy.ts
+++ b/src/payment/strategies/opy/opy.ts
@@ -1,0 +1,31 @@
+import PaymentMethod from '../../payment-method';
+
+export enum ActionTypes {
+    FORM_POST = 'FormPost',
+    WAIT_FOR_CUSTOMER = 'WaitForCustomer',
+}
+
+interface FormPost {
+    type: ActionTypes.FORM_POST;
+    formPost: {
+        formPostUrl: string;
+        formFields: [{
+            fieldName: string;
+            fieldValue: string;
+        }];
+    };
+}
+
+interface WaitForCustomer {
+    type: ActionTypes.WAIT_FOR_CUSTOMER;
+}
+
+export interface OpyPaymentMethod extends PaymentMethod {
+    initializationData: {
+        nextAction: FormPost | WaitForCustomer;
+    };
+}
+
+export function isOpyPaymentMethod(paymentMethod: PaymentMethod): paymentMethod is OpyPaymentMethod {
+    return !!paymentMethod.initializationData?.nextAction;
+}


### PR DESCRIPTION
## What? [INT-4646](https://jira.bigcommerce.com/browse/INT-4646)
Create an **Openpay** payment strategy and make it available at checkout.

## Why?
A new payment strategy is required to support **Openpay**.

## Testing / Proof
Watch the video [>>here<<](https://drive.google.com/file/d/1gW1DynaEpqWtI72pKFTEcu-r-qoxKVbh/view?usp=sharing)

## Dependency of
👉 https://github.com/bigcommerce/checkout-js/pull/692

## Depends on
👉 https://github.com/bigcommerce/bigcommerce/pull/43424 to load the Openpay page ➡️
👉 https://github.com/bigcommerce/bigpay/pull/4495 to purchase 🤑
👉 https://github.com/bigcommerce/bigcommerce/pull/43457 to go back to the confirmation page ↩️

@bigcommerce/apex-integrations  @bigcommerce/checkout @bigcommerce/payments