### PR TITLE
feat(payment): BOLT-78 changed background color for mounted Bolt payment field

### DIFF
--- a/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -318,7 +318,8 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
     private _mountBoltEmbeddedField(containerId: string) {
         const boltEmbedded = this._getBoltEmbedded();
 
-        const embeddedField = boltEmbedded.create('payment_field');
+        const styles = { backgroundColor: '#fff' };
+        const embeddedField = boltEmbedded.create('payment_field', { styles });
         embeddedField.mount(`#${containerId}`);
 
         this._embeddedField = embeddedField;

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -16,8 +16,12 @@ export interface BoltOpenCheckoutCallbacks {
     close?(): void;
 }
 
+export interface BoltEmbeddedOptions {
+    styles: { backgroundColor: string };
+}
+
 export interface BoltEmbedded {
-    create(name: string): BoltEmbededField;
+    create(name: string, options?: BoltEmbeddedOptions): BoltEmbededField;
 }
 
 export interface BoltEmbededField {


### PR DESCRIPTION
## What?
Changed background color for mounted Bolt payment field 

## Why?
Because the field had almost the same background as the parent's block that confused our beta merchants

## Testing / Proof
Here is a screenshot of the field with updated background color:
<img width="565" alt="Screenshot 2021-10-21 at 13 13 21" src="https://user-images.githubusercontent.com/25133454/138263200-cc8fa31e-07ce-4ede-9e62-f7d9b978f6b5.png">


@bigcommerce/checkout @bigcommerce/payments
