### PR TITLE
test(payment): INT-4928 Increase code coverage for GooglePayCheckoutCom

### DIFF
--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
@@ -13,6 +13,7 @@ import { BillingAddressFormat, GooglePaymentData, GooglePayInitializer, GooglePa
 export default class GooglePayCheckoutcomInitializer implements GooglePayInitializer {
     private _publishableKey: string = '';
     private _testMode: boolean = true;
+    private _errorMessage: string = 'Unable to parse response from GooglePay.';
 
     constructor(
        private _requestSender: RequestSender
@@ -42,11 +43,11 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
         try {
             token = JSON.parse(paymentData.paymentMethodData.tokenizationData.token);
         } catch (err) {
-            throw new InvalidArgumentError('Unable to parse response from Google Pay.');
+            throw new InvalidArgumentError(this._errorMessage);
         }
 
         if (!token.signature || !token.protocolVersion || !token.signedMessage) {
-            throw new PaymentMethodFailedError('Unable to parse response from Google Pay.');
+            throw new PaymentMethodFailedError(this._errorMessage);
         }
         const finalToken = await this._convertToken(this._testMode, this._publishableKey, token);
 
@@ -62,10 +63,6 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
     }
 
     private async _convertToken(testMode: boolean, checkoutcomkey: string, token: CheckoutcomGooglePayToken): Promise<string> {
-        if (!token || !token.protocolVersion) {
-            throw new PaymentMethodFailedError('Unable to parse response from GooglePay.');
-        }
-
         const checkoutcomToken: CheckoutcomToken = await this._requestCheckoutcomTokenize(testMode, checkoutcomkey, {
             type: 'googlepay',
             token_data: token,


### PR DESCRIPTION
## What? [INT-4928](https://jira.bigcommerce.com/browse/INT-4928)

Increase Code Coverage for googlepay-checkoutcom-initializer.ts

## Why?

To increase code coverage

## Testing / Proof

### Before 
![Screen Shot 2022-03-16 at 14 53 16](https://user-images.githubusercontent.com/69221626/158689015-8368684c-9b89-42fe-bb80-2d7455e1dbed.png)

### After

![Screen Shot 2022-03-16 at 14 50 27](https://user-images.githubusercontent.com/69221626/158688575-5abaf915-16d9-4ffb-b3c3-3aa64d1a0e4a.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations
