### PR TITLE
fix(checkout): ADYEN-431 AdyenV3 component state fix

### DIFF
--- a/src/payment/strategies/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/src/payment/strategies/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -95,7 +95,6 @@ describe('AdyenV3PaymentStrategy', () => {
                     return;
                 }),
                 unmount: jest.fn(),
-                state: getComponentState(),
             };
 
             cardVerificationComponent = {
@@ -105,7 +104,6 @@ describe('AdyenV3PaymentStrategy', () => {
                     return;
                 }),
                 unmount: jest.fn(),
-                state: getComponentState(),
             };
 
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(getAdyenV3());

--- a/src/payment/strategies/adyenv3/adyenv3.mock.ts
+++ b/src/payment/strategies/adyenv3/adyenv3.mock.ts
@@ -87,11 +87,13 @@ export function getAdyenError(): AdyenError {
 export function getComponentState(isValid: boolean = true): AdyenV3ComponentState {
     return {
         data: {
-            encryptedCardNumber: 'ENCRYPTED_CARD_NUMBER',
-            encryptedExpiryMonth: 'ENCRYPTED_EXPIRY_MONTH',
-            encryptedExpiryYear: 'ENCRYPTED_EXPIRY_YEAR',
-            encryptedSecurityCode: 'ENCRYPTED_CVV',
-            holderName: 'John Smith',
+            paymentMethod: {
+                encryptedCardNumber: 'ENCRYPTED_CARD_NUMBER',
+                encryptedExpiryMonth: 'ENCRYPTED_EXPIRY_MONTH',
+                encryptedExpiryYear: 'ENCRYPTED_EXPIRY_YEAR',
+                encryptedSecurityCode: 'ENCRYPTED_CVV',
+                holderName: 'John Smith',
+            },
         },
         isValid,
     };

--- a/src/payment/strategies/adyenv3/adyenv3.ts
+++ b/src/payment/strategies/adyenv3/adyenv3.ts
@@ -490,10 +490,14 @@ export interface Card {
 }
 
 export interface CardState {
-    data: CardPaymentMethodState;
+    data: CardDataPaymentMethodState;
     isValid?: boolean;
     valid?: {[key: string]: boolean};
     errors?: CardStateErrors;
+}
+
+interface CardDataPaymentMethodState {
+    paymentMethod: CardPaymentMethodState;
 }
 
 export interface CardStateErrors {
@@ -814,12 +818,12 @@ export interface ThreeDS2DeviceFingerprintComponentOptions {
     onError(error: AdyenError): void;
 }
 
-export type AdyenV3ComponentState = CardState;
+export type AdyenV3ComponentState = CardState | WechatState;
 
 export type AdyenComponentOptions = AdyenV3CreditCardComponentOptions | AdyenV3IdealComponentOptions | AdyenCustomCardComponentOptions;
 
 export function isCardState(param: unknown): param is CardState {
     return typeof param === 'object' && !!param &&
-        typeof (param as CardState).data.encryptedSecurityCode === 'string' ||
-        typeof (param as CardState).data.encryptedExpiryMonth === 'string';
+        typeof (param as CardState).data.paymentMethod.encryptedSecurityCode === 'string' ||
+        typeof (param as CardState).data.paymentMethod.encryptedExpiryMonth === 'string';
 }


### PR DESCRIPTION
## What?
In this PR was implemented AdyenV3 component state fix.
Previously data was received directly from the adyen sdk componentState object but it was a mistake because Adyen SDK modifies this data before submitting. ComponentState data gets on onChange event via Adyen SDK API.

## Why?
Due to the fix of https://jira.bigcommerce.com/browse/ADYEN-431

## Testing / Proof
Manually/Units

@bigcommerce/checkout @bigcommerce/payments
