### PR TITLE
feat(payment): INT-4897 Humm - Add Humm strategy as external payment

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -25,6 +25,7 @@ import { CyberSourcePaymentStrategy } from './strategies/cybersource';
 import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
 import { DigitalRiverPaymentStrategy } from './strategies/digitalriver';
 import { GooglePayPaymentStrategy } from './strategies/googlepay';
+import { HummPaymentStrategy } from './strategies/humm';
 import { KlarnaPaymentStrategy } from './strategies/klarna';
 import { LegacyPaymentStrategy } from './strategies/legacy';
 import { MasterpassPaymentStrategy } from './strategies/masterpass';
@@ -176,6 +177,11 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate googlepayorbital', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.ORBITAL_GOOGLE_PAY);
         expect(paymentStrategy).toBeInstanceOf(GooglePayPaymentStrategy);
+    });
+
+    it('can instantiate humm', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.HUMM);
+        expect(paymentStrategy).toBeInstanceOf(HummPaymentStrategy);
     });
 
     it('can instantiate klarna', () => {

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -45,6 +45,7 @@ import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
 import { DigitalRiverPaymentStrategy, DigitalRiverScriptLoader } from './strategies/digitalriver';
 import { ExternalPaymentStrategy } from './strategies/external';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayOrbitalInitializer,  GooglePayPaymentStrategy, GooglePayStripeInitializer } from './strategies/googlepay';
+import { HummPaymentStrategy } from './strategies/humm';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
 import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
 import { LegacyPaymentStrategy } from './strategies/legacy';
@@ -471,6 +472,15 @@ export default function createPaymentStrategyRegistry(
             paymentMethodActionCreator,
             remoteCheckoutActionCreator,
             new KlarnaV2ScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register(PaymentStrategyType.HUMM, () =>
+        new HummPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formPoster
         )
     );
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -355,6 +355,19 @@ export function getClearpay(): PaymentMethod {
     };
 }
 
+export function getHumm(): PaymentMethod {
+    return {
+        id: 'humm',
+        logoUrl: '',
+        method: 'humm',
+        supportedCards: [],
+        config: {
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+    };
+}
+
 export function getStripe(): PaymentMethod {
     return {
         id: 'stripe',
@@ -812,6 +825,7 @@ export function getPaymentMethods(): PaymentMethod[] {
         getGooglePayAdyenV2(),
         getGooglePayCybersourceV2(),
         getGooglePayOrbital(),
+        getHumm(),
         getKlarna(),
         getMollie(),
         getMoneris(),

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -22,6 +22,7 @@ enum PaymentStrategyType {
     CYBERSOURCEV2 = 'cybersourcev2',
     DIGITALRIVER = 'digitalriver',
     CYBERSOURCEV2_GOOGLE_PAY = 'googlepaycybersourcev2',
+    HUMM = 'humm',
     KLARNA = 'klarna',
     KLARNAV2 = 'klarnav2',
     LAYBUY = 'laybuy',

--- a/src/payment/strategies/humm/humm-payment-strategy.spec.ts
+++ b/src/payment/strategies/humm/humm-payment-strategy.spec.ts
@@ -1,0 +1,133 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { merge } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getHumm } from '../../../payment/payment-methods.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType } from '../../payment-actions';
+import PaymentMethod from '../../payment-method';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+
+import HummPaymentStrategy from './humm-payment-strategy';
+
+describe('HummPaymentStrategy', () => {
+    let checkoutValidator: CheckoutValidator;
+    let checkoutRequestSender: CheckoutRequestSender;
+    let orderActionCreator: OrderActionCreator;
+    let orderRequestSender: OrderRequestSender;
+    let payload: OrderRequestBody;
+    let paymentActionCreator: PaymentActionCreator;
+    let paymentMethod: PaymentMethod;
+    let submitOrderAction: Observable<Action>;
+    let submitPaymentAction: Observable<Action>;
+    let store: CheckoutStore;
+    let strategy: HummPaymentStrategy;
+    let formPoster: FormPoster;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        orderRequestSender = new OrderRequestSender(createRequestSender());
+        checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
+        checkoutValidator = new CheckoutValidator(checkoutRequestSender);
+        orderActionCreator = new OrderActionCreator(orderRequestSender, checkoutValidator);
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        paymentMethod = getHumm();
+        payload = merge({}, getOrderRequestBody(), {
+            payment: {
+                methodId: paymentMethod.id,
+                gatewayId: paymentMethod.gateway,
+            },
+        });
+
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        formPoster = createFormPoster();
+
+        jest.spyOn(store, 'dispatch');
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockReturnValue(Promise.resolve());
+
+        strategy = new HummPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formPoster
+        );
+
+    });
+
+    describe('#execute()', () => {
+        it('throws error when undefined payment is provided', async () => {
+            payload = {payment: undefined};
+
+            await expect(strategy.execute(payload)).rejects.toThrow(PaymentArgumentInvalidError);
+        });
+
+        it('returns checkout state', async () => {
+            const output = await strategy.execute(getOrderRequestBody());
+
+            expect(output).toEqual(store.getState());
+        });
+
+        it('redirect to Humm', async () => {
+            const data = JSON.stringify({data: 'data'});
+
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                provider_data: data,
+                additional_action_required: {
+                    type: 'offsite_redirect',
+                    data : {
+                        redirect_url: 'https://sandbox-payment.humm.com',
+                    },
+                },
+                status:  'additional_action_required',
+            }));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+            strategy.execute(payload);
+
+            await new Promise(resolve => process.nextTick(resolve));
+            expect(formPoster.postForm).toHaveBeenCalledWith('https://sandbox-payment.humm.com', {data: 'data'});
+        });
+
+        it('reject payment when error is different to additional_action_required', async () => {
+            const error = new RequestError(getResponse(getErrorPaymentResponseBody()));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+            await expect(strategy.execute(getOrderRequestBody())).rejects.toThrowError(error);
+        });
+    });
+});

--- a/src/payment/strategies/humm/humm-payment-strategy.ts
+++ b/src/payment/strategies/humm/humm-payment-strategy.ts
@@ -1,0 +1,90 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { PaymentStrategy } from '..';
+import { PaymentActionCreator } from '../..';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { PaymentArgumentInvalidError } from '../../errors';
+import { PaymentRequestOptions } from '../../payment-request-options';
+
+export default class HummPaymentStrategy implements PaymentStrategy {
+    constructor(
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _formPoster: FormPoster
+    ) { }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+
+        if (!payment?.methodId) {
+            throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+        try {
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({methodId: payment.methodId}));
+        } catch (error) {
+            if (this._isOffsiteRedirectResponse(error)) {
+                return this._handleOffsiteRedirectResponse(error);
+            }
+
+            return Promise.reject(error);
+        }
+    }
+
+    finalize(): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    initialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _handleOffsiteRedirectResponse(response: OffsiteRedirectResponse): Promise<never> {
+        const url = response.body.additional_action_required.data.redirect_url;
+        const data = response.body.provider_data;
+
+        return new Promise(() => {
+            this._formPoster.postForm(url, JSON.parse(data));
+        });
+    }
+
+    private _isOffsiteRedirectResponse(response: unknown): response is OffsiteRedirectResponse {
+        if (typeof response !== 'object' || response === null) {
+            return false;
+        }
+
+        const partialResponse: Partial<OffsiteRedirectResponse> = response;
+
+        if (!partialResponse.body) {
+            return false;
+        }
+
+        const partialBody: Partial<OffsiteRedirectResponse['body']> = partialResponse.body;
+
+        return partialBody.status === 'additional_action_required'
+            && !!partialBody.additional_action_required
+            && partialBody.additional_action_required.type === 'offsite_redirect'
+            && typeof partialBody.provider_data === 'string';
+    }
+}
+
+interface OffsiteRedirectResponse {
+    body: {
+        additional_action_required: {
+            type: 'offsite_redirect';
+            data: {
+                redirect_url: string;
+            };
+        };
+        status: string;
+        provider_data: string;
+    };
+}

--- a/src/payment/strategies/humm/index.ts
+++ b/src/payment/strategies/humm/index.ts
@@ -1,0 +1,1 @@
+export { default as HummPaymentStrategy } from './humm-payment-strategy';


### PR DESCRIPTION
## What? [INT-4897](https://jira.bigcommerce.com/browse/INT-4897)
Adding humm payment in the registry as external payment

## Why?
it's required to support humm

## Testing / Proof
![image](https://user-images.githubusercontent.com/4907027/136618521-650c2254-f170-42cb-bc00-165612b2cfe8.png)

@bigcommerce/checkout @bigcommerce/payments 
