### PR TITLE
[WIP]chore(checkout): ADYEN-261 bump adyen sdk version

### DIFF
--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -59,6 +59,10 @@ export default class PaymentStrategyRegistry extends Registry<PaymentStrategy, P
             return PaymentStrategyType.PAYPAL_COMMERCE_ALTERNATIVE_METHODS;
         }
 
+        if (paymentMethod.gateway === PaymentStrategyType.ADYENV3) {
+            return PaymentStrategyType.ADYENV2;
+        }
+
         if (paymentMethod.gateway === PaymentStrategyType.CHECKOUTCOM) {
             return paymentMethod.id in checkoutcomStrategies
                 ? checkoutcomStrategies[paymentMethod.id]

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -1,5 +1,6 @@
 enum PaymentStrategyType {
     ADYENV2 = 'adyenv2',
+    ADYENV3 = 'adyenv3',
     ADYENV2_GOOGLEPAY = 'googlepayadyenv2',
     AFFIRM = 'affirm',
     AFTERPAY = 'afterpay',

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.spec.ts
@@ -23,8 +23,10 @@ describe('AdyenV2ScriptLoader', () => {
         const adyenClient = getAdyenClient();
         const configuration = getAdyenConfiguration();
         const configurationWithClientKey = getAdyenConfiguration(false);
-        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js';
-        const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css';
+        const jsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/4.7.4/adyen.js';
+        const cssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/4.7.4/adyen.css';
+        const legacyJsUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js';
+        const legacyCssUrl = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css';
 
         beforeEach(() => {
             scriptLoader.loadScript = jest.fn(() => {
@@ -45,18 +47,22 @@ describe('AdyenV2ScriptLoader', () => {
         it('loads the JS and CSS', async () => {
             await adyenV2ScriptLoader.load(configuration);
 
-            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
-            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(legacyJsUrl);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(legacyCssUrl);
         });
 
         it('returns the JS from the window using originKey', async () => {
             const adyenJs = await adyenV2ScriptLoader.load(configuration);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(legacyJsUrl);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(legacyCssUrl);
 
             expect(adyenJs).toBe(adyenClient);
         });
 
         it('returns the JS from the window using clientKey', async () => {
             const adyenJs = await adyenV2ScriptLoader.load(configurationWithClientKey);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(jsUrl);
+            expect(stylesheetLoader.loadStylesheet).toHaveBeenCalledWith(cssUrl);
 
             expect(adyenJs).toBe(adyenClient);
         });

--- a/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-script-loader.ts
@@ -12,9 +12,11 @@ export default class AdyenV2ScriptLoader {
     ) { }
 
     async load(configuration: AdyenConfiguration): Promise<AdyenClient> {
+        const adyenSdkVersion = configuration.hasOwnProperty('clientKey') ? '4.7.4' : '3.10.1';
+
         await Promise.all([
-            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.10.1/adyen.css`),
-            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js`),
+            this._stylesheetLoader.loadStylesheet(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/${adyenSdkVersion}/adyen.css`),
+            this._scriptLoader.loadScript(`https://checkoutshopper-${configuration.environment}.adyen.com/checkoutshopper/sdk/${adyenSdkVersion}/adyen.js`),
         ]);
 
         if (!this._window.AdyenCheckout) {


### PR DESCRIPTION
## What?
Added ability to render adyen checkout for AdyenV3 gateway

## Why?
Due to the https://jira.bigcommerce.com/browse/ADYEN-261

## Testing / Proof
Tested manually. For user nothing should change, but AdyenV3 needs to be rendered in the same way as v2

@bigcommerce/checkout
