### PR TITLE
fix(common): CHECKOUT-6268 Check in array while loading config

### DIFF
--- a/webpack-cdn.config.js
+++ b/webpack-cdn.config.js
@@ -85,7 +85,7 @@ async function getCdnLoaderConfig(options, argv) {
 
 // This configuration is for building distribution files for CDN deployment
 async function getConfigs(options, argv) {
-    if (argv.configName === 'umd-loader') {
+    if (argv.configName.includes('umd-loader')) {
         return await getCdnLoaderConfig(options, argv);
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,3 +60,4 @@ async function getConfigs(options, argv) {
 }
 
 module.exports = getConfigs;
+module.exports.parallelism = 2;


### PR DESCRIPTION
## What?
Fix build process for cdn-deploy

## Why?
As a config-name args has a type of string[], due to which the build for cdn was failing. Apply the fix.

## Testing / Proof
![Screen Shot 2022-04-26 at 2 07 19 pm](https://user-images.githubusercontent.com/7134802/165219110-09678678-a3da-435a-a5f4-a7bd65f3ea52.png)


@bigcommerce/checkout 
