### PR TITLE
chore(common): Update node image in circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ aliases:
   - &node_executor
       executor:
         name: node/node
-        node-version: "10"
+        node-version: "10-buster"
 
   - &release_filter
       branches:


### PR DESCRIPTION
## What?
Update node image in circle

## Why?
There was an issue building the container and it was recommended that we update the node version to 10-buster.

## Testing / Proof
- Circle

@bigcommerce/checkout @bigcommerce/payments
