### PR TITLE
feat(payment): PAYMENTS-7270 skip PPSDK finalization when order is marked complete

### DIFF
--- a/src/payment/strategies/ppsdk/ppsdk-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.ts
@@ -49,6 +49,12 @@ export class PPSDKStrategy implements PaymentStrategy {
     }
 
     async finalize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const order = this._store.getState().order.getOrderOrThrow();
+
+        if (order.isComplete) {
+            return this._store.getState();
+        }
+
         const { bigpayBaseUrl } = this._store.getState().config.getStoreConfigOrThrow().paymentSettings;
 
         if (!options?.methodId) {


### PR DESCRIPTION
**N.B** this PPSDK work is behind a WIP feature toggle

## What?

- Resolve PPSDK strategy finalization method when the current order is already completed

## Why?

- `finalize` is invoked when checkout finds loads an order with an existing order payment. In the case that the order is already complete (i.e. payment has been successfully authorised in full offsite) we can skip reaching out to BigPay and honour the order's status of completed. 

## Testing / Proof

- Unit

@bigcommerce/checkout @bigcommerce/payments
