### PR TITLE
fix(payment): ADYEN-296 Card fields validation

### DIFF
--- a/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
@@ -1,5 +1,6 @@
 import { Omit } from '../../../common/types';
 
+import { AdyenComponentState } from '.';
 import { AdyenAdditionalActionOptions, AdyenCreditCardComponentOptions, AdyenIdealComponentOptions, AdyenThreeDS2Options } from './adyenv2';
 
 /**
@@ -101,4 +102,8 @@ export default interface AdyenV2PaymentInitializeOptions {
      * Optional. Overwriting the default options
      */
     options?: Omit<AdyenCreditCardComponentOptions, 'onChange'> | AdyenIdealComponentOptions;
+
+    shouldShowNumberField?: boolean;
+
+    validateCardFields(componentState: AdyenComponentState): void;
 }

--- a/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -6,7 +6,7 @@ import { getBrowserInfo } from '../../../common/browser-info';
 import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
+import { PaymentArgumentInvalidError, PaymentInvalidFormError, PaymentInvalidFormErrorDetails, PaymentMethodCancelledError } from '../../errors';
 import isVaultedInstrument from '../../is-vaulted-instrument';
 import Payment, { HostedInstrument } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
@@ -14,7 +14,7 @@ import PaymentMethod from '../../payment-method';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import { isAccountState, isCardState, AdyenAction, AdyenActionType, AdyenAdditionalAction, AdyenAdditionalActionState, AdyenClient, AdyenComponent, AdyenComponentState, AdyenComponentType, AdyenError, AdyenPaymentMethodType, AdyenPlaceholderData } from './adyenv2';
+import { isAccountState, isCardState, AdyenAction, AdyenActionType, AdyenAdditionalAction, AdyenAdditionalActionState, AdyenClient, AdyenComponent, AdyenComponentState, AdyenComponentType, AdyenError, AdyenPaymentMethodType, AdyenPlaceholderData, CardStateErrors } from './adyenv2';
 import AdyenV2PaymentInitializeOptions from './adyenv2-initialize-options';
 import AdyenV2ScriptLoader from './adyenv2-script-loader';
 
@@ -82,6 +82,8 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
         }
+
+        this._validateCardData();
 
         return this._store.dispatch(this._orderActionCreator.submitOrder(order, options))
             .then(() => {
@@ -266,8 +268,20 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
             if (adyenv2.cardVerificationContainerId) {
                 cardVerificationComponent = adyenClient.create(AdyenComponentType.SecuredFields, {
                     ...adyenv2.options,
+                    styles: {
+                        error: {
+                            color: 'red',
+                        },
+                        validated: {
+                            color: 'green',
+                        },
+                    },
                     onChange: componentState => this._updateComponentState(componentState),
-                    onError: componentState => this._updateComponentState(componentState),
+                    onError: componentState => {
+                        this._updateComponentState(componentState);
+                        adyenv2.validateCardFields(componentState);
+                    },
+                    onFieldValid: componentState => adyenv2.validateCardFields(componentState),
                 });
 
                 try {
@@ -376,5 +390,57 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
 
     private _updateComponentState(componentState: AdyenComponentState) {
         this._componentState = componentState;
+    }
+
+    private _validateCardData(): void {
+        const adyenv2 = this._getPaymentInitializeOptions();
+        const cardComponent = adyenv2.hasVaultedInstruments ? this._cardVerificationComponent : this._paymentComponent;
+
+        if (!cardComponent?.componentRef?.showValidation || !cardComponent?.state) {
+            return;
+        }
+
+        adyenv2.hasVaultedInstruments ?
+            adyenv2.validateCardFields(cardComponent.state) :
+            cardComponent.componentRef.showValidation();
+
+        if ( Object.keys(cardComponent.state).length === 0 || !this._isFieldsValid(cardComponent, adyenv2) ) {
+            throw new PaymentInvalidFormError( this._mapCardErrors(cardComponent?.state?.errors) );
+        }
+    }
+
+    private _isFieldsValid(cardComponent: AdyenComponent, adyenv2: AdyenV2PaymentInitializeOptions): boolean {
+        return adyenv2.hasVaultedInstruments ? this._isInstrumentValid(cardComponent, adyenv2) : !!cardComponent.state?.isValid;
+    }
+
+    private _isInstrumentValid(cardComponent: AdyenComponent, adyenv2: AdyenV2PaymentInitializeOptions): boolean {
+        if (!!adyenv2.shouldShowNumberField) {
+            return !!cardComponent.state?.isValid;
+        }
+
+        let isValid = true;
+        const fieldsValidationState = cardComponent?.state?.valid || {};
+
+        for (const fieldKey in fieldsValidationState) {
+            if (fieldKey !== 'encryptedCardNumber' && !fieldsValidationState[fieldKey]) {
+                isValid = false;
+                break;
+            }
+        }
+
+        return isValid;
+    }
+
+    private _mapCardErrors(cardStateErrors: CardStateErrors = {}): PaymentInvalidFormErrorDetails {
+        const errors: PaymentInvalidFormErrorDetails = {};
+
+        Object.keys(cardStateErrors).forEach(key => {
+            errors[key] = [{
+                message: cardStateErrors[key],
+                type: key,
+            }];
+        });
+
+        return errors;
     }
 }

--- a/src/payment/strategies/adyenv2/adyenv2.mock.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.mock.ts
@@ -136,6 +136,7 @@ export function getInitializeOptions(hasVaultedInstruments = false): PaymentInit
                 onComplete: jest.fn(),
                 onLoad: jest.fn(),
             },
+            validateCardFields: jest.fn(),
         },
     };
 }
@@ -158,6 +159,7 @@ export function getInitializeOptionsWithNoCallbacks(): PaymentInitializeOptions 
             additionalActionOptions: {
                 containerId: 'adyen-scheme-additional-action-component-field',
             },
+            validateCardFields: jest.fn(),
         },
     };
 }
@@ -185,6 +187,7 @@ export function getInitializeOptionsWithUndefinedWidgetSize(): PaymentInitialize
                 onComplete: jest.fn(),
                 onLoad: jest.fn(),
             },
+            validateCardFields: jest.fn(),
         },
     };
 }

--- a/src/payment/strategies/adyenv2/adyenv2.ts
+++ b/src/payment/strategies/adyenv2/adyenv2.ts
@@ -74,7 +74,7 @@ interface CardPaymentMethodState extends AdyenPaymentMethodState {
     encryptedExpiryMonth: string;
     encryptedExpiryYear: string;
     encryptedSecurityCode: string;
-    holderName?: string;
+    holderName: string;
 }
 
 export interface AdyenAction {
@@ -171,6 +171,8 @@ export interface AdyenComponentEvents {
      *  incomplete field. Called again when errors are cleared.
      */
     onError?(state: AdyenComponentState, component: AdyenComponent): void;
+
+    onFieldValid?(state: AdyenComponentState, component: AdyenComponent): void;
 }
 
 export interface AdyenClient {
@@ -180,6 +182,10 @@ export interface AdyenClient {
 }
 
 export interface AdyenComponent {
+    componentRef?: {
+        showValidation(): void;
+    };
+    state?: CardState;
     mount(containerId: string): HTMLElement;
     unmount(): void;
 }
@@ -486,6 +492,12 @@ export interface Card {
 export interface CardState {
     data: CardDataPaymentMethodState;
     isValid?: boolean;
+    valid?: {[key: string]: boolean};
+    errors?: CardStateErrors;
+}
+
+export interface CardStateErrors {
+    [key: string]: string;
 }
 
 export interface WechatState {


### PR DESCRIPTION
## What?
Fix validation for Adyen card fields

## Why?
because of task: [https://jira.bigcommerce.com/browse/ADYEN-296](https://jira.bigcommerce.com/browse/ADYEN-296)

## Testing / Proof
<img width="595" alt="Screenshot 2021-12-15 at 18 19 47" src="https://user-images.githubusercontent.com/9430298/146226780-95f72486-8681-45b1-8099-cb4fc055a818.png">
Tests:
<img width="345" alt="Screenshot 2021-12-15 at 18 23 11" src="https://user-images.githubusercontent.com/9430298/146226843-c37062fa-4838-4950-b6da-dd22b74cf6f4.png">


@bigcommerce/checkout @bigcommerce/payments
