### PR TITLE
CHECKOUT-6264: Add payment integration service

### DIFF
--- a/src/common/data-store/create-data-store-projection.ts
+++ b/src/common/data-store/create-data-store-projection.ts
@@ -1,4 +1,4 @@
-import { createAction, createDataStore, Action, DataStore, ReadableDataStore } from '@bigcommerce/data-store';
+import { createAction, createDataStore, Action, ReadableDataStore } from '@bigcommerce/data-store';
 
 enum ProjectionActionType {
     Synchronize = 'SYNCHRONIZE',
@@ -14,7 +14,7 @@ export interface DataStoreProjection<TTransformedState> extends ReadableDataStor
 }
 
 export default function createDataStoreProjection<TState, TTransformedState = TState>(
-    store: DataStore<any, Action, TState>,
+    store: ReadableDataStore<TState>,
     stateTransformer: (state: TState) => TTransformedState
 ): DataStoreProjection<TTransformedState> {
     const projection = createDataStore<TState | undefined, SynchronizeAction<TState>, TTransformedState>(

--- a/src/common/error/errors/missing-data-error.ts
+++ b/src/common/error/errors/missing-data-error.ts
@@ -11,8 +11,11 @@ export enum MissingDataErrorType {
     MissingOrderConfig,
     MissingOrderId,
     MissingPayment,
+    MissingPaymentId,
     MissingPaymentInstrument,
     MissingPaymentMethod,
+    MissingPaymentRedirectUrl,
+    MissingPaymentStatus,
     MissingPaymentToken,
     MissingShippingAddress,
 }

--- a/src/core/payment-integration/create-payment-integration-selectors.spec.ts
+++ b/src/core/payment-integration/create-payment-integration-selectors.spec.ts
@@ -1,0 +1,305 @@
+import { merge } from 'lodash';
+
+import { createInternalCheckoutSelectors, InternalCheckoutSelectors } from '../../checkout';
+import { getCheckoutStoreStateWithOrder } from '../../checkout/checkouts.mock';
+
+import createPaymentIntegrationSelectors from './create-payment-integration-selectors';
+import PaymentIntegrationSelectors from './payment-integration-selectors';
+
+describe('createPaymentIntegrationSelectors', () => {
+    describe('PaymentIntegrationSelectors', () => {
+        let subject: PaymentIntegrationSelectors;
+        let internalSelectors: InternalCheckoutSelectors;
+
+        beforeEach(() => {
+            internalSelectors = createInternalCheckoutSelectors(getCheckoutStoreStateWithOrder());
+            subject = createPaymentIntegrationSelectors(internalSelectors);
+        });
+
+        it('returns copy of billing address', () => {
+            const output = subject.getBillingAddress();
+
+            expect(output)
+                .toEqual(internalSelectors.billingAddress.getBillingAddress());
+            expect(output)
+                .not.toBe(internalSelectors.billingAddress.getBillingAddress());
+        });
+
+        it('throws if billing address is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    billingAddress: { getBillingAddressOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getBillingAddressOrThrow())
+                .toThrow();
+        });
+
+        it('returns copy of cart', () => {
+            const output = subject.getCart();
+
+            expect(output)
+                .toEqual(internalSelectors.cart.getCart());
+            expect(output)
+                .not.toBe(internalSelectors.cart.getCart());
+        });
+
+        it('throws if cart is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    cart: { getCartOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getCartOrThrow())
+                .toThrow();
+        });
+
+        it('returns copy of checkout', () => {
+            const output = subject.getCheckout();
+
+            expect(output)
+                .toEqual(internalSelectors.checkout.getCheckout());
+            expect(output)
+                .not.toBe(internalSelectors.checkout.getCheckout());
+        });
+
+        it('throws if checkout is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    checkout: { getCheckoutOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getCheckoutOrThrow())
+                .toThrow();
+        });
+
+        it('returns copy of config', () => {
+            const output = subject.getStoreConfig();
+
+            expect(output)
+                .toEqual(internalSelectors.config.getStoreConfig());
+            expect(output)
+                .not.toBe(internalSelectors.config.getStoreConfig());
+        });
+
+        it('throws if config is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    config: { getStoreConfigOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getStoreConfigOrThrow())
+                .toThrow();
+        });
+
+        it('returns copy of consignments', () => {
+            const output = subject.getConsignments();
+
+            expect(output)
+                .toEqual(internalSelectors.consignments.getConsignments());
+            expect(output)
+                .not.toBe(internalSelectors.consignments.getConsignments());
+        });
+
+        it('throws if consignments are missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    consignments: { getConsignmentsOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getConsignmentsOrThrow())
+                .toThrow();
+        });
+
+        it('returns copy of customer', () => {
+            const output = subject.getCustomer();
+
+            expect(output)
+                .toEqual(internalSelectors.customer.getCustomer());
+            expect(output)
+                .not.toBe(internalSelectors.customer.getCustomer());
+        });
+
+        it('throws if customer is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    customer: { getCustomerOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getCustomerOrThrow())
+                .toThrow();
+        });
+
+        it('returns copy of card instrument', () => {
+            const output = subject.getCardInstrument('123');
+
+            expect(output)
+                .toEqual(internalSelectors.instruments.getCardInstrument('123'));
+            expect(output)
+                .not.toBe(internalSelectors.instruments.getCardInstrument('123'));
+        });
+
+        it('throws if card instrument is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    instruments: { getCardInstrumentOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getCardInstrumentOrThrow('123'))
+                .toThrow();
+        });
+
+        it('returns copy of order', () => {
+            const output = subject.getOrder();
+
+            expect(output)
+                .toEqual(internalSelectors.order.getOrder());
+            expect(output)
+                .not.toBe(internalSelectors.order.getOrder());
+        });
+
+        it('throws if order is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    order: { getOrderOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getOrderOrThrow())
+                .toThrow();
+        });
+
+        it('returns payment token', () => {
+            const output = subject.getPaymentToken();
+
+            expect(output)
+                .toEqual(internalSelectors.payment.getPaymentToken());
+        });
+
+        it('throws if payment token is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    payment: { getPaymentTokenOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getPaymentTokenOrThrow())
+                .toThrow();
+        });
+
+        it('returns payment id', () => {
+            const output = subject.getPaymentId();
+
+            expect(output)
+                .toEqual(internalSelectors.payment.getPaymentId());
+        });
+
+        it('throws if payment id is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    payment: { getPaymentIdOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getPaymentIdOrThrow())
+                .toThrow();
+        });
+
+        it('returns payment status', () => {
+            const output = subject.getPaymentStatus();
+
+            expect(output)
+                .toEqual(internalSelectors.payment.getPaymentStatus());
+        });
+
+        it('throws if payment status is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    payment: { getPaymentStatusOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getPaymentStatusOrThrow())
+                .toThrow();
+        });
+
+        it('returns payment redirect URL', () => {
+            const output = subject.getPaymentRedirectUrl();
+
+            expect(output)
+                .toEqual(internalSelectors.payment.getPaymentRedirectUrl());
+        });
+
+        it('throws if payment redirect URL is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    payment: { getPaymentRedirectUrlOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getPaymentRedirectUrlOrThrow())
+                .toThrow();
+        });
+
+        it('returns copy of payment method', () => {
+            const output = subject.getPaymentMethod('braintree');
+
+            expect(output)
+                .toEqual(internalSelectors.paymentMethods.getPaymentMethod('braintree'));
+            expect(output)
+                .not.toBe(internalSelectors.paymentMethods.getPaymentMethod('braintree'));
+        });
+
+        it('throws if payment method is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    paymentMethods: { getPaymentMethodOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getPaymentMethodOrThrow('braintree'))
+                .toThrow();
+        });
+
+        it('returns copy of shipping address', () => {
+            const output = subject.getShippingAddress();
+
+            expect(output)
+                .toEqual(internalSelectors.shippingAddress.getShippingAddress());
+            expect(output)
+                .not.toBe(internalSelectors.shippingAddress.getShippingAddress());
+        });
+
+        it('throws if shipping address is missing', () => {
+            subject = createPaymentIntegrationSelectors(
+                merge(internalSelectors, {
+                    shippingAddress: { getShippingAddressOrThrow: () => { throw new Error(); } },
+                })
+            );
+
+            expect(() => subject.getShippingAddressOrThrow())
+                .toThrow();
+        });
+
+        it('returns is payment data required', () => {
+            const output = subject.isPaymentDataRequired();
+
+            expect(output)
+                .toEqual(internalSelectors.payment.isPaymentDataRequired());
+        });
+
+        it('returns is payment data initialized', () => {
+            const output = subject.isPaymentMethodInitialized('braintree');
+
+            expect(output)
+                .toEqual(internalSelectors.paymentStrategies.isInitialized('braintree'));
+        });
+    });
+});

--- a/src/core/payment-integration/create-payment-integration-selectors.ts
+++ b/src/core/payment-integration/create-payment-integration-selectors.ts
@@ -1,0 +1,94 @@
+import { InternalCheckoutSelectors } from '../../checkout';
+import { cloneResult as clone } from '../../common/utility';
+
+import PaymentIntegrationSelectors from './payment-integration-selectors';
+
+export default function createPaymentIntegrationSelectors({
+    billingAddress: {
+        getBillingAddress,
+        getBillingAddressOrThrow,
+    },
+    cart: {
+        getCart,
+        getCartOrThrow,
+    },
+    checkout: {
+        getCheckout,
+        getCheckoutOrThrow,
+    },
+    config: {
+        getStoreConfig,
+        getStoreConfigOrThrow,
+    },
+    consignments: {
+        getConsignments,
+        getConsignmentsOrThrow,
+    },
+    customer: {
+        getCustomer,
+        getCustomerOrThrow,
+    },
+    instruments: {
+        getCardInstrument,
+        getCardInstrumentOrThrow,
+    },
+    order: {
+        getOrder,
+        getOrderOrThrow,
+    },
+    payment: {
+        getPaymentToken,
+        getPaymentTokenOrThrow,
+        getPaymentId,
+        getPaymentIdOrThrow,
+        getPaymentStatus,
+        getPaymentStatusOrThrow,
+        getPaymentRedirectUrl,
+        getPaymentRedirectUrlOrThrow,
+        isPaymentDataRequired,
+    },
+    paymentMethods: {
+        getPaymentMethod,
+        getPaymentMethodOrThrow,
+    },
+    paymentStrategies: {
+        isInitialized: isPaymentMethodInitialized,
+    },
+    shippingAddress: {
+        getShippingAddress,
+        getShippingAddressOrThrow,
+    },
+}: InternalCheckoutSelectors): PaymentIntegrationSelectors {
+    return {
+        getBillingAddress: clone(getBillingAddress),
+        getBillingAddressOrThrow: clone(getBillingAddressOrThrow),
+        getCart: clone(getCart),
+        getCartOrThrow: clone(getCartOrThrow),
+        getCheckout: clone(getCheckout),
+        getCheckoutOrThrow: clone(getCheckoutOrThrow),
+        getStoreConfig: clone(getStoreConfig),
+        getStoreConfigOrThrow: clone(getStoreConfigOrThrow),
+        getConsignments: clone(getConsignments),
+        getConsignmentsOrThrow: clone(getConsignmentsOrThrow),
+        getCustomer: clone(getCustomer),
+        getCustomerOrThrow: clone(getCustomerOrThrow),
+        getCardInstrument: clone(getCardInstrument),
+        getCardInstrumentOrThrow: clone(getCardInstrumentOrThrow),
+        getOrder: clone(getOrder),
+        getOrderOrThrow: clone(getOrderOrThrow),
+        getPaymentToken,
+        getPaymentTokenOrThrow,
+        getPaymentId,
+        getPaymentIdOrThrow,
+        getPaymentStatus,
+        getPaymentStatusOrThrow,
+        getPaymentRedirectUrl,
+        getPaymentRedirectUrlOrThrow,
+        getPaymentMethod: clone(getPaymentMethod),
+        getPaymentMethodOrThrow: clone(getPaymentMethodOrThrow),
+        getShippingAddress: clone(getShippingAddress),
+        getShippingAddressOrThrow: clone(getShippingAddressOrThrow),
+        isPaymentDataRequired,
+        isPaymentMethodInitialized,
+    };
+}

--- a/src/core/payment-integration/default-payment-integration-service.spec.ts
+++ b/src/core/payment-integration/default-payment-integration-service.spec.ts
@@ -1,0 +1,183 @@
+import { createAction } from '@bigcommerce/data-store';
+
+import { BillingAddressActionCreator } from '../../billing';
+import { getBillingAddress } from '../../billing/billing-addresses.mock';
+import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../checkout';
+import { DataStoreProjection } from '../../common/data-store';
+import { OrderActionCreator } from '../../order';
+import { getOrder } from '../../order/orders.mock';
+import { PaymentActionCreator, PaymentMethodActionCreator } from '../../payment';
+import { getPayment } from '../../payment/payments.mock';
+import { ConsignmentActionCreator } from '../../shipping';
+import { getShippingAddress } from '../../shipping/shipping-addresses.mock';
+
+import DefaultPaymentIntegrationService from './default-payment-integration-service';
+import PaymentIntegrationSelectors from './payment-integration-selectors';
+import PaymentIntegrationService from './payment-integration-service';
+import PaymentIntegrationStoreProjectionFactory from './payment-integration-store-projection-factory';
+
+describe('DefaultPaymentIntegrationService', () => {
+    let subject: PaymentIntegrationService;
+    let paymentIntegrationSelectors: PaymentIntegrationSelectors;
+    let internalCheckoutSelectors: InternalCheckoutSelectors;
+    let store: Pick<CheckoutStore, 'dispatch' | 'getState'>;
+    let storeProjection: Pick<DataStoreProjection<PaymentIntegrationSelectors>, 'getState' | 'subscribe' | 'getState'>;
+    let storeProjectionFactory: Pick<PaymentIntegrationStoreProjectionFactory, 'create'>;
+    let checkoutActionCreator: Pick<CheckoutActionCreator, 'loadCurrentCheckout'>;
+    let orderActionCreator: Pick<OrderActionCreator, 'submitOrder' | 'finalizeOrder'>;
+    let billingAddressActionCreator: Pick<BillingAddressActionCreator, 'updateAddress'>;
+    let consignmentActionCreator: Pick<ConsignmentActionCreator, 'updateAddress'>;
+    let paymentMethodActionCreator: Pick<PaymentMethodActionCreator, 'loadPaymentMethod'>;
+    let paymentActionCreator: Pick<PaymentActionCreator, 'submitPayment'>;
+
+    beforeEach(() => {
+        paymentIntegrationSelectors = {} as PaymentIntegrationSelectors;
+
+        internalCheckoutSelectors = {
+            order: {
+                getOrderOrThrow: () => getOrder(),
+            },
+        } as InternalCheckoutSelectors;
+
+        store = {
+            dispatch: jest.fn(async () => await internalCheckoutSelectors),
+            getState: jest.fn(() => internalCheckoutSelectors),
+        };
+
+        storeProjection = {
+            subscribe: jest.fn(() => () => {}),
+            getState: jest.fn(() => paymentIntegrationSelectors),
+        };
+
+        storeProjectionFactory = {
+            create: jest.fn(() => storeProjection),
+        };
+
+        checkoutActionCreator = {
+            loadCurrentCheckout: jest.fn(async () => () => createAction('LOAD_CHECKOUT')),
+        };
+
+        orderActionCreator = {
+            submitOrder: jest.fn(async () => () => createAction('SUBMIT_ORDER')),
+            finalizeOrder: jest.fn(async () => () => createAction('FINALIZE_ORDER')),
+        };
+
+        billingAddressActionCreator = {
+            updateAddress: jest.fn(async () => () => createAction('UPDATE_BILLING_ADDRESS')),
+        };
+
+        consignmentActionCreator = {
+            updateAddress: jest.fn(async () => () => createAction('UPDATE_CONSIGNMENT_ADDRESS')),
+        };
+
+        paymentMethodActionCreator = {
+            loadPaymentMethod: jest.fn(async () => () => createAction('LOAD_PAYMENT_METHOD')),
+        };
+
+        paymentActionCreator = {
+            submitPayment: jest.fn(async () => () => createAction('LOAD_PAYMENT_METHOD')),
+        };
+
+        subject = new DefaultPaymentIntegrationService(
+            store as CheckoutStore,
+            storeProjectionFactory as PaymentIntegrationStoreProjectionFactory,
+            checkoutActionCreator as CheckoutActionCreator,
+            orderActionCreator as OrderActionCreator,
+            billingAddressActionCreator as BillingAddressActionCreator,
+            consignmentActionCreator as ConsignmentActionCreator,
+            paymentMethodActionCreator as PaymentMethodActionCreator,
+            paymentActionCreator as PaymentActionCreator
+        );
+    });
+
+    describe('#loadCheckout', () => {
+        it('loads current checkout', async () => {
+            const output = await subject.loadCheckout();
+
+            expect(checkoutActionCreator.loadCurrentCheckout)
+                .toHaveBeenCalled();
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(checkoutActionCreator.loadCurrentCheckout());
+            expect(output)
+                .toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#loadPaymentMethod', () => {
+        it('loads payment method', async () => {
+            const output = await subject.loadPaymentMethod('braintree');
+
+            expect(paymentMethodActionCreator.loadPaymentMethod)
+                .toHaveBeenCalledWith('braintree');
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(paymentMethodActionCreator.loadPaymentMethod('braintree'));
+            expect(output)
+                .toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#submitOrder', () => {
+        it('submits order', async () => {
+            const output = await subject.submitOrder();
+
+            expect(orderActionCreator.submitOrder)
+                .toHaveBeenCalled();
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(orderActionCreator.submitOrder());
+            expect(output)
+                .toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#submitPayment', () => {
+        it('submit payment', async () => {
+            const output = await subject.submitPayment(getPayment());
+
+            expect(paymentActionCreator.submitPayment)
+                .toHaveBeenCalled();
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(paymentActionCreator.submitPayment(getPayment()));
+            expect(output)
+                .toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#finalizeOrder', () => {
+        it('finalizes order', async () => {
+            const output = await subject.finalizeOrder();
+
+            expect(orderActionCreator.finalizeOrder)
+                .toHaveBeenCalled();
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(orderActionCreator.finalizeOrder(getOrder().orderId));
+            expect(output)
+                .toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#updateBillingAddress', () => {
+        it('update billing address', async () => {
+            const output = await subject.updateBillingAddress(getBillingAddress());
+
+            expect(billingAddressActionCreator.updateAddress)
+                .toHaveBeenCalledWith(getBillingAddress());
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(billingAddressActionCreator.updateAddress(getBillingAddress()));
+            expect(output)
+                .toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#updateShippingAddress', () => {
+        it('update shipping address', async () => {
+            const output = await subject.updateShippingAddress(getShippingAddress());
+
+            expect(consignmentActionCreator.updateAddress)
+                .toHaveBeenCalledWith(getShippingAddress());
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(consignmentActionCreator.updateAddress(getShippingAddress()));
+            expect(output)
+                .toEqual(paymentIntegrationSelectors);
+        });
+    });
+});

--- a/src/core/payment-integration/default-payment-integration-service.ts
+++ b/src/core/payment-integration/default-payment-integration-service.ts
@@ -1,0 +1,93 @@
+import { BillingAddressActionCreator, BillingAddressRequestBody } from '../../billing';
+import { CheckoutActionCreator, CheckoutStore } from '../../checkout';
+import { DataStoreProjection } from '../../common/data-store';
+import { OrderActionCreator, OrderRequestBody } from '../../order';
+import { Payment, PaymentActionCreator, PaymentMethodActionCreator } from '../../payment';
+import { ConsignmentActionCreator, ShippingAddressRequestBody } from '../../shipping';
+
+import PaymentIntegrationSelectors from './payment-integration-selectors';
+import PaymentIntegrationService from './payment-integration-service';
+import PaymentIntegrationStoreProjectionFactory from './payment-integration-store-projection-factory';
+
+export default class DefaultPaymentIntegrationService implements PaymentIntegrationService {
+    private _storeProjection: DataStoreProjection<PaymentIntegrationSelectors>;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _storeProjectionFactory: PaymentIntegrationStoreProjectionFactory,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _orderActionCreator: OrderActionCreator,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _consignmentActionCreator: ConsignmentActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _paymentActionCreator: PaymentActionCreator
+    ) {
+        this._storeProjection = this._storeProjectionFactory.create(this._store);
+    }
+
+    subscribe(subscriber: (state: PaymentIntegrationSelectors) => void, ...filters: Array<(state: PaymentIntegrationSelectors) => any>): () => void {
+        return this._storeProjection.subscribe(subscriber, ...filters);
+    }
+
+    getState(): PaymentIntegrationSelectors {
+        return this._storeProjection.getState();
+    }
+
+    async loadCheckout(): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._checkoutActionCreator.loadCurrentCheckout()
+        );
+
+        return this._storeProjection.getState();
+    }
+
+    async loadPaymentMethod(methodId: string): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._paymentMethodActionCreator.loadPaymentMethod(methodId)
+        );
+
+        return this._storeProjection.getState();
+    }
+
+    async submitOrder(payload?: OrderRequestBody): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._orderActionCreator.submitOrder(payload)
+        );
+
+        return this._storeProjection.getState();
+    }
+
+    async submitPayment(payment: Payment): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._paymentActionCreator.submitPayment(payment)
+        );
+
+        return this._storeProjection.getState();
+    }
+
+    async finalizeOrder(): Promise<PaymentIntegrationSelectors> {
+        const { order: { getOrderOrThrow } } = this._store.getState();
+
+        await this._store.dispatch(
+            this._orderActionCreator.finalizeOrder(getOrderOrThrow().orderId)
+        );
+
+        return this._storeProjection.getState();
+    }
+
+    async updateBillingAddress(payload: BillingAddressRequestBody): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._billingAddressActionCreator.updateAddress(payload)
+        );
+
+        return this._storeProjection.getState();
+    }
+
+    async updateShippingAddress(payload: ShippingAddressRequestBody): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._consignmentActionCreator.updateAddress(payload)
+        );
+
+        return this._storeProjection.getState();
+    }
+}

--- a/src/core/payment-integration/index.ts
+++ b/src/core/payment-integration/index.ts
@@ -1,0 +1,3 @@
+export { default as DefaultPaymentIntegrationService } from './default-payment-integration-service';
+export { default as PaymentIntegrationService } from './payment-integration-service';
+export { default as PaymentIntegrationSelectors } from './payment-integration-selectors';

--- a/src/core/payment-integration/payment-integration-selectors.ts
+++ b/src/core/payment-integration/payment-integration-selectors.ts
@@ -1,0 +1,56 @@
+import { BillingAddress } from '../../billing';
+import { Cart } from '../../cart';
+import { Checkout } from '../../checkout';
+import { StoreConfig } from '../../config';
+import { Customer } from '../../customer';
+import { Order } from '../../order';
+import { PaymentMethod } from '../../payment';
+import { CardInstrument } from '../../payment/instrument';
+import { Consignment, ShippingAddress } from '../../shipping';
+
+export default interface PaymentIntegrationSelectors {
+    getBillingAddress(): BillingAddress | undefined;
+    getBillingAddressOrThrow(): BillingAddress;
+
+    getCart(): Cart | undefined;
+    getCartOrThrow(): Cart;
+
+    getCheckout(): Checkout | undefined;
+    getCheckoutOrThrow(): Checkout;
+
+    getStoreConfig(): StoreConfig | undefined;
+    getStoreConfigOrThrow(): StoreConfig;
+
+    getConsignments(): Consignment[] | undefined;
+    getConsignmentsOrThrow(): Consignment[];
+
+    getCustomer(): Customer | undefined;
+    getCustomerOrThrow(): Customer;
+
+    getCardInstrument(instrumentId: string): CardInstrument | undefined;
+    getCardInstrumentOrThrow(instrumentId: string): CardInstrument;
+
+    getOrder(): Order | undefined;
+    getOrderOrThrow(): Order;
+
+    getPaymentToken(): string | undefined;
+    getPaymentTokenOrThrow(): string;
+
+    getPaymentId(): { providerId: string; gatewayId?: string } | undefined;
+    getPaymentIdOrThrow(): { providerId: string; gatewayId?: string };
+
+    getPaymentStatus(): string | undefined;
+    getPaymentStatusOrThrow(): string;
+
+    getPaymentRedirectUrl(): string | undefined;
+    getPaymentRedirectUrlOrThrow(): string;
+
+    getPaymentMethod(methodId: string, gatewayId?: string): PaymentMethod | undefined;
+    getPaymentMethodOrThrow(methodId: string, gatewayId?: string): PaymentMethod;
+
+    getShippingAddress(): ShippingAddress | undefined;
+    getShippingAddressOrThrow(): ShippingAddress;
+
+    isPaymentDataRequired(useStoreCredit?: boolean): boolean;
+    isPaymentMethodInitialized(methodId: string): boolean;
+}

--- a/src/core/payment-integration/payment-integration-service.ts
+++ b/src/core/payment-integration/payment-integration-service.ts
@@ -1,0 +1,26 @@
+import { BillingAddressRequestBody } from '../../billing';
+import { OrderRequestBody } from '../../order';
+import { Payment } from '../../payment';
+import { ShippingAddressRequestBody } from '../../shipping';
+
+import PaymentIntegrationSelectors from './payment-integration-selectors';
+
+export default interface PaymentIntegrationService {
+    subscribe(subscriber: (state: PaymentIntegrationSelectors) => void, ...filters: Array<(state: PaymentIntegrationSelectors) => any>): () => void;
+
+    getState(): PaymentIntegrationSelectors;
+
+    loadCheckout(): Promise<PaymentIntegrationSelectors>;
+
+    loadPaymentMethod(methodId: string): Promise<PaymentIntegrationSelectors>;
+
+    submitOrder(payload?: OrderRequestBody): Promise<PaymentIntegrationSelectors>;
+
+    submitPayment(payment: Payment): Promise<PaymentIntegrationSelectors>;
+
+    finalizeOrder(): Promise<PaymentIntegrationSelectors>;
+
+    updateBillingAddress(payload: BillingAddressRequestBody): Promise<PaymentIntegrationSelectors>;
+
+    updateShippingAddress(payload: ShippingAddressRequestBody): Promise<PaymentIntegrationSelectors>;
+}

--- a/src/core/payment-integration/payment-integration-store-projection-factory.spec.ts
+++ b/src/core/payment-integration/payment-integration-store-projection-factory.spec.ts
@@ -1,0 +1,42 @@
+import { ReadableDataStore } from '@bigcommerce/data-store';
+
+import { createCheckoutStore, InternalCheckoutSelectors } from '../../checkout';
+
+import createPaymentIntegrationSelectors from './create-payment-integration-selectors';
+import PaymentIntegrationSelectors from './payment-integration-selectors';
+import PaymentIntegrationStoreProjectionFactory from './payment-integration-store-projection-factory';
+
+describe('PaymentIntegrationStoreProjectionFactory', () => {
+    let subject: PaymentIntegrationStoreProjectionFactory;
+    let store: ReadableDataStore<InternalCheckoutSelectors>;
+    let selectors: PaymentIntegrationSelectors;
+    let transformer: (selectors: InternalCheckoutSelectors) => PaymentIntegrationSelectors;
+
+    beforeEach(() => {
+        store = createCheckoutStore();
+        selectors = createPaymentIntegrationSelectors(store.getState());
+        transformer = jest.fn(() => selectors);
+        subject = new PaymentIntegrationStoreProjectionFactory(transformer);
+    });
+
+    describe('#create', () => {
+        it('returns data store projection that returns payment integration selectors', () => {
+            const output = subject.create(store);
+
+            expect(output.getState())
+                .toEqual(selectors);
+        });
+
+        it('returns data store projection that notifies subscribers with payment integration selectors', () => {
+            const store = createCheckoutStore();
+            const output = subject.create(store);
+            const subscriber = jest.fn();
+
+            output.subscribe(subscriber);
+            output.notifyState();
+
+            expect(subscriber)
+                .toHaveBeenCalledWith(selectors);
+        });
+    });
+});

--- a/src/core/payment-integration/payment-integration-store-projection-factory.ts
+++ b/src/core/payment-integration/payment-integration-store-projection-factory.ts
@@ -1,0 +1,14 @@
+import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../../checkout';
+import { createDataStoreProjection, DataStoreProjection } from '../../common/data-store';
+
+import PaymentIntegrationSelectors from './payment-integration-selectors';
+
+export default class PaymentIntegrationStoreProjectionFactory {
+    constructor(
+        private _transformSelectors: (selectors: InternalCheckoutSelectors) => PaymentIntegrationSelectors
+    ) {}
+
+    create(store: ReadableCheckoutStore): DataStoreProjection<PaymentIntegrationSelectors> {
+        return createDataStoreProjection(store, this._transformSelectors);
+    }
+}

--- a/src/order/order-action-creator.ts
+++ b/src/order/order-action-creator.ts
@@ -62,7 +62,7 @@ export default class OrderActionCreator {
         });
     }
 
-    submitOrder(payload: OrderRequestBody, options?: RequestOptions): ThunkAction<SubmitOrderAction, InternalCheckoutSelectors> {
+    submitOrder(payload?: OrderRequestBody, options?: RequestOptions): ThunkAction<SubmitOrderAction, InternalCheckoutSelectors> {
         return store => concat(
             of(createAction(OrderActionType.SubmitOrderRequested)),
             defer(() => {
@@ -83,7 +83,7 @@ export default class OrderActionCreator {
                     this._checkoutValidator.validate(checkout, options)
                         .then(() => this._orderRequestSender.submitOrder(
                             this._mapToOrderRequestBody(
-                                payload,
+                                payload ?? {},
                                 checkout.customerMessage,
                                 externalSource
                             ),

--- a/src/order/order-request-sender.ts
+++ b/src/order/order-request-sender.ts
@@ -46,7 +46,7 @@ export default class OrderRequestSender {
         });
     }
 
-    submitOrder(body: InternalOrderRequestBody, { headers, timeout }: SubmitOrderRequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
+    submitOrder(body?: InternalOrderRequestBody, { headers, timeout }: SubmitOrderRequestOptions = {}): Promise<Response<InternalOrderResponseBody>> {
         const url = '/internalapi/v1/checkout/order';
 
         return this._requestSender.post<InternalOrderResponseBody>(url, {

--- a/src/shipping/consignment-selector.ts
+++ b/src/shipping/consignment-selector.ts
@@ -3,7 +3,9 @@ import { find } from 'lodash';
 
 import { isAddressEqual, AddressRequestBody } from '../address';
 import { CartSelector, PhysicalItem } from '../cart';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { createSelector } from '../common/selector';
+import { guard } from '../common/utility';
 
 import Consignment from './consignment';
 import ConsignmentState, { DEFAULT_STATE } from './consignment-state';
@@ -11,6 +13,7 @@ import ShippingOption from './shipping-option';
 
 export default interface ConsignmentSelector {
     getConsignments(): Consignment[] | undefined;
+    getConsignmentsOrThrow(): Consignment[];
     getConsignmentById(id: string): Consignment | undefined;
     getConsignmentByAddress(address: AddressRequestBody): Consignment | undefined;
     getShippingOption(): ShippingOption | undefined;
@@ -44,6 +47,13 @@ export function createConsignmentSelectorFactory(): ConsignmentSelectorFactory {
     const getConsignments = createSelector(
         (state: ConsignmentState) => state.data,
         consignments => () => consignments
+    );
+
+    const getConsignmentsOrThrow = createSelector(
+        getConsignments,
+        getConsignments => () => {
+            return guard(getConsignments(), () => new MissingDataError(MissingDataErrorType.MissingConsignments));
+        }
     );
 
     const getConsignmentById = createSelector(
@@ -224,6 +234,7 @@ export function createConsignmentSelectorFactory(): ConsignmentSelectorFactory {
     ): ConsignmentSelector => {
         return {
             getConsignments: getConsignments(state),
+            getConsignmentsOrThrow: getConsignmentsOrThrow(state),
             getConsignmentById: getConsignmentById(state),
             getConsignmentByAddress: getConsignmentByAddress(state),
             getShippingOption: getShippingOption(state),

--- a/src/shipping/index.ts
+++ b/src/shipping/index.ts
@@ -17,6 +17,7 @@ export { default as PickupOptionSelector, PickupOptionSelectorFactory, createPic
 export { default as PickupOptionState } from './pickup-option-state';
 export { default as pickupOptionReducer } from './pickup-option-reducer';
 
+export { ShippingAddress, ShippingAddressRequestBody } from './shipping-address';
 export { default as ShippingAddressSelector, ShippingAddressSelectorFactory, createShippingAddressSelectorFactory } from './shipping-address-selector';
 
 export { default as ShippingCountryActionCreator } from './shipping-country-action-creator';

--- a/src/shipping/shipping-address-selector.ts
+++ b/src/shipping/shipping-address-selector.ts
@@ -1,12 +1,15 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 
 import { Address } from '../address';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { createSelector } from '../common/selector';
+import { guard } from '../common/utility';
 
 import ConsignmentState, { DEFAULT_STATE } from './consignment-state';
 
 export default interface ShippingAddressSelector {
     getShippingAddress(): Address | undefined;
+    getShippingAddressOrThrow(): Address;
 }
 
 export type ShippingAddressSelectorFactory = (state: ConsignmentState) => ShippingAddressSelector;
@@ -23,11 +26,19 @@ export function createShippingAddressSelectorFactory(): ShippingAddressSelectorF
         }
     );
 
+    const getShippingAddressOrThrow = createSelector(
+        getShippingAddress,
+        getShippingAddress => () => {
+            return guard(getShippingAddress(), () => new MissingDataError(MissingDataErrorType.MissingShippingAddress));
+        }
+    );
+
     return memoizeOne((
         state: ConsignmentState = DEFAULT_STATE
     ): ShippingAddressSelector => {
         return {
             getShippingAddress: getShippingAddress(state),
+            getShippingAddressOrThrow: getShippingAddressOrThrow(state),
         };
     });
 }

--- a/src/shipping/shipping-address.ts
+++ b/src/shipping/shipping-address.ts
@@ -1,0 +1,4 @@
+import { Address, AddressRequestBody } from '../address';
+
+export type ShippingAddress = Address;
+export type ShippingAddressRequestBody = AddressRequestBody;


### PR DESCRIPTION
## What?
Add `PaymentIntegrationService` to be used in payment strategies according to [this proposal](https://github.com/bigcommerce/documentation/pull/707).

## Why?
So that payment strategies, which will be extracted into their own packages, can depend on an established API contract implemented by the checkout team.

## Testing / Proof
Unit

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team
