### PR TITLE
feat(payment): INT-4917 Add logo property to PaymentMethodCon…

### DIFF
--- a/src/payment/payment-method-config.ts
+++ b/src/payment/payment-method-config.ts
@@ -9,6 +9,7 @@ export default interface PaymentMethodConfig {
     isVaultingCvvEnabled?: boolean;
     isVaultingEnabled?: boolean;
     isVisaCheckoutEnabled?: boolean;
+    logo?: string;
     merchantId?: string;
     redirectUrl?: string;
     requireCustomerCode?: boolean;


### PR DESCRIPTION
…fig interface

## What? [INT-4917](https://jira.bigcommerce.com/browse/INT-4917)
Added a new property called `logo` to the `PaymentMethodConfig` interface.

## Why?
This new property contains the saved logo from the Openpay settings page on the checkout page.

## Testing / Proof
`GET /api/storefront/payments`

![image](https://user-images.githubusercontent.com/4843328/138170906-d081fac9-d13f-4b1b-9585-78359135dae8.png)

## Depends on
https://github.com/bigcommerce/bigcommerce/pull/43234 to get the new property.

## Dependency of
https://github.com/bigcommerce/checkout-js/pull/731 to recognize the new property.

@bigcommerce/checkout @bigcommerce/payments
