### PR TITLE
feat(payment): BOLT-109 added extra check for transaction reference what comes from Bolt

### DIFF
--- a/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -3,7 +3,7 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitia
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { StoreCreditActionCreator } from '../../../store-credit';
-import { PaymentArgumentInvalidError, PaymentMethodCancelledError, PaymentMethodInvalidError } from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodCancelledError, PaymentMethodFailedError, PaymentMethodInvalidError } from '../../errors';
 import { withAccountCreation } from '../../index';
 import { NonceInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
@@ -137,7 +137,12 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
 
         const transaction: BoltTransaction = await new Promise((resolve, reject) => {
             const onSuccess = (transaction: BoltTransaction,  callback: () => void) => {
-                resolve(transaction);
+                if (!transaction.reference) {
+                    reject(new PaymentMethodFailedError('Unable to proceed because transaction reference is unavailable. Please try again later.'));
+                } else {
+                    resolve(transaction);
+                }
+
                 callback();
             };
 

--- a/src/payment/strategies/bolt/bolt.mock.ts
+++ b/src/payment/strategies/bolt/bolt.mock.ts
@@ -1,9 +1,9 @@
 import { BoltCallbacks, BoltCheckout, BoltClient, BoltEmbedded, BoltTransaction } from './bolt';
 
-export function getBoltClientScriptMock(shouldSucceed: boolean = false): BoltCheckout {
+export function getBoltClientScriptMock(shouldSucceed: boolean = false, isValidTransactionReference: boolean = true): BoltCheckout {
     return {
         configure: jest.fn((_cart: object, _hints: {}, callbacks?: BoltCallbacks) => {
-            return getConfiguredBoltMock(shouldSucceed, callbacks || { success: () => {}, close: () => {}});
+            return getConfiguredBoltMock(shouldSucceed, isValidTransactionReference, callbacks || { success: () => {}, close: () => {}});
         }),
         getTransactionReference: jest.fn(),
         hasBoltAccount: jest.fn(),
@@ -24,9 +24,9 @@ export function getBoltEmbeddedScriptMock(): BoltEmbedded {
     };
 }
 
-export function getConfiguredBoltMock(shouldSucceed: boolean, callbacks: BoltCallbacks): BoltClient {
+export function getConfiguredBoltMock(shouldSucceed: boolean, isValidTransactionReference: boolean, callbacks: BoltCallbacks): BoltClient {
     const mockTransaction: BoltTransaction = {
-        reference: 'transactionReference',
+        reference: isValidTransactionReference ? 'transactionReference' : '',
         id: 'id',
         status: 'complete',
         type: 'authorization',


### PR DESCRIPTION
## What?
Added extra check for transaction reference what comes from Bolt for safety

## Why?
To prevent the issue when we get empty transaction reference and passing it to nonce payment object before submit.

Due the task: https://jira.bigcommerce.com/browse/BOLT-109

## Testing / Proof
Manual tests
Unit tests

Screen recording: 
https://user-images.githubusercontent.com/25133454/145768738-e91f25a7-60eb-4eb4-8639-187875281d87.mov

Screenshot of the error:
<img width="828" alt="Screenshot 2021-12-10 at 18 47 34" src="https://user-images.githubusercontent.com/25133454/145768788-017ab74d-5adf-4147-bb0b-15fc8e30827e.png">


@bigcommerce/checkout @bigcommerce/payments
