### PR TITLE
[WIP] feat(payment): PAYPAL-1177 added Braintree 3DS verification for Stored Credit Card

### DIFF
--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -60,12 +60,7 @@ import { OfflinePaymentStrategy } from './strategies/offline';
 import { OffsitePaymentStrategy } from './strategies/offsite';
 import { OpyPaymentStrategy, OpyScriptLoader } from './strategies/opy';
 import { PaypalExpressPaymentStrategy, PaypalProPaymentStrategy, PaypalScriptLoader } from './strategies/paypal';
-import { createPaypalCommercePaymentProcessor,
-    PaypalCommerceCreditCardPaymentStrategy,
-    PaypalCommerceFundingKeyResolver,
-    PaypalCommerceHostedForm,
-    PaypalCommercePaymentStrategy,
-    PaypalCommerceRequestSender } from './strategies/paypal-commerce';
+import { createPaypalCommercePaymentProcessor, PaypalCommerceCreditCardPaymentStrategy, PaypalCommerceFundingKeyResolver, PaypalCommerceHostedForm, PaypalCommercePaymentStrategy, PaypalCommerceRequestSender } from './strategies/paypal-commerce';
 import { createStepHandler, createSubStrategyRegistry, PaymentResumer, PPSDKStrategy } from './strategies/ppsdk';
 import { QuadpayPaymentStrategy } from './strategies/quadpay';
 import { SagePayPaymentStrategy } from './strategies/sage-pay';
@@ -90,7 +85,7 @@ export default function createPaymentStrategyRegistry(
         new BillingAddressRequestSender(requestSender),
         new SubscriptionsActionCreator(new SubscriptionsRequestSender(requestSender))
     );
-    const braintreePaymentProcessor = createBraintreePaymentProcessor(scriptLoader);
+    const braintreePaymentProcessor = createBraintreePaymentProcessor(scriptLoader, store, requestSender);
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
     const spamProtectionActionCreator = new SpamProtectionActionCreator(spamProtection, new SpamProtectionRequestSender(requestSender));

--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -18,7 +18,7 @@ export function getBraintree(): PaymentMethod {
             displayName: 'Credit Card',
             cardCode: true,
             enablePaypal: true,
-            merchantId: '',
+            merchantId: '100000',
             testMode: true,
             isVisaCheckoutEnabled: false,
         },

--- a/src/payment/payment-selector.ts
+++ b/src/payment/payment-selector.ts
@@ -129,6 +129,8 @@ export function createPaymentSelectorFactory(): PaymentSelectorFactory {
         getOrderMeta => () => {
             const meta = getOrderMeta();
 
+            console.log('meta', meta);
+
             return meta && meta.token;
         }
     );

--- a/src/payment/strategies/braintree/braintree.mock.ts
+++ b/src/payment/strategies/braintree/braintree.mock.ts
@@ -1,5 +1,6 @@
 import { OrderPaymentRequestBody } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getVaultedInstrument } from '../../payments.mock';
 
 import { BraintreeClient, BraintreeDataCollector, BraintreeHostedFields, BraintreeModule, BraintreeModuleCreator, BraintreePaypalCheckout, BraintreeRequestData, BraintreeShippingAddressOverride, BraintreeThreeDSecure, BraintreeTokenizePayload, BraintreeTokenizeResponse, BraintreeVerifyPayload, BraintreeVisaCheckout, GooglePayBraintreeSDK, VenmoInstance } from './braintree';
 import { BraintreeThreeDSecureOptions } from './braintree-payment-options';
@@ -162,6 +163,13 @@ export function getBraintreePaymentData(): OrderPaymentRequestBody {
     return {
         ...getOrderRequestBody().payment,
         methodId: 'braintree',
+    };
+}
+
+export function getBraintreeVaultedPaymentData(): OrderPaymentRequestBody {
+    return {
+        methodId: 'braintree',
+        paymentData: getVaultedInstrument(),
     };
 }
 

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -98,6 +98,7 @@ export interface BraintreeGooglePayThreeDSecure {
 export interface BraintreeThreeDSecureOptions {
     nonce: string;
     amount: number;
+    challengeRequested: boolean;
     showLoader?: boolean;
     addFrame(error: Error | undefined, iframe: HTMLIFrameElement): void;
     removeFrame(): void;

--- a/src/payment/strategies/braintree/create-braintree-payment-processor.ts
+++ b/src/payment/strategies/braintree/create-braintree-payment-processor.ts
@@ -1,5 +1,7 @@
+import { RequestSender } from '@bigcommerce/request-sender';
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
+import { CheckoutStore } from '../../../checkout';
 import { Overlay } from '../../../common/overlay';
 
 import BraintreeHostedForm from './braintree-hosted-form';
@@ -7,7 +9,7 @@ import BraintreePaymentProcessor from './braintree-payment-processor';
 import BraintreeScriptLoader from './braintree-script-loader';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 
-export default function createBraintreePaymentProcessor(scriptLoader: ScriptLoader) {
+export default function createBraintreePaymentProcessor(scriptLoader: ScriptLoader, store: CheckoutStore, requestSender: RequestSender) {
     const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader);
     const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
     const braintreeHostedForm = new BraintreeHostedForm(braintreeSDKCreator);
@@ -16,6 +18,8 @@ export default function createBraintreePaymentProcessor(scriptLoader: ScriptLoad
     return new BraintreePaymentProcessor(
         braintreeSDKCreator,
         braintreeHostedForm,
-        overlay
+        overlay,
+        store,
+        requestSender
     );
 }


### PR DESCRIPTION
## What?
Added Braintree 3DS verification for Stored Credit Card for Hosted and non-Hosted forms.

## Why?
Some EU merchants are having the issue with payments made with stored credit cards. When the customer tried to pay with store credit card the Braintree had an error with **"Authentication Required: The customer’s bank declined the transaction because a 3D Secure authentication was not performed during checkout"** message. 

The main point is in our implementation of 3DS verification for Braintree, or specifically in the fact that 3DS is skipped for stored credit card payments.

This behaviour seems to be by design, but the receiving banks are now rejecting these transactions due to this functionality. This is because of the new 3DS2 EU requirements stipulating that 3DS much be checked.

## Testing / Proof
- will be provided soon.

@bigcommerce/checkout @bigcommerce/payments
