### PR TITLE
chore(payment): PAYMENTS-7402 rename PPSDK subStrategy method from process to execute

### DIFF
--- a/src/payment/strategies/ppsdk/ppsdk-strategy.spec.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.spec.ts
@@ -54,7 +54,7 @@ describe('PPSDKStrategy', () => {
                     it('submits the order and calls the sub-strategy', async () => {
                         const strategy = new PPSDKStrategy(store, orderActionCreator, subStrategyRegistry, paymentResumer, new BrowserStorage('ppsdk'));
 
-                        const mockSubStrategy = { process: jest.fn() };
+                        const mockSubStrategy = { execute: jest.fn() };
                         jest.spyOn(subStrategyRegistry, 'getByMethod').mockReturnValue(mockSubStrategy);
                         jest.spyOn(store.getState().order, 'getOrderMeta').mockReturnValue({ token: 'some-token' });
 
@@ -62,7 +62,7 @@ describe('PPSDKStrategy', () => {
                         await strategy.execute({}, { methodId: 'cabbagepay' });
 
                         expect(store.dispatch).toBeCalledWith(submitSpy.mock.results[0].value);
-                        expect(mockSubStrategy.process).toHaveBeenCalled();
+                        expect(mockSubStrategy.execute).toHaveBeenCalled();
                     });
                 });
             });
@@ -72,7 +72,7 @@ describe('PPSDKStrategy', () => {
                     it('throws a MissingDataError error, does not call the sub-strategy', async () => {
                         const strategy = new PPSDKStrategy(store, orderActionCreator, subStrategyRegistry, paymentResumer, new BrowserStorage('ppsdk'));
 
-                        const mockSubStrategy = { process: jest.fn() };
+                        const mockSubStrategy = { execute: jest.fn() };
                         jest.spyOn(subStrategyRegistry, 'getByMethod').mockReturnValue(mockSubStrategy);
                         jest.spyOn(store.getState().order, 'getOrderMeta').mockReturnValue({ token: undefined });
 
@@ -82,7 +82,7 @@ describe('PPSDKStrategy', () => {
                             .rejects.toBeInstanceOf(MissingDataError);
 
                         expect(store.dispatch).toBeCalledWith(submitSpy.mock.results[0].value);
-                        expect(mockSubStrategy.process).not.toHaveBeenCalled();
+                        expect(mockSubStrategy.execute).not.toHaveBeenCalled();
                     });
                 });
             });

--- a/src/payment/strategies/ppsdk/ppsdk-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.ts
@@ -49,7 +49,7 @@ export class PPSDKStrategy implements PaymentStrategy {
             throw new MissingDataError(MissingDataErrorType.MissingOrder);
         }
 
-        await subStrategy.process({ methodId, payment, bigpayBaseUrl, token });
+        await subStrategy.execute({ methodId, payment, bigpayBaseUrl, token });
 
         return this._store.getState();
     }

--- a/src/payment/strategies/ppsdk/ppsdk-sub-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-sub-strategy.ts
@@ -8,5 +8,5 @@ export interface SubStrategySettings {
 }
 
 export interface SubStrategy {
-    process(settings: SubStrategySettings): Promise<void>;
+    execute(settings: SubStrategySettings): Promise<void>;
 }

--- a/src/payment/strategies/ppsdk/sub-strategies/none-sub-strategy.spec.ts
+++ b/src/payment/strategies/ppsdk/sub-strategies/none-sub-strategy.spec.ts
@@ -11,12 +11,12 @@ describe('NoneSubStrategy', () => {
     const stepHandler = new StepHandler(new ContinueHandler(new FormPoster()));
     const noneSubStrategy = new NoneSubStrategy(requestSender, stepHandler);
 
-    describe('#process', () => {
+    describe('#execute', () => {
         it('posts the Payment Method ID to the BigPay Payments endpoint', async () => {
             const requestSenderSpy = jest.spyOn(requestSender, 'post').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await noneSubStrategy.process({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
+            await noneSubStrategy.execute({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(requestSenderSpy).toBeCalledWith(
                 'https://some-domain.com/payments',
@@ -35,7 +35,7 @@ describe('NoneSubStrategy', () => {
             jest.spyOn(requestSender, 'post').mockResolvedValue({ body: 'some-api-response' });
             const stepHandlerSpy = jest.spyOn(stepHandler, 'handle').mockResolvedValue({});
 
-            await noneSubStrategy.process({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
+            await noneSubStrategy.execute({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' });
 
             expect(stepHandlerSpy).toBeCalledWith({ body: 'some-api-response' });
         });
@@ -44,7 +44,7 @@ describe('NoneSubStrategy', () => {
             jest.spyOn(requestSender, 'post').mockResolvedValue({});
             jest.spyOn(stepHandler, 'handle').mockResolvedValue({ someValue: 12345 });
 
-            await expect(noneSubStrategy.process({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' }))
+            await expect(noneSubStrategy.execute({ methodId: 'some-id.some-method', bigpayBaseUrl: 'https://some-domain.com', token: 'some-token' }))
                 .resolves.toStrictEqual({ someValue: 12345 });
         });
     });

--- a/src/payment/strategies/ppsdk/sub-strategies/none-sub-strategy.ts
+++ b/src/payment/strategies/ppsdk/sub-strategies/none-sub-strategy.ts
@@ -10,7 +10,7 @@ export class NoneSubStrategy implements SubStrategy {
         private _stepHandler: StepHandler
     ) {}
 
-    process({ methodId, bigpayBaseUrl, token }: SubStrategySettings) {
+    execute({ methodId, bigpayBaseUrl, token }: SubStrategySettings) {
         const body = { payment_method_id: methodId };
         const options = {
             credentials: false,


### PR DESCRIPTION
## What?

- rename PPSDK subStrategy method from `process` to `execute`

## Why?

- to better replicate current strategy method naming conventions
- (will be joined by `deinitialise` in a future commit, furthering similarities)

## Testing / Proof

- Passing tests

@bigcommerce/checkout @bigcommerce/payments
