### PR TITLE
[DRAFT] feat(forms): PAYMENTS-7400 Hosted forms updates for PPSDK payments

### DIFF
--- a/src/hosted-form/hosted-field-events.ts
+++ b/src/hosted-form/hosted-field-events.ts
@@ -6,18 +6,21 @@ import HostedFormOrderData from './hosted-form-order-data';
 
 export enum HostedFieldEventType {
     AttachRequested = 'HOSTED_FIELD:ATTACH_REQUESTED',
+    PpsdkSubmitRequested = 'HOSTED_FIELD:PPSDK_SUBMIT_REQUESTED',
     SubmitRequested = 'HOSTED_FIELD:SUBMITTED_REQUESTED',
     ValidateRequested = 'HOSTED_FIELD:VALIDATE_REQUESTED',
 }
 
 export interface HostedFieldEventMap {
     [HostedFieldEventType.AttachRequested]: HostedFieldAttachEvent;
+    [HostedFieldEventType.PpsdkSubmitRequested]: HostedFieldPpsdkSubmitRequestEvent;
     [HostedFieldEventType.SubmitRequested]: HostedFieldSubmitRequestEvent;
     [HostedFieldEventType.ValidateRequested]: HostedFieldValidateRequestEvent;
 }
 
 export type HostedFieldEvent = (
     HostedFieldAttachEvent |
+    HostedFieldPpsdkSubmitRequestEvent |
     HostedFieldSubmitRequestEvent |
     HostedFieldValidateRequestEvent
 );
@@ -37,6 +40,15 @@ export interface HostedFieldAttachEvent {
 
 export interface HostedFieldSubmitRequestEvent {
     type: HostedFieldEventType.SubmitRequested;
+    payload: {
+        data: HostedFormOrderData;
+        fields: HostedFieldType[];
+    };
+}
+
+// Different PPSDK-related payload can be defined here
+export interface HostedFieldPpsdkSubmitRequestEvent {
+    type: HostedFieldEventType.PpsdkSubmitRequested;
     payload: {
         data: HostedFormOrderData;
         fields: HostedFieldType[];

--- a/src/hosted-form/iframe-content/hosted-card-expiry-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-card-expiry-input.spec.ts
@@ -9,6 +9,7 @@ import { HostedInputEvent } from './hosted-input-events';
 import HostedInputPaymentHandler from './hosted-input-payment-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
+import PpsdkHostedInputPaymentHandler from './ppsdk-hosted-input-payment-handler';
 
 describe('HostedCardExpiryInput', () => {
     let container: HTMLFormElement;
@@ -57,6 +58,7 @@ describe('HostedCardExpiryInput', () => {
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
             paymentHandler as HostedInputPaymentHandler,
+            paymentHandler as unknown as PpsdkHostedInputPaymentHandler,
             expiryFormatter as CardExpiryFormatter
         );
     });

--- a/src/hosted-form/iframe-content/hosted-card-expiry-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-expiry-input.ts
@@ -9,6 +9,7 @@ import { HostedInputEvent } from './hosted-input-events';
 import HostedInputPaymentHandler from './hosted-input-payment-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
+import PpsdkHostedInputPaymentHandler from './ppsdk-hosted-input-payment-handler';
 
 export default class HostedCardExpiryInput extends HostedInput {
     /**
@@ -26,6 +27,7 @@ export default class HostedCardExpiryInput extends HostedInput {
         inputAggregator: HostedInputAggregator,
         inputValidator: HostedInputValidator,
         paymentHandler: HostedInputPaymentHandler,
+        ppsdkPaymentHandler: PpsdkHostedInputPaymentHandler,
         private _formatter: CardExpiryFormatter
     ) {
         super(
@@ -40,7 +42,8 @@ export default class HostedCardExpiryInput extends HostedInput {
             eventPoster,
             inputAggregator,
             inputValidator,
-            paymentHandler
+            paymentHandler,
+            ppsdkPaymentHandler
         );
     }
 

--- a/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.spec.ts
@@ -11,6 +11,7 @@ import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
 import HostedInputPaymentHandler from './hosted-input-payment-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
+import PpsdkHostedInputPaymentHandler from './ppsdk-hosted-input-payment-handler';
 
 describe('HostedCardNumberInput', () => {
     let autocompleteFieldset: HostedAutocompleteFieldset;
@@ -66,6 +67,7 @@ describe('HostedCardNumberInput', () => {
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
             paymentHandler as HostedInputPaymentHandler,
+            paymentHandler as unknown as PpsdkHostedInputPaymentHandler,
             autocompleteFieldset,
             numberFormatter as CardNumberFormatter
         );

--- a/src/hosted-form/iframe-content/hosted-card-number-input.ts
+++ b/src/hosted-form/iframe-content/hosted-card-number-input.ts
@@ -13,6 +13,7 @@ import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
 import HostedInputPaymentHandler from './hosted-input-payment-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
+import PpsdkHostedInputPaymentHandler from './ppsdk-hosted-input-payment-handler';
 
 export default class HostedCardNumberInput extends HostedInput {
     /**
@@ -31,6 +32,7 @@ export default class HostedCardNumberInput extends HostedInput {
         inputAggregator: HostedInputAggregator,
         inputValidator: HostedInputValidator,
         paymentHandler: HostedInputPaymentHandler,
+        ppsdkPaymentHandler: PpsdkHostedInputPaymentHandler,
         private _autocompleteFieldset: HostedAutocompleteFieldset,
         private _formatter: CardNumberFormatter
     ) {
@@ -46,7 +48,8 @@ export default class HostedCardNumberInput extends HostedInput {
             eventPoster,
             inputAggregator,
             inputValidator,
-            paymentHandler
+            paymentHandler,
+            ppsdkPaymentHandler
         );
     }
 

--- a/src/hosted-form/iframe-content/hosted-input-factory.ts
+++ b/src/hosted-form/iframe-content/hosted-input-factory.ts
@@ -19,6 +19,7 @@ import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 import mapToAccessibilityLabel from './map-to-accessibility-label';
 import mapToAutocompleteType from './map-to-autocomplete-type';
+import PpsdkHostedInputPaymentHandler from './ppsdk-hosted-input-payment-handler';
 
 export default class HostedInputFactory {
     constructor(
@@ -92,6 +93,7 @@ export default class HostedInputFactory {
             new HostedInputAggregator(window.parent),
             new HostedInputValidator(),
             this._createPaymentHandler(),
+            this._createPpsdkPaymentHandler(),
             new CardExpiryFormatter()
         );
     }
@@ -119,6 +121,7 @@ export default class HostedInputFactory {
             new HostedInputAggregator(window.parent),
             new HostedInputValidator(cardInstrument),
             this._createPaymentHandler(cardInstrument),
+            this._createPpsdkPaymentHandler(cardInstrument),
             new HostedAutocompleteFieldset(
                 form,
                 [HostedFieldType.CardCode, HostedFieldType.CardExpiry, HostedFieldType.CardName],
@@ -150,7 +153,8 @@ export default class HostedInputFactory {
             new IframeEventPoster(this._parentOrigin, window.parent),
             new HostedInputAggregator(window.parent),
             new HostedInputValidator(cardInstrument),
-            this._createPaymentHandler(cardInstrument)
+            this._createPaymentHandler(cardInstrument),
+            this._createPpsdkPaymentHandler(cardInstrument)
         );
     }
 
@@ -164,6 +168,19 @@ export default class HostedInputFactory {
             new IframeEventPoster(this._parentOrigin, window.parent),
             new PaymentRequestSender(createBigpayClient()),
             new PaymentRequestTransformer()
+        );
+    }
+
+    private _createPpsdkPaymentHandler(
+        cardInstrument?: CardInstrument
+    ): PpsdkHostedInputPaymentHandler {
+        return new PpsdkHostedInputPaymentHandler(
+            new HostedInputAggregator(window.parent),
+            new HostedInputValidator(cardInstrument),
+            getHostedInputStorage(),
+            new IframeEventPoster(this._parentOrigin, window.parent),
+            new PaymentRequestSender(createBigpayClient()),
+            new PaymentRequestTransformer() // may be another transformer
         );
     }
 }

--- a/src/hosted-form/iframe-content/hosted-input.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input.spec.ts
@@ -11,6 +11,7 @@ import HostedInputPaymentHandler from './hosted-input-payment-handler';
 import { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 import HostedInputValues from './hosted-input-values';
+import PpsdkHostedInputPaymentHandler from './ppsdk-hosted-input-payment-handler';
 
 describe('HostedInput', () => {
     let container: HTMLFormElement;
@@ -91,7 +92,8 @@ describe('HostedInput', () => {
             eventPoster as IframeEventPoster<HostedInputEvent>,
             inputAggregator as HostedInputAggregator,
             inputValidator as HostedInputValidator,
-            paymentHandler as HostedInputPaymentHandler
+            paymentHandler as HostedInputPaymentHandler,
+            paymentHandler as unknown as PpsdkHostedInputPaymentHandler
         );
     });
 

--- a/src/hosted-form/iframe-content/hosted-input.ts
+++ b/src/hosted-form/iframe-content/hosted-input.ts
@@ -11,6 +11,7 @@ import HostedInputPaymentHandler from './hosted-input-payment-handler';
 import HostedInputStyles, { HostedInputStylesMap } from './hosted-input-styles';
 import HostedInputValidator from './hosted-input-validator';
 import HostedInputWindow from './hosted-input-window';
+import PpsdkHostedInputPaymentHandler from './ppsdk-hosted-input-payment-handler';
 
 export default class HostedInput {
     protected _input: HTMLInputElement;
@@ -33,7 +34,8 @@ export default class HostedInput {
         protected _eventPoster: IframeEventPoster<HostedInputEvent>,
         protected _inputAggregator: HostedInputAggregator,
         protected _inputValidator: HostedInputValidator,
-        protected _paymentHandler: HostedInputPaymentHandler
+        protected _paymentHandler: HostedInputPaymentHandler,
+        protected _ppsdkPaymentHandler: PpsdkHostedInputPaymentHandler
     ) {
         this._input = document.createElement('input');
 
@@ -42,6 +44,7 @@ export default class HostedInput {
         this._input.addEventListener('focus', this._handleFocus);
         this._eventListener.addListener(HostedFieldEventType.ValidateRequested, this._handleValidate);
         this._eventListener.addListener(HostedFieldEventType.SubmitRequested, this._paymentHandler.handle);
+        this._eventListener.addListener(HostedFieldEventType.PpsdkSubmitRequested, this._ppsdkPaymentHandler.handle);
 
         this._configureInput();
     }

--- a/src/hosted-form/iframe-content/ppsdk-hosted-input-payment-handler.ts
+++ b/src/hosted-form/iframe-content/ppsdk-hosted-input-payment-handler.ts
@@ -1,0 +1,73 @@
+import { Response } from '@bigcommerce/request-sender';
+import { snakeCase } from 'lodash';
+
+import { PaymentErrorResponseBody } from '../../common/error';
+import { IframeEventPoster } from '../../common/iframe';
+import { PaymentRequestSender, PaymentRequestTransformer } from '../../payment';
+import { InvalidHostedFormValueError } from '../errors';
+import { HostedFieldPpsdkSubmitRequestEvent } from '../hosted-field-events';
+
+import HostedInputAggregator from './hosted-input-aggregator';
+import { HostedInputEvent, HostedInputEventType } from './hosted-input-events';
+import HostedInputStorage from './hosted-input-storage';
+import HostedInputValidator from './hosted-input-validator';
+
+export default class PpsdkHostedInputPaymentHandler {
+    constructor(
+        private _inputAggregator: HostedInputAggregator,
+        private _inputValidator: HostedInputValidator,
+        private _inputStorage: HostedInputStorage,
+        private _eventPoster: IframeEventPoster<HostedInputEvent>,
+        private _paymentRequestSender: PaymentRequestSender,
+        private _paymentRequestTransformer: PaymentRequestTransformer
+    ) {}
+
+    handle: (event: HostedFieldPpsdkSubmitRequestEvent) => Promise<void> = async ({ payload: { data } }) => {
+        const values = this._inputAggregator.getInputValues();
+        const results = await this._inputValidator.validate(values);
+
+        this._eventPoster.post({
+            type: HostedInputEventType.Validated,
+            payload: results,
+        });
+
+        if (!results.isValid) {
+            const error = new InvalidHostedFormValueError(results.errors);
+
+            return this._eventPoster.post({
+                type: HostedInputEventType.SubmitFailed,
+                payload: {
+                    error: { code: snakeCase(error.name), message: error.message },
+                },
+            });
+        }
+
+        try {
+            await this._paymentRequestSender.submitPpsdkPayment(
+                this._paymentRequestTransformer.transformWithHostedFormData(
+                    values,
+                    data,
+                    this._inputStorage.getNonce() || ''
+                )
+            );
+
+            this._eventPoster.post({ type: HostedInputEventType.SubmitSucceeded });
+        } catch (error) {
+            this._eventPoster.post({
+                type: HostedInputEventType.SubmitFailed,
+                payload: this._isPaymentErrorResponse(error) ?
+                    { error: error.body.errors[0], response: error } :
+                    { error: { code: snakeCase(error.name), message: error.message } },
+            });
+        }
+    };
+
+    private _isPaymentErrorResponse(response: any): response is Response<PaymentErrorResponseBody> {
+        const { body: { errors = [] } = {} } = response || {};
+
+        return (
+            typeof (errors[0] && errors[0].code) === 'string' &&
+            typeof (errors[0] && errors[0].message) === 'string'
+        );
+    }
+}

--- a/src/hosted-form/ppsdk-hosted-form-factory.ts
+++ b/src/hosted-form/ppsdk-hosted-form-factory.ts
@@ -1,0 +1,67 @@
+import { pick } from 'lodash';
+
+import { ReadableCheckoutStore } from '../checkout';
+import { DetachmentObserver, MutationObserverFactory } from '../common/dom';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import { CardInstrument } from '../payment/instrument';
+
+import HostedField from './hosted-field';
+import HostedFieldType from './hosted-field-type';
+import HostedFormOptions, { HostedCardFieldOptionsMap, HostedStoredCardFieldOptionsMap } from './hosted-form-options';
+import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
+import PpsdkHostedForm from './ppsdk-hosted-form';
+
+export default class PpsdkHostedFormFactory {
+    constructor(
+        private _store: ReadableCheckoutStore
+    ) {}
+
+    create(host: string, options: HostedFormOptions): PpsdkHostedForm {
+        const fieldTypes = Object.keys(options.fields) as HostedFieldType[];
+        const fields = fieldTypes.reduce<HostedField[]>((result, type) => {
+            const fields = options.fields as HostedStoredCardFieldOptionsMap & HostedCardFieldOptionsMap;
+            const fieldOptions = fields[type];
+
+            if (!fieldOptions) {
+                return result;
+            }
+
+            return [
+                ...result,
+                new HostedField(
+                    type,
+                    fieldOptions.containerId,
+                    fieldOptions.placeholder || '',
+                    fieldOptions.accessibilityLabel || '',
+                    options.styles || {},
+                    new IframeEventPoster(host),
+                    new IframeEventListener(host),
+                    new DetachmentObserver(new MutationObserverFactory()),
+                    'instrumentId' in fieldOptions ?
+                        this._getCardInstrument(fieldOptions.instrumentId) :
+                        undefined
+                ),
+            ];
+        }, []);
+
+        // Another order data transformer for PPDSK can be used
+        return new PpsdkHostedForm(
+            fields,
+            new IframeEventListener(host),
+            new HostedFormOrderDataTransformer(this._store),
+            pick(options, 'onBlur', 'onEnter', 'onFocus', 'onCardTypeChange', 'onValidate')
+        );
+    }
+
+    private _getCardInstrument(instrumentId: string): CardInstrument {
+        const { instruments: { getCardInstrument } } = this._store.getState();
+        const instrument = getCardInstrument(instrumentId);
+
+        if (!instrument) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentInstrument);
+        }
+
+        return instrument;
+    }
+}

--- a/src/hosted-form/ppsdk-hosted-form.ts
+++ b/src/hosted-form/ppsdk-hosted-form.ts
@@ -1,0 +1,100 @@
+import { noop, without } from 'lodash';
+
+import { IframeEventListener } from '../common/iframe';
+import { OrderPaymentRequestBody } from '../order';
+
+import { InvalidHostedFormConfigError } from './errors';
+import HostedField from './hosted-field';
+import HostedFormOptions from './hosted-form-options';
+import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer';
+import { HostedInputEnterEvent, HostedInputEventMap, HostedInputEventType } from './iframe-content';
+
+type HostedFormEventCallbacks = Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onEnter' | 'onValidate'>;
+
+export default class PpsdkHostedForm {
+    private _bin?: string;
+    private _cardType?: string;
+
+    constructor(
+        private _fields: HostedField[],
+        private _eventListener: IframeEventListener<HostedInputEventMap>,
+        // Another ppsdk-related transformer can bee used
+        private _payloadTransformer: HostedFormOrderDataTransformer,
+        private _eventCallbacks: HostedFormEventCallbacks
+    ) {
+        const { onBlur = noop, onCardTypeChange = noop, onFocus = noop, onValidate = noop } = this._eventCallbacks;
+
+        this._eventListener.addListener(HostedInputEventType.Blurred, ({ payload }) => onBlur(payload));
+        this._eventListener.addListener(HostedInputEventType.CardTypeChanged, ({ payload }) => onCardTypeChange(payload));
+        this._eventListener.addListener(HostedInputEventType.Focused, ({ payload }) => onFocus(payload));
+        this._eventListener.addListener(HostedInputEventType.Validated, ({ payload }) => onValidate(payload));
+        this._eventListener.addListener(HostedInputEventType.Entered, this._handleEnter);
+
+        this._eventListener.addListener(HostedInputEventType.CardTypeChanged, ({ payload }) => this._cardType = payload.cardType);
+        this._eventListener.addListener(HostedInputEventType.BinChanged, ({ payload }) => this._bin = payload.bin);
+    }
+
+    getBin(): string | undefined {
+        return this._bin;
+    }
+
+    getCardType(): string | undefined {
+        return this._cardType;
+    }
+
+    async attach(): Promise<void> {
+        this._eventListener.listen();
+
+        const field = this._getFirstField();
+        const otherFields = without(this._fields, field);
+
+        await field.attach();
+        await Promise.all(otherFields.map(otherField => otherField.attach()));
+    }
+
+    detach(): void {
+        this._eventListener.stopListen();
+
+        this._fields.forEach(field => {
+            field.detach();
+        });
+    }
+
+    // PPSDK-related sumbit logic will be implemented
+    async submit(payload: OrderPaymentRequestBody): Promise<void> {
+        return await this._getFirstField().submitPpsdkForm(
+            this._fields.map(field => field.getType()),
+            this._payloadTransformer.transform(payload)
+        );
+    }
+
+    async validate(): Promise<void> {
+        return await this._getFirstField().validateForm();
+    }
+
+    private _getFirstField(): HostedField {
+        const field = this._fields[0];
+
+        if (!field) {
+            throw new InvalidHostedFormConfigError('Unable to proceed because the payment form has no field defined.');
+        }
+
+        return field;
+    }
+
+    private _handleEnter: (event: HostedInputEnterEvent) => Promise<void> = async ({ payload }) => {
+        try {
+            await this.validate();
+        } catch (error) {
+            // Catch form validation error because we want to trigger `onEnter`
+            // irrespective of the validation result.
+            if (error.name !== 'InvalidHostedFormValueError') {
+                throw error;
+            }
+        }
+
+        const { onEnter = noop } = this._eventCallbacks;
+
+        onEnter(payload);
+    };
+}

--- a/src/payment/payment-request-sender.ts
+++ b/src/payment/payment-request-sender.ts
@@ -26,6 +26,18 @@ export default class PaymentRequestSender {
         });
     }
 
+    submitPpsdkPayment(payload: PaymentRequestBody): Promise<Response<any>> {
+        return new Promise((resolve, reject) => {
+            this._client.submitPpsdkPayment(payload, (error: any, response: any) => {
+                if (error) {
+                    reject(this._transformResponse(error));
+                } else {
+                    resolve(this._transformResponse(response));
+                }
+            });
+        });
+    }
+
     initializeOffsitePayment(payload: PaymentRequestBody, target?: string): Promise<void> {
         return new Promise(() => {
             this._client.initializeOffsitePayment(payload, null, target);


### PR DESCRIPTION
## What?
To implement PPSDK Credit Card strategy (actually sub-strategy), we need hosted forms that connect to the new endpoint. We have two approaches in mind:

1- Create another copy of the whole `hosted-form` module (a new `ppsdk-hosted-form`) with all the required webpack, circle-ci and bigpay updates. Despite the good separation of concern, this approach will result in much redundant code as both copies will probably have the same form input components, form handling events, and input validators.

2- Create only PPSDK-related components in the existing `hosted-form` module like `PpsdkHostedForm`, `PpsdkHostedFormFactory` and `PpsdkHostedInputPaymentHandler`, in addition to a few updates, a couple of ppsdk-related events and probably a new data transformer.

This PR is a draft of the second approach.

## Sibling PR
bigpay-client-js PR: https://github.com/bigcommerce/bigpay-client-js/pull/130

## Why?
Needed for PPSDK Credit Card sub-strategy.

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments
