### PR TITLE
feat(payment): BOLT-135 multi-field component

### DIFF
--- a/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -325,7 +325,10 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
         const boltEmbedded = this._getBoltEmbedded();
 
         const styles = { backgroundColor: '#fff' };
-        const embeddedField = boltEmbedded.create('payment_field', { styles });
+        const embeddedField = boltEmbedded.create('payment_field', {
+            styles,
+            renderSeparateFields: true,
+        });
         embeddedField.mount(`#${containerId}`);
 
         this._embeddedField = embeddedField;

--- a/src/payment/strategies/bolt/bolt.ts
+++ b/src/payment/strategies/bolt/bolt.ts
@@ -18,6 +18,7 @@ export interface BoltOpenCheckoutCallbacks {
 
 export interface BoltEmbeddedOptions {
     styles: { backgroundColor: string };
+    renderSeparateFields?: boolean;
 }
 
 export interface BoltEmbedded {


### PR DESCRIPTION
## What?
Replace Bolt single line payment component to the multi-field component

## Why?
Because of task: [https://jira.bigcommerce.com/browse/BOLT-135](https://jira.bigcommerce.com/browse/BOLT-135)

## Testing / Proof
Before:
<img width="623" alt="Screenshot 2022-01-13 at 15 18 19" src="https://user-images.githubusercontent.com/9430298/149337417-ac972b61-56b4-476d-8018-13908503f298.png"><img width="626" alt="Screenshot 2022-01-13 at 15 18 34" src="https://user-images.githubusercontent.com/9430298/149337451-270589fd-9cae-41e1-b419-7935b2c9dc6d.png">


After:
<img width="674" alt="Screenshot 2022-01-13 at 15 12 58" src="https://user-images.githubusercontent.com/9430298/149336642-00709d9a-8ca4-431c-b2c4-26b57468bb01.png"><img width="651" alt="Screenshot 2022-01-13 at 15 13 18" src="https://user-images.githubusercontent.com/9430298/149336662-0760a98a-2927-4366-af13-46f830368f61.png">

Tests:
<img width="305" alt="Screenshot 2022-01-13 at 15 09 03" src="https://user-images.githubusercontent.com/9430298/149336132-a244242e-77f1-4108-b2c9-876c994fd7a5.png">


@bigcommerce/checkout @bigcommerce/payments
