### PR TITLE
feat(payment): INT-5034 StripeUPE Add support for EPS

### DIFF
--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -15,7 +15,10 @@ import PaymentStrategy from '../payment-strategy';
 import { StripeElement, StripeElements, StripePaymentMethodType, StripeUPEClient } from './stripe-upe';
 import StripeUPEScriptLoader from './stripe-upe-script-loader';
 
-const APM_REDIRECT = [StripePaymentMethodType.SOFORT];
+const APM_REDIRECT = [
+  StripePaymentMethodType.SOFORT,
+  StripePaymentMethodType.EPS,
+];
 
 export default class StripeUPEPaymentStrategy implements PaymentStrategy {
     private _stripeUPEClient?: StripeUPEClient;

--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -126,4 +126,5 @@ export interface StripeHostWindow extends Window {
 export enum StripePaymentMethodType {
     CreditCard = 'card',
     SOFORT = 'sofort',
+    EPS = 'eps',
 }


### PR DESCRIPTION
## What?
Add Support for EPS payment Method on StripeUpe

## Why?
As a customer, when the currency is EUR and the country is Austria, I want to be able to pay with EPS

## Testing / Proof
<img width="1561" alt="image" src="https://user-images.githubusercontent.com/64860381/154166785-ba83d6aa-0e61-491f-af09-218cc87da5e1.png">

[https://drive.google.com/file/d/1yM7BMqOZHpBlmnnUQSfm3DPL75y_6aaY/view?usp=sharing](https://drive.google.com/file/d/1yM7BMqOZHpBlmnnUQSfm3DPL75y_6aaY/view?usp=sharing)

## Depends on
INT-5090
INT-5035

Ping @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team @bigcommerce/payments 
