### PR TITLE
fix(shipping): CHECKOUT-6422 Update consignment interface and relevant selector method

### DIFF
--- a/src/shipping/consignment-selector.ts
+++ b/src/shipping/consignment-selector.ts
@@ -15,7 +15,7 @@ export default interface ConsignmentSelector {
     getConsignments(): Consignment[] | undefined;
     getConsignmentsOrThrow(): Consignment[];
     getConsignmentById(id: string): Consignment | undefined;
-    getConsignmentByAddress(address: AddressRequestBody): Consignment | undefined;
+    getConsignmentByAddress(address?: AddressRequestBody): Consignment | undefined;
     getShippingOption(): ShippingOption | undefined;
     getLoadError(): Error | undefined;
     getCreateError(): Error | undefined;
@@ -69,7 +69,11 @@ export function createConsignmentSelectorFactory(): ConsignmentSelectorFactory {
 
     const getConsignmentByAddress = createSelector(
         (state: ConsignmentState) => state.data,
-        consignments => (address: AddressRequestBody) => {
+        consignments => (address?: AddressRequestBody) => {
+            if (!address) {
+                return;
+            }
+
             if (!consignments || !consignments.length) {
                 return;
             }

--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -28,7 +28,7 @@ export interface ConsignmentCreateRequestBody {
 }
 
 export interface ConsignmentAssignmentRequestBody {
-    address: AddressRequestBody;
+    address?: AddressRequestBody;
     shippingAddress?: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;


### PR DESCRIPTION
## What?
- Update interface to assign/unassign items to a consignment
- Update selector method to get consignment by address

## Why?
As per changes due to pickup options, address is an optional property for a consignment. Hence need to make changes to relevant interfaces to reflect that.

Update the selector method accordingly.

## Testing / Proof
- Tests

@bigcommerce/checkout
