### PR TITLE
feat(payment): BOLT-73 send orderId during payment creation for Bolt Full Ckeckout

### DIFF
--- a/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -5,7 +5,7 @@ import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, Checkout, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
-import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { getCheckout, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
@@ -53,7 +53,7 @@ describe('BoltPaymentStrategy', () => {
     let submitPaymentAction: Observable<SubmitPaymentAction>;
 
     beforeEach(() => {
-        store = createCheckoutStore(getCheckoutStoreState());
+        store = createCheckoutStore(getCheckoutStoreStateWithOrder());
         paymentMethodMock = getBolt();
         scriptLoader = createScriptLoader();
         requestSender = createRequestSender();
@@ -284,6 +284,7 @@ describe('BoltPaymentStrategy', () => {
             await strategy.initialize(boltTakeOverInitializationOptions);
             await strategy.execute(payload);
             expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+            expect(boltClient.setOrderId).toHaveBeenCalled();
             expect(boltClient.getTransactionReference).toHaveBeenCalled();
             expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expectedPayment);
@@ -303,6 +304,7 @@ describe('BoltPaymentStrategy', () => {
             }
 
             expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+            expect(boltClient.setOrderId).toHaveBeenCalled();
             expect(boltClient.getTransactionReference).toHaveBeenCalled();
             expect(store.dispatch).not.toHaveBeenCalledWith(submitPaymentAction);
             expect(paymentActionCreator.submitPayment).not.toHaveBeenCalledWith(expectedPayment);

--- a/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -252,6 +252,8 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
 
         await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
+        await this._setBoltOrderId();
+
         const transactionReference = await boltClient.getTransactionReference();
 
         if (!transactionReference) {
@@ -296,6 +298,18 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
 
         try {
             return await boltClient.hasBoltAccount(email);
+        } catch {
+            throw new PaymentMethodInvalidError();
+        }
+    }
+
+    private async _setBoltOrderId() {
+        const state = this._store.getState();
+        const order = state.order.getOrderOrThrow();
+        const boltClient = this._getBoltClient();
+
+        try {
+            await boltClient.setOrderId(order.orderId);
         } catch {
             throw new PaymentMethodInvalidError();
         }

--- a/src/payment/strategies/bolt/bolt.mock.ts
+++ b/src/payment/strategies/bolt/bolt.mock.ts
@@ -9,6 +9,7 @@ export function getBoltClientScriptMock(shouldSucceed: boolean = false): BoltChe
         hasBoltAccount: jest.fn(),
         openCheckout: jest.fn(),
         setClientCustomCallbacks: jest.fn(),
+        setOrderId: jest.fn(),
     };
 }
 

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -9,6 +9,7 @@ export interface BoltCheckout {
     getTransactionReference(): Promise<string | undefined>;
     openCheckout(email: string, callbacks?: BoltOpenCheckoutCallbacks): void;
     setClientCustomCallbacks(callbacks: BoltCallbacks): void;
+    setOrderId(orderId: number): void;
 }
 
 export interface BoltOpenCheckoutCallbacks {


### PR DESCRIPTION
## What?
Send `orderId` using `boltClient.setOrderId` during payment creation 

## Why?
When BigCommerce creates an order, Bolt needs to know `order_id` early to use it during payment creation. Bolt team asked us to pass current `orderId` through `boltClient.setOrderId` method to fix the issue that they have.

## Testing / Proof
Unit tests
