### PR TITLE
fix(common): CHECKOUT-6268 Update asset path

### DIFF
--- a/scripts/webpack/transform-manifest.js
+++ b/scripts/webpack/transform-manifest.js
@@ -3,7 +3,7 @@ const { flatMap } = require('lodash');
 function transformManifest(assets, version) {
     return {
         version,
-        js: flatMap(Object.values(assets.entrypoints), entry => entry.js),
+        js: flatMap(Object.values(assets.entrypoints), entry => entry.assets.js),
     };
 }
 


### PR DESCRIPTION
## What?
As above

## Why?
With the upgrade of the dependant plugin now `Assets for an entrypoint are now included in an assets property`

Reference https://www.npmjs.com/package/webpack-assets-manifest

## Testing / Proof
- Manifest from integration deploy

![Screen Shot 2022-04-26 at 5 52 16 pm](https://user-images.githubusercontent.com/7134802/165249941-46b4bee5-f24c-4dc6-be6f-429f11177510.png)


@bigcommerce/checkout
