### PR TITLE
feat(payment): INT-5090 Stripe UPE add return url for SOFORT support

### DIFF
--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -1,6 +1,6 @@
 import { CustomFont, PaymentIntent, StripeConfigurationOptions, StripeElement } from '../stripev3';
 
-export { StripeElement } from '../stripev3';
+export { StripeAdditionalAction, StripeElement } from '../stripev3';
 
 export interface StripeError {
     /**
@@ -125,4 +125,5 @@ export interface StripeHostWindow extends Window {
 
 export enum StripePaymentMethodType {
     CreditCard = 'card',
+    SOFORT = 'sofort',
 }


### PR DESCRIPTION
## What? [INT-5090](https://jira.bigcommerce.com/browse/INT-5090)
Added a function to handle 'redirect required' methods

## Why?
To be able to pay using sofort via Stripe UPE

## Testing / Proof
https://drive.google.com/file/d/1-AspMwus-uDN_950-SjAtN_w9_pVRBtN/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments
