### PR TITLE
fix(payment): BOLT-79 Discount isn't applied to bolt modal

### DIFF
--- a/src/customer/strategies/bolt/bolt-customer-strategy.spec.ts
+++ b/src/customer/strategies/bolt/bolt-customer-strategy.spec.ts
@@ -47,6 +47,7 @@ describe('BoltCustomerStrategy', () => {
         boltCheckout.configure = jest.fn();
         boltCheckout.setClientCustomCallbacks = jest.fn();
         boltCheckout.openCheckout = jest.fn();
+        boltCheckout.reloadBigCommerceCart = jest.fn();
         boltCheckout.hasBoltAccount = jest.fn();
 
         boltScriptLoader = new BoltScriptLoader(scriptLoader);
@@ -226,6 +227,7 @@ describe('BoltCustomerStrategy', () => {
             await strategy.executePaymentMethodCheckout(options);
 
             expect(boltCheckout.hasBoltAccount).toHaveBeenCalledWith('test@bigcommerce.com');
+            expect(boltCheckout.reloadBigCommerceCart).toHaveBeenCalled();
             expect(boltCheckout.openCheckout).toHaveBeenCalled();
         });
 
@@ -247,6 +249,7 @@ describe('BoltCustomerStrategy', () => {
             await strategy.executePaymentMethodCheckout(options);
 
             expect(boltCheckout.hasBoltAccount).toHaveBeenCalledWith('test@bigcommerce.com');
+            expect(boltCheckout.reloadBigCommerceCart).toHaveBeenCalled();
             expect(boltCheckout.openCheckout).toHaveBeenCalled();
             expect(mockCallback.mock.calls.length).toBe(1);
         });

--- a/src/customer/strategies/bolt/bolt-customer-strategy.ts
+++ b/src/customer/strategies/bolt/bolt-customer-strategy.ts
@@ -105,7 +105,7 @@ export default class BoltCustomerStrategy implements CustomerStrategy {
                         },
                     };
 
-                    boltClient.reloadBigCommerceCart();
+                    await boltClient.reloadBigCommerceCart();
                     await boltClient.openCheckout(email, callbacks);
                 } else {
                     continueWithCheckoutCallback();

--- a/src/customer/strategies/bolt/bolt-customer-strategy.ts
+++ b/src/customer/strategies/bolt/bolt-customer-strategy.ts
@@ -105,6 +105,7 @@ export default class BoltCustomerStrategy implements CustomerStrategy {
                         },
                     };
 
+                    boltClient.reloadBigCommerceCart();
                     await boltClient.openCheckout(email, callbacks);
                 } else {
                     continueWithCheckoutCallback();

--- a/src/payment/strategies/bolt/bolt.mock.ts
+++ b/src/payment/strategies/bolt/bolt.mock.ts
@@ -10,6 +10,7 @@ export function getBoltClientScriptMock(shouldSucceed: boolean = false): BoltChe
         openCheckout: jest.fn(),
         setClientCustomCallbacks: jest.fn(),
         setOrderId: jest.fn(),
+        reloadBigCommerceCart: jest.fn(),
     };
 }
 

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -10,7 +10,7 @@ export interface BoltCheckout {
     openCheckout(email: string, callbacks?: BoltOpenCheckoutCallbacks): void;
     setClientCustomCallbacks(callbacks: BoltCallbacks): void;
     setOrderId(orderId: number): void;
-    reloadBigCommerceCart(): void;
+    reloadBigCommerceCart(): Promise<void>;
 }
 
 export interface BoltOpenCheckoutCallbacks {

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -10,6 +10,7 @@ export interface BoltCheckout {
     openCheckout(email: string, callbacks?: BoltOpenCheckoutCallbacks): void;
     setClientCustomCallbacks(callbacks: BoltCallbacks): void;
     setOrderId(orderId: number): void;
+    reloadBigCommerceCart(): void;
 }
 
 export interface BoltOpenCheckoutCallbacks {


### PR DESCRIPTION
## What?
Fix bug [BOLT-79](https://jira.bigcommerce.com/browse/BOLT-79) Discount isn't applied to bolt modal

## Why?
Because of the task: [https://jira.bigcommerce.com/browse/BOLT-79](https://jira.bigcommerce.com/browse/BOLT-79)

## Testing / Proof
Before:
![Screenshot 2021-10-20 at 15 40 05](https://user-images.githubusercontent.com/9430298/138094595-71315895-447e-4fd2-829d-ce26147c19ca.png)

After:
![Screenshot 2021-10-20 at 15 40 50](https://user-images.githubusercontent.com/9430298/138094635-a38eef05-d86d-4328-86ab-972b34668976.png)

Tests:
<img width="276" alt="Screenshot 2021-10-20 at 15 18 23" src="https://user-images.githubusercontent.com/9430298/138092525-21207e59-6c99-4f06-b8bc-82c73b54518b.png">


@bigcommerce/checkout @bigcommerce/payments
