### PR TITLE
feat(payment): INT-5000 Throw error when payment method isn't available

### DIFF
--- a/src/payment/strategies/digitalriver/digitalriver-error.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-error.spec.ts
@@ -1,0 +1,11 @@
+import DigitalRiverError from './digitalriver-error';
+
+describe('DigitalRiverError', () => {
+    it('returns error name, type and message', () => {
+        const error = new DigitalRiverError('payment.digitalriver_checkout_error', 'digitalRiverCheckoutError');
+
+        expect(error.name).toEqual('digitalRiverCheckoutError');
+        expect(error.type).toEqual('payment.digitalriver_checkout_error');
+        expect(error.message).toEqual('There was an error while processing your payment. Please try again or contact us.');
+    });
+});

--- a/src/payment/strategies/digitalriver/digitalriver-error.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-error.ts
@@ -1,0 +1,12 @@
+import { StandardError } from '../../../common/error/errors';
+
+const defaultMessage: string = 'There was an error while processing your payment. Please try again or contact us.';
+
+export default class DigitalRiverError extends StandardError {
+    constructor(type: string, name: string, message?: string) {
+        super(message || defaultMessage);
+
+        this.type = type;
+        this.name = name;
+    }
+}

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -28,6 +28,7 @@ import { getVaultedInstrument } from '../../payments.mock';
 import { getAdditionalActionError, getClientMock, getDigitalRiverJSMock, getDigitalRiverPaymentMethodMock, getInitializeOptionsMock, getOrderRequestBodyWithVaultedInstrument } from '../digitalriver/digitalriver.mock';
 
 import { AuthenticationSourceStatus, OnCancelOrErrorResponse, OnSuccessResponse } from './digitalriver';
+import DigitalRiverError from './digitalriver-error';
 import DigitalRiverPaymentStrategy from './digitalriver-payment-strategy';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
 
@@ -269,13 +270,11 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when load response is empty or not provided', () => {
-            const error = 'There was a problem with your checkout, please check your details and try again or contact customer service.';
-
             jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(undefined));
 
             const promise = strategy.initialize(options);
 
-            return expect(promise).rejects.toThrow(error);
+            return expect(promise).rejects.toThrowError(DigitalRiverError);
         });
 
         it('throws an error when DigitalRiver options is not provided', () => {
@@ -288,23 +287,21 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when DigitalRiver clientToken is not provided', () => {
-            const error = new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service.');
             paymentMethodMock = {...getDigitalRiverPaymentMethodMock(), clientToken: ''};
             loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, {methodId: paymentMethodMock.id}));
 
             const promise = strategy.initialize(options);
 
-            return expect(promise).rejects.toThrow(error);
+            return expect(promise).rejects.toThrowError(DigitalRiverError);
         });
 
         it('throws an error when DigitalRiver clientToken is not receiving correct data ', () => {
-            const error = new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service.');
             paymentMethodMock = {...getDigitalRiverPaymentMethodMock(), clientToken: 'ok'};
             loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, {methodId: paymentMethodMock.id}));
 
             const promise = strategy.initialize(options);
 
-            return expect(promise).rejects.toThrow(error);
+            return expect(promise).rejects.toThrowError(DigitalRiverError);
         });
 
         it('throws an error when data on onSuccess event is not provided', async () => {

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -8,7 +8,7 @@ import { of, Observable } from 'rxjs';
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { createCheckoutStore, Checkout, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { getCustomer } from '../../../customer/customers.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
@@ -269,7 +269,7 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when load response is empty or not provided', () => {
-            const error = 'Unable to proceed because the payment step of checkout has not been initialized.';
+            const error = 'There was a problem with your checkout, please check your details and try again or contact customer service';
 
             jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(undefined));
 
@@ -288,7 +288,7 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when DigitalRiver clientToken is not provided', () => {
-            const error = new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            const error = new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service');
             paymentMethodMock = {...getDigitalRiverPaymentMethodMock(), clientToken: ''};
             loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, {methodId: paymentMethodMock.id}));
 
@@ -298,7 +298,7 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when DigitalRiver clientToken is not receiving correct data ', () => {
-            const error = new Error('Unexpected token o in JSON at position 0');
+            const error = new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service');
             paymentMethodMock = {...getDigitalRiverPaymentMethodMock(), clientToken: 'ok'};
             loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, {methodId: paymentMethodMock.id}));
 

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -269,7 +269,7 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when load response is empty or not provided', () => {
-            const error = 'There was a problem with your checkout, please check your details and try again or contact customer service';
+            const error = 'There was a problem with your checkout, please check your details and try again or contact customer service.';
 
             jest.spyOn(digitalRiverScriptLoader, 'load').mockReturnValue(Promise.resolve(undefined));
 
@@ -288,7 +288,7 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when DigitalRiver clientToken is not provided', () => {
-            const error = new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service');
+            const error = new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service.');
             paymentMethodMock = {...getDigitalRiverPaymentMethodMock(), clientToken: ''};
             loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, {methodId: paymentMethodMock.id}));
 
@@ -298,7 +298,7 @@ describe('DigitalRiverPaymentStrategy', () => {
         });
 
         it('throws an error when DigitalRiver clientToken is not receiving correct data ', () => {
-            const error = new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service');
+            const error = new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service.');
             paymentMethodMock = {...getDigitalRiverPaymentMethodMock(), clientToken: 'ok'};
             loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, {methodId: paymentMethodMock.id}));
 

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -208,7 +208,8 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
     }
 
     private async _loadWidget(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
-        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(options.methodId)).then(async state => {
+        try {
+            const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(options.methodId));
             const billing = state.billingAddress.getBillingAddressOrThrow();
             const customer = state.customer.getCustomerOrThrow();
             const {paymentMethodConfiguration} = this._getDigitalRiverInitializeOptions().configuration;
@@ -264,12 +265,12 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
             this._digitalRiverDropComponent.mount(containerId);
 
             return state;
-        }).catch(() => {
+        } catch {
             throw new DigitalRiverError(
                 'payment.digitalriver_checkout_error',
                 'digitalRiverCheckoutError'
             );
-        });
+        }
     }
 
     private _isAuthenticateSourceAction(error: unknown): boolean {

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -264,7 +264,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
 
             return state;
         }).catch(() => {
-            throw new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service');
+            throw new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service.');
         });
     }
 

--- a/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -13,6 +13,7 @@ import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-r
 import PaymentStrategy from '../payment-strategy';
 
 import DigitalRiverJS, { AuthenticationSourceStatus, DigitalRiverAdditionalProviderData, DigitalRiverAuthenticateSourceResponse, DigitalRiverDropIn, DigitalRiverElementOptions, DigitalRiverInitializeToken, OnCancelOrErrorResponse, OnReadyResponse, OnSuccessResponse } from './digitalriver';
+import DigitalRiverError from './digitalriver-error';
 import DigitalRiverPaymentInitializeOptions from './digitalriver-payment-initialize-options';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
 
@@ -264,7 +265,10 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
 
             return state;
         }).catch(() => {
-            throw new InvalidArgumentError('There was a problem with your checkout, please check your details and try again or contact customer service.');
+            throw new DigitalRiverError(
+                'payment.digitalriver_checkout_error',
+                'digitalRiverCheckoutError'
+            );
         });
     }
 


### PR DESCRIPTION
[INT-5000](https://jira.bigcommerce.com/browse/INT-5000)
## What?
I added a validation when the payment method isn't available to explain the shopper what is happening, instead of do nothing

## Why?
Digital River requested it because the shopper doesn't know what happened if the drop in element isn't rendered
![image](https://user-images.githubusercontent.com/35146660/140789462-89b14ae8-00e1-4265-b308-06eb892cf356.png)


## Testing / Proof
![image](https://user-images.githubusercontent.com/35146660/140583098-f2e479d4-9791-48d1-979c-5ead3c2ea3b9.png)
![image](https://user-images.githubusercontent.com/35146660/140789241-9675dad3-6741-4b15-bf25-dec1d779cb91.png)

## Dependency Of
https://github.com/bigcommerce/checkout-js/pull/748

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
