### PR TITLE
fix(checkout): CHECKOUT-6631 Sentry issue bugfix

### DIFF
--- a/src/payment/payment-method-action-creator.spec.ts
+++ b/src/payment/payment-method-action-creator.spec.ts
@@ -5,12 +5,12 @@ import { catchError, toArray } from 'rxjs/operators';
 import { ErrorResponseBody } from '../common/error';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
+import { PaymentMethodInvalidError } from './errors';
 import PaymentMethod from './payment-method';
 import PaymentMethodActionCreator from './payment-method-action-creator';
 import { PaymentMethodActionType } from './payment-method-actions';
 import PaymentMethodRequestSender from './payment-method-request-sender';
 import { getPaymentMethod, getPaymentMethods, getPaymentMethodsMeta } from './payment-methods.mock';
-import {PaymentMethodInvalidError} from "./errors";
 
 describe('PaymentMethodActionCreator', () => {
     let errorResponse: Response<ErrorResponseBody>;

--- a/src/payment/payment-method-action-creator.spec.ts
+++ b/src/payment/payment-method-action-creator.spec.ts
@@ -80,25 +80,6 @@ describe('PaymentMethodActionCreator', () => {
                 { type: PaymentMethodActionType.LoadPaymentMethodsFailed, payload: errorResponse, error: true },
             ]);
         });
-
-        it('throws PaymentMethodInvalidError if payment methods list is an empty string', async () => {
-            jest.spyOn(paymentMethodRequestSender, 'loadPaymentMethods')
-                .mockReturnValue(Promise.resolve({...paymentMethodsResponse, body: ''}));
-
-            const errorHandler = jest.fn(action => of(action));
-            const actions = await paymentMethodActionCreator.loadPaymentMethods()
-                .pipe(
-                    catchError(errorHandler),
-                    toArray()
-                )
-                .toPromise();
-
-            expect(errorHandler).toHaveBeenCalled();
-            expect(actions).toEqual([
-                { type: PaymentMethodActionType.LoadPaymentMethodsRequested },
-                { type: PaymentMethodActionType.LoadPaymentMethodsFailed, payload: new PaymentMethodInvalidError(), error: true },
-            ]);
-        });
     });
 
     describe('#loadPaymentMethod()', () => {

--- a/src/payment/payment-method-action-creator.spec.ts
+++ b/src/payment/payment-method-action-creator.spec.ts
@@ -5,7 +5,6 @@ import { catchError, toArray } from 'rxjs/operators';
 import { ErrorResponseBody } from '../common/error';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
-import { PaymentMethodInvalidError } from './errors';
 import PaymentMethod from './payment-method';
 import PaymentMethodActionCreator from './payment-method-action-creator';
 import { PaymentMethodActionType } from './payment-method-actions';

--- a/src/payment/payment-method-action-creator.ts
+++ b/src/payment/payment-method-action-creator.ts
@@ -5,10 +5,10 @@ import { cachableAction, ActionOptions } from '../common/data-store';
 import { RequestOptions } from '../common/http-request';
 
 import { PaymentMethod } from '.';
+import { PaymentMethodInvalidError } from './errors';
 import { LoadPaymentMethodsAction, LoadPaymentMethodAction, PaymentMethodActionType } from './payment-method-actions';
 import PaymentMethodRequestSender from './payment-method-request-sender';
 import { isApplePayWindow } from './strategies/apple-pay';
-import {PaymentMethodInvalidError} from "./errors";
 
 const APPLEPAYID = 'applepay';
 

--- a/src/payment/payment-method-action-creator.ts
+++ b/src/payment/payment-method-action-creator.ts
@@ -29,6 +29,7 @@ export default class PaymentMethodActionCreator {
                     };
                     const methods = response.body;
                     const filteredMethods = Array.isArray(methods) ? this._filterApplePay(methods) : methods;
+
                     observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, filteredMethods, meta));
                     observer.complete();
                 })

--- a/src/payment/payment-method-action-creator.ts
+++ b/src/payment/payment-method-action-creator.ts
@@ -8,6 +8,7 @@ import { PaymentMethod } from '.';
 import { LoadPaymentMethodsAction, LoadPaymentMethodAction, PaymentMethodActionType } from './payment-method-actions';
 import PaymentMethodRequestSender from './payment-method-request-sender';
 import { isApplePayWindow } from './strategies/apple-pay';
+import {PaymentMethodInvalidError} from "./errors";
 
 const APPLEPAYID = 'applepay';
 
@@ -53,12 +54,16 @@ export default class PaymentMethodActionCreator {
     }
 
     private _filterApplePay(methods: PaymentMethod[]): PaymentMethod[] {
-        return methods.filter(method => {
-            if (method.id === APPLEPAYID && !isApplePayWindow(window)) {
-                return false;
-            }
+        try {
+            return methods.filter(method => {
+                if (method.id === APPLEPAYID && !isApplePayWindow(window)) {
+                    return false;
+                }
 
-            return true;
-        });
+                return true;
+            });
+        } catch {
+            throw new PaymentMethodInvalidError();
+        }
     }
 }


### PR DESCRIPTION
## What?
Fix Sentry Issue: [CHECKOUT-JS-4WG](https://sentry.io/organizations/bigcommerce/issues/2782844130/?referrer=jira_integration).

## Why?

![Screen Shot 2022-04-29 at 11 49 52 am](https://user-images.githubusercontent.com/88361607/165884176-07ef2153-55da-49fd-bf40-b7800db0d8d0.png)

When this happens, I'm guessing a shopper gets a message like this.

The reason for `t.filter is not a function` could be that `methods` within `methods.filter()` is an empty string. This bugfix provides a readable error message and instructs the shopper to try again.

## Testing / Proof
After applying the fix.
![Screen Shot 2022-04-29 at 1 38 17 pm](https://user-images.githubusercontent.com/88361607/165884127-f8bb250c-78d8-47f8-a9cc-299f3f002901.png)

@bigcommerce/checkout @bigcommerce/payments
