### PR TITLE
feat(shipping): CHECKOUT-6422 Add address property to consignment interface

### DIFF
--- a/src/checkout/checkout-service.spec.ts
+++ b/src/checkout/checkout-service.spec.ts
@@ -945,6 +945,7 @@ describe('CheckoutService', () => {
             jest.spyOn(store, 'dispatch');
 
             const payload = {
+                address,
                 shippingAddress: address,
                 lineItems: [{
                     itemId: 'item-foo',
@@ -974,6 +975,7 @@ describe('CheckoutService', () => {
             jest.spyOn(store, 'dispatch');
 
             const payload = {
+                address,
                 shippingAddress: address,
                 lineItems: [{
                     itemId: 'item-foo',

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -323,9 +323,12 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         getConsignments => clone(() => {
             const consignments = getConsignments();
 
-            if (consignments && consignments.length) {
-                return consignments[0].availableShippingOptions;
+            if (!consignments) {
+                return;
             }
+            const shippingConsignment = consignments.find(consignment => !consignment.selectedPickupOption);
+
+            return shippingConsignment && shippingConsignment.availableShippingOptions;
         })
     );
 
@@ -339,11 +342,13 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         getConsignments => clone(() => {
             const consignments = getConsignments();
 
-            if (!consignments || !consignments.length) {
+            if (!consignments) {
                 return;
             }
 
-            return consignments[0].selectedShippingOption;
+            const shippingConsignment = consignments.find(consignment => !consignment.selectedPickupOption);
+
+            return shippingConsignment && shippingConsignment.selectedShippingOption;
         })
     );
 

--- a/src/checkout/checkout-store-selector.ts
+++ b/src/checkout/checkout-store-selector.ts
@@ -323,12 +323,9 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         getConsignments => clone(() => {
             const consignments = getConsignments();
 
-            if (!consignments) {
-                return;
-            }
-            const shippingConsignment = consignments.find(consignment => !consignment.selectedPickupOption);
+            const shippingConsignment = consignments?.find(consignment => !consignment.selectedPickupOption);
 
-            return shippingConsignment && shippingConsignment.availableShippingOptions;
+            return shippingConsignment?.availableShippingOptions;
         })
     );
 
@@ -341,14 +338,9 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         ({ consignments }: InternalCheckoutSelectors) => consignments.getConsignments,
         getConsignments => clone(() => {
             const consignments = getConsignments();
+            const shippingConsignment = consignments?.find(consignment => !consignment.selectedPickupOption);
 
-            if (!consignments) {
-                return;
-            }
-
-            const shippingConsignment = consignments.find(consignment => !consignment.selectedPickupOption);
-
-            return shippingConsignment && shippingConsignment.selectedShippingOption;
+            return shippingConsignment?.selectedShippingOption;
         })
     );
 

--- a/src/shipping/consignment-action-creator.spec.ts
+++ b/src/shipping/consignment-action-creator.spec.ts
@@ -112,7 +112,6 @@ describe('consignmentActionCreator', () => {
         beforeEach(() => {
             payload = [{
                 address: consignment.address,
-                shippingAddress: consignment.shippingAddress,
                 lineItems: [],
             }];
 
@@ -201,7 +200,6 @@ describe('consignmentActionCreator', () => {
         beforeEach(() => {
             payload = {
                 address: consignment.address,
-                shippingAddress: consignment.shippingAddress,
                 lineItems: [{
                     itemId: 'unassigned',
                     quantity: 1,
@@ -311,7 +309,6 @@ describe('consignmentActionCreator', () => {
                     {
                         id: consignment.id,
                         address: consignment.address,
-                        shippingAddress: consignment.address,
                         lineItems: [
                             {
                                 itemId: 'existing',
@@ -387,7 +384,6 @@ describe('consignmentActionCreator', () => {
         beforeEach(() => {
             payload = {
                 address: consignment.address,
-                shippingAddress: consignment.shippingAddress,
                 lineItems: [{
                     itemId: 'unassigned',
                     quantity: 2,
@@ -486,7 +482,6 @@ describe('consignmentActionCreator', () => {
                     {
                         id: consignment.id,
                         address: consignment.address,
-                        shippingAddress: consignment.address,
                         lineItems: payload.lineItems,
                     },
                     options
@@ -521,7 +516,6 @@ describe('consignmentActionCreator', () => {
                     {
                         id: consignment.id,
                         address: consignment.address,
-                        shippingAddress: consignment.shippingAddress,
                         lineItems: [
                             {
                                 itemId: 'unassigned',
@@ -915,7 +909,6 @@ describe('consignmentActionCreator', () => {
                 {
                     id: '55c96cda6f04c',
                     address,
-                    shippingAddress: address,
                     lineItems: [
                         {
                             itemId: '666',
@@ -941,7 +934,6 @@ describe('consignmentActionCreator', () => {
                 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 [{
                     address,
-                    shippingAddress: address,
                     lineItems: [
                         {
                             itemId: '666',

--- a/src/shipping/consignment-action-creator.spec.ts
+++ b/src/shipping/consignment-action-creator.spec.ts
@@ -111,6 +111,7 @@ describe('consignmentActionCreator', () => {
 
         beforeEach(() => {
             payload = [{
+                address: consignment.address,
                 shippingAddress: consignment.shippingAddress,
                 lineItems: [],
             }];
@@ -199,6 +200,7 @@ describe('consignmentActionCreator', () => {
 
         beforeEach(() => {
             payload = {
+                address: consignment.address,
                 shippingAddress: consignment.shippingAddress,
                 lineItems: [{
                     itemId: 'unassigned',
@@ -308,7 +310,8 @@ describe('consignmentActionCreator', () => {
                     'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                     {
                         id: consignment.id,
-                        shippingAddress: consignment.shippingAddress,
+                        address: consignment.address,
+                        shippingAddress: consignment.address,
                         lineItems: [
                             {
                                 itemId: 'existing',
@@ -383,6 +386,7 @@ describe('consignmentActionCreator', () => {
 
         beforeEach(() => {
             payload = {
+                address: consignment.address,
                 shippingAddress: consignment.shippingAddress,
                 lineItems: [{
                     itemId: 'unassigned',
@@ -481,7 +485,8 @@ describe('consignmentActionCreator', () => {
                     'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                     {
                         id: consignment.id,
-                        shippingAddress: consignment.shippingAddress,
+                        address: consignment.address,
+                        shippingAddress: consignment.address,
                         lineItems: payload.lineItems,
                     },
                     options
@@ -515,6 +520,7 @@ describe('consignmentActionCreator', () => {
                     'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                     {
                         id: consignment.id,
+                        address: consignment.address,
                         shippingAddress: consignment.shippingAddress,
                         lineItems: [
                             {
@@ -908,6 +914,7 @@ describe('consignmentActionCreator', () => {
                 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 {
                     id: '55c96cda6f04c',
+                    address,
                     shippingAddress: address,
                     lineItems: [
                         {
@@ -933,6 +940,7 @@ describe('consignmentActionCreator', () => {
             expect(consignmentRequestSender.createConsignments).toHaveBeenCalledWith(
                 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 [{
+                    address,
                     shippingAddress: address,
                     lineItems: [
                         {

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -30,7 +30,7 @@ export default class ConsignmentActionCreator {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckout);
             }
 
-            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.shippingAddress);
+            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.address);
 
             if (!existingConsignment) {
                 throw new InvalidArgumentError('No consignment found for the specified address');
@@ -48,7 +48,8 @@ export default class ConsignmentActionCreator {
 
             return this.updateConsignment({
                 id: existingConsignment.id,
-                shippingAddress: consignment.shippingAddress,
+                address: consignment.address,
+                shippingAddress: consignment.address,
                 lineItems,
             }, options)(store);
         };
@@ -60,11 +61,12 @@ export default class ConsignmentActionCreator {
     ): ThunkAction<UpdateConsignmentAction | CreateConsignmentsAction, InternalCheckoutSelectors> {
         return store => {
             const state = store.getState();
-            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.shippingAddress);
+            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.address);
 
             return this._createOrUpdateConsignment({
                 id: existingConsignment && existingConsignment.id,
-                shippingAddress: consignment.shippingAddress,
+                address: consignment.address,
+                shippingAddress: consignment.address,
                 lineItems: this._addLineItems(
                     consignment.lineItems,
                     existingConsignment,
@@ -285,7 +287,7 @@ export default class ConsignmentActionCreator {
     }
 
     private _getUpdateAddressRequestBody(
-        shippingAddress: AddressRequestBody,
+        address: AddressRequestBody,
         store: ReadableCheckoutStore
     ): ConsignmentRequestBody {
         const state = store.getState();
@@ -297,7 +299,8 @@ export default class ConsignmentActionCreator {
         const { physicalItems, customItems = [] } = cart.lineItems;
 
         return {
-            shippingAddress,
+            address,
+            shippingAddress: address,
             lineItems: [ ...physicalItems, ...customItems ].map(item => ({
                 itemId: item.id,
                 quantity: item.quantity,

--- a/src/shipping/consignment-action-creator.ts
+++ b/src/shipping/consignment-action-creator.ts
@@ -30,7 +30,7 @@ export default class ConsignmentActionCreator {
                 throw new MissingDataError(MissingDataErrorType.MissingCheckout);
             }
 
-            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.address);
+            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.address ?? consignment.shippingAddress);
 
             if (!existingConsignment) {
                 throw new InvalidArgumentError('No consignment found for the specified address');
@@ -48,8 +48,7 @@ export default class ConsignmentActionCreator {
 
             return this.updateConsignment({
                 id: existingConsignment.id,
-                address: consignment.address,
-                shippingAddress: consignment.address,
+                address: consignment.address ?? consignment.shippingAddress,
                 lineItems,
             }, options)(store);
         };
@@ -61,12 +60,11 @@ export default class ConsignmentActionCreator {
     ): ThunkAction<UpdateConsignmentAction | CreateConsignmentsAction, InternalCheckoutSelectors> {
         return store => {
             const state = store.getState();
-            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.address);
+            const existingConsignment = state.consignments.getConsignmentByAddress(consignment.address ?? consignment.shippingAddress);
 
             return this._createOrUpdateConsignment({
                 id: existingConsignment && existingConsignment.id,
-                address: consignment.address,
-                shippingAddress: consignment.address,
+                address: consignment.address ?? consignment.shippingAddress,
                 lineItems: this._addLineItems(
                     consignment.lineItems,
                     existingConsignment,
@@ -300,7 +298,6 @@ export default class ConsignmentActionCreator {
 
         return {
             address,
-            shippingAddress: address,
             lineItems: [ ...physicalItems, ...customItems ].map(item => ({
                 itemId: item.id,
                 quantity: item.quantity,

--- a/src/shipping/consignment-request-sender.spec.ts
+++ b/src/shipping/consignment-request-sender.spec.ts
@@ -14,6 +14,8 @@ describe('ConsignmentRequestSender', () => {
     const consignment = getConsignmentRequestBody();
     const consignments = [{
         // tslint:disable-next-line:no-non-null-assertion
+        address: consignment.address!,
+        // tslint:disable-next-line:no-non-null-assertion
         shippingAddress: consignment.shippingAddress!,
         // tslint:disable-next-line:no-non-null-assertion
         lineItems: consignment.lineItems!,

--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -5,6 +5,7 @@ import ShippingOption from './shipping-option';
 
 export default interface Consignment {
     id: string;
+    address: Address;
     shippingAddress: Address;
     handlingCost: number;
     shippingCost: number;
@@ -20,12 +21,14 @@ export type ConsignmentRequestBody =
     ConsignmentShippingOptionRequestBody;
 
 export interface ConsignmentCreateRequestBody {
-    shippingAddress: AddressRequestBody;
+    address?: AddressRequestBody;
+    shippingAddress?: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;
 }
 
 export interface ConsignmentAssignmentRequestBody {
+    address: AddressRequestBody;
     shippingAddress: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;
@@ -33,6 +36,7 @@ export interface ConsignmentAssignmentRequestBody {
 
 export interface ConsignmentUpdateRequestBody {
     id: string;
+    address?: AddressRequestBody;
     shippingAddress?: AddressRequestBody;
     lineItems?: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;

--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -29,7 +29,7 @@ export interface ConsignmentCreateRequestBody {
 
 export interface ConsignmentAssignmentRequestBody {
     address: AddressRequestBody;
-    shippingAddress: AddressRequestBody;
+    shippingAddress?: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;
 }

--- a/src/shipping/consignments.mock.ts
+++ b/src/shipping/consignments.mock.ts
@@ -10,6 +10,7 @@ import ConsignmentState from './consignment-state';
 export function getConsignment(): Consignment {
     return {
         id: '55c96cda6f04c',
+        address: omit(getShippingAddress(), 'id') as Address,
         selectedShippingOption: getShippingOption(),
         shippingCost: 0,
         handlingCost: 0,
@@ -49,6 +50,7 @@ export function getConsignmentsState(): ConsignmentState {
 export function getConsignmentRequestBody(): ConsignmentUpdateRequestBody {
     return {
         id: '55c96cda6f04c',
+        address: getShippingAddress(),
         lineItems: [{
             itemId: '12e11c8f-7dce-4da3-9413-b649533f8bad',
             quantity: 1,

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -15,13 +15,9 @@ export function createShippingAddressSelectorFactory(): ShippingAddressSelectorF
     const getShippingAddress = createSelector(
         (state: ConsignmentState) => state.data,
         consignments => () => {
-            if (!consignments) {
-                return;
-            }
+            const shippingConsignment = consignments?.find(consignment => !consignment.selectedPickupOption);
 
-            const shippingConsignment = consignments.find(consignment => !consignment.selectedPickupOption);
-
-            return shippingConsignment && shippingConsignment.shippingAddress;
+            return shippingConsignment?.shippingAddress;
         }
     );
 

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -15,11 +15,13 @@ export function createShippingAddressSelectorFactory(): ShippingAddressSelectorF
     const getShippingAddress = createSelector(
         (state: ConsignmentState) => state.data,
         consignments => () => {
-            if (!consignments || !consignments[0]) {
+            if (!consignments) {
                 return;
             }
 
-            return consignments[0].shippingAddress;
+            const shippingConsignment = consignments.find(consignment => !consignment.selectedPickupOption);
+
+            return shippingConsignment && shippingConsignment.shippingAddress;
         }
     );
 


### PR DESCRIPTION
## What?
- Add address field as an alias to ShippingAddress
- Update shipping selector methods to return details for first shipping consignment rather than the first consignment.

## Why?
Due to changes to consignment API add changes to interface.
Also address selector methods related to shipping consignment to return details from first shipping consignment

## Testing / Proof
- Tests
![Screen Shot 2022-03-21 at 3 53 57 pm](https://user-images.githubusercontent.com/7134802/159208029-2fc7ee6e-9a77-4318-884b-10092b8a6d47.png)


@bigcommerce/checkout
