### PR TITLE
feat(payment): INT-4282 removing masterpass logic for square

### DIFF
--- a/src/payment/strategies/square/square-form.ts
+++ b/src/payment/strategies/square/square-form.ts
@@ -46,7 +46,6 @@ export interface SquareFormOptions {
     cvv: SquareFormElement;
     expirationDate: SquareFormElement;
     postalCode: SquareFormElement;
-    masterpass: SquareFormElement;
 }
 export interface LineItem {
     label: string;
@@ -106,7 +105,6 @@ export enum CardBrand {
 
 export enum DigitalWalletType {
     applePay = 'APPLEPAY',
-    masterpass = 'MASTERPASS',
     none = 'NONE',
 }
 

--- a/src/payment/strategies/square/square-payment-initialize-options.ts
+++ b/src/payment/strategies/square/square-payment-initialize-options.ts
@@ -34,45 +34,6 @@ import { NonceGenerationError, SquareFormElement } from './square-form';
  *     },
  * });
  * ```
- *
- * Additional options can be passed in to enable Masterpass (if configured for
- * the account) and customize the fields.
- *
- * ```html
- * <!-- This container is where Masterpass button will be inserted -->
- * <div id="masterpass"></div>
- * ```
- *
- * ```js
- * service.initializePayment({
- *     methodId: 'squarev2',
- *     square: {
- *         cardNumber: {
- *             elementId: 'card-number',
- *         },
- *         cvv: {
- *             elementId: 'card-code',
- *         },
- *         expirationDate: {
- *             elementId: 'card-expiry',
- *         },
- *         postalCode: {
- *             elementId: 'card-code',
- *         },
- *         inputClass: 'form-input',
- *         inputStyles: [
- *             {
- *                 color: '#333',
- *                 fontSize: '13px',
- *                 lineHeight: '20px',
- *             },
- *         ],
- *         masterpass: {
- *             elementId: 'masterpass',
- *         },
- *     },
- * });
- * ```
  */
 export default interface SquarePaymentInitializeOptions {
     /**
@@ -104,11 +65,6 @@ export default interface SquarePaymentInitializeOptions {
      * The set of CSS styles to apply to all form fields.
      */
     inputStyles?: Array<{ [key: string]: string }>;
-
-    /**
-     * Initialize Masterpass placeholder ID
-     */
-    masterpass?: SquareFormElement;
 
     /**
      * A callback that gets called when the customer selects a payment option.

--- a/src/payment/strategies/square/square-payment-strategy-mock.ts
+++ b/src/payment/strategies/square/square-payment-strategy-mock.ts
@@ -23,7 +23,7 @@ export function getCardData(): CardData {
         exp_month: 1,
         exp_year: 2020,
         billing_postal_code: '12345',
-        digital_wallet_type: DigitalWalletType.masterpass,
+        digital_wallet_type: DigitalWalletType.applePay,
     };
 }
 
@@ -74,9 +74,6 @@ export function getSquarePaymentInitializeOptions(): PaymentInitializeOptions {
             },
             onError: jest.fn(),
             onPaymentSelect: () => { },
-            masterpass: {
-                elementId: 'sq-masterpass',
-            },
         },
     };
 }

--- a/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -165,21 +165,6 @@ describe('SquarePaymentStrategy', () => {
                 }
             });
 
-            it('Shows the masterpass button', async () => {
-                await strategy.initialize(initOptions);
-
-                let container: HTMLDivElement;
-                container = document.createElement('div');
-                container.id = 'sq-masterpass';
-                document.body.appendChild(container);
-
-                if (callbacks.methodsSupported) {
-                    callbacks.methodsSupported({ masterpass: true });
-                }
-
-                expect(scriptLoader.load).toHaveBeenCalledTimes(1);
-            });
-
             describe('Payment Request callback fired', () => {
 
                 beforeEach(async () => {
@@ -356,7 +341,7 @@ describe('SquarePaymentStrategy', () => {
             describe('when the nonce is received', () => {
                 const payloadVaulted = getPayloadVaulted();
 
-                it('calls submit order with the order request information for masterpass', async () => {
+                it('calls submit order with the order request information for applepay', async () => {
                     await strategy.initialize(initOptions);
                     cardData.digital_wallet_type = DigitalWalletType.none;
 

--- a/src/payment/strategies/square/square-payment-strategy.ts
+++ b/src/payment/strategies/square/square-payment-strategy.ts
@@ -14,7 +14,7 @@ import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-r
 import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
 import PaymentStrategy from '../payment-strategy';
 
-import SquarePaymentForm, { CardData, Contact, DeferredPromise, DigitalWalletType, SquareFormElement, SquareFormOptions, SquareIntent, SquarePaymentRequest, SquareVerificationError, SquareVerificationResult, VerificationDetails } from './square-form';
+import SquarePaymentForm, { CardData, Contact, DeferredPromise, DigitalWalletType, SquareFormOptions, SquareIntent, SquarePaymentRequest, SquareVerificationError, SquareVerificationResult, VerificationDetails } from './square-form';
 import SquarePaymentInitializeOptions from './square-payment-initialize-options';
 import SquareScriptLoader from './square-script-loader';
 
@@ -164,13 +164,6 @@ export default class SquarePaymentStrategy implements PaymentStrategy {
                     }
                 },
                 createPaymentRequest: this._paymentRequestPayload.bind(this),
-                methodsSupported: methods => {
-                    const { masterpass } = this._getInitializeOptions();
-
-                    if (masterpass) {
-                        this._showPaymentMethods(methods, masterpass);
-                    }
-                },
                 paymentFormLoaded: () => {
                     deferred.resolve();
                     this._setPostalCode();
@@ -272,14 +265,6 @@ export default class SquarePaymentStrategy implements PaymentStrategy {
 
         if (billingAddress && billingAddress.postalCode) {
             this._getPaymentForm().setPostalCode(billingAddress.postalCode);
-        }
-    }
-
-    private _showPaymentMethods(methods: { [key: string]: boolean }, element: SquareFormElement): void {
-        const masterpassBtn = document.getElementById(element.elementId);
-
-        if (masterpassBtn && methods.masterpass) {
-            masterpassBtn.style.display = 'inline-block';
         }
     }
 


### PR DESCRIPTION
## What? [INT-4282](https://jira.bigcommerce.com/browse/INT-4282)
remove Masterpass support for square

## Why?
The project has been canceled and will not be developed or launched.

## Depends on
https://github.com/bigcommerce/bigpay/pull/4470
https://github.com/bigcommerce/bigcommerce/pull/43061
 https://github.com/bigcommerce/ng-payments/pull/1437
 
 ## Dependency of
https://github.com/bigcommerce/checkout-js/pull/718

## Testing / Proof
![image](https://user-images.githubusercontent.com/42154828/136611933-f618b634-b3f3-41d1-b593-d0b40c23b8ad.png)
![image](https://user-images.githubusercontent.com/42154828/136612036-7d87a7d3-c08d-4d9d-97d0-29297814c78e.png)

## NOTE
Based on tests, the order to merge the PR’s avoiding problems should be the following:
1.- Ng-payments https://github.com/bigcommerce/ng-payments/pull/1437 and bump
2.- Bcapp: https://github.com/bigcommerce/bigcommerce/pull/43061
3.- SDK and bump  
4.- JS using SDK bump
5.- bump JS into BCAPP
6.- Bigpay https://github.com/bigcommerce/bigpay/pull/4470

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
