### PR TITLE
fix(checkout) INT-5409: Change error message when payment data is unavailable

### DIFF
--- a/src/payment/strategies/opy/opy-payment-error.spec.ts
+++ b/src/payment/strategies/opy/opy-payment-error.spec.ts
@@ -1,0 +1,11 @@
+import OpyError from './opy-payment-error';
+
+describe('DigitalRiverError', () => {
+    it('returns error name, type and message', () => {
+        const error = new OpyError('payment.opy_invalid_cart_error', 'opyInvalidCartError');
+
+        expect(error.name).toEqual('opyInvalidCartError');
+        expect(error.type).toEqual('payment.opy_invalid_cart_error');
+        expect(error.message).toEqual('Unable to proceed because cart data is unavailable or payment for this order has already been made');
+    });
+});

--- a/src/payment/strategies/opy/opy-payment-error.ts
+++ b/src/payment/strategies/opy/opy-payment-error.ts
@@ -1,0 +1,12 @@
+import { StandardError } from '../../../common/error/errors';
+
+const defaultMessage: string = 'Unable to proceed because cart data is unavailable or payment for this order has already been made';
+
+export default class OpyError extends StandardError {
+    constructor(type: string, name: string, message?: string) {
+        super(message || defaultMessage);
+
+        this.type = type;
+        this.name = name;
+    }
+}

--- a/src/payment/strategies/opy/opy-payment-strategy.spec.ts
+++ b/src/payment/strategies/opy/opy-payment-strategy.spec.ts
@@ -29,6 +29,7 @@ import { getErrorPaymentResponseBody } from '../../payments.mock';
 import StorefrontPaymentRequestSender from '../../storefront-payment-request-sender';
 
 import { ActionTypes, OpyPaymentMethod } from './opy';
+import OpyError from './opy-payment-error';
 import OpyPaymentStrategy from './opy-payment-strategy';
 
 describe('OpyPaymentStrategy', () => {
@@ -166,7 +167,7 @@ describe('OpyPaymentStrategy', () => {
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValueOnce({ ...getOpy(), initializationData: undefined });
 
-                await expect(strategy.execute(payload, options)).rejects.toThrow(MissingDataError);
+                await expect(strategy.execute(payload, options)).rejects.toThrow(OpyError);
             });
 
             it('nonce is empty', async () => {

--- a/src/payment/strategies/opy/opy-payment-strategy.ts
+++ b/src/payment/strategies/opy/opy-payment-strategy.ts
@@ -10,6 +10,7 @@ import StorefrontPaymentRequestSender from '../../storefront-payment-request-sen
 import PaymentStrategy from '../payment-strategy';
 
 import { isOpyPaymentMethod, ActionTypes } from './opy';
+import OpyError from './opy-payment-error';
 
 export default class OpyPaymentStrategy implements PaymentStrategy {
     constructor(
@@ -40,7 +41,7 @@ export default class OpyPaymentStrategy implements PaymentStrategy {
         const paymentMethod = getPaymentMethodOrThrow(methodId);
 
         if (!isOpyPaymentMethod(paymentMethod)) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            throw new OpyError('payment.opy_invalid_cart_error', 'opyInvalidCartError');
         }
 
         const {


### PR DESCRIPTION

## What?
When trying to modify a cart for an order already paid, an error message
is shown informing the user that payment method is not available.

This modifies the message in order to be more verbose with the customer,
as the error occurs due to missing cart information or if the order has
already been paid.

## Testing  / Proof
![Screen Shot 2022-01-24 at 13 31 42](https://user-images.githubusercontent.com/92743730/150851473-c3817c71-1725-4b91-83c1-820a1cf1daa6.png)


https://user-images.githubusercontent.com/92743730/150851576-75ef50f3-f8bc-4cfa-a536-d97b08f688ab.mov


@bigcommerce/checkout @bigcommerce/payments
