### PR TITLE
feat(payment): INT-5060 Stripe UPE Look and Feel - map theme styles to stripe appearance API

### DIFF
--- a/src/payment/strategies/stripe-upe/stripe-upe-initialize-options.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-initialize-options.ts
@@ -25,4 +25,11 @@ export default interface StripeUPEPaymentInitializeOptions {
      * The location to insert the credit card number form field.
      */
     containerId: string;
+
+    /**
+     * Checkout styles from store theme
+     */
+    style?: {
+        [key: string]: string;
+    };
 }

--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -208,6 +208,132 @@ describe('StripeUPEPaymentStrategy', () => {
                     .rejects.toThrow(InvalidArgumentError);
             });
         });
+
+        describe('mounts payment element with styles', () => {
+            const testColor = '#123456';
+            beforeEach(() => {
+                options = getStripeUPEInitializeOptionsMock();
+
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValue(getStripeUPE());
+            });
+
+            it('mounts stripe element with valid styles', async () => {
+                jest.spyOn(stripeScriptLoader, 'load')
+                    .mockReturnValue(Promise.resolve(stripeUPEJsMock));
+
+                const style = {
+                    labelText: testColor,
+                    fieldText: testColor,
+                    fieldPlaceholderText: testColor,
+                    fieldErrorText: testColor,
+                    fieldBackground: testColor,
+                    fieldInnerShadow: testColor,
+                    fieldBorder: testColor,
+                };
+                options = getStripeUPEInitializeOptionsMock(StripePaymentMethodType.CreditCard, style);
+
+                await strategy.initialize(options);
+
+                expect(stripeUPEJsMock.elements).toHaveBeenCalledWith(
+                    {
+                        locale: 'en',
+                        clientSecret: 'myToken',
+                        appearance: {
+                            rules: {
+                                '.Input': {
+                                    borderColor: testColor,
+                                    boxShadow: testColor,
+                                    color: testColor,
+                                },
+                            },
+                            variables: {
+                                colorBackground: testColor,
+                                colorDanger: testColor,
+                                colorIcon: testColor,
+                                colorPrimary: testColor,
+                                colorText: testColor,
+                                colorTextPlaceholder: testColor,
+                                colorTextSecondary: testColor,
+                            },
+                        },
+                    }
+                );
+            });
+
+            it('mounts stripe element regardless of invalid styles', async () => {
+                jest.spyOn(stripeScriptLoader, 'load')
+                    .mockReturnValue(Promise.resolve(stripeUPEJsMock));
+
+                const style = {
+                    labelText: 'not valid #123456',
+                    invalidStyle: '#123456',
+                };
+                options = getStripeUPEInitializeOptionsMock(StripePaymentMethodType.CreditCard, style);
+
+                await strategy.initialize(options);
+
+                expect(stripeUPEJsMock.elements).toHaveBeenCalledWith(
+                    {
+                        locale: 'en',
+                        clientSecret: 'myToken',
+                        appearance: {
+                            rules: {
+                                '.Input': {
+                                    borderColor: undefined,
+                                    boxShadow: undefined,
+                                    color: undefined,
+                                },
+                            },
+                            variables: {
+                                colorBackground: undefined,
+                                colorDanger: undefined,
+                                colorIcon: undefined,
+                                colorPrimary: undefined,
+                                colorText: 'not valid #123456',
+                                colorTextPlaceholder: undefined,
+                                colorTextSecondary: 'not valid #123456',
+                            },
+                        },
+                    }
+                );
+            });
+
+            it('mounts stripe element with no styles', async () => {
+                jest.spyOn(stripeScriptLoader, 'load')
+                    .mockReturnValue(Promise.resolve(stripeUPEJsMock));
+
+                const style = {};
+                options = getStripeUPEInitializeOptionsMock(StripePaymentMethodType.CreditCard, style);
+
+                await strategy.initialize(options);
+
+                expect(stripeUPEJsMock.elements).toHaveBeenCalledWith(
+                    {
+                        locale: 'en',
+                        clientSecret: 'myToken',
+                        appearance: {
+                            rules: {
+                                '.Input': {
+                                    borderColor: undefined,
+                                    boxShadow: undefined,
+                                    color: undefined,
+                                },
+                            },
+                            variables: {
+                                colorBackground: undefined,
+                                colorDanger: undefined,
+                                colorIcon: undefined,
+                                colorPrimary: undefined,
+                                colorText: undefined,
+                                colorTextPlaceholder: undefined,
+                                colorTextSecondary: undefined,
+                            },
+                        },
+                    }
+                );
+            });
+        });
     });
 
     describe('#execute()', () => {

--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -15,7 +15,7 @@ import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-r
 import PaymentStrategy from '../payment-strategy';
 
 import formatLocale from './format-locale';
-import { AddressOptions, StripeConfirmPaymentData, StripeElement, StripeElements, StripeError, StripePaymentMethodType, StripeStringConstants, StripeUPEClient } from './stripe-upe';
+import { AddressOptions, StripeConfirmPaymentData, StripeElement, StripeElements, StripeError, StripePaymentMethodType, StripeStringConstants, StripeUPEAppearanceOptions, StripeUPEClient } from './stripe-upe';
 import StripeUPEScriptLoader from './stripe-upe-script-loader';
 
 const APM_REDIRECT = [
@@ -60,10 +60,33 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         }
 
         this._stripeUPEClient = await this._loadStripeJs(stripePublishableKey, stripeConnectedAccount);
+        let appearance: StripeUPEAppearanceOptions | undefined;
+        if (stripeupe.style) {
+            const styles = stripeupe.style;
+            appearance = {
+                variables: {
+                    colorPrimary: styles.fieldInnerShadow,
+                    colorBackground: styles.fieldBackground,
+                    colorText: styles.labelText,
+                    colorDanger: styles.fieldErrorText,
+                    colorTextSecondary: styles.labelText,
+                    colorTextPlaceholder: styles.fieldPlaceholderText,
+                    colorIcon: styles.fieldPlaceholderText,
+                },
+                rules: {
+                    '.Input': {
+                        borderColor: styles.fieldBorder,
+                        color: styles.fieldText,
+                        boxShadow: styles.fieldInnerShadow,
+                    },
+                },
+            };
+        }
 
         this._stripeElements = this._stripeElements ?? this._stripeUPEClient.elements({
             clientSecret: paymentMethod.clientToken,
             locale: formatLocale(shopperLanguage),
+            appearance,
         });
 
         const stripeElement: StripeElement = this._stripeElements.getElement(StripeStringConstants.PAYMENT) || this._stripeElements.create(StripeStringConstants.PAYMENT,

--- a/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
@@ -35,12 +35,13 @@ export function getFailingStripeUPEJsMock(): StripeUPEClient {
     };
 }
 
-export function getStripeUPEInitializeOptionsMock(stripePaymentMethodType: StripePaymentMethodType = StripePaymentMethodType.CreditCard): PaymentInitializeOptions {
+export function getStripeUPEInitializeOptionsMock(stripePaymentMethodType: StripePaymentMethodType = StripePaymentMethodType.CreditCard, style: {[key: string]: string} = {fieldText: '#ccc'}): PaymentInitializeOptions {
     return {
         methodId: stripePaymentMethodType,
         gatewayId,
         stripeupe: {
             containerId: `stripe-${stripePaymentMethodType}-component-field`,
+            style,
         },
     };
 }

--- a/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -115,7 +115,7 @@ export interface WalletOptions {
 }
 
 /**
- * All available options are herehttps://stripe.com/docs/js/elements_object/create_payment_element
+ * All available options are here https://stripe.com/docs/js/elements_object/create_payment_element
  */
 export interface StripeElementsCreateOptions {
     fields?: FieldsOptions;
@@ -132,6 +132,31 @@ export interface StripeElements {
      * Looks up a previously created `payment` element.
      */
     getElement(elementType: StripeStringConstants.PAYMENT): StripeElement | null;
+}
+
+/**
+ * All available options are here https://stripe.com/docs/stripe-js/appearance-api#supported-css-properties
+ */
+export interface StripeUPEAppearanceOptions {
+    variables?: {
+        colorPrimary?: string;
+        colorBackground?: string;
+        colorText?: string;
+        colorDanger?: string;
+        colorTextSecondary?: string;
+        colorTextPlaceholder?: string;
+        colorIcon?: string;
+        colorIconCardError?: string;
+        colorIconRedirect?: string;
+    };
+
+    rules?: {
+        '.Input'?: {
+            borderColor?: string;
+            color?: string;
+            boxShadow?: string;
+        };
+    };
 }
 
 export interface StripeElementsOptions {
@@ -158,6 +183,12 @@ export interface StripeElementsOptions {
      * Refer to our docs to accept a payment and learn about how client_secret should be handled.
      */
     clientSecret: string;
+
+    /**
+     * Match the design of your site with the appearance option.
+     * The layout of each Element stays consistent, but you can modify colors, fonts, borders, padding, and more.
+     */
+    appearance?: StripeUPEAppearanceOptions;
 }
 
 export interface StripeUPEClient {


### PR DESCRIPTION
## What? [INT-5060](https://jira.bigcommerce.com/browse/INT-5060)
Gets the store theme checkout styles to change the appearance of the Stripe UPE

## Why?
To have the payment element style match with the store style

## Testing / Proof
![Screen Shot 2022-03-22 at 12 01 10](https://user-images.githubusercontent.com/87149598/159610656-6468906c-6942-4bf0-a249-d4726dbb6f90.png)
![image](https://user-images.githubusercontent.com/87149598/159610784-8cfbdd52-3710-417f-9553-14ec1f0a105c.png)


## Depends on
https://github.com/bigcommerce/checkout-js/pull/832

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/kyiv-payments-team 

