### PR TITLE
feat(payment): INT-5156 Klarna add support for poland, portugal, ireland

### DIFF
--- a/src/payment/strategies/klarnav2/klarna-supported-countries.ts
+++ b/src/payment/strategies/klarnav2/klarna-supported-countries.ts
@@ -1,2 +1,2 @@
-export const supportedCountries = ['AT', 'BE', 'CA', 'CH', 'DE', 'DK', 'ES', 'FI', 'FR', 'GB', 'IT', 'NL', 'NO', 'NZ', 'SE'];
+export const supportedCountries = ['AT', 'BE', 'CA', 'CH', 'DE', 'DK', 'ES', 'FI', 'FR', 'GB', 'IE', 'IT', 'NL', 'NO', 'NZ', 'PL', 'PT', 'SE'];
 export const supportedCountriesRequiringStates = ['AU'];


### PR DESCRIPTION
## What? [INT-5156](https://jira.bigcommerce.com/browse/INT-5156)
Add support for poland(PL), portugal(PT) and ireland(IE) on klarna eu

## Why?
So shoppers can pay using klarna from poland with PLN, from portugal and ireland with EUR

## Depends on
https://github.com/bigcommerce/bigpay/pull/4974

## Testing / Proof
### Ireland:
![Screen Shot 2022-02-09 at 11 59 37](https://user-images.githubusercontent.com/8669574/153266950-211774e1-b2cb-4be8-b59d-88e7a6f9ea36.png)
![Screen Shot 2022-02-09 at 12 02 39](https://user-images.githubusercontent.com/8669574/153266963-e18c4a87-36d2-4d22-9c0c-4ebcab52ccff.png)

### Poland:
![Screen Shot 2022-02-09 at 12 05 04](https://user-images.githubusercontent.com/8669574/153267013-a78cd3d0-46fa-46e2-9619-a2e0a819a434.png)
![Screen Shot 2022-02-09 at 12 06 24](https://user-images.githubusercontent.com/8669574/153267033-bebfbc44-5ee4-48bc-ae00-180cbcc7e2c8.png)

### Portugal:
![Screen Shot 2022-02-09 at 11 51 21](https://user-images.githubusercontent.com/8669574/153267064-5825b6f1-068b-4279-935e-39d53c740647.png)
![Screen Shot 2022-02-09 at 11 53 04](https://user-images.githubusercontent.com/8669574/153267076-238b199b-2c63-4a4f-9f98-b0c4353324ff.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
