### PR TITLE
feat(payment): INT-5057 STRIPE UPE use vaulted card

### DIFF
--- a/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
@@ -15,6 +15,7 @@ export function getStripeUPEJsMock(): StripeUPEClient {
             getElement: jest.fn().mockReturnValue(null),
         })),
         confirmPayment: jest.fn(),
+        confirmCardPayment: jest.fn(),
     };
 }
 
@@ -30,6 +31,7 @@ export function getFailingStripeUPEJsMock(): StripeUPEClient {
             getElement: jest.fn().mockReturnValue(null),
         })),
         confirmPayment: jest.fn(),
+        confirmCardPayment: jest.fn(),
     };
 }
 

--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -162,10 +162,16 @@ export interface StripeElementsOptions {
 
 export interface StripeUPEClient {
     /**
+     * Use confirmPayment to confirm a PaymentIntent using data collected by the Payment Element.
      * When called, confirmPayment will attempt to complete any required actions,
      * such as authenticating your user by displaying a 3DS dialog or redirecting them to a bank authorization page.
      */
     confirmPayment(options: StripeConfirmPaymentData): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+
+    /**
+     * When called, it will confirm the PaymentIntent with data you provide and carry out 3DS or other next actions if they are required.
+     */
+     confirmCardPayment(clientSecret: string): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
 
     /**
      * Create an `Elements` instance, which manages a group of elements.


### PR DESCRIPTION
## What? [INT-5057](https://jira.bigcommerce.com/browse/INT-5057)
Support for using vaulted cards with Stripe UPE

## Why?
To allow shoppers to save their credit card and use it in future purchases

## Testing / Proof
![image](https://user-images.githubusercontent.com/87149598/157751654-6d4eed7a-24b8-4a7a-90b1-3f4c4b5fc232.png)
![image](https://user-images.githubusercontent.com/87149598/157751541-f4b0e552-55c7-47ee-bfe7-0dfb8b5ac903.png)
![image](https://user-images.githubusercontent.com/87149598/157751770-d84acf12-21a0-4b36-85c7-fc18d5489f3f.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/kyiv-payments-team 
