### PR TITLE
feat(payment): INT-5033 - INT-5053 [Stripe UPE] Add support for Giropay and Alipay

### DIFF
--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -23,6 +23,7 @@ const APM_REDIRECT = [
   StripePaymentMethodType.BANCONTACT,
   StripePaymentMethodType.IDEAL,
   StripePaymentMethodType.GIROPAY,
+  StripePaymentMethodType.ALIPAY,
 ];
 
 export default class StripeUPEPaymentStrategy implements PaymentStrategy {

--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -22,6 +22,7 @@ const APM_REDIRECT = [
   StripePaymentMethodType.GRABPAY,
   StripePaymentMethodType.BANCONTACT,
   StripePaymentMethodType.IDEAL,
+  StripePaymentMethodType.GIROPAY,
 ];
 
 export default class StripeUPEPaymentStrategy implements PaymentStrategy {

--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -130,4 +130,5 @@ export enum StripePaymentMethodType {
     GRABPAY = 'grabpay',
     BANCONTACT = 'bancontact',
     IDEAL = 'ideal',
+    GIROPAY = 'giropay',
 }

--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -131,4 +131,5 @@ export enum StripePaymentMethodType {
     BANCONTACT = 'bancontact',
     IDEAL = 'ideal',
     GIROPAY = 'giropay',
+    ALIPAY = 'alipay',
 }


### PR DESCRIPTION
## What?  [INT-5033](https://jira.bigcommerce.com/browse/INT-5033) - [INT-5053](https://jira.bigcommerce.com/browse/INT-5053)
Added Giropay and Alipay experiments and options to enable it on Stripe UPE settings page.

## Why?
To enable and use Giropay and Alipay with Stripe UPE.

## Testing / Proof
Manual tests

## Depends on
https://github.com/bigcommerce/checkout-sdk-js/pull/1348

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team 
