### PR TITLE
feat(checkout): INT-5126 [MPGS] Add 3DS support to MPGS

### DIFF
--- a/src/payment/create-payment-strategy-registry.spec.ts
+++ b/src/payment/create-payment-strategy-registry.spec.ts
@@ -17,6 +17,7 @@ import { ApplePayPaymentStrategy } from './strategies/apple-pay';
 import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy } from './strategies/braintree';
+import { CBAMPGSPaymentStrategy } from './strategies/cba-mpgs';
 import { ChasepayPaymentStrategy } from './strategies/chasepay';
 import { CheckoutcomAPMPaymentStrategy, CheckoutcomSEPAPaymentStrategy } from './strategies/checkoutcom-custom';
 import { ClearpayPaymentStrategy } from './strategies/clearpay';
@@ -310,5 +311,10 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate ppsdk', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.PPSDK);
         expect(paymentStrategy).toBeInstanceOf(PPSDKStrategy);
+    });
+
+    it('can instantiate MPGS', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.CBA_MPGS);
+        expect(paymentStrategy).toBeInstanceOf(CBAMPGSPaymentStrategy);
     });
 });

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -36,6 +36,7 @@ import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BoltPaymentStrategy, BoltScriptLoader } from './strategies/bolt';
 import { createBraintreePaymentProcessor, createBraintreeVisaCheckoutPaymentProcessor, BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVisaCheckoutPaymentStrategy, VisaCheckoutScriptLoader } from './strategies/braintree';
 import { CardinalClient, CardinalScriptLoader, CardinalThreeDSecureFlow, CardinalThreeDSecureFlowV2 } from './strategies/cardinal';
+import { CBAMPGSPaymentStrategy, CBAMPGSScriptLoader } from './strategies/cba-mpgs';
 import { ChasePayPaymentStrategy, ChasePayScriptLoader } from './strategies/chasepay';
 import { CheckoutcomiDealPaymentStrategy, CheckoutcomAPMPaymentStrategy, CheckoutcomFawryPaymentStrategy, CheckoutcomSEPAPaymentStrategy } from './strategies/checkoutcom-custom';
 import { ClearpayPaymentStrategy, ClearpayScriptLoader } from './strategies/clearpay';
@@ -333,6 +334,18 @@ export default function createPaymentStrategyRegistry(
             paymentMethodActionCreator,
             storeCreditActionCreator,
             new BoltScriptLoader(scriptLoader)
+        )
+    );
+
+    registry.register(PaymentStrategyType.CBA_MPGS, () =>
+        new CBAMPGSPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory,
+            paymentMethodActionCreator,
+            new CBAMPGSScriptLoader(scriptLoader),
+            locale
         )
     );
 

--- a/src/payment/instrument/supported-payment-instruments.ts
+++ b/src/payment/instrument/supported-payment-instruments.ts
@@ -125,6 +125,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'moneris',
         method: 'credit_card',
     },
+    cba_mpgs: {
+        provider: 'cba_mpgs',
+        method: 'credit_card',
+    },
 };
 
 export default supportedInstruments;

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -888,6 +888,26 @@ export function getOpy(): PaymentMethod {
     };
 }
 
+export function getCBAMPGS(): PaymentMethod {
+    return {
+        id: 'cba_mpgs',
+        gateway: '',
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: [],
+        clientToken: 'foo',
+        config: {
+            displayName: 'CBA MPGS',
+            is3dsEnabled: true,
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        initializationData: {
+            merchantId: 'ABC123',
+        },
+    };
+}
+
 export function getPaymentMethods(): PaymentMethod[] {
     return [
         getAdyenAmex(),

--- a/src/payment/payment-response-body.ts
+++ b/src/payment/payment-response-body.ts
@@ -39,6 +39,7 @@ export interface AdditionalActionRequired {
 
 export interface AdditionalRedirectData {
     redirect_url: string;
+    transaction_id?: string;
 }
 
 export enum AdditionalActionType {

--- a/src/payment/payment-strategy-type.ts
+++ b/src/payment/payment-strategy-type.ts
@@ -12,6 +12,7 @@ enum PaymentStrategyType {
     BARCLAYS = 'barclays',
     BLUESNAPV2 = 'bluesnapv2',
     BOLT = 'bolt',
+    CBA_MPGS = 'cba_mpgs',
     CHECKOUTCOM = 'checkoutcom',
     CHECKOUTCOM_APM = 'checkoutcomapm',
     CHECKOUTCOM_FAWRY = 'checkoutcomfawry',

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.spec.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.spec.ts
@@ -1,0 +1,421 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
+import { merge } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { MissingDataError, NotInitializedError, RequestError } from '../../../common/error/errors';
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { getConfig } from '../../../config/configs.mock';
+import { HostedFormFactory } from '../../../hosted-form';
+import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getOrder } from '../../../order/orders.mock';
+import { PaymentMethodActionCreator } from '../../../payment';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import { PaymentArgumentInvalidError, PaymentMethodDeclinedError, PaymentMethodFailedError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType } from '../../payment-actions';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodRequestSender from '../../payment-method-request-sender';
+import { getCBAMPGS } from '../../payment-methods.mock';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+import * as paymentStatusTypes from '../../payment-status-types';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+
+import { CBAMPGSPaymentStrategy, CBAMPGSScriptLoader } from './';
+import { ThreeDSjs } from './cba-mpgs';
+import { getCBAMPGSScriptMock } from './cba-mpgs.mock';
+
+describe('CBAMPGSPaymentStrategy', () => {
+    let scriptLoader: ScriptLoader;
+    let cbaMPGSScriptLoader: CBAMPGSScriptLoader;
+    let threeDSjs: ThreeDSjs;
+    let finalizeOrderAction: Observable<FinalizeOrderAction>;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let orderRequestSender: OrderRequestSender;
+    let payload: OrderRequestBody;
+    let paymentMethod: PaymentMethod;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: CBAMPGSPaymentStrategy;
+    let submitOrderAction: Observable<Action>;
+    let submitPaymentAction: Observable<Action>;
+
+    beforeEach(() => {
+        store = createCheckoutStore();
+        requestSender = createRequestSender();
+        scriptLoader = createScriptLoader();
+        orderRequestSender = new OrderRequestSender(requestSender);
+        orderActionCreator = new OrderActionCreator(
+            orderRequestSender,
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(requestSender)
+        );
+
+        threeDSjs = getCBAMPGSScriptMock();
+
+        cbaMPGSScriptLoader = new CBAMPGSScriptLoader(scriptLoader);
+
+        strategy = new CBAMPGSPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            new HostedFormFactory(store),
+            paymentMethodActionCreator,
+            cbaMPGSScriptLoader,
+            'en_US'
+        );
+
+        paymentMethod = getCBAMPGS();
+
+        payload = merge({}, getOrderRequestBody(), {
+            payment: {
+                methodId: paymentMethod.id,
+                gatewayId: paymentMethod.gateway,
+            },
+        });
+
+        finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow')
+            .mockReturnValue(getConfig().storeConfig);
+
+        jest.spyOn(cbaMPGSScriptLoader, 'load')
+            .mockResolvedValue(threeDSjs);
+
+        jest.spyOn(orderActionCreator, 'finalizeOrder')
+            .mockReturnValue(finalizeOrderAction);
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
+            .mockResolvedValue(store.getState());
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(paymentMethod);
+
+        jest.spyOn(store.getState().order, 'getOrder')
+            .mockReturnValue(getOrder());
+
+        jest.spyOn(store, 'dispatch');
+    });
+
+    describe('#initialize', () => {
+        it('should initialize the base strategy if 3ds is disabled', async () => {
+            paymentMethod.config.is3dsEnabled = false;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(cbaMPGSScriptLoader.load).not.toHaveBeenCalled();
+        });
+
+        it('should initialize the strategy and load ThreeDSjs script if 3ds is enabled', async () => {
+            const configurePayload = {
+                merchantId: paymentMethod.initializationData.merchantId,
+                sessionId: expect.any(String),
+                callback: expect.any(Function),
+                configuration: {
+                    userLanguage: 'en_US',
+                    wsVersion: 62,
+                },
+            };
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(cbaMPGSScriptLoader.load).toHaveBeenCalled();
+            expect(threeDSjs.configure).toHaveBeenCalledWith(configurePayload);
+            expect(threeDSjs.isConfigured).toHaveBeenCalled();
+        });
+
+        it('should fail to initialize strategy if the script loader fails to load the script', () => {
+            jest.spyOn(cbaMPGSScriptLoader, 'load')
+                .mockResolvedValue(undefined);
+
+            expect(strategy.initialize({ methodId: paymentMethod.id })).rejects.toThrow(NotInitializedError);
+
+            expect(threeDSjs.configure).not.toHaveBeenCalled();
+            expect(threeDSjs.isConfigured).not.toHaveBeenCalled();
+        });
+
+        it('should fail to initialize strategy if the information required to configure the client script is missing', () => {
+            paymentMethod.clientToken = undefined;
+
+            expect(strategy.initialize({ methodId: paymentMethod.id })).rejects.toThrow(MissingDataError);
+
+            expect(threeDSjs.configure).not.toHaveBeenCalled();
+            expect(threeDSjs.isConfigured).not.toHaveBeenCalled();
+        });
+
+        it('should fail to initialize strategy if client script is not properly configured', () => {
+            threeDSjs = getCBAMPGSScriptMock(false);
+
+            expect(strategy.initialize({ methodId: paymentMethod.id })).rejects.toThrow(PaymentMethodFailedError);
+
+            expect(threeDSjs.configure).not.toHaveBeenCalled();
+            expect(threeDSjs.isConfigured).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#execute', () => {
+        beforeEach(() => {
+            const error = new RequestError(getResponse({
+              ...getErrorPaymentResponseBody(),
+              errors: [
+                  { code: 'three_d_secure_required' },
+              ],
+              three_ds_result: {
+                  acs_url: null,
+                  payer_auth_request: null,
+                  merchant_data: null,
+                  callback_url: null,
+                  token: 'session-id-uuid',
+              },
+              status: 'error',
+            }));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+        });
+
+        it('should execute the base strategy if 3ds is disabled', async () => {
+            paymentMethod.config.is3dsEnabled = false;
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(submitPaymentAction);
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            await strategy.execute(payload);
+
+            expect(threeDSjs.initiateAuthentication).not.toHaveBeenCalled();
+            expect(threeDSjs.authenticatePayer).not.toHaveBeenCalled();
+        });
+
+        it('should execute the 3DS strategy successfully if 3ds is enabled', async () => {
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            strategy.execute(payload);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(threeDSjs.initiateAuthentication).toHaveBeenCalledWith(
+                `${getConfig().storeConfig.storeProfile.storeId}_${getOrder().orderId}`,
+                'session-id-uuid',
+                expect.any(Function)
+            );
+
+            expect(threeDSjs.authenticatePayer).toHaveBeenCalledWith(
+                `${getConfig().storeConfig.storeProfile.storeId}_${getOrder().orderId}`,
+                'session-id-uuid',
+                expect.any(Function),
+                { fullScreenRedirect: true }
+            );
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    paymentData: expect.objectContaining({
+                        threeDSecure: {
+                            token: expect.any(String),
+                        },
+                    }),
+                })
+            );
+        });
+
+        it('should fail to execute the 3DS strategy if payment data is missing', async () => {
+            payload.payment = undefined;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(strategy.execute(payload)).rejects.toThrow(PaymentArgumentInvalidError);
+
+            expect(threeDSjs.initiateAuthentication).not.toHaveBeenCalled();
+            expect(threeDSjs.authenticatePayer).not.toHaveBeenCalled();
+        });
+
+        it('should fail to execute the 3DS strategy if an error different to three_d_secure_required occurs', async () => {
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [
+                    { code: 'gateway_error' },
+                ],
+                status: 'error',
+            }));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(strategy.execute(payload)).rejects.toThrow(RequestError);
+
+            expect(threeDSjs.initiateAuthentication).not.toHaveBeenCalled();
+            expect(threeDSjs.authenticatePayer).not.toHaveBeenCalled();
+        });
+
+        it('should fail to execute the 3DS strategy if threeDS result is missing the token', async () => {
+            const error = new RequestError(getResponse({
+                ...getErrorPaymentResponseBody(),
+                errors: [
+                    { code: 'three_d_secure_required' },
+                ],
+                three_ds_result: {
+                    acs_url: null,
+                    payer_auth_request: null,
+                    merchant_data: null,
+                    callback_url: null,
+                    token: undefined,
+                },
+                status: 'error',
+            }));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValue(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, error)));
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(strategy.execute(payload)).rejects.toThrow(RequestError);
+
+            expect(threeDSjs.initiateAuthentication).not.toHaveBeenCalled();
+            expect(threeDSjs.authenticatePayer).not.toHaveBeenCalled();
+        });
+
+        it('should fail to execute the 3DS strategy if an error occurs when initializing Authentication', async () => {
+            const _threeDSjs = getCBAMPGSScriptMock(true, true, true, true, true);
+
+            jest.spyOn(cbaMPGSScriptLoader, 'load')
+                  .mockResolvedValue(_threeDSjs);
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(strategy.execute(payload)).rejects.toThrow(PaymentMethodDeclinedError);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(_threeDSjs.initiateAuthentication).toHaveBeenCalled();
+            expect(_threeDSjs.authenticatePayer).not.toHaveBeenCalled();
+        });
+
+        it('should fail to execute the 3DS strategy if gateway recomendation is DO_NOT_PROCEED when initializing Authentication', async () => {
+            const _threeDSjs = getCBAMPGSScriptMock(true, false);
+
+            jest.spyOn(cbaMPGSScriptLoader, 'load')
+                  .mockResolvedValue(_threeDSjs);
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(strategy.execute(payload)).rejects.toThrow(PaymentMethodDeclinedError);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(_threeDSjs.initiateAuthentication).toHaveBeenCalled();
+            expect(_threeDSjs.authenticatePayer).not.toHaveBeenCalled();
+        });
+
+        it('should fail to execute the 3DS strategy if authentication is not available when initializing Authentication', async () => {
+            const _threeDSjs = getCBAMPGSScriptMock(true, true, true, false);
+
+            jest.spyOn(cbaMPGSScriptLoader, 'load')
+                  .mockResolvedValue(_threeDSjs);
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(strategy.execute(payload)).rejects.toThrow(PaymentMethodDeclinedError);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(_threeDSjs.initiateAuthentication).toHaveBeenCalled();
+            expect(_threeDSjs.authenticatePayer).not.toHaveBeenCalled();
+        });
+
+        it('should retry to authenticate payer if server is busy', async () => {
+            const _threeDSjs = getCBAMPGSScriptMock(true, true, true, true, true, true);
+
+            jest.spyOn(cbaMPGSScriptLoader, 'load')
+                  .mockResolvedValue(_threeDSjs);
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(strategy.execute(payload)).rejects.toThrow(PaymentMethodDeclinedError);
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(_threeDSjs.initiateAuthentication).toHaveBeenCalled();
+            expect(_threeDSjs.authenticatePayer).not.toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('#finalize',  () => {
+        it('finalizes order if order is created and payment is finalized', async () => {
+            const state = store.getState();
+
+            jest.spyOn(state.order, 'getOrder')
+                .mockReturnValue(getOrder());
+
+            jest.spyOn(state.payment, 'getPaymentStatus')
+                .mockReturnValue(paymentStatusTypes.FINALIZE);
+
+            await strategy.finalize();
+
+            expect(orderActionCreator.finalizeOrder).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(finalizeOrderAction);
+        });
+
+        it('does not finalize order if order is not created', async () => {
+            const state = store.getState();
+
+            jest.spyOn(state.order, 'getOrder')
+                .mockReturnValue(null);
+
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+            expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+            expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+            });
+
+        it('does not finalize order if order is not finalized', async () => {
+            const state = store.getState();
+
+            jest.spyOn(state.payment, 'getPaymentStatus')
+                .mockReturnValue(paymentStatusTypes.INITIALIZE);
+
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+            expect(orderActionCreator.finalizeOrder).not.toHaveBeenCalled();
+            expect(store.dispatch).not.toHaveBeenCalledWith(finalizeOrderAction);
+        });
+
+        it('throws error if order is missing', async () => {
+            const state = store.getState();
+
+            jest.spyOn(state.order, 'getOrder')
+                .mockReturnValue(null);
+
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+          });
+    });
+
+    describe('#deinitialize', () => {
+        it('deinitializes strategy', async () => {
+            await expect(strategy.deinitialize()).resolves.toEqual(store.getState());
+        });
+  });
+});

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.ts
@@ -1,0 +1,186 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { PaymentArgumentInvalidError, PaymentMethodDeclinedError, PaymentMethodFailedError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { AdditionalActionRequired } from '../../payment-response-body';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+import { RestApiResponse, ThreeDSjs, THREE_D_SECURE_AVAILABLE, THREE_D_SECURE_BUSY, THREE_D_SECURE_PROCEED } from './cba-mpgs';
+import CBAMPGSScriptLoader from './cba-mpgs-script-loader';
+
+export default class CBAMPGSPaymentStrategy extends CreditCardPaymentStrategy {
+    private _threeDSjs?: ThreeDSjs;
+    private _sessionId?: string;
+
+    constructor(
+        store: CheckoutStore,
+        orderActionCreator: OrderActionCreator,
+        paymentActionCreator: PaymentActionCreator,
+        hostedFormFactory: HostedFormFactory,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _CBAMGPSScriptLoader: CBAMPGSScriptLoader,
+        private _locale: string
+    ) {
+        super(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        );
+    }
+
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        await super.initialize(options);
+
+        const { methodId } = options;
+
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const { clientToken, initializationData: { merchantId }, config: { is3dsEnabled, testMode } } = paymentMethod;
+
+        if (is3dsEnabled) {
+            this._threeDSjs = await this._CBAMGPSScriptLoader.load(testMode);
+
+            if (!this._threeDSjs) {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+
+            if (!clientToken || !merchantId ) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            this._sessionId = clientToken;
+
+            await this._threeDSjs.configure({
+                merchantId,
+                sessionId: this._sessionId,
+                callback: () => {
+                    if (this._threeDSjs?.isConfigured()) {
+                        return this._store.getState();
+                    }
+
+                    throw new PaymentMethodFailedError('Failed to configure 3DS API.');
+                },
+                configuration: {
+                    userLanguage: this._locale,
+                    wsVersion: 62,
+                },
+            });
+        }
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = payload;
+        const paymentData = payment && payment.paymentData;
+
+        if (!payment || !paymentData) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(payment.methodId);
+
+        if (paymentMethod.config.is3dsEnabled) {
+            await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+            const state = this._store.getState();
+            const _order = state.order.getOrder();
+            const { storeProfile: { storeId } } = state.config.getStoreConfigOrThrow();
+
+            if (!_order || !this._sessionId) {
+                throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+            }
+
+            const orderId = `${storeId}_${_order.orderId.toString()}`;
+
+            // Debug Block, comment try/catch block
+            // const transactionId = prompt('Transaction ID:', '');
+
+            // return this._initiateAuthentication(orderId, transactionId || '');
+            //
+
+            try {
+                return this._store.dispatch(this._paymentActionCreator.submitPayment({
+                    ...payment,
+                    paymentData: {
+                        ...paymentData,
+                        nonce: this._sessionId,
+                    },
+                }));
+            } catch (error) {
+                if (error instanceof RequestError && error.body.status === 'additional_action_required') {
+                    const additionalActionRequired: AdditionalActionRequired = error.body.additional_action_required;
+                    const transactionId = additionalActionRequired.data.transaction_id;
+
+                    if (!transactionId) {
+                        return Promise.reject(error);
+                    }
+
+                    return this._initiateAuthentication(orderId, transactionId);
+                } else {
+                    return Promise.reject(error);
+                }
+            } 
+        } else {
+            return super.execute(payload, options);
+        }
+    }
+
+    private async _initiateAuthentication(orderId: string, transactionId: string): Promise<InternalCheckoutSelectors> {
+        const response: RestApiResponse = await new Promise((resolve, reject) => {
+            if (!this._threeDSjs) {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+
+            this._threeDSjs.initiateAuthentication(orderId, transactionId, data =>  {
+                const error = data.error;
+
+                if (error) {
+                    return reject(new PaymentMethodDeclinedError(error.msg));
+                }
+
+                if (this._threeDSjs && data.gatewayRecommendation === THREE_D_SECURE_PROCEED) {
+                    return resolve(data.restApiResponse);
+                }
+
+                return reject(new PaymentMethodDeclinedError());
+            });
+        });
+
+        if (response.transaction && response.transaction.authenticationStatus === THREE_D_SECURE_AVAILABLE) {
+            return this._authenticatePayer(orderId, transactionId);
+        } else {
+            throw new PaymentMethodDeclinedError();
+        }
+    }
+
+    private async _authenticatePayer(orderId: string, transactionId: string): Promise<InternalCheckoutSelectors> {
+        return await new Promise((_resolve, reject) => {
+            if (!this._threeDSjs) {
+                throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+            }
+
+            this._threeDSjs.authenticatePayer(orderId, transactionId, data => {
+                const error = data.error;
+
+                if (error) {
+                    if (error.cause && error.cause === THREE_D_SECURE_BUSY) {
+                        return this._authenticatePayer(orderId, transactionId);
+                    }
+
+                    return reject(new PaymentMethodDeclinedError());
+                }
+
+                if (data.gatewayRecommendation !== THREE_D_SECURE_PROCEED) {
+                    return reject(new PaymentMethodDeclinedError());
+                }
+            }, { fullScreenRedirect: true });
+        });
+    }
+}

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.ts
@@ -109,14 +109,14 @@ export default class CBAMPGSPaymentStrategy extends CreditCardPaymentStrategy {
                 }
 
                 const state = this._store.getState();
-                const _order = state.order.getOrder();
+                const order = state.order.getOrder();
                 const { storeProfile: { storeId } } = state.config.getStoreConfigOrThrow();
 
-                if (!_order || !this._sessionId) {
+                if (!order || !this._sessionId) {
                     throw new MissingDataError(MissingDataErrorType.MissingCheckout);
                 }
 
-                const orderId = `${storeId}_${_order.orderId.toString()}`;
+                const orderId = `${storeId}_${order.orderId}`;
 
                 const { three_ds_result: { token: transactionId } } = error.body;
 

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-script-loader.spec.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-script-loader.spec.ts
@@ -1,0 +1,53 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { CBAMPGSHostWindow, ThreeDSjs } from './cba-mpgs';
+import CBAMPGSScriptLoader from './cba-mpgs-script-loader';
+import { getCBAMPGSScriptMock } from './cba-mpgs.mock';
+
+describe('CBAMPGSScriptLoader', () => {
+    let cbaMPGSScriptLoader: CBAMPGSScriptLoader;
+    let scriptLoader: ScriptLoader;
+    let mockWindow: CBAMPGSHostWindow;
+
+    beforeEach(() => {
+        mockWindow = {} as CBAMPGSHostWindow;
+        scriptLoader = {} as ScriptLoader;
+        cbaMPGSScriptLoader = new CBAMPGSScriptLoader(scriptLoader, mockWindow);
+    });
+
+    describe('#load()', () => {
+        let threeDsScript: ThreeDSjs;
+
+        beforeEach(() => {
+            threeDsScript = getCBAMPGSScriptMock();
+
+            scriptLoader.loadScript = jest.fn(() => {
+                mockWindow.ThreeDS = threeDsScript;
+
+                return Promise.resolve();
+            });
+        });
+
+        it('loads the Script', async () => {
+            await cbaMPGSScriptLoader.load(false);
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith('//ap-gateway.mastercard.com/static/threeDS/1.3.0/three-ds.min.js');
+        });
+
+        it('returns the Script from the window', async () => {
+            const ThreeDSjs = await cbaMPGSScriptLoader.load();
+            expect(ThreeDSjs).toBe(threeDsScript);
+        });
+
+        describe('when testMode is on', () => {
+            it('loads the Script in sandbox mode', async () => {
+                await cbaMPGSScriptLoader.load(true);
+                expect(scriptLoader.loadScript).toHaveBeenCalledWith('//test-gateway.mastercard.com/static/threeDS/1.3.0/three-ds.min.js');
+            });
+
+            it('returns the Script from the window', async () => {
+                const ThreeDSjs = await cbaMPGSScriptLoader.load(true);
+                expect(ThreeDSjs).toBe(threeDsScript);
+            });
+        });
+    });
+});

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-script-loader.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-script-loader.ts
@@ -1,0 +1,22 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentMethodClientUnavailableError } from '../../errors';
+
+import { CBAMPGSHostWindow, ThreeDSjs } from './cba-mpgs';
+
+export default class CBAMPGSScriptLoader {
+    constructor(
+        private _scriptLoader: ScriptLoader,
+        public _window: CBAMPGSHostWindow = window
+    ) {}
+
+    async load(testMode?: boolean): Promise<ThreeDSjs> {
+        await this._scriptLoader.loadScript(`//${testMode ? 'test' : 'ap' }-gateway.mastercard.com/static/threeDS/1.3.0/three-ds.min.js`);
+
+        if (!this._window.ThreeDS) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this._window.ThreeDS;
+    }
+}

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-script-loader.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-script-loader.ts
@@ -7,7 +7,7 @@ import { CBAMPGSHostWindow, ThreeDSjs } from './cba-mpgs';
 export default class CBAMPGSScriptLoader {
     constructor(
         private _scriptLoader: ScriptLoader,
-        public _window: CBAMPGSHostWindow = window
+        private _window: CBAMPGSHostWindow = window
     ) {}
 
     async load(testMode?: boolean): Promise<ThreeDSjs> {

--- a/src/payment/strategies/cba-mpgs/cba-mpgs.mock.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs.mock.ts
@@ -1,0 +1,42 @@
+import { ThreeDSjs, ThreeDSAuthenticationResponse, THREE_D_SECURE_AVAILABLE, THREE_D_SECURE_BUSY, THREE_D_SECURE_PROCEED } from './cba-mpgs';
+
+export function getCBAMPGSScriptMock(
+    configureSuccess: boolean = true,
+    initiateAuthSuccess: boolean = true,
+    authPayerSuccess: boolean = true,
+    authAvailable: boolean = true,
+    includeError: boolean = false,
+    retryErrorCode: boolean = false
+    ): ThreeDSjs {
+        const authenticatePayerRetry = jest.fn()
+            .mockImplementationOnce((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, retryErrorCode, includeError, authAvailable)))
+            .mockImplementationOnce((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, false, includeError, authAvailable)));
+
+        return {
+            configure: jest.fn(config => config.callback()),
+            isConfigured: jest.fn(() => configureSuccess),
+            initiateAuthentication: jest.fn((_orderId, _transactionId, callback) => callback(_authenticationResponse(initiateAuthSuccess, retryErrorCode, includeError, authAvailable))),
+            authenticatePayer: retryErrorCode ? authenticatePayerRetry : jest.fn((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, retryErrorCode, includeError, authAvailable))),
+        };
+}
+
+function _authenticationResponse(success: boolean, retryError?: boolean, includeError?: boolean, authAvailable?: boolean): ThreeDSAuthenticationResponse {
+    const response: ThreeDSAuthenticationResponse = {
+        restApiResponse: {
+            transaction: {
+                authenticationStatus: authAvailable ? THREE_D_SECURE_AVAILABLE : 'AUTHENTICATION_UNAVAILABLE',
+            },
+        },
+        gatewayRecommendation: success ?  THREE_D_SECURE_PROCEED : 'DO_NOT_PROCEED',
+    };
+
+    if (includeError) {
+        response.error = {
+            code: 'error_code',
+            msg: 'something went wrong',
+            cause: retryError ? THREE_D_SECURE_BUSY : undefined,
+        };
+    }
+
+    return response;
+}

--- a/src/payment/strategies/cba-mpgs/cba-mpgs.mock.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs.mock.ts
@@ -5,18 +5,39 @@ export function getCBAMPGSScriptMock(
     initiateAuthSuccess: boolean = true,
     authPayerSuccess: boolean = true,
     authAvailable: boolean = true,
-    includeError: boolean = false,
+    includeErrorStep1: boolean = false,
+    includeErrorStep2: boolean = false,
     retryErrorCode: boolean = false
     ): ThreeDSjs {
         const authenticatePayerRetry = jest.fn()
-            .mockImplementationOnce((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, retryErrorCode, includeError, authAvailable)))
-            .mockImplementationOnce((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, false, includeError, authAvailable)));
+            .mockImplementationOnce((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, retryErrorCode, includeErrorStep2, authAvailable)))
+            .mockImplementationOnce((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, false, includeErrorStep2, authAvailable)));
 
         return {
             configure: jest.fn(config => config.callback()),
             isConfigured: jest.fn(() => configureSuccess),
-            initiateAuthentication: jest.fn((_orderId, _transactionId, callback) => callback(_authenticationResponse(initiateAuthSuccess, retryErrorCode, includeError, authAvailable))),
-            authenticatePayer: retryErrorCode ? authenticatePayerRetry : jest.fn((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, retryErrorCode, includeError, authAvailable))),
+            initiateAuthentication: jest.fn((_orderId, _transactionId, callback) => callback(_authenticationResponse(initiateAuthSuccess, retryErrorCode, includeErrorStep1, authAvailable))),
+            authenticatePayer: retryErrorCode ? authenticatePayerRetry : jest.fn((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, retryErrorCode, includeErrorStep2, authAvailable))),
+        };
+}
+
+export function getCBAMPGSScriptMockRetryOnly(
+    configureSuccess: boolean = true,
+    initiateAuthSuccess: boolean = true,
+    authPayerSuccess: boolean = true,
+    authAvailable: boolean = true,
+    includeErrorStep1: boolean = false,
+    includeErrorStep2: boolean = false,
+    retryErrorCode: boolean = false
+    ): ThreeDSjs {
+        const authenticatePayerRetry = jest.fn()
+            .mockImplementation((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, retryErrorCode, includeErrorStep2, authAvailable)));
+
+        return {
+            configure: jest.fn(config => config.callback()),
+            isConfigured: jest.fn(() => configureSuccess),
+            initiateAuthentication: jest.fn((_orderId, _transactionId, callback) => callback(_authenticationResponse(initiateAuthSuccess, retryErrorCode, includeErrorStep1, authAvailable))),
+            authenticatePayer: retryErrorCode ? authenticatePayerRetry : jest.fn((_orderId, _transactionId, callback) => callback(_authenticationResponse(authPayerSuccess, retryErrorCode, includeErrorStep2, authAvailable))),
         };
 }
 

--- a/src/payment/strategies/cba-mpgs/cba-mpgs.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs.ts
@@ -1,0 +1,62 @@
+export const THREE_D_SECURE_PROCEED = 'PROCEED';
+export const THREE_D_SECURE_BUSY = 'SERVER_BUSY';
+export const THREE_D_SECURE_AVAILABLE = 'AUTHENTICATION_AVAILABLE';
+
+export interface CBAMPGSHostWindow extends Window {
+  ThreeDS?: ThreeDSjs;
+}
+
+export interface ThreeDSjs {
+  // Configuration method for initializing the API.
+  configure(config: ThreeDSConfiguration): Promise<void>;
+  // Convenience method to check if the API has been configured successfully.
+  isConfigured(): boolean;
+  // Authentication for the arguments passed.
+  initiateAuthentication(orderId: string, transactionId: string, callback: (data: ThreeDSAuthenticationResponse) => void): void;
+  authenticatePayer(orderId: string, transactionId: string, callback: (data: ThreeDSAuthenticationResponse) => void, optionalParams?: AuthenticatePayerOptionalParams): void;
+}
+
+export interface RestApiResponse {
+  transaction: {
+    authenticationStatus: string;
+  };
+}
+
+// Configuration required to configure ThreeDS
+export interface ThreeDSConfiguration {
+  merchantId: string;
+  sessionId: string;
+  containerId?: string;
+  configuration: ThreeDSAPIConfiguration;
+  callback(): void;
+}
+
+export interface ThreeDSAuthenticationResponse {
+  error?: ThreeDSAuthenticationError;
+  restApiResponse: RestApiResponse;
+  correlationId: string;
+  gatewayRecommendation: string;
+  htmlRedirectCode: string;
+  authenticationVersion: string;
+}
+
+export interface AuthenticatePayerOptionalParams {
+  fullScreenRedirect: boolean;
+}
+
+export interface ThreeDSAuthenticationError {
+  code: string;
+  msg: string;
+  result: string;
+  status: string;
+  cause?: string;
+}
+
+// JSON value supporting data elements like userLanguage, REST API version (wsVersion)
+export interface ThreeDSAPIConfiguration {
+  // A language identifier or IETF language tag to control the language of the payment page displayed to the payer.
+  //  For example, "en_US", es, "fr-CA". By default, the language is "en_US".
+  userLanguage: string;
+  // The Web Services API version that you submitted the request in. IE: 62
+  wsVersion: number;
+}

--- a/src/payment/strategies/cba-mpgs/cba-mpgs.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs.ts
@@ -26,7 +26,6 @@ export interface RestApiResponse {
 export interface ThreeDSConfiguration {
   merchantId: string;
   sessionId: string;
-  containerId?: string;
   configuration: ThreeDSAPIConfiguration;
   callback(): void;
 }
@@ -34,10 +33,7 @@ export interface ThreeDSConfiguration {
 export interface ThreeDSAuthenticationResponse {
   error?: ThreeDSAuthenticationError;
   restApiResponse: RestApiResponse;
-  correlationId: string;
   gatewayRecommendation: string;
-  htmlRedirectCode: string;
-  authenticationVersion: string;
 }
 
 export interface AuthenticatePayerOptionalParams {
@@ -47,8 +43,6 @@ export interface AuthenticatePayerOptionalParams {
 export interface ThreeDSAuthenticationError {
   code: string;
   msg: string;
-  result: string;
-  status: string;
   cause?: string;
 }
 

--- a/src/payment/strategies/cba-mpgs/index.ts
+++ b/src/payment/strategies/cba-mpgs/index.ts
@@ -1,0 +1,2 @@
+export { default as CBAMPGSPaymentStrategy } from './cba-mpgs-payment-strategy';
+export { default as CBAMPGSScriptLoader } from './cba-mpgs-script-loader';


### PR DESCRIPTION
## What?
Create a payment strategy for CBA-MPGS that implement MPGS' ThreeDsJs and allows the redirection to the challenge site.

## Why?
So Payments with 3DS for MPGS are supported.

## Testing / Proof
Demo Video:
https://drive.google.com/file/d/1RKs3W7-oRx5pP0XAa9JCX_VxqcWyEQpQ/view?usp=sharing

<img width="838" alt="Screen Shot 2022-04-05 at 1 30 50 PM" src="https://user-images.githubusercontent.com/35502707/161825258-9206cef2-37ff-4039-aeb5-e4340774249d.png">


## SiblingPRs
https://github.com/bigcommerce/checkout-js/pull/822
https://github.com/bigcommerce/bigcommerce/pull/45233
https://github.com/bigcommerce/bigpay/pull/5055

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
