### PR TITLE
feat(checkout): CHECKOUT-6071 Update Apple Pay in Cart

### DIFF
--- a/src/checkout-buttons/checkout-button-initializer.spec.ts
+++ b/src/checkout-buttons/checkout-button-initializer.spec.ts
@@ -4,7 +4,7 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { of } from 'rxjs';
 
 import { createCheckoutStore, CheckoutStore } from '../checkout';
-import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
+import { createPaymentClient, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 
 import { CheckoutButtonActionType } from './checkout-button-actions';
 import CheckoutButtonErrorSelector from './checkout-button-error-selector';
@@ -21,8 +21,9 @@ describe('CheckoutButtonInitializer', () => {
 
     beforeEach(() => {
         store = createCheckoutStore();
+        const paymentClient = createPaymentClient(store);
         buttonActionCreator = new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store, createRequestSender(), createFormPoster(), 'en'),
+            createCheckoutButtonRegistry(store, paymentClient, createRequestSender(), createFormPoster(), 'en'),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()))
         );
 

--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -2,6 +2,7 @@ import { RequestOptions } from '../common/http-request';
 
 import { CheckoutButtonMethodType } from './strategies';
 import { AmazonPayV2ButtonInitializeOptions } from './strategies/amazon-pay-v2';
+import { ApplePayButtonInitializeOptions } from './strategies/apple-pay';
 import { BraintreePaypalButtonInitializeOptions } from './strategies/braintree';
 import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
@@ -18,6 +19,12 @@ export interface CheckoutButtonOptions extends RequestOptions {
 }
 
 export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
+    /**
+     * The options that are required to initialize the ApplePay payment method.
+     * They can be omitted unless you need to support ApplePay in cart.
+     */
+    applepay?: ApplePayButtonInitializeOptions;
+
     /**
      * The options that are required to facilitate AmazonPayV2. They can be
      * omitted unless you need to support AmazonPayV2.

--- a/src/checkout-buttons/create-checkout-button-initializer.ts
+++ b/src/checkout-buttons/create-checkout-button-initializer.ts
@@ -2,7 +2,7 @@ import { createFormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { createCheckoutStore } from '../checkout';
-import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
+import { createPaymentClient, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 
 import CheckoutButtonInitializer from './checkout-button-initializer';
 import CheckoutButtonInitializerOptions from './checkout-button-initializer-options';
@@ -37,13 +37,14 @@ export default function createCheckoutButtonInitializer(
 ): CheckoutButtonInitializer {
     const { host, locale = 'en' } = options ?? {};
     const store = createCheckoutStore();
+    const paymentClient = createPaymentClient(store);
     const requestSender = createRequestSender({ host });
     const formPoster = createFormPoster({ host });
 
     return new CheckoutButtonInitializer(
         store,
         new CheckoutButtonStrategyActionCreator(
-            createCheckoutButtonRegistry(store, requestSender, formPoster, locale, host),
+            createCheckoutButtonRegistry(store, paymentClient, requestSender, formPoster, locale, host),
             new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender))
         )
     );

--- a/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -3,10 +3,12 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 
 import { createCheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
+import { createPaymentClient } from '../payment';
 
 import createCheckoutButtonRegistry from './create-checkout-button-registry';
 import { CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
+import { ApplePayButtonStrategy } from './strategies/apple-pay';
 import { BraintreePaypalButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 
@@ -14,7 +16,13 @@ describe('createCheckoutButtonRegistry', () => {
     let registry: Registry<CheckoutButtonStrategy>;
 
     beforeEach(() => {
-        registry = createCheckoutButtonRegistry(createCheckoutStore(), createRequestSender(), createFormPoster(), 'en');
+        const store = createCheckoutStore();
+        const paymentClient = createPaymentClient(store);
+        registry = createCheckoutButtonRegistry(store, paymentClient, createRequestSender(), createFormPoster(), 'en');
+    });
+
+    it('returns registry with ApplePay registered', () => {
+        expect(registry.get('applepay')).toEqual(expect.any(ApplePayButtonStrategy));
     });
 
     it('returns registry with Braintree PayPal registered', () => {

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-initialize-options.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-initialize-options.ts
@@ -14,12 +14,4 @@
      * A callback that gets called when a payment is successfully completed.
      */
     onPaymentAuthorize(): void;
-
-    /**
-     * A callback that gets called if unable to initialize the widget or select
-     * one of the address options provided by the widget.
-     *
-     * @param error - The error object describing the failure.
-     */
-    onError?(error?: Error): void;
 }

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-initialize-options.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-initialize-options.ts
@@ -1,0 +1,40 @@
+/**
+ * A set of options that are required to initialize ApplePay in cart.
+ *
+ * When ApplePay is initialized, an ApplePay button will be inserted into the
+ * DOM. When a customer clicks on it, it will trigger Apple sheet.
+ */
+ export default interface ApplePayButtonInitializeOptions {
+    /**
+     * The ID of a container which the sign-in button should insert into.
+     */
+    container: string;
+
+    /**
+     * The class name of the ApplePay button style.
+     */
+    buttonClassName?: string;
+
+    /**
+     * Shipping label to be passed to apple sheet.
+     */
+    shippingLabel?: string;
+
+    /**
+     * Sub total label to be passed to apple sheet.
+     */
+    subtotalLabel?: string;
+
+    /**
+     * A callback that gets called when a payment is successfully completed.
+     */
+    onPaymentAuthorize(): void;
+
+    /**
+     * A callback that gets called if unable to initialize the widget or select
+     * one of the address options provided by the widget.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error?: Error): void;
+}

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-initialize-options.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-initialize-options.ts
@@ -6,24 +6,9 @@
  */
  export default interface ApplePayButtonInitializeOptions {
     /**
-     * The ID of a container which the sign-in button should insert into.
-     */
-    container: string;
-
-    /**
      * The class name of the ApplePay button style.
      */
     buttonClassName?: string;
-
-    /**
-     * Shipping label to be passed to apple sheet.
-     */
-    shippingLabel?: string;
-
-    /**
-     * Sub total label to be passed to apple sheet.
-     */
-    subtotalLabel?: string;
 
     /**
      * A callback that gets called when a payment is successfully completed.

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-mock.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-mock.ts
@@ -1,0 +1,33 @@
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import { CheckoutButtonMethodType } from '../index';
+
+export function getApplePayButtonInitializationOptions(): CheckoutButtonInitializeOptions {
+    return {
+        containerId: 'applePayCheckoutButton',
+        methodId: CheckoutButtonMethodType.APPLEPAY,
+        applepay: {
+            container: 'applePayCheckoutButton',
+            shippingLabel: 'Shipping',
+            subtotalLabel: 'Subtotal',
+            onPaymentAuthorize: jest.fn(),
+            onError: jest.fn(),
+        },
+    };
+}
+
+export function getContactAddress() {
+    return {
+        administrativeArea: 'CA',
+        country: 'United States',
+        countryCode: 'US',
+        emailAddress: 'test@test.com',
+        familyName: '',
+        givenName: '',
+        locality: 'San Francisco',
+        phoneticFamilyName: '',
+        phoneticGivenName: '',
+        postalCode: '94114',
+        subAdministrativeArea: '',
+        subLocality: '',
+    };
+}

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-mock.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-mock.ts
@@ -7,7 +7,6 @@ export function getApplePayButtonInitializationOptions(): CheckoutButtonInitiali
         methodId: CheckoutButtonMethodType.APPLEPAY,
         applepay: {
             onPaymentAuthorize: jest.fn(),
-            onError: jest.fn(),
         },
     };
 }

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-mock.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-mock.ts
@@ -6,9 +6,6 @@ export function getApplePayButtonInitializationOptions(): CheckoutButtonInitiali
         containerId: 'applePayCheckoutButton',
         methodId: CheckoutButtonMethodType.APPLEPAY,
         applepay: {
-            container: 'applePayCheckoutButton',
-            shippingLabel: 'Shipping',
-            subtotalLabel: 'Subtotal',
             onPaymentAuthorize: jest.fn(),
             onError: jest.fn(),
         },

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.spec.ts
@@ -227,8 +227,11 @@ describe('ApplePayButtonStrategy', () => {
                         validationURL: 'test',
                     } as ApplePayJS.ApplePayValidateMerchantEvent;
 
-                    await applePaySession.onvalidatemerchant(validateEvent);
-                    expect(CheckoutButtonInitializeOptions.applepay.onError).toHaveBeenCalled();
+                    try {
+                        await applePaySession.onvalidatemerchant(validateEvent);
+                    } catch (error) {
+                        expect(error).toBeInstanceOf(Error);
+                    }
                 }
             }
         });
@@ -266,9 +269,11 @@ describe('ApplePayButtonStrategy', () => {
                         shippingContact: getContactAddress(),
                     } as ApplePayJS.ApplePayShippingContactSelectedEvent;
 
-                    await applePaySession.onshippingcontactselected(event);
-
-                    expect(CheckoutButtonInitializeOptions.applepay.onError).toHaveBeenCalled();
+                    try {
+                        await applePaySession.onshippingcontactselected(event);
+                    } catch (error) {
+                        expect(error).toBeInstanceOf(Error);
+                    }
                 }
             }
         });
@@ -315,9 +320,11 @@ describe('ApplePayButtonStrategy', () => {
                         },
                     } as ApplePayJS.ApplePayShippingMethodSelectedEvent;
 
-                    await applePaySession.onshippingmethodselected(event);
-
-                    expect(CheckoutButtonInitializeOptions.applepay.onError).toHaveBeenCalled();
+                    try {
+                        await applePaySession.onshippingmethodselected(event);
+                    } catch (error) {
+                        expect(error).toBeInstanceOf(Error);
+                    }
                 }
             }
         });
@@ -369,11 +376,14 @@ describe('ApplePayButtonStrategy', () => {
                 const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
-                    await applePaySession.onpaymentauthorized(authEvent);
 
-                    expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
-                    expect(applePaySession.completePayment).toHaveBeenCalled();
-                    expect(CheckoutButtonInitializeOptions.applepay.onError).toHaveBeenCalled();
+                    try {
+                        await applePaySession.onpaymentauthorized(authEvent);
+                    } catch (error) {
+                        expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                        expect(applePaySession.completePayment).toHaveBeenCalled();
+                        expect(error).toBeInstanceOf(Error);
+                    }
                 }
             }
         });

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.spec.ts
@@ -181,8 +181,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
 
@@ -199,8 +198,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
 
@@ -221,8 +219,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
 
@@ -240,8 +237,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
 
@@ -262,8 +258,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
 
@@ -282,8 +277,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
 
@@ -308,8 +302,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
 
@@ -344,8 +337,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
                     await applePaySession.onpaymentauthorized(authEvent);
@@ -374,8 +366,7 @@ describe('ApplePayButtonStrategy', () => {
             const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
             await strategy.initialize(CheckoutButtonInitializeOptions);
             if (CheckoutButtonInitializeOptions.applepay) {
-                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
-                const button = buttonContainer?.firstChild as HTMLElement;
+                const button = container.firstChild as HTMLElement;
                 if (button) {
                     button.click();
                     await applePaySession.onpaymentauthorized(authEvent);

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.spec.ts
@@ -1,0 +1,390 @@
+import { createAction } from '@bigcommerce/data-store';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { merge } from 'lodash';
+import { of } from 'rxjs/internal/observable/of';
+import { Observable } from 'rxjs/internal/Observable';
+
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
+import { createPaymentClient, PaymentActionCreator, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentRequestTransformer } from '../../../payment';
+// eslint-disable-next-line import/no-internal-modules
+import { PaymentActionType, SubmitPaymentAction } from '../../../payment/payment-actions';
+import { ApplePaySessionFactory } from '../../../payment/strategies/apple-pay';
+import { MockApplePaySession } from '../../../payment/strategies/apple-pay/apple-pay-payment.mock';
+import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
+import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+import { CheckoutButtonMethodType } from '../index';
+
+import { ApplePayButtonStrategy } from '.';
+import { getApplePayButtonInitializationOptions, getContactAddress } from './apple-pay-button-mock';
+
+describe('ApplePayButtonStrategy', () => {
+    let container: HTMLDivElement;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: CheckoutButtonStrategy;
+    let paymentClient: OrderRequestSender;
+    let applePaySession: MockApplePaySession;
+    let paymentActionCreator: PaymentActionCreator;
+    let billingAddressActionCreator: BillingAddressActionCreator;
+    let consignmentActionCreator: ConsignmentActionCreator;
+    let orderActionCreator: OrderActionCreator;
+    let applePayFactory: ApplePaySessionFactory;
+    let submitPaymentAction: Observable<SubmitPaymentAction>;
+    let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
+    let checkoutActionCreator: CheckoutActionCreator;
+
+    beforeEach(() => {
+        applePaySession = new MockApplePaySession();
+
+        Object.defineProperty(window, 'ApplePaySession', {
+            writable: true,
+            value: applePaySession,
+        });
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = createRequestSender();
+        paymentClient = createPaymentClient(store);
+        applePayFactory = new ApplePaySessionFactory();
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        consignmentActionCreator = new ConsignmentActionCreator(
+            new ConsignmentRequestSender(requestSender),
+            new CheckoutRequestSender(requestSender)
+        );
+
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
+        remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(
+            new RemoteCheckoutRequestSender(requestSender),
+            checkoutActionCreator
+        );
+
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(requestSender),
+            new SubscriptionsActionCreator(
+                new SubscriptionsRequestSender(requestSender)
+            )
+        );
+
+        orderActionCreator = new OrderActionCreator(
+            paymentClient,
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(paymentClient),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(requestSender)
+        );
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(of(createAction(OrderActionType.SubmitOrderRequested)));
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+            .mockResolvedValue(store.getState());
+        jest.spyOn(requestSender, 'post')
+            .mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'updateAddress')
+            .mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'selectShippingOption')
+            .mockReturnValue(true);
+        jest.spyOn(billingAddressActionCreator, 'updateAddress')
+            .mockReturnValue(true);
+        jest.spyOn(applePayFactory, 'create')
+            .mockReturnValue(applePaySession);
+        jest.spyOn(checkoutActionCreator, 'loadCurrentCheckout')
+            .mockReturnValue(true);
+        jest.spyOn(remoteCheckoutActionCreator, 'signOut')
+            .mockReturnValue(true);
+
+        strategy = new ApplePayButtonStrategy(
+            store,
+            checkoutActionCreator,
+            requestSender,
+            paymentMethodActionCreator,
+            consignmentActionCreator,
+            billingAddressActionCreator,
+            paymentActionCreator,
+            remoteCheckoutActionCreator,
+            orderActionCreator,
+            applePayFactory
+        );
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'applePayCheckoutButton');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    describe('#initialize()', () => {
+        it('creates the button', async () => {
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            let children = container.children;
+            expect(children.length).toBe(0);
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            children = container.children;
+
+            expect(children.length).toBe(1);
+            expect(container.getElementsByClassName('apple-pay-checkout-button')[0]).toBeTruthy();
+        });
+
+        it('creates the button with a custom style class name', async () => {
+            const customClass = 'testClassName';
+            const CheckoutButtonInitializeOptions = merge(getApplePayButtonInitializationOptions(), { applepay: { buttonClassName: customClass }});
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+
+            expect(container.getElementsByClassName(customClass)[0]).toBeTruthy();
+        });
+
+        it('throws error when payment data is empty', async () => {
+            await expect(strategy.initialize({containerId: '', methodId: CheckoutButtonMethodType.APPLEPAY, params: {}})).rejects.toThrow(MissingDataError);
+        });
+
+        it('throws error when ApplePay object is empty', async () => {
+            await expect(strategy.initialize({containerId: '', params: {}, methodId: CheckoutButtonMethodType.APPLEPAY })).rejects.toThrow(MissingDataError);
+        });
+
+        it('throws error when ApplePay object is empty', async () => {
+            const options = {
+                methodId: 'applepay',
+                applepay: {},
+            } as CheckoutButtonInitializeOptions;
+            await expect(strategy.initialize(options)).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('throws error when ApplePay payment sheet is cancelled', async () => {
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    expect(applePaySession.begin).toHaveBeenCalled();
+                    await applePaySession.oncancel();
+
+                    expect(remoteCheckoutActionCreator.signOut).toHaveBeenCalled();
+                    expect(checkoutActionCreator.loadCurrentCheckout).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('validates merchant successfully', async () => {
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const validateEvent = {
+                        validationURL: 'test',
+                    } as ApplePayJS.ApplePayValidateMerchantEvent;
+
+                    await applePaySession.onvalidatemerchant(validateEvent);
+
+                    expect(requestSender.post).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('throws error if merchant validation fails', async () => {
+            jest.spyOn(requestSender, 'post')
+                .mockRejectedValue(false);
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const validateEvent = {
+                        validationURL: 'test',
+                    } as ApplePayJS.ApplePayValidateMerchantEvent;
+
+                    await applePaySession.onvalidatemerchant(validateEvent);
+                    expect(CheckoutButtonInitializeOptions.applepay.onError).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('gets shipping contact selected successfully', async () => {
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingContact: getContactAddress(),
+                    } as ApplePayJS.ApplePayShippingContactSelectedEvent;
+
+                    await applePaySession.onshippingcontactselected(event);
+
+                    expect(applePaySession.completeShippingContactSelection).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('throws error if call to update address fails', async () => {
+            jest.spyOn(consignmentActionCreator, 'updateAddress')
+                .mockRejectedValue(false);
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingContact: getContactAddress(),
+                    } as ApplePayJS.ApplePayShippingContactSelectedEvent;
+
+                    await applePaySession.onshippingcontactselected(event);
+
+                    expect(CheckoutButtonInitializeOptions.applepay.onError).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('gets shipping method selected successfully', async () => {
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingMethod: {
+                            label: 'test',
+                            detail: 'test2',
+                            amount: '10',
+                            identifier: '1',
+                        },
+                    } as ApplePayJS.ApplePayShippingMethodSelectedEvent;
+                    await applePaySession.onshippingmethodselected(event);
+
+                    expect(applePaySession.completeShippingMethodSelection).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('gets call to update shipping option in consignment fails', async () => {
+            jest.spyOn(consignmentActionCreator, 'selectShippingOption')
+                .mockRejectedValue(false);
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingMethod: {
+                            label: 'test',
+                            detail: 'test2',
+                            amount: '10',
+                            identifier: '1',
+                        },
+                    } as ApplePayJS.ApplePayShippingMethodSelectedEvent;
+
+                    await applePaySession.onshippingmethodselected(event);
+
+                    expect(CheckoutButtonInitializeOptions.applepay.onError).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('submits payment when shopper authorises', async () => {
+            const authEvent = {
+                payment: {
+                    billingContact: getContactAddress(),
+                    shippingContact: getContactAddress(),
+                    token: {
+                        paymentData: {},
+                        paymentMethod: {},
+                        transactionIdentifier: {},
+                    },
+                },
+            } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+                    await applePaySession.onpaymentauthorized(authEvent);
+
+                    expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                    expect(applePaySession.completePayment).toHaveBeenCalled();
+                    expect(CheckoutButtonInitializeOptions.applepay.onPaymentAuthorize).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('returns an error if autorize payment fails', async () => {
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockRejectedValue(false);
+            const authEvent = {
+                payment: {
+                    billingContact: getContactAddress(),
+                    shippingContact: getContactAddress(),
+                    token: {
+                        paymentData: {},
+                        paymentMethod: {},
+                        transactionIdentifier: {},
+                    },
+                },
+            } as ApplePayJS.ApplePayPaymentAuthorizedEvent;
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(CheckoutButtonInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+                    await applePaySession.onpaymentauthorized(authEvent);
+
+                    expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                    expect(applePaySession.completePayment).toHaveBeenCalled();
+                    expect(CheckoutButtonInitializeOptions.applepay.onError).toHaveBeenCalled();
+                }
+            }
+        });
+    });
+});

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
@@ -4,7 +4,7 @@ import { noop } from 'lodash';
 import { AddressRequestBody } from '../../../address';
 import { BillingAddressActionCreator } from '../../../billing';
 import { Cart } from '../../../cart';
-import { Checkout, CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { Checkout, CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { bindDecorator as bind } from '../../../common/utility';
 import { StoreConfig } from '../../../config';
@@ -49,7 +49,7 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
         private _sessionFactory: ApplePaySessionFactory
     ) {}
 
-    async initialize(options: CheckoutButtonInitializeOptions): Promise<InternalCheckoutSelectors> {
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
 
         const { methodId, containerId , applepay}  = options;
 
@@ -61,14 +61,10 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
 
         const {
             buttonClassName,
-            shippingLabel,
-            subtotalLabel,
             onError = () => {},
             onPaymentAuthorize,
         } = applepay;
 
-        this._shippingLabel = shippingLabel || DefaultLabels.Shipping;
-        this._subTotalLabel = subtotalLabel || DefaultLabels.Subtotal;
         this._onAuthorizeCallback = onPaymentAuthorize;
         this._onError = onError;
 
@@ -78,11 +74,11 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
         this._applePayButton = this._createButton(containerId, buttonClassName);
         this._applePayButton.addEventListener('click', this._handleWalletButtonClick);
 
-        return this._store.getState();
+        return Promise.resolve();
     }
 
-    deinitialize(): Promise<InternalCheckoutSelectors> {
-        return Promise.resolve(this._store.getState());
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
     }
 
     private _createButton(containerId: string, buttonClassName: string = 'apple-pay-checkout-button'): HTMLElement {

--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
@@ -1,0 +1,397 @@
+import { RequestSender } from '@bigcommerce/request-sender';
+import { noop } from 'lodash';
+
+import { AddressRequestBody } from '../../../address';
+import { BillingAddressActionCreator } from '../../../billing';
+import { Cart } from '../../../cart';
+import { Checkout, CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { bindDecorator as bind } from '../../../common/utility';
+import { StoreConfig } from '../../../config';
+import { OrderActionCreator } from '../../../order';
+import { Payment, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
+import { PaymentMethodCancelledError } from '../../../payment/errors';
+import { assertApplePayWindow, ApplePaySessionFactory } from '../../../payment/strategies/apple-pay';
+import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
+import { ConsignmentActionCreator, ShippingOption } from '../../../shipping';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+const validationEndpoint = (bigPayEndpoint: string) => `${bigPayEndpoint}/api/public/v1/payments/applepay/validate_merchant`;
+
+enum DefaultLabels {
+    Subtotal = 'Subtotal',
+    Shipping = 'Shipping',
+}
+
+function isShippingOptions(options: ShippingOption[] | undefined): options is ShippingOption[] {
+    return options instanceof Array;
+}
+
+export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
+    private _paymentMethod?: PaymentMethod;
+    private _applePayButton?: HTMLElement;
+    private _onAuthorizeCallback = noop;
+    private _onError = noop;
+    private _subTotalLabel: string = DefaultLabels.Subtotal;
+    private _shippingLabel: string = DefaultLabels.Shipping;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _requestSender: RequestSender,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _consignmentActionCreator: ConsignmentActionCreator,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
+        private _orderActionCreator: OrderActionCreator,
+        private _sessionFactory: ApplePaySessionFactory
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<InternalCheckoutSelectors> {
+
+        const { methodId, containerId , applepay}  = options;
+
+        assertApplePayWindow(window);
+
+        if (!methodId || !applepay) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const {
+            buttonClassName,
+            shippingLabel,
+            subtotalLabel,
+            onError = () => {},
+            onPaymentAuthorize,
+        } = applepay;
+
+        this._shippingLabel = shippingLabel || DefaultLabels.Shipping;
+        this._subTotalLabel = subtotalLabel || DefaultLabels.Subtotal;
+        this._onAuthorizeCallback = onPaymentAuthorize;
+        this._onError = onError;
+
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        this._applePayButton = this._createButton(containerId, buttonClassName);
+        this._applePayButton.addEventListener('click', this._handleWalletButtonClick);
+
+        return this._store.getState();
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _createButton(containerId: string, buttonClassName: string = 'apple-pay-checkout-button'): HTMLElement {
+        const container = document.getElementById(containerId);
+        if (!container) {
+            throw new InvalidArgumentError('Unable to create wallet button without valid container ID.');
+        }
+
+        const button = document.createElement('div');
+        button.classList.add(buttonClassName);
+        button.setAttribute('role', 'button');
+        button.setAttribute('aria-label', 'Apple Pay button');
+        container.appendChild(button);
+
+        return button;
+    }
+
+    @bind
+    private _handleWalletButtonClick(event: Event) {
+        event.preventDefault();
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const config = state.config.getStoreConfigOrThrow();
+        const checkout = state.checkout.getCheckoutOrThrow();
+
+        if (!this._paymentMethod || !this._paymentMethod.initializationData) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+        const request = this._getBaseRequest(cart, checkout, config, this._paymentMethod);
+        const applePaySession = this._sessionFactory.create(request);
+        this._handleApplePayEvents(applePaySession, this._paymentMethod, config);
+
+        applePaySession.begin();
+    }
+
+    private _getBaseRequest(
+        cart: Cart,
+        checkout: Checkout,
+        config: StoreConfig,
+        paymentMethod: PaymentMethod
+    ): ApplePayJS.ApplePayPaymentRequest {
+        const { storeProfile: { storeCountryCode, storeName } } = config;
+        const { currency: { code, decimalPlaces} } = cart;
+
+        const { initializationData : { merchantCapabilities, supportedNetworks } } = paymentMethod;
+
+        const requiresShipping = cart.lineItems.physicalItems.length > 0;
+        const total: ApplePayJS.ApplePayLineItem = requiresShipping ? {
+            label: storeName,
+            amount: `${checkout.grandTotal.toFixed(decimalPlaces)}`,
+            type: 'pending',
+        } : {
+            label: storeName,
+            amount: `${checkout.grandTotal.toFixed(decimalPlaces)}`,
+            type: 'final',
+        };
+
+        const request: ApplePayJS.ApplePayPaymentRequest = {
+            requiredBillingContactFields: ['postalAddress'],
+            requiredShippingContactFields: ['email', 'phone'],
+            countryCode: storeCountryCode,
+            currencyCode: code,
+            merchantCapabilities,
+            supportedNetworks,
+            lineItems: [],
+            total,
+        };
+
+        if (requiresShipping) {
+            request.requiredShippingContactFields?.push('postalAddress');
+        } else {
+            const lineItems: ApplePayJS.ApplePayLineItem[] = [
+                { label: this._subTotalLabel, amount: `${checkout.subtotal.toFixed(decimalPlaces)}`},
+            ];
+
+            checkout.taxes.forEach(tax =>
+                lineItems.push({ label: tax.name, amount: `${tax.amount.toFixed(decimalPlaces)}` }));
+
+            request.lineItems = lineItems;
+        }
+
+        return request;
+    }
+
+    private _handleApplePayEvents(
+        applePaySession: ApplePaySession,
+        paymentMethod: PaymentMethod,
+        config: StoreConfig
+    ) {
+        applePaySession.onvalidatemerchant = async event => {
+            try {
+                const { body: merchantSession } = await this._onValidateMerchant(paymentMethod, event);
+                applePaySession.completeMerchantValidation(merchantSession);
+            } catch (err) {
+                this._onError(err);
+            }
+        };
+
+        applePaySession.onshippingcontactselected = async event =>
+            this._handleShippingContactSelected(applePaySession, config, event);
+
+        applePaySession.onshippingmethodselected = async event =>
+            this._handleShippingMethodSelected(applePaySession, config, event);
+
+        applePaySession.oncancel = async () => {
+            try {
+                await this._store.dispatch(this._remoteCheckoutActionCreator.signOut(paymentMethod.id));
+
+                return this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout());
+            } catch (error) {
+                return this._onError(new PaymentMethodCancelledError());
+            }
+        };
+
+        applePaySession.onpaymentauthorized = async event =>
+            this._onPaymentAuthorized(event, applePaySession, paymentMethod);
+    }
+
+    private async _handleShippingContactSelected(
+        applePaySession: ApplePaySession,
+        config: StoreConfig,
+        event: ApplePayJS.ApplePayShippingContactSelectedEvent
+    ) {
+        const shippingAddress = this._transformContactToAddress(event.shippingContact);
+
+        try {
+            await this._store.dispatch(
+                this._consignmentActionCreator.updateAddress(shippingAddress)
+            );
+        } catch (error) {
+            applePaySession.abort();
+
+            return this._onError(error);
+        }
+
+        const { storeProfile: { storeName } } = config;
+        let state = this._store.getState();
+        const { currency: { decimalPlaces } } = state.cart.getCartOrThrow();
+        let checkout = state.checkout.getCheckoutOrThrow();
+        const availableOptions = checkout.consignments[0].availableShippingOptions;
+        const shippingOptions = availableOptions?.map(option => ({
+            label: option.description,
+            amount: `${option.cost.toFixed(decimalPlaces)}`,
+            detail: option.additionalDescription,
+            identifier: option.id,
+        }));
+
+        if (!isShippingOptions(availableOptions)) {
+            throw new Error('Shipping options not available.');
+        } else {
+            const recommendedOption = availableOptions.find(
+                option => option.isRecommended
+            );
+
+            const optionId = recommendedOption ? recommendedOption.id : availableOptions[0].id;
+            try {
+                await this._updateShippingOption(optionId);
+            } catch (error) {
+                return this._onError(error);
+            }
+        }
+
+        state = this._store.getState();
+        checkout = state.checkout.getCheckoutOrThrow();
+
+        applePaySession.completeShippingContactSelection({
+            newShippingMethods: shippingOptions,
+            newTotal: {
+                type: 'final',
+                label: storeName,
+                amount: `${checkout.grandTotal.toFixed(decimalPlaces)}`,
+            },
+            newLineItems: this._getUpdatedLineItems(checkout, decimalPlaces),
+        });
+    }
+
+    private async _handleShippingMethodSelected(
+        applePaySession: ApplePaySession,
+        config: StoreConfig,
+        event: ApplePayJS.ApplePayShippingMethodSelectedEvent
+    ) {
+        const { storeProfile: { storeName } } = config;
+        const { shippingMethod: { identifier: optionId } } = event;
+        try {
+            await this._updateShippingOption(optionId);
+        } catch (error) {
+            applePaySession.abort();
+
+            return this._onError(error);
+        }
+
+        const state = this._store.getState();
+        const { currency: { decimalPlaces } } = state.cart.getCartOrThrow();
+        const checkout = state.checkout.getCheckoutOrThrow();
+
+        applePaySession.completeShippingMethodSelection({
+            newTotal: {
+                type: 'final',
+                label: storeName,
+                amount: `${checkout.grandTotal.toFixed(decimalPlaces)}`,
+            },
+            newLineItems: this._getUpdatedLineItems(checkout, decimalPlaces),
+        });
+    }
+
+    private _getUpdatedLineItems(checkout: Checkout, decimalPlaces: number): ApplePayJS.ApplePayLineItem[] {
+        const lineItems: ApplePayJS.ApplePayLineItem[] = [
+            { label: this._subTotalLabel, amount: `${checkout.subtotal.toFixed(decimalPlaces)}`},
+        ];
+
+        checkout.taxes.forEach(tax =>
+            lineItems.push({ label: tax.name, amount: `${tax.amount.toFixed(decimalPlaces)}` }));
+        lineItems.push({ label: this._shippingLabel, amount: `${checkout.shippingCostTotal.toFixed(decimalPlaces)}`});
+
+        return lineItems;
+    }
+
+    private async _updateShippingOption(optionId: string) {
+        return await this._store.dispatch(
+            this._consignmentActionCreator.selectShippingOption(optionId)
+        );
+    }
+
+    private async _onValidateMerchant(paymentData: PaymentMethod, event: ApplePayJS.ApplePayValidateMerchantEvent) {
+        const body = [
+            `validationUrl=${event.validationURL}`,
+            `merchantIdentifier=${paymentData.initializationData.merchantId}`,
+            `displayName=${paymentData.initializationData.storeName}`,
+            `domainName=${window.location.hostname}`,
+        ].join('&');
+
+        return this._requestSender.post(validationEndpoint(paymentData.initializationData.paymentsUrl), {
+            credentials: false,
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-XSRF-TOKEN': null,
+            },
+            body,
+        });
+    }
+
+    private async _onPaymentAuthorized(
+        event: ApplePayJS.ApplePayPaymentAuthorizedEvent,
+        applePaySession: ApplePaySession,
+        paymentMethod: PaymentMethod
+    ) {
+        const { token, billingContact, shippingContact } = event.payment;
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const requiresShipping = cart.lineItems.physicalItems.length > 0;
+        const payment: Payment = {
+            methodId: paymentMethod.id,
+            paymentData: {
+                formattedPayload: {
+                    apple_pay_token: {
+                        payment_data: token.paymentData,
+                        payment_method: token.paymentMethod,
+                        transaction_id: token.transactionIdentifier,
+                    },
+                },
+            },
+        };
+
+        const transformedBillingAddress = this._transformContactToAddress(billingContact);
+        const transformedShippingAddress = this._transformContactToAddress(shippingContact);
+        const emailAddress = shippingContact?.emailAddress;
+
+        try {
+            await this._store.dispatch(
+                this._billingAddressActionCreator.updateAddress({ ...transformedBillingAddress, email: emailAddress })
+            );
+
+            if (requiresShipping) {
+                await this._store.dispatch(
+                    this._consignmentActionCreator.updateAddress(transformedShippingAddress)
+                );
+            }
+
+            await this._store.dispatch(this._orderActionCreator.submitOrder(
+                {
+                    useStoreCredit: false,
+                })
+            );
+            await this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
+            applePaySession.completePayment(ApplePaySession.STATUS_SUCCESS);
+
+            return this._onAuthorizeCallback();
+        } catch (error) {
+            applePaySession.completePayment(ApplePaySession.STATUS_FAILURE);
+
+            return this._onError(error);
+        }
+    }
+
+    private _transformContactToAddress(contact?: ApplePayJS.ApplePayPaymentContact): AddressRequestBody {
+        return {
+            firstName: contact?.givenName || '',
+            lastName: contact?.familyName || '',
+            city: contact?.locality || '',
+            company: '',
+            address1: contact?.addressLines && contact?.addressLines[0] || '',
+            address2: contact?.addressLines && contact?.addressLines[1] || '',
+            postalCode: contact?.postalCode || '',
+            countryCode: contact?.countryCode || '',
+            phone: contact?.phoneNumber || '',
+            stateOrProvince: contact?.administrativeArea || '',
+            stateOrProvinceCode: contact?.administrativeArea || '',
+            customFields: [],
+        };
+    }
+}

--- a/src/checkout-buttons/strategies/apple-pay/index.ts
+++ b/src/checkout-buttons/strategies/apple-pay/index.ts
@@ -1,0 +1,2 @@
+export { default as ApplePayButtonStrategy } from './apple-pay-button-strategy';
+export { default as ApplePayButtonInitializeOptions } from './apple-pay-button-initialize-options';

--- a/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -1,4 +1,5 @@
 enum CheckoutButtonMethodType {
+    APPLEPAY = 'applepay',
     AMAZON_PAY_V2 = 'amazonpay',
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',

--- a/src/checkout-buttons/strategies/checkout-button-strategy.ts
+++ b/src/checkout-buttons/strategies/checkout-button-strategy.ts
@@ -1,7 +1,8 @@
+import { InternalCheckoutSelectors } from '../../checkout';
 import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
 
 export default interface CheckoutButtonStrategy {
-    initialize(options: CheckoutButtonInitializeOptions): Promise<void>;
+    initialize(options: CheckoutButtonInitializeOptions): Promise<void | InternalCheckoutSelectors>;
 
-    deinitialize(): Promise<void>;
+    deinitialize(): Promise<void | InternalCheckoutSelectors>;
 }

--- a/src/checkout-buttons/strategies/checkout-button-strategy.ts
+++ b/src/checkout-buttons/strategies/checkout-button-strategy.ts
@@ -1,8 +1,7 @@
-import { InternalCheckoutSelectors } from '../../checkout';
 import { CheckoutButtonInitializeOptions } from '../checkout-button-options';
 
 export default interface CheckoutButtonStrategy {
-    initialize(options: CheckoutButtonInitializeOptions): Promise<void | InternalCheckoutSelectors>;
+    initialize(options: CheckoutButtonInitializeOptions): Promise<void>;
 
-    deinitialize(): Promise<void | InternalCheckoutSelectors>;
+    deinitialize(): Promise<void>;
 }


### PR DESCRIPTION
## What?
Replace ApplePay in cart with the new code from `checkout-sdk-js`. Most code is based on [ApplePay customer strategy](https://github.com/bigcommerce/checkout-sdk-js/pull/1307) . 

Also:
- Allow a developer to initialize the button with a cutom class name.
- Default button styles `apple-pay-checkout-button` are defined in [BCapp/templates/__master/Styles/styles.css](https://github.com/bigcommerce/bigcommerce/blob/60c07dcbe0fd98f7af293f1059817e79090163e6/templates/__master/Styles/styles.css#L570). Developers might already use this class name to create their own ApplePay button.

# Depends on
https://github.com/bigcommerce/bigcommerce/pull/44819

## Why?
Consolidate BigCommerce's digital wallet experience for developers and shopers.

## Testing / Proof
![Screen Shot 2022-01-31 at 10 51 26 am](https://user-images.githubusercontent.com/88361607/151727401-98621f0a-ec00-40d1-a127-dd55e98d6fae.png)

https://user-images.githubusercontent.com/88361607/151727538-bc946483-e555-4b50-aad5-944bb22e80d4.mov


