### PR TITLE
fix(checkout): CHECKOUT-6563 Apple Pay on Cart Page Loads Checkout Settings

### DIFF
--- a/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
+++ b/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
@@ -65,6 +65,8 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
 
         this._onAuthorizeCallback = onPaymentAuthorize;
 
+        await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+
         const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
         this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
 


### PR DESCRIPTION
## What?
Add `loadDefaultCheckout()` to the Apple Pay checkout button.

## Why?
Apple Pay throws a `MissingDataError` error on the cart page.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/88361607/162906812-d19120e2-baba-4e16-8912-0e5192809a6f.png">

## Testing / Proof
The bugfix is currently on the intergration stage.
Demo: https://ivansilva1649702646-testsworthy.my-integration.zone/.
<img width="600" alt="image (1)" src="https://user-images.githubusercontent.com/88361607/162907897-224ceabe-1d77-453c-b468-fe6bebabf215.png">


@bigcommerce/checkout @bigcommerce/payments
