### PR TITLE
fix(payment): PAYMENTS-7408 suppress repeated thrown errors when resuming a PPSDK payment

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -5,6 +5,7 @@ import { createScriptLoader, getScriptLoader, getStylesheetLoader } from '@bigco
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
 import { LoadingIndicator } from '../common/loading-indicator';
+import { BrowserStorage } from '../common/storage';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { HostedFormFactory } from '../hosted-form';
@@ -625,7 +626,8 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             createPaymentProcessorRegistry(requestSender, stepHandler),
-            new PaymentResumer(requestSender, stepHandler)
+            new PaymentResumer(requestSender, stepHandler),
+            new BrowserStorage('PPSDK')
         )
     );
 

--- a/src/payment/strategies/ppsdk/ppsdk-completed-payments.spec.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-completed-payments.spec.ts
@@ -1,0 +1,19 @@
+import { BrowserStorage } from '../../../common/storage';
+
+import { PPSDKCompletedPayments } from './ppsdk-completed-payments';
+
+it('returns true for a matching paymentId', () => {
+    const completedPayments = new PPSDKCompletedPayments(new BrowserStorage('ppsdk'));
+
+    completedPayments.setCompleted('123');
+
+    expect(completedPayments.isCompleted('123')).toBe(true);
+});
+
+it('returns false for a non-matching paymentId', () => {
+    const completedPayments = new PPSDKCompletedPayments(new BrowserStorage('ppsdk'));
+
+    completedPayments.setCompleted('123');
+
+    expect(completedPayments.isCompleted('456')).toBe(false);
+});

--- a/src/payment/strategies/ppsdk/ppsdk-completed-payments.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-completed-payments.ts
@@ -1,0 +1,30 @@
+import { BrowserStorage } from '../../../common/storage';
+
+type CompletedPayments = string[];
+const COMPLETED_PAYMENTS_KEY = 'completed-payments';
+
+export class PPSDKCompletedPayments {
+    constructor(
+        private _browserStorage: BrowserStorage
+    ) { }
+
+    isCompleted(paymentId: string): boolean {
+        return this.getCompletedPayments().indexOf(paymentId) >= 0;
+    }
+
+    setCompleted(paymentId: string): void {
+        const completedPayments = this.getCompletedPayments();
+
+        completedPayments.push(paymentId);
+
+        this.setCompletedPayments(completedPayments);
+    }
+
+    private getCompletedPayments(): CompletedPayments {
+        return this._browserStorage.getItem<CompletedPayments>(COMPLETED_PAYMENTS_KEY) || [];
+    }
+
+    private setCompletedPayments(completedPayments: CompletedPayments): void {
+        this._browserStorage.setItem<CompletedPayments>(COMPLETED_PAYMENTS_KEY, completedPayments);
+    }
+}


### PR DESCRIPTION
## What?

- When trying to resume a PPSDK payment which has failed or errored: re-throw the original error once, then fallback to throwing only `OrderFinalizationNotRequiredError` if repeated
- The 'repeated' nature is deduced by storing payment IDs which have resulting in errors or failure in local storage (via the `BrowserStorage` class)

## Why?

- To consider the consumer 'notified' with the first error thrown
- In practice (with `checkout-js`) this leads to only one error modal being displayed (rather than the same one over and over with refreshes or repeated attempts to finalise the payment)

## Testing / Proof

- Updated tests

@bigcommerce/checkout @bigcommerce/payments
