### PR TITLE
feat(payment): PAYMENTS-7269 allow PPSDK payment methods to finalise in progress payments

### DIFF
--- a/src/payment/strategies/ppsdk/ppsdk-strategy.spec.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.spec.ts
@@ -90,6 +90,7 @@ describe('PPSDKStrategy', () => {
 
                         jest.spyOn(store.getState().order, 'getPaymentId').mockReturnValue('abc');
                         jest.spyOn(store.getState().order, 'getOrderMeta').mockReturnValue({ token: 'some-token' });
+                        jest.spyOn(store.getState().order, 'getOrder').mockReturnValue({ orderId: 'some-order-id' });
 
                         const resumerSpy = jest.spyOn(paymentResumer, 'resume').mockResolvedValue(undefined);
 

--- a/src/payment/strategies/ppsdk/ppsdk-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.ts
@@ -56,14 +56,16 @@ export class PPSDKStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to submit payment because "options.methodId" argument is not provided.');
         }
 
+        const order = this._store.getState().order.getOrder();
         const paymentId = this._store.getState().order.getPaymentId(options?.methodId);
-        const token = this._store.getState().order.getOrderMeta()?.token;
 
-        if (!paymentId || !token) {
+        if (!paymentId || !order) {
             throw new OrderFinalizationNotRequiredError();
         }
 
-        await this._paymentResumer.resume({ paymentId, bigpayBaseUrl, token });
+        const { orderId } = order;
+
+        await this._paymentResumer.resume({ paymentId, bigpayBaseUrl, orderId });
 
         return this._store.getState();
     }


### PR DESCRIPTION
**N.B.** this PPSDK work is behind a WIP feature flag

## What?

- Make use of the new `/api/storefront/payments/auth-token` (https://github.com/bigcommerce/bigcommerce/pull/42774) endpoint within the PPSDK strategy's `finalize` method

## Why?

- To allow the strategy to resume authenticated communication over the BigPay `/payments` endpoint

## Testing / Proof

- Manual
- Unit

@bigcommerce/checkout @bigcommerce/payments
