### PR TITLE
fix(payment): INT-5821 Error on the Checkout related to Hide some fields using APM's

### DIFF
--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -630,6 +630,11 @@ describe('StripeUPEPaymentStrategy', () => {
                         expect(stripeUPEJsMock.confirmPayment).toHaveBeenCalledWith(
                             expect.objectContaining({
                                 confirmParams: {
+                                    payment_method_data: {
+                                        billing_details: expect.objectContaining({
+                                            email: 'test@bigcommerce.com',
+                                        }),
+                                    },
                                     return_url: 'https://redirect-url.com',
                                 },
                             })

--- a/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -227,13 +227,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             const action = error.body.additional_action_required;
 
             if (action && action.type === 'redirect_to_url' && action.data.redirect_url) {
-                const { paymentIntent, error: stripeError } = await this._stripeUPEClient.confirmPayment({
-                    elements: this._stripeElements,
-                    redirect: StripeStringConstants.IF_REQUIRED,
-                    confirmParams: {
-                        return_url: action.data.redirect_url,
-                    },
-                });
+                const { paymentIntent, error: stripeError } = await this._stripeUPEClient.confirmPayment(this._mapStripePaymentData(action.data.redirect_url));
 
                 if (stripeError) {
                     this._throwDisplayableStripeError(stripeError);
@@ -308,7 +302,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
     }
 
-    private _mapStripePaymentData(): StripeConfirmPaymentData {
+    private _mapStripePaymentData(returnUrl?: string): StripeConfirmPaymentData {
         const billingAddress = this._store.getState().billingAddress.getBillingAddress();
         const address = this._mapStripeAddress(billingAddress);
 
@@ -332,6 +326,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                         address,
                     },
                 },
+                ...(returnUrl && { return_url: returnUrl }),
             },
         };
     }


### PR DESCRIPTION
## What? [INT-5821](https://jira.bigcommerce.com/browse/INT-5821)
Fix for redirect payments with hidden fields

## Why?
Confirming redirect based methods was failing because the hidden fields were not being added to the confirm parameters

## Testing / Proof
https://drive.google.com/file/d/1_fgvCNJRsaKHDKoTz1u78P2ikguWonII/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/kyiv-payments-team 

