### PR TITLE
fix(shipping): CHECKOUT-6422 Use union type for consignment assignment interface

### DIFF
--- a/src/shipping/consignment.ts
+++ b/src/shipping/consignment.ts
@@ -27,12 +27,20 @@ export interface ConsignmentCreateRequestBody {
     pickupOption?: ConsignmentPickupOption;
 }
 
-export interface ConsignmentAssignmentRequestBody {
+export interface ConsignmentAssignmentBaseRequestBodyWithAddress {
     address: AddressRequestBody;
-    shippingAddress?: AddressRequestBody;
     lineItems: ConsignmentLineItem[];
     pickupOption?: ConsignmentPickupOption;
 }
+
+export interface ConsignmentAssignmentBaseRequestBodyWithShippingAddress {
+    shippingAddress: AddressRequestBody;
+    lineItems: ConsignmentLineItem[];
+    pickupOption?: ConsignmentPickupOption;
+}
+
+export type ConsignmentAssignmentRequestBody =
+    ConsignmentAssignmentBaseRequestBodyWithShippingAddress | ConsignmentAssignmentBaseRequestBodyWithAddress;
 
 export interface ConsignmentUpdateRequestBody {
     id: string;


### PR DESCRIPTION
## What?
Use union type for consignment assignment interface

## Why?
As part of interface update it causes a breaking change which is not out intention at this point. So implement a union interface with a type guard so custom checkouts can update sdk without having build issues for their checkout

## Testing / Proof
- Test

@bigcommerce/checkout
