### PR TITLE
fix(payment): INT-5402 Afterpay - Change the SDK URL to the newest one

### DIFF
--- a/src/payment/strategies/afterpay/afterpay-script-loader.spec.ts
+++ b/src/payment/strategies/afterpay/afterpay-script-loader.spec.ts
@@ -62,7 +62,7 @@ describe('AfterpayScriptLoader', () => {
         afterpayScriptLoader.load(method, 'US');
 
         expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-            '//portal.us-sandbox.afterpay.com/afterpay-async.js'
+            '//portal.sandbox.afterpay.com/afterpay-async.js'
         );
     });
 });

--- a/src/payment/strategies/afterpay/afterpay-script-loader.ts
+++ b/src/payment/strategies/afterpay/afterpay-script-loader.ts
@@ -17,7 +17,7 @@ const SCRIPTS_DEFAULT: AfterpayScripts = {
 
 const SCRIPTS_US: AfterpayScripts = {
     PROD: '//portal.afterpay.com/afterpay-async.js',
-    SANDBOX: '//portal.us-sandbox.afterpay.com/afterpay-async.js',
+    SANDBOX: '//portal.sandbox.afterpay.com/afterpay-async.js',
 };
 
 /** Class responsible for loading the Afterpay SDK */


### PR DESCRIPTION
## What? [INT-5402](https://jira.bigcommerce.com/browse/INT-5402)
Replace the SDK URL to the newest one and modify the unit tests

## Why?
Afterpay has deprecated the current URL without any previous notice so tests started to fail.

## Testing / Proof
![image](https://user-images.githubusercontent.com/36899206/149380586-ffd36fb7-5137-4923-a5ee-07490ce8a56a.png)

ping @bigcommerce/apex-integrations @bigcommerce/payments 
