### PR TITLE
feat(checkout): CHECKOUT-5777 Send SDK version as a header for all SDK API requests

### DIFF
--- a/src/billing/billing-address-request-sender.spec.ts
+++ b/src/billing/billing-address-request-sender.spec.ts
@@ -2,7 +2,7 @@ import { createRequestSender, createTimeout, RequestSender, Response } from '@bi
 
 import { Checkout } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import BillingAddressRequestSender from './billing-address-request-sender';
@@ -39,6 +39,7 @@ describe('BillingAddressRequestSender', () => {
                 body: address,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include,
@@ -59,6 +60,7 @@ describe('BillingAddressRequestSender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
             });
         });
@@ -77,6 +79,7 @@ describe('BillingAddressRequestSender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
             });
         });
@@ -94,6 +97,7 @@ describe('BillingAddressRequestSender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
             });
         });

--- a/src/billing/billing-address-request-sender.spec.ts
+++ b/src/billing/billing-address-request-sender.spec.ts
@@ -2,7 +2,7 @@ import { createRequestSender, createTimeout, RequestSender, Response } from '@bi
 
 import { Checkout } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
-import { ContentType, SDK_HEADERS } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import BillingAddressRequestSender from './billing-address-request-sender';
@@ -39,7 +39,7 @@ describe('BillingAddressRequestSender', () => {
                 body: address,
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include,
@@ -60,7 +60,7 @@ describe('BillingAddressRequestSender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -79,7 +79,7 @@ describe('BillingAddressRequestSender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -97,7 +97,7 @@ describe('BillingAddressRequestSender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });

--- a/src/billing/billing-address-request-sender.ts
+++ b/src/billing/billing-address-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { AddressRequestBody } from '../address';
 import { Checkout } from '../checkout';
-import { ContentType, RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
 
 import { BillingAddressUpdateRequestBody } from './billing-address';
 
@@ -22,7 +22,10 @@ export default class BillingAddressRequestSender {
 
     createAddress(checkoutId: string, address: Partial<AddressRequestBody>, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/billing-address`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_HEADERS,
+        };
 
         return this._requestSender.post(url, { body: address, params: DEFAULT_PARAMS, headers, timeout });
     }
@@ -30,7 +33,10 @@ export default class BillingAddressRequestSender {
     updateAddress(checkoutId: string, address: Partial<BillingAddressUpdateRequestBody>, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const { id, ...body } = address;
         const url = `/api/storefront/checkouts/${checkoutId}/billing-address/${id}`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_HEADERS,
+        };
 
         return this._requestSender.put(url, { params: DEFAULT_PARAMS, body, headers, timeout });
     }

--- a/src/billing/billing-address-request-sender.ts
+++ b/src/billing/billing-address-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { AddressRequestBody } from '../address';
 import { Checkout } from '../checkout';
-import { ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
+import { ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import { BillingAddressUpdateRequestBody } from './billing-address';
 
@@ -24,7 +24,7 @@ export default class BillingAddressRequestSender {
         const url = `/api/storefront/checkouts/${checkoutId}/billing-address`;
         const headers = {
             Accept: ContentType.JsonV1,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.post(url, { body: address, params: DEFAULT_PARAMS, headers, timeout });
@@ -35,7 +35,7 @@ export default class BillingAddressRequestSender {
         const url = `/api/storefront/checkouts/${checkoutId}/billing-address/${id}`;
         const headers = {
             Accept: ContentType.JsonV1,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.put(url, { params: DEFAULT_PARAMS, body, headers, timeout });

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -2,6 +2,7 @@ import { FormPoster } from '@bigcommerce/form-poster';
 
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { SDK_HEADERS } from '../../../common/http-request';
 import { bindDecorator as bind } from '../../../common/utility';
 import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getShippableItemsCount } from '../../../shipping';
@@ -127,6 +128,7 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
+                ...SDK_HEADERS,
             },
         });
     }

--- a/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -2,7 +2,7 @@ import { FormPoster } from '@bigcommerce/form-poster';
 
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
-import { SDK_HEADERS } from '../../../common/http-request';
+import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { bindDecorator as bind } from '../../../common/utility';
 import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { getShippableItemsCount } from '../../../shipping';
@@ -128,7 +128,7 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
-                ...SDK_HEADERS,
+                ...SDK_VERSION_HEADERS,
             },
         });
     }

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
@@ -3,7 +3,7 @@ import { pick } from 'lodash';
 
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../../common/error/errors';
-import { INTERNAL_USE_ONLY, SDK_HEADERS } from '../../../common/http-request';
+import { INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { PaymentMethod } from '../../../payment';
 import { PaypalActions, PaypalAuthorizeData, PaypalClientToken, PaypalScriptLoader } from '../../../payment/strategies/paypal';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
@@ -90,7 +90,7 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
                 return actions.request.post(`${this._host}/api/storefront/payment/paypalexpress`, { merchantId, cartId }, {
                     headers: {
                         'X-API-INTERNAL': INTERNAL_USE_ONLY,
-                        ...SDK_HEADERS,
+                        ...SDK_VERSION_HEADERS,
                     },
                 });
             })

--- a/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
+++ b/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
@@ -3,7 +3,7 @@ import { pick } from 'lodash';
 
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../../common/error/errors';
-import { INTERNAL_USE_ONLY } from '../../../common/http-request';
+import { INTERNAL_USE_ONLY, SDK_HEADERS } from '../../../common/http-request';
 import { PaymentMethod } from '../../../payment';
 import { PaypalActions, PaypalAuthorizeData, PaypalClientToken, PaypalScriptLoader } from '../../../payment/strategies/paypal';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
@@ -90,6 +90,7 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
                 return actions.request.post(`${this._host}/api/storefront/payment/paypalexpress`, { merchantId, cartId }, {
                     headers: {
                         'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                        ...SDK_HEADERS,
                     },
                 });
             })

--- a/src/checkout/checkout-request-sender.spec.ts
+++ b/src/checkout/checkout-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_HEADERS } from '../common/http-request';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import Checkout from './checkout';
@@ -43,6 +43,7 @@ describe('CheckoutRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -61,6 +62,7 @@ describe('CheckoutRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include: defaultIncludes.concat(`,${CheckoutIncludes.AvailableShippingOptions}`),
@@ -110,6 +112,7 @@ describe('CheckoutRequestSender', () => {
             expect(requestSender.put).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 body: {
                     customerMessage: 'foo',

--- a/src/checkout/checkout-request-sender.spec.ts
+++ b/src/checkout/checkout-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, SDK_HEADERS } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import Checkout from './checkout';
@@ -43,7 +43,7 @@ describe('CheckoutRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -62,7 +62,7 @@ describe('CheckoutRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes.concat(`,${CheckoutIncludes.AvailableShippingOptions}`),
@@ -112,7 +112,7 @@ describe('CheckoutRequestSender', () => {
             expect(requestSender.put).toHaveBeenCalledWith('/api/storefront/checkout/6cb62bfc-c92d-45f5-869b-d3d9681a58d4', {
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 body: {
                     customerMessage: 'foo',

--- a/src/checkout/checkout-request-sender.ts
+++ b/src/checkout/checkout-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { joinOrMergeIncludes, ContentType, RequestOptions } from '../common/http-request';
+import { joinOrMergeIncludes, ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
 
 import Checkout, { CheckoutRequestBody } from './checkout';
 import CHECKOUT_DEFAULT_INCLUDES from './checkout-default-includes';
@@ -14,7 +14,10 @@ export default class CheckoutRequestSender {
 
     loadCheckout(id: string, { params: { include } = {}, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkout/${id}`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_HEADERS,
+        };
 
         return this._requestSender.get<Checkout>(url, {
             params: {
@@ -33,7 +36,10 @@ export default class CheckoutRequestSender {
 
     updateCheckout(id: string, body: CheckoutRequestBody, { params: { include } = {}, timeout }: RequestOptions<CheckoutParams> = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkout/${id}`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_HEADERS,
+        };
 
         return this._requestSender.put(url, {
             params: {

--- a/src/checkout/checkout-request-sender.ts
+++ b/src/checkout/checkout-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { joinOrMergeIncludes, ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
+import { joinOrMergeIncludes, ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import Checkout, { CheckoutRequestBody } from './checkout';
 import CHECKOUT_DEFAULT_INCLUDES from './checkout-default-includes';
@@ -16,7 +16,7 @@ export default class CheckoutRequestSender {
         const url = `/api/storefront/checkout/${id}`;
         const headers = {
             Accept: ContentType.JsonV1,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.get<Checkout>(url, {
@@ -38,7 +38,7 @@ export default class CheckoutRequestSender {
         const url = `/api/storefront/checkout/${id}`;
         const headers = {
             Accept: ContentType.JsonV1,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.put(url, {

--- a/src/common/http-request/index.ts
+++ b/src/common/http-request/index.ts
@@ -1,4 +1,5 @@
 export * from './internal-api-headers';
+export * from './sdk-version-headers';
 
 export { default as InternalResponseBody } from './internal-response-body';
 export { default as ContentType } from './content-type';

--- a/src/common/http-request/internal-api-headers.ts
+++ b/src/common/http-request/internal-api-headers.ts
@@ -1,1 +1,3 @@
 export const INTERNAL_USE_ONLY = 'This API endpoint is for internal use only and may change in the future';
+
+export const SDK_HEADERS = { 'X-Checkout-SDK-Version': LIBRARY_VERSION };

--- a/src/common/http-request/internal-api-headers.ts
+++ b/src/common/http-request/internal-api-headers.ts
@@ -1,3 +1,3 @@
 export const INTERNAL_USE_ONLY = 'This API endpoint is for internal use only and may change in the future';
 
-export const SDK_HEADERS = { 'X-Checkout-SDK-Version': LIBRARY_VERSION };
+export const SDK_VERSION_HEADERS = { 'X-Checkout-SDK-Version': LIBRARY_VERSION };

--- a/src/common/http-request/internal-api-headers.ts
+++ b/src/common/http-request/internal-api-headers.ts
@@ -1,3 +1,1 @@
 export const INTERNAL_USE_ONLY = 'This API endpoint is for internal use only and may change in the future';
-
-export const SDK_VERSION_HEADERS = { 'X-Checkout-SDK-Version': LIBRARY_VERSION };

--- a/src/common/http-request/sdk-version-headers.ts
+++ b/src/common/http-request/sdk-version-headers.ts
@@ -1,0 +1,1 @@
+export const SDK_VERSION_HEADERS = { 'X-Checkout-SDK-Version': LIBRARY_VERSION };

--- a/src/config/config-request-sender.spec.ts
+++ b/src/config/config-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout, Response } from '@bigcommerce/request-sender';
 
 import { CheckoutNotAvailableError } from '../checkout/errors';
-import { ContentType, INTERNAL_USE_ONLY, SDK_HEADERS } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import Config from './config';
@@ -34,7 +34,7 @@ describe('ConfigRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -49,7 +49,7 @@ describe('ConfigRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });

--- a/src/config/config-request-sender.spec.ts
+++ b/src/config/config-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout, Response } from '@bigcommerce/request-sender';
 
 import { CheckoutNotAvailableError } from '../checkout/errors';
-import { ContentType, INTERNAL_USE_ONLY } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_HEADERS } from '../common/http-request';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import Config from './config';
@@ -34,6 +34,7 @@ describe('ConfigRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_HEADERS,
                 },
             });
         });
@@ -48,6 +49,7 @@ describe('ConfigRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_HEADERS,
                 },
             });
         });

--- a/src/config/config-request-sender.ts
+++ b/src/config/config-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { CheckoutNotAvailableError } from '../checkout/errors';
-import { ContentType, INTERNAL_USE_ONLY, RequestOptions } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, RequestOptions, SDK_HEADERS } from '../common/http-request';
 
 import Config from './config';
 
@@ -18,6 +18,7 @@ export default class ConfigRequestSender {
             headers: {
                 Accept: ContentType.JsonV1,
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                ...SDK_HEADERS,
             },
         }).catch(error => {
             if (error.status >= 400 && error.status < 500) {

--- a/src/config/config-request-sender.ts
+++ b/src/config/config-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { CheckoutNotAvailableError } from '../checkout/errors';
-import { ContentType, INTERNAL_USE_ONLY, RequestOptions, SDK_HEADERS } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import Config from './config';
 
@@ -18,7 +18,7 @@ export default class ConfigRequestSender {
             headers: {
                 Accept: ContentType.JsonV1,
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
-                ...SDK_HEADERS,
+                ...SDK_VERSION_HEADERS,
             },
         }).catch(error => {
             if (error.status >= 400 && error.status < 500) {

--- a/src/coupon/coupon-request-sender.spec.ts
+++ b/src/coupon/coupon-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCheckoutWithCoupons } from '../checkout/checkouts.mock';
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import CouponRequestSender from './coupon-request-sender';
@@ -46,6 +46,7 @@ describe('Coupon Request Sender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
             });
         });
@@ -66,6 +67,7 @@ describe('Coupon Request Sender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
             });
         });
@@ -82,6 +84,7 @@ describe('Coupon Request Sender', () => {
             expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons/myCouponCode1234', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -101,6 +104,7 @@ describe('Coupon Request Sender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,

--- a/src/coupon/coupon-request-sender.spec.ts
+++ b/src/coupon/coupon-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCheckoutWithCoupons } from '../checkout/checkouts.mock';
-import { ContentType, SDK_HEADERS } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import CouponRequestSender from './coupon-request-sender';
@@ -46,7 +46,7 @@ describe('Coupon Request Sender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -67,7 +67,7 @@ describe('Coupon Request Sender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -84,7 +84,7 @@ describe('Coupon Request Sender', () => {
             expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/coupons/myCouponCode1234', {
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -104,7 +104,7 @@ describe('Coupon Request Sender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,

--- a/src/coupon/coupon-request-sender.ts
+++ b/src/coupon/coupon-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Checkout, CheckoutIncludes, CHECKOUT_DEFAULT_INCLUDES } from '../checkout';
-import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
+import { joinIncludes, ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
 
 export default class CouponRequestSender {
     constructor(
@@ -10,7 +10,10 @@ export default class CouponRequestSender {
 
     applyCoupon(checkoutId: string, couponCode: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/coupons`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_HEADERS,
+        };
 
         return this._requestSender.post(url, {
             headers,
@@ -27,7 +30,10 @@ export default class CouponRequestSender {
 
     removeCoupon(checkoutId: string, couponCode: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/coupons/${couponCode}`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_HEADERS,
+        };
 
         return this._requestSender.delete(url, {
             headers,

--- a/src/coupon/coupon-request-sender.ts
+++ b/src/coupon/coupon-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Checkout, CheckoutIncludes, CHECKOUT_DEFAULT_INCLUDES } from '../checkout';
-import { joinIncludes, ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
+import { joinIncludes, ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 export default class CouponRequestSender {
     constructor(
@@ -12,7 +12,7 @@ export default class CouponRequestSender {
         const url = `/api/storefront/checkouts/${checkoutId}/coupons`;
         const headers = {
             Accept: ContentType.JsonV1,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.post(url, {
@@ -32,7 +32,7 @@ export default class CouponRequestSender {
         const url = `/api/storefront/checkouts/${checkoutId}/coupons/${couponCode}`;
         const headers = {
             Accept: ContentType.JsonV1,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.delete(url, {

--- a/src/coupon/gift-certificate-request-sender.spec.ts
+++ b/src/coupon/gift-certificate-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCheckoutWithGiftCertificates } from '../checkout/checkouts.mock';
-import { ContentType, SDK_HEADERS } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import GiftCertificateRequestSender from './gift-certificate-request-sender';
@@ -52,7 +52,7 @@ describe('Gift Certificate Request Sender', () => {
                 body: { giftCertificateCode },
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -75,7 +75,7 @@ describe('Gift Certificate Request Sender', () => {
                 body: { giftCertificateCode },
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -97,7 +97,7 @@ describe('Gift Certificate Request Sender', () => {
             expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/gift-certificates/myGiftCertificate1234', {
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -119,7 +119,7 @@ describe('Gift Certificate Request Sender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,

--- a/src/coupon/gift-certificate-request-sender.spec.ts
+++ b/src/coupon/gift-certificate-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCheckoutWithGiftCertificates } from '../checkout/checkouts.mock';
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import GiftCertificateRequestSender from './gift-certificate-request-sender';
@@ -52,6 +52,7 @@ describe('Gift Certificate Request Sender', () => {
                 body: { giftCertificateCode },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -74,6 +75,7 @@ describe('Gift Certificate Request Sender', () => {
                 body: { giftCertificateCode },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -95,6 +97,7 @@ describe('Gift Certificate Request Sender', () => {
             expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/gift-certificates/myGiftCertificate1234', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -116,6 +119,7 @@ describe('Gift Certificate Request Sender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,

--- a/src/coupon/gift-certificate-request-sender.ts
+++ b/src/coupon/gift-certificate-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Checkout, CHECKOUT_DEFAULT_INCLUDES } from '../checkout';
-import { joinIncludes, ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
+import { joinIncludes, ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 export default class GiftCertificateRequestSender {
     constructor(
@@ -12,7 +12,7 @@ export default class GiftCertificateRequestSender {
         const url = `/api/storefront/checkouts/${checkoutId}/gift-certificates`;
         const headers = {
             Accept: ContentType.JsonV1,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.post(url, {
@@ -29,7 +29,7 @@ export default class GiftCertificateRequestSender {
         const url = `/api/storefront/checkouts/${checkoutId}/gift-certificates/${giftCertificateCode}`;
         const headers = {
             Accept: ContentType.JsonV1,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.delete(url, {

--- a/src/coupon/gift-certificate-request-sender.ts
+++ b/src/coupon/gift-certificate-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Checkout, CHECKOUT_DEFAULT_INCLUDES } from '../checkout';
-import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
+import { joinIncludes, ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
 
 export default class GiftCertificateRequestSender {
     constructor(
@@ -10,7 +10,10 @@ export default class GiftCertificateRequestSender {
 
     applyGiftCertificate(checkoutId: string, giftCertificateCode: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/gift-certificates`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_HEADERS,
+        };
 
         return this._requestSender.post(url, {
             headers,
@@ -24,7 +27,10 @@ export default class GiftCertificateRequestSender {
 
     removeGiftCertificate(checkoutId: string, giftCertificateCode: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/gift-certificates/${giftCertificateCode}`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_HEADERS,
+        };
 
         return this._requestSender.delete(url, {
             headers,

--- a/src/customer/customer-request-sender.spec.ts
+++ b/src/customer/customer-request-sender.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, createTimeout, RequestSender, Response } from '@bigcommerce/request-sender';
 
+import { SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 
@@ -45,11 +46,12 @@ describe('CustomerRequestSender', () => {
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/customer', {
                 body: customerAccount,
+                headers: SDK_VERSION_HEADERS,
             });
         });
 
         it('posts customer credentials with timeout', async () => {
-            const options = { timeout: createTimeout() };
+            const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
             const output = await customerRequestSender.createAccount(customerAccount, options);
 
             expect(output).toEqual(response);
@@ -78,11 +80,12 @@ describe('CustomerRequestSender', () => {
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/customer-address', {
                 body: customerAddress,
+                headers: SDK_VERSION_HEADERS,
             });
         });
 
         it('posts customer credentials with timeout', async () => {
-            const options = { timeout: createTimeout() };
+            const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
             const output = await customerRequestSender.createAddress(customerAddress, options);
 
             expect(output).toEqual(response);
@@ -110,11 +113,12 @@ describe('CustomerRequestSender', () => {
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', {
                 body: credentials,
+                headers: SDK_VERSION_HEADERS,
             });
         });
 
         it('posts customer credentials with timeout', async () => {
-            const options = { timeout: createTimeout() };
+            const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
             const output = await customerRequestSender.signInCustomer(credentials, options);
 
             expect(output).toEqual(response);
@@ -138,11 +142,11 @@ describe('CustomerRequestSender', () => {
             const output = await customerRequestSender.signOutCustomer();
 
             expect(output).toEqual(response);
-            expect(requestSender.delete).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', { timeout: undefined });
+            expect(requestSender.delete).toHaveBeenCalledWith('/internalapi/v1/checkout/customer', { timeout: undefined, headers: SDK_VERSION_HEADERS });
         });
 
         it('signs out customer with timeout', async () => {
-            const options = { timeout: createTimeout() };
+            const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
             const output = await customerRequestSender.signOutCustomer(options);
 
             expect(output).toEqual(response);

--- a/src/customer/customer-request-sender.ts
+++ b/src/customer/customer-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import Customer from './customer';
 import { CustomerAccountInternalRequestBody, CustomerAddressRequestBody } from './customer-account';
@@ -15,24 +15,24 @@ export default class CustomerRequestSender {
     createAccount(customerAccount: CustomerAccountInternalRequestBody, { timeout }: RequestOptions = {}): Promise<Response<{}>> {
         const url = '/api/storefront/customer';
 
-        return this._requestSender.post(url, { timeout, body: customerAccount });
+        return this._requestSender.post(url, { timeout, headers: SDK_VERSION_HEADERS, body: customerAccount });
     }
 
     createAddress(customerAddress: CustomerAddressRequestBody, { timeout }: RequestOptions = {}): Promise<Response<Customer>> {
         const url = `/api/storefront/customer-address`;
 
-        return this._requestSender.post<Customer>(url, { timeout, body: customerAddress });
+        return this._requestSender.post<Customer>(url, { timeout, headers: SDK_VERSION_HEADERS, body: customerAddress });
     }
 
     signInCustomer(credentials: CustomerCredentials, { timeout }: RequestOptions = {}): Promise<Response<InternalCustomerResponseBody>> {
         const url = '/internalapi/v1/checkout/customer';
 
-        return this._requestSender.post(url, { timeout, body: credentials });
+        return this._requestSender.post(url, { timeout, headers: SDK_VERSION_HEADERS, body: credentials });
     }
 
     signOutCustomer({ timeout }: RequestOptions = {}): Promise<Response<InternalCustomerResponseBody>> {
         const url = '/internalapi/v1/checkout/customer';
 
-        return this._requestSender.delete(url, { timeout });
+        return this._requestSender.delete(url, { timeout, headers: SDK_VERSION_HEADERS });
     }
 }

--- a/src/customer/strategies/chasepay/chasepay-customer-strategy.ts
+++ b/src/customer/strategies/chasepay/chasepay-customer-strategy.ts
@@ -3,7 +3,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
-import { SDK_HEADERS } from '../../../common/http-request';
+import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { ChasePayScriptLoader, ChasePaySuccessPayload } from '../../../payment/strategies/chasepay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
@@ -129,7 +129,7 @@ export default class ChasePayCustomerStrategy implements CustomerStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-                ...SDK_HEADERS,
+                ...SDK_VERSION_HEADERS,
             },
             body: {
                 sessionToken: payload.sessionToken,
@@ -146,7 +146,7 @@ export default class ChasePayCustomerStrategy implements CustomerStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
-                ...SDK_HEADERS,
+                ...SDK_VERSION_HEADERS,
             },
             params: {
                 fromChasePay: true,

--- a/src/customer/strategies/chasepay/chasepay-customer-strategy.ts
+++ b/src/customer/strategies/chasepay/chasepay-customer-strategy.ts
@@ -3,6 +3,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { SDK_HEADERS } from '../../../common/http-request';
 import { PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { ChasePayScriptLoader, ChasePaySuccessPayload } from '../../../payment/strategies/chasepay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
@@ -128,6 +129,7 @@ export default class ChasePayCustomerStrategy implements CustomerStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+                ...SDK_HEADERS,
             },
             body: {
                 sessionToken: payload.sessionToken,
@@ -144,6 +146,7 @@ export default class ChasePayCustomerStrategy implements CustomerStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
+                ...SDK_HEADERS,
             },
             params: {
                 fromChasePay: true,

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -2,6 +2,7 @@ import { FormPoster } from '@bigcommerce/form-poster';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from '../../../common/error/errors';
+import { SDK_HEADERS } from '../../../common/http-request';
 import { bindDecorator as bind } from '../../../common/utility';
 import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
@@ -144,6 +145,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
+                ...SDK_HEADERS,
             },
         });
     }

--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -2,7 +2,7 @@ import { FormPoster } from '@bigcommerce/form-poster';
 
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from '../../../common/error/errors';
-import { SDK_HEADERS } from '../../../common/http-request';
+import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { bindDecorator as bind } from '../../../common/utility';
 import { GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
@@ -145,7 +145,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
-                ...SDK_HEADERS,
+                ...SDK_VERSION_HEADERS,
             },
         });
     }

--- a/src/form/form-fields-request-sender.spec.ts
+++ b/src/form/form-fields-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import { FormFields } from './form-field';
@@ -33,6 +33,7 @@ describe('FormFieldsRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_HEADERS,
                 },
             });
         });
@@ -47,6 +48,7 @@ describe('FormFieldsRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_HEADERS,
                 },
             });
         });

--- a/src/form/form-fields-request-sender.spec.ts
+++ b/src/form/form-fields-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY, SDK_HEADERS } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import { FormFields } from './form-field';
@@ -33,7 +33,7 @@ describe('FormFieldsRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -48,7 +48,7 @@ describe('FormFieldsRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });

--- a/src/form/form-fields-request-sender.ts
+++ b/src/form/form-fields-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY, RequestOptions } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, RequestOptions, SDK_HEADERS } from '../common/http-request';
 
 import { FormFields } from './form-field';
 
@@ -17,6 +17,7 @@ export default class FormFieldsRequestSender {
             headers: {
                 Accept: ContentType.JsonV1,
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                ...SDK_HEADERS,
             },
         });
     }

--- a/src/form/form-fields-request-sender.ts
+++ b/src/form/form-fields-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY, RequestOptions, SDK_HEADERS } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import { FormFields } from './form-field';
 
@@ -17,7 +17,7 @@ export default class FormFieldsRequestSender {
             headers: {
                 Accept: ContentType.JsonV1,
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
-                ...SDK_HEADERS,
+                ...SDK_VERSION_HEADERS,
             },
         });
     }

--- a/src/geography/country-request-sender.spec.ts
+++ b/src/geography/country-request-sender.spec.ts
@@ -1,4 +1,5 @@
 import { createRequestSender, createTimeout, RequestSender, Response } from '@bigcommerce/request-sender';
+import { SDK_HEADERS } from '../common/http-request';
 
 import { getResponse } from '../common/http-request/responses.mock';
 
@@ -31,6 +32,7 @@ describe('CountryRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/internalapi/v1/store/countries', {
                 headers: {
                     'Accept-Language': 'en',
+                    ...SDK_HEADERS,
                 },
             });
         });
@@ -44,6 +46,7 @@ describe('CountryRequestSender', () => {
                 ...options,
                 headers: {
                     'Accept-Language': 'en',
+                    ...SDK_HEADERS,
                 },
             });
         });

--- a/src/geography/country-request-sender.spec.ts
+++ b/src/geography/country-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, RequestSender, Response } from '@bigcommerce/request-sender';
-import { SDK_HEADERS } from '../common/http-request';
 
+import { SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import { getCountriesResponseBody } from './countries.mock';
@@ -32,7 +32,7 @@ describe('CountryRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/internalapi/v1/store/countries', {
                 headers: {
                     'Accept-Language': 'en',
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -46,7 +46,7 @@ describe('CountryRequestSender', () => {
                 ...options,
                 headers: {
                     'Accept-Language': 'en',
-                    ...SDK_HEADERS,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });

--- a/src/geography/country-request-sender.ts
+++ b/src/geography/country-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { RequestOptions, SDK_HEADERS } from '../common/http-request';
 
 import { CountryResponseBody } from './country-responses';
 
@@ -14,6 +14,7 @@ export default class CountryRequestSender {
         const url = '/internalapi/v1/store/countries';
         const headers = {
             'Accept-Language': this._config.locale,
+            ...SDK_HEADERS,
         };
 
         return this._requestSender.get(url, { headers, timeout });

--- a/src/geography/country-request-sender.ts
+++ b/src/geography/country-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions, SDK_HEADERS } from '../common/http-request';
+import { RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import { CountryResponseBody } from './country-responses';
 
@@ -14,7 +14,7 @@ export default class CountryRequestSender {
         const url = '/internalapi/v1/store/countries';
         const headers = {
             'Accept-Language': this._config.locale,
-            ...SDK_HEADERS,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.get(url, { headers, timeout });

--- a/src/order/order-request-sender.spec.ts
+++ b/src/order/order-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, Response } from '@bigcommerce/request-sender';
 
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import { InternalOrderResponseBody } from './internal-order-responses';
@@ -41,6 +41,7 @@ describe('OrderRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: { include },
                 timeout: undefined,
@@ -57,6 +58,7 @@ describe('OrderRequestSender', () => {
                 params: { include },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -67,6 +69,7 @@ describe('OrderRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: { include },
                 timeout: undefined,
@@ -83,6 +86,7 @@ describe('OrderRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: { include: expectedInclude },
                 timeout: undefined,
@@ -123,7 +127,10 @@ describe('OrderRequestSender', () => {
 
         it('submits order with checkout variant header and library version when variant is provided', async () => {
             const payload = {};
-            const headers = { checkoutVariant: 'default' };
+            const headers = {
+                checkoutVariant: 'default',
+                ...SDK_VERSION_HEADERS,
+            };
 
             await orderRequestSender.submitOrder(payload, { headers });
 

--- a/src/order/order-request-sender.spec.ts
+++ b/src/order/order-request-sender.spec.ts
@@ -173,6 +173,7 @@ describe('OrderRequestSender', () => {
             expect(output).toEqual(response);
             expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order/295', {
                 timeout: undefined,
+                headers: SDK_VERSION_HEADERS,
             });
         });
 
@@ -181,7 +182,10 @@ describe('OrderRequestSender', () => {
             const output = await orderRequestSender.finalizeOrder(295, options);
 
             expect(output).toEqual(response);
-            expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order/295', options);
+            expect(requestSender.post).toHaveBeenCalledWith('/internalapi/v1/checkout/order/295', {
+                ...options,
+                headers: SDK_VERSION_HEADERS,
+            });
         });
     });
 });

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -61,6 +61,6 @@ export default class OrderRequestSender {
     finalizeOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
         const url = `/internalapi/v1/checkout/order/${orderId}`;
 
-        return this._requestSender.post(url, { timeout });
+        return this._requestSender.post(url, { timeout, headers: SDK_VERSION_HEADERS });
     }
 }

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 import { isNil, omitBy } from 'lodash';
 
-import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
+import { joinIncludes, ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
 
 import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
@@ -49,7 +49,7 @@ export default class OrderRequestSender {
             body,
             headers: omitBy({
                 'X-Checkout-Variant': headers && headers.checkoutVariant,
-                'X-Checkout-SDK-Version': LIBRARY_VERSION,
+                ...SDK_HEADERS,
             }, isNil),
             timeout,
         });

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 import { isNil, omitBy } from 'lodash';
 
-import { joinIncludes, ContentType, RequestOptions, SDK_HEADERS } from '../common/http-request';
+import { joinIncludes, ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
@@ -21,7 +21,10 @@ export default class OrderRequestSender {
 
     loadOrder(orderId: number, { timeout, params }: RequestOptions<OrderParams> = {}): Promise<Response<Order>> {
         const url = `/api/storefront/orders/${orderId}`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
         const include = [
             'payments',
             'lineItems.physicalItems.socialMedia',
@@ -49,7 +52,7 @@ export default class OrderRequestSender {
             body,
             headers: omitBy({
                 'X-Checkout-Variant': headers && headers.checkoutVariant,
-                ...SDK_HEADERS,
+                ...SDK_VERSION_HEADERS,
             }, isNil),
             timeout,
         });

--- a/src/payment/payment-method-request-sender.spec.ts
+++ b/src/payment/payment-method-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import PaymentMethod from './payment-method';
@@ -33,6 +33,7 @@ describe('PaymentMethodRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -49,6 +50,7 @@ describe('PaymentMethodRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -74,6 +76,7 @@ describe('PaymentMethodRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -90,6 +93,7 @@ describe('PaymentMethodRequestSender', () => {
                 headers: {
                     Accept: ContentType.JsonV1,
                     'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });

--- a/src/payment/payment-method-request-sender.ts
+++ b/src/payment/payment-method-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY, RequestOptions } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import PaymentMethod from './payment-method';
 
@@ -17,6 +17,7 @@ export default class PaymentMethodRequestSender {
             headers: {
                 Accept: ContentType.JsonV1,
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                ...SDK_VERSION_HEADERS,
             },
         });
     }
@@ -29,6 +30,7 @@ export default class PaymentMethodRequestSender {
             headers: {
                 Accept: ContentType.JsonV1,
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                ...SDK_VERSION_HEADERS,
             },
         });
     }

--- a/src/payment/storefront-payment-request-sender.spec.ts
+++ b/src/payment/storefront-payment-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import StorefrontPaymentRequestSender from './storefront-payment-request-sender';
 
@@ -20,6 +20,7 @@ describe('StorefrontPaymentRequestSender', () => {
         const headers = {
             Accept: ContentType.JsonV1,
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            ...SDK_VERSION_HEADERS,
         };
 
         it('saves external id for Zip', async () => {

--- a/src/payment/storefront-payment-request-sender.ts
+++ b/src/payment/storefront-payment-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY } from '../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../common/http-request';
 
 export default class StorefrontPaymentRequestSender {
     constructor(
@@ -13,6 +13,7 @@ export default class StorefrontPaymentRequestSender {
             headers: {
                 Accept: ContentType.JsonV1,
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                ...SDK_VERSION_HEADERS,
             },
             body: {
                 externalId: token,

--- a/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
+++ b/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
@@ -1,6 +1,7 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
 import { Address, LegacyAddress } from '../../../address';
+import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 
 import { BraintreeDataCollector } from './braintree';
 import BraintreeSDKCreator from './braintree-sdk-creator';
@@ -68,6 +69,7 @@ export default class BraintreeVisaCheckoutPaymentProcessor {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
+                ...SDK_VERSION_HEADERS,
             },
             body: {
                 payment_type: paymentData.type,

--- a/src/payment/strategies/braintree/visacheckout.mock.ts
+++ b/src/payment/strategies/braintree/visacheckout.mock.ts
@@ -1,3 +1,4 @@
+import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { VisaCheckoutAddress, VisaCheckoutPaymentSuccessPayload, VisaCheckoutSDK, VisaCheckoutTokenizedPayload, VisaCheckoutUserData } from './visacheckout';
 
 export function getVisaCheckoutSDKMock(): VisaCheckoutSDK {
@@ -115,6 +116,7 @@ export function getVisaCheckoutRequestBody() {
         headers: {
             Accept: 'text/html',
             'Content-Type': 'application/x-www-form-urlencoded',
+            ...SDK_VERSION_HEADERS,
         },
     };
 }

--- a/src/payment/strategies/braintree/visacheckout.mock.ts
+++ b/src/payment/strategies/braintree/visacheckout.mock.ts
@@ -1,4 +1,5 @@
 import { SDK_VERSION_HEADERS } from '../../../common/http-request';
+
 import { VisaCheckoutAddress, VisaCheckoutPaymentSuccessPayload, VisaCheckoutSDK, VisaCheckoutTokenizedPayload, VisaCheckoutUserData } from './visacheckout';
 
 export function getVisaCheckoutSDKMock(): VisaCheckoutSDK {

--- a/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
+++ b/src/payment/strategies/chasepay/chasepay-payment-strategy.ts
@@ -4,6 +4,7 @@ import { take } from 'rxjs/operators';
 
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { bindDecorator as bind } from '../../../common/utility';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
@@ -179,6 +180,7 @@ export default class ChasePayPaymentStrategy implements PaymentStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+                ...SDK_VERSION_HEADERS,
             },
             body: {
                 action: 'set_external_checkout',

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -4,6 +4,7 @@ import { AddressRequestBody } from '../../../address';
 import { BillingAddressActionCreator, BillingAddressUpdateRequestBody } from '../../../billing';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { RemoteCheckoutSynchronizationError } from '../../../remote-checkout/errors';
 import { ConsignmentActionCreator } from '../../../shipping';
 import { PaymentMethodInvalidError } from '../../errors';
@@ -212,6 +213,7 @@ export default class GooglePayPaymentProcessor {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
+                ...SDK_VERSION_HEADERS,
             },
             body: {
                 payment_type: postPaymentData.type,

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.spec.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY } from '../../../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../../../common/http-request';
 
 import { PaypalCommerceRequestSender } from './index';
 
@@ -30,6 +30,7 @@ describe('PaypalCommerceRequestSender', () => {
             const headers = {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
             };
 
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommerce', expect.objectContaining({
@@ -44,6 +45,7 @@ describe('PaypalCommerceRequestSender', () => {
             const headers = {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
             };
 
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommercecredit', expect.objectContaining({
@@ -58,6 +60,7 @@ describe('PaypalCommerceRequestSender', () => {
             const headers = {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
             };
 
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommercecheckout', expect.objectContaining({
@@ -72,6 +75,7 @@ describe('PaypalCommerceRequestSender', () => {
             const headers = {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
             };
 
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommercecreditcheckout', expect.objectContaining({
@@ -86,6 +90,7 @@ describe('PaypalCommerceRequestSender', () => {
             const headers = {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
             };
 
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommercecreditcardscheckout', expect.objectContaining({
@@ -100,6 +105,7 @@ describe('PaypalCommerceRequestSender', () => {
             const headers = {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
             };
 
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/payment/paypalcommercealternativemethodscheckout', expect.objectContaining({

--- a/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
-import { ContentType, INTERNAL_USE_ONLY } from '../../../common/http-request';
+import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../../../common/http-request';
 
 import { OrderData, OrderStatus } from './paypal-commerce-sdk';
 
@@ -37,6 +37,7 @@ export default class PaypalCommerceRequestSender {
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
             'Content-Type': ContentType.Json,
+            ...SDK_VERSION_HEADERS,
         };
 
         const res = await this._requestSender.post(url, { headers, body });
@@ -49,6 +50,7 @@ export default class PaypalCommerceRequestSender {
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
             'Content-Type': ContentType.Json,
+            ...SDK_VERSION_HEADERS,
         };
 
         const res = await this._requestSender.get<OrderStatus>(url, {headers});

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -3,6 +3,7 @@ import { isEmpty, noop, omit } from 'lodash';
 
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, TimeoutError, UnsupportedBrowserError } from '../../../common/error/errors';
+import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { NonceInstrument } from '../../payment';
@@ -258,6 +259,7 @@ export default class SquarePaymentStrategy implements PaymentStrategy {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',
+                ...SDK_VERSION_HEADERS,
             },
             body: {
                 nonce,

--- a/src/remote-checkout/remote-checkout-request-sender.spec.ts
+++ b/src/remote-checkout/remote-checkout-request-sender.spec.ts
@@ -1,4 +1,5 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
+import { SDK_VERSION_HEADERS } from '../common/http-request';
 
 import { getResponse } from '../common/http-request/responses.mock';
 
@@ -17,7 +18,7 @@ describe('RemoteCheckoutRequestSender', () => {
     it('sends request to initialize billing', async () => {
         const response = getResponse(getRemoteBillingResponseBody());
         const params = { referenceId: '511ed7ed-221c-418c-8286-f5102e49220b' };
-        const options = { timeout: createTimeout() };
+        const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
 
         jest.spyOn(requestSender, 'get').mockReturnValue(response);
 
@@ -30,7 +31,7 @@ describe('RemoteCheckoutRequestSender', () => {
     it('sends request to initialize shipping', async () => {
         const response = getResponse(getRemoteShippingResponseBody());
         const params = { referenceId: '511ed7ed-221c-418c-8286-f5102e49220b' };
-        const options = { timeout: createTimeout() };
+        const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
 
         jest.spyOn(requestSender, 'get').mockReturnValue(response);
 
@@ -43,7 +44,7 @@ describe('RemoteCheckoutRequestSender', () => {
     it('sends request to initialize payment', async () => {
         const response = getResponse(getRemotePaymentResponseBody());
         const params = { referenceId: '511ed7ed-221c-418c-8286-f5102e49220b' };
-        const options = { timeout: createTimeout() };
+        const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
 
         jest.spyOn(requestSender, 'get').mockReturnValue(response);
 
@@ -55,7 +56,7 @@ describe('RemoteCheckoutRequestSender', () => {
 
     it('sends request to sign out from remote checkout provider', async () => {
         const response = getResponse({});
-        const options = { timeout: createTimeout() };
+        const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
 
         jest.spyOn(requestSender, 'get').mockReturnValue(response);
 
@@ -67,7 +68,7 @@ describe('RemoteCheckoutRequestSender', () => {
 
     it('sends request to generate token', async () => {
         const response = getResponse(getRemoteTokenResponseBody());
-        const options = { timeout: createTimeout() };
+        const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
 
         jest.spyOn(requestSender, 'get').mockReturnValue(response);
 
@@ -79,7 +80,7 @@ describe('RemoteCheckoutRequestSender', () => {
 
     it('sends request to track authorization event', async () => {
         const response = getResponse({});
-        const options = { timeout: createTimeout() };
+        const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
 
         jest.spyOn(requestSender, 'post').mockReturnValue(response);
 
@@ -91,7 +92,7 @@ describe('RemoteCheckoutRequestSender', () => {
 
     it('sends request to forget the remote checkout provider', async () => {
         const response = getResponse({});
-        const options = { timeout: createTimeout() };
+        const options = { timeout: createTimeout(), headers: SDK_VERSION_HEADERS };
 
         jest.spyOn(requestSender, 'post').mockReturnValue(response);
 

--- a/src/remote-checkout/remote-checkout-request-sender.spec.ts
+++ b/src/remote-checkout/remote-checkout-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
-import { SDK_VERSION_HEADERS } from '../common/http-request';
 
+import { SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import RemoteCheckoutRequestSender from './remote-checkout-request-sender';

--- a/src/remote-checkout/remote-checkout-request-sender.ts
+++ b/src/remote-checkout/remote-checkout-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 /**
  * @todo Convert this file into TypeScript properly
@@ -13,49 +13,49 @@ export default class RemoteCheckoutRequestSender {
     initializeBilling(methodName: string, params?: { referenceId: string }, { timeout }: RequestOptions = {}): Promise<Response<any>> {
         const url = `/remote-checkout/${methodName}/billing`;
 
-        return this._requestSender.get(url, { params, timeout });
+        return this._requestSender.get(url, { params, timeout, headers: SDK_VERSION_HEADERS });
     }
 
     initializeShipping(methodName: string, params?: { referenceId: string }, { timeout }: RequestOptions = {}): Promise<Response<any>> {
         const url = `/remote-checkout/${methodName}/shipping`;
 
-        return this._requestSender.get(url, { params, timeout });
+        return this._requestSender.get(url, { params, timeout, headers: SDK_VERSION_HEADERS });
     }
 
     initializePayment(methodName: string, params?: InitializePaymentOptions, { timeout }: RequestOptions = {}): Promise<Response<any>> {
         const url = `/remote-checkout/${methodName}/payment`;
 
-        return this._requestSender.get(url, { params, timeout });
+        return this._requestSender.get(url, { params, timeout, headers: SDK_VERSION_HEADERS });
     }
 
     loadSettings(methodName: string, { timeout }: RequestOptions = {}): Promise<Response<any>> {
         const url = `/remote-checkout/${methodName}/settings`;
 
-        return this._requestSender.get(url, { timeout });
+        return this._requestSender.get(url, { timeout, headers: SDK_VERSION_HEADERS });
     }
 
     signOut(methodName: string, { timeout }: RequestOptions = {}): Promise<Response<any>> {
         const url = `/remote-checkout/${methodName}/signout`;
 
-        return this._requestSender.get(url, { timeout });
+        return this._requestSender.get(url, { timeout, headers: SDK_VERSION_HEADERS });
     }
 
     generateToken({ timeout }: RequestOptions = {}): Promise<Response<any>> {
         const url = '/remote-checkout-token';
 
-        return this._requestSender.get(url, { timeout });
+        return this._requestSender.get(url, { timeout, headers: SDK_VERSION_HEADERS });
     }
 
     trackAuthorizationEvent({ timeout }: RequestOptions = {}): Promise<Response<any>> {
         const url = '/remote-checkout/events/shopper-checkout-service-provider-authorization-requested';
 
-        return this._requestSender.post(url, { timeout });
+        return this._requestSender.post(url, { timeout, headers: SDK_VERSION_HEADERS });
     }
 
     forgetCheckout({ timeout }: RequestOptions = {}): Promise<Response<any>> {
         const url = `/remote-checkout/forget-checkout`;
 
-        return this._requestSender.post(url, { timeout });
+        return this._requestSender.post(url, { timeout, headers: SDK_VERSION_HEADERS });
     }
 }
 

--- a/src/shipping/consignment-request-sender.spec.ts
+++ b/src/shipping/consignment-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout } from '@bigcommerce/request-sender';
 
 import { getCheckout } from '../checkout/checkouts.mock';
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import ConsignmentRequestSender from './consignment-request-sender';
 import { getConsignmentRequestBody } from './consignments.mock';
@@ -44,6 +44,7 @@ describe('ConsignmentRequestSender', () => {
                 body: consignments,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include,
@@ -59,6 +60,7 @@ describe('ConsignmentRequestSender', () => {
                 body: consignments,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include,
@@ -79,6 +81,7 @@ describe('ConsignmentRequestSender', () => {
                 body: consignments,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: baseInclude,
@@ -97,6 +100,7 @@ describe('ConsignmentRequestSender', () => {
                 body,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include,
@@ -112,6 +116,7 @@ describe('ConsignmentRequestSender', () => {
                 body,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include,
@@ -132,6 +137,7 @@ describe('ConsignmentRequestSender', () => {
                 body,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: baseInclude,
@@ -147,6 +153,7 @@ describe('ConsignmentRequestSender', () => {
             expect(requestSender.delete).toHaveBeenCalledWith(`/api/storefront/checkouts/foo/consignments/${consignment.id}`, {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include,
@@ -161,6 +168,7 @@ describe('ConsignmentRequestSender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include,

--- a/src/shipping/consignment-request-sender.ts
+++ b/src/shipping/consignment-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Checkout, CheckoutParams } from '../checkout';
-import { joinIncludes, joinOrMergeIncludes, ContentType, RequestOptions } from '../common/http-request';
+import { joinIncludes, joinOrMergeIncludes, ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import { ConsignmentsRequestBody, ConsignmentUpdateRequestBody } from './consignment';
 
@@ -24,7 +24,10 @@ export default class ConsignmentRequestSender {
         { timeout, params: { include } = {} }: RequestOptions<CheckoutParams> = {}
     ): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/consignments`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
 
         return this._requestSender.post(url, {
             body: consignments,
@@ -43,7 +46,10 @@ export default class ConsignmentRequestSender {
     ): Promise<Response<Checkout>> {
         const { id, ...body } = consignment;
         const url = `/api/storefront/checkouts/${checkoutId}/consignments/${id}`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
 
         return this._requestSender.put(url, {
             body,
@@ -61,7 +67,10 @@ export default class ConsignmentRequestSender {
         { timeout }: RequestOptions = {}
     ): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/consignments/${consignmentId}`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
         const include = joinIncludes(DEFAULT_INCLUDES);
 
         return this._requestSender.delete(url, { params: { include }, headers, timeout });

--- a/src/shipping/shipping-country-request-sender.spec.ts
+++ b/src/shipping/shipping-country-request-sender.spec.ts
@@ -1,5 +1,6 @@
 import { createRequestSender, createTimeout, RequestSender, Response } from '@bigcommerce/request-sender';
 
+import { SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 import { CountryResponseBody } from '../geography';
 
@@ -31,6 +32,7 @@ describe('ShippingCountryRequestSender', () => {
             expect(requestSender.get).toHaveBeenCalledWith('/internalapi/v1/shipping/countries', {
                 headers: {
                     'Accept-Language': 'en',
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -44,6 +46,7 @@ describe('ShippingCountryRequestSender', () => {
                 ...options,
                 headers: {
                     'Accept-Language': 'en',
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });

--- a/src/shipping/shipping-country-request-sender.ts
+++ b/src/shipping/shipping-country-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { RequestOptions } from '../common/http-request';
+import { RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 import { CountryResponseBody } from '../geography';
 
 export default class ShippingCountryRequestSender {
@@ -13,6 +13,7 @@ export default class ShippingCountryRequestSender {
         const url = '/internalapi/v1/shipping/countries';
         const headers = {
             'Accept-Language': this._config.locale,
+            ...SDK_VERSION_HEADERS,
         };
 
         return this._requestSender.get(url, { headers, timeout });

--- a/src/signin-email/signin-email-request-sender.spec.ts
+++ b/src/signin-email/signin-email-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import SignInEmailRequestSender from './signin-email-request-sender';
 
@@ -29,7 +29,10 @@ describe('SignInEmailRequestSender', () => {
                         email: 'foo',
                         redirect_url: '/',
                     },
-                    headers: { Accept: ContentType.JsonV1 },
+                    headers: {
+                        Accept: ContentType.JsonV1,
+                        ...SDK_VERSION_HEADERS,
+                    },
                     timeout: undefined,
                 }
             );
@@ -50,7 +53,10 @@ describe('SignInEmailRequestSender', () => {
                         email: 'foo',
                         redirect_url: 'foo.bar',
                     },
-                    headers: { Accept: ContentType.JsonV1 },
+                    headers: {
+                        Accept: ContentType.JsonV1,
+                        ...SDK_VERSION_HEADERS,
+                    },
                 }
             );
         });

--- a/src/signin-email/signin-email-request-sender.ts
+++ b/src/signin-email/signin-email-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 import { parseUrl } from '../common/url';
 
 import { SignInEmail, SignInEmailRequestBody } from './signin-email';
@@ -20,7 +20,10 @@ export default class SignInEmailRequestSender {
         }: RequestOptions = {}
     ): Promise<Response<SignInEmail>> {
         const url = '/login.php?action=passwordless_login';
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
 
         return this._requestSender.post(url, { body: {
             email,

--- a/src/spam-protection/spam-protection-request-sender.spec.ts
+++ b/src/spam-protection/spam-protection-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCheckout } from '../checkout/checkouts.mock';
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import SpamProtectionRequestSender from './spam-protection-request-sender';
@@ -33,6 +33,7 @@ describe('SpamProtection Request Sender', () => {
             expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/spam-protection', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 body: {
                     token,
@@ -52,6 +53,7 @@ describe('SpamProtection Request Sender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 body: {
                     token,

--- a/src/spam-protection/spam-protection-request-sender.ts
+++ b/src/spam-protection/spam-protection-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Checkout } from '../checkout';
-import { ContentType, RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 export default class SpamProtectionRequestSender {
     constructor(
@@ -10,7 +10,10 @@ export default class SpamProtectionRequestSender {
 
     validate(checkoutId: string, token: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/spam-protection`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
 
         return this._requestSender.post(url, { body: { token }, headers, timeout });
     }

--- a/src/store-credit/store-credit-request-sender.spec.ts
+++ b/src/store-credit/store-credit-request-sender.spec.ts
@@ -1,7 +1,7 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
 import { getCheckout } from '../checkout/checkouts.mock';
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
 import StoreCreditRequestSender from './store-credit-request-sender';
@@ -43,6 +43,7 @@ describe('StoreCredit Request Sender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -62,6 +63,7 @@ describe('StoreCredit Request Sender', () => {
                 },
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
             });
         });
@@ -78,6 +80,7 @@ describe('StoreCredit Request Sender', () => {
             expect(requestSender.delete).toHaveBeenCalledWith('/api/storefront/checkouts/checkoutId1234/store-credit', {
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,
@@ -97,6 +100,7 @@ describe('StoreCredit Request Sender', () => {
                 ...options,
                 headers: {
                     Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
                 },
                 params: {
                     include: defaultIncludes,

--- a/src/store-credit/store-credit-request-sender.ts
+++ b/src/store-credit/store-credit-request-sender.ts
@@ -1,7 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { Checkout, CHECKOUT_DEFAULT_INCLUDES } from '../checkout';
-import { joinIncludes, ContentType, RequestOptions } from '../common/http-request';
+import { joinIncludes, ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 export default class StoreCreditRequestSender {
     constructor(
@@ -10,7 +10,10 @@ export default class StoreCreditRequestSender {
 
     applyStoreCredit(checkoutId: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/store-credit`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
 
         return this._requestSender.post(url, {
             headers,
@@ -23,7 +26,10 @@ export default class StoreCreditRequestSender {
 
     removeStoreCredit(checkoutId: string, { timeout }: RequestOptions = {}): Promise<Response<Checkout>> {
         const url = `/api/storefront/checkouts/${checkoutId}/store-credit`;
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
 
         return this._requestSender.delete(url, {
             headers,

--- a/src/subscription/subscriptions-request-sender.spec.ts
+++ b/src/subscription/subscriptions-request-sender.spec.ts
@@ -1,6 +1,6 @@
 import { createRequestSender, createTimeout, RequestSender } from '@bigcommerce/request-sender';
 
-import { ContentType } from '../common/http-request';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import { Subscriptions } from './subscriptions';
 import SubscriptionsRequestSender from './subscriptions-request-sender';
@@ -31,7 +31,10 @@ describe('SubscriptionsRequestSender', () => {
                 '/api/storefront/subscriptions',
                 {
                     body: subscriptionsRequestBody,
-                    headers: { Accept: ContentType.JsonV1 },
+                    headers: {
+                        Accept: ContentType.JsonV1,
+                        ...SDK_VERSION_HEADERS,
+                    },
                     timeout: undefined,
                 }
             );
@@ -46,7 +49,10 @@ describe('SubscriptionsRequestSender', () => {
                 {
                     ...options,
                     body: subscriptionsRequestBody,
-                    headers: { Accept: ContentType.JsonV1 },
+                    headers: {
+                        Accept: ContentType.JsonV1,
+                        ...SDK_VERSION_HEADERS,
+                    },
                 }
             );
         });

--- a/src/subscription/subscriptions-request-sender.ts
+++ b/src/subscription/subscriptions-request-sender.ts
@@ -1,6 +1,6 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, RequestOptions } from '../common/http-request';
+import { ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 import { Subscriptions } from './subscriptions';
 
@@ -11,7 +11,10 @@ export default class SubscriptionsRequestSender {
 
     updateSubscriptions(subscriptions: Subscriptions, { timeout }: RequestOptions = {}): Promise<Response<Subscriptions>> {
         const url = '/api/storefront/subscriptions';
-        const headers = { Accept: ContentType.JsonV1 };
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
 
         return this._requestSender.post(url, { body: subscriptions, headers, timeout });
     }


### PR DESCRIPTION
## What?
- Create a static value at `/src/common/http-request/internal-api-headers.ts` to serve as centralised management of SDK  version headers.
- Add it to all API requests.
- All `GET`, `POST`, `PUT`, ~~PATCH~~  or `DELETE`requests through `@bigcommerce/request-sender` and all occurences of `headers` have been checked to see whether they are fit to have SDK verision information in the header.
## Why? [Checkout-5777](https://jira.bigcommerce.com/browse/CHECKOUT-5777)
Now, we only send the checkout SDK version on a specific API request that creates orders. It seems like a good idea to simply send this header all the time, so we're able to track SDK version usage across many different endpoints.
## Testing / Proof
![Fullscreen_17_9_21__1_40_pm](https://user-images.githubusercontent.com/88361607/133720668-040ce512-c1c0-479f-9923-32b28851be14.png)

