### PR TITLE
fix(payment): INT-5175 fixing redirect in googlepay using embedded checkout on customer section

### DIFF
--- a/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -144,12 +144,16 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
     }
 
     private _onPaymentSelectComplete(): void {
-        this._formPoster.postForm('/checkout.php', {
-            headers: {
-                Accept: 'text/html',
-                'Content-Type': 'application/x-www-form-urlencoded',
-                ...SDK_VERSION_HEADERS,
-            },
-        });
+        const checkoutUrl = this._store.getState().config.getStoreConfigOrThrow().links.siteLink;
+
+        this._formPoster.postForm(
+            window.location.pathname === '/embedded-checkout' ? `${checkoutUrl}/checkout` : '/checkout.php',
+            {
+                headers: {
+                    Accept: 'text/html',
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    ...SDK_VERSION_HEADERS,
+                },
+            });
     }
 }


### PR DESCRIPTION
## What? [INT-5176](https://jira.bigcommerce.com/browse/INT-5176)
- Fix redirect in googlepay using embedded checkout on customer section

## Why?
- When a client clicks Gpay button on the customer section using embedded Checkout page, the application redirects to BC store to continue the payment process instead of the current page

## Testing / Proof
[VIDEO](https://drive.google.com/file/d/16ySUzMdSAlvUtFFE6MyoFkZNGAKxsZkd/view?usp=sharing)
![image](https://user-images.githubusercontent.com/42154828/147297218-2d489a9a-2421-431f-a552-ca1b83863891.png)
## depends on
https://github.com/bigcommerce/bigcommerce/pull/44273


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
