### PR TITLE
fix(payment): CHECKOUT-6070 Update style of apple pay customer step button

### DIFF
--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -24,6 +24,17 @@ enum DefaultLabels {
     Shipping = 'Shipping',
 }
 
+const style = {
+    width: '160px',
+    backgroundColor: '#000',
+    backgroundPosition: '50% 50%',
+    backgroundSize: '100% 60%',
+    padding: '1.5rem',
+    backgroundImage: '-webkit-named-image(apple-pay-logo-white)',
+    borderRadius: '4px',
+    backgroundRepeat: 'no-repeat',
+};
+
 function isShippingOptions(options: ShippingOption[] | undefined): options is ShippingOption[] {
     return options instanceof Array;
 }
@@ -109,11 +120,11 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
             throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
         }
 
-        const button = document.createElement('input');
-        button.type = 'image';
-        button.src = this._paymentMethod?.logoUrl || '';
-        button.style.height = '40px';
-        button.style.width = '75px';
+        const button = document.createElement('button');
+
+        button.setAttribute('type', 'button');
+        button.setAttribute('aria-label', 'Apple Pay');
+        Object.assign(button.style, style);
         container.appendChild(button);
 
         return button;


### PR DESCRIPTION
## What?
As above

## Why?
The current implementation of wallet button for apple pay doesn't resemble the wallet button in cart page. As part of experience make the customer step button similar to cart page.

## Testing / Proof
- Screenshot

![Screen Shot 2022-02-03 at 3 49 01 pm (2)](https://user-images.githubusercontent.com/7134802/152283284-8f5696da-203a-4ca2-8acb-156dda838171.png)


@bigcommerce/checkout @bigcommerce/payments
