### PR TITLE
fix(payment): INT-5175 fixing redirect in googlepay using embedded checkout on customer section

### DIFF
--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -14,6 +14,7 @@ import GooglePayCustomerInitializeOptions from './googlepay-customer-initialize-
 
 export default class GooglePayCustomerStrategy implements CustomerStrategy {
     private _walletButton?: HTMLElement;
+    private _StoreUrl?: string;
 
     constructor(
         private _store: CheckoutStore,
@@ -29,6 +30,13 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
 
         if (!methodId) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+
+        if (paymentMethod && paymentMethod.initializationData) {
+            this._StoreUrl = paymentMethod?.initializationData.storeUrl || null;
         }
 
         return this._googlePayPaymentProcessor.initialize(methodId)
@@ -139,7 +147,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
     }
 
     private _onPaymentSelectComplete(): void {
-        this._formPoster.postForm('/checkout.php', {
+        this._formPoster.postForm(`${this._StoreUrl}/checkout`, {
             headers: {
                 Accept: 'text/html',
                 'Content-Type': 'application/x-www-form-urlencoded',


### PR DESCRIPTION
## What? [INT-5176](https://jira.bigcommerce.com/browse/INT-5176)
- Fix redirect in googlepay using embedded checkout on customer section

## Why?
- When a client clicks Gpay button on the customer section using embedded Checkout page, the application redirects to BC store to continue the payment process instead of the current page

## Testing / Proof
![image](https://user-images.githubusercontent.com/42154828/147297218-2d489a9a-2421-431f-a552-ca1b83863891.png)


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
