### PR TITLE
fix(checkout): ADYEN-260 fixed googlepay updates billing info, removed update of customer email

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -157,7 +157,7 @@ export default class GooglePayPaymentProcessor {
         return this._methodId;
     }
 
-    private _mapGooglePayAddressToBillingAddress(paymentData: GooglePaymentData, id: string): BillingAddressUpdateRequestBody {
+    private _mapGooglePayAddressToBillingAddress(paymentData: GooglePaymentData, id: string, customerEmail?: string): BillingAddressUpdateRequestBody {
         const fullName = paymentData.paymentMethodData.info.billingAddress.name;
         const [firstName, lastName] = getFirstAndLastName(fullName);
         const address1 =  paymentData.paymentMethodData.info.billingAddress.address1;
@@ -183,7 +183,7 @@ export default class GooglePayPaymentProcessor {
             countryCode,
             phone: paymentData.paymentMethodData.info.billingAddress.phoneNumber,
             customFields: [],
-            email: paymentData.email,
+            email: customerEmail || paymentData.email,
         };
     }
 
@@ -232,7 +232,7 @@ export default class GooglePayPaymentProcessor {
             throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
         }
 
-        const googlePayAddressMapped = this._mapGooglePayAddressToBillingAddress(paymentData, remoteBillingAddress.id);
+        const googlePayAddressMapped = this._mapGooglePayAddressToBillingAddress(paymentData, remoteBillingAddress.id, remoteBillingAddress.email);
 
         return this._store.dispatch(
             this._billingAddressActionCreator.updateAddress(googlePayAddressMapped)


### PR DESCRIPTION
## What?
Fixed googlepay updates billing info, removed update of customer email.
If customer is doing payment via googlepay cart button, system will pass googlepay email as customer email.
Changes ware made after this issue https://jira.bigcommerce.com/browse/INT-4900 and after revert of the previous PR related to the ADYEN-260

## Why?
Due to the https://jira.bigcommerce.com/browse/ADYEN-260

## Testing / Proof


https://user-images.githubusercontent.com/79574476/135050738-d1ce6282-bec2-4413-bb16-378cfd46bb8c.mov


https://user-images.githubusercontent.com/79574476/135050753-43a4a90e-e812-4a66-8d91-6f3dd54c1ec2.mov


@bigcommerce/checkout @bigcommerce/payments
