### PR TITLE
Revert "feat(payment): PAYMENTS-7269 allow PPSDK payment methods to finalise in progress payments"

### DIFF
--- a/src/payment/strategies/ppsdk/ppsdk-payment-resumer.spec.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-resumer.spec.ts
@@ -1,9 +1,6 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 
-import { getErrorResponse } from '../../../common/http-request/responses.mock';
-import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-
 import { PaymentResumer } from './ppsdk-payment-resumer';
 import { StepHandler } from './step-handler';
 import { ContinueHandler } from './step-handler/continue-handler';
@@ -14,21 +11,11 @@ describe('PaymentResumer', () => {
     const paymentResumer = new PaymentResumer(requestSender, stepHandler);
 
     describe('#resume', () => {
-        it('throws a OrderFinalizationNotRequiredError error if the payment token endpoint returns a 404', async () => {
-            jest.spyOn(requestSender, 'get').mockRejectedValue(getErrorResponse(undefined, undefined, 404));
-
-            await expect(
-                paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', orderId: 12345 })
-            ).rejects.toBeInstanceOf(OrderFinalizationNotRequiredError);
-        });
-
         it('requests the payment entity from the BigPay Payments endpoint', async () => {
-            const requestSenderSpy = jest.spyOn(requestSender, 'get')
-                .mockResolvedValueOnce({ body: { auth_token: 'some-token' } })
-                .mockResolvedValueOnce({});
+            const requestSenderSpy = jest.spyOn(requestSender, 'get').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', orderId: 12345 });
+            await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(requestSenderSpy).toBeCalledWith(
                 'https://some-domain.com/payments/some-id',
@@ -42,23 +29,19 @@ describe('PaymentResumer', () => {
         });
 
         it('passes the Payments endpoint response to the stepHandler', async () => {
-            jest.spyOn(requestSender, 'get')
-                .mockResolvedValueOnce({ body: { auth_token: 'some-token' } })
-                .mockResolvedValueOnce({ body: 'some-api-response' });
+            jest.spyOn(requestSender, 'get').mockResolvedValue({ body: 'some-api-response' });
             const stepHandlerSpy = jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', orderId: 12345 });
+            await paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(stepHandlerSpy).toBeCalledWith({ body: 'some-api-response' });
         });
 
         it('returns the final value from the stepHandler', async () => {
-            jest.spyOn(requestSender, 'get')
-                .mockResolvedValueOnce({ body: { auth_token: 'some-token' } })
-                .mockResolvedValueOnce({});
+            jest.spyOn(requestSender, 'get').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({ someValue: 12345 });
 
-            await expect(paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', orderId: 12345 }))
+            await expect(paymentResumer.resume({ paymentId: 'some-id', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' }))
                 .resolves.toStrictEqual({ someValue: 12345 });
         });
     });

--- a/src/payment/strategies/ppsdk/ppsdk-payment-resumer.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-payment-resumer.ts
@@ -1,12 +1,10 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
-import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-
 import { PaymentsAPIResponse } from './ppsdk-payments-api-response';
 import { StepHandler } from './step-handler';
 
 interface ResumeSettings {
-    orderId: number;
+    token: string;
     paymentId: string;
     bigpayBaseUrl: string;
 }
@@ -17,11 +15,7 @@ export class PaymentResumer {
         private _stepHandler: StepHandler
     ) {}
 
-    async resume({ paymentId, bigpayBaseUrl, orderId }: ResumeSettings): Promise<void> {
-        const token = await this._getToken(orderId).catch(() => {
-            throw new OrderFinalizationNotRequiredError();
-        });
-
+    resume({ paymentId, bigpayBaseUrl, token }: ResumeSettings): Promise<void> {
         const options = {
             credentials: false,
             headers: {
@@ -32,18 +26,5 @@ export class PaymentResumer {
 
         return this._requestSender.get<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments/${paymentId}`, options)
             .then(response => this._stepHandler.handle(response));
-    }
-
-    private async _getToken(orderId: number): Promise<string> {
-        const url = `/api/storefront/payments/auth-token`;
-        const options = {
-            params: {
-                order_id: orderId,
-            },
-        };
-
-        return this._requestSender
-            .get<{ auth_token: string }>(url, options)
-            .then(({ body }) => body.auth_token);
     }
 }

--- a/src/payment/strategies/ppsdk/ppsdk-strategy.spec.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.spec.ts
@@ -92,7 +92,6 @@ describe('PPSDKStrategy', () => {
                         jest.spyOn(store.getState().order, 'getOrderOrThrow').mockReturnValue(incompleteOrder);
                         jest.spyOn(store.getState().order, 'getPaymentId').mockReturnValue('abc');
                         jest.spyOn(store.getState().order, 'getOrderMeta').mockReturnValue({ token: 'some-token' });
-                        jest.spyOn(store.getState().order, 'getOrder').mockReturnValue({ orderId: 'some-order-id' });
 
                         const resumerSpy = jest.spyOn(paymentResumer, 'resume').mockResolvedValue(undefined);
 

--- a/src/payment/strategies/ppsdk/ppsdk-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.ts
@@ -61,16 +61,14 @@ export class PPSDKStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to submit payment because "options.methodId" argument is not provided.');
         }
 
-        const order = this._store.getState().order.getOrder();
         const paymentId = this._store.getState().order.getPaymentId(options?.methodId);
+        const token = this._store.getState().order.getOrderMeta()?.token;
 
-        if (!paymentId || !order) {
+        if (!paymentId || !token) {
             throw new OrderFinalizationNotRequiredError();
         }
 
-        const { orderId } = order;
-
-        await this._paymentResumer.resume({ paymentId, bigpayBaseUrl, orderId });
+        await this._paymentResumer.resume({ paymentId, bigpayBaseUrl, token });
 
         return this._store.getState();
     }


### PR DESCRIPTION
Reverts bigcommerce/checkout-sdk-js#1252

PR cause build error due to accidental redeclaration of block-scoped variable.

Will rebase and add minor refactor to avoid this. 