### PR TITLE
chore(payment): PAYMENTS-7188 remove WIP feature toggle for PPSDK strategy

### DIFF
--- a/src/payment/payment-strategy-registry.spec.ts
+++ b/src/payment/payment-strategy-registry.spec.ts
@@ -1,5 +1,3 @@
-import { set } from 'lodash';
-
 import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../checkout';
 import { getConfigState } from '../config/configs.mock';
 import { getFormFieldsState } from '../form/form.mock';
@@ -73,29 +71,8 @@ describe('PaymentStrategyRegistry', () => {
             registry.register(PaymentStrategyType.PPSDK, () => new PPSDKPaymentStrategy(store));
         });
 
-        describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is off', () => {
-            it('does not return ppsdk strategy if type is "PAYMENT_TYPE_SDK"', () => {
-                expect(registry.getByMethod(getPPSDK())).not.toBeInstanceOf(PPSDKPaymentStrategy);
-            });
-        });
-
-        describe('PAYMENTS-6806.enable_ppsdk_strategy feature flag is on', () => {
-            const featureFlagPath = 'data.storeConfig.checkoutSettings.features';
-            const flagValues = { 'PAYMENTS-6806.enable_ppsdk_strategy': true };
-
-            const store = createCheckoutStore({
-                config: set(getConfigState(), featureFlagPath, flagValues),
-                formFields: getFormFieldsState(),
-            });
-
-            const registry = new PaymentStrategyRegistry(store);
-
-            registry.register(PaymentStrategyType.LEGACY, () => new LegacyPaymentStrategy(store));
-            registry.register(PaymentStrategyType.PPSDK, () => new PPSDKPaymentStrategy(store));
-
-            it('returns ppsdk strategy if type is "PAYMENT_TYPE_SDK"', () => {
-                expect(registry.getByMethod(getPPSDK())).toBeInstanceOf(PPSDKPaymentStrategy);
-            });
+        it('returns ppsdk strategy if type is "PAYMENT_TYPE_SDK"', () => {
+            expect(registry.getByMethod(getPPSDK())).toBeInstanceOf(PPSDKPaymentStrategy);
         });
 
         it('returns strategy if registered with method name', () => {

--- a/src/payment/payment-strategy-registry.ts
+++ b/src/payment/payment-strategy-registry.ts
@@ -43,12 +43,7 @@ export default class PaymentStrategyRegistry extends Registry<PaymentStrategy, P
     }
 
     private _getToken(paymentMethod: PaymentMethod): PaymentStrategyType {
-        const ppsdkFeatureOn =
-            this._store.getState()
-                .config.getStoreConfig()
-                ?.checkoutSettings.features['PAYMENTS-6806.enable_ppsdk_strategy'];
-
-        if (ppsdkFeatureOn && isPPSDKPaymentMethod(paymentMethod)) {
+        if (isPPSDKPaymentMethod(paymentMethod)) {
             return PaymentStrategyType.PPSDK;
         }
 


### PR DESCRIPTION
## What?

- Remove WIP feature toggle which enables/disables the new PPSSDK strategy

## Why?

- Now that contracts have solidified, we can safely remove this WIP toggle
- Should we want to disable PPSDK functionality on the view, we can do this by stopping PPSDK methods coming from the BE 

## Testing / Proof

- Updated tests

@bigcommerce/checkout @bigcommerce/payments
