### PR TITLE
feat(payment): PAYPAL-1177 added implementation to handle 3DS required error from backend

### DIFF
--- a/src/payment/payment.ts
+++ b/src/payment/payment.ts
@@ -24,7 +24,6 @@ export type PaymentInstrument = (
     ThreeDSVaultedInstrument |
     VaultedInstrument |
     VaultedInstrument & WithHostedFormNonce |
-    VaultedInstrumentWithNonceVerification |
     WithAccountCreation
 );
 
@@ -95,11 +94,6 @@ export interface VaultedInstrument {
     instrumentId: string;
     ccCvv?: string;
     ccNumber?: string;
-}
-
-export interface VaultedInstrumentWithNonceVerification {
-    instrumentId: string;
-    nonce: string;
 }
 
 export interface ThreeDSVaultedInstrument extends VaultedInstrument {

--- a/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -1,13 +1,14 @@
-import { pick } from 'lodash';
+import { some } from 'lodash';
 
 import { Address } from '../../../address';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
-import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { MissingDataError, MissingDataErrorType, RequestError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError, PaymentMethodFailedError } from '../../errors';
+import { isHostedInstrumentLike, PaymentMethod } from '../../index';
 import isVaultedInstrument from '../../is-vaulted-instrument';
-import { CreditCardInstrument, NonceInstrument, PaymentInstrument, PaymentInstrumentMeta, VaultedInstrumentWithNonceVerification } from '../../payment';
+import { CreditCardInstrument, NonceInstrument, PaymentInstrument, PaymentInstrumentMeta } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
@@ -19,6 +20,7 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
     private _is3dsEnabled?: boolean;
     private _isHostedFormInitialized?: boolean;
     private _deviceSessionId?: string;
+    private _paymentMethod?: PaymentMethod;
 
     constructor(
         private _store: CheckoutStore,
@@ -30,20 +32,21 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
 
     async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
         const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(options.methodId));
-        const paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId);
+        this._paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId);
 
-        if (!paymentMethod || !paymentMethod.clientToken) {
+        if (!this._paymentMethod?.clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         try {
-            this._braintreePaymentProcessor.initialize(paymentMethod.clientToken, options.braintree);
+            this._braintreePaymentProcessor.initialize(this._paymentMethod.clientToken, options.braintree);
 
             if (this._isHostedPaymentFormEnabled(options.methodId, options.gatewayId) && options.braintree?.form) {
-                this._isHostedFormInitialized = await this._braintreePaymentProcessor.initializeHostedForm(options.braintree.form);
+                await this._braintreePaymentProcessor.initializeHostedForm(options.braintree.form);
+                this._isHostedFormInitialized = this._braintreePaymentProcessor.isInitializedHostedForm();
             }
 
-            this._is3dsEnabled = paymentMethod.config.is3dsEnabled;
+            this._is3dsEnabled = this._paymentMethod.config.is3dsEnabled;
             this._deviceSessionId = await this._braintreePaymentProcessor.getSessionId();
         } catch (error) {
             this._handleError(error);
@@ -73,22 +76,21 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
             return state;
         }
 
+        const billingAddress = getBillingAddressOrThrow();
+        const orderAmount = getOrderOrThrow().orderAmount;
+
         try {
-            return this._store.dispatch(this._paymentActionCreator.submitPayment({
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({
                 ...payment,
-                paymentData: this._isHostedFormInitialized ?
-                    await this._prepareHostedPaymentData(
-                        payment,
-                        getBillingAddressOrThrow(),
-                        getOrderOrThrow().orderAmount
-                    ) :
-                    await this._preparePaymentData(
-                        payment,
-                        getBillingAddressOrThrow(),
-                        getOrderOrThrow().orderAmount
-                    ),
+                paymentData: this._isHostedFormInitialized
+                    ? await this._prepareHostedPaymentData(payment, billingAddress, orderAmount)
+                    : await this._preparePaymentData(payment, billingAddress, orderAmount),
             }));
         } catch (error) {
+            if (this._is3DSFixExperimentOn()) {
+                return this._processAdditionalAction(error, payment, orderAmount);
+            }
+
             this._handleError(error);
         }
     }
@@ -117,72 +119,100 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
     }
 
     private async _preparePaymentData(payment: OrderPaymentRequestBody, billingAddress: Address, orderAmount: number): Promise<PaymentInstrument & PaymentInstrumentMeta> {
+        const { paymentData } = payment;
         const commonPaymentData = { deviceSessionId: this._deviceSessionId };
 
         if (this._isSubmittingWithStoredCard(payment) || this._isStoringNewCard(payment)) {
             return {
                 ...commonPaymentData,
-                ...payment.paymentData,
+                ...paymentData,
             };
         }
 
-        if (this._shouldPerform3DSVerification(payment)) {
-            return {
-                ...commonPaymentData,
-                ...this._mapToNonceInstrument({
-                    ...payment.paymentData,
-                    ...await this._braintreePaymentProcessor.verifyCard(payment, billingAddress, orderAmount),
-                }),
-            };
-        }
+        const {
+            shouldSaveInstrument = false,
+            shouldSetAsDefaultInstrument = false,
+        } = isHostedInstrumentLike(paymentData) ? paymentData : {};
+
+        const { nonce } = this._shouldPerform3DSVerification(payment)
+            ? await this._braintreePaymentProcessor.verifyCard(payment, billingAddress, orderAmount)
+            : await this._braintreePaymentProcessor.tokenizeCard(payment, billingAddress);
 
         return {
             ...commonPaymentData,
-            ...this._mapToNonceInstrument({
-                ...payment.paymentData,
-                ...await this._braintreePaymentProcessor.tokenizeCard(payment, billingAddress),
-            }),
+            nonce,
+            shouldSaveInstrument,
+            shouldSetAsDefaultInstrument,
         };
     }
 
     private async _prepareHostedPaymentData(payment: OrderPaymentRequestBody, billingAddress: Address, orderAmount: number): Promise<PaymentInstrument & PaymentInstrumentMeta> {
+        const { paymentData } = payment;
         const commonPaymentData = { deviceSessionId: this._deviceSessionId };
 
-        if (this._shouldPerform3DSVerification(payment)) {
+        if (this._isSubmittingWithStoredCard(payment)) {
+            const { nonce } = await this._braintreePaymentProcessor.tokenizeHostedFormForStoredCardVerification();
+
             return {
                 ...commonPaymentData,
-                ...this._mapToNonceInstrument({
-                    ...payment.paymentData,
-                    ...await this._braintreePaymentProcessor.verifyCardWithHostedForm(billingAddress, orderAmount),
-                }),
+                ...paymentData,
+                nonce,
             };
         }
 
-        if (this._isSubmittingWithStoredCard(payment)) {
+        const {
+            shouldSaveInstrument = false,
+            shouldSetAsDefaultInstrument = false,
+        } = isHostedInstrumentLike(paymentData) ? paymentData : {};
+
+        if (this._shouldPerform3DSVerification(payment)) {
+            const merchantAccountId = this._getMerchantAccountIdOrThrow();
+
+            const { nonce } = this._is3DSFixExperimentOn()
+                ? await this._braintreePaymentProcessor.verifyCardWithHostedFormAnd3DSCheck(billingAddress, orderAmount, merchantAccountId)
+                : await this._braintreePaymentProcessor.verifyCardWithHostedForm(billingAddress, orderAmount);
+
             return {
                 ...commonPaymentData,
-                ...this._mapToVaultedInstrumentWithNonceVerification({
-                    ...payment.paymentData,
-                    ...await this._braintreePaymentProcessor.tokenizeHostedFormForStoredCardVerification(),
-                }),
+                shouldSaveInstrument,
+                shouldSetAsDefaultInstrument,
+                nonce,
             };
         }
+
+        const { nonce } = await this._braintreePaymentProcessor.tokenizeHostedForm(billingAddress);
 
         return {
             ...commonPaymentData,
-            ...this._mapToNonceInstrument({
-                ...payment.paymentData,
-                ...await this._braintreePaymentProcessor.tokenizeHostedForm(billingAddress),
-            }),
+            shouldSaveInstrument,
+            shouldSetAsDefaultInstrument,
+            nonce,
         };
     }
 
-    private _mapToNonceInstrument(instrument: PaymentInstrument): NonceInstrument {
-        return pick(instrument as NonceInstrument, 'nonce', 'shouldSaveInstrument', 'shouldSetAsDefaultInstrument');
-    }
+    private async _processAdditionalAction(
+        error: Error,
+        payment: OrderPaymentRequestBody,
+        orderAmount: number
+    ): Promise<InternalCheckoutSelectors> {
+        if (!(error instanceof RequestError) || !some(error.body.errors, { code: 'three_d_secure_required' })) {
+            return this._handleError(error);
+        }
 
-    private _mapToVaultedInstrumentWithNonceVerification(instrument: PaymentInstrument): VaultedInstrumentWithNonceVerification {
-        return pick(instrument as VaultedInstrumentWithNonceVerification, 'nonce', 'instrumentId');
+        try {
+            const { payer_auth_request: storedCreditCardNonce } = error.body.three_ds_result || {};
+            const { nonce } = await this._braintreePaymentProcessor.challenge3DSVerification(storedCreditCardNonce, orderAmount);
+
+            return await this._store.dispatch(this._paymentActionCreator.submitPayment({
+                ...payment,
+                paymentData: {
+                    deviceSessionId: this._deviceSessionId,
+                    nonce,
+                },
+            }));
+        } catch (error) {
+            return this._handleError(error);
+        }
     }
 
     private _isHostedPaymentFormEnabled(methodId?: string, gatewayId?: string): boolean {
@@ -206,5 +236,22 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
 
     private _shouldPerform3DSVerification(payment: OrderPaymentRequestBody): boolean {
         return !!(this._is3dsEnabled && !this._isSubmittingWithStoredCard(payment));
+    }
+
+    private _getMerchantAccountIdOrThrow(): string {
+        const merchantAccountId = this._paymentMethod?.initializationData.merchantAccountId;
+
+        if (!merchantAccountId) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return merchantAccountId;
+    }
+
+    private _is3DSFixExperimentOn(): boolean {
+        const state = this._store.getState();
+        const storeConfig = state.config.getStoreConfigOrThrow();
+
+        return storeConfig.checkoutSettings.features['PAYPAL-1177.braintree-3ds-issue'];
     }
 }

--- a/src/payment/strategies/braintree/braintree.ts
+++ b/src/payment/strategies/braintree/braintree.ts
@@ -98,6 +98,7 @@ export interface BraintreeGooglePayThreeDSecure {
 export interface BraintreeThreeDSecureOptions {
     nonce: string;
     amount: number;
+    challengeRequested: boolean;
     showLoader?: boolean;
     addFrame(error: Error | undefined, iframe: HTMLIFrameElement): void;
     removeFrame(): void;
@@ -158,11 +159,16 @@ export interface BraintreeHostedFieldsTokenizeOptions {
     billingAddress?: BraintreeBillingAddressRequestData;
 }
 
-export interface BraintreeHostedFieldsTokenizePayload {
+export interface BraintreeAuthenticationInsight {
+    authenticationInsight?: BraintreeRegulationEnvironment;
+}
+
+export interface BraintreeRegulationEnvironment {
+    regulationEnvironment: 'psd2' | 'unregulated' | 'unavailable';
+}
+
+export interface BraintreeHostedFieldsTokenizePayload extends BraintreeAuthenticationInsight {
     nonce: string;
-    authenticationInsight?: {
-        regulationEnvironment: string;
-    };
     details: {
         bin: string;
         cardType: string;


### PR DESCRIPTION
## What?
- added implementation to handle 3DS required error for stored credit card;
- added extra check on 3DS regulation for credit card (not stored);
- added extra test coverage for Braintree strategy, payment processor and hosted form functionality;

## Why?
Some EU merchants are having the issue with payments made with stored credit cards. When the customer tried to pay with store credit card the Braintree had an error with "Authentication Required: The customer’s bank declined the transaction because a 3D Secure authentication was not performed during checkout" message.

The main point is in our implementation of 3DS verification for Braintree, or specifically in the fact that 3DS is skipped for stored credit card payments.

This behaviour seems to be by design, but the receiving banks are now rejecting these transactions due to this functionality. This is because of the new 3DS2 EU requirements stipulating that 3DS must be checked.

## Testing / Proof
Unit tests
Manual tests

Here is a screenshot of 3DS verification modal:
<img width="1150" alt="Screenshot 2022-04-19 at 11 08 50" src="https://user-images.githubusercontent.com/25133454/164879269-5a737972-b9e4-4ed5-ada6-95b26f60306b.png">
