### PR TITLE
fix(payment): PAYMENTS-7390 use location.assign in PPSDK redirects to maintain correct browser history

### DIFF
--- a/src/payment/strategies/ppsdk/step-handler/continue-handler/redirect.spec.ts
+++ b/src/payment/strategies/ppsdk/step-handler/continue-handler/redirect.spec.ts
@@ -9,7 +9,7 @@ describe('handleRedirect', () => {
         it('calls location assign with the url, never resolves or rejects', () => {
             const resolveMock = jest.fn();
             const rejectMock = jest.fn();
-            const assignSpy = jest.spyOn(window.location, 'replace').mockImplementation(jest.fn);
+            const assignSpy = jest.spyOn(window.location, 'assign').mockImplementation(jest.fn);
 
             const redirectContinueResponse = {
                 url: 'http://some-url.com',

--- a/src/payment/strategies/ppsdk/step-handler/continue-handler/redirect.ts
+++ b/src/payment/strategies/ppsdk/step-handler/continue-handler/redirect.ts
@@ -33,7 +33,7 @@ export const handleRedirect = ({ url, formFields }: Parameters, formPoster: Form
     if (formFields) {
         formPoster.postForm(url, formFields);
     } else {
-        window.location.replace(url);
+        window.location.assign(url);
     }
 
     return new Promise(noop);


### PR DESCRIPTION
**N.B.** No live payment providers are currently using this flow

## What?

- Change PPSDK redirects to use `location.assign` instead of `location.replace`

## Why?

- When we move users on to a 3rd party website to collect payment, they may change their minds and want to return
- `assign` maintains the true navigation history, allowing user to use the browsers back button to return to the checkout page

## Testing / Proof

- Updated passing tests

@bigcommerce/checkout @bigcommerce/payments
