### PR TITLE
feat(shipping): CHECKOUT-6003 Add method to fetch available shipping options

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -26,7 +26,7 @@ import { getAuthorizenet, getPaymentMethod, getPaymentMethods } from '../payment
 import { PaymentStrategy } from '../payment/strategies';
 import { NoPaymentDataRequiredPaymentStrategy } from '../payment/strategies/no-payment';
 import { OfflinePaymentStrategy } from '../payment/strategies/offline';
-import { createShippingStrategyRegistry, ConsignmentActionCreator, ConsignmentRequestSender, ShippingCountryActionCreator, ShippingCountryRequestSender, ShippingStrategyActionCreator } from '../shipping';
+import { createShippingStrategyRegistry, ConsignmentActionCreator, ConsignmentRequestSender, PickupOptionActionCreator, PickupOptionRequestSender, ShippingCountryActionCreator, ShippingCountryRequestSender, ShippingStrategyActionCreator } from '../shipping';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 import { getShippingOptions } from '../shipping/shipping-options.mock';
 import { SignInEmailActionCreator, SignInEmailRequestSender } from '../signin-email';
@@ -272,6 +272,9 @@ describe('CheckoutService', () => {
             orderActionCreator,
             paymentMethodActionCreator,
             paymentStrategyActionCreator,
+            new PickupOptionActionCreator(
+                new PickupOptionRequestSender(requestSender)
+            ),
             new ShippingCountryActionCreator(shippingCountryRequestSender),
             shippingStrategyActionCreator,
             signInEmailActionCreator,

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -444,7 +444,22 @@ export default class CheckoutService {
      * Loads a list of pickup options for a given criteria.
      *
      * ```js
-     * const state = await service.loadPickupOptions(query);
+     * const state = await service.loadPickupOptions({
+     *     search_area: {
+     *         radius: {
+     *             value: 1.4,
+     *             unit: 0
+     *         },
+     *         coordinates: {
+     *             latitude: 1.4,
+     *             longitude: 0
+     *         },
+     *     },
+     *     items: [{
+     *         variantId: 1,
+     *         quantity: 1
+     *     }]
+     * });
      *
      * console.log(state.data.getPickupOptions());
      * ```

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -15,7 +15,7 @@ import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
 import { PaymentInitializeOptions, PaymentMethodActionCreator, PaymentRequestOptions, PaymentStrategyActionCreator } from '../payment';
 import { InstrumentActionCreator } from '../payment/instrument';
-import { ConsignmentsRequestBody, ConsignmentActionCreator, ConsignmentAssignmentRequestBody, ConsignmentUpdateRequestBody, ShippingCountryActionCreator, ShippingInitializeOptions, ShippingRequestOptions, ShippingStrategyActionCreator } from '../shipping';
+import { ConsignmentsRequestBody, ConsignmentActionCreator, ConsignmentAssignmentRequestBody, ConsignmentUpdateRequestBody, PickupOptionActionCreator, PickupOptionRequestBody, ShippingCountryActionCreator, ShippingInitializeOptions, ShippingRequestOptions, ShippingStrategyActionCreator } from '../shipping';
 import { SignInEmailActionCreator, SignInEmailRequestBody } from '../signin-email';
 import { SpamProtectionActionCreator, SpamProtectionOptions } from '../spam-protection';
 import { StoreCreditActionCreator } from '../store-credit';
@@ -61,6 +61,7 @@ export default class CheckoutService {
         private _orderActionCreator: OrderActionCreator,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _paymentStrategyActionCreator: PaymentStrategyActionCreator,
+        private _pickupOptionActionCreator: PickupOptionActionCreator,
         private _shippingCountryActionCreator: ShippingCountryActionCreator,
         private _shippingStrategyActionCreator: ShippingStrategyActionCreator,
         private _signInEmailActionCreator: SignInEmailActionCreator,
@@ -436,6 +437,25 @@ export default class CheckoutService {
         const action = this._shippingCountryActionCreator.loadCountries(options);
 
         return this._dispatch(action, { queueId: 'shippingCountries' });
+    }
+
+    /**
+     * This is still in beta.
+     * Loads a list of pickup options for a given criteria.
+     *
+     * ```js
+     * const state = await service.loadPickupOptions(query);
+     *
+     * console.log(state.data.getPickupOptions());
+     * ```
+     *
+     * @param options - Options for loading the available shipping countries.
+     * @returns A promise that resolves to the current state.
+     */
+    loadPickupOptions(query: PickupOptionRequestBody): Promise<CheckoutSelectors> {
+        const action = this._pickupOptionActionCreator.loadPickupOptions(query);
+
+        return this._dispatch(action, { queueId: 'pickupOptions' });
     }
 
     /**

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -455,10 +455,7 @@ export default class CheckoutService {
      *             longitude: 0
      *         },
      *     },
-     *     items: [{
-     *         variantId: 1,
-     *         quantity: 1
-     *     }]
+     *     consignmentId: 1,
      * });
      *
      * console.log(state.data.getPickupOptions());

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -440,7 +440,6 @@ export default class CheckoutService {
     }
 
     /**
-     * This is still in beta.
      * Loads a list of pickup options for a given criteria.
      *
      * ```js
@@ -461,6 +460,7 @@ export default class CheckoutService {
      * console.log(state.data.getPickupOptions());
      * ```
      *
+     * @alpha
      * @param options - Options for loading the available shipping countries.
      * @returns A promise that resolves to the current state.
      */

--- a/src/checkout/checkout-store-state.ts
+++ b/src/checkout/checkout-store-state.ts
@@ -10,7 +10,7 @@ import { OrderState } from '../order';
 import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
 import { InstrumentState } from '../payment/instrument';
 import { RemoteCheckoutState } from '../remote-checkout';
-import { ConsignmentState, ShippingCountryState, ShippingStrategyState } from '../shipping';
+import { ConsignmentState, PickupOptionState, ShippingCountryState, ShippingStrategyState } from '../shipping';
 import { SignInEmailState } from '../signin-email';
 import { StoreCreditState } from '../store-credit';
 import { SubscriptionsState } from '../subscription';
@@ -35,6 +35,7 @@ export default interface CheckoutStoreState {
     payment: PaymentState;
     paymentMethods: PaymentMethodState;
     paymentStrategies: PaymentStrategyState;
+    pickupOptions: PickupOptionState;
     remoteCheckout: RemoteCheckoutState;
     shippingCountries: ShippingCountryState;
     shippingStrategies: ShippingStrategyState;

--- a/src/checkout/checkouts.mock.ts
+++ b/src/checkout/checkouts.mock.ts
@@ -15,6 +15,7 @@ import { getPaymentMethod, getPaymentMethodsState } from '../payment/payment-met
 import { getPaymentState } from '../payment/payments.mock';
 import { getRemoteCheckoutState } from '../remote-checkout/remote-checkout.mock';
 import { getConsignment, getConsignmentsState } from '../shipping/consignments.mock';
+import { getPickupOptionsState } from '../shipping/pickup-option.mock';
 import { getShippingCountriesState } from '../shipping/shipping-countries.mock';
 
 import Checkout, { CheckoutPayment } from './checkout';
@@ -134,6 +135,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         payment: getPaymentState(),
         paymentMethods: getPaymentMethodsState(),
         paymentStrategies: { data: {}, errors: {}, statuses: {} },
+        pickupOptions: getPickupOptionsState(),
         remoteCheckout: getRemoteCheckoutState(),
         shippingCountries: getShippingCountriesState(),
         shippingStrategies: { data: {}, errors: {}, statuses: {} },

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -13,7 +13,7 @@ import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { createPaymentClient, createPaymentStrategyRegistry, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentStrategyActionCreator } from '../payment';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
-import { createShippingStrategyRegistry, ConsignmentActionCreator, ConsignmentRequestSender, ShippingCountryActionCreator, ShippingCountryRequestSender, ShippingStrategyActionCreator } from '../shipping';
+import { createShippingStrategyRegistry, ConsignmentActionCreator, ConsignmentRequestSender, ShippingCountryActionCreator, ShippingCountryRequestSender, ShippingStrategyActionCreator, PickupOptionActionCreator, PickupOptionRequestSender } from '../shipping';
 import { SignInEmailActionCreator, SignInEmailRequestSender } from '../signin-email';
 import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../spam-protection';
 import { StoreCreditActionCreator, StoreCreditRequestSender } from '../store-credit';
@@ -104,6 +104,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
             orderActionCreator,
             spamProtectionActionCreator
         ),
+        new PickupOptionActionCreator(new PickupOptionRequestSender(requestSender)),
         new ShippingCountryActionCreator(new ShippingCountryRequestSender(requestSender, { locale })),
         new ShippingStrategyActionCreator(createShippingStrategyRegistry(store, requestSender)),
         new SignInEmailActionCreator(new SignInEmailRequestSender(requestSender)),

--- a/src/checkout/create-checkout-service.ts
+++ b/src/checkout/create-checkout-service.ts
@@ -13,7 +13,7 @@ import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { createPaymentClient, createPaymentStrategyRegistry, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentStrategyActionCreator } from '../payment';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
-import { createShippingStrategyRegistry, ConsignmentActionCreator, ConsignmentRequestSender, ShippingCountryActionCreator, ShippingCountryRequestSender, ShippingStrategyActionCreator, PickupOptionActionCreator, PickupOptionRequestSender } from '../shipping';
+import { createShippingStrategyRegistry, ConsignmentActionCreator, ConsignmentRequestSender, PickupOptionActionCreator, PickupOptionRequestSender, ShippingCountryActionCreator, ShippingCountryRequestSender, ShippingStrategyActionCreator } from '../shipping';
 import { SignInEmailActionCreator, SignInEmailRequestSender } from '../signin-email';
 import { createSpamProtection, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../spam-protection';
 import { StoreCreditActionCreator, StoreCreditRequestSender } from '../store-credit';

--- a/src/checkout/create-checkout-store-reducer.ts
+++ b/src/checkout/create-checkout-store-reducer.ts
@@ -12,7 +12,7 @@ import { orderReducer } from '../order';
 import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
 import { instrumentReducer } from '../payment/instrument';
 import { remoteCheckoutReducer } from '../remote-checkout';
-import { consignmentReducer, shippingCountryReducer, shippingStrategyReducer } from '../shipping';
+import { consignmentReducer, pickupOptionReducer, shippingCountryReducer, shippingStrategyReducer } from '../shipping';
 import { signInEmailReducer } from '../signin-email';
 import { storeCreditReducer } from '../store-credit';
 import { subscriptionsReducer } from '../subscription';
@@ -39,6 +39,7 @@ export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState
         payment: paymentReducer,
         paymentMethods: paymentMethodReducer,
         paymentStrategies: paymentStrategyReducer,
+        pickupOptions: pickupOptionReducer,
         remoteCheckout: remoteCheckoutReducer,
         shippingCountries: shippingCountryReducer,
         shippingStrategies: shippingStrategyReducer,

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -11,7 +11,7 @@ import { createOrderSelectorFactory } from '../order';
 import { createPaymentMethodSelectorFactory, createPaymentSelectorFactory, createPaymentStrategySelectorFactory } from '../payment';
 import { createInstrumentSelectorFactory } from '../payment/instrument';
 import { createRemoteCheckoutSelectorFactory } from '../remote-checkout';
-import { createConsignmentSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, createShippingStrategySelectorFactory } from '../shipping';
+import { createConsignmentSelectorFactory, createPickupOptionSelectorFactory, createShippingAddressSelectorFactory, createShippingCountrySelectorFactory, createShippingStrategySelectorFactory } from '../shipping';
 import { createSignInEmailSelectorFactory } from '../signin-email';
 import { createStoreCreditSelectorFactory } from '../store-credit';
 import { createSubscriptionsSelectorFactory } from '../subscription';
@@ -40,6 +40,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createFormSelector = createFormSelectorFactory();
     const createPaymentMethodSelector = createPaymentMethodSelectorFactory();
     const createPaymentStrategySelector = createPaymentStrategySelectorFactory();
+    const createPickupOptionSelector = createPickupOptionSelectorFactory();
     const createRemoteCheckoutSelector = createRemoteCheckoutSelectorFactory();
     const createShippingAddressSelector = createShippingAddressSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
@@ -65,6 +66,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const instruments = createInstrumentSelector(state.instruments);
         const paymentMethods = createPaymentMethodSelector(state.paymentMethods);
         const paymentStrategies = createPaymentStrategySelector(state.paymentStrategies);
+        const pickupOptions = createPickupOptionSelector(state.pickupOptions);
         const remoteCheckout = createRemoteCheckoutSelector(state.remoteCheckout);
         const shippingAddress = createShippingAddressSelector(state.consignments);
         const shippingCountries = createShippingCountrySelector(state.shippingCountries);
@@ -98,6 +100,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             payment,
             paymentMethods,
             paymentStrategies,
+            pickupOptions,
             remoteCheckout,
             shippingAddress,
             shippingCountries,

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -14,6 +14,7 @@ export { default as isPrivate } from './is-private';
 export { default as mergeOrPush } from './merge-or-push';
 export { default as omitDeep } from './omit-deep';
 export { default as omitPrivate } from './omit-private';
+export { default as objectFlatten } from './object-flatten';
 export { default as objectMerge } from './object-merge';
 export { default as objectSet } from './object-set';
 export { default as replace } from './replace';

--- a/src/common/utility/index.ts
+++ b/src/common/utility/index.ts
@@ -17,6 +17,7 @@ export { default as omitPrivate } from './omit-private';
 export { default as objectFlatten } from './object-flatten';
 export { default as objectMerge } from './object-merge';
 export { default as objectSet } from './object-set';
+export { default as objectWithSortedKeys } from './object-with-sorted-keys';
 export { default as replace } from './replace';
 export { default as setPrototypeOf } from './set-prototype-of';
 export { default as toSingleLine } from './to-single-line';

--- a/src/common/utility/object-flatten.spec.ts
+++ b/src/common/utility/object-flatten.spec.ts
@@ -1,0 +1,31 @@
+import objectFlatten from './object-flatten';
+
+const testObject = {
+    consignmentId: '55c96cda6f04c',
+    searchArea: {
+        radius: {
+            value: 1.4,
+            unit: 0,
+        },
+        coordinates: {
+            latitude: 1.4,
+            longitude: 1.4,
+        },
+    },
+};
+
+describe('objectFlatten()', () => {
+    it('flattens a nested object', () => {
+        const newValue = {
+            consignmentId: '55c96cda6f04c',
+            ['searchArea.radius.value']: 1.4,
+            ['searchArea.radius.unit']: 0,
+            ['searchArea.coordinates.latitude']: 1.4,
+            ['searchArea.coordinates.longitude']: 1.4,
+        };
+
+        const result = objectFlatten(testObject);
+
+        expect(result).toEqual(newValue);
+    });
+});

--- a/src/common/utility/object-flatten.ts
+++ b/src/common/utility/object-flatten.ts
@@ -1,0 +1,20 @@
+/**
+ * Takes a nested object and flattens it.
+ */
+export default function objectFlatten(
+    object: { [ key: string ]: any },
+    parent?: string
+): { [ key: string ]: any } {
+    const flattened: {[key: string]: any} = {};
+    Object.keys(object).forEach((key: string) => {
+        const value = object[key];
+        const keyString = parent ? parent + '.' + key : key;
+        if (typeof value === 'object') {
+            Object.assign(flattened, objectFlatten(value, keyString));
+        } else {
+            flattened[keyString] = value;
+        }
+    });
+
+    return flattened;
+}

--- a/src/common/utility/object-with-sorted-keys.spec.ts
+++ b/src/common/utility/object-with-sorted-keys.spec.ts
@@ -1,0 +1,19 @@
+import objectWithSortedKeys from './object-with-sorted-keys';
+
+const unsortedObject = {
+    test: 'test',
+    a: '1',
+};
+
+describe('objectFlatten()', () => {
+    it('flattens a nested object', () => {
+        const sortedObject = {
+            a: '1',
+            test: 'test',
+        };
+
+        const result = objectWithSortedKeys(unsortedObject);
+
+        expect(result).toEqual(sortedObject);
+    });
+});

--- a/src/common/utility/object-with-sorted-keys.ts
+++ b/src/common/utility/object-with-sorted-keys.ts
@@ -1,0 +1,13 @@
+export default function objectWithSortedKeys(
+    object: { [ key: string ]: any }
+) {
+    const keys = Object.keys(object);
+    const sortedKeys = keys.sort();
+
+    const sortedArray = sortedKeys.reduce((previous, current) => ({
+        ...previous,
+        [current]: object[current],
+    }), {});
+
+    return sortedArray;
+}

--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -1,6 +1,6 @@
 import { Address, AddressRequestBody } from '../address';
 
-import PickupOption from './pickup-option';
+import { ConsignmentPickupOption } from './pickup-option';
 import ShippingOption from './shipping-option';
 
 export default interface Consignment {
@@ -10,7 +10,7 @@ export default interface Consignment {
     shippingCost: number;
     availableShippingOptions?: ShippingOption[];
     selectedShippingOption?: ShippingOption;
-    selectedPickupOption?: PickupOption;
+    selectedPickupOption?: ConsignmentPickupOption;
     lineItemIds: string[];
 }
 
@@ -22,20 +22,20 @@ export type ConsignmentRequestBody =
 export interface ConsignmentCreateRequestBody {
     shippingAddress: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
-    pickupOption?: PickupOption;
+    pickupOption?: ConsignmentPickupOption;
 }
 
 export interface ConsignmentAssignmentRequestBody {
     shippingAddress: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
-    pickupOption?: PickupOption;
+    pickupOption?: ConsignmentPickupOption;
 }
 
 export interface ConsignmentUpdateRequestBody {
     id: string;
     shippingAddress?: AddressRequestBody;
     lineItems?: ConsignmentLineItem[];
-    pickupOption?: PickupOption;
+    pickupOption?: ConsignmentPickupOption;
 }
 
 export interface ConsignmentMeta {

--- a/src/shipping/index.ts
+++ b/src/shipping/index.ts
@@ -10,6 +10,13 @@ export { default as consignmentReducer } from './consignment-reducer';
 export { default as ConsignmentActionCreator } from './consignment-action-creator';
 export { default as ConsignmentRequestSender } from './consignment-request-sender';
 
+export { PickupOptionRequestBody } from './pickup-option';
+export { default as PickupOptionActionCreator } from './pickup-option-action-creator';
+export { default as PickupOptionRequestSender } from './pickup-option-request-sender';
+export { default as PickupOptionSelector, PickupOptionSelectorFactory, createPickupOptionSelectorFactory } from './pickup-option-selector';
+export { default as PickupOptionState } from './pickup-option-state';
+export { default as pickupOptionReducer } from './pickup-option-reducer';
+
 export { default as ShippingAddressSelector, ShippingAddressSelectorFactory, createShippingAddressSelectorFactory } from './shipping-address-selector';
 
 export { default as ShippingCountryActionCreator } from './shipping-country-action-creator';

--- a/src/shipping/pickup-option-action-creator.spec.ts
+++ b/src/shipping/pickup-option-action-creator.spec.ts
@@ -41,7 +41,8 @@ describe('PickupOptionActionCreator', () => {
         const id = getCart().lineItems.physicalItems[0].id;
         consignment.lineItemIds.push(id.toString());
         jest.spyOn(store.getState().consignments, 'getConsignmentById').mockReturnValue(consignment);
-        const actions = await from(pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())(store))
+        const query = getQueryForPickupOptions();
+        const actions = await from(pickupOptionActionCreator.loadPickupOptions(query)(store))
             .pipe(toArray())
             .toPromise();
 
@@ -49,7 +50,7 @@ describe('PickupOptionActionCreator', () => {
 
         expect(actions).toEqual([
             { type: PickupOptionActionType.LoadPickupOptionsRequested },
-            { type: PickupOptionActionType.LoadPickupOptionsSucceeded, payload: response.body.results },
+            { type: PickupOptionActionType.LoadPickupOptionsSucceeded, payload: response.body.results, meta: query },
         ]);
     });
 
@@ -81,7 +82,8 @@ describe('PickupOptionActionCreator', () => {
         const id = getCart().lineItems.physicalItems[0].id;
         consignment.lineItemIds.push(id.toString());
         jest.spyOn(store.getState().consignments, 'getConsignmentById').mockReturnValue(consignment);
-        const actions = await from(pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())(store))
+        const query = getQueryForPickupOptions();
+        const actions = await from(pickupOptionActionCreator.loadPickupOptions(query)(store))
             .pipe(toArray())
             .toPromise();
 
@@ -89,7 +91,7 @@ describe('PickupOptionActionCreator', () => {
 
         expect(actions).toEqual([
             { type: PickupOptionActionType.LoadPickupOptionsRequested },
-            { type: PickupOptionActionType.LoadPickupOptionsSucceeded, payload: response.body.results },
+            { type: PickupOptionActionType.LoadPickupOptionsSucceeded, payload: response.body.results, meta: query },
         ]);
     });
 

--- a/src/shipping/pickup-option-action-creator.spec.ts
+++ b/src/shipping/pickup-option-action-creator.spec.ts
@@ -1,24 +1,32 @@
 import { createRequestSender, Response } from '@bigcommerce/request-sender';
-import { of } from 'rxjs';
+import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
-import { ErrorResponseBody } from '../common/error';
+import { getCart } from '../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../checkout';
+import { getCheckoutState } from '../checkout/checkouts.mock';
+import { MissingDataError } from '../common/error/errors';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
+import { getConsignment } from './consignments.mock';
 import PickupOptionActionCreator from './pickup-option-action-creator';
 import { PickupOptionActionType } from './pickup-option-actions';
 import PickupOptionRequestSender from './pickup-option-request-sender';
-import { getPickupOptionsResponseBody, getQueryForPickupOptions } from './pickup-option.mock';
+import { getApiQueryForPickupOptions, getPickupOptionsResponseBody, getQueryForPickupOptions } from './pickup-option.mock';
 
 describe('PickupOptionActionCreator', () => {
     let pickupOptionRequestSender: PickupOptionRequestSender;
     let pickupOptionActionCreator: PickupOptionActionCreator;
-    let errorResponse: Response<ErrorResponseBody>;
+    let errorResponse: Response<Error>;
     let response: Response<any>;
+    let store: CheckoutStore;
 
     beforeEach(() => {
         response = getResponse(getPickupOptionsResponseBody());
         errorResponse = getErrorResponse();
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+        });
 
         pickupOptionRequestSender = new PickupOptionRequestSender(createRequestSender());
         pickupOptionActionCreator = new PickupOptionActionCreator(pickupOptionRequestSender);
@@ -26,23 +34,77 @@ describe('PickupOptionActionCreator', () => {
         jest.spyOn(pickupOptionRequestSender, 'fetchPickupOptions').mockReturnValue(Promise.resolve(response));
     });
 
-    it('emits actions if able to fetch pickup options', () => {
-        pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())
+    it('emits actions if able to fetch pickup options', async () => {
+        jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(getCart());
+        const consignment = getConsignment();
+        consignment.lineItemIds.pop();
+        const id = getCart().lineItems.physicalItems[0].id;
+        consignment.lineItemIds.push(id.toString());
+        jest.spyOn(store.getState().consignments, 'getConsignmentById').mockReturnValue(consignment);
+        const actions = await from(pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())(store))
             .pipe(toArray())
-            .subscribe(actions => {
-                expect(actions).toEqual([
-                    { type: PickupOptionActionType.LoadPickupOptionsRequested },
-                    { type: PickupOptionActionType.LoadPickupOptionsSucceeded, payload: response.body.results },
-                ]);
-            });
+            .toPromise();
+
+        expect(pickupOptionRequestSender.fetchPickupOptions).toHaveBeenCalledWith(getApiQueryForPickupOptions());
+
+        expect(actions).toEqual([
+            { type: PickupOptionActionType.LoadPickupOptionsRequested },
+            { type: PickupOptionActionType.LoadPickupOptionsSucceeded, payload: response.body.results },
+        ]);
     });
 
-    it('emits error actions if unable to fetch pickup options', () => {
+    it('throws an exception when there is no cart', async () => {
+        try {
+            await from(pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())(store))
+                .pipe(toArray())
+                .toPromise();
+        } catch (exception) {
+            expect(exception).toBeInstanceOf(MissingDataError);
+        }
+    });
+
+    it('throws an exception when there is no consignment', async () => {
+        jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(getCart());
+        try {
+            await from(pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())(store))
+                .pipe(toArray())
+                .toPromise();
+        } catch (exception) {
+            expect(exception).toBeInstanceOf(MissingDataError);
+        }
+    });
+
+    it('emits actions if able to fetch pickup options', async () => {
+        jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(getCart());
+        const consignment = getConsignment();
+        consignment.lineItemIds.pop();
+        const id = getCart().lineItems.physicalItems[0].id;
+        consignment.lineItemIds.push(id.toString());
+        jest.spyOn(store.getState().consignments, 'getConsignmentById').mockReturnValue(consignment);
+        const actions = await from(pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())(store))
+            .pipe(toArray())
+            .toPromise();
+
+        expect(pickupOptionRequestSender.fetchPickupOptions).toHaveBeenCalledWith(getApiQueryForPickupOptions());
+
+        expect(actions).toEqual([
+            { type: PickupOptionActionType.LoadPickupOptionsRequested },
+            { type: PickupOptionActionType.LoadPickupOptionsSucceeded, payload: response.body.results },
+        ]);
+    });
+
+    it('emits error actions if unable to fetch pickup options', async () => {
+        jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(getCart());
+        const consignment = getConsignment();
+        consignment.lineItemIds.pop();
+        const id = getCart().lineItems.physicalItems[0].id;
+        consignment.lineItemIds.push(id.toString());
+        jest.spyOn(store.getState().consignments, 'getConsignmentById').mockReturnValue(consignment);
         jest.spyOn(pickupOptionRequestSender, 'fetchPickupOptions').mockReturnValue(Promise.reject(errorResponse));
 
         const errorHandler = jest.fn(action => of(action));
 
-        pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())
+        await from(pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())(store))
             .pipe(
                 catchError(errorHandler),
                 toArray()

--- a/src/shipping/pickup-option-action-creator.spec.ts
+++ b/src/shipping/pickup-option-action-creator.spec.ts
@@ -1,0 +1,57 @@
+import { createRequestSender, Response } from '@bigcommerce/request-sender';
+import { of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { ErrorResponseBody } from '../common/error';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+
+import PickupOptionActionCreator from './pickup-option-action-creator';
+import { PickupOptionActionType } from './pickup-option-actions';
+import PickupOptionRequestSender from './pickup-option-request-sender';
+import { getPickupOptionsResponseBody, getQueryForPickupOptions } from './pickup-option.mock';
+
+describe('PickupOptionActionCreator', () => {
+    let pickupOptionRequestSender: PickupOptionRequestSender;
+    let pickupOptionActionCreator: PickupOptionActionCreator;
+    let errorResponse: Response<ErrorResponseBody>;
+    let response: Response<any>;
+
+    beforeEach(() => {
+        response = getResponse(getPickupOptionsResponseBody());
+        errorResponse = getErrorResponse();
+
+        pickupOptionRequestSender = new PickupOptionRequestSender(createRequestSender());
+        pickupOptionActionCreator = new PickupOptionActionCreator(pickupOptionRequestSender);
+
+        jest.spyOn(pickupOptionRequestSender, 'fetchPickupOptions').mockReturnValue(Promise.resolve(response));
+    });
+
+    it('emits actions if able to fetch pickup options', () => {
+        pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())
+            .pipe(toArray())
+            .subscribe(actions => {
+                expect(actions).toEqual([
+                    { type: PickupOptionActionType.LoadPickupOptionsRequested },
+                    { type: PickupOptionActionType.LoadPickupOptionsSucceeded, payload: response.body.results },
+                ]);
+            });
+    });
+
+    it('emits error actions if unable to fetch pickup options', () => {
+        jest.spyOn(pickupOptionRequestSender, 'fetchPickupOptions').mockReturnValue(Promise.reject(errorResponse));
+
+        const errorHandler = jest.fn(action => of(action));
+
+        pickupOptionActionCreator.loadPickupOptions(getQueryForPickupOptions())
+            .pipe(
+                catchError(errorHandler),
+                toArray()
+            )
+            .subscribe(actions => {
+                expect(actions).toEqual([
+                    { type: PickupOptionActionType.LoadPickupOptionsRequested },
+                    { type: PickupOptionActionType.LoadPickupOptionsFailed, payload: errorResponse, error: true },
+                ]);
+            });
+    });
+});

--- a/src/shipping/pickup-option-action-creator.ts
+++ b/src/shipping/pickup-option-action-creator.ts
@@ -1,7 +1,7 @@
 import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
 import { Observable, Observer } from 'rxjs';
 
-import { PickupOption, PickupOptionRequestBody } from './pickup-option';
+import { PickupOptionRequestBody, PickupOptionResult } from './pickup-option';
 import { PickupOptionActionType } from './pickup-option-actions';
 import PickupOptionRequestSender from './pickup-option-request-sender';
 
@@ -10,8 +10,8 @@ export default class PickupOptionActionCreator {
         private _pickupOptionRequestSender: PickupOptionRequestSender
     ) {}
 
-    loadPickupOptions(query: PickupOptionRequestBody): Observable<Action<PickupOption[]>> {
-        return new Observable((observer: Observer<Action<PickupOption[]>>) => {
+    loadPickupOptions(query: PickupOptionRequestBody): Observable<Action<PickupOptionResult[]>> {
+        return new Observable((observer: Observer<Action<PickupOptionResult[]>>) => {
             observer.next(createAction(PickupOptionActionType.LoadPickupOptionsRequested));
 
             this._pickupOptionRequestSender.fetchPickupOptions(query)

--- a/src/shipping/pickup-option-action-creator.ts
+++ b/src/shipping/pickup-option-action-creator.ts
@@ -1,7 +1,7 @@
 import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
 import { Observable, Observer } from 'rxjs';
 
-import { PickupOption, PickupOptionRequestPayload } from './pickup-option';
+import { PickupOption, PickupOptionRequestBody } from './pickup-option';
 import { PickupOptionActionType } from './pickup-option-actions';
 import PickupOptionRequestSender from './pickup-option-request-sender';
 
@@ -10,13 +10,13 @@ export default class PickupOptionActionCreator {
         private _pickupOptionRequestSender: PickupOptionRequestSender
     ) {}
 
-    loadPickupOptions(query: PickupOptionRequestPayload): Observable<Action<PickupOption[]>> {
+    loadPickupOptions(query: PickupOptionRequestBody): Observable<Action<PickupOption[]>> {
         return new Observable((observer: Observer<Action<PickupOption[]>>) => {
             observer.next(createAction(PickupOptionActionType.LoadPickupOptionsRequested));
 
             this._pickupOptionRequestSender.fetchPickupOptions(query)
                 .then(response => {
-                    observer.next(createAction(PickupOptionActionType.LoadPickupOptionSucceeded, response.body.results));
+                    observer.next(createAction(PickupOptionActionType.LoadPickupOptionsSucceeded, response.body.results));
                     observer.complete();
                 }).
                 catch(response => {

--- a/src/shipping/pickup-option-action-creator.ts
+++ b/src/shipping/pickup-option-action-creator.ts
@@ -24,8 +24,8 @@ export default class PickupOptionActionCreator {
                 .then(response => {
                     observer.next(createAction(PickupOptionActionType.LoadPickupOptionsSucceeded, response.body.results));
                     observer.complete();
-                }).
-                catch(response => {
+                })
+                .catch(response => {
                     observer.error(createErrorAction(PickupOptionActionType.LoadPickupOptionsFailed, response));
                 });
         });

--- a/src/shipping/pickup-option-action-creator.ts
+++ b/src/shipping/pickup-option-action-creator.ts
@@ -22,7 +22,7 @@ export default class PickupOptionActionCreator {
 
             this._pickupOptionRequestSender.fetchPickupOptions(apiQuery)
                 .then(response => {
-                    observer.next(createAction(PickupOptionActionType.LoadPickupOptionsSucceeded, response.body.results));
+                    observer.next(createAction(PickupOptionActionType.LoadPickupOptionsSucceeded, response.body.results, query));
                     observer.complete();
                 })
                 .catch(response => {

--- a/src/shipping/pickup-option-action-creator.ts
+++ b/src/shipping/pickup-option-action-creator.ts
@@ -1,0 +1,27 @@
+import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+import { Observable, Observer } from 'rxjs';
+
+import { PickupOption, PickupOptionRequestPayload } from './pickup-option';
+import { PickupOptionActionType } from './pickup-option-actions';
+import PickupOptionRequestSender from './pickup-option-request-sender';
+
+export default class PickupOptionActionCreator {
+    constructor(
+        private _pickupOptionRequestSender: PickupOptionRequestSender
+    ) {}
+
+    loadPickupOptions(query: PickupOptionRequestPayload): Observable<Action<PickupOption[]>> {
+        return new Observable((observer: Observer<Action<PickupOption[]>>) => {
+            observer.next(createAction(PickupOptionActionType.LoadPickupOptionsRequested));
+
+            this._pickupOptionRequestSender.fetchPickupOptions(query)
+                .then(response => {
+                    observer.next(createAction(PickupOptionActionType.LoadPickupOptionSucceeded, response.body.results));
+                    observer.complete();
+                }).
+                catch(response => {
+                    observer.error(createErrorAction(PickupOptionActionType.LoadPickupOptionsFailed, response));
+                });
+        });
+    }
+}

--- a/src/shipping/pickup-option-actions.ts
+++ b/src/shipping/pickup-option-actions.ts
@@ -1,6 +1,6 @@
 import { Action } from '@bigcommerce/data-store';
 
-import { PickupOption } from './pickup-option';
+import { PickupOptionResult } from './pickup-option';
 
 export enum PickupOptionActionType {
     LoadPickupOptionsRequested = 'LOAD_PICKUP_OPTIONS_REQUESTED',
@@ -17,7 +17,7 @@ export interface PickupOptionRequestedAction extends Action {
     type: PickupOptionActionType.LoadPickupOptionsRequested;
 }
 
-export interface LoadPickupOptionsSucceededAction extends Action<PickupOption[]> {
+export interface LoadPickupOptionsSucceededAction extends Action<PickupOptionResult[]> {
     type: PickupOptionActionType.LoadPickupOptionsSucceeded;
 }
 

--- a/src/shipping/pickup-option-actions.ts
+++ b/src/shipping/pickup-option-actions.ts
@@ -1,0 +1,26 @@
+import { Action } from '@bigcommerce/data-store';
+
+import { PickupOption } from './pickup-option';
+
+export enum PickupOptionActionType {
+    LoadPickupOptionsRequested = 'LOAD_PICKUP_OPTIONS_REQUESTED',
+    LoadPickupOptionSucceeded = 'LOAD_PICKUP_OPTIONS_SUCCEEDED',
+    LoadPickupOptionsFailed = 'LOAD_PICKUP_OPTIONS_FAILED',
+}
+
+export type LoadPickupOptionsAction =
+    PickupOptionRequestedAction |
+    LoadPickupOptionsSucceededAction |
+    LoadPickupOptionsFailedAction;
+
+export interface PickupOptionRequestedAction extends Action {
+    type: PickupOptionActionType.LoadPickupOptionsRequested;
+}
+
+export interface LoadPickupOptionsSucceededAction extends Action<PickupOption[]> {
+    type: PickupOptionActionType.LoadPickupOptionSucceeded;
+}
+
+export interface LoadPickupOptionsFailedAction extends Action<Error> {
+    type: PickupOptionActionType.LoadPickupOptionsFailed;
+}

--- a/src/shipping/pickup-option-actions.ts
+++ b/src/shipping/pickup-option-actions.ts
@@ -4,7 +4,7 @@ import { PickupOption } from './pickup-option';
 
 export enum PickupOptionActionType {
     LoadPickupOptionsRequested = 'LOAD_PICKUP_OPTIONS_REQUESTED',
-    LoadPickupOptionSucceeded = 'LOAD_PICKUP_OPTIONS_SUCCEEDED',
+    LoadPickupOptionsSucceeded = 'LOAD_PICKUP_OPTIONS_SUCCEEDED',
     LoadPickupOptionsFailed = 'LOAD_PICKUP_OPTIONS_FAILED',
 }
 
@@ -18,7 +18,7 @@ export interface PickupOptionRequestedAction extends Action {
 }
 
 export interface LoadPickupOptionsSucceededAction extends Action<PickupOption[]> {
-    type: PickupOptionActionType.LoadPickupOptionSucceeded;
+    type: PickupOptionActionType.LoadPickupOptionsSucceeded;
 }
 
 export interface LoadPickupOptionsFailedAction extends Action<Error> {

--- a/src/shipping/pickup-option-actions.ts
+++ b/src/shipping/pickup-option-actions.ts
@@ -1,6 +1,6 @@
 import { Action } from '@bigcommerce/data-store';
 
-import { PickupOptionResult } from './pickup-option';
+import { PickupOptionMeta, PickupOptionResult } from './pickup-option';
 
 export enum PickupOptionActionType {
     LoadPickupOptionsRequested = 'LOAD_PICKUP_OPTIONS_REQUESTED',
@@ -17,7 +17,7 @@ export interface PickupOptionRequestedAction extends Action {
     type: PickupOptionActionType.LoadPickupOptionsRequested;
 }
 
-export interface LoadPickupOptionsSucceededAction extends Action<PickupOptionResult[]> {
+export interface LoadPickupOptionsSucceededAction extends Action<PickupOptionResult[], PickupOptionMeta> {
     type: PickupOptionActionType.LoadPickupOptionsSucceeded;
 }
 

--- a/src/shipping/pickup-option-reducer.spec.ts
+++ b/src/shipping/pickup-option-reducer.spec.ts
@@ -1,3 +1,5 @@
+import { objectFlatten } from '../common/utility';
+
 import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
 import pickupOptionReducer from './pickup-option-reducer';
 import PickupOptionState from './pickup-option-state';
@@ -25,7 +27,7 @@ describe('pickupOptionReducer()', () => {
         });
     });
 
-    it.only('returns a new state when pickup options are fetched', () => {
+    it('returns a new state when pickup options are fetched', () => {
         const query = getQueryForPickupOptions();
         const action: LoadPickupOptionsAction = {
             type: PickupOptionActionType.LoadPickupOptionsSucceeded,
@@ -33,7 +35,7 @@ describe('pickupOptionReducer()', () => {
             payload: [getPickupOptions()],
         };
 
-        const codedKey = btoa(`${query.consignmentId}-${JSON.stringify(query.searchArea)}`);
+        const codedKey = btoa(`${JSON.stringify(objectFlatten(query))}`);
 
         expect(pickupOptionReducer(initialState, action)).toEqual({
             data: {

--- a/src/shipping/pickup-option-reducer.spec.ts
+++ b/src/shipping/pickup-option-reducer.spec.ts
@@ -1,7 +1,7 @@
 import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
 import pickupOptionReducer from './pickup-option-reducer';
 import PickupOptionState from './pickup-option-state';
-import { getPickupOptions } from './pickup-option.mock';
+import { getPickupOptions, getQueryForPickupOptions } from './pickup-option.mock';
 
 describe('pickupOptionReducer()', () => {
     let initialState: PickupOptionState;
@@ -25,14 +25,20 @@ describe('pickupOptionReducer()', () => {
         });
     });
 
-    it('returns a new state when pickup options are fetched', () => {
+    it.only('returns a new state when pickup options are fetched', () => {
+        const query = getQueryForPickupOptions();
         const action: LoadPickupOptionsAction = {
             type: PickupOptionActionType.LoadPickupOptionsSucceeded,
+            meta: query,
             payload: [getPickupOptions()],
         };
 
+        const codedKey = btoa(`${query.consignmentId}-${JSON.stringify(query.searchArea)}`);
+
         expect(pickupOptionReducer(initialState, action)).toEqual({
-            data: action.payload,
+            data: {
+                [codedKey]: action.payload,
+            },
             errors: { loadError: undefined },
             statuses: { isLoading: false },
         });

--- a/src/shipping/pickup-option-reducer.spec.ts
+++ b/src/shipping/pickup-option-reducer.spec.ts
@@ -1,0 +1,52 @@
+import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
+import pickupOptionReducer from './pickup-option-reducer';
+import PickupOptionState from './pickup-option-state';
+import { getPickupOptions } from './pickup-option.mock';
+
+describe('pickupOptionReducer()', () => {
+    let initialState: PickupOptionState;
+
+    beforeEach(() => {
+        initialState = {
+            errors: {},
+            statuses: {},
+        };
+    });
+
+    it('returns a new state when fetching pickup options', () => {
+        const action: LoadPickupOptionsAction = {
+            type: PickupOptionActionType.LoadPickupOptionsRequested,
+        };
+
+        expect(pickupOptionReducer(initialState, action)).toEqual({
+            ...initialState,
+            errors: {},
+            statuses: { isLoading: true },
+        });
+    });
+
+    it('returns a new state when pickup options are fetched', () => {
+        const action: LoadPickupOptionsAction = {
+            type: PickupOptionActionType.LoadPickupOptionsSucceeded,
+            payload: [getPickupOptions()],
+        };
+
+        expect(pickupOptionReducer(initialState, action)).toEqual({
+            data: action.payload,
+            errors: { loadError: undefined },
+            statuses: { isLoading: false },
+        });
+    });
+
+    it('returns a new state when pickup options cannot be fetched', () => {
+        const action: LoadPickupOptionsAction = {
+            type: PickupOptionActionType.LoadPickupOptionsFailed,
+        };
+
+        expect(pickupOptionReducer(initialState, action)).toEqual({
+            ...initialState,
+            errors: { loadError: action.payload },
+            statuses: { isLoading: false },
+        });
+    });
+});

--- a/src/shipping/pickup-option-reducer.spec.ts
+++ b/src/shipping/pickup-option-reducer.spec.ts
@@ -1,4 +1,4 @@
-import { objectFlatten } from '../common/utility';
+import { objectFlatten, objectWithSortedKeys } from '../common/utility';
 
 import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
 import pickupOptionReducer from './pickup-option-reducer';
@@ -35,7 +35,7 @@ describe('pickupOptionReducer()', () => {
             payload: [getPickupOptions()],
         };
 
-        const codedKey = btoa(`${JSON.stringify(objectFlatten(query))}`);
+        const codedKey = btoa(`${JSON.stringify(objectWithSortedKeys(objectFlatten(query)))}`);
 
         expect(pickupOptionReducer(initialState, action)).toEqual({
             data: {

--- a/src/shipping/pickup-option-reducer.ts
+++ b/src/shipping/pickup-option-reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { clearErrorReducer } from '../common/error';
-import { objectFlatten, objectSet } from '../common/utility';
+import { objectFlatten, objectSet, objectWithSortedKeys } from '../common/utility';
 
 import { PickupOptionQueryMap } from './pickup-option';
 import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
@@ -28,7 +28,8 @@ function dataReducer(
         case PickupOptionActionType.LoadPickupOptionsSucceeded:
             if (action.meta) {
                 const flattenedMeta = objectFlatten(action.meta);
-                const keyString = btoa(`${JSON.stringify(flattenedMeta)}`);
+                const sortedflattenedMeta = objectWithSortedKeys(flattenedMeta);
+                const keyString = btoa(`${JSON.stringify(sortedflattenedMeta)}`);
 
                 return objectSet(data, keyString , action.payload);
             }

--- a/src/shipping/pickup-option-reducer.ts
+++ b/src/shipping/pickup-option-reducer.ts
@@ -1,0 +1,67 @@
+import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
+
+import { clearErrorReducer } from '../common/error';
+import { arrayReplace, objectSet } from '../common/utility';
+
+import { PickupOption } from './pickup-option';
+import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
+import PickupOptionState, { DEFAULT_STATE, PickupOptionErrorsState, PickupOptionStatusesState } from './pickup-option-state';
+
+export default function pickupOptionReducer(
+    state: PickupOptionState = DEFAULT_STATE,
+    action: Action
+): PickupOptionState {
+    const reducer = combineReducers<PickupOptionState>({
+        data: dataReducer,
+        errors: composeReducers(errorsReducer, clearErrorReducer),
+        statuses: statusesReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: PickupOption[] | undefined,
+    action: LoadPickupOptionsAction
+): PickupOption[] | undefined {
+    switch (action.type) {
+        case PickupOptionActionType.LoadPickupOptionSucceeded:
+            return arrayReplace(data, action.payload);
+
+        default:
+            return data;
+    }
+}
+
+function errorsReducer(
+    errors: PickupOptionErrorsState = DEFAULT_STATE.errors,
+    action: Action
+) {
+    switch (action.type) {
+        case PickupOptionActionType.LoadPickupOptionsRequested:
+        case PickupOptionActionType.LoadPickupOptionSucceeded:
+            return objectSet(errors, 'loadError', undefined);
+
+        case PickupOptionActionType.LoadPickupOptionsFailed:
+            return objectSet(errors, 'loadError', action.payload);
+
+        default:
+            return errors;
+    }
+}
+
+function statusesReducer(
+    statuses: PickupOptionStatusesState = DEFAULT_STATE.statuses,
+    action: Action
+) {
+    switch (action.type) {
+        case PickupOptionActionType.LoadPickupOptionsRequested:
+            return objectSet(statuses, 'isLoading', true);
+        case PickupOptionActionType.LoadPickupOptionSucceeded:
+        case PickupOptionActionType.LoadPickupOptionsFailed:
+            return objectSet(statuses, 'isLoading', false);
+
+        default:
+            return statuses;
+    }
+}

--- a/src/shipping/pickup-option-reducer.ts
+++ b/src/shipping/pickup-option-reducer.ts
@@ -1,7 +1,7 @@
 import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { clearErrorReducer } from '../common/error';
-import { objectSet } from '../common/utility';
+import { objectFlatten, objectSet } from '../common/utility';
 
 import { PickupOptionQueryMap } from './pickup-option';
 import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
@@ -27,7 +27,8 @@ function dataReducer(
     switch (action.type) {
         case PickupOptionActionType.LoadPickupOptionsSucceeded:
             if (action.meta) {
-                const keyString = btoa(`${action.meta.consignmentId}-${JSON.stringify(action.meta.searchArea)}`);
+                const flattenedMeta = objectFlatten(action.meta);
+                const keyString = btoa(`${JSON.stringify(flattenedMeta)}`);
 
                 return objectSet(data, keyString , action.payload);
             }

--- a/src/shipping/pickup-option-reducer.ts
+++ b/src/shipping/pickup-option-reducer.ts
@@ -3,7 +3,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 import { clearErrorReducer } from '../common/error';
 import { objectSet } from '../common/utility';
 
-import { PickupOptionQueryMap, PickupOptionResult } from './pickup-option';
+import { PickupOptionQueryMap } from './pickup-option';
 import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
 import PickupOptionState, { DEFAULT_STATE, PickupOptionErrorsState, PickupOptionStatusesState } from './pickup-option-state';
 

--- a/src/shipping/pickup-option-reducer.ts
+++ b/src/shipping/pickup-option-reducer.ts
@@ -25,7 +25,7 @@ function dataReducer(
     action: LoadPickupOptionsAction
 ): PickupOption[] | undefined {
     switch (action.type) {
-        case PickupOptionActionType.LoadPickupOptionSucceeded:
+        case PickupOptionActionType.LoadPickupOptionsSucceeded:
             return arrayReplace(data, action.payload);
 
         default:
@@ -39,7 +39,7 @@ function errorsReducer(
 ) {
     switch (action.type) {
         case PickupOptionActionType.LoadPickupOptionsRequested:
-        case PickupOptionActionType.LoadPickupOptionSucceeded:
+        case PickupOptionActionType.LoadPickupOptionsSucceeded:
             return objectSet(errors, 'loadError', undefined);
 
         case PickupOptionActionType.LoadPickupOptionsFailed:
@@ -57,7 +57,7 @@ function statusesReducer(
     switch (action.type) {
         case PickupOptionActionType.LoadPickupOptionsRequested:
             return objectSet(statuses, 'isLoading', true);
-        case PickupOptionActionType.LoadPickupOptionSucceeded:
+        case PickupOptionActionType.LoadPickupOptionsSucceeded:
         case PickupOptionActionType.LoadPickupOptionsFailed:
             return objectSet(statuses, 'isLoading', false);
 

--- a/src/shipping/pickup-option-reducer.ts
+++ b/src/shipping/pickup-option-reducer.ts
@@ -3,7 +3,7 @@ import { combineReducers, composeReducers, Action } from '@bigcommerce/data-stor
 import { clearErrorReducer } from '../common/error';
 import { arrayReplace, objectSet } from '../common/utility';
 
-import { PickupOption } from './pickup-option';
+import { PickupOptionResult } from './pickup-option';
 import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
 import PickupOptionState, { DEFAULT_STATE, PickupOptionErrorsState, PickupOptionStatusesState } from './pickup-option-state';
 
@@ -21,9 +21,9 @@ export default function pickupOptionReducer(
 }
 
 function dataReducer(
-    data: PickupOption[] | undefined,
+    data: PickupOptionResult[] | undefined,
     action: LoadPickupOptionsAction
-): PickupOption[] | undefined {
+): PickupOptionResult[] | undefined {
     switch (action.type) {
         case PickupOptionActionType.LoadPickupOptionsSucceeded:
             return arrayReplace(data, action.payload);

--- a/src/shipping/pickup-option-reducer.ts
+++ b/src/shipping/pickup-option-reducer.ts
@@ -1,9 +1,9 @@
 import { combineReducers, composeReducers, Action } from '@bigcommerce/data-store';
 
 import { clearErrorReducer } from '../common/error';
-import { arrayReplace, objectSet } from '../common/utility';
+import { objectSet } from '../common/utility';
 
-import { PickupOptionResult } from './pickup-option';
+import { PickupOptionQueryMap, PickupOptionResult } from './pickup-option';
 import { LoadPickupOptionsAction, PickupOptionActionType } from './pickup-option-actions';
 import PickupOptionState, { DEFAULT_STATE, PickupOptionErrorsState, PickupOptionStatusesState } from './pickup-option-state';
 
@@ -21,12 +21,16 @@ export default function pickupOptionReducer(
 }
 
 function dataReducer(
-    data: PickupOptionResult[] | undefined,
+    data: PickupOptionQueryMap | undefined,
     action: LoadPickupOptionsAction
-): PickupOptionResult[] | undefined {
+): PickupOptionQueryMap | undefined {
     switch (action.type) {
         case PickupOptionActionType.LoadPickupOptionsSucceeded:
-            return arrayReplace(data, action.payload);
+            if (action.meta) {
+                const keyString = btoa(`${action.meta.consignmentId}-${JSON.stringify(action.meta.searchArea)}`);
+
+                return objectSet(data, keyString , action.payload);
+            }
 
         default:
             return data;

--- a/src/shipping/pickup-option-request-sender.spec.ts
+++ b/src/shipping/pickup-option-request-sender.spec.ts
@@ -1,0 +1,38 @@
+import { createRequestSender, RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
+import { getResponse } from '../common/http-request/responses.mock';
+
+import { PickupOptionResponse } from './pickup-option';
+import PickupOptionRequestSender from './pickup-option-request-sender';
+import { getPickupOptionsResponseBody, getQueryForPickupOptions } from './pickup-option.mock';
+
+describe('PickupOptionRequestSender', () => {
+    let pickupOptionRequestSender: PickupOptionRequestSender;
+    let requestSender: RequestSender;
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+        pickupOptionRequestSender = new PickupOptionRequestSender(requestSender);
+    });
+
+    describe('#fetchPickupOptions', () => {
+        let response: Response<PickupOptionResponse>;
+
+        beforeEach(() => {
+            response = getResponse(getPickupOptionsResponseBody());
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve(response));
+        });
+
+        it('fetches pickup options', async () => {
+            const query = getQueryForPickupOptions();
+            const output = await pickupOptionRequestSender.fetchPickupOptions(query);
+
+            expect(output).toEqual(response);
+            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/pickup-options', {
+                headers: { Accept: ContentType.Json, ...SDK_VERSION_HEADERS },
+                body: query,
+            });
+        });
+    });
+});

--- a/src/shipping/pickup-option-request-sender.spec.ts
+++ b/src/shipping/pickup-option-request-sender.spec.ts
@@ -5,7 +5,7 @@ import { getResponse } from '../common/http-request/responses.mock';
 
 import { PickupOptionResponse } from './pickup-option';
 import PickupOptionRequestSender from './pickup-option-request-sender';
-import { getPickupOptionsResponseBody, getQueryForPickupOptions } from './pickup-option.mock';
+import { getApiQueryForPickupOptions, getPickupOptionsResponseBody } from './pickup-option.mock';
 
 describe('PickupOptionRequestSender', () => {
     let pickupOptionRequestSender: PickupOptionRequestSender;
@@ -25,7 +25,7 @@ describe('PickupOptionRequestSender', () => {
         });
 
         it('fetches pickup options', async () => {
-            const query = getQueryForPickupOptions();
+            const query = getApiQueryForPickupOptions();
             const output = await pickupOptionRequestSender.fetchPickupOptions(query);
 
             expect(output).toEqual(response);

--- a/src/shipping/pickup-option-request-sender.ts
+++ b/src/shipping/pickup-option-request-sender.ts
@@ -1,0 +1,18 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
+
+const url = '/api/storefront/pickup-options';
+
+export default class PickupOptionRequestSender {
+    constructor(
+        private _requestSender: RequestSender
+    ) {}
+
+    fetchPickupOptions(query: any): Promise<Response<any>> {
+        return this._requestSender.post(url, {
+            headers: { Accept: ContentType.Json, ...SDK_VERSION_HEADERS },
+            body: query,
+        });
+    }
+}

--- a/src/shipping/pickup-option-request-sender.ts
+++ b/src/shipping/pickup-option-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 
-import { PickupOptionRequestPayload, PickupOptionResponse } from './pickup-option';
+import { PickupOptionRequestBody, PickupOptionResponse } from './pickup-option';
 
 const url = '/api/storefront/pickup-options';
 
@@ -11,7 +11,7 @@ export default class PickupOptionRequestSender {
         private _requestSender: RequestSender
     ) {}
 
-    fetchPickupOptions(query: PickupOptionRequestPayload): Promise<Response<PickupOptionResponse>> {
+    fetchPickupOptions(query: PickupOptionRequestBody): Promise<Response<PickupOptionResponse>> {
         return this._requestSender.post(url, {
             headers: { Accept: ContentType.Json, ...SDK_VERSION_HEADERS },
             body: query,

--- a/src/shipping/pickup-option-request-sender.ts
+++ b/src/shipping/pickup-option-request-sender.ts
@@ -2,6 +2,8 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 
+import { PickupOptionRequestPayload, PickupOptionResponse } from './pickup-option';
+
 const url = '/api/storefront/pickup-options';
 
 export default class PickupOptionRequestSender {
@@ -9,7 +11,7 @@ export default class PickupOptionRequestSender {
         private _requestSender: RequestSender
     ) {}
 
-    fetchPickupOptions(query: any): Promise<Response<any>> {
+    fetchPickupOptions(query: PickupOptionRequestPayload): Promise<Response<PickupOptionResponse>> {
         return this._requestSender.post(url, {
             headers: { Accept: ContentType.Json, ...SDK_VERSION_HEADERS },
             body: query,

--- a/src/shipping/pickup-option-request-sender.ts
+++ b/src/shipping/pickup-option-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender, Response } from '@bigcommerce/request-sender';
 
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 
-import { PickupOptionRequestBody, PickupOptionResponse } from './pickup-option';
+import { PickupOptionAPIRequestBody, PickupOptionResponse } from './pickup-option';
 
 const url = '/api/storefront/pickup-options';
 
@@ -11,7 +11,7 @@ export default class PickupOptionRequestSender {
         private _requestSender: RequestSender
     ) {}
 
-    fetchPickupOptions(query: PickupOptionRequestBody): Promise<Response<PickupOptionResponse>> {
+    fetchPickupOptions(query: PickupOptionAPIRequestBody): Promise<Response<PickupOptionResponse>> {
         return this._requestSender.post(url, {
             headers: { Accept: ContentType.Json, ...SDK_VERSION_HEADERS },
             body: query,

--- a/src/shipping/pickup-option-selector.spec.ts
+++ b/src/shipping/pickup-option-selector.spec.ts
@@ -1,0 +1,68 @@
+import { CheckoutStoreState } from '../checkout';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+
+import PickupOptionSelector, { createPickupOptionSelectorFactory, PickupOptionSelectorFactory } from './pickup-option-selector';
+
+describe('PickupOptionSelector', () => {
+    let pickupOptionSelector: PickupOptionSelector;
+    let createPickupOptionSelector: PickupOptionSelectorFactory;
+    let state: CheckoutStoreState;
+
+    beforeEach(() => {
+        createPickupOptionSelector = createPickupOptionSelectorFactory();
+        state = getCheckoutStoreState();
+    });
+
+    describe('#getPickupOptions()', () => {
+        it('returns a list of pickup options', () => {
+            pickupOptionSelector = createPickupOptionSelector(state.pickupOptions);
+
+            expect(pickupOptionSelector.getPickupOptions()).toEqual(state.pickupOptions.data);
+        });
+
+        it('returns an empty array if there are no pickup options', () => {
+            pickupOptionSelector = createPickupOptionSelector({
+                ...state.pickupOptions,
+                data: [],
+            });
+
+            expect(pickupOptionSelector.getPickupOptions()).toEqual([]);
+        });
+    });
+
+    describe('#getLoadError()', () => {
+        it('returns error if unable to load', () => {
+            const loadError = new Error();
+
+            pickupOptionSelector = createPickupOptionSelector({
+                ...state.pickupOptions,
+                errors: { loadError },
+            });
+
+            expect(pickupOptionSelector.getLoadError()).toEqual(loadError);
+        });
+
+        it('does not returns error if able to load', () => {
+            pickupOptionSelector = createPickupOptionSelector(state.pickupOptions);
+
+            expect(pickupOptionSelector.getLoadError()).toBeUndefined();
+        });
+    });
+
+    describe('#isLoading()', () => {
+        it('returns true if loading countries', () => {
+            pickupOptionSelector = createPickupOptionSelector({
+                ...state.pickupOptions,
+                statuses: { isLoading: true },
+            });
+
+            expect(pickupOptionSelector.isLoading()).toEqual(true);
+        });
+
+        it('returns false if not loading countries', () => {
+            pickupOptionSelector = createPickupOptionSelector(state.pickupOptions);
+
+            expect(pickupOptionSelector.isLoading()).toEqual(false);
+        });
+    });
+});

--- a/src/shipping/pickup-option-selector.spec.ts
+++ b/src/shipping/pickup-option-selector.spec.ts
@@ -1,7 +1,7 @@
 
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
-import { objectFlatten } from '../common/utility';
+import { objectFlatten, objectWithSortedKeys } from '../common/utility';
 
 import { PickupOptionRequestBody } from '.';
 import PickupOptionSelector, { createPickupOptionSelectorFactory, PickupOptionSelectorFactory } from './pickup-option-selector';
@@ -23,7 +23,8 @@ describe('PickupOptionSelector', () => {
         it.only('returns a list of pickup options', () => {
             pickupOptionSelector = createPickupOptionSelector(state.pickupOptions);
             const flattenedQuery = objectFlatten(query);
-            const result = state.pickupOptions.data && state.pickupOptions.data[btoa(JSON.stringify(flattenedQuery))];
+            const sortedFlattenedQuery = objectWithSortedKeys(flattenedQuery);
+            const result = state.pickupOptions.data && state.pickupOptions.data[btoa(JSON.stringify(sortedFlattenedQuery))];
 
             expect(pickupOptionSelector.getPickupOptions(
                 query.consignmentId, query.searchArea

--- a/src/shipping/pickup-option-selector.spec.ts
+++ b/src/shipping/pickup-option-selector.spec.ts
@@ -1,6 +1,7 @@
 
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+import { objectFlatten } from '../common/utility';
 
 import { PickupOptionRequestBody } from '.';
 import PickupOptionSelector, { createPickupOptionSelectorFactory, PickupOptionSelectorFactory } from './pickup-option-selector';
@@ -21,7 +22,8 @@ describe('PickupOptionSelector', () => {
     describe('#getPickupOptions()', () => {
         it.only('returns a list of pickup options', () => {
             pickupOptionSelector = createPickupOptionSelector(state.pickupOptions);
-            const result = state.pickupOptions.data && state.pickupOptions.data[btoa(JSON.stringify(query))];
+            const flattenedQuery = objectFlatten(query);
+            const result = state.pickupOptions.data && state.pickupOptions.data[btoa(JSON.stringify(flattenedQuery))];
 
             expect(pickupOptionSelector.getPickupOptions(
                 query.consignmentId, query.searchArea

--- a/src/shipping/pickup-option-selector.spec.ts
+++ b/src/shipping/pickup-option-selector.spec.ts
@@ -1,32 +1,40 @@
+
 import { CheckoutStoreState } from '../checkout';
 import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 
+import { PickupOptionRequestBody } from '.';
 import PickupOptionSelector, { createPickupOptionSelectorFactory, PickupOptionSelectorFactory } from './pickup-option-selector';
+import { getQueryForPickupOptions } from './pickup-option.mock';
 
 describe('PickupOptionSelector', () => {
     let pickupOptionSelector: PickupOptionSelector;
     let createPickupOptionSelector: PickupOptionSelectorFactory;
     let state: CheckoutStoreState;
+    let query: PickupOptionRequestBody;
 
     beforeEach(() => {
         createPickupOptionSelector = createPickupOptionSelectorFactory();
         state = getCheckoutStoreState();
+        query = getQueryForPickupOptions();
     });
 
     describe('#getPickupOptions()', () => {
-        it('returns a list of pickup options', () => {
+        it.only('returns a list of pickup options', () => {
             pickupOptionSelector = createPickupOptionSelector(state.pickupOptions);
+            const result = state.pickupOptions.data && state.pickupOptions.data[btoa(JSON.stringify(query))];
 
-            expect(pickupOptionSelector.getPickupOptions()).toEqual(state.pickupOptions.data);
+            expect(pickupOptionSelector.getPickupOptions(
+                query.consignmentId, query.searchArea
+            )).toEqual(result);
         });
 
         it('returns an empty array if there are no pickup options', () => {
             pickupOptionSelector = createPickupOptionSelector({
                 ...state.pickupOptions,
-                data: [],
+                data: {},
             });
 
-            expect(pickupOptionSelector.getPickupOptions()).toEqual([]);
+            expect(pickupOptionSelector.getPickupOptions(query.consignmentId, query.searchArea)).toEqual(undefined);
         });
     });
 

--- a/src/shipping/pickup-option-selector.ts
+++ b/src/shipping/pickup-option-selector.ts
@@ -2,11 +2,11 @@ import { memoizeOne } from '@bigcommerce/memoize';
 
 import { createSelector } from '../common/selector';
 
-import { PickupOption } from './pickup-option';
+import { PickupOptionResult } from './pickup-option';
 import PickupOptionState, { DEFAULT_STATE } from './pickup-option-state';
 
 export default interface PickupOptionSelector {
-    getPickupOptions(): PickupOption[] | undefined;
+    getPickupOptions(): PickupOptionResult[] | undefined;
     getLoadError(): Error | undefined;
     isLoading(): boolean;
 }

--- a/src/shipping/pickup-option-selector.ts
+++ b/src/shipping/pickup-option-selector.ts
@@ -20,7 +20,7 @@ export function createPickupOptionSelectorFactory(): PickupOptionSelectorFactory
             if (!pickupOptions) {
                 return;
             }
-            const keyString = btoa(`${consignmentId}-${JSON.stringify(searchArea)}`);
+            const keyString = btoa(`${consignmentId}-${JSON.stringify({ searchArea })}`);
 
             return pickupOptions[keyString];
         }

--- a/src/shipping/pickup-option-selector.ts
+++ b/src/shipping/pickup-option-selector.ts
@@ -1,6 +1,7 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 
 import { createSelector } from '../common/selector';
+import { objectFlatten } from '../common/utility';
 
 import { PickupOptionResult, SearchArea } from './pickup-option';
 import PickupOptionState, { DEFAULT_STATE } from './pickup-option-state';
@@ -20,7 +21,8 @@ export function createPickupOptionSelectorFactory(): PickupOptionSelectorFactory
             if (!pickupOptions) {
                 return;
             }
-            const keyString = btoa(`${consignmentId}-${JSON.stringify({ searchArea })}`);
+            const flattenedParams = objectFlatten({ consignmentId, searchArea });
+            const keyString = btoa(`${JSON.stringify(flattenedParams)}`);
 
             return pickupOptions[keyString];
         }

--- a/src/shipping/pickup-option-selector.ts
+++ b/src/shipping/pickup-option-selector.ts
@@ -2,11 +2,11 @@ import { memoizeOne } from '@bigcommerce/memoize';
 
 import { createSelector } from '../common/selector';
 
-import { PickupOptionResult } from './pickup-option';
+import { PickupOptionResult, SearchArea } from './pickup-option';
 import PickupOptionState, { DEFAULT_STATE } from './pickup-option-state';
 
 export default interface PickupOptionSelector {
-    getPickupOptions(): PickupOptionResult[] | undefined;
+    getPickupOptions(consignmentId: string, searchArea: SearchArea): PickupOptionResult[] | undefined;
     getLoadError(): Error | undefined;
     isLoading(): boolean;
 }
@@ -16,7 +16,14 @@ export type PickupOptionSelectorFactory = (state: PickupOptionState) => PickupOp
 export function createPickupOptionSelectorFactory(): PickupOptionSelectorFactory {
     const getPickupOptions = createSelector(
         (state: PickupOptionState) => state.data,
-        pickupOptions => () => pickupOptions
+        pickupOptions => (consignmentId: string, searchArea: SearchArea) => {
+            if (!pickupOptions) {
+                return;
+            }
+            const keyString = btoa(`${consignmentId}-${JSON.stringify(searchArea)}`);
+
+            return pickupOptions[keyString];
+        }
     );
 
     const getLoadError = createSelector(

--- a/src/shipping/pickup-option-selector.ts
+++ b/src/shipping/pickup-option-selector.ts
@@ -1,7 +1,7 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 
 import { createSelector } from '../common/selector';
-import { objectFlatten } from '../common/utility';
+import { objectFlatten, objectWithSortedKeys } from '../common/utility';
 
 import { PickupOptionResult, SearchArea } from './pickup-option';
 import PickupOptionState, { DEFAULT_STATE } from './pickup-option-state';
@@ -22,7 +22,8 @@ export function createPickupOptionSelectorFactory(): PickupOptionSelectorFactory
                 return;
             }
             const flattenedParams = objectFlatten({ consignmentId, searchArea });
-            const keyString = btoa(`${JSON.stringify(flattenedParams)}`);
+            const sortedFlattenedParams = objectWithSortedKeys(flattenedParams);
+            const keyString = btoa(`${JSON.stringify(sortedFlattenedParams)}`);
 
             return pickupOptions[keyString];
         }

--- a/src/shipping/pickup-option-selector.ts
+++ b/src/shipping/pickup-option-selector.ts
@@ -1,0 +1,41 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { createSelector } from '../common/selector';
+
+import { PickupOption } from './pickup-option';
+import PickupOptionState, { DEFAULT_STATE } from './pickup-option-state';
+
+export default interface PickupOptionSelector {
+    getPickupOptions(): PickupOption[] | undefined;
+    getLoadError(): Error | undefined;
+    isLoading(): boolean;
+}
+
+export type PickupOptionSelectorFactory = (state: PickupOptionState) => PickupOptionSelector;
+
+export function createPickupOptionSelectorFactory(): PickupOptionSelectorFactory {
+    const getPickupOptions = createSelector(
+        (state: PickupOptionState) => state.data,
+        pickupOptions => () => pickupOptions
+    );
+
+    const getLoadError = createSelector(
+        (state: PickupOptionState) => state.errors.loadError,
+        error => () => error
+    );
+
+    const isLoading = createSelector(
+        (state: PickupOptionState) => !!state.statuses.isLoading,
+        status => () => status
+    );
+
+    return memoizeOne((
+        state: PickupOptionState = DEFAULT_STATE
+    ): PickupOptionSelector => {
+        return {
+            getPickupOptions: getPickupOptions(state),
+            getLoadError: getLoadError(state),
+            isLoading: isLoading(state),
+        };
+    });
+}

--- a/src/shipping/pickup-option-state.ts
+++ b/src/shipping/pickup-option-state.ts
@@ -1,7 +1,7 @@
-import { PickupOptionResult } from './pickup-option';
+import { PickupOptionQueryMap } from './pickup-option';
 
 export default interface PickupOptionState {
-    data?: PickupOptionResult[];
+    data?: PickupOptionQueryMap;
     errors: PickupOptionErrorsState;
     statuses: PickupOptionStatusesState;
 }

--- a/src/shipping/pickup-option-state.ts
+++ b/src/shipping/pickup-option-state.ts
@@ -1,0 +1,20 @@
+import { PickupOption } from './pickup-option';
+
+export default interface PickupOptionState {
+    data?: PickupOption[];
+    errors: PickupOptionErrorsState;
+    statuses: PickupOptionStatusesState;
+}
+
+export interface PickupOptionErrorsState {
+    loadError?: Error;
+}
+
+export interface PickupOptionStatusesState {
+    isLoading?: boolean;
+}
+
+export const DEFAULT_STATE: PickupOptionState = {
+    errors: {},
+    statuses: {},
+};

--- a/src/shipping/pickup-option-state.ts
+++ b/src/shipping/pickup-option-state.ts
@@ -1,7 +1,7 @@
-import { PickupOption } from './pickup-option';
+import { PickupOptionResult } from './pickup-option';
 
 export default interface PickupOptionState {
-    data?: PickupOption[];
+    data?: PickupOptionResult[];
     errors: PickupOptionErrorsState;
     statuses: PickupOptionStatusesState;
 }

--- a/src/shipping/pickup-option.mock.ts
+++ b/src/shipping/pickup-option.mock.ts
@@ -1,0 +1,55 @@
+import { PickupOptionState } from '.';
+import { PickupOption, PickupOptionRequestBody, PickupOptionResponse } from './pickup-option';
+
+export function getQueryForPickupOptions(): PickupOptionRequestBody {
+    return {
+        search_area: {
+            radius: {
+                value: 1.4,
+                unit: 0,
+            },
+            coordinates: {
+                latitude: 1.4,
+                longitude: 1.4,
+            },
+        },
+        items: [{
+            variant_id: 1,
+            quantity: 1,
+        }],
+    };
+}
+
+export function getPickupOptions(): PickupOption {
+    return {
+        options: [
+            {
+                pickup_method: {
+                    id: 1,
+                    location_id: 1,
+                    display_name: 'test',
+                    collection_instructions: 'none',
+                    collection_time_description: 'desc',
+                },
+                item_quantities: {
+                    variant_id: 1,
+                    quantity: 1,
+                },
+            },
+        ],
+    };
+}
+
+export function getPickupOptionsResponseBody(): PickupOptionResponse {
+    return {
+        results: [getPickupOptions()],
+    };
+}
+
+export function getPickupOptionsState(): PickupOptionState {
+    return {
+        data: [getPickupOptions()],
+        errors: {},
+        statuses: {},
+    };
+}

--- a/src/shipping/pickup-option.mock.ts
+++ b/src/shipping/pickup-option.mock.ts
@@ -1,9 +1,9 @@
 import { PickupOptionState } from '.';
-import { PickupOptionRequestBody, PickupOptionResponse, PickupOptionResult } from './pickup-option';
+import { PickupOptionAPIRequestBody, PickupOptionRequestBody, PickupOptionResponse, PickupOptionResult } from './pickup-option';
 
-export function getQueryForPickupOptions(): PickupOptionRequestBody {
+export function getApiQueryForPickupOptions(): PickupOptionAPIRequestBody {
     return {
-        search_area: {
+        searchArea: {
             radius: {
                 value: 1.4,
                 unit: 0,
@@ -14,9 +14,25 @@ export function getQueryForPickupOptions(): PickupOptionRequestBody {
             },
         },
         items: [{
-            variant_id: 1,
+            variantId: 71,
             quantity: 1,
         }],
+    };
+}
+
+export function getQueryForPickupOptions(): PickupOptionRequestBody {
+    return {
+        searchArea: {
+            radius: {
+                value: 1.4,
+                unit: 0,
+            },
+            coordinates: {
+                latitude: 1.4,
+                longitude: 1.4,
+            },
+        },
+        consignmentId: '55c96cda6f04c',
     };
 }
 
@@ -24,15 +40,15 @@ export function getPickupOptions(): PickupOptionResult {
     return {
         options: [
             {
-                pickup_method: {
+                pickupMethod: {
                     id: 1,
-                    location_id: 1,
-                    display_name: 'test',
-                    collection_instructions: 'none',
-                    collection_time_description: 'desc',
+                    locationId: 1,
+                    displayName: 'test',
+                    collectionInstructions: 'none',
+                    collectionTimeDescription: 'desc',
                 },
-                item_quantities: {
-                    variant_id: 1,
+                itemQuantities: {
+                    variantId: 1,
                     quantity: 1,
                 },
             },

--- a/src/shipping/pickup-option.mock.ts
+++ b/src/shipping/pickup-option.mock.ts
@@ -22,6 +22,7 @@ export function getApiQueryForPickupOptions(): PickupOptionAPIRequestBody {
 
 export function getQueryForPickupOptions(): PickupOptionRequestBody {
     return {
+        consignmentId: '55c96cda6f04c',
         searchArea: {
             radius: {
                 value: 1.4,
@@ -32,7 +33,6 @@ export function getQueryForPickupOptions(): PickupOptionRequestBody {
                 longitude: 1.4,
             },
         },
-        consignmentId: '55c96cda6f04c',
     };
 }
 
@@ -62,9 +62,14 @@ export function getPickupOptionsResponseBody(): PickupOptionResponse {
     };
 }
 
+const query = getQueryForPickupOptions();
+const keyString = btoa(`${query.consignmentId}-${JSON.stringify(query.searchArea)}`);
+
 export function getPickupOptionsState(): PickupOptionState {
     return {
-        data: [getPickupOptions()],
+        data: {
+            [keyString]: [getPickupOptions()],
+        },
         errors: {},
         statuses: {},
     };

--- a/src/shipping/pickup-option.mock.ts
+++ b/src/shipping/pickup-option.mock.ts
@@ -1,5 +1,5 @@
 import { PickupOptionState } from '.';
-import { PickupOption, PickupOptionRequestBody, PickupOptionResponse } from './pickup-option';
+import { PickupOptionRequestBody, PickupOptionResponse, PickupOptionResult } from './pickup-option';
 
 export function getQueryForPickupOptions(): PickupOptionRequestBody {
     return {
@@ -20,7 +20,7 @@ export function getQueryForPickupOptions(): PickupOptionRequestBody {
     };
 }
 
-export function getPickupOptions(): PickupOption {
+export function getPickupOptions(): PickupOptionResult {
     return {
         options: [
             {

--- a/src/shipping/pickup-option.ts
+++ b/src/shipping/pickup-option.ts
@@ -22,7 +22,7 @@ interface PickupMethod {
     id: number;
     locationId: number;
     displayName: string;
-    collectionUnstructions: string;
+    collectionInstructions: string;
     collectionTimeDescription: string;
 }
 

--- a/src/shipping/pickup-option.ts
+++ b/src/shipping/pickup-option.ts
@@ -26,16 +26,16 @@ interface PickupMethod {
     collection_time_description: string;
 }
 
-interface Options {
+interface Option {
     pickup_method: PickupMethod;
     item_quantities: Item;
 }
 
 export interface PickupOption {
-    options: Options[];
+    options: Option[];
 }
 
-export interface PickupOptionRequestPayload {
+export interface PickupOptionRequestBody {
     search_area: SearchArea;
     items: Item[];
 }

--- a/src/shipping/pickup-option.ts
+++ b/src/shipping/pickup-option.ts
@@ -31,7 +31,7 @@ interface Options {
     item_quantities: Item;
 }
 
-interface PickupOptionsResult {
+export interface PickupOption {
     options: Options[];
 }
 
@@ -44,6 +44,6 @@ export interface ConsignmentPickupOption {
     pickupMethodId: number;
 }
 
-export interface PickupOptionResponseBody {
-    results: PickupOptionsResult[];
+export interface PickupOptionResponse {
+    results: PickupOption[];
 }

--- a/src/shipping/pickup-option.ts
+++ b/src/shipping/pickup-option.ts
@@ -1,5 +1,5 @@
 interface Item {
-    variant_id: number;
+    variantId: number;
     quantity: number;
 }
 
@@ -20,15 +20,15 @@ interface SearchArea {
 
 interface PickupMethod {
     id: number;
-    location_id: number;
-    display_name: string;
-    collection_instructions: string;
-    collection_time_description: string;
+    locationId: number;
+    displayName: string;
+    collectionUnstructions: string;
+    collectionTimeDescription: string;
 }
 
 interface Option {
-    pickup_method: PickupMethod;
-    item_quantities: Item;
+    pickupMethod: PickupMethod;
+    itemQuantities: Item;
 }
 
 export interface PickupOptionResult {
@@ -36,7 +36,12 @@ export interface PickupOptionResult {
 }
 
 export interface PickupOptionRequestBody {
-    search_area: SearchArea;
+    searchArea: SearchArea;
+    consignmentId: string;
+}
+
+export interface PickupOptionAPIRequestBody {
+    searchArea: SearchArea;
     items: Item[];
 }
 

--- a/src/shipping/pickup-option.ts
+++ b/src/shipping/pickup-option.ts
@@ -1,3 +1,49 @@
-export default interface PickupOption {
+interface Item {
+    variant_id: number;
+    quantity: number;
+}
+
+interface Radius {
+    value: number;
+    unit: number;
+}
+
+interface Coordinates {
+    latitude: number;
+    longitude: number;
+}
+
+interface SearchArea {
+    radius: Radius;
+    coordinates: Coordinates;
+}
+
+interface PickupMethod {
+    id: number;
+    location_id: number;
+    display_name: string;
+    collection_instructions: string;
+    collection_time_description: string;
+}
+
+interface Options {
+    pickup_method: PickupMethod;
+    item_quantities: Item;
+}
+
+interface PickupOptionsResult {
+    options: Options[];
+}
+
+export interface PickupOptionRequestPayload {
+    search_area: SearchArea;
+    items: Item[];
+}
+
+export interface ConsignmentPickupOption {
     pickupMethodId: number;
+}
+
+export interface PickupOptionResponseBody {
+    results: PickupOptionsResult[];
 }

--- a/src/shipping/pickup-option.ts
+++ b/src/shipping/pickup-option.ts
@@ -31,7 +31,7 @@ interface Option {
     item_quantities: Item;
 }
 
-export interface PickupOption {
+export interface PickupOptionResult {
     options: Option[];
 }
 
@@ -45,5 +45,5 @@ export interface ConsignmentPickupOption {
 }
 
 export interface PickupOptionResponse {
-    results: PickupOption[];
+    results: PickupOptionResult[];
 }

--- a/src/shipping/pickup-option.ts
+++ b/src/shipping/pickup-option.ts
@@ -13,7 +13,7 @@ interface Coordinates {
     longitude: number;
 }
 
-interface SearchArea {
+export interface SearchArea {
     radius: Radius;
     coordinates: Coordinates;
 }
@@ -51,4 +51,10 @@ export interface ConsignmentPickupOption {
 
 export interface PickupOptionResponse {
     results: PickupOptionResult[];
+}
+
+export type PickupOptionMeta = PickupOptionRequestBody;
+
+export interface PickupOptionQueryMap {
+    [index: string]: PickupOptionResult[] | undefined;
 }


### PR DESCRIPTION
## What?
Add implementation to fetch available shipping options.

## Why?
We have an endpoint to fetch available shipping options as part of MLI project. Hence adding methods so partners can leverage that functionality via SDK

## Testing / Proof
- Tests
<img width="700" alt="Screen Shot 2022-02-02 at 5 12 21 pm" src="https://user-images.githubusercontent.com/7134802/152102227-ab30a1d8-c03e-4ab6-ad05-69b4b318408e.png">


@bigcommerce/checkout @bigcommerce/shipping 
