### PR TITLE
fix(checkout): INT-5543 [CKO] Update to 3ds on Googlepay

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -277,7 +277,6 @@ export default function createPaymentStrategyRegistry(
                 )
             ),
             undefined,
-            undefined,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader))
         )
     );
@@ -453,7 +452,6 @@ export default function createPaymentStrategyRegistry(
                 store,
                 new GooglePayCheckoutcomInitializer(requestSender)
             ),
-            undefined,
             new GooglePayCheckoutcomPaymentProcessor()
         )
     );

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -46,7 +46,7 @@ import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
 import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
 import { DigitalRiverPaymentStrategy, DigitalRiverScriptLoader } from './strategies/digitalriver';
 import { ExternalPaymentStrategy } from './strategies/external';
-import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAdyenV3Initializer, GooglePayAdyenV3PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCybersourceV2Initializer, GooglePayOrbitalInitializer,  GooglePayPaymentStrategy, GooglePayStripeInitializer, GooglePayStripeUPEInitializer } from './strategies/googlepay';
+import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAdyenV3Initializer, GooglePayAdyenV3PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCheckoutcomPaymentProcessor, GooglePayCybersourceV2Initializer, GooglePayOrbitalInitializer,  GooglePayPaymentStrategy, GooglePayStripeInitializer, GooglePayStripeUPEInitializer } from './strategies/googlepay';
 import { HummPaymentStrategy } from './strategies/humm';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
 import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
@@ -277,6 +277,7 @@ export default function createPaymentStrategyRegistry(
                 )
             ),
             undefined,
+            undefined,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader))
         )
     );
@@ -451,7 +452,9 @@ export default function createPaymentStrategyRegistry(
             createGooglePayPaymentProcessor(
                 store,
                 new GooglePayCheckoutcomInitializer(requestSender)
-            )
+            ),
+            undefined,
+            new GooglePayCheckoutcomPaymentProcessor()
         )
     );
 

--- a/src/payment/strategies/checkoutcom/checkoutcom-token.ts
+++ b/src/payment/strategies/checkoutcom/checkoutcom-token.ts
@@ -1,3 +1,4 @@
 export default interface CheckoutcomToken {
     token: string;
+    token_format?: string;
 }

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.ts
@@ -7,6 +7,7 @@ import { PaymentMethodCancelledError } from '../../errors';
 import { AdyenAction, AdyenAdditionalAction, AdyenAdditionalActionState, AdyenClient, AdyenError, AdyenV2ScriptLoader } from '../adyenv2';
 
 import { GooglePayProviderProcessor } from './googlepay';
+
 export default class GooglePayAdyenV2PaymentProcessor implements GooglePayProviderProcessor {
     private _adyenClient?: AdyenClient;
 

--- a/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.ts
@@ -6,7 +6,8 @@ import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitial
 import { PaymentMethodCancelledError } from '../../errors';
 import { AdyenAction, AdyenAdditionalAction, AdyenAdditionalActionState, AdyenClient, AdyenError, AdyenV2ScriptLoader } from '../adyenv2';
 
-export default class GooglePayAdyenV2PaymentProcessor {
+import { GooglePayProviderProcessor } from './googlepay';
+export default class GooglePayAdyenV2PaymentProcessor implements GooglePayProviderProcessor {
     private _adyenClient?: AdyenClient;
 
     constructor(private _store: CheckoutStore, private _paymentActionCreator: PaymentActionCreator, private _scriptLoader: AdyenV2ScriptLoader) {}

--- a/src/payment/strategies/googlepay/googlepay-adyenv3-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-adyenv3-payment-processor.ts
@@ -6,7 +6,9 @@ import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitial
 import { PaymentMethodCancelledError } from '../../errors';
 import { AdyenAction, AdyenAdditionalAction, AdyenAdditionalActionState, AdyenClient, AdyenError, AdyenV3ScriptLoader } from '../adyenv3';
 
-export default class GooglePayAdyenV3PaymentProcessor {
+import { GooglePayProviderProcessor } from './googlepay';
+
+export default class GooglePayAdyenV3PaymentProcessor implements GooglePayProviderProcessor {
     private _adyenClient?: AdyenClient;
 
     constructor(private _store: CheckoutStore, private _paymentActionCreator: PaymentActionCreator, private _scriptLoader: AdyenV3ScriptLoader) {}

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.spec.ts
@@ -5,7 +5,7 @@ import { InvalidArgumentError } from '../../../common/error/errors';
 import { PaymentMethodFailedError } from '../../errors';
 
 import GooglePayCheckoutcomInitializer from './googlepay-checkoutcom-initializer';
-import { getCheckoutMock, getGooglePaymentCheckoutcomDataMock, getGooglePaymentDataMock, getGooglePayCheckoutcomPaymentDataRequestMock, getGooglePayTokenizePayloadCheckoutcom, getGooglePayTokenizePayloadCheckoutcomWithTokenFormat, getPaymentMethodMock } from './googlepay.mock';
+import { getCheckoutMock, getGooglePaymentCheckoutcomDataMock, getGooglePaymentDataMock, getGooglePayCheckoutcomPaymentDataRequestMock, getGooglePayTokenizePayloadCheckoutcom, getPaymentMethodMock } from './googlepay.mock';
 
 describe('GooglePayCheckoutcomInitializer', () => {
     const requestSender: RequestSender = createRequestSender();

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.spec.ts
@@ -1,10 +1,11 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { merge } from 'lodash';
 
 import { InvalidArgumentError } from '../../../common/error/errors';
 import { PaymentMethodFailedError } from '../../errors';
 
 import GooglePayCheckoutcomInitializer from './googlepay-checkoutcom-initializer';
-import { getCheckoutMock, getGooglePaymentCheckoutcomDataMock, getGooglePaymentDataMock, getGooglePayCheckoutcomPaymentDataRequestMock, getGooglePayTokenizePayloadCheckoutcom, getPaymentMethodMock } from './googlepay.mock';
+import { getCheckoutMock, getGooglePaymentCheckoutcomDataMock, getGooglePaymentDataMock, getGooglePayCheckoutcomPaymentDataRequestMock, getGooglePayTokenizePayloadCheckoutcom, getGooglePayTokenizePayloadCheckoutcomWithTokenFormat, getPaymentMethodMock } from './googlepay.mock';
 
 describe('GooglePayCheckoutcomInitializer', () => {
     const requestSender: RequestSender = createRequestSender();
@@ -48,6 +49,15 @@ describe('GooglePayCheckoutcomInitializer', () => {
 
             expect(tokenizePayload).toBeTruthy();
             expect(tokenizePayload).toEqual(getGooglePayTokenizePayloadCheckoutcom());
+        });
+
+        it('parses a response from google pay payload received with token format', async () => {
+            jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve({ body: { token: 'parsedToken', token_format: 'pan_only' } }));
+
+            const tokenizePayload = await googlePayCheckoutcomInitializer.parseResponse(getGooglePaymentCheckoutcomDataMock());
+
+            expect(tokenizePayload).toBeTruthy();
+            expect(tokenizePayload).toEqual(merge({ tokenFormat: 'pan_only' }, getGooglePayTokenizePayloadCheckoutcom()));
         });
 
         it('throws when try to parse a response from google pay payload received', () => {

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
@@ -51,8 +51,8 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
         }
         const finalToken = await this._convertToken(this._testMode, this._publishableKey, token);
 
-        return {
-            nonce: finalToken,
+        const payload: TokenizePayload = {
+            nonce: finalToken.token,
             type: 'CreditCard',
             description: paymentData.paymentMethodData.description,
             details: {
@@ -60,9 +60,15 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
                 lastFour: paymentData.paymentMethodData.info.cardDetails,
             },
         };
+
+        if (finalToken.token_format) {
+            payload.tokenFormat = finalToken.token_format;
+        }
+
+        return payload;
     }
 
-    private async _convertToken(testMode: boolean, checkoutcomkey: string, token: CheckoutcomGooglePayToken): Promise<string> {
+    private async _convertToken(testMode: boolean, checkoutcomkey: string, token: CheckoutcomGooglePayToken): Promise<CheckoutcomToken> {
         const checkoutcomToken: CheckoutcomToken = await this._requestCheckoutcomTokenize(testMode, checkoutcomkey, {
             type: 'googlepay',
             token_data: token,
@@ -72,7 +78,7 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
             throw new PaymentMethodFailedError('Unable to parse response from Checkout.com');
         }
 
-        return checkoutcomToken.token;
+        return checkoutcomToken;
     }
 
     private async _requestCheckoutcomTokenize(testMode: boolean, checkoutcomKey: string, data = {}): Promise<CheckoutcomToken> {

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.spec.ts
@@ -6,7 +6,7 @@ describe('GooglePayCheckoutcomPaymentProcessor', () => {
     let processor: GooglePayCheckoutcomPaymentProcessor;
 
     beforeEach(() => {
-        jest.spyOn(window.location, 'replace')
+        jest.spyOn(window.location, 'assign')
             .mockResolvedValue(undefined);
 
         processor = new GooglePayCheckoutcomPaymentProcessor();
@@ -33,12 +33,12 @@ describe('GooglePayCheckoutcomPaymentProcessor', () => {
 
         await new Promise(resolve => process.nextTick(resolve));
 
-        expect(window.location.replace).toHaveBeenCalledWith(err.body.three_ds_result.acs_url);
+        expect(window.location.assign).toHaveBeenCalledWith(err.body.three_ds_result.acs_url);
     });
 
     it('does not redirect the customer if threeDSecure is not required', async () => {
         await expect(processor.processAdditionalAction(new Error())).rejects.toThrow(Error);
 
-        expect(window.location.replace).not.toHaveBeenCalled();
+        expect(window.location.assign).not.toHaveBeenCalled();
     });
 });

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.spec.ts
@@ -1,0 +1,44 @@
+import { RequestError } from '../../../common/error/errors';
+
+import { GooglePayCheckoutcomPaymentProcessor } from './index';
+
+describe('GooglePayCheckoutcomPaymentProcessor', () => {
+    let processor: GooglePayCheckoutcomPaymentProcessor;
+
+    beforeEach(() => {
+        jest.spyOn(window.location, 'replace')
+            .mockResolvedValue(undefined);
+
+        processor = new GooglePayCheckoutcomPaymentProcessor();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('redirects the customer to the proper url', async () => {
+        const err: RequestError = new RequestError({
+            body: {
+                errors: [{ code: 'three_d_secure_required' }],
+                three_ds_result: {
+                    acs_url: 'https://acs/url',
+                },
+            },
+            headers: {},
+            status: 400,
+            statusText: 'ThreeDSecure is required.',
+        });
+
+        processor.processAdditionalAction(err);
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(window.location.replace).toHaveBeenCalledWith(err.body.three_ds_result.acs_url);
+    });
+
+    it('does not redirect the customer if threeDSecure is not required', async () => {
+        await expect(processor.processAdditionalAction(new Error())).rejects.toThrow(Error);
+
+        expect(window.location.replace).not.toHaveBeenCalled();
+    });
+});

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.ts
@@ -2,8 +2,14 @@ import { some } from 'lodash';
 
 import { InternalCheckoutSelectors } from '../../../checkout';
 import { RequestError } from '../../../common/error/errors';
+import { PaymentInitializeOptions } from '../../payment-request-options';
 
-export default class GooglePayCheckoutcomPaymentProcessor {
+import { GooglePayProviderProcessor } from './googlepay';
+export default class GooglePayCheckoutcomPaymentProcessor implements GooglePayProviderProcessor {
+    initialize(_options: PaymentInitializeOptions): Promise<void> {
+        return Promise.resolve();
+    }
+
     async processAdditionalAction(error: unknown): Promise<InternalCheckoutSelectors> {
         if (!(error instanceof RequestError) || !some(error.body.errors, {code: 'three_d_secure_required'})) {
             return Promise.reject(error);

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.ts
@@ -23,7 +23,7 @@ export default class GooglePayCheckoutcomPaymentProcessor implements GooglePayPr
 
     private _performRedirect(redirectUrl: string): Promise<InternalCheckoutSelectors> {
         return new Promise(() => {
-            window.location.replace(redirectUrl);
+            window.location.assign(redirectUrl);
         });
     }
 }

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.ts
@@ -1,0 +1,22 @@
+import { some } from 'lodash';
+
+import { InternalCheckoutSelectors } from '../../../checkout';
+import { RequestError } from '../../../common/error/errors';
+
+export default class GooglePayCheckoutcomPaymentProcessor {
+    async processAdditionalAction(error: unknown): Promise<InternalCheckoutSelectors> {
+        if (!(error instanceof RequestError) || !some(error.body.errors, {code: 'three_d_secure_required'})) {
+            return Promise.reject(error);
+        }
+
+        const redirectUrl = error.body.three_ds_result.acs_url;
+
+        return this._performRedirect(redirectUrl);
+    }
+
+    private _performRedirect(redirectUrl: string): Promise<InternalCheckoutSelectors> {
+        return new Promise(() => {
+            window.location.replace(redirectUrl);
+        });
+    }
+}

--- a/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-checkoutcom-payment-processor.ts
@@ -5,6 +5,7 @@ import { RequestError } from '../../../common/error/errors';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 
 import { GooglePayProviderProcessor } from './googlepay';
+
 export default class GooglePayCheckoutcomPaymentProcessor implements GooglePayProviderProcessor {
     initialize(_options: PaymentInitializeOptions): Promise<void> {
         return Promise.resolve();

--- a/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -218,6 +218,7 @@ export default class GooglePayPaymentProcessor {
             body: {
                 payment_type: postPaymentData.type,
                 nonce: postPaymentData.nonce,
+                tokenFormat: postPaymentData.tokenFormat,
                 provider: this._getMethodId(),
                 action: 'set_external_checkout',
                 card_information: this._getCardInformation(cardInformation),

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -166,7 +166,6 @@ describe('GooglePayPaymentStrategy', () => {
                 orderActionCreator,
                 googlePayPaymentProcessor,
                 undefined,
-                undefined,
                 braintreeSDKCreator
             );
         });
@@ -643,7 +642,6 @@ describe('GooglePayPaymentStrategy', () => {
                 orderActionCreator,
                 googlePayPaymentProcessor,
                 googlePayAdyenV2PaymentProcessor,
-                googlePayCheckoutcomPaymentProcessor,
                 braintreeSDKCreator
             );
         });
@@ -714,7 +712,6 @@ describe('GooglePayPaymentStrategy', () => {
                 paymentActionCreator,
                 orderActionCreator,
                 googlePayPaymentProcessor,
-                googlePayAdyenV2PaymentProcessor,
                 googlePayCheckoutcomPaymentProcessor,
                 braintreeSDKCreator
             );
@@ -767,8 +764,7 @@ describe('GooglePayPaymentStrategy', () => {
                 paymentActionCreator,
                 orderActionCreator,
                 googlePayPaymentProcessor,
-                googlePayAdyenV2PaymentProcessor,
-                googlePayCheckoutcomPaymentProcessor,
+                undefined,
                 braintreeSDKCreator
             );
         });

--- a/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -146,11 +146,11 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     }
 
     private _processAdditionalAction(error: unknown): Promise<InternalCheckoutSelectors> {
-        if (this._googlePayProviderProcessor) {
-            return this._googlePayProviderProcessor.processAdditionalAction(error);
+        if (!this._googlePayProviderProcessor) {
+            return Promise.reject(error);
         }
 
-        return Promise.reject(error);
+        return this._googlePayProviderProcessor.processAdditionalAction(error);
     }
 
     private async _verifyCard(methodId: string , amount: number,  payment: PaymentMethodData): Promise<GooglePayVerifyPayload>  {

--- a/src/payment/strategies/googlepay/googlepay.ts
+++ b/src/payment/strategies/googlepay/googlepay.ts
@@ -1,4 +1,5 @@
-import { Checkout } from '../../../checkout';
+import { PaymentInitializeOptions } from '../..';
+import { Checkout, InternalCheckoutSelectors } from '../../../checkout';
 import PaymentMethod from '../../payment-method';
 import { BraintreeModuleCreator, BraintreeVerifyPayload, GooglePayBraintreeSDK } from '../braintree';
 
@@ -9,6 +10,11 @@ export interface GooglePayInitializer {
     initialize(checkout: Checkout, paymentMethod: PaymentMethod, hasShippingAddress: boolean, publishableKey?: string): Promise<GooglePayPaymentDataRequestV2>;
     teardown(): Promise<void>;
     parseResponse(paymentData: GooglePaymentData): Promise<TokenizePayload>;
+}
+
+export interface GooglePayProviderProcessor {
+    initialize(options: PaymentInitializeOptions): Promise<void>;
+    processAdditionalAction(error: unknown): Promise<InternalCheckoutSelectors>;
 }
 
 export interface GooglePayCreator extends BraintreeModuleCreator<GooglePayBraintreeSDK> {}

--- a/src/payment/strategies/googlepay/googlepay.ts
+++ b/src/payment/strategies/googlepay/googlepay.ts
@@ -44,6 +44,7 @@ export interface GooglePayHostWindow extends Window {
 
 export interface TokenizePayload {
     nonce: string;
+    tokenFormat?: string;
     details: {
         cardType: string;
         lastFour: string;

--- a/src/payment/strategies/googlepay/index.ts
+++ b/src/payment/strategies/googlepay/index.ts
@@ -7,6 +7,7 @@ export { default as GooglePayAdyenV2Initializer } from './googlepay-adyenv2-init
 export { default as GooglePayAdyenV2PaymentProcessor } from './googlepay-adyenv2-payment-processor';
 export { default as GooglePayAdyenV3Initializer } from './googlepay-adyenv3-initializer';
 export { default as GooglePayAdyenV3PaymentProcessor } from './googlepay-adyenv3-payment-processor';
+export { default as GooglePayCheckoutcomPaymentProcessor } from './googlepay-checkoutcom-payment-processor';
 export { default as GooglePayBraintreeInitializer } from './googlepay-braintree-initializer';
 export { default as GooglePayCheckoutcomInitializer } from './googlepay-checkoutcom-initializer';
 export { default as GooglePayCybersourceV2Initializer } from './googlepay-cybersourcev2-initializer';


### PR DESCRIPTION
## What? [INT-5543](https://jira.bigcommerce.com/browse/INT-5543)
Create a payment processor for GooglePay on Checkout.com that handles the redirection to the 3DS challenge page.

Update the GooglePay payment strategy to receive a generic payment processor for specific provider instead of directly expecting the Adyen payment processor.

Also send the token_format in the Checkout.com's Google Pay initializer so it can be stored in the session.

## Why?
GooglePay on  Checkout.com will be implementing 3DS starting March 30th, the current implementation does not support the 3DS redirection and throws an error, these changes are made to support the redirection to the challenge page and proceed with the payment.

The new strategy interface will allow to pass any processor in the constructor so It will be able to support different providers.

Passing the token format to the session is needed so the 3DS redirection can be determined in the backend.

## Testing / Proof
[Demo Video](https://drive.google.com/file/d/1FTuDYjBL7YUgdXZWVCeLN4lxuASvZEqz/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
