### PR TITLE
feat(payment): INT-5573 Add shopper locale to Mollie strategy

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -820,7 +820,9 @@ export function getMollie(): PaymentMethod {
             requireCustomerCode: false,
             testMode: true,
         },
-        initializationData: null,
+        initializationData: {
+            locale: 'en-US',
+        },
         type: 'PAYMENT_TYPE_API',
     };
 }

--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -58,6 +58,7 @@ export interface WithDocumentInstrument {
 
 export interface WithMollieIssuerInstrument {
     issuer: string;
+    shopper_locale: string;
 }
 
 export interface WithCheckoutcomSEPAInstrument {

--- a/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -175,6 +175,7 @@ describe('MolliePaymentStrategy', () => {
                             credit_card_token : {
                                 token: 'tkn_test',
                             },
+                            shopper_locale: 'en-US',
                         },
                     },
                 });
@@ -202,6 +203,7 @@ describe('MolliePaymentStrategy', () => {
                                 token: 'tkn_test',
                             },
                             set_as_default_stored_instrument: true,
+                            shopper_locale: 'en-US',
                             vault_payment_instrument: true,
                         },
                     },
@@ -218,8 +220,10 @@ describe('MolliePaymentStrategy', () => {
                     paymentData: {
                         formattedPayload: {
                             issuer: 'foo',
+                            shopper_locale: 'en-US',
                         },
                         issuer: 'foo',
+                        shopper_locale: 'en-US',
                     },
                 });
             });
@@ -234,6 +238,7 @@ describe('MolliePaymentStrategy', () => {
                     paymentData: {
                         formattedPayload: {
                             issuer: '',
+                            shopper_locale: 'en-US',
                         },
                         shouldSaveInstrument: true,
                         shouldSetAsDefaultInstrument: false,

--- a/src/payment/strategies/mollie/mollie.mock.ts
+++ b/src/payment/strategies/mollie/mollie.mock.ts
@@ -82,6 +82,7 @@ export function getOrderRequestBodyAPMs(): OrderRequestBody {
             gatewayId: 'mollie',
             paymentData: {
                 issuer: 'foo',
+                shopper_locale: 'en-US',
             },
         },
     };


### PR DESCRIPTION
## What?
[INT-5573](https://jira.bigcommerce.com/browse/INT-5573): Add shopper locale to Mollie strategy.

## Why?
Payment methods are not displaying in the correct language when merchant selects _Enable automatic translation based on shopper’s browser language_ at Store Profile. We need this parameter to determine the locale on Mollie payments in BigPay.

## Testing / Proof
Mollie payment method redirection using shopper's browser language settings:
![INT-5573](https://user-images.githubusercontent.com/46331158/162798662-845055a7-843e-40a1-a696-90697b742d75.gif)

## Depends on
* https://github.com/bigcommerce/bigcommerce/pull/45854
* https://github.com/bigcommerce/bigpay/pull/5223

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
