### PR TITLE
feat(payment): PAYPAL-972 added threeDSecure check for googlepaybraintree

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -239,7 +239,9 @@ export default function createPaymentStrategyRegistry(
                         new BraintreeScriptLoader(scriptLoader)
                     )
                 )
-            )
+            ),
+            undefined,
+            new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader))
         )
     );
 

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -88,12 +88,23 @@ export interface BraintreeThreeDSecure extends BraintreeModule {
     cancelVerifyCard(): Promise<BraintreeVerifyPayload>;
 }
 
+export interface BraintreeGooglePayThreeDSecure {
+    verifyCard(options: BraintreeGooglePayThreeDSecureOptions): Promise<BraintreeVerifyPayload>;
+}
+
 export interface BraintreeThreeDSecureOptions {
     nonce: string;
     amount: number;
     showLoader?: boolean;
     addFrame(error: Error | undefined, iframe: HTMLIFrameElement): void;
     removeFrame(): void;
+    onLookupComplete(data: BraintreeThreeDSecureVerificationData, next: () => void): void;
+}
+
+export interface BraintreeGooglePayThreeDSecureOptions {
+    nonce: string;
+    amount: number;
+    showLoader?: boolean;
     onLookupComplete(data: BraintreeThreeDSecureVerificationData, next: () => void): void;
 }
 

--- a/src/payment/strategies/googlepay/googlepay.ts
+++ b/src/payment/strategies/googlepay/googlepay.ts
@@ -1,6 +1,6 @@
 import { Checkout } from '../../../checkout';
 import PaymentMethod from '../../payment-method';
-import { BraintreeModuleCreator, GooglePayBraintreeSDK } from '../braintree';
+import { BraintreeModuleCreator, BraintreeVerifyPayload, GooglePayBraintreeSDK } from '../braintree';
 
 export type EnvironmentType = 'PRODUCTION' | 'TEST';
 export type TokenizeType = 'AndroidPayCard' | 'CreditCard' | 'CARD';
@@ -16,6 +16,8 @@ export interface GooglePayCreator extends BraintreeModuleCreator<GooglePayBraint
 export interface GooglePayPaymentOptions {
     environment: EnvironmentType;
 }
+
+export type GooglePayVerifyPayload = BraintreeVerifyPayload | undefined;
 
 export interface GooglePayIsReadyToPayResponse {
     result: boolean;


### PR DESCRIPTION
## What?
Added threeDSecure check for googlepaybraintree

## Why?
According to task https://jira.bigcommerce.com/browse/PAYPAL-972

## Testing / Proof
<img width="998" alt="Screenshot 2021-09-14 at 16 37 12" src="https://user-images.githubusercontent.com/56301104/133267681-bc583b1c-d8a4-410d-828b-9fff6d6d9858.png">


@bigcommerce/checkout @bigcommerce/payments
