### PR TITLE
feat(payment): PAYPAL-1420 POC of new order creation process for PayPal oxxo APM

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -53,7 +53,13 @@ export default function createCheckoutButtonRegistry(
     const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
     const remoteCheckoutRequestSender = new RemoteCheckoutRequestSender(requestSender);
     const remoteCheckoutActionCreator = new RemoteCheckoutActionCreator(remoteCheckoutRequestSender, checkoutActionCreator);
-    const paypalCommercePaymentProcessor = createPaypalCommercePaymentProcessor(scriptLoader, requestSender);
+    const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
+    const orderActionCreator = new OrderActionCreator(new OrderRequestSender(requestSender), checkoutValidator);
+    const paymentRequestSender = new PaymentRequestSender(paymentClient);
+    const paymentRequestTransformer = new PaymentRequestTransformer();
+    const paymentHumanVerificationHandler = new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()));
+    const paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator, paymentRequestTransformer, paymentHumanVerificationHandler);
+    const paypalCommercePaymentProcessor = createPaypalCommercePaymentProcessor(scriptLoader, requestSender, store, orderActionCreator, paymentActionCreator);
 
     registry.register(CheckoutButtonMethodType.APPLEPAY, () =>
         new ApplePayButtonStrategy(

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -12,7 +12,8 @@ import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
-import { PaymentMethod, PaymentMethodActionType } from '../../../payment';
+import { OrderActionCreator } from '../../../order';
+import { PaymentActionCreator, PaymentMethod, PaymentMethodActionType } from '../../../payment';
 import { getPaypalCommerce } from '../../../payment/payment-methods.mock';
 import { PaypalCommercePaymentProcessor, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, StyleButtonColor, StyleButtonLabel } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
@@ -36,6 +37,8 @@ describe('PaypalCommerceButtonStrategy', () => {
     let cart: Cart;
     let fundingSource: string;
     let messageContainer: HTMLDivElement;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());
@@ -49,7 +52,16 @@ describe('PaypalCommerceButtonStrategy', () => {
             new ConfigActionCreator(new ConfigRequestSender(requestSender)),
             new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
-        paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor(new PaypalCommerceScriptLoader(getScriptLoader()), new PaypalCommerceRequestSender(requestSender));
+        orderActionCreator = {} as OrderActionCreator;
+        paymentActionCreator = {} as PaymentActionCreator;
+
+        paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor(
+            new PaypalCommerceScriptLoader(getScriptLoader()),
+            new PaypalCommerceRequestSender(requestSender),
+            store,
+            orderActionCreator,
+            paymentActionCreator
+        );
         eventEmitter = new EventEmitter();
 
         paypalOptions = {

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -664,7 +664,7 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
-            createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
+            createPaypalCommercePaymentProcessor(scriptLoader, requestSender, store, orderActionCreator, paymentActionCreator),
             new PaypalCommerceFundingKeyResolver(),
             new PaypalCommerceRequestSender(requestSender),
             new LoadingIndicator({ styles: { backgroundColor: 'black' } })
@@ -676,7 +676,7 @@ export default function createPaymentStrategyRegistry(
             store,
             orderActionCreator,
             paymentActionCreator,
-            createPaypalCommercePaymentProcessor(scriptLoader, requestSender),
+            createPaypalCommercePaymentProcessor(scriptLoader, requestSender, store, orderActionCreator, paymentActionCreator),
             new PaypalCommerceFundingKeyResolver(),
             new PaypalCommerceRequestSender(requestSender),
             new LoadingIndicator({ styles: { backgroundColor: 'black' } })
@@ -687,7 +687,7 @@ export default function createPaymentStrategyRegistry(
         new PaypalCommerceCreditCardPaymentStrategy(
             store,
             paymentMethodActionCreator,
-            new PaypalCommerceHostedForm(createPaypalCommercePaymentProcessor(scriptLoader, requestSender)),
+            new PaypalCommerceHostedForm(createPaypalCommercePaymentProcessor(scriptLoader, requestSender, store, orderActionCreator, paymentActionCreator)),
             orderActionCreator,
             paymentActionCreator
         )

--- a/packages/core/src/payment/strategies/paypal-commerce/create-paypal-commerce-payment-processor.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/create-paypal-commerce-payment-processor.ts
@@ -1,11 +1,27 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
+import { CheckoutStore } from '../../../checkout';
+import { OrderActionCreator } from '../../../order';
+import PaymentActionCreator from '../../payment-action-creator';
+
 import { PaypalCommercePaymentProcessor, PaypalCommerceRequestSender, PaypalCommerceScriptLoader } from './index';
 
-export default function createPaypalCommercePaymentProcessor(scriptLoader: ScriptLoader, requestSender: RequestSender) {
+export default function createPaypalCommercePaymentProcessor(
+    scriptLoader: ScriptLoader,
+    requestSender: RequestSender,
+    store: CheckoutStore,
+    orderActionCreator: OrderActionCreator,
+    paymentActionCreator: PaymentActionCreator
+) {
     const paypalScriptLoader = new PaypalCommerceScriptLoader(scriptLoader);
     const paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
 
-    return new PaypalCommercePaymentProcessor(paypalScriptLoader, paypalCommerceRequestSender);
+    return new PaypalCommercePaymentProcessor(
+        paypalScriptLoader,
+        paypalCommerceRequestSender,
+        store,
+        orderActionCreator,
+        paymentActionCreator
+    );
 }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
@@ -46,7 +46,13 @@ describe('PaypalCommerceCreditCardPaymentStrategy', () => {
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
         paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
-        paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor(paypalScriptLoader, new PaypalCommerceRequestSender(requestSender));
+        paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor(
+            paypalScriptLoader,
+            new PaypalCommerceRequestSender(requestSender),
+            store,
+            orderActionCreator,
+            paymentActionCreator
+        );
         paypalCommerceHostedForm = new PaypalCommerceHostedForm(paypalCommercePaymentProcessor);
 
         orderId = 'orderId';

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.spec.ts
@@ -55,5 +55,9 @@ describe('paypalCommerceFundingKeyResolver', () => {
         it('should return "VENMO"', () => {
             expect(paypalCommerceFundingKeyResolver.resolve('venmo', 'paypalcommercealternativemethods')).toEqual('VENMO');
         });
+
+        it('should return "OXXO"', () => {
+            expect(paypalCommerceFundingKeyResolver.resolve('oxxo', 'paypalcommercealternativemethods')).toEqual('OXXO');
+        });
     });
 });

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-funding-key-resolver.ts
@@ -36,6 +36,8 @@ export default class PaypalCommerceFundingKeyResolver {
                     return 'SEPA';
                 case 'venmo':
                     return 'VENMO';
+                case 'oxxo':
+                    return 'OXXO';
             }
         }
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -51,7 +51,13 @@ describe('PaypalCommercePaymentStrategy', () => {
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
         requestSender = createRequestSender();
-        paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor(new PaypalCommerceScriptLoader(getScriptLoader()), new PaypalCommerceRequestSender(requestSender));
+        paypalCommercePaymentProcessor = new PaypalCommercePaymentProcessor(
+            new PaypalCommerceScriptLoader(getScriptLoader()),
+            new PaypalCommerceRequestSender(requestSender),
+            store,
+            orderActionCreator,
+            paymentActionCreator
+        );
         eventEmitter = new EventEmitter();
         paypalCommerceFundingKeyResolver = new PaypalCommerceFundingKeyResolver();
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -10,16 +10,7 @@ import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
-import { ApproveDataOptions,
-    ButtonsOptions,
-    ComponentsScriptType,
-    PaypalCommerceCreditCardPaymentInitializeOptions,
-    PaypalCommerceFundingKeyResolver,
-    PaypalCommerceInitializationData,
-    PaypalCommercePaymentInitializeOptions,
-    PaypalCommercePaymentProcessor,
-    PaypalCommerceRequestSender,
-    PaypalCommerceScriptParams } from './index';
+import { ApproveDataOptions, ButtonsOptions, ComponentsScriptType, NON_INSTANT_PAYMENT_METHODS, PaypalCommerceCreditCardPaymentInitializeOptions, PaypalCommerceFundingKeyResolver, PaypalCommerceInitializationData, PaypalCommercePaymentInitializeOptions, PaypalCommercePaymentProcessor, PaypalCommerceRequestSender, PaypalCommerceScriptParams } from './index';
 
 const ORDER_STATUS_APPROVED = 'APPROVED';
 const ORDER_STATUS_CREATED = 'CREATED';
@@ -163,7 +154,10 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
                 },
             },
         };
-        await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+        if (NON_INSTANT_PAYMENT_METHODS.indexOf(options.methodId) === -1) {
+            await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+        }
 
         return this._store.dispatch(this._paymentActionCreator.submitPayment({ ...payment, paymentData }));
     }
@@ -181,7 +175,7 @@ export default class PaypalCommercePaymentStrategy implements PaymentStrategy {
     }
 
     private _initializePollingMechanism(submitForm: () => void, gatewayId?: string, methodId?: any, paypalcommerce?: any ) {
-        if (!this._isAPM)  {
+        if (!this._isAPM || NON_INSTANT_PAYMENT_METHODS.indexOf(methodId) > -1)  {
             this._loadingIndicator?.hide();
 
             return;

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -203,6 +203,8 @@ export interface PaypalCommerceSDKFunding {
     VENMO: string;
 }
 
+export const NON_INSTANT_PAYMENT_METHODS = ['oxxo'];
+
 export interface PaypalCommerceSDK {
     FUNDING: PaypalCommerceSDKFunding;
     HostedFields: {

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -194,6 +194,7 @@ export interface PaypalCommerceSDKFunding {
     EPS: string;
     IDEAL: string;
     MYBANK: string;
+    OXXO: string;
     SOFORT: string;
     SEPA: string;
     BLIK: string;

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
@@ -19,6 +19,7 @@ export function getPaypalCommerceMock(): PaypalCommerceSDK {
             EPS: 'eps',
             IDEAL: 'ideal',
             MYBANK: 'mybank',
+            OXXO: 'oxxo',
             SOFORT: 'sofort',
             TRUSTLY: 'trustly',
             SEPA: 'sepa',


### PR DESCRIPTION
## What?
POC of new order creation process for PayPal OXXO APM

OXXO APM requires PayPal order patching before popup is opened. We need to implement the next flow:
-> click
   --> PayPal order create
   --> BC order create
   --> patch PayPal order
    --> return order id
           -----> popup opens (order becomes COMPLETE)
              -------->  order approve

Existing approach for other APMs
-> click
   --> PayPal order create   
      ----> popup opens (order becomes CREATE)
         ------> order approve
         ------> BC order create
         ------> patch PayPal order
         ------> return order id


## Why?
After popup is opened on checkout page the PayPal OXXO order becomes COMPLETE. PayPal order can not be patched with COMPLETED status  

## Testing / Proof

![Screenshot 2022-04-27 at 18 08 12 2](https://user-images.githubusercontent.com/18176525/165551099-da65fe06-e556-4fbc-8c48-f14028bca69d.png)

## Depends on
https://github.com/bigcommerce/bigpay/pull/5305
https://github.com/bigcommerce/interfaces/pull/2089
https://github.com/bigcommerce/bigcommerce/pull/45934


@bigcommerce/checkout @bigcommerce/payments
