### PR TITLE
feat(payments): CHECKOUT-6070 Add apple pay customer strategy

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -223,7 +223,7 @@ describe('CheckoutService', () => {
         consignmentActionCreator = new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender);
 
         customerStrategyActionCreator = new CustomerStrategyActionCreator(
-            createCustomerStrategyRegistry(store, requestSender, locale)
+            createCustomerStrategyRegistry(store, paymentClient, requestSender, locale)
         );
 
         instrumentActionCreator = new InstrumentActionCreator(instrumentRequestSender);

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -93,7 +93,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new ConsignmentActionCreator(new ConsignmentRequestSender(requestSender), checkoutRequestSender),
         new CountryActionCreator(new CountryRequestSender(requestSender, { locale })),
         new CouponActionCreator(new CouponRequestSender(requestSender)),
-        new CustomerStrategyActionCreator(createCustomerStrategyRegistry(store, requestSender, locale)),
+        new CustomerStrategyActionCreator(createCustomerStrategyRegistry(store, paymentClient, requestSender, locale)),
         new ErrorActionCreator(),
         new GiftCertificateActionCreator(new GiftCertificateRequestSender(requestSender)),
         new InstrumentActionCreator(new InstrumentRequestSender(paymentClient, requestSender)),

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -226,7 +226,6 @@ export default function createCustomerStrategyRegistry(
         new ApplePayCustomerStrategy(
             store,
             requestSender,
-            remoteCheckoutActionCreator,
             paymentMethodActionCreator,
             new ConsignmentActionCreator(
                 new ConsignmentRequestSender(requestSender),

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -9,6 +9,7 @@ import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
+import { ApplePaySessionFactory } from '../payment/strategies/apple-pay';
 import { BoltScriptLoader } from '../payment/strategies/bolt';
 import { createBraintreeVisaCheckoutPaymentProcessor, BraintreeScriptLoader, BraintreeSDKCreator, VisaCheckoutScriptLoader } from '../payment/strategies/braintree';
 import { ChasePayScriptLoader } from '../payment/strategies/chasepay';
@@ -23,6 +24,7 @@ import CustomerStrategyActionCreator from './customer-strategy-action-creator';
 import { CustomerStrategy } from './strategies';
 import { AmazonPayCustomerStrategy } from './strategies/amazon';
 import { AmazonPayV2CustomerStrategy } from './strategies/amazon-pay-v2';
+import { ApplePayCustomerStrategy } from './strategies/apple-pay';
 import { BoltCustomerStrategy } from './strategies/bolt';
 import { BraintreeVisaCheckoutCustomerStrategy } from './strategies/braintree';
 import { ChasePayCustomerStrategy } from './strategies/chasepay';
@@ -212,6 +214,15 @@ export default function createCustomerStrategyRegistry(
                 new GooglePayStripeInitializer()
             ),
             formPoster
+        )
+    );
+
+    registry.register('applepay', () => 
+        new ApplePayCustomerStrategy(
+            store,
+            remoteCheckoutActionCreator,
+            paymentMethodActionCreator,
+            new ApplePaySessionFactory(),
         )
     );
 

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -1,14 +1,13 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
 import { RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
-import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
-import { OrderRequestSender } from '../order';
-import OrderActionCreator from '../order/order-action-creator';
+import { OrderActionCreator, OrderRequestSender } from '../order';
 import { PaymentActionCreator, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentRequestTransformer } from '../payment';
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
@@ -223,7 +222,7 @@ export default function createCustomerStrategyRegistry(
         )
     );
 
-    registry.register('applepay', () => 
+    registry.register('applepay', () =>
         new ApplePayCustomerStrategy(
             store,
             requestSender,
@@ -243,7 +242,7 @@ export default function createCustomerStrategyRegistry(
                 new PaymentRequestSender(paymentClient),
                 new OrderActionCreator(
                     new OrderRequestSender(requestSender),
-                    new CheckoutValidator(checkoutRequestSender),
+                    new CheckoutValidator(checkoutRequestSender)
                 ),
                 new PaymentRequestTransformer(),
                 new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
@@ -252,7 +251,7 @@ export default function createCustomerStrategyRegistry(
                 new OrderRequestSender(requestSender),
                 new CheckoutValidator(checkoutRequestSender)
             ),
-            new ApplePaySessionFactory(),
+            new ApplePaySessionFactory()
         )
     );
 

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -16,6 +16,7 @@ import { ChasePayScriptLoader } from '../payment/strategies/chasepay';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayOrbitalInitializer, GooglePayStripeInitializer } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../remote-checkout';
+import { ConsignmentActionCreator, ConsignmentRequestSender } from '../shipping';
 import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../spam-protection';
 
 import CustomerActionCreator from './customer-action-creator';
@@ -220,8 +221,13 @@ export default function createCustomerStrategyRegistry(
     registry.register('applepay', () => 
         new ApplePayCustomerStrategy(
             store,
+            requestSender,
             remoteCheckoutActionCreator,
             paymentMethodActionCreator,
+            new ConsignmentActionCreator(
+                new ConsignmentRequestSender(requestSender),
+                new CheckoutRequestSender(requestSender)
+            ),
             new ApplePaySessionFactory(),
         )
     );

--- a/src/customer/create-customer-strategy-registry.ts
+++ b/src/customer/create-customer-strategy-registry.ts
@@ -225,6 +225,7 @@ export default function createCustomerStrategyRegistry(
     registry.register('applepay', () =>
         new ApplePayCustomerStrategy(
             store,
+            checkoutActionCreator,
             requestSender,
             paymentMethodActionCreator,
             new ConsignmentActionCreator(
@@ -246,6 +247,7 @@ export default function createCustomerStrategyRegistry(
                 new PaymentRequestTransformer(),
                 new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
             ),
+            remoteCheckoutActionCreator,
             new OrderActionCreator(
                 new OrderRequestSender(requestSender),
                 new CheckoutValidator(checkoutRequestSender)

--- a/src/customer/customer-request-options.ts
+++ b/src/customer/customer-request-options.ts
@@ -2,6 +2,7 @@ import { RequestOptions } from '../common/http-request';
 
 import { AmazonPayCustomerInitializeOptions } from './strategies/amazon';
 import { AmazonPayV2CustomerInitializeOptions } from './strategies/amazon-pay-v2';
+import { ApplePayCustomerInitializeOptions } from './strategies/apple-pay';
 import { BoltCustomerInitializeOptions } from './strategies/bolt';
 import { BraintreeVisaCheckoutCustomerInitializeOptions } from './strategies/braintree';
 import { ChasePayCustomerInitializeOptions } from './strategies/chasepay';
@@ -41,6 +42,12 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      * when using AmazonPayV2.
      */
     amazonpay?: AmazonPayV2CustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the customer step of checkout
+     * when using ApplePay.
+     */
+     applepay?: ApplePayCustomerInitializeOptions;
 
     /**
      * The options that are required to initialize the customer step of checkout

--- a/src/customer/customer-strategy-action-creator.spec.ts
+++ b/src/customer/customer-strategy-action-creator.spec.ts
@@ -1,3 +1,4 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { ScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
@@ -25,6 +26,7 @@ describe('CustomerStrategyActionCreator', () => {
     let state: CheckoutStoreState;
     let store: CheckoutStore;
     let strategy: DefaultCustomerStrategy;
+    let paymentClient: any;
 
     beforeEach(() => {
         const requestSender = createRequestSender();
@@ -33,6 +35,7 @@ describe('CustomerStrategyActionCreator', () => {
             new ConfigActionCreator(new ConfigRequestSender(requestSender)),
             new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
+        paymentClient = createPaymentClient();
 
         const mockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
         const scriptLoader = new ScriptLoader();
@@ -42,7 +45,7 @@ describe('CustomerStrategyActionCreator', () => {
 
         state = getCheckoutStoreState();
         store = createCheckoutStore(state);
-        registry = createCustomerStrategyRegistry(store, createRequestSender(), 'en');
+        registry = createCustomerStrategyRegistry(store, paymentClient, createRequestSender(), 'en');
         strategy = new DefaultCustomerStrategy(
             store,
             new CustomerActionCreator(

--- a/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
@@ -25,4 +25,12 @@
      * A callback that gets called when a payment is successfully completed.
      */
     onPaymentAuthorize(): void
+
+    /**
+    * A callback that gets called if unable to initialize the widget or select
+     * one of the address options provided by the widget.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error?: Error): void;
 }

--- a/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
@@ -1,0 +1,13 @@
+/**
+ * A set of options that are required to initialize the customer step of
+ * checkout in order to support ApplePay.
+ *
+ * When ApplePay is initialized, a sign-in button will be inserted into the
+ * DOM. When the customer clicks on it, it will trigger apple sheet
+ */
+ export default interface ApplePayCustomerInitializeOptions {
+    /**
+     * The ID of a container which the sign-in button should insert into.
+     */
+    container: string;
+}

--- a/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
@@ -14,12 +14,12 @@
     /**
      * Shipping label to be passed to apple sheet.
      */
-     shippingLabel?: string;
+    shippingLabel?: string;
 
     /**
      * Sub total label to be passed to apple sheet.
      */
-     subtotalLabel?: string;
+    subtotalLabel?: string;
 
     /**
      * A callback that gets called when a payment is successfully completed.

--- a/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
@@ -24,10 +24,10 @@
     /**
      * A callback that gets called when a payment is successfully completed.
      */
-    onPaymentAuthorize(): void
+    onPaymentAuthorize(): void;
 
     /**
-    * A callback that gets called if unable to initialize the widget or select
+     * A callback that gets called if unable to initialize the widget or select
      * one of the address options provided by the widget.
      *
      * @param error - The error object describing the failure.

--- a/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-initialize-options.ts
@@ -10,4 +10,19 @@
      * The ID of a container which the sign-in button should insert into.
      */
     container: string;
+
+    /**
+     * Shipping label to be passed to apple sheet.
+     */
+     shippingLabel?: string;
+
+    /**
+     * Sub total label to be passed to apple sheet.
+     */
+     subtotalLabel?: string;
+
+    /**
+     * A callback that gets called when a payment is successfully completed.
+     */
+    onPaymentAuthorize(): void
 }

--- a/src/customer/strategies/apple-pay/apple-pay-customer-mock.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-mock.ts
@@ -2,6 +2,7 @@ import { CustomerInitializeOptions } from '../../customer-request-options';
 
 export function getApplePayCustomerInitializationOptions(): CustomerInitializeOptions {
     return {
+        methodId: 'applepay',
         applepay: {
             container: 'applePayCheckoutButton',
             shippingLabel: 'Shipping',
@@ -9,5 +10,22 @@ export function getApplePayCustomerInitializationOptions(): CustomerInitializeOp
             onPaymentAuthorize: jest.fn(),
             onError: jest.fn(),
         },
+    };
+}
+
+export function getContactAddress() {
+    return {
+        administrativeArea: 'CA',
+        country: 'United States',
+        countryCode: 'US',
+        emailAddress: 'test@test.com',
+        familyName: '',
+        givenName: '',
+        locality: 'San Francisco',
+        phoneticFamilyName: '',
+        phoneticGivenName: '',
+        postalCode: '94114',
+        subAdministrativeArea: '',
+        subLocality: '',
     };
 }

--- a/src/customer/strategies/apple-pay/apple-pay-customer-mock.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-mock.ts
@@ -1,0 +1,13 @@
+import { CustomerInitializeOptions } from '../../customer-request-options';
+
+export function getApplePayCustomerInitializationOptions(): CustomerInitializeOptions {
+    return {
+        applepay: {
+            container: 'applePayCheckoutButton',
+            shippingLabel: 'Shipping',
+            subtotalLabel: 'Subtotal',
+            onPaymentAuthorize: jest.fn(),
+            onError: jest.fn(),
+        },
+    };
+}

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.spec.ts
@@ -7,21 +7,22 @@ import { Observable } from 'rxjs/internal/Observable';
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { InvalidArgumentError } from '../../../common/error/errors';
-import { OrderActionCreator, OrderRequestSender } from '../../../order';
-import { createPaymentClient, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentRequestTransformer } from '../../../payment';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
+import { createPaymentClient, PaymentActionCreator, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentRequestTransformer } from '../../../payment';
+import { PaymentMethodCancelledError } from '../../../payment/errors';
 // eslint-disable-next-line import/no-internal-modules
 import { PaymentActionType, SubmitPaymentAction } from '../../../payment/payment-actions';
-import { getApplePay } from '../../../payment/payment-methods.mock';
 import { ApplePaySessionFactory } from '../../../payment/strategies/apple-pay';
 import { MockApplePaySession } from '../../../payment/strategies/apple-pay/apple-pay-payment.mock';
 import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import { CustomerInitializeOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
 import { ApplePayCustomerStrategy } from '.';
-import { getApplePayCustomerInitializationOptions } from './apple-pay-customer-mock';
+import { getApplePayCustomerInitializationOptions, getContactAddress } from './apple-pay-customer-mock';
 
 describe('ApplePayCustomerStrategy', () => {
     let container: HTMLDivElement;
@@ -30,7 +31,6 @@ describe('ApplePayCustomerStrategy', () => {
     let store: CheckoutStore;
     let strategy: CustomerStrategy;
     let paymentClient: OrderRequestSender;
-    let paymentMethod: PaymentMethod;
     let applePaySession: MockApplePaySession;
     let paymentActionCreator: PaymentActionCreator;
     let billingAddressActionCreator: BillingAddressActionCreator;
@@ -50,7 +50,6 @@ describe('ApplePayCustomerStrategy', () => {
         store = createCheckoutStore(getCheckoutStoreState());
         requestSender = createRequestSender();
         paymentClient = createPaymentClient(store);
-        paymentMethod = getApplePay();
         applePayFactory = new ApplePaySessionFactory();
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
 
@@ -82,9 +81,19 @@ describe('ApplePayCustomerStrategy', () => {
             new PaymentMethodRequestSender(requestSender)
         );
 
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(of(createAction(OrderActionType.SubmitOrderRequested)));
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
             .mockResolvedValue(store.getState());
         jest.spyOn(requestSender, 'post')
+            .mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'updateAddress')
+            .mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'selectShippingOption')
+            .mockReturnValue(true);
+        jest.spyOn(billingAddressActionCreator, 'updateAddress')
             .mockReturnValue(true);
         jest.spyOn(applePayFactory, 'create')
             .mockReturnValue(applePaySession);
@@ -109,7 +118,240 @@ describe('ApplePayCustomerStrategy', () => {
         document.body.removeChild(container);
     });
 
-    describe('#iniialize', () => {});
+    describe('#initialize()', () => {
+        it('creates the button', async () => {
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            let children = container.children;
+            expect(children.length).toBe(0);
+            await strategy.initialize(customerInitializeOptions);
+            children = container.children;
+
+            expect(children.length).toBe(1);
+        });
+
+        it('throws error when payment data is empty', async () => {
+            await expect(strategy.initialize({})).rejects.toThrow(MissingDataError);
+        });
+
+        it('throws error when applepay object is empty', async () => {
+            await expect(strategy.initialize({methodId: 'applepay'})).rejects.toThrow(MissingDataError);
+        });
+
+        it('throws error when applepay object is empty', async () => {
+            const options = {
+                methodId: 'applepay',
+                applepay: {},
+            } as CustomerInitializeOptions;
+            await expect(strategy.initialize(options)).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('throws error when Apple Pay payment sheet is cancelled', async () => {
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    expect(applePaySession.begin).toHaveBeenCalled();
+                    expect(() => applePaySession.oncancel()).toThrow(PaymentMethodCancelledError);
+                }
+            }
+        });
+
+        it('validates merchant successfully', async () => {
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const validateEvent = {
+                        validationURL: 'test',
+                    } as ApplePayJS.ApplePayValidateMerchantEvent;
+
+                    await applePaySession.onvalidatemerchant(validateEvent);
+
+                    expect(requestSender.post).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('throws error if merchant validation fails', async () => {
+            jest.spyOn(requestSender, 'post')
+                .mockRejectedValue(false);
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const validateEvent = {
+                        validationURL: 'test',
+                    } as ApplePayJS.ApplePayValidateMerchantEvent;
+
+                    await applePaySession.onvalidatemerchant(validateEvent);
+                    expect(customerInitializeOptions.applepay.onError).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('gets shipping contact selected successfully', async () => {
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingContact: getContactAddress(),
+                    } as ApplePayJS.ApplePayShippingContactSelectedEvent;
+
+                    await applePaySession.onshippingcontactselected(event);
+
+                    expect(applePaySession.completeShippingContactSelection).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('throws error if call to update address fails', async () => {
+            jest.spyOn(consignmentActionCreator, 'updateAddress')
+                .mockRejectedValue(false);
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingContact: getContactAddress(),
+                    } as ApplePayJS.ApplePayShippingContactSelectedEvent;
+
+                    await applePaySession.onshippingcontactselected(event);
+
+                    expect(customerInitializeOptions.applepay.onError).toHaveBeenCalled()
+                }
+            }
+        });
+
+        it('gets shipping method selected successfully', async () => {
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingMethod: {
+                            label: 'test',
+                            detail: 'test2',
+                            amount: '10',
+                            identifier: '1',
+                        },
+                    } as ApplePayJS.ApplePayShippingMethodSelectedEvent;
+                    await applePaySession.onshippingmethodselected(event);
+
+                    expect(applePaySession.completeShippingMethodSelection).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('gets call to update shipping option in consignment fails', async () => {
+            jest.spyOn(consignmentActionCreator, 'selectShippingOption')
+                .mockRejectedValue(false);
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingMethod: {
+                            label: 'test',
+                            detail: 'test2',
+                            amount: '10',
+                            identifier: '1',
+                        },
+                    } as ApplePayJS.ApplePayShippingMethodSelectedEvent;
+
+                    await applePaySession.onshippingmethodselected(event);
+
+                    expect(customerInitializeOptions.applepay.onError).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('submits payment when shopper authorises', async () => {
+            const authEvent = {
+                payment: {
+                    billingContact: getContactAddress(),
+                    shippingContact: getContactAddress(),
+                    token: {
+                        paymentData: {},
+                        paymentMethod: {},
+                        transactionIdentifier: {},
+                    },
+                },
+            } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+                    await applePaySession.onpaymentauthorized(authEvent);
+
+                    expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                    expect(applePaySession.completePayment).toHaveBeenCalled();
+                    expect(customerInitializeOptions.applepay.onPaymentAuthorize).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('returns an error if autorize payment fails', async () => {
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockRejectedValue(false);
+            const authEvent = {
+                payment: {
+                    billingContact: getContactAddress(),
+                    shippingContact: getContactAddress(),
+                    token: {
+                        paymentData: {},
+                        paymentMethod: {},
+                        transactionIdentifier: {},
+                    },
+                },
+            } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            await strategy.initialize(customerInitializeOptions);
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+                    await applePaySession.onpaymentauthorized(authEvent);
+
+                    expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                    expect(applePaySession.completePayment).toHaveBeenCalled();
+                    expect(customerInitializeOptions.applepay.onError).toHaveBeenCalled();
+                }
+            }
+        });
+    });
 
     describe('#signIn()', () => {
         it('throws error if trying to sign in programmatically', () => {

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.spec.ts
@@ -1,0 +1,209 @@
+// import { createAction } from '@bigcommerce/data-store';
+// import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+// import { createScriptLoader } from '@bigcommerce/script-loader';
+// import { merge } from 'lodash';
+// import { of, Observable } from 'rxjs';
+
+// import { getCart } from '../../../cart/carts.mock';
+// import { CheckoutActionCreator, createCheckoutStore, CheckoutRequestSender,  CheckoutStore, CheckoutValidator } from '../../../checkout';
+// import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+// import { InvalidArgumentError } from '../../../common/error/errors';
+// import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
+// import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+// import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+// import { createPaymentClient,
+//     PaymentActionCreator,
+//     PaymentMethod,
+//     PaymentMethodActionCreator,
+//     PaymentMethodRequestSender,
+//     PaymentRequestSender,
+//     PaymentRequestTransformer } from '../../../payment';
+// import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../../payment/errors';
+// import { PaymentActionType, SubmitPaymentAction } from '../../../payment/payment-actions';
+// import { getApplePay } from '../../../payment/payment-methods.mock';
+// import { MockApplePaySession } from '../../../payment/strategies/apple-pay/apple-pay-payment.mock';
+// import ApplePaySessionFactory from '../../../payment/strategies/apple-pay/apple-pay-session-factory';
+// import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+// import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
+// import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+
+// import { ApplePayCustomerStrategy } from '.';
+
+// describe('ApplePayCustomerStrategy', () => {
+//     let store: CheckoutStore;
+//     let requestSender: RequestSender;
+//     let paymentClient: OrderRequestSender;
+//     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+//     let paymentMethodActionCreator: PaymentMethodActionCreator;
+//     let consignmentActionCreator: ConsignmentActionCreator;
+//     let paymentMethod: PaymentMethod;
+//     let strategy: ApplePayCustomerStrategy;
+//     let applePaySession: MockApplePaySession;
+//     let submitPaymentAction: Observable<SubmitPaymentAction>;
+//     let applePayFactory: ApplePaySessionFactory;
+
+//     beforeEach(() => {
+//         applePaySession = new MockApplePaySession();
+
+//         Object.defineProperty(window, 'ApplePaySession', {
+//             writable: true,
+//             value: applePaySession,
+//         });
+
+//         store = createCheckoutStore(getCheckoutStoreState());
+//         requestSender = createRequestSender();
+//         paymentClient = createPaymentClient(store);
+//         paymentMethod = getApplePay();
+//         applePayFactory = new ApplePaySessionFactory();
+//         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+//         remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+//             new RemoteCheckoutRequestSender(requestSender),
+//             checkoutActionCreator
+//         );
+
+//         consignmentActionCreator = new ConsignmentActionCreator(
+//             new ConsignmentRequestSender(requestSender),
+//             new CheckoutRequestSender(requestSender)
+//         );
+
+//         paymentMethodActionCreator = new PaymentMethodActionCreator(
+//             new PaymentMethodRequestSender(requestSender)
+//         );
+
+//         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+//             .mockResolvedValue(store.getState());
+//         jest.spyOn(requestSender, 'post')
+//             .mockReturnValue(true);
+//         jest.spyOn(applePayFactory, 'create')
+//             .mockReturnValue(applePaySession);
+
+//         strategy = new ApplePayCustomerStrategy(
+//             store,
+//             requestSender,
+//             remoteCheckoutActionCreator,
+//             paymentMethodActionCreator,
+//             consignmentActionCreator,
+//             applePayFactory
+//         );
+//     });
+
+//     describe('#initialize()', () => {
+//         it('throws invalid argument error if no method id', async () => {
+//             await expect(strategy.initialize())
+//                 .rejects.toBeInstanceOf(InvalidArgumentError);
+//         });
+
+//         it('initializes the strategy successfully', async () => {
+//             await strategy.initialize({ methodId: 'applepay' });
+//             expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalled();
+//         });
+//     });
+
+//     describe('#execute()', () => {
+//         beforeEach(() => {
+//             jest.spyOn(store.getState().cart, 'getCartOrThrow')
+//                 .mockReturnValue(getCart());
+//         });
+
+//         it('throws error when payment data is empty', async () => {
+//             await expect(strategy.execute({})).rejects.toThrow(PaymentArgumentInvalidError);
+//         });
+
+//         it('validates merchant', async () => {
+//             const payload = merge({}, getOrderRequestBody(), {
+//                 payment: { methodId: paymentMethod.id },
+//             });
+//             strategy.execute(payload);
+
+//             const validateEvent = {
+//                 validationURL: 'test',
+//             } as ApplePayJS.ApplePayValidateMerchantEvent;
+
+//             await new Promise(resolve => process.nextTick(resolve));
+//             await applePaySession.onvalidatemerchant(validateEvent);
+
+//             expect(applePaySession.begin).toHaveBeenCalled();
+//             expect(requestSender.post).toHaveBeenCalled();
+//         });
+
+//         it('throws error if merchant validation fails', async () => {
+//             jest.spyOn(requestSender, 'post')
+//                 .mockRejectedValue(false);
+
+//             const payload = merge({}, getOrderRequestBody(), {
+//                 payment: { methodId: paymentMethod.id },
+//             });
+//             strategy.execute(payload);
+
+//             await new Promise(resolve => process.nextTick(resolve));
+
+//             const validateEvent = {
+//                 validationURL: 'test',
+//             } as ApplePayJS.ApplePayValidateMerchantEvent;
+
+//             try {
+//                 await applePaySession.onvalidatemerchant(validateEvent);
+//             } catch (error) {
+//                 expect(error).toBeInstanceOf(Error);
+//             }
+//         });
+
+//         // tests for Sign in and sign out??
+
+//         it('updates shipping contact when shopper selects contact', async () => {
+//             // todo
+//         });
+
+//         it('updates shipping address when shopper selects address', async () => {
+//             // todo
+//         });
+
+//         it('throws error when Apple Pay payment sheet is cancelled', async () => {
+//             jest.spyOn(requestSender, 'post')
+//                 .mockRejectedValue(false);
+
+//             const payload = merge({}, getOrderRequestBody(), {
+//                 payment: { methodId: paymentMethod.id },
+//             });
+//             const promise = strategy.execute(payload);
+//             await new Promise(resolve => process.nextTick(resolve));
+//             applePaySession.oncancel();
+
+//             expect(promise).rejects.toThrow(new PaymentMethodCancelledError('Continue with applepay'));
+//         });
+
+//         it('submits payment when shopper authorises', async () => {
+//             const payload = merge({}, getOrderRequestBody(), {
+//                 payment: { methodId: paymentMethod.id },
+//             });
+//             const authEvent = {
+//                 payment: {
+//                     token: {
+//                         paymentData: {},
+//                         paymentMethod: {},
+//                         transactionIdentifier: {},
+//                     },
+//                 },
+//             } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
+//             strategy.execute(payload);
+//             await new Promise(resolve => process.nextTick(resolve));
+//             await applePaySession.onpaymentauthorized(authEvent);
+
+//             expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+//             expect(applePaySession.completePayment).toHaveBeenCalled();
+//         });
+//     });
+
+//     describe('#finalize()', () => {
+//         it('throws error to inform that order finalization is not required', async () => {
+//             await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+//         });
+//     });
+
+//     describe('#deinitialize()', () => {
+//         it('deinitializes strategy', async () => {
+//             await expect(strategy.deinitialize()).resolves.toEqual(store.getState());
+//         });
+//     });
+// });

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -10,6 +10,7 @@ import { bindDecorator as bind } from '../../../common/utility';
 import { StoreConfig } from '../../../config';
 import { OrderActionCreator } from '../../../order';
 import { Payment, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
+import { PaymentMethodCancelledError } from '../../../payment/errors';
 import { assertApplePayWindow, ApplePaySessionFactory } from '../../../payment/strategies/apple-pay';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
 import { ConsignmentActionCreator, ShippingOption } from '../../../shipping';
@@ -211,7 +212,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
 
                 return this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout());
             } catch (error) {
-                return this._onError(error);
+                return this._onError(new PaymentMethodCancelledError());
             }
         };
 

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -12,9 +12,8 @@ import { OrderActionCreator } from '../../../order';
 import { Payment, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { PaymentMethodCancelledError } from '../../../payment/errors';
 import { assertApplePayWindow, ApplePaySessionFactory } from '../../../payment/strategies/apple-pay';
-import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
 import { ConsignmentActionCreator, ShippingOption } from '../../../shipping';
-import { CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from '../../customer-request-options';
+import { CustomerInitializeOptions, ExecutePaymentMethodCheckoutOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
 
 const validationEndpoint = (bigPayEndpoint: string) => `${bigPayEndpoint}/api/public/v1/payments/applepay/validate_merchant`;
@@ -39,7 +38,6 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
     constructor(
         private _store: CheckoutStore,
         private _requestSender: RequestSender,
-        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _consignmentActionCreator: ConsignmentActionCreator,
         private _billingAddressActionCreator: BillingAddressActionCreator,
@@ -89,15 +87,10 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         );
     }
 
-    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
-        const state = this._store.getState();
-        const payment = state.payment.getPaymentId();
-
-        if (!payment) {
-            return Promise.resolve(this._store.getState());
-        }
-
-        return this._store.dispatch(this._remoteCheckoutActionCreator.forgetCheckout(payment.providerId, options));
+    signOut(): Promise<InternalCheckoutSelectors> {
+        throw new NotImplementedError(
+            'Need to do signout via apple.'
+        );
     }
 
     executePaymentMethodCheckout(options?: ExecutePaymentMethodCheckoutOptions): Promise<InternalCheckoutSelectors> {

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -226,7 +226,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
             try {
                 await this._updateShippingOption(optionId);
             } catch (error) {
-                this._onError(error);
+                return this._onError(error);
             }
         }
 

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -205,7 +205,9 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
                 this._consignmentActionCreator.updateAddress(shippingAddress)
             );
         } catch (error) {
-            this._onError(error);
+            applePaySession.abort();
+
+            return this._onError(error);
         }
 
         const { storeProfile: { storeName } } = config;
@@ -259,7 +261,9 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         try {
             await this._updateShippingOption(optionId);
         } catch (error) {
-            this._onError(error);
+            applePaySession.abort();
+
+            return this._onError(error);
         }
 
         const state = this._store.getState();

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -206,9 +206,13 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
             this._handleShippingMethodSelected(applePaySession, config, event);
 
         applePaySession.oncancel = async () => {
-            await this._store.dispatch(this._remoteCheckoutActionCreator.signOut(paymentMethod.id));
+            try {
+                await this._store.dispatch(this._remoteCheckoutActionCreator.signOut(paymentMethod.id));
 
-            return this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout());
+                return this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout());
+            } catch (error) {
+                return this._onError(error);
+            }
         };
 
         applePaySession.onpaymentauthorized = async event =>

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -1,0 +1,140 @@
+import { bindDecorator as bind } from '../../../common/utility';
+import { Cart } from "../../../cart";
+import { Checkout, CheckoutStore } from "../../../checkout";
+import InternalCheckoutSelectors from "../../../checkout/internal-checkout-selectors";
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotImplementedError } from "../../../common/error/errors";
+import { StoreConfig } from "../../../config";
+import { PaymentMethod, PaymentMethodActionCreator } from "../../../payment";
+import { ApplePaySessionFactory } from "../../../payment/strategies/apple-pay";
+import { RemoteCheckoutActionCreator } from "../../../remote-checkout";
+import { CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from "../../customer-request-options";
+import CustomerStrategy from "../customer-strategy";
+
+enum DefaultLabels {
+    Shipping = 'Shipping',
+    Subtotal = 'Subtotal',
+}
+
+export default class ApplePayCustomerStrategy implements CustomerStrategy {
+    private _paymentMethod?: PaymentMethod;
+    private _applePayButton?: HTMLElement;
+    private _shippingLabel: string = DefaultLabels.Shipping;
+    private _subTotalLabel: string = DefaultLabels.Subtotal;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _sessionFactory: ApplePaySessionFactory
+    ) {}
+
+    async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        console.log('Initialize called', options);
+        const { methodId, applepay }  = options;
+
+        if (!methodId || !applepay) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const { container } = applepay;
+
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        this._applePayButton = this._createButton(container);
+        this._applePayButton.addEventListener('click', this._handleWalletButtonClick);
+
+        return this._store.getState();
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    signIn(): Promise<InternalCheckoutSelectors> {
+        throw new NotImplementedError(
+            'In order to sign in via Apple, the shopper must click on "Apple Pay" button.'
+        );
+    }
+
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const payment = state.payment.getPaymentId();
+
+        if (!payment) {
+            return Promise.resolve(this._store.getState());
+        }
+
+        return this._store.dispatch(this._remoteCheckoutActionCreator.forgetCheckout(payment.providerId, options));
+    }
+
+    executePaymentMethodCheckout(options?: ExecutePaymentMethodCheckoutOptions): Promise<InternalCheckoutSelectors> {
+        options?.continueWithCheckoutCallback?.();
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _createButton(containerId: string): HTMLElement {
+        const container = document.getElementById(containerId);
+
+        if (!container) {
+            throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
+        }
+
+        const button = document.createElement('input');
+        button.type = 'image';
+        button.src = this._paymentMethod?.logoUrl || '';
+        button.style.height = '40px';
+        button.style.width = '75px';
+        container.appendChild(button);
+        
+        return button;
+    }
+
+    @bind
+    private _handleWalletButtonClick(event: Event) {
+        event.preventDefault();
+        const state = this._store.getState();
+        const checkout = state.checkout.getCheckoutOrThrow();
+        const cart = state.cart.getCartOrThrow();
+        const config = state.config.getStoreConfigOrThrow();
+        const request = this._getBaseRequest(cart, checkout, config);
+        const applePaySession = this._sessionFactory.create(request);
+
+        applePaySession.begin();
+    }
+
+    private _getBaseRequest(
+        cart: Cart,
+        checkout: Checkout,
+        config: StoreConfig,
+    ): ApplePayJS.ApplePayPaymentRequest {
+        const { storeProfile: { storeCountryCode, storeName } } = config;
+        const { currency : { decimalPlaces } } = cart;
+        if (!this._paymentMethod || !this._paymentMethod.initializationData) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+        const { initializationData : { merchantCapabilities, supportedNetworks } } = this._paymentMethod;
+        const lineItems: ApplePayJS.ApplePayLineItem[] = [
+            { label: this._subTotalLabel, amount: `${checkout.subtotal.toFixed(decimalPlaces)}`},
+        ];
+
+        checkout.taxes.forEach(tax =>
+            lineItems.push({ label: tax.name, amount: `${tax.amount.toFixed()}` }));
+
+        lineItems.push({ label: this._shippingLabel, amount: `${checkout.shippingCostTotal.toFixed(decimalPlaces)}`});
+
+        return {
+            countryCode: storeCountryCode,
+            currencyCode: cart.currency.code,
+            merchantCapabilities,
+            supportedNetworks,
+            lineItems,
+            total: {
+                label: storeName,
+                amount: `${checkout.grandTotal.toFixed(cart.currency.decimalPlaces)}`,
+                type: 'final',
+            },
+        };
+    }
+}

--- a/src/customer/strategies/apple-pay/index.ts
+++ b/src/customer/strategies/apple-pay/index.ts
@@ -1,0 +1,2 @@
+export { default as ApplePayCustomerStrategy } from './apple-pay-customer-strategy';
+export { default as ApplePayCustomerInitializeOptions } from './apple-pay-customer-initialize-options';

--- a/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
@@ -1,4 +1,5 @@
 import { createAction } from '@bigcommerce/data-store';
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
@@ -28,6 +29,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
     let braintreeVisaCheckoutPaymentProcessor: BraintreeVisaCheckoutPaymentProcessor;
     let checkoutActionCreator: CheckoutActionCreator;
     let container: HTMLDivElement;
+    let paymentClient: any;
     let customerStrategyActionCreator: CustomerStrategyActionCreator;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
     let paymentMethodMock: PaymentMethod;
@@ -41,6 +43,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
     beforeEach(() => {
         const scriptLoader = createScriptLoader();
         const requestSender = createRequestSender();
+        paymentClient = createPaymentClient();
         braintreeVisaCheckoutPaymentProcessor = createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender);
         braintreeVisaCheckoutPaymentProcessor.initialize = jest.fn(() => Promise.resolve());
         braintreeVisaCheckoutPaymentProcessor.handleSuccess = jest.fn(() => Promise.resolve());
@@ -64,7 +67,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
 
         formPoster = createFormPoster();
 
-        const registry = createCustomerStrategyRegistry(store, requestSender, '');
+        const registry = createCustomerStrategyRegistry(store, paymentClient, requestSender, '');
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),

--- a/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
+++ b/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
@@ -1,5 +1,5 @@
-import { createAction } from '@bigcommerce/data-store';
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';

--- a/src/payment/strategies/apple-pay/apple-pay-payment.mock.ts
+++ b/src/payment/strategies/apple-pay/apple-pay-payment.mock.ts
@@ -7,6 +7,12 @@ export class MockApplePaySession {
 
     begin = jest.fn();
 
+    completeShippingContactSelection = jest.fn();
+
+    completeShippingMethodSelection = jest.fn();
+
+    abort = jest.fn();
+
     completeMerchantValidation() {
         return true;
     }
@@ -16,6 +22,14 @@ export class MockApplePaySession {
     }
 
     onpaymentauthorized(event?: ApplePayJS.ApplePayPaymentAuthorizedEvent) {
+        return event;
+    }
+
+    onshippingcontactselected(event?: ApplePayJS.ApplePayShippingContactSelectedEvent) {
+        return event;
+    }
+
+    onshippingmethodselected(event?: ApplePayJS.ApplePayShippingMethodSelectedEvent) {
         return event;
     }
 

--- a/src/payment/strategies/apple-pay/index.ts
+++ b/src/payment/strategies/apple-pay/index.ts
@@ -1,4 +1,4 @@
-export { ApplePayWindow, default as isApplePayWindow } from './is-apple-pay-window';
+export { ApplePayWindow, assertApplePayWindow, default as isApplePayWindow } from './is-apple-pay-window';
 export { default as ApplePayPaymentInitializeOptions } from './apple-pay-payment-initialize-options';
 export { default as ApplePayPaymentStrategy } from './apple-pay-payment-strategy';
 export { default as ApplePaySessionFactory } from './apple-pay-session-factory';


### PR DESCRIPTION
## What?
Add apple pay customer strategy

## Why?
Add wallet button for apple pay, so shoppers can checkout using a wallet button in customer step.

## Testing / Proof
- Screencast


https://user-images.githubusercontent.com/7134802/146874158-8d39a584-d572-4f9f-b4e5-77117ee67673.mov


@bigcommerce/checkout @bigcommerce/payments
