### PR TITLE
fix(payment): INT-5645 Openpay: Change `OpyError` message

### DIFF
--- a/src/payment/strategies/opy/opy-payment-error.spec.ts
+++ b/src/payment/strategies/opy/opy-payment-error.spec.ts
@@ -1,11 +1,12 @@
-import OpyError from './opy-payment-error';
+import OpyError, { OpyErrorType } from './opy-payment-error';
 
-describe('DigitalRiverError', () => {
-    it('returns error name, type and message', () => {
-        const error = new OpyError('payment.opy_invalid_cart_error', 'opyInvalidCartError');
+describe('OpyError', () => {
+    it('returns error name, type, subtype and message', () => {
+        const error = new OpyError(OpyErrorType.InvalidCart, 'Foo Payment Method');
 
-        expect(error.name).toEqual('opyInvalidCartError');
-        expect(error.type).toEqual('payment.opy_invalid_cart_error');
-        expect(error.message).toEqual('Unable to proceed because cart data is unavailable or payment for this order has already been made');
+        expect(error.name).toEqual('OpyError');
+        expect(error.type).toEqual('opy_error');
+        expect(error.subtype).toEqual('invalid_cart');
+        expect(error.message).toEqual('Cart price is different to Foo Payment Method plan amount.');
     });
 });

--- a/src/payment/strategies/opy/opy-payment-error.ts
+++ b/src/payment/strategies/opy/opy-payment-error.ts
@@ -1,12 +1,26 @@
 import { StandardError } from '../../../common/error/errors';
 
-const defaultMessage: string = 'Unable to proceed because cart data is unavailable or payment for this order has already been made';
-
+export enum OpyErrorType {
+    InvalidCart = 'invalid_cart',
+}
 export default class OpyError extends StandardError {
-    constructor(type: string, name: string, message?: string) {
-        super(message || defaultMessage);
+    subtype: string;
 
-        this.type = type;
-        this.name = name;
+    constructor(subtype: OpyErrorType, displayName: string) {
+        super(getErrorMessage(subtype, displayName));
+
+        this.name = 'OpyError';
+        this.type = 'opy_error';
+        this.subtype = subtype;
+    }
+}
+
+function getErrorMessage(type: OpyErrorType, displayName: string): string {
+    switch (type) {
+    case OpyErrorType.InvalidCart:
+        return `Cart price is different to ${displayName} plan amount.`;
+
+    default:
+        return 'There was an error while processing your payment. Please try again or contact us.';
     }
 }

--- a/src/payment/strategies/opy/opy-payment-strategy.spec.ts
+++ b/src/payment/strategies/opy/opy-payment-strategy.spec.ts
@@ -30,7 +30,7 @@ import StorefrontPaymentRequestSender from '../../storefront-payment-request-sen
 
 import { ActionTypes, OpyPaymentMethod } from './opy';
 import { OpyWidget } from './opy-library';
-import OpyError from './opy-payment-error';
+import OpyError, { OpyErrorType } from './opy-payment-error';
 import OpyPaymentStrategy from './opy-payment-strategy';
 import OpyScriptLoader from './opy-script-loader';
 
@@ -287,7 +287,9 @@ describe('OpyPaymentStrategy', () => {
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValueOnce(opy);
 
-                await expect(strategy.execute(payload, options)).rejects.toThrow(OpyError);
+                await expect(strategy.execute(payload, options)).rejects.toThrow(
+                    new OpyError(OpyErrorType.InvalidCart, 'Openpay')
+                );
             });
 
             it('nonce is empty', async () => {

--- a/src/payment/strategies/opy/opy-payment-strategy.ts
+++ b/src/payment/strategies/opy/opy-payment-strategy.ts
@@ -11,7 +11,7 @@ import PaymentStrategy from '../payment-strategy';
 
 import { isOpyPaymentMethod, ActionTypes } from './opy';
 import { OpyWidgetConfig } from './opy-library';
-import OpyError from './opy-payment-error';
+import OpyError, { OpyErrorType } from './opy-payment-error';
 import OpyScriptLoader from './opy-script-loader';
 
 export default class OpyPaymentStrategy implements PaymentStrategy {
@@ -67,7 +67,9 @@ export default class OpyPaymentStrategy implements PaymentStrategy {
         } = paymentMethod;
 
         if (!nextAction) {
-            throw new OpyError('payment.opy_invalid_cart_error', 'opyInvalidCartError');
+            const { displayName = 'Openpay' } = paymentMethod.config;
+
+            throw new OpyError(OpyErrorType.InvalidCart, displayName);
         }
 
         if (!nonce) {


### PR DESCRIPTION
## What? [INT-5645](https://jira.bigcommerce.com/browse/INT-5645)
Change the `OpyError` message for an invalid cart.

## Why?
The Openpay team wants us to use the following messages:
- For AU/UK/NZ: "Cart price is different to Openpay plan amount."
- For US merchants: "Cart price is different to Opy plan amount."

## Testing / Proof
![Screen Shot 2022-03-08 at 6 37 44 PM](https://user-images.githubusercontent.com/4843328/157350114-091ef0aa-dc89-4213-b1a5-80b1e42b417c.png)

## Dependency of
https://github.com/bigcommerce/checkout-js/pull/825

@bigcommerce/checkout @bigcommerce/payments
