### PR TITLE
docs(shipping): CHECKOUT-0000 Update address variables in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,13 @@ To set the shipping address, you can collate all the address fields and construc
 const address = {
     firstName: 'Test',
     lastName: 'Tester',
-    addressLine1: '12345 Testing Way',
+    address1: '12345 Testing Way',
     city: 'Some City',
-    provinceCode: 'CA',
-    postCode: '95555',
+    stateOrProvinceCode: 'CA',
+    postalCode: '95555',
     countryCode: 'US',
     phone: '555-555-5555',
+    email: 'test.tester@test.com'
 };
 
 const state = await service.updateShippingAddress(address);


### PR DESCRIPTION
We've changed the required address variables for the checkout SDK since this readme was created, figured we could get them updated for a more accurate example.

## What?
The example address object in the shipping details section of the ReadMe is using outdated variables that are no longer supported.

## Why?
To ensure consistency and accuracy in the documentation and keep it up to date with the new standards

## Testing / Proof
When following the documentation examples and attempting to set my shipping addresses for a checkout, I received several errors because the provided address parameter/variable names were invalid.

@bigcommerce/checkout @bigcommerce/payments
