### PR TITLE
feat(payment): INT-4893 Retrieve initialization data from Humm

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -481,7 +481,8 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
-            formPoster
+            formPoster,
+            paymentMethodActionCreator
         )
     );
 

--- a/src/payment/errors/index.ts
+++ b/src/payment/errors/index.ts
@@ -6,3 +6,4 @@ export { default as PaymentMethodDeclinedError } from './payment-method-declined
 export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';
 export { default as PaymentInstrumentNotValidError } from './payment-instrument-not-valid-error';
 export { default as PaymentInvalidFormError, PaymentInvalidFormErrorDetails } from './payment-invalid-form-error';
+export { default as PaymentExecuteError } from './payment-execute-error';

--- a/src/payment/errors/payment-execute-error.spec.ts
+++ b/src/payment/errors/payment-execute-error.spec.ts
@@ -1,0 +1,16 @@
+import PaymentExecuteError from './payment-execute-error';
+
+describe('ExecuteError', () => {
+    it('returns error name, type and message', () => {
+        const error = new PaymentExecuteError(
+            'payment.humm_not_processable_error',
+            'hummNotProcessableError',
+            'Humm cannot process your payment for this order, please select another payment method.'
+        );
+
+        expect(error.name).toEqual('hummNotProcessableError');
+        expect(error.type).toEqual('custom_provider_execute_error');
+        expect(error.subtype).toEqual('payment.humm_not_processable_error');
+        expect(error.message).toEqual('Humm cannot process your payment for this order, please select another payment method.');
+    });
+});

--- a/src/payment/errors/payment-execute-error.ts
+++ b/src/payment/errors/payment-execute-error.ts
@@ -1,0 +1,15 @@
+import { StandardError } from '../../common/error/errors';
+
+const defaultMessage: string = 'Payment cannot be processed for this order, please select another payment method';
+
+export default class PaymentExecuteError extends StandardError {
+    type = 'custom_provider_execute_error';
+    subtype: string;
+
+    constructor(subtype: string, name: string, message?: string) {
+        super(message || defaultMessage);
+
+        this.name = name;
+        this.subtype = subtype;
+    }
+}

--- a/src/payment/strategies/humm/humm-payment-strategy.spec.ts
+++ b/src/payment/strategies/humm/humm-payment-strategy.spec.ts
@@ -8,12 +8,12 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { InvalidArgumentError, RequestError } from '../../../common/error/errors';
+import { RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
-import { PaymentArgumentInvalidError } from '../../errors';
+import { PaymentArgumentInvalidError, PaymentExecuteError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
@@ -132,11 +132,11 @@ describe('HummPaymentStrategy', () => {
             expect(formPoster.postForm).toHaveBeenCalledWith('https://sandbox-payment.humm.com', {data: 'data'});
         });
 
-        it('throws InvalidArgumentError when not processable', async () => {
+        it('throws PaymentExecuteError when not processable', async () => {
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                 .mockReturnValue({ ...getHumm(), initializationData: { processable: false }});
 
-            await expect(strategy.execute(payload)).rejects.toThrow(InvalidArgumentError);
+            await expect(strategy.execute(payload)).rejects.toThrow(PaymentExecuteError);
         });
 
         it('reject payment when error is different to additional_action_required', async () => {

--- a/src/payment/strategies/humm/humm-payment-strategy.spec.ts
+++ b/src/payment/strategies/humm/humm-payment-strategy.spec.ts
@@ -8,16 +8,18 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { RequestError } from '../../../common/error/errors';
+import { InvalidArgumentError, RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
-import { getHumm } from '../../../payment/payment-methods.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
 import { PaymentArgumentInvalidError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
+import { getHumm } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
@@ -32,6 +34,7 @@ describe('HummPaymentStrategy', () => {
     let payload: OrderRequestBody;
     let paymentActionCreator: PaymentActionCreator;
     let paymentMethod: PaymentMethod;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
     let submitOrderAction: Observable<Action>;
     let submitPaymentAction: Observable<Action>;
     let store: CheckoutStore;
@@ -50,6 +53,7 @@ describe('HummPaymentStrategy', () => {
             new PaymentRequestTransformer(),
             new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
         );
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
 
         paymentMethod = getHumm();
         payload = merge({}, getOrderRequestBody(), {
@@ -75,11 +79,18 @@ describe('HummPaymentStrategy', () => {
         jest.spyOn(formPoster, 'postForm')
             .mockReturnValue(Promise.resolve());
 
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+            .mockResolvedValue(store.getState());
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue({ ...getHumm(), initializationData: { processable: true }});
+
         strategy = new HummPaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,
-            formPoster
+            formPoster,
+            paymentMethodActionCreator
         );
 
     });
@@ -119,6 +130,13 @@ describe('HummPaymentStrategy', () => {
 
             await new Promise(resolve => process.nextTick(resolve));
             expect(formPoster.postForm).toHaveBeenCalledWith('https://sandbox-payment.humm.com', {data: 'data'});
+        });
+
+        it('throws InvalidArgumentError when not processable', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue({ ...getHumm(), initializationData: { processable: false }});
+
+            await expect(strategy.execute(payload)).rejects.toThrow(InvalidArgumentError);
         });
 
         it('reject payment when error is different to additional_action_required', async () => {

--- a/src/payment/strategies/humm/humm-payment-strategy.ts
+++ b/src/payment/strategies/humm/humm-payment-strategy.ts
@@ -3,9 +3,11 @@ import { FormPoster } from '@bigcommerce/form-poster';
 import { PaymentStrategy } from '..';
 import { PaymentActionCreator } from '../..';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { InvalidArgumentError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentRequestOptions } from '../../payment-request-options';
 
 export default class HummPaymentStrategy implements PaymentStrategy {
@@ -13,7 +15,8 @@ export default class HummPaymentStrategy implements PaymentStrategy {
         private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
-        private _formPoster: FormPoster
+        private _formPoster: FormPoster,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator
     ) { }
 
     async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
@@ -21,6 +24,12 @@ export default class HummPaymentStrategy implements PaymentStrategy {
 
         if (!payment?.methodId) {
             throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(payment.methodId, options));
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(payment.methodId);
+        if (!paymentMethod.initializationData?.processable) {
+            throw new InvalidArgumentError('Humm cannot process your payment for this order, please select another payment method');
         }
 
         await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));

--- a/src/payment/strategies/humm/humm-payment-strategy.ts
+++ b/src/payment/strategies/humm/humm-payment-strategy.ts
@@ -3,10 +3,9 @@ import { FormPoster } from '@bigcommerce/form-poster';
 import { PaymentStrategy } from '..';
 import { PaymentActionCreator } from '../..';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { InvalidArgumentError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentArgumentInvalidError } from '../../errors';
+import { PaymentArgumentInvalidError, PaymentExecuteError } from '../../errors';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentRequestOptions } from '../../payment-request-options';
 
@@ -29,7 +28,7 @@ export default class HummPaymentStrategy implements PaymentStrategy {
         const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(payment.methodId, options));
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(payment.methodId);
         if (!paymentMethod.initializationData?.processable) {
-            throw new InvalidArgumentError('Humm cannot process your payment for this order, please select another payment method');
+            throw new PaymentExecuteError('payment.humm_not_processable_error', 'hummNotProcessableError');
         }
 
         await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));


### PR DESCRIPTION
## What? [INT-4893](https://jira.bigcommerce.com/browse/INT-4893)
Retrieve additional data related to the method before start processing the payment

## Why?
We need the processable value to be able to start the payment process, it will be determined by some configuration set by the merchant in the settings page

## Testing / Proof
![image](https://user-images.githubusercontent.com/36899206/141188222-d773562a-c3bd-401f-83f3-78a2276d4339.png)
![image](https://user-images.githubusercontent.com/36899206/141188265-ef04c486-5aec-4c58-818c-ba1d1babf371.png)

ping @bigcommerce/apex-integrations @bigcommerce/payments 
