### PR TITLE
feat(payment): INT-5042 [Stripe UPE] Add support for Bancontact & iDeal

### DIFF
--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -20,6 +20,8 @@ const APM_REDIRECT = [
   StripePaymentMethodType.SOFORT,
   StripePaymentMethodType.EPS,
   StripePaymentMethodType.GRABPAY,
+  StripePaymentMethodType.BANCONTACT,
+  StripePaymentMethodType.IDEAL,
 ];
 
 export default class StripeUPEPaymentStrategy implements PaymentStrategy {

--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -128,4 +128,6 @@ export enum StripePaymentMethodType {
     SOFORT = 'sofort',
     EPS = 'eps',
     GRABPAY = 'grabpay',
+    BANCONTACT = 'bancontact',
+    IDEAL = 'ideal',
 }


### PR DESCRIPTION
## What? [INT-5042](https://jira.bigcommerce.com/browse/INT-5042) & [INT-5052](https://jira.bigcommerce.com/browse/INT-5052)
Add support for Bancontact & iDeal as a payment methods on StripeUPE.

## Why?
As a Shopper
I want to be able to pay for my order using BANCONTACT or IDEAL
So that I can complete my purchase.

## Testing / Proof

<img width="1312" alt="Screen Shot 2022-02-22 at 1 24 33 PM" src="https://user-images.githubusercontent.com/69487174/155205272-f3008fb7-0e33-4cd3-be44-de42b7b3a05c.png">

### Bancontact
- [Video](https://drive.google.com/file/d/1ukxScnqYRweHE2XK7bIiQ8oSbl6bv1PI/view?usp=sharing)

![Screen Shot 2022-02-21 at 8 45 29 AM](https://user-images.githubusercontent.com/69487174/154980583-9b8f9fed-5218-4b2a-906f-3ae62d5d7d30.png)

![Screen Shot 2022-02-21 at 8 45 50 AM](https://user-images.githubusercontent.com/69487174/154980621-a0039f7a-5fac-4ab8-81b0-b460ce6a96b7.png)

### iDeal
- [Video](https://drive.google.com/file/d/1uYhervsyDjCxsP89-EOopzSyxNLo9wz3/view?usp=sharing)

<img width="585" alt="Screen Shot 2022-02-22 at 1 29 32 PM" src="https://user-images.githubusercontent.com/69487174/155205392-b493aa68-3b20-4845-96a7-7c9cb7c0f0eb.png">

<img width="1321" alt="Screen Shot 2022-02-22 at 1 33 37 PM" src="https://user-images.githubusercontent.com/69487174/155205550-4f36e319-01b8-4f73-b2a1-9eb056f4fc49.png">


@bigcommerce/checkout @bigcommerce/payments
