### PR TITLE
fixing deinitialize logic for mollie strategy

### DIFF
--- a/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -85,6 +85,7 @@ describe('MolliePaymentStrategy', () => {
 
         jest.spyOn(mollieClient, 'createComponent')
             .mockReturnValue(mollieElement);
+        jest.spyOn(document, 'querySelectorAll');
 
         formFactory = new HostedFormFactory(store);
         strategy = new MolliePaymentStrategy(
@@ -124,6 +125,7 @@ describe('MolliePaymentStrategy', () => {
                 jest.runAllTimers();
                 expect(mollieClient.createComponent).toBeCalledTimes(4);
                 expect(mollieElement.mount).toBeCalledTimes(4);
+                expect(document.querySelectorAll).toHaveBeenNthCalledWith(1, '.mollie-components-controller');
             });
 
             it('does initialize without containerId', async () => {
@@ -325,6 +327,7 @@ describe('MolliePaymentStrategy', () => {
 
     describe('#deinitialize', () => {
         let options: PaymentInitializeOptions;
+        const initializeOptions = { methodId: 'credit_card', gatewayId: 'mollie' };
 
         beforeEach(() => {
             options = getInitializeOptions();
@@ -334,8 +337,6 @@ describe('MolliePaymentStrategy', () => {
 
             jest.spyOn(store.getState().config, 'getStoreConfig')
                 .mockReturnValue({ storeProfile: { storeLanguage:  'en_US' } });
-
-            jest.spyOn(document, 'querySelectorAll');
         });
 
         it('deinitialize mollie payment strategy', async () => {
@@ -344,12 +345,11 @@ describe('MolliePaymentStrategy', () => {
             jest.runAllTimers();
             expect(mollieClient.createComponent).toBeCalledTimes(4);
             expect(mollieElement.mount).toBeCalledTimes(4);
+            jest.spyOn(document, 'getElementById');
+            const promise = strategy.deinitialize(initializeOptions);
 
-            const promise = strategy.deinitialize();
-
-            expect(document.querySelectorAll).toBeCalledTimes(2);
-            expect(document.querySelectorAll).toHaveBeenNthCalledWith(1, '.mollie-component');
-            expect(document.querySelectorAll).toHaveBeenNthCalledWith(2, '.mollie-components-controller');
+            expect(document.getElementById).toHaveBeenNthCalledWith(1, `${options.gatewayId}-${options.methodId}`);
+            expect(document.querySelectorAll).toHaveBeenNthCalledWith(1, '.mollie-components-controller');
 
             return expect(promise).resolves.toBe(store.getState());
         });

--- a/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -49,6 +49,10 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to initialize payment because "methodId" and/or "gatewayId" argument is not provided.');
         }
 
+        const controllers = document.querySelectorAll('.mollie-components-controller');
+
+        each(controllers, controller => controller.remove());
+
         const state = this._store.getState();
         const storeConfig = state.config.getStoreConfig();
 
@@ -106,10 +110,16 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         return Promise.resolve(this._store.getState());
     }
 
-    deinitialize(): Promise<InternalCheckoutSelectors> {
+    deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
         this._mollieClient = undefined;
 
-        this.removeMollieComponents();
+        if (options && options.methodId && options.gatewayId) {
+            const element = document.getElementById(`${options.gatewayId}-${options.methodId}`);
+
+            if (element) {
+                element.remove();
+            }
+        }
 
         return Promise.resolve(this._store.getState());
     }
@@ -212,16 +222,6 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         const options = this._getInitializeOptions();
 
         return !!options.form?.fields;
-    }
-
-    private removeMollieComponents(): void {
-        const mollieComponents = document.querySelectorAll('.mollie-component');
-
-        each(mollieComponents, component => component.remove());
-
-        const controllers = document.querySelectorAll('.mollie-components-controller');
-
-        each(controllers, controller => controller.remove());
     }
 
     private _processAdditionalAction(error: any): Promise<InternalCheckoutSelectors> {


### PR DESCRIPTION
## What? [INT-5619](https://jira.bigcommerce.com/browse/INT-5619)
change the way to delete elements of the dom when it is deinitialized.

## Why?
Mollie payment gateway's credit card information form is not interactable when switching to Mollie APM then returning to   credit card.

## Testing / Proof
[VIDEO](https://drive.google.com/file/d/13pAjWm9TdAhF2pyTitF4QwXvOt-4DX9e/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
