### PR TITLE
fix(shipping): CHECKOUT-0000 Throw error if no shipping options present

### DIFF
--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
@@ -225,17 +225,32 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');
-        } else {
-            const recommendedOption = availableOptions.find(
-                option => option.isRecommended
+        }
+
+        if (availableOptions.length === 0) {
+            applePaySession.completeShippingContactSelection(
+                ApplePaySession.STATUS_INVALID_SHIPPING_POSTAL_ADDRESS,
+                [],
+                {
+                    type: 'pending',
+                    label: storeName,
+                    amount: `${checkout.grandTotal.toFixed(decimalPlaces)}`,
+                },
+                []
             );
 
-            const optionId = recommendedOption ? recommendedOption.id : availableOptions[0].id;
-            try {
-                await this._updateShippingOption(optionId);
-            } catch (error) {
-                throw new Error('Shipping options update failed');
-            }
+            return;
+        }
+
+        const recommendedOption = availableOptions.find(
+            option => option.isRecommended
+        );
+
+        const optionId = recommendedOption ? recommendedOption.id : availableOptions[0].id;
+        try {
+            await this._updateShippingOption(optionId);
+        } catch (error) {
+            throw new Error('Shipping options update failed');
         }
 
         state = this._store.getState();

--- a/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -262,17 +262,32 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');
-        } else {
-            const recommendedOption = availableOptions.find(
-                option => option.isRecommended
+        }
+
+        if (availableOptions.length === 0) {
+            applePaySession.completeShippingContactSelection(
+                ApplePaySession.STATUS_INVALID_SHIPPING_POSTAL_ADDRESS,
+                [],
+                {
+                    type: 'pending',
+                    label: storeName,
+                    amount: `${checkout.grandTotal.toFixed(decimalPlaces)}`,
+                },
+                []
             );
 
-            const optionId = recommendedOption ? recommendedOption.id : availableOptions[0].id;
-            try {
-                await this._updateShippingOption(optionId);
-            } catch (error) {
-                return this._onError(error);
-            }
+            return;
+        }
+
+        const recommendedOption = availableOptions.find(
+            option => option.isRecommended
+        );
+
+        const optionId = recommendedOption ? recommendedOption.id : availableOptions[0].id;
+        try {
+            await this._updateShippingOption(optionId);
+        } catch (error) {
+            return this._onError(error);
         }
 
         state = this._store.getState();


### PR DESCRIPTION
## What?
Throw error if no shipping options present

## Why?
At the moment if there are no shipping options returned for a particular address, then apple pay sheet breaks and errors out. 
Catch and throw the exception instead of the code erroring out.

## Testing / Proof
- Unit tests 
- Screencast


https://user-images.githubusercontent.com/7134802/160533270-7a32000e-f1c1-47d9-8371-7be1f54b7389.mov


@bigcommerce/checkout @BC-ISilva 
