### PR TITLE
Update node version requirement to >=14.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/bigcommerce/checkout-sdk-js/issues"
   },
   "engines": {
-    "node": "14.18",
+    "node": ">=14.18",
     "npm": "6"
   },
   "homepage": "https://github.com/bigcommerce/checkout-sdk-js",


### PR DESCRIPTION
## What?
Update node version requirements in the package.json from `14.18` to `>=14.18`

## Why?
Currently cannot install this SDK on any project unless it is explicitly node v 14.18

IMO this is a short-term fix and the node version should be upgraded to the current stable version, `16.14` at the time of this PR.

## Testing / Proof

![Checkout-SDK-node-error](https://user-images.githubusercontent.com/766503/165174710-cc1f711f-d880-4def-8316-f09ea44b7268.png)

@bigcommerce/checkout @bigcommerce/payments
