### PR TITLE
feat(shipping): CHECKOUT-6004 Add pick up options to consignment interface

### DIFF
--- a/src/shipping/consignment-request-sender.ts
+++ b/src/shipping/consignment-request-sender.ts
@@ -6,12 +6,12 @@ import { joinIncludes, joinOrMergeIncludes, ContentType, RequestOptions, SDK_VER
 import { ConsignmentsRequestBody, ConsignmentUpdateRequestBody } from './consignment';
 
 const DEFAULT_INCLUDES = [
-        'consignments.availableShippingOptions',
-        'cart.lineItems.physicalItems.options',
-        'cart.lineItems.digitalItems.options',
-        'customer',
-        'promotions.banners',
-    ];
+    'consignments.availableShippingOptions',
+    'cart.lineItems.physicalItems.options',
+    'cart.lineItems.digitalItems.options',
+    'customer',
+    'promotions.banners',
+];
 
 export default class ConsignmentRequestSender {
     constructor(

--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -1,5 +1,6 @@
 import { Address, AddressRequestBody } from '../address';
 
+import PickupOption from './pickup-option';
 import ShippingOption from './shipping-option';
 
 export default interface Consignment {
@@ -9,6 +10,7 @@ export default interface Consignment {
     shippingCost: number;
     availableShippingOptions?: ShippingOption[];
     selectedShippingOption?: ShippingOption;
+    selectedPickupOption?: PickupOption;
     lineItemIds: string[];
 }
 
@@ -20,17 +22,20 @@ export type ConsignmentRequestBody =
 export interface ConsignmentCreateRequestBody {
     shippingAddress: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
+    pickupOption?: PickupOption;
 }
 
 export interface ConsignmentAssignmentRequestBody {
     shippingAddress: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
+    pickupOption?: PickupOption;
 }
 
 export interface ConsignmentUpdateRequestBody {
     id: string;
     shippingAddress?: AddressRequestBody;
     lineItems?: ConsignmentLineItem[];
+    pickupOption?: PickupOption;
 }
 
 export interface ConsignmentMeta {

--- a/src/shipping/pickup-option.ts
+++ b/src/shipping/pickup-option.ts
@@ -1,0 +1,3 @@
+export default interface PickupOption {
+    pickupMethodId: number;
+}


### PR DESCRIPTION
## What?
Add pickup options and address to consignment interface

## Why?
As we introduce MLI, we need to add pickup options and address to consignment. 

## Testing / Proof
- Tests

@bigcommerce/checkout
