### PR TITLE
feat(payment): INT-3925 StripeV3: BOPIS

### DIFF
--- a/packages/core/src/payment/payment-methods.mock.ts
+++ b/packages/core/src/payment/payment-methods.mock.ts
@@ -672,6 +672,7 @@ export function getQuadpay(): PaymentMethod {
 export function getStripeV3(method = 'card', shouldUseIndividualCardFields = false, isHostedFormEnabled = false): PaymentMethod {
     return {
         id: method,
+        gateway: 'stripev3',
         logoUrl: '',
         method,
         supportedCards: [],
@@ -684,6 +685,10 @@ export function getStripeV3(method = 'card', shouldUseIndividualCardFields = fal
         initializationData: {
             stripePublishableKey: 'key',
             useIndividualCardFields: shouldUseIndividualCardFields,
+            bopis: {
+                enabled: false,
+                requiredAddress: 'none',
+            },
         },
         type: 'PAYMENT_TYPE_API',
         clientToken: 'clientToken',


### PR DESCRIPTION
## What? [INT-3925](https://bigcommercecloud.atlassian.net/browse/INT-3925)
Check if BOPIS is enabled and send `null` as the shipping address to Stripe if the shopper selects to pick up the entire order.

## Why?
When the shopper selects to pick up the entire order, nothing is passed in for shipping to Stripe.

## Testing / Proof
_**BC Control Panel:**_
<img width="1316" alt="Screen Shot 2022-04-27 at 2 40 11 PM" src="https://user-images.githubusercontent.com/4843328/165612642-2798b4fa-544e-4496-b831-9ec877c1f799.png">
_**Stripe Control Panel:**_
<img width="718" alt="Screen Shot 2022-04-27 at 2 30 33 PM" src="https://user-images.githubusercontent.com/4843328/165612766-3d5a5263-9f52-423c-a88d-b7e0dcd41ad5.png">

## Sibling PR
~👉 https://github.com/bigcommerce/bigcommerce/pull/46057 to get the `isBopisEnabled` flag.~
👉 https://github.com/bigcommerce/bigcommerce/pull/47101 to get the BOPIS data.

@bigcommerce/checkout @bigcommerce/payments
