### PR TITLE
fix(payment): INT-5166 CKO mapping for vaulted instrument

### DIFF
--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -63,7 +63,7 @@ const supportedInstruments: SupportedInstruments = {
     },
     'checkoutcom.card': {
         provider: 'checkoutcom',
-        method: 'credit_card',
+        method: 'card',
     },
     stripe: {
         provider: 'stripe',


### PR DESCRIPTION
## What? [INT-5166](https://jira.bigcommerce.com/browse/INT-5166)
Set cko card method mapping to card instead of credit_card

## Why?
BigPay will now vault it, as card, so its required so storefront shows correctly the stored instrument

## Testing / Proof
![Screen Shot 2021-12-06 at 15 50 46](https://user-images.githubusercontent.com/8669574/144928400-57ad4e9d-abee-4d55-83d6-4ef350e65ed8.png)

## Dependency of
none

## Depends on
[BigPay](https://github.com/bigcommerce/bigpay/pull/4641)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
