### PR TITLE
feat(shipping): CHECKOUT-6422 Add address property to consignment interface

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -918,6 +918,7 @@ describe('CheckoutService', () => {
             jest.spyOn(store, 'dispatch');
 
             const payload = {
+                address,
                 id: 'foo',
                 shippingAddress: address,
                 lineItems: [],
@@ -945,6 +946,7 @@ describe('CheckoutService', () => {
             jest.spyOn(store, 'dispatch');
 
             const payload = {
+                address,
                 shippingAddress: address,
                 lineItems: [{
                     itemId: 'item-foo',
@@ -974,6 +976,7 @@ describe('CheckoutService', () => {
             jest.spyOn(store, 'dispatch');
 
             const payload = {
+                address,
                 shippingAddress: address,
                 lineItems: [{
                     itemId: 'item-foo',
@@ -993,9 +996,11 @@ describe('CheckoutService', () => {
 
     describe('#createConsignments()', () => {
         it('dispatches action to create consignments', async () => {
+            const address = getShippingAddress();
             const consignments = [{
+                address,
                 lineItems: [],
-                shippingAddress: getShippingAddress(),
+                shippingAddress: address,
             }];
             const options = { timeout: createTimeout() };
             const action = of(createAction('CREATE_CONSIGNMENTS'));

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -517,19 +517,19 @@ export default class CheckoutService {
      * to capture their address.
      *
      * Once the method has been executed successfully, you can call
-     * `CheckoutStoreSelector#getAddressFields` to retrieve the set of
+     * `CheckoutStoreSelector#getFulfilmentAddressFields` to retrieve the set of
      * form fields.
      *
      * ```js
-     * const state = service.loadAddressFields();
+     * const state = service.loadFulfilmentAddressFields();
      *
-     * console.log(state.data.loadAddressFields('US'));
+     * console.log(state.data.loadFulfilmentAddressFields('US'));
      * ```
      *
      * @param options - Options for loading the shipping address form fields.
      * @returns A promise that resolves to the current state.
      */
-     loadAddressFields(options?: RequestOptions): Promise<CheckoutSelectors> {
+     loadFulfilmentAddressFields(options?: RequestOptions): Promise<CheckoutSelectors> {
         return this.loadShippingCountries(options);
     }
 
@@ -876,7 +876,7 @@ export default class CheckoutService {
      * When a customer updates their shipping address for an order, they will
      * see an updated list of shipping options and the cost for each option,
      * unless no options are available. If the update is successful, you can
-     * call `CheckoutStoreSelector#getAddress` to retrieve the address.
+     * call `CheckoutStoreSelector#getFulfilmentAddress` to retrieve the address.
      *
      * If the shipping address changes and the selected shipping option becomes
      * unavailable for the updated address, the shipping option will be
@@ -888,7 +888,7 @@ export default class CheckoutService {
      * ```js
      * const state = await service.updateShippingAddress(address);
      *
-     * console.log(state.data.getAddress());
+     * console.log(state.data.getFulfilmentAddress());
      * ```
      *
      * @param address - The address to be used for shipping.

--- a/src/checkout/checkout-service.ts
+++ b/src/checkout/checkout-service.ts
@@ -491,6 +491,7 @@ export default class CheckoutService {
     }
 
     /**
+     * @deprecated
      * Loads a set of form fields that should be presented to customers in order
      * to capture their shipping address.
      *
@@ -508,6 +509,27 @@ export default class CheckoutService {
      * @returns A promise that resolves to the current state.
      */
     loadShippingAddressFields(options?: RequestOptions): Promise<CheckoutSelectors> {
+        return this.loadShippingCountries(options);
+    }
+
+    /**
+     * Loads a set of form fields that should be presented to customers in order
+     * to capture their address.
+     *
+     * Once the method has been executed successfully, you can call
+     * `CheckoutStoreSelector#getAddressFields` to retrieve the set of
+     * form fields.
+     *
+     * ```js
+     * const state = service.loadAddressFields();
+     *
+     * console.log(state.data.loadAddressFields('US'));
+     * ```
+     *
+     * @param options - Options for loading the shipping address form fields.
+     * @returns A promise that resolves to the current state.
+     */
+     loadAddressFields(options?: RequestOptions): Promise<CheckoutSelectors> {
         return this.loadShippingCountries(options);
     }
 
@@ -854,7 +876,7 @@ export default class CheckoutService {
      * When a customer updates their shipping address for an order, they will
      * see an updated list of shipping options and the cost for each option,
      * unless no options are available. If the update is successful, you can
-     * call `CheckoutStoreSelector#getShippingAddress` to retrieve the address.
+     * call `CheckoutStoreSelector#getAddress` to retrieve the address.
      *
      * If the shipping address changes and the selected shipping option becomes
      * unavailable for the updated address, the shipping option will be
@@ -866,7 +888,7 @@ export default class CheckoutService {
      * ```js
      * const state = await service.updateShippingAddress(address);
      *
-     * console.log(state.data.getShippingAddress());
+     * console.log(state.data.getAddress());
      * ```
      *
      * @param address - The address to be used for shipping.

--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -205,6 +205,47 @@ describe('CheckoutStoreSelector', () => {
         });
     });
 
+    describe('#getAddress()', () => {
+        it('returns address', () => {
+            expect(selector.getAddress()).toEqual(internalSelectors.address.getAddress());
+        });
+
+        it('returns geo-ip dummy address', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.address, 'getAddress').mockReturnValue(undefined);
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getAddress()).toEqual({
+                address1: '',
+                address2: '',
+                city: '',
+                company: '',
+                country: '',
+                customFields: [],
+                firstName: '',
+                lastName: '',
+                phone: '',
+                postalCode: '',
+                stateOrProvince: '',
+                stateOrProvinceCode: '',
+                countryCode: 'AU',
+            });
+        });
+
+        it('returns undefined if address & geoIp are not present', () => {
+            internalSelectors = createInternalCheckoutSelectors(state);
+
+            jest.spyOn(internalSelectors.address, 'getAddress').mockReturnValue(undefined);
+            jest.spyOn(internalSelectors.config, 'getContextConfig').mockReturnValue(undefined);
+
+            selector = createCheckoutStoreSelector(internalSelectors);
+
+            expect(selector.getAddress()).toBeUndefined();
+        });
+    });
+
     it('returns instruments', () => {
         expect(selector.getInstruments()).toEqual(internalSelectors.instruments.getInstruments());
     });
@@ -221,6 +262,16 @@ describe('CheckoutStoreSelector', () => {
 
     it('returns shipping address fields', () => {
         const results = selector.getShippingAddressFields('AU');
+        const predicate = ({ name }: FormField) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
+        const field = find(results, { name: 'stateOrProvinceCode' });
+
+        expect(reject(results, predicate)).toEqual(reject(getAddressFormFields(), predicate));
+        expect(field && field.options && field.options.items)
+            .toEqual(getAustralia().subdivisions.map(({ code, name }) => ({ label: name, value: code })));
+    });
+
+    it('returns address fields', () => {
+        const results = selector.getAddressFields('AU');
         const predicate = ({ name }: FormField) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
         const field = find(results, { name: 'stateOrProvinceCode' });
 

--- a/src/checkout/checkout-store-selector.spec.ts
+++ b/src/checkout/checkout-store-selector.spec.ts
@@ -205,19 +205,19 @@ describe('CheckoutStoreSelector', () => {
         });
     });
 
-    describe('#getAddress()', () => {
-        it('returns address', () => {
-            expect(selector.getAddress()).toEqual(internalSelectors.address.getAddress());
+    describe('#getFulfilmentAddress()', () => {
+        it('returns fulfilment address', () => {
+            expect(selector.getFulfilmentAddress()).toEqual(internalSelectors.fulfilmentAddress.getFulfilmentAddress());
         });
 
         it('returns geo-ip dummy address', () => {
             internalSelectors = createInternalCheckoutSelectors(state);
 
-            jest.spyOn(internalSelectors.address, 'getAddress').mockReturnValue(undefined);
+            jest.spyOn(internalSelectors.fulfilmentAddress, 'getFulfilmentAddress').mockReturnValue(undefined);
 
             selector = createCheckoutStoreSelector(internalSelectors);
 
-            expect(selector.getAddress()).toEqual({
+            expect(selector.getFulfilmentAddress()).toEqual({
                 address1: '',
                 address2: '',
                 city: '',
@@ -237,12 +237,12 @@ describe('CheckoutStoreSelector', () => {
         it('returns undefined if address & geoIp are not present', () => {
             internalSelectors = createInternalCheckoutSelectors(state);
 
-            jest.spyOn(internalSelectors.address, 'getAddress').mockReturnValue(undefined);
+            jest.spyOn(internalSelectors.fulfilmentAddress, 'getFulfilmentAddress').mockReturnValue(undefined);
             jest.spyOn(internalSelectors.config, 'getContextConfig').mockReturnValue(undefined);
 
             selector = createCheckoutStoreSelector(internalSelectors);
 
-            expect(selector.getAddress()).toBeUndefined();
+            expect(selector.getFulfilmentAddress()).toBeUndefined();
         });
     });
 
@@ -270,8 +270,8 @@ describe('CheckoutStoreSelector', () => {
             .toEqual(getAustralia().subdivisions.map(({ code, name }) => ({ label: name, value: code })));
     });
 
-    it('returns address fields', () => {
-        const results = selector.getAddressFields('AU');
+    it('returns fulfilment address fields', () => {
+        const results = selector.getFulfilmentAddressFields('AU');
         const predicate = ({ name }: FormField) => name === 'stateOrProvince' || name === 'stateOrProvinceCode' || name === 'countryCode';
         const field = find(results, { name: 'stateOrProvinceCode' });
 

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -75,7 +75,7 @@ export default interface CheckoutStoreSelector {
      * @returns The address object if it is loaded, otherwise
      * undefined.
      */
-     getAddress(): Address | undefined;
+     getFulfilmentAddress(): Address | undefined;
 
     /**
      * Gets a list of shipping options available for the shipping address.
@@ -274,7 +274,7 @@ export default interface CheckoutStoreSelector {
      * @returns The set of address form fields if it is loaded,
      * otherwise undefined.
      */
-     getAddressFields(countryCode: string): FormField[];
+     getFulfilmentAddressFields(countryCode: string): FormField[];
 
     /**
      * Gets a list of pickup options for specified parameters.
@@ -338,11 +338,11 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         })
     );
 
-    const getAddress = createSelector(
-        ({ shippingAddress }: InternalCheckoutSelectors) => shippingAddress.getAddress,
+    const getFulfilmentAddress = createSelector(
+        ({ shippingAddress }: InternalCheckoutSelectors) => shippingAddress.getFulfilmentAddress,
         ({ config }: InternalCheckoutSelectors) => config.getContextConfig,
-        (getAddress, getContextConfig) => clone(() => {
-            const address = getAddress();
+        (getFulfilmentAddress, getContextConfig) => clone(() => {
+            const address = getFulfilmentAddress();
             const context = getContextConfig();
 
             if (!address) {
@@ -541,7 +541,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         })
     );
 
-    const getAddressFields = createSelector(
+    const getFulfilmentAddressFields = createSelector(
         ({ form }: InternalCheckoutSelectors) => form.getShippingAddressFields,
         ({ shippingCountries }: InternalCheckoutSelectors) => shippingCountries.getShippingCountries,
         (getShippingAddressFields, getShippingCountries) => clone((countryCode: string) => {
@@ -567,7 +567,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             getOrder: getOrder(state),
             getConfig: getConfig(state),
             getFlashMessages: getFlashMessages(state),
-            getAddress: getAddress(state),
+            getFulfilmentAddress: getFulfilmentAddress(state),
             getShippingAddress: getShippingAddress(state),
             getShippingOptions: getShippingOptions(state),
             getConsignments: getConsignments(state),
@@ -590,7 +590,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             getBillingAddressFields: getBillingAddressFields(state),
             getShippingAddressFields: getShippingAddressFields(state),
             getPickupOptions: getPickupOptions(state),
-            getAddressFields: getAddressFields(state),
+            getFulfilmentAddressFields: getFulfilmentAddressFields(state),
         };
     });
 }

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -54,6 +54,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createSignInEmailSelector = createSignInEmailSelectorFactory();
 
     return (state, options = {}) => {
+        const address = createShippingAddressSelector(state.consignments);
         const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = createCartSelector(state.cart);
         const checkoutButton = createCheckoutButtonSelector(state.checkoutButton);
@@ -83,6 +84,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const config = createConfigSelector(state.config, state.formFields);
 
         const selectors = {
+            address,
             billingAddress,
             cart,
             checkout,

--- a/src/checkout/create-internal-checkout-selectors.ts
+++ b/src/checkout/create-internal-checkout-selectors.ts
@@ -54,7 +54,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createSignInEmailSelector = createSignInEmailSelectorFactory();
 
     return (state, options = {}) => {
-        const address = createShippingAddressSelector(state.consignments);
+        const fulfilmentAddress = createShippingAddressSelector(state.consignments);
         const billingAddress = createBillingAddressSelector(state.billingAddress);
         const cart = createCartSelector(state.cart);
         const checkoutButton = createCheckoutButtonSelector(state.checkoutButton);
@@ -84,7 +84,6 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const config = createConfigSelector(state.config, state.formFields);
 
         const selectors = {
-            address,
             billingAddress,
             cart,
             checkout,
@@ -96,6 +95,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             customer,
             customerStrategies,
             form,
+            fulfilmentAddress,
             giftCertificates,
             instruments,
             order,

--- a/src/checkout/internal-checkout-selectors.ts
+++ b/src/checkout/internal-checkout-selectors.ts
@@ -18,7 +18,6 @@ import { SubscriptionsSelector } from '../subscription';
 import CheckoutSelector from './checkout-selector';
 
 export default interface InternalCheckoutSelectors {
-    address: ShippingAddressSelector;
     billingAddress: BillingAddressSelector;
     cart: CartSelector;
     checkout: CheckoutSelector;
@@ -30,6 +29,7 @@ export default interface InternalCheckoutSelectors {
     customer: CustomerSelector;
     customerStrategies: CustomerStrategySelector;
     form: FormSelector;
+    fulfilmentAddress: ShippingAddressSelector;
     giftCertificates: GiftCertificateSelector;
     instruments: InstrumentSelector;
     order: OrderSelector;

--- a/src/checkout/internal-checkout-selectors.ts
+++ b/src/checkout/internal-checkout-selectors.ts
@@ -18,6 +18,7 @@ import { SubscriptionsSelector } from '../subscription';
 import CheckoutSelector from './checkout-selector';
 
 export default interface InternalCheckoutSelectors {
+    address: ShippingAddressSelector;
     billingAddress: BillingAddressSelector;
     cart: CartSelector;
     checkout: CheckoutSelector;

--- a/src/shipping/consignment-action-creator.spec.ts
+++ b/src/shipping/consignment-action-creator.spec.ts
@@ -111,6 +111,7 @@ describe('consignmentActionCreator', () => {
 
         beforeEach(() => {
             payload = [{
+                address: consignment.address,
                 shippingAddress: consignment.shippingAddress,
                 lineItems: [],
             }];
@@ -199,6 +200,7 @@ describe('consignmentActionCreator', () => {
 
         beforeEach(() => {
             payload = {
+                address: consignment.address,
                 shippingAddress: consignment.shippingAddress,
                 lineItems: [{
                     itemId: 'unassigned',
@@ -308,6 +310,7 @@ describe('consignmentActionCreator', () => {
                     'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                     {
                         id: consignment.id,
+                        address: consignment.address,
                         shippingAddress: consignment.shippingAddress,
                         lineItems: [
                             {
@@ -383,6 +386,7 @@ describe('consignmentActionCreator', () => {
 
         beforeEach(() => {
             payload = {
+                address: consignment.address,
                 shippingAddress: consignment.shippingAddress,
                 lineItems: [{
                     itemId: 'unassigned',
@@ -481,6 +485,7 @@ describe('consignmentActionCreator', () => {
                     'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                     {
                         id: consignment.id,
+                        address: consignment.address,
                         shippingAddress: consignment.shippingAddress,
                         lineItems: payload.lineItems,
                     },
@@ -515,6 +520,7 @@ describe('consignmentActionCreator', () => {
                     'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                     {
                         id: consignment.id,
+                        address: consignment.address,
                         shippingAddress: consignment.shippingAddress,
                         lineItems: [
                             {
@@ -908,6 +914,7 @@ describe('consignmentActionCreator', () => {
                 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 {
                     id: '55c96cda6f04c',
+                    address,
                     shippingAddress: address,
                     lineItems: [
                         {
@@ -933,6 +940,7 @@ describe('consignmentActionCreator', () => {
             expect(consignmentRequestSender.createConsignments).toHaveBeenCalledWith(
                 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 [{
+                    address,
                     shippingAddress: address,
                     lineItems: [
                         {

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -30,7 +30,7 @@ export default class ConsignmentActionCreator {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckout);
             }
 
-            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.shippingAddress);
+            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.address);
 
             if (!existingConsignment) {
                 throw new InvalidArgumentError('No consignment found for the specified address');
@@ -48,7 +48,8 @@ export default class ConsignmentActionCreator {
 
             return this.updateConsignment({
                 id: existingConsignment.id,
-                shippingAddress: consignment.shippingAddress,
+                address: consignment.address,
+                shippingAddress: consignment.address,
                 lineItems,
             }, options)(store);
         };
@@ -60,11 +61,12 @@ export default class ConsignmentActionCreator {
     ): ThunkAction<UpdateConsignmentAction | CreateConsignmentsAction, InternalCheckoutSelectors> {
         return store => {
             const state = store.getState();
-            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.shippingAddress);
+            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.address);
 
             return this._createOrUpdateConsignment({
                 id: existingConsignment && existingConsignment.id,
-                shippingAddress: consignment.shippingAddress,
+                address: consignment.address,
+                shippingAddress: consignment.address,
                 lineItems: this._addLineItems(
                     consignment.lineItems,
                     existingConsignment,
@@ -285,7 +287,7 @@ export default class ConsignmentActionCreator {
     }
 
     private _getUpdateAddressRequestBody(
-        shippingAddress: AddressRequestBody,
+        address: AddressRequestBody,
         store: ReadableCheckoutStore
     ): ConsignmentRequestBody {
         const state = store.getState();
@@ -297,7 +299,8 @@ export default class ConsignmentActionCreator {
         const { physicalItems, customItems = [] } = cart.lineItems;
 
         return {
-            shippingAddress,
+            address,
+            shippingAddress: address,
             lineItems: [ ...physicalItems, ...customItems ].map(item => ({
                 itemId: item.id,
                 quantity: item.quantity,

--- a/src/shipping/consignment-request-sender.spec.ts
+++ b/src/shipping/consignment-request-sender.spec.ts
@@ -14,6 +14,8 @@ describe('ConsignmentRequestSender', () => {
     const consignment = getConsignmentRequestBody();
     const consignments = [{
         // tslint:disable-next-line:no-non-null-assertion
+        address: consignment.address!,
+        // tslint:disable-next-line:no-non-null-assertion
         shippingAddress: consignment.shippingAddress!,
         // tslint:disable-next-line:no-non-null-assertion
         lineItems: consignment.lineItems!,

--- a/src/shipping/consignment-selector.ts
+++ b/src/shipping/consignment-selector.ts
@@ -65,7 +65,7 @@ export function createConsignmentSelectorFactory(): ConsignmentSelectorFactory {
             }
 
             return find(consignments, consignment =>
-                isAddressEqual(consignment.shippingAddress, address)
+                isAddressEqual(consignment.address, address)
             );
         }
     );

--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -5,6 +5,7 @@ import ShippingOption from './shipping-option';
 
 export default interface Consignment {
     id: string;
+    address: Address;
     shippingAddress: Address;
     handlingCost: number;
     shippingCost: number;
@@ -20,12 +21,14 @@ export type ConsignmentRequestBody =
     ConsignmentShippingOptionRequestBody;
 
 export interface ConsignmentCreateRequestBody {
+    address: AddressRequestBody;
     shippingAddress: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;
 }
 
 export interface ConsignmentAssignmentRequestBody {
+    address: AddressRequestBody;
     shippingAddress: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;
@@ -33,6 +36,7 @@ export interface ConsignmentAssignmentRequestBody {
 
 export interface ConsignmentUpdateRequestBody {
     id: string;
+    address?: AddressRequestBody;
     shippingAddress?: AddressRequestBody;
     lineItems?: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;

--- a/src/shipping/consignments.mock.ts
+++ b/src/shipping/consignments.mock.ts
@@ -16,6 +16,7 @@ export function getConsignment(): Consignment {
         lineItemIds: [
             '12e11c8f-7dce-4da3-9413-b649533f8bad',
         ],
+        address: omit(getShippingAddress(), 'id') as Address,
         shippingAddress: omit(getShippingAddress(), 'id') as Address,
         availableShippingOptions: [
             getShippingOption(),
@@ -49,6 +50,7 @@ export function getConsignmentsState(): ConsignmentState {
 export function getConsignmentRequestBody(): ConsignmentUpdateRequestBody {
     return {
         id: '55c96cda6f04c',
+        address: getShippingAddress(),
         lineItems: [{
             itemId: '12e11c8f-7dce-4da3-9413-b649533f8bad',
             quantity: 1,

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -6,7 +6,7 @@ import { createSelector } from '../common/selector';
 import ConsignmentState, { DEFAULT_STATE } from './consignment-state';
 
 export default interface ShippingAddressSelector {
-    getAddress(): Address | undefined;
+    getFulfilmentAddress(): Address | undefined;
     getShippingAddress(): Address | undefined;
 }
 
@@ -29,7 +29,7 @@ export function createShippingAddressSelectorFactory(): ShippingAddressSelectorF
     ): ShippingAddressSelector => {
         return {
             getShippingAddress: getShippingAddress(state),
-            getAddress: getShippingAddress(state),
+            getFulfilmentAddress: getShippingAddress(state),
         };
     });
 }

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -6,6 +6,7 @@ import { createSelector } from '../common/selector';
 import ConsignmentState, { DEFAULT_STATE } from './consignment-state';
 
 export default interface ShippingAddressSelector {
+    getAddress(): Address | undefined;
     getShippingAddress(): Address | undefined;
 }
 
@@ -19,7 +20,7 @@ export function createShippingAddressSelectorFactory(): ShippingAddressSelectorF
                 return;
             }
 
-            return consignments[0].shippingAddress;
+            return consignments[0].address;
         }
     );
 
@@ -28,6 +29,7 @@ export function createShippingAddressSelectorFactory(): ShippingAddressSelectorF
     ): ShippingAddressSelector => {
         return {
             getShippingAddress: getShippingAddress(state),
+            getAddress: getShippingAddress(state),
         };
     });
 }


### PR DESCRIPTION
## What?
Add address field as an alias to ShippingAddress

## Why?
We discussed it would make more sense to return an Address field in the consignment api so it works for Pickup and Shipping - Given this change, we think it also makes sense to update the request to match the response.

## Testing / Proof
- Tests
![Screen Shot 2022-03-21 at 3 53 57 pm](https://user-images.githubusercontent.com/7134802/159208029-2fc7ee6e-9a77-4318-884b-10092b8a6d47.png)


@bigcommerce/checkout
