### PR TITLE
feat(checkout): INT-5273 Non-Default Shipping Method Selection On Cart Page Is Not Persisted to Apple Pay

### DIFF
--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
@@ -218,13 +218,25 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
         let state = this._store.getState();
         const { currency: { decimalPlaces } } = state.cart.getCartOrThrow();
         let checkout = state.checkout.getCheckoutOrThrow();
+        const selectionShippingOptionId = checkout.consignments[0].selectedShippingOption?.id;
         const availableOptions = checkout.consignments[0].availableShippingOptions;
-        const shippingOptions = availableOptions?.map(option => ({
-            label: option.description,
-            amount: `${option.cost.toFixed(decimalPlaces)}`,
-            detail: option.additionalDescription,
-            identifier: option.id,
-        }));
+        const selectedOption = availableOptions?.find(({id}) => id === selectionShippingOptionId);
+        const unselectedOptions = availableOptions?.filter(option => option.id !== selectionShippingOptionId);
+        let shippingOptions: ApplePayJS.ApplePayShippingMethod[];
+        shippingOptions = selectedOption ? [{
+            label: selectedOption.description,
+            amount: `${selectedOption.cost.toFixed(decimalPlaces)}`,
+            detail: selectedOption.additionalDescription,
+            identifier: selectedOption.id,
+        }] : [];
+        unselectedOptions?.forEach(option => shippingOptions.push(
+            {
+                label: option.description,
+                amount: `${option.cost.toFixed(decimalPlaces)}`,
+                detail: option.additionalDescription,
+                identifier: option.id,
+            }
+        ));
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');
@@ -250,8 +262,9 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
         );
 
         const optionId = recommendedOption ? recommendedOption.id : availableOptions[0].id;
+        const selectedOptionId = selectedOption ? selectedOption.id : optionId;
         try {
-            await this._updateShippingOption(optionId);
+            await this._updateShippingOption(selectedOptionId);
         } catch (error) {
             throw new Error('Shipping options update failed');
         }

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.spec.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.spec.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs/internal/Observable';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
-import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
@@ -18,6 +18,8 @@ import { ApplePaySessionFactory } from '../../../payment/strategies/apple-pay';
 import { MockApplePaySession } from '../../../payment/strategies/apple-pay/apple-pay-payment.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
+import { getConsignment } from '../../../shipping/consignments.mock';
+import { getShippingOption } from '../../../shipping/shipping-options.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
 import { CustomerInitializeOptions } from '../../customer-request-options';
@@ -241,6 +243,65 @@ describe('ApplePayCustomerStrategy', () => {
                     await applePaySession.onshippingcontactselected(event);
 
                     expect(applePaySession.completeShippingContactSelection).toHaveBeenCalled();
+                }
+            }
+        });
+
+        it('gets shipping contact selected successfully with a selected shipping option', async () => {
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+            const newCheckout = {
+                ...getCheckout(),
+                consignments: [
+                    {
+                        ...getConsignment(),
+                        selectedShippingOption: {
+                            ...getShippingOption(),
+                            description: 'Free Shipping',
+                            additionalDescription: 'Free shipping to your order',
+                            id: '0:61d4bb52f746477e1d4fb41127361823',
+                        },
+                        availableShippingOptions: [
+                            getShippingOption(),
+                            {
+                                ...getShippingOption(),
+                                description: 'Free Shipping',
+                                additionalDescription: 'Free shipping to your order',
+                                id: '0:61d4bb52f746477e1d4fb41127361823',
+                            },
+                        ],
+                    },
+                ],
+            };
+            const availableShippingMethods = newCheckout.consignments[0].availableShippingOptions.reverse().map(option => ({
+                label: option.description,
+                amount: option.cost.toFixed(2),
+                detail: option.additionalDescription,
+                identifier: option.id,
+            }));
+
+            jest.spyOn(store.getState().checkout, 'getCheckoutOrThrow')
+                .mockReturnValue(newCheckout);
+            await strategy.initialize(customerInitializeOptions);
+
+            if (customerInitializeOptions.applepay) {
+                const buttonContainer = document.getElementById(customerInitializeOptions?.applepay.container);
+                const button = buttonContainer?.firstChild as HTMLElement;
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingContact: getContactAddress(),
+                    } as ApplePayJS.ApplePayShippingContactSelectedEvent;
+
+                    await applePaySession.onshippingcontactselected(event);
+
+                    expect(consignmentActionCreator.selectShippingOption)
+                        .toHaveBeenCalledWith('0:61d4bb52f746477e1d4fb41127361823');
+                    expect(applePaySession.completeShippingContactSelection).toHaveBeenCalledWith({
+                        newShippingMethods: availableShippingMethods,
+                        newTotal: expect.anything(),
+                        newLineItems: expect.anything(),
+                    });
                 }
             }
         });


### PR DESCRIPTION
## What? [INT-5273](https://jira.bigcommerce.com/browse/INT-5273)
When a shopper selects a non-default shipping method on the cart page, updates shipping, and then clicks the express pay button for Apple Pay, the shipping method is not persisted into the Apple Pay modal. 

## Why?
The shipping option/method that the shopper selects on the cart page should be automatically selected within the Apple Pay modal. 

The expected behavior should occur on all Apple Pay compatible providers:
- Adyen
- Authorize.Net
- Bolt Payments
- Checkout.com
- Stripe
- PayPal powered by Braintree
- Chase Merchant Services (beta)
- Moneris (beta)

## Testing / Proof
[Demo Video](https://drive.google.com/file/d/1-N8MHvMqA0XXYB_dhJ8ArOwgKHsLnVID/view?usp=sharing)

![Screen Shot 2022-02-25 at 4 55 00 PM](https://user-images.githubusercontent.com/90646906/155813898-54c1f8f8-d6e4-4c5d-858c-5b22964e8d5f.png)

![Screen Shot 2022-02-25 at 4 56 21 PM](https://user-images.githubusercontent.com/90646906/155814018-db874694-1c16-4827-a344-0f1bbb18a065.png)


## How can this change be undone in case of failure?
Revert PR

ping @bigcommerce/apex-integrations @bigcommerce/checkout @bigcommerce/payments
