### PR TITLE
docs(checkout): CHECKOUT-6260 Update Order Interface Documentation

### DIFF
--- a/src/order/order.ts
+++ b/src/order/order.ts
@@ -11,6 +11,7 @@ export default interface Order {
     billingAddress: BillingAddress;
     cartId: string;
     coupons: Coupon[];
+    consignments: OrderConsignment[];
     currency: Currency;
     customerCanBeCreated: boolean;
     customerId: number;
@@ -59,4 +60,46 @@ export interface GiftCertificateOrderPayment extends OrderPayment {
         code: string;
         remaining: number;
     };
+}
+
+export interface OrderConsignment {
+    shipping: OrderShippingConsignment[];
+}
+
+export interface OrderShippingConsignment {
+    lineItems: Array<{
+        id: number;
+    }>;
+    shippingAddressId: number;
+    firstName: string;
+    lastName: string;
+    company: string;
+    address1: string;
+    address2: string;
+    city: string;
+    stateOrProvince: string;
+    postalCode: string;
+    country: string;
+    countryCode: string;
+    email: string;
+    phone: string;
+    itemsTotal: number;
+    itemsShipped: number;
+    shippingMethod: string;
+    baseCost: number;
+    costExTax: number;
+    costIncTax: number;
+    costTax: number;
+    costTaxClassId: number;
+    baseHandlingCost: number;
+    handlingCostExTax: number;
+    handlingCostIncTax: number;
+    handlingCostTax: number;
+    handlingCostTaxClassId: number;
+    shippingZoneId: number;
+    shippingZoneName: string;
+    customFields: Array<{
+        name: string;
+        value: string | null;
+    }>;
 }

--- a/src/order/orders.mock.ts
+++ b/src/order/orders.mock.ts
@@ -5,7 +5,7 @@ import { getCurrency } from '../currency/currencies.mock';
 
 import { getAwaitingOrder, getSubmitOrderResponseHeaders } from './internal-orders.mock';
 import { getPhysicalItem } from './line-items.mock';
-import Order, { GatewayOrderPayment, GiftCertificateOrderPayment } from './order';
+import Order, { GatewayOrderPayment, GiftCertificateOrderPayment, OrderConsignment, OrderShippingConsignment } from './order';
 import OrderState, { OrderMetaState } from './order-state';
 
 export function getOrder(): Order {
@@ -13,6 +13,7 @@ export function getOrder(): Order {
         baseAmount: 200,
         billingAddress: getBillingAddress(),
         cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+        consignments: [getOrderConsignment()],
         coupons: [
             getCoupon(),
             getShippingCoupon(),
@@ -104,5 +105,55 @@ export function getOrderState(): OrderState {
         meta: getOrderMeta(),
         errors: {},
         statuses: {},
+    };
+}
+
+export function getOrderConsignment(): OrderConsignment {
+    return {
+      shipping: [getOrderShippingConsignment()],
+    };
+}
+
+export function getOrderShippingConsignment(): OrderShippingConsignment {
+    return {
+        lineItems: [
+            {
+                id: 123,
+            },
+        ],
+        shippingAddressId: 1,
+        firstName: 'firstName',
+        lastName: 'lastName',
+        company: 'companyName',
+        address1: '2802 Skyway Cir',
+        address2: 'Balcony',
+        city: 'Austin',
+        stateOrProvince: 'Texas',
+        postalCode: '78704',
+        country: 'United States',
+        countryCode: 'US',
+        email: 'test@bigcommerce.com',
+        phone: '0410123452',
+        itemsTotal: 1,
+        itemsShipped: 0,
+        shippingMethod: 'Flat Rate',
+        baseCost: 15.5,
+        costExTax: 15.5,
+        costIncTax: 16.7,
+        costTax: 1.2,
+        costTaxClassId: 2,
+        baseHandlingCost: 0,
+        handlingCostExTax: 0,
+        handlingCostIncTax: 0,
+        handlingCostTax: 0,
+        handlingCostTaxClassId: 2,
+        shippingZoneId: 1,
+        shippingZoneName: 'United States',
+        customFields: [
+            {
+                name: 'customerMessage',
+                value: 'foobar',
+            },
+        ],
     };
 }


### PR DESCRIPTION
## What?
Update `Order` Interface to document the new `consignments` property.

`consignments`'s back-end documentation is [here](https://github.com/bigcommerce/api-specs/blob/master/reference/orders.sf.yml).

 _* leave `pickup` consignments for future work._ 

## Why?
[ORDERS-4432](https://jira.bigcommerce.com/browse/ORDERS-4432) introduced a new `consignments` property to responses from the Storefront [Order](https://github.com/bigcommerce/checkout-sdk-js/blob/55edbb9e8f7ad895517809ed10bef6750a8914c2/docs/interfaces/order.md) API. 

The Order object returned by [getOrder](https://github.com/bigcommerce/checkout-sdk-js/blob/55edbb9e8f7ad895517809ed10bef6750a8914c2/docs/interfaces/checkoutstoreselector.md#getorder) already has a new `consignments` property, but it is not yet documented.

## Testing / Proof
![Screen Shot 2022-02-09 at 2 56 25 pm](https://user-images.githubusercontent.com/88361607/153119019-0f56811c-64a4-4d21-8af7-b2738a426b3e.png)

