### PR TITLE
feat(payment): INT-5572 Stripe UPE Hide Fields

### DIFF
--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -25,7 +25,7 @@ import { getStripeUPE } from '../../payment-methods.mock';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
 
-import { StripeElement, StripeElements, StripeElementsOptions, StripePaymentMethodType, StripeUPEClient } from './stripe-upe';
+import { StripeElement, StripeElements, StripeElementsOptions, StripePaymentMethodType, StripeStringConstants, StripeUPEClient } from './stripe-upe';
 import StripeUPEPaymentStrategy from './stripe-upe-payment-strategy';
 import StripeUPEScriptLoader from './stripe-upe-script-loader';
 import { getConfirmPaymentResponse, getFailingStripeUPEJsMock, getStripeUPEInitializeOptionsMock, getStripeUPEJsMock, getStripeUPEOrderRequestBodyMock, getStripeUPEOrderRequestBodyVaultMock } from './stripe-upe.mock';
@@ -258,7 +258,7 @@ describe('StripeUPEPaymentStrategy', () => {
 
                 beforeEach(() => {
                     elements = stripeUPEJsMock.elements(elementsOptions);
-                    cardElement = elements.create('payment');
+                    cardElement = elements.create(StripeStringConstants.PAYMENT);
 
                     stripeUPEJsMock.confirmPayment = jest.fn(
                         () => Promise.resolve(getConfirmPaymentResponse())
@@ -635,7 +635,7 @@ describe('StripeUPEPaymentStrategy', () => {
 
                 beforeEach(() => {
                     elements = stripeUPEJsMock.elements(elementsOptions);
-                    element = elements.create('payment');
+                    element = elements.create(StripeStringConstants.PAYMENT);
                     options = getStripeUPEInitializeOptionsMock(method);
                     paymentMethodMock = { ...getStripeUPE(method), clientToken: 'myToken' };
                     loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, { methodId: `stripeupe?method=${paymentMethodMock.id }`}));
@@ -767,7 +767,7 @@ describe('StripeUPEPaymentStrategy', () => {
 
         beforeEach(() => {
             const elements = stripeUPEJsMock.elements(elementsOptions);
-            cardElement = elements.create('payment');
+            cardElement = elements.create(StripeStringConstants.PAYMENT);
 
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                 .mockReturnValue(getStripeUPE());

--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -410,12 +410,11 @@ describe('StripeUPEPaymentStrategy', () => {
                         .mockReturnValue(undefined);
 
                     await strategy.initialize(options);
-                    const response = await strategy.execute(getStripeUPEOrderRequestBodyMock());
+                    await expect(strategy.execute(getStripeUPEOrderRequestBodyMock())).rejects.toBeInstanceOf(MissingDataError);
 
-                    expect(orderActionCreator.submitOrder).toHaveBeenCalled();
                     expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalled();
-                    expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
-                    expect(response).toBe(store.getState());
+                    expect(orderActionCreator.submitOrder).not.toHaveBeenCalled();
+                    expect(paymentActionCreator.submitPayment).not.toHaveBeenCalled();
                 });
 
                 it('fires additional action outside of bigcommerce', async () => {

--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -34,12 +34,12 @@ export interface AddressOptions {
  * Object definition for part of the data sent to confirm the PaymentIntent.
  */
 export interface AddressProperties {
-    city?: 'auto' | 'never';
-    country?: 'auto' | 'never';
-    state?: 'auto' | 'never';
-    postalCode?: 'auto' | 'never';
-    line1?: 'auto' | 'never';
-    line2?: 'auto' | 'never';
+    city?: AutoOrNever;
+    country?: AutoOrNever;
+    state?: AutoOrNever;
+    postalCode?: AutoOrNever;
+    line1?: AutoOrNever;
+    line2?: AutoOrNever;
 }
 
 /**
@@ -56,10 +56,10 @@ export interface BillingDetailsOptions {
  * Object definition for part of the data sent to confirm the PaymentIntent.
  */
 export interface BillingDetailsProperties {
-    name?: 'auto' | 'never';
-    email?: 'auto' | 'never';
-    address?: 'auto' | 'never' | AddressProperties;
-    phone?: 'auto' | 'never';
+    name?: AutoOrNever;
+    email?: AutoOrNever;
+    address?: AutoOrNever | AddressProperties;
+    phone?: AutoOrNever;
 }
 
 /**
@@ -102,16 +102,16 @@ export interface StripeConfirmPaymentData {
      * By default, confirmPayment will always redirect to your return_url after a successful confirmation.
      * If you set redirect: "if_required", then confirmPayment will only redirect if your user chooses a redirect-based payment method.
      */
-    redirect?: 'always' | 'if_required';
+    redirect?: StripeStringConstants.ALWAYS | StripeStringConstants.IF_REQUIRED;
 }
 
 export interface FieldsOptions {
-    billingDetails?: 'auto' | 'never' | BillingDetailsProperties;
+    billingDetails?: AutoOrNever | BillingDetailsProperties;
 }
 
 export interface WalletOptions {
-    applePay?: 'auto' | 'never';
-    googlePay?: 'auto' | 'never';
+    applePay?: AutoOrNever;
+    googlePay?: AutoOrNever;
 }
 
 /**
@@ -126,12 +126,12 @@ export interface StripeElements {
     /**
      * Creates a `payment` element.
      */
-    create(elementType: 'payment', options?: StripeElementsCreateOptions): StripeElement;
+    create(elementType: StripeStringConstants.PAYMENT, options?: StripeElementsCreateOptions): StripeElement;
 
     /**
      * Looks up a previously created `payment` element.
      */
-    getElement(elementType: 'payment'): StripeElement | null;
+    getElement(elementType: StripeStringConstants.PAYMENT): StripeElement | null;
 }
 
 export interface StripeElementsOptions {
@@ -184,4 +184,14 @@ export enum StripePaymentMethodType {
     CreditCard = 'card',
     SOFORT = 'sofort',
     EPS = 'eps',
+}
+
+type AutoOrNever = StripeStringConstants.AUTO | StripeStringConstants.NEVER;
+
+export enum StripeStringConstants {
+    NEVER = 'never',
+    AUTO = 'auto',
+    ALWAYS = 'always',
+    PAYMENT = 'payment',
+    IF_REQUIRED = 'if_required',
 }

--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -19,6 +19,57 @@ export interface StripeError {
 }
 
 /**
+ * Object definition for part of the data sent to confirm the PaymentIntent.
+ */
+export interface AddressOptions {
+    city?: string;
+    country?: string;
+    state?: string;
+    postal_code?: string;
+    line1?: string;
+    line2?: string;
+}
+
+/**
+ * Object definition for part of the data sent to confirm the PaymentIntent.
+ */
+export interface AddressProperties {
+    city?: 'auto' | 'never';
+    country?: 'auto' | 'never';
+    state?: 'auto' | 'never';
+    postalCode?: 'auto' | 'never';
+    line1?: 'auto' | 'never';
+    line2?: 'auto' | 'never';
+}
+
+/**
+ * Object definition for part of the data sent to confirm the PaymentIntent.
+ */
+export interface BillingDetailsOptions {
+    name?: string;
+    email?: string;
+    address?: AddressOptions;
+    phone?: string;
+}
+
+/**
+ * Object definition for part of the data sent to confirm the PaymentIntent.
+ */
+export interface BillingDetailsProperties {
+    name?: 'auto' | 'never';
+    email?: 'auto' | 'never';
+    address?: 'auto' | 'never' | AddressProperties;
+    phone?: 'auto' | 'never';
+}
+
+/**
+ * Object definition for part of the data sent to confirm the PaymentIntent.
+ */
+export interface PaymentMethodDataOptions {
+    billing_details: BillingDetailsOptions;
+}
+
+/**
  * Parameters that will be passed on to the Stripe API to confirm the PaymentIntent.
  */
 export interface StripeUPEConfirmParams {
@@ -29,6 +80,7 @@ export interface StripeUPEConfirmParams {
      * @recommended
      */
     return_url?: string;
+    payment_method_data?: PaymentMethodDataOptions;
 }
 
 /**
@@ -44,13 +96,17 @@ export interface StripeConfirmPaymentData {
     /**
      * Parameters that will be passed on to the Stripe API to confirm the PaymentIntent.
      */
-     confirmParams?: StripeUPEConfirmParams;
+    confirmParams?: StripeUPEConfirmParams;
 
     /**
      * By default, confirmPayment will always redirect to your return_url after a successful confirmation.
      * If you set redirect: "if_required", then confirmPayment will only redirect if your user chooses a redirect-based payment method.
      */
     redirect?: 'always' | 'if_required';
+}
+
+export interface FieldsOptions {
+    billingDetails?: 'auto' | 'never' | BillingDetailsProperties;
 }
 
 export interface WalletOptions {
@@ -62,6 +118,7 @@ export interface WalletOptions {
  * All available options are herehttps://stripe.com/docs/js/elements_object/create_payment_element
  */
 export interface StripeElementsCreateOptions {
+    fields?: FieldsOptions;
     wallets?: WalletOptions;
 }
 


### PR DESCRIPTION
## What? [INT-5572](https://jira.bigcommerce.com/browse/INT-5572)
Stripe Payment Element hides the following fields that are required earlier in the checkout flow: **email**, **address**, **city**, **postal code/zip code**, **country**, **state/province** for all supported Stripe UPE payment methods.
These fields are collected from the billing data and provided to stripe in the confirm step

## Why?
To avoid having my shopper re-enter any information in the payment step that was collected earlier in the checkout flow
So that I can allow them to checkout faster

## Testing / Proof
Before
<img width="682" alt="image" src="https://user-images.githubusercontent.com/87149598/155740882-1f3f8bb3-99d1-4b00-8c03-b59438140662.png">
After
![image](https://user-images.githubusercontent.com/87149598/155236960-4a50df31-45aa-42b0-86df-2e75e4983805.png)
Card element without Country/postal code fields

Before
<img width="659" alt="image" src="https://user-images.githubusercontent.com/87149598/155741505-527ce1ef-ccd0-4a90-b25a-ae970ef3b2c5.png">
After (name is not on the list of fields to hide)
![image](https://user-images.githubusercontent.com/87149598/155747858-37a38482-7898-460f-9033-73924d3a3646.png)


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/kyiv-payments-team 