### PR TITLE
fix(payment): ADYEN-253 Disabled showing error modal on Adyen GooglePay 3ds

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -114,8 +114,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
             return await this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
         } catch (error) {
-            this._googlePayAdyenV2PaymentProcessor?.processAdditionalAction(error);
-            throw error;
+            return this._googlePayAdyenV2PaymentProcessor?.processAdditionalAction(error) || Promise.reject(error);
         }
     }
 


### PR DESCRIPTION
## What?
Disabled showing error modal on Adyen GooglePay 3ds.
I fond out that after refactoring checkout started to show modal [on this line in PR](https://github.com/bigcommerce/checkout-sdk-js/pull/1082/files#diff-ffa8fb97c784b953d53f6ae3923e8869b16c410016854e84f3fd4dd0c6e153b7R112)
I've made changes to return to the previous version at that line.


## Why?
Due to the https://jira.bigcommerce.com/browse/ADYEN-253

## Testing / Proof
**Before:**

https://user-images.githubusercontent.com/79574476/135474660-f61f6843-b3c0-4841-b572-627a04c521db.mov

**After:**

https://user-images.githubusercontent.com/79574476/135474728-63f097a6-1946-4a9d-be30-fe01c0f8560a.mov




@bigcommerce/checkout @bigcommerce/payments
