### PR TITLE
feat(checkout): CHECKOUT-6248 Throw Custom Error When Tax Service Unavailable

### DIFF
--- a/src/order/errors/index.ts
+++ b/src/order/errors/index.ts
@@ -1,2 +1,3 @@
 export { default as OrderFinalizationNotRequiredError } from './order-finalization-not-required-error';
 export { default as OrderFinalizationNotCompletedError } from './order-finalization-not-completed-error';
+export { default as OrderTaxProviderUnavailableError } from './order-tax-provider-unavailable-error';

--- a/src/order/errors/order-tax-provider-unavailable-error.spec.ts
+++ b/src/order/errors/order-tax-provider-unavailable-error.spec.ts
@@ -1,0 +1,9 @@
+import OrderTaxProviderUnavailableError from './order-tax-provider-unavailable-error';
+
+describe('OrderTaxProviderUnavailableError', () => {
+    it('returns error name', () => {
+        const error = new OrderTaxProviderUnavailableError();
+
+        expect(error.name).toEqual('OrderTaxProviderUnavailableError');
+    });
+});

--- a/src/order/errors/order-tax-provider-unavailable-error.ts
+++ b/src/order/errors/order-tax-provider-unavailable-error.ts
@@ -1,0 +1,14 @@
+import {StandardError} from '../../common/error/errors';
+
+/**
+ * Checkout prevents consumers from placing their orders when a merchant wishes
+ * to be able to block transactions if the automated tax provider cannot be reached.
+ */
+export default class OrderTaxProviderUnavailableError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'The tax provider is unavailable.');
+
+        this.name = 'OrderTaxProviderUnavailableError';
+        this.type = 'tax_provider_unavailable';
+    }
+}

--- a/src/order/errors/order-tax-provider-unavailable-error.ts
+++ b/src/order/errors/order-tax-provider-unavailable-error.ts
@@ -1,4 +1,4 @@
-import {StandardError} from '../../common/error/errors';
+import { StandardError } from '../../common/error/errors';
 
 /**
  * Checkout prevents consumers from placing their orders when a merchant wishes

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -57,7 +57,7 @@ export default class OrderRequestSender {
             }, isNil),
             timeout,
         }).catch(error => {
-            if (error.status === 500 && error.body.type === 'tax_provider_unavailable') {
+            if (error.body.type === 'tax_provider_unavailable') {
                 throw new OrderTaxProviderUnavailableError();
             }
 

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -3,6 +3,7 @@ import { isNil, omitBy } from 'lodash';
 
 import { joinIncludes, ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
+import { OrderTaxProviderUnavailableError } from './errors';
 import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import Order from './order';
@@ -48,13 +49,19 @@ export default class OrderRequestSender {
     submitOrder(body: InternalOrderRequestBody, { headers, timeout }: SubmitOrderRequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
         const url = '/internalapi/v1/checkout/order';
 
-        return this._requestSender.post(url, {
+        return this._requestSender.post<InternalOrderResponseBody>(url, {
             body,
             headers: omitBy({
                 'X-Checkout-Variant': headers && headers.checkoutVariant,
                 ...SDK_VERSION_HEADERS,
             }, isNil),
             timeout,
+        }).catch(error => {
+            if (error.status === 500 && error.body.type === 'tax_provider_unavailable') {
+                throw new OrderTaxProviderUnavailableError();
+            }
+
+            throw error;
         });
     }
 


### PR DESCRIPTION
## What? [CHECKOUT-6248](https://jira.bigcommerce.com/browse/CHECKOUT-6248)
* Parent ticket: [CHECKOUT-6174](https://jira.bigcommerce.com/browse/CHECKOUT-6174).
* When a tax service is unavailable, `checkout-sdk-js` throws a custom error.

## Depends on
https://github.com/bigcommerce/bigcommerce/pull/43996

The back-end response is expected to be:
```
{
   "status":500,
   "code":10000,
   "title":"The tax provider is unavailable.",
   "type":"tax_provider_unavailable"
}
```

## Related checkout-js PR
https://github.com/bigcommerce/checkout-js/pull/761


## Why?
When a merchant wants to be able to block transactions if the automated tax provider cannot be accessed, we want Checkout to stop customers from placing orders.

## Testing / Proof

https://user-images.githubusercontent.com/88361607/146317182-a09fd3f1-c92e-46ee-9abf-863efc528587.mov
