### PR TITLE
feat(payment): CHECKOUT-6067 Filter applepay based on browser

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -660,7 +660,7 @@ describe('CheckoutService', () => {
         it('returns payment methods', async () => {
             const state = await checkoutService.loadPaymentMethods();
 
-            expect(state.data.getPaymentMethods()).toEqual(getPaymentMethods());
+            expect(state.data.getPaymentMethods()).toEqual(getPaymentMethods().filter(method => method.id !== 'applepay'));
         });
 
         it('dispatches action with queue id', async () => {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,0 @@
-interface Window {
-    ApplePaySession(): void;
-}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+    ApplePaySession(): void;
+}

--- a/src/payment/payment-method-action-creator.spec.ts
+++ b/src/payment/payment-method-action-creator.spec.ts
@@ -52,7 +52,7 @@ describe('PaymentMethodActionCreator', () => {
                 { type: PaymentMethodActionType.LoadPaymentMethodsRequested },
                 {
                     type: PaymentMethodActionType.LoadPaymentMethodsSucceeded,
-                    payload: paymentMethodsResponse.body,
+                    payload: paymentMethodsResponse.body.filter(method => method.id !== 'applepay'),
                     meta: {
                         deviceSessionId: paymentMethodsResponse.headers['x-device-session-id'],
                         sessionHash: paymentMethodsResponse.headers['x-session-hash'],

--- a/src/payment/payment-method-action-creator.ts
+++ b/src/payment/payment-method-action-creator.ts
@@ -4,8 +4,11 @@ import { Observable, Observer } from 'rxjs';
 import { cachableAction, ActionOptions } from '../common/data-store';
 import { RequestOptions } from '../common/http-request';
 
+import { PaymentMethod } from '.';
 import { LoadPaymentMethodsAction, LoadPaymentMethodAction, PaymentMethodActionType } from './payment-method-actions';
 import PaymentMethodRequestSender from './payment-method-request-sender';
+
+const APPLEPAYID = 'applepay';
 
 export default class PaymentMethodActionCreator {
     constructor(
@@ -23,7 +26,7 @@ export default class PaymentMethodActionCreator {
                         sessionHash: response.headers['x-session-hash'],
                     };
 
-                    observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, response.body, meta));
+                    observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, this._filterApplePay(response.body), meta));
                     observer.complete();
                 })
                 .catch(response => {
@@ -45,6 +48,16 @@ export default class PaymentMethodActionCreator {
                 .catch(response => {
                     observer.error(createErrorAction(PaymentMethodActionType.LoadPaymentMethodFailed, response, { methodId }));
                 });
+        });
+    }
+
+    private _filterApplePay(methods: PaymentMethod[]): PaymentMethod[] {
+        return methods.filter(method => {
+            if (method.id === APPLEPAYID && typeof window.ApplePaySession !== 'function') {
+                return false;
+            }
+
+            return true;
         });
     }
 }

--- a/src/payment/payment-method-action-creator.ts
+++ b/src/payment/payment-method-action-creator.ts
@@ -7,6 +7,7 @@ import { RequestOptions } from '../common/http-request';
 import { PaymentMethod } from '.';
 import { LoadPaymentMethodsAction, LoadPaymentMethodAction, PaymentMethodActionType } from './payment-method-actions';
 import PaymentMethodRequestSender from './payment-method-request-sender';
+import { isApplePayWindow } from './strategies/apple-pay';
 
 const APPLEPAYID = 'applepay';
 
@@ -53,7 +54,7 @@ export default class PaymentMethodActionCreator {
 
     private _filterApplePay(methods: PaymentMethod[]): PaymentMethod[] {
         return methods.filter(method => {
-            if (method.id === APPLEPAYID && typeof window.ApplePaySession !== 'function') {
+            if (method.id === APPLEPAYID && !isApplePayWindow(window)) {
                 return false;
             }
 

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -786,7 +786,49 @@ export function getPaymentMethods(): PaymentMethod[] {
         getMoneris(),
         getPPSDK(),
         getUnsupportedPPSDK(),
+        getApplePay(),
     ];
+}
+
+export function getApplePay() {
+    return {
+        id: 'applepay',
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: [],
+        providesShippingAddress: true,
+        config: {
+            displayName: '',
+            helpText: '',
+            testMode: false,
+            requireCustomerCode: false,
+            isVaultingEnabled: false,
+            hasDefaultStoredInstrument: false,
+            isHostedFormEnabled: false,
+        },
+        type: 'PAYMENT_TYPE_WALLET',
+        initializationStrategy: {
+            type: 'not_applicable',
+        },
+        nonce: undefined,
+        initializationData: {
+            storeName: 'test store',
+            countryCode: 'US',
+            currencyCode: 'USD',
+            supportedNetworks: [
+                'visa',
+                'masterCard',
+                'amex',
+                'discover',
+            ],
+            gateway: 'adyenv2',
+            merchantCapabilities: [
+                'supports3DS',
+            ],
+            merchantId: 'abc',
+            paymentsUrl: 'https://bigpay.service.bcdev',
+        },
+    };
 }
 
 export function getPaymentMethodsMeta() {

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -796,7 +796,7 @@ export function getApplePay() {
         logoUrl: '',
         method: 'credit-card',
         supportedCards: [],
-        providesShippingAddress: true,
+        providesShippingAddress: false,
         config: {
             displayName: '',
             helpText: '',

--- a/src/payment/strategies/apple-pay/index.ts
+++ b/src/payment/strategies/apple-pay/index.ts
@@ -1,0 +1,1 @@
+export { ApplePayWindow, default as isApplePayWindow } from './is-apple-pay-window';

--- a/src/payment/strategies/apple-pay/is-apple-pay-window.ts
+++ b/src/payment/strategies/apple-pay/is-apple-pay-window.ts
@@ -1,0 +1,7 @@
+export interface ApplePayWindow extends Window {
+    ApplePaySession(): void;
+}
+
+export default function isApplePayWindow(window: Window): window is ApplePayWindow {
+    return 'ApplePaySession' in window;
+}


### PR DESCRIPTION
## What?
Filter apple pay based on the brower

## Why?
Since applepay only works in safari, therefore filter apple pay from the list of payment methods that are sent to checkout if the browser used is not safari.

## Future changes
- Update the interface of `ApplePaySession` on window object as per what is defined by apple.
- There is more filtering of payment methods that is done in checkout-js, move that logic slowly to SDK as well

## Testing / Proof
- Unit tests
- Screenshot

## Safari
<img width="1680" alt="Screen Shot 2021-11-03 at 3 34 40 pm" src="https://user-images.githubusercontent.com/7134802/140010443-dd38bb1f-e7b7-4551-aa44-d0f56b05120b.png">

## Chrome
![Screen Shot 2021-11-03 at 3 36 55 pm (2)](https://user-images.githubusercontent.com/7134802/140010545-2cdcc979-9b3e-4fdc-9590-e91acafa7817.png)

@bigcommerce/checkout
