### PR TITLE
feat(payment): Payments 7707 Create PPSDK credit card substrategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng=="
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ=="
     },
     "@babel/core": {
       "version": "7.6.2",
@@ -200,23 +200,23 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
       "requires": {
-        "@babel/compat-data": "^7.16.4",
+        "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.19.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
-          "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+          "version": "4.20.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+          "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
           "requires": {
-            "caniuse-lite": "^1.0.30001312",
-            "electron-to-chromium": "^1.4.71",
+            "caniuse-lite": "^1.0.30001317",
+            "electron-to-chromium": "^1.4.84",
             "escalade": "^3.1.1",
             "node-releases": "^2.0.2",
             "picocolors": "^1.0.0"
@@ -1356,9 +1356,9 @@
       }
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.16.0.tgz",
-      "integrity": "sha512-aAU7LN0Ivayrk/JTg3wyTRyfMmKEJBeq1LSq4nBzAyvLhIsI18JWDd9fuS/pFuYXa5b9E2u5fXPnfadPHIGU1Q==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.17.0.tgz",
+      "integrity": "sha512-S3ps6C59JB/VrAIWluz4F0Us/JTi5S6yRnwF+zHLO4OpNU3dBIYytLTs/q7eXwCe5CkOeZXVx9mspItV97c13g==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^27.4.6",
@@ -1375,9 +1375,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
-          "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.9.tgz",
+          "integrity": "sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==",
           "requires": {
             "@babel/types": "^7.17.0",
             "jsesc": "^2.5.1",
@@ -1392,21 +1392,12 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-          "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+          "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
           "requires": {
-            "@babel/helper-get-function-arity": "^7.16.7",
             "@babel/template": "^7.16.7",
-            "@babel/types": "^7.16.7"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-          "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-          "requires": {
-            "@babel/types": "^7.16.7"
+            "@babel/types": "^7.17.0"
           }
         },
         "@babel/helper-hoist-variables": {
@@ -1426,13 +1417,13 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.17.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
-          "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+          "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
           "requires": {
             "@babel/helper-environment-visitor": "^7.16.7",
             "@babel/helper-module-imports": "^7.16.7",
-            "@babel/helper-simple-access": "^7.16.7",
+            "@babel/helper-simple-access": "^7.17.7",
             "@babel/helper-split-export-declaration": "^7.16.7",
             "@babel/helper-validator-identifier": "^7.16.7",
             "@babel/template": "^7.16.7",
@@ -1441,11 +1432,11 @@
           }
         },
         "@babel/helper-simple-access": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-          "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+          "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
           "requires": {
-            "@babel/types": "^7.16.7"
+            "@babel/types": "^7.17.0"
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -1457,19 +1448,19 @@
           }
         },
         "@babel/helpers": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-          "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+          "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
           "requires": {
             "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.17.0",
+            "@babel/traverse": "^7.17.9",
             "@babel/types": "^7.17.0"
           }
         },
         "@babel/highlight": {
-          "version": "7.16.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-          "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+          "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.16.7",
             "chalk": "^2.0.0",
@@ -1523,9 +1514,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
-          "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA=="
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz",
+          "integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg=="
         },
         "@babel/template": {
           "version": "7.16.7",
@@ -1538,17 +1529,17 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz",
+          "integrity": "sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==",
           "requires": {
             "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.3",
+            "@babel/generator": "^7.17.9",
             "@babel/helper-environment-visitor": "^7.16.7",
-            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-function-name": "^7.17.9",
             "@babel/helper-hoist-variables": "^7.16.7",
             "@babel/helper-split-export-declaration": "^7.16.7",
-            "@babel/parser": "^7.17.3",
+            "@babel/parser": "^7.17.9",
             "@babel/types": "^7.17.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
@@ -1598,9 +1589,9 @@
           }
         },
         "@types/babel__core": {
-          "version": "7.1.18",
-          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
-          "integrity": "sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==",
+          "version": "7.1.19",
+          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
+          "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
           "requires": {
             "@babel/parser": "^7.1.0",
             "@babel/types": "^7.0.0",
@@ -1725,9 +1716,9 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -1760,9 +1751,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.9",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-          "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "has-flag": {
           "version": "4.0.0",
@@ -1792,24 +1783,24 @@
           },
           "dependencies": {
             "@babel/core": {
-              "version": "7.17.5",
-              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
-              "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
+              "version": "7.17.9",
+              "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
+              "integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
               "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.17.3",
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helpers": "^7.17.2",
-                "@babel/parser": "^7.17.3",
+                "@babel/generator": "^7.17.9",
+                "@babel/helper-compilation-targets": "^7.17.7",
+                "@babel/helper-module-transforms": "^7.17.7",
+                "@babel/helpers": "^7.17.9",
+                "@babel/parser": "^7.17.9",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.17.3",
+                "@babel/traverse": "^7.17.9",
                 "@babel/types": "^7.17.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
-                "json5": "^2.1.2",
+                "json5": "^2.2.1",
                 "semver": "^6.3.0"
               }
             },
@@ -1903,20 +1894,17 @@
           "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "json5": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
         },
         "micromatch": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
           "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.2.3"
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
           },
           "dependencies": {
             "picomatch": {
@@ -1925,11 +1913,6 @@
               "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
             }
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "ms": {
           "version": "2.1.2",
@@ -4050,9 +4033,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+      "version": "1.0.30001332",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -5928,9 +5911,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.75",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
-      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q=="
+      "version": "1.4.111",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
+      "integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -7226,7 +7209,6 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7422,8 +7404,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7513,8 +7494,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -10564,9 +10544,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
+      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw=="
     },
     "normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@bigcommerce/bigpay-client": "^5.16.0",
+    "@bigcommerce/bigpay-client": "^5.17.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",

--- a/src/hosted-form/hosted-form-factory.spec.ts
+++ b/src/hosted-form/hosted-form-factory.spec.ts
@@ -1,4 +1,8 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
 import { createCheckoutStore, ReadableCheckoutStore } from '../checkout';
+import { StepHandler } from '../payment/strategies/ppsdk/step-handler';
+import { ContinueHandler } from '../payment/strategies/ppsdk/step-handler/continue-handler';
 
 import HostedFieldType from './hosted-field-type';
 import HostedForm from './hosted-form';
@@ -10,7 +14,7 @@ describe('HostedFormFactory', () => {
 
     beforeEach(() => {
         store = createCheckoutStore();
-        factory = new HostedFormFactory(store);
+        factory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(new FormPoster())));
     });
 
     it('creates hosted form', () => {

--- a/src/hosted-form/hosted-form-factory.ts
+++ b/src/hosted-form/hosted-form-factory.ts
@@ -17,10 +17,11 @@ import HostedFormOrderDataTransformer from './hosted-form-order-data-transformer
 
 export default class HostedFormFactory {
     constructor(
-        private _store: ReadableCheckoutStore
+        private _store: ReadableCheckoutStore,
+        private _ppsdkStepHandler: StepHandler
     ) {}
 
-    create(host: string, options: HostedFormOptions, ppsdkStepHandler?: StepHandler): HostedForm {
+    create(host: string, options: HostedFormOptions): HostedForm {
         const fieldTypes = Object.keys(options.fields) as HostedFieldType[];
         const fields = fieldTypes.reduce<HostedField[]>((result, type) => {
             const fields = options.fields as HostedStoredCardFieldOptionsMap & HostedCardFieldOptionsMap;
@@ -54,7 +55,7 @@ export default class HostedFormFactory {
             new HostedFormOrderDataTransformer(this._store),
             pick(options, 'onBlur', 'onEnter', 'onFocus', 'onCardTypeChange', 'onValidate'),
             new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader())),
-            ppsdkStepHandler
+            this._ppsdkStepHandler
         );
     }
 

--- a/src/hosted-form/hosted-form-factory.ts
+++ b/src/hosted-form/hosted-form-factory.ts
@@ -6,6 +6,7 @@ import { DetachmentObserver, MutationObserverFactory } from '../common/dom';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 import { CardInstrument } from '../payment/instrument';
+import { StepHandler } from '../payment/strategies/ppsdk/step-handler';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../spam-protection';
 
 import HostedField from './hosted-field';
@@ -19,7 +20,7 @@ export default class HostedFormFactory {
         private _store: ReadableCheckoutStore
     ) {}
 
-    create(host: string, options: HostedFormOptions): HostedForm {
+    create(host: string, options: HostedFormOptions, ppsdkStepHandler?: StepHandler): HostedForm {
         const fieldTypes = Object.keys(options.fields) as HostedFieldType[];
         const fields = fieldTypes.reduce<HostedField[]>((result, type) => {
             const fields = options.fields as HostedStoredCardFieldOptionsMap & HostedCardFieldOptionsMap;
@@ -52,7 +53,8 @@ export default class HostedFormFactory {
             new IframeEventListener(host),
             new HostedFormOrderDataTransformer(this._store),
             pick(options, 'onBlur', 'onEnter', 'onFocus', 'onCardTypeChange', 'onValidate'),
-            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader())),
+            ppsdkStepHandler
         );
     }
 

--- a/src/hosted-form/hosted-form.spec.ts
+++ b/src/hosted-form/hosted-form.spec.ts
@@ -1,9 +1,12 @@
+import { FormPoster } from '@bigcommerce/form-poster';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse, getErrorResponseBody } from '../common/http-request/responses.mock';
 import { IframeEventListener } from '../common/iframe';
 import { PaymentAdditionalAction } from '../payment';
+import { StepHandler } from '../payment/strategies/ppsdk/step-handler';
+import { ContinueHandler } from '../payment/strategies/ppsdk/step-handler/continue-handler';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../spam-protection';
 
 import HostedField from './hosted-field';
@@ -66,7 +69,8 @@ describe('HostedForm', () => {
             eventListener,
             payloadTransformer as HostedFormOrderDataTransformer,
             callbacks,
-            paymentHumanVerificationHandler
+            paymentHumanVerificationHandler,
+            new StepHandler(new ContinueHandler(new FormPoster()))
         );
 
         errorResponse = {

--- a/src/hosted-form/hosted-form.ts
+++ b/src/hosted-form/hosted-form.ts
@@ -2,6 +2,7 @@ import { noop, without } from 'lodash';
 
 import { IframeEventListener } from '../common/iframe';
 import { OrderPaymentRequestBody } from '../order';
+import { StepHandler } from '../payment/strategies/ppsdk/step-handler';
 import { PaymentHumanVerificationHandler } from '../spam-protection';
 
 import { InvalidHostedFormConfigError } from './errors';
@@ -21,7 +22,8 @@ export default class HostedForm {
         private _eventListener: IframeEventListener<HostedInputEventMap>,
         private _payloadTransformer: HostedFormOrderDataTransformer,
         private _eventCallbacks: HostedFormEventCallbacks,
-        private _paymentHumanVerificationHandler: PaymentHumanVerificationHandler
+        private _paymentHumanVerificationHandler: PaymentHumanVerificationHandler,
+        ppsdkStepHandler?: StepHandler
     ) {
         const { onBlur = noop, onCardTypeChange = noop, onFocus = noop, onValidate = noop } = this._eventCallbacks;
 
@@ -33,6 +35,8 @@ export default class HostedForm {
 
         this._eventListener.addListener(HostedInputEventType.CardTypeChanged, ({ payload }) => this._cardType = payload.cardType);
         this._eventListener.addListener(HostedInputEventType.BinChanged, ({ payload }) => this._bin = payload.bin);
+
+        this._eventListener.addListener(HostedInputEventType.SubmitSucceeded, ({ payload }) => ppsdkStepHandler?.handle(payload));
     }
 
     getBin(): string | undefined {

--- a/src/hosted-form/iframe-content/hosted-input-events.ts
+++ b/src/hosted-form/iframe-content/hosted-input-events.ts
@@ -106,6 +106,10 @@ export interface HostedInputEnterEvent {
 
 export interface HostedInputSubmitSuccessEvent {
     type: HostedInputEventType.SubmitSucceeded;
+    payload: {
+        paymentType?: string;
+        response: Response<unknown>;
+    };
 }
 
 export interface HostedInputSubmitErrorEvent {

--- a/src/hosted-form/iframe-content/hosted-input-payment-handler.spec.ts
+++ b/src/hosted-form/iframe-content/hosted-input-payment-handler.spec.ts
@@ -139,7 +139,7 @@ describe('HostedInputPaymentHandler', () => {
             .toHaveBeenCalledWith(getPaymentRequestBody());
     });
 
-    it('posts event if payment submission succeeds', async () => {
+    it('posts event with payload if payment submission succeeds', async () => {
         jest.spyOn(eventPoster, 'post');
 
         await handler.handle({
@@ -148,7 +148,18 @@ describe('HostedInputPaymentHandler', () => {
         });
 
         expect(eventPoster.post)
-            .toHaveBeenCalledWith({ type: HostedInputEventType.SubmitSucceeded });
+            .toHaveBeenCalledWith({
+                type: HostedInputEventType.SubmitSucceeded,
+                payload: {
+                    paymentType: 'PAYMENT_TYPE_API',
+                    response: {
+                        body: getPaymentResponseBody(),
+                        headers: { 'content-type': 'application/json' },
+                        status: 200,
+                        statusText: 'OK',
+                    },
+                },
+            });
     });
 
     it('posts event if payment submission fails', async () => {

--- a/src/hosted-form/iframe-content/hosted-input-payment-handler.ts
+++ b/src/hosted-form/iframe-content/hosted-input-payment-handler.ts
@@ -43,7 +43,7 @@ export default class HostedInputPaymentHandler {
         }
 
         try {
-            await this._paymentRequestSender.submitPayment(
+            const response = await this._paymentRequestSender.submitPayment(
                 this._paymentRequestTransformer.transformWithHostedFormData(
                     values,
                     data,
@@ -51,7 +51,10 @@ export default class HostedInputPaymentHandler {
                 )
             );
 
-            this._eventPoster.post({ type: HostedInputEventType.SubmitSucceeded });
+            this._eventPoster.post({
+                type: HostedInputEventType.SubmitSucceeded,
+                payload: { paymentType: data.paymentMethod?.type, response },
+            });
         } catch (error) {
             this._eventPoster.post({
                 type: HostedInputEventType.SubmitFailed,

--- a/src/payment/create-payment-strategy-registry.ts
+++ b/src/payment/create-payment-strategy-registry.ts
@@ -106,9 +106,9 @@ export default function createPaymentStrategyRegistry(
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender, checkoutActionCreator);
     const paymentStrategyActionCreator = new PaymentStrategyActionCreator(registry, orderActionCreator, spamProtectionActionCreator);
     const formPoster = createFormPoster();
-    const hostedFormFactory = new HostedFormFactory(store);
-    const storefrontPaymentRequestSender = new StorefrontPaymentRequestSender(requestSender);
     const stepHandler = createStepHandler(formPoster);
+    const hostedFormFactory = new HostedFormFactory(store, stepHandler);
+    const storefrontPaymentRequestSender = new StorefrontPaymentRequestSender(requestSender);
 
     registry.register(PaymentStrategyType.ADYENV2, () =>
         new AdyenV2PaymentStrategy(
@@ -705,7 +705,7 @@ export default function createPaymentStrategyRegistry(
         new PPSDKStrategy(
             store,
             orderActionCreator,
-            createSubStrategyRegistry(requestSender, stepHandler),
+            createSubStrategyRegistry(store, orderActionCreator, requestSender, stepHandler, hostedFormFactory),
             new PaymentResumer(requestSender, stepHandler),
             new BrowserStorage('PPSDK')
         )

--- a/src/payment/payment-strategy-action-creator.spec.ts
+++ b/src/payment/payment-strategy-action-creator.spec.ts
@@ -1,5 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction } from '@bigcommerce/data-store';
+import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
@@ -29,6 +30,8 @@ import PaymentStrategyType from './payment-strategy-type';
 import { PaymentStrategy } from './strategies';
 import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { NoPaymentDataRequiredPaymentStrategy } from './strategies/no-payment';
+import { StepHandler } from './strategies/ppsdk/step-handler';
+import { ContinueHandler } from './strategies/ppsdk/step-handler/continue-handler';
 
 describe('PaymentStrategyActionCreator', () => {
     let orderActionCreator: OrderActionCreator;
@@ -65,7 +68,7 @@ describe('PaymentStrategyActionCreator', () => {
                 new PaymentRequestTransformer(),
                 paymentHumanVerificationHandler
             ),
-            new HostedFormFactory(store)
+            new HostedFormFactory(store, new StepHandler(new ContinueHandler(new FormPoster())))
         );
         noPaymentDataStrategy = new NoPaymentDataRequiredPaymentStrategy(
             store,

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.spec.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
@@ -26,6 +27,8 @@ import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import * as paymentStatusTypes from '../../payment-status-types';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
+import { StepHandler } from '../ppsdk/step-handler';
+import { ContinueHandler } from '../ppsdk/step-handler/continue-handler';
 
 import { CBAMPGSPaymentStrategy, CBAMPGSScriptLoader } from './';
 import { ThreeDSjs } from './cba-mpgs';
@@ -77,7 +80,7 @@ describe('CBAMPGSPaymentStrategy', () => {
             store,
             orderActionCreator,
             paymentActionCreator,
-            new HostedFormFactory(store),
+            new HostedFormFactory(store, new StepHandler(new ContinueHandler(new FormPoster()))),
             paymentMethodActionCreator,
             cbaMPGSScriptLoader,
             'en_US'

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-apm/checkoutcom-apm-payment-strategy.spec.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-apm/checkoutcom-apm-payment-strategy.spec.ts
@@ -24,6 +24,8 @@ import PaymentRequestSender from '../../../payment-request-sender';
 import PaymentRequestTransformer from '../../../payment-request-transformer';
 import * as paymentStatusTypes from '../../../payment-status-types';
 import { getErrorPaymentResponseBody } from '../../../payments.mock';
+import { StepHandler } from '../../ppsdk/step-handler';
+import { ContinueHandler } from '../../ppsdk/step-handler/continue-handler';
 
 import CheckoutcomAPMPaymentStrategy from './checkoutcom-apm-payment-strategy';
 
@@ -42,7 +44,6 @@ describe('CheckoutcomAPMPaymentStrategy', () => {
     let state: InternalCheckoutSelectors;
 
     beforeEach(() => {
-        formFactory = new HostedFormFactory(store);
         requestSender = createRequestSender();
         orderRequestSender = new OrderRequestSender(requestSender);
         orderActionCreator = new OrderActionCreator(
@@ -58,6 +59,7 @@ describe('CheckoutcomAPMPaymentStrategy', () => {
         );
 
         formPoster = createFormPoster();
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(formPoster)));
         store = createCheckoutStore(getCheckoutStoreState());
 
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.spec.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-ideal/checkoutcom-ideal-payment-strategy.spec.ts
@@ -17,6 +17,8 @@ import { PaymentActionType, SubmitPaymentAction } from '../../../payment-actions
 import { getPaymentMethod } from '../../../payment-methods.mock';
 import PaymentRequestSender from '../../../payment-request-sender';
 import PaymentRequestTransformer from '../../../payment-request-transformer';
+import { StepHandler } from '../../ppsdk/step-handler';
+import { ContinueHandler } from '../../ppsdk/step-handler/continue-handler';
 
 import CheckoutcomiDealPaymentStrategy from './checkoutcom-ideal-payment-strategy';
 
@@ -35,7 +37,6 @@ describe('CheckoutcomiDealPaymentStrategy', () => {
     let state: InternalCheckoutSelectors;
 
     beforeEach(() => {
-        formFactory = new HostedFormFactory(store);
         requestSender = createRequestSender();
         orderRequestSender = new OrderRequestSender(requestSender);
         orderActionCreator = new OrderActionCreator(
@@ -51,6 +52,7 @@ describe('CheckoutcomiDealPaymentStrategy', () => {
         );
 
         formPoster = createFormPoster();
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(formPoster)));
         store = createCheckoutStore(getCheckoutStoreState());
 
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-fawry-payment-strategy.spec.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-fawry-payment-strategy.spec.ts
@@ -17,6 +17,8 @@ import { PaymentActionType, SubmitPaymentAction } from '../../../payment-actions
 import { getPaymentMethod } from '../../../payment-methods.mock';
 import PaymentRequestSender from '../../../payment-request-sender';
 import PaymentRequestTransformer from '../../../payment-request-transformer';
+import { StepHandler } from '../../ppsdk/step-handler';
+import { ContinueHandler } from '../../ppsdk/step-handler/continue-handler';
 
 import CheckoutcomFawryPaymentStrategy from './checkoutcom-fawry-payment-strategy';
 
@@ -35,7 +37,6 @@ describe('CheckoutcomFawryPaymentStrategy', () => {
     let state: InternalCheckoutSelectors;
 
     beforeEach(() => {
-        formFactory = new HostedFormFactory(store);
         requestSender = createRequestSender();
         orderRequestSender = new OrderRequestSender(requestSender);
         orderActionCreator = new OrderActionCreator(
@@ -51,6 +52,7 @@ describe('CheckoutcomFawryPaymentStrategy', () => {
         );
 
         formPoster = createFormPoster();
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(formPoster)));
         store = createCheckoutStore(getCheckoutStoreState());
 
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));

--- a/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-sepa-payment-strategy.spec.ts
+++ b/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-sepa-payment-strategy.spec.ts
@@ -24,6 +24,8 @@ import PaymentRequestSender from '../../../payment-request-sender';
 import PaymentRequestTransformer from '../../../payment-request-transformer';
 import * as paymentStatusTypes from '../../../payment-status-types';
 import { getErrorPaymentResponseBody } from '../../../payments.mock';
+import { StepHandler } from '../../ppsdk/step-handler';
+import { ContinueHandler } from '../../ppsdk/step-handler/continue-handler';
 
 import CheckoutcomSEPAPaymentStrategy from './checkoutcom-sepa-payment-strategy';
 
@@ -42,7 +44,6 @@ describe('CheckoutcomSEPAPaymentStrategy', () => {
     let state: InternalCheckoutSelectors;
 
     beforeEach(() => {
-        formFactory = new HostedFormFactory(store);
         requestSender = createRequestSender();
         orderRequestSender = new OrderRequestSender(requestSender);
         orderActionCreator = new OrderActionCreator(
@@ -58,6 +59,7 @@ describe('CheckoutcomSEPAPaymentStrategy', () => {
         );
 
         formPoster = createFormPoster();
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(formPoster)));
         store = createCheckoutStore(getCheckoutStoreState());
 
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));

--- a/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card-redirect/credit-card-redirect-payment-strategy.spec.ts
@@ -24,6 +24,8 @@ import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import * as paymentStatusTypes from '../../payment-status-types';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
+import { StepHandler } from '../ppsdk/step-handler';
+import { ContinueHandler } from '../ppsdk/step-handler/continue-handler';
 
 import CreditCardRedirectPaymentStrategy from './credit-card-redirect-payment-strategy';
 
@@ -41,7 +43,6 @@ describe('CreditCardRedirectPaymentStrategy', () => {
     let submitPaymentAction: Observable<SubmitPaymentAction>;
 
     beforeEach(() => {
-        formFactory = new HostedFormFactory(store);
         requestSender = createRequestSender();
         orderRequestSender = new OrderRequestSender(requestSender);
         orderActionCreator = new OrderActionCreator(
@@ -57,6 +58,7 @@ describe('CreditCardRedirectPaymentStrategy', () => {
         );
 
         formPoster = createFormPoster();
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(formPoster)));
         store = createCheckoutStore(getCheckoutStoreState());
 
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));

--- a/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
+++ b/src/payment/strategies/credit-card/credit-card-payment-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
+import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge, omit } from 'lodash';
@@ -19,6 +20,8 @@ import { getPaymentMethod } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
+import { StepHandler } from '../ppsdk/step-handler';
+import { ContinueHandler } from '../ppsdk/step-handler/continue-handler';
 
 import CreditCardPaymentStrategy from './credit-card-payment-strategy';
 
@@ -49,7 +52,7 @@ describe('CreditCardPaymentStrategy', () => {
             new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
         );
 
-        formFactory = new HostedFormFactory(store);
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(new FormPoster())));
 
         strategy = new CreditCardPaymentStrategy(
             store,

--- a/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction } from '@bigcommerce/data-store';
+import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { of, Observable } from 'rxjs';
@@ -18,6 +19,8 @@ import { getMollie } from '../../payment-methods.mock';
 import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
+import { StepHandler } from '../ppsdk/step-handler';
+import { ContinueHandler } from '../ppsdk/step-handler/continue-handler';
 
 import {  MollieClient, MollieElement, MollieHostWindow } from './mollie';
 import MolliePaymentStrategy from './mollie-payment-strategy';
@@ -87,7 +90,7 @@ describe('MolliePaymentStrategy', () => {
             .mockReturnValue(mollieElement);
         jest.spyOn(document, 'querySelectorAll');
 
-        formFactory = new HostedFormFactory(store);
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(new FormPoster())));
         strategy = new MolliePaymentStrategy(
             formFactory,
             store,

--- a/src/payment/strategies/moneris/moneris-payment-strategy.spec.ts
+++ b/src/payment/strategies/moneris/moneris-payment-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
+import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
@@ -22,6 +23,8 @@ import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentRequestTransformer from '../../payment-request-transformer';
+import { StepHandler } from '../ppsdk/step-handler';
+import { ContinueHandler } from '../ppsdk/step-handler/continue-handler';
 
 import MonerisPaymentStrategy from './moneris-payment-strategy';
 import { getHostedFormInitializeOptions, getOrderRequestBodyVaultedCC } from './moneris.mock';
@@ -120,7 +123,7 @@ describe('MonerisPaymentStrategy', () => {
 
         jest.spyOn(window, 'removeEventListener');
 
-        formFactory = new HostedFormFactory(store);
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(new FormPoster())));
         strategy = new MonerisPaymentStrategy(
             formFactory,
             store,

--- a/src/payment/strategies/ppsdk/create-ppsdk-sub-strategy-registry.ts
+++ b/src/payment/strategies/ppsdk/create-ppsdk-sub-strategy-registry.ts
@@ -1,12 +1,27 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 
+import { CheckoutStore } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator } from '../../../order';
+
 import { SubStrategyRegistry } from './ppsdk-sub-strategy-registry';
 import { SubStrategyType } from './ppsdk-sub-strategy-type';
 import { StepHandler } from './step-handler';
-import { NoneSubStrategy } from './sub-strategies';
+import { CardSubStrategy, NoneSubStrategy } from './sub-strategies';
 
-export const createSubStrategyRegistry = (requestSender: RequestSender, stepHandler: StepHandler) => {
+export const createSubStrategyRegistry = (
+    store: CheckoutStore,
+    orderActionCreator: OrderActionCreator,
+    requestSender: RequestSender,
+    stepHandler: StepHandler,
+    hostedFormFactory: HostedFormFactory
+) => {
     const registry = new SubStrategyRegistry();
+
+    registry.register(
+        SubStrategyType.CARD,
+        () => new CardSubStrategy(store, orderActionCreator, hostedFormFactory)
+    );
 
     registry.register(
         SubStrategyType.NONE,

--- a/src/payment/strategies/ppsdk/initialization-strategies/card.ts
+++ b/src/payment/strategies/ppsdk/initialization-strategies/card.ts
@@ -1,0 +1,7 @@
+import { InitializationStrategy } from '../../../';
+interface Card {
+    type: 'card_ui';
+}
+
+export const isCard = (strategy: Pick<InitializationStrategy, 'type'>): strategy is Card =>
+    strategy.type === 'card_ui';

--- a/src/payment/strategies/ppsdk/initialization-strategies/index.ts
+++ b/src/payment/strategies/ppsdk/initialization-strategies/index.ts
@@ -1,1 +1,2 @@
+export { isCard } from './card';
 export { isNone } from './none';

--- a/src/payment/strategies/ppsdk/ppsdk-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-strategy.ts
@@ -101,10 +101,14 @@ export class PPSDKStrategy implements PaymentStrategy {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
+        await this._subStrategy.initialize(options);
+
         return this._store.getState();
     }
 
     async deinitialize(_options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        this._subStrategy?.deinitialize();
+
         return this._store.getState();
     }
 }

--- a/src/payment/strategies/ppsdk/ppsdk-sub-strategy-registry.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-sub-strategy-registry.ts
@@ -3,11 +3,12 @@ import { cond, constant, stubTrue } from 'lodash';
 import { Registry } from '../../../common/registry';
 import { PPSDKPaymentMethod } from '../../ppsdk-payment-method';
 
-import { isNone } from './initialization-strategies';
+import { isCard, isNone } from './initialization-strategies';
 import { SubStrategy } from './ppsdk-sub-strategy';
 import { SubStrategyType } from './ppsdk-sub-strategy-type';
 
 const getToken = cond([
+    [isCard, constant(SubStrategyType.CARD)],
     [isNone, constant(SubStrategyType.NONE)],
     [stubTrue, constant(SubStrategyType.UNSUPPORTED)],
 ]);

--- a/src/payment/strategies/ppsdk/ppsdk-sub-strategy-type.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-sub-strategy-type.ts
@@ -1,4 +1,5 @@
 export enum SubStrategyType {
+    CARD = 'card_ui',
     NONE = 'none',
     UNSUPPORTED = 'unsupported',
 }

--- a/src/payment/strategies/ppsdk/ppsdk-sub-strategy.ts
+++ b/src/payment/strategies/ppsdk/ppsdk-sub-strategy.ts
@@ -1,4 +1,5 @@
 import { OrderPaymentRequestBody } from '../../../order';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 
 export interface SubStrategySettings {
     token: string;
@@ -9,4 +10,8 @@ export interface SubStrategySettings {
 
 export interface SubStrategy {
     execute(settings: SubStrategySettings): Promise<void>;
+
+    initialize(options?: PaymentInitializeOptions): Promise<void>;
+
+    deinitialize(options?: PaymentRequestOptions): void;
 }

--- a/src/payment/strategies/ppsdk/step-handler/continue-handler/continue-handler.ts
+++ b/src/payment/strategies/ppsdk/step-handler/continue-handler/continue-handler.ts
@@ -20,6 +20,7 @@ export class ContinueHandler {
         switch (body.code) {
             case 'redirect':
                 return handleRedirect(body.parameters, this._formPoster);
+            // TODO: Add a case for human verification handling
         }
     }
 }

--- a/src/payment/strategies/ppsdk/sub-strategies/card-sub-strategy.spec.ts
+++ b/src/payment/strategies/ppsdk/sub-strategies/card-sub-strategy.spec.ts
@@ -1,0 +1,183 @@
+import { createAction } from '@bigcommerce/data-store';
+import { FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../../checkout';
+import { getCheckoutStoreState } from '../../../../checkout/checkouts.mock';
+import { InvalidArgumentError, NotInitializedError } from '../../../../common/error/errors';
+import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../../hosted-form';
+import { LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderPaymentRequestBody, OrderRequestSender } from '../../../../order';
+import { getOrder } from '../../../../order/orders.mock';
+import { PaymentArgumentInvalidError } from '../../../errors';
+import { PaymentInitializeOptions } from '../../../payment-request-options';
+import { getPayment } from '../../../payments.mock';
+import { createStepHandler } from '../step-handler';
+
+import { CardSubStrategy } from './card-sub-strategy';
+
+describe('CreditCardPaymentStrategy', () => {
+    const stepHandler = createStepHandler(new FormPoster());
+    const requestSender = createRequestSender();
+
+    let formFactory: HostedFormFactory;
+    let form: Pick<HostedForm, 'attach' | 'submit' | 'validate'>;
+    let initializeOptions: PaymentInitializeOptions;
+    let loadOrderAction: Observable<LoadOrderSucceededAction>;
+    let orderActionCreator: OrderActionCreator;
+    let store: CheckoutStore;
+    let cardSubStrategy: CardSubStrategy;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        orderActionCreator = new OrderActionCreator(
+            new OrderRequestSender(requestSender),
+            new CheckoutValidator(new CheckoutRequestSender(requestSender))
+        );
+        formFactory = new HostedFormFactory(store, stepHandler);
+
+        cardSubStrategy = new CardSubStrategy(store, orderActionCreator, formFactory);
+
+        form = {
+            attach: jest.fn(() => Promise.resolve()),
+            submit: jest.fn(() => Promise.resolve()),
+            validate: jest.fn(() => Promise.resolve()),
+        };
+        initializeOptions = {
+            creditCard: {
+                form: {
+                    fields: {
+                        [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                        [HostedFieldType.CardName]: { containerId: 'card-name' },
+                        [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                    },
+                },
+            },
+            methodId: 'cabbage_pay.card',
+        };
+        loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
+
+        jest.spyOn(orderActionCreator, 'loadCurrentOrder')
+            .mockReturnValue(loadOrderAction);
+
+        jest.spyOn(formFactory, 'create')
+            .mockReturnValue(form);
+
+        jest.spyOn(store, 'dispatch');
+    });
+
+    describe('initialize()', () => {
+        it('creates hosted form', async () => {
+            await cardSubStrategy.initialize(initializeOptions);
+
+            expect(formFactory.create)
+                .toHaveBeenCalledWith(
+                    'https://bigpay.integration.zone',
+                    // tslint:disable-next-line:no-non-null-assertion
+                    initializeOptions.creditCard!.form!
+                );
+        });
+
+        it('attaches hosted form to container', async () => {
+            await cardSubStrategy.initialize(initializeOptions);
+
+            expect(form.attach)
+                .toHaveBeenCalled();
+        });
+
+        it('throws error form when fields does not exist ', async () => {
+            initializeOptions = {
+                methodId: 'cabbage_pay.card',
+            };
+            try {
+                await cardSubStrategy.initialize(initializeOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+    });
+
+    describe('execute()', () => {
+        const payment = getPayment() as OrderPaymentRequestBody;
+
+        it('throws error if hosted form does not exist', async () => {
+            try {
+                // execute without initialization
+                await cardSubStrategy.execute({
+                    payment,
+                    methodId: 'cabbage_pay.card',
+                    bigpayBaseUrl: 'https://bigpay.integration.zone',
+                    token: 'abc',
+                });
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
+        });
+
+        it('throws error if payment data is missing', async () => {
+            try {
+                await cardSubStrategy.initialize(initializeOptions);
+                await cardSubStrategy.execute({
+                    payment: undefined,
+                    methodId: 'cabbage_pay.card',
+                    bigpayBaseUrl: 'https://bigpay.integration.zone',
+                    token: 'abc',
+                });
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
+            }
+        });
+
+        it('validates user input before submitting data', async () => {
+            await cardSubStrategy.initialize(initializeOptions);
+            await cardSubStrategy.execute({
+                payment,
+                methodId: 'cabbage_pay.card',
+                bigpayBaseUrl: 'https://bigpay.integration.zone',
+                token: 'abc',
+            });
+
+            expect(form.validate).toHaveBeenCalled();
+        });
+
+        it('does not submit payment data with hosted form if validation fails', async () => {
+            jest.spyOn(form, 'validate').mockRejectedValue(new Error());
+
+            try {
+                await cardSubStrategy.initialize(initializeOptions);
+                await cardSubStrategy.execute({
+                    payment,
+                    methodId: 'cabbage_pay.card',
+                    bigpayBaseUrl: 'https://bigpay.integration.zone',
+                    token: 'abc',
+                });
+            } catch (error) {
+                expect(form.submit).not.toHaveBeenCalled();
+            }
+        });
+
+        it('submits payment data with hosted form', async () => {
+            await cardSubStrategy.initialize(initializeOptions);
+            await cardSubStrategy.execute({
+                payment,
+                methodId: 'cabbage_pay.card',
+                bigpayBaseUrl: 'https://bigpay.integration.zone',
+                token: 'abc',
+            });
+
+            expect(form.submit).toHaveBeenCalledWith(payment);
+        });
+
+        it('loads current order after payment submission', async () => {
+            await cardSubStrategy.initialize(initializeOptions);
+            await cardSubStrategy.execute({
+                payment,
+                methodId: 'cabbage_pay.card',
+                bigpayBaseUrl: 'https://bigpay.integration.zone',
+                token: 'abc',
+            });
+
+            expect(store.dispatch).toHaveBeenCalledWith(loadOrderAction);
+        });
+    });
+});

--- a/src/payment/strategies/ppsdk/sub-strategies/card-sub-strategy.ts
+++ b/src/payment/strategies/ppsdk/sub-strategies/card-sub-strategy.ts
@@ -1,0 +1,57 @@
+import { CheckoutStore } from '../../../../checkout';
+import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType } from '../../../../common/error/errors';
+import { HostedForm, HostedFormFactory } from '../../../../hosted-form';
+import { OrderActionCreator } from '../../../../order';
+import { PaymentArgumentInvalidError } from '../../../errors';
+import { PaymentInitializeOptions } from '../../../payment-request-options';
+import { SubStrategy, SubStrategySettings } from '../ppsdk-sub-strategy';
+
+export class CardSubStrategy implements SubStrategy {
+    protected _hostedForm?: HostedForm;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _hostedFormFactory: HostedFormFactory
+    ) {}
+
+    async execute({ payment }: SubStrategySettings): Promise<void> {
+        const form = this._hostedForm;
+
+        if (!form) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (!payment || !payment.methodId) {
+            throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+
+        await form.validate();
+
+        await form.submit(payment);
+
+        await this._store.dispatch(this._orderActionCreator.loadCurrentOrder());
+    }
+
+    async initialize(options?: PaymentInitializeOptions): Promise<void> {
+        const formOptions = options && options.creditCard && options.creditCard.form;
+        const { config } = this._store.getState();
+        const { paymentSettings: { bigpayBaseUrl: host = '' } = {} } = config.getStoreConfig() || {};
+
+        if (!formOptions) {
+            throw new InvalidArgumentError();
+        }
+
+        const form = formOptions && this._hostedFormFactory.create(host, formOptions);
+
+        await form.attach();
+
+        this._hostedForm = form;
+    }
+
+    deinitialize(): void {
+        if (this._hostedForm) {
+            this._hostedForm.detach();
+        }
+    }
+}

--- a/src/payment/strategies/ppsdk/sub-strategies/index.ts
+++ b/src/payment/strategies/ppsdk/sub-strategies/index.ts
@@ -1,1 +1,2 @@
+export { CardSubStrategy } from './card-sub-strategy';
 export { NoneSubStrategy } from './none-sub-strategy';

--- a/src/payment/strategies/ppsdk/sub-strategies/none-sub-strategy.ts
+++ b/src/payment/strategies/ppsdk/sub-strategies/none-sub-strategy.ts
@@ -10,7 +10,7 @@ export class NoneSubStrategy implements SubStrategy {
         private _stepHandler: StepHandler
     ) {}
 
-    execute({ methodId, bigpayBaseUrl, token }: SubStrategySettings) {
+    execute({ methodId, bigpayBaseUrl, token }: SubStrategySettings): Promise<void> {
         const body = { payment_method_id: methodId };
         const options = {
             credentials: false,
@@ -23,5 +23,13 @@ export class NoneSubStrategy implements SubStrategy {
 
         return this._requestSender.post<PaymentsAPIResponse['body']>(`${bigpayBaseUrl}/payments`, options)
             .then(response => this._stepHandler.handle(response));
+    }
+
+    initialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    deinitialize(): void {
+        return;
     }
 }

--- a/src/payment/strategies/sage-pay/sage-pay-payment-strategy.spec.ts
+++ b/src/payment/strategies/sage-pay/sage-pay-payment-strategy.spec.ts
@@ -24,6 +24,8 @@ import PaymentRequestTransformer from '../../payment-request-transformer';
 import * as paymentStatusTypes from '../../payment-status-types';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
 import { CreditCardPaymentStrategy } from '../credit-card';
+import { StepHandler } from '../ppsdk/step-handler';
+import { ContinueHandler } from '../ppsdk/step-handler/continue-handler';
 
 import SagePayPaymentStrategy from './sage-pay-payment-strategy';
 
@@ -54,7 +56,7 @@ describe('SagePayPaymentStrategy', () => {
         );
 
         formPoster = createFormPoster();
-        hostedFormFactory = new HostedFormFactory(store);
+        hostedFormFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(formPoster)));
         store = createCheckoutStore(getCheckoutStoreState());
 
         finalizeOrderAction = of(createAction(OrderActionType.FinalizeOrderRequested));

--- a/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { of, Observable } from 'rxjs';
@@ -26,6 +27,8 @@ import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { getStripeV3 } from '../../payment-methods.mock';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
+import { StepHandler } from '../ppsdk/step-handler';
+import { ContinueHandler } from '../ppsdk/step-handler/continue-handler';
 
 import { StripeElement, StripeElements, StripeElementType, StripePaymentMethodType, StripeV3Client } from './stripev3';
 import StripeV3PaymentStrategy from './stripev3-payment-strategy';
@@ -104,7 +107,7 @@ describe('StripeV3PaymentStrategy', () => {
         jest.spyOn(store.getState().checkout, 'getCheckoutOrThrow')
             .mockReturnValue(checkoutMock);
 
-        formFactory = new HostedFormFactory(store);
+        formFactory = new HostedFormFactory(store, new StepHandler(new ContinueHandler(new FormPoster())));
 
         strategy = new StripeV3PaymentStrategy(
             store,

--- a/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
+++ b/src/payment/strategies/wepay/wepay-payment-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
 import { createAction, Action } from '@bigcommerce/data-store';
+import { FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
@@ -16,6 +17,8 @@ import PaymentMethod from '../../payment-method';
 import { getWepay } from '../../payment-methods.mock';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
+import { StepHandler } from '../ppsdk/step-handler';
+import { ContinueHandler } from '../ppsdk/step-handler/continue-handler';
 
 import WepayPaymentStrategy from './wepay-payment-strategy';
 import WepayRiskClient from './wepay-risk-client';
@@ -56,7 +59,7 @@ describe('WepayPaymentStrategy', () => {
             store,
             orderActionCreator,
             paymentActionCreator,
-            new HostedFormFactory(store),
+            new HostedFormFactory(store, new StepHandler(new ContinueHandler(new FormPoster()))),
             wepayRiskClient
         );
 


### PR DESCRIPTION
## What?
Create a new payment strategy for Credit Card Payment methods by PPSDK payment providers, instead of using the existing generic credit card payment strategy.

## Why?
To allow handling of different credit card payment features that will be available via PPSDK, like human verification, 3D security check, vaulting credit cards, save as default payment method.

# Related PRs
checkout-js PR: https://github.com/bigcommerce/checkout-js/pull/841

## Testing / Proof
Unit tests
Screenshots
**Hosted form is rendered when PPSDK integration type experiment is turned on:**
<img width="1231" alt="Screen Shot 2022-04-05 at 11 06 49 am" src="https://user-images.githubusercontent.com/36555311/161658789-712742ce-359e-4ae0-9ed1-a9c534bbf39e.png">

**Method returns from bcapp as PAYMENT_TYPE_SDK:**
<img width="727" alt="Screen Shot 2022-04-05 at 11 08 11 am" src="https://user-images.githubusercontent.com/36555311/161679541-d8ea0691-e629-4466-bc0d-c9519cc675bb.png">

**The new payment endpoint is used:**
<img width="996" alt="Screen Shot 2022-04-05 at 11 10 08 am" src="https://user-images.githubusercontent.com/36555311/161658805-73e564bd-bdc8-4c6f-87cb-339c1907b298.png">

@bigcommerce/checkout @bigcommerce/payments
