### PR TITLE
fix(payment): INT-5826 AmazonPayV2: Provide a relative URL

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -56,7 +56,7 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
     private async _getAmazonPayV2ButtonOptions(paymentMethod: PaymentMethod): Promise<AmazonPayV2ButtonParams> {
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         const cart = state.cart.getCart();
-        const { storeProfile: { shopPath } } = state.config.getStoreConfigOrThrow();
+        const { storeProfile: { shopPath }, checkoutSettings: { features } } = state.config.getStoreConfigOrThrow();
 
         const {
             config: {
@@ -78,7 +78,10 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
         return {
             merchantId,
             createCheckoutSession: {
-                url: `${shopPath}/remote-checkout/${paymentMethod.id}/payment-session`,
+                // tslint:disable-next-line: no-string-literal
+                url: features['INT-5826.amazon_relative_url']
+                    ? `/remote-checkout/${paymentMethod.id}/payment-session`
+                    : `${shopPath}/remote-checkout/${paymentMethod.id}/payment-session`,
                 method: checkoutSessionMethod,
                 extractAmazonCheckoutSessionId,
             },

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
@@ -106,6 +106,30 @@ describe('AmazonPayV2CustomerStrategy', () => {
             expect(paymentProcessor.createButton).toHaveBeenCalledWith('#amazonpayCheckoutButton', expectedOptions);
         });
 
+        it('creates the button with a relative checkout session url', async () => {
+            const config = getConfig();
+
+            jest.spyOn(store.getState().config, 'getStoreConfig')
+                .mockReturnValue({
+                    ...config.storeConfig,
+                    checkoutSettings: {
+                        ...config.storeConfig.checkoutSettings,
+                        features: {
+                            'INT-5826.amazon_relative_url': true,
+                        },
+                    },
+                });
+
+            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            expectedOptions.createCheckoutSession.url = `/remote-checkout/amazonpay/payment-session`;
+
+            customerInitializeOptions = getAmazonPayV2CustomerInitializeOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+
+            expect(paymentProcessor.createButton).toHaveBeenCalledWith('#amazonpayCheckoutButton', expectedOptions);
+        });
+
         it('creates the button and validates if cart contains physical items', async () => {
             const expectedOptions = getAmazonPayV2ButtonParamsMock();
             expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
@@ -116,7 +116,10 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
                 AmazonPayV2PayOptions.PayAndShip,
             createCheckoutSession: {
                 method: checkoutSessionMethod,
-                url: `${config.storeProfile.shopPath}/remote-checkout/${methodId}/payment-session`,
+                // tslint:disable-next-line: no-string-literal
+                url: config.checkoutSettings.features['INT-5826.amazon_relative_url']
+                    ? `/remote-checkout/${methodId}/payment-session`
+                    : `${config.storeProfile.shopPath}/remote-checkout/${methodId}/payment-session`,
                 extractAmazonCheckoutSessionId,
             },
             placement: AmazonPayV2Placement.Checkout,

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
@@ -175,6 +175,30 @@ describe('AmazonPayV2PaymentStrategy', () => {
             expect(amazonPayV2PaymentProcessor.createButton).toHaveBeenCalledWith(`#AmazonPayButton`, expectedOptions);
         });
 
+        it('creates the signin button with a relative url if no paymentToken is present on initializationData', async () => {
+            const config = getConfig();
+
+            jest.spyOn(store.getState().config, 'getStoreConfig')
+                .mockReturnValue({
+                    ...config.storeConfig,
+                    checkoutSettings: {
+                        ...config.storeConfig.checkoutSettings,
+                        features: {
+                            'INT-5826.amazon_relative_url': true,
+                        },
+                    },
+                });
+
+            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            expectedOptions.createCheckoutSession.url = `/remote-checkout/amazonpay/payment-session`;
+
+            await strategy.initialize(initializeOptions);
+
+            expect(amazonPayV2PaymentProcessor.bindButton).not.toHaveBeenCalled();
+            expect(amazonPayV2PaymentProcessor.initialize).toHaveBeenCalledWith(paymentMethodMock);
+            expect(amazonPayV2PaymentProcessor.createButton).toHaveBeenCalledWith(`#AmazonPayButton`, expectedOptions);
+        });
+
         it('fails to initialize the strategy if there is no payment method data', async () => {
             const paymentMethods = { ...getPaymentMethodsState(), data: undefined };
             const state = { ...getCheckoutStoreState(), paymentMethods };

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
@@ -10,6 +10,7 @@ import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutVali
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError, RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
+import { getConfig } from '../../../config/configs.mock';
 import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
@@ -26,9 +27,10 @@ import { PaymentStrategyActionType } from '../../payment-strategy-actions';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
 
 import { AmazonPayV2PaymentProcessor } from '.';
+import { AmazonPayV2PayOptions } from './amazon-pay-v2';
 import AmazonPayV2PaymentInitializeOptions from './amazon-pay-v2-payment-initialize-options';
 import AmazonPayV2PaymentStrategy from './amazon-pay-v2-payment-strategy';
-import { getPaymentMethodMockUndefinedMerchant } from './amazon-pay-v2.mock';
+import { getAmazonPayV2ButtonParamsMock, getPaymentMethodMockUndefinedMerchant } from './amazon-pay-v2.mock';
 import createAmazonPayV2PaymentProcessor from './create-amazon-pay-v2-payment-processor';
 
 describe('AmazonPayV2PaymentStrategy', () => {
@@ -163,11 +165,14 @@ describe('AmazonPayV2PaymentStrategy', () => {
         });
 
         it('creates the signin button if no paymentToken is present on initializationData', async () => {
+            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
+
             await strategy.initialize(initializeOptions);
 
             expect(amazonPayV2PaymentProcessor.bindButton).not.toHaveBeenCalled();
             expect(amazonPayV2PaymentProcessor.initialize).toHaveBeenCalledWith(paymentMethodMock);
-            expect(amazonPayV2PaymentProcessor.createButton).toHaveBeenCalledWith(`#AmazonPayButton`, expect.any(Object));
+            expect(amazonPayV2PaymentProcessor.createButton).toHaveBeenCalledWith(`#AmazonPayButton`, expectedOptions);
         });
 
         it('fails to initialize the strategy if there is no payment method data', async () => {
@@ -186,13 +191,17 @@ describe('AmazonPayV2PaymentStrategy', () => {
             await expect(strategy.initialize(initializeOptions)).rejects.toThrow(MissingDataError);
         });
 
-        it('initialize the strategy and validates if cart contains physical items', async () => {
+        it('creates the button and validates if cart contains physical items', async () => {
+            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
+            expectedOptions.productType = AmazonPayV2PayOptions.PayOnly;
+
             jest.spyOn(store.getState().cart, 'getCart')
-                .mockReturnValue({...store.getState().cart.getCart(), lineItems: {physicalItems: []}});
+                .mockReturnValue({ ...store.getState().cart.getCart(), lineItems: { physicalItems: [] } });
 
             await strategy.initialize(initializeOptions);
 
-            expect(amazonPayV2PaymentProcessor.createButton).toHaveBeenCalled();
+            expect(amazonPayV2PaymentProcessor.createButton).toHaveBeenCalledWith(`#AmazonPayButton`, expectedOptions);
         });
 
         it('fails to initialize the strategy if no methodid is supplied', async () => {
@@ -213,6 +222,7 @@ describe('AmazonPayV2PaymentStrategy', () => {
 
             await expect(strategy.initialize(initializeOptions)).rejects.toThrow(MissingDataError);
         });
+
         it('binds edit method button if paymentToken is present on initializationData', async () => {
             paymentMethodMock.initializationData.paymentToken = paymentToken;
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
@@ -206,7 +206,10 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
                 AmazonPayV2PayOptions.PayAndShip,
             createCheckoutSession: {
                 method: checkoutSessionMethod,
-                url: `${config.storeProfile.shopPath}/remote-checkout/${paymentMethod.id}/payment-session`,
+                // tslint:disable-next-line: no-string-literal
+                url: config.checkoutSettings.features['INT-5826.amazon_relative_url']
+                    ? `/remote-checkout/${paymentMethod.id}/payment-session`
+                    : `${config.storeProfile.shopPath}/remote-checkout/${paymentMethod.id}/payment-session`,
                 extractAmazonCheckoutSessionId,
             },
             placement: AmazonPayV2Placement.Checkout,


### PR DESCRIPTION
for `createCheckoutSession.url`

## What? [INT-5826](https://bigcommercecloud.atlassian.net/browse/INT-5826)
As per [Amazon's Docs](https://developer.amazon.com/docs/amazon-pay-checkout/v1-add-the-amazon-pay-button.html#3-render-the-button):
> The Amazon Pay script will make an AJAX request using the configuration provided for the createCheckoutSession button parameter.

With that in mind, I decided to pass a relative URL instead for `createCheckoutSession.url` and let the `XMLHttpRequest` object resolve the URL of the request, which will be the URL of the document that contains the Amazon Pay script (our checkout page).

## Why?
This way we cover special cases for stores using [Weglot](https://weglot.com/integrations/translate-bigcommerce-website/), which uses specific subdomains for each language. Therefore, subdomains are trying to hit the main `StoreProfile.shopPath`, causing session problems due to domain mismatch in cookies.

So, before the change we had:

`es.example.com` requesting `example.com/remote-checkout/amazonpay/payment-session` ❌ 🍪
`fr.example.com` requesting `example.com/remote-checkout/amazonpay/payment-session` ❌ 🍪
`it.example.com` requesting `example.com/remote-checkout/amazonpay/payment-session` ❌ 🍪

And after the change we have:

`es.example.com` requesting `es.example.com/remote-checkout/amazonpay/payment-session` ✅ 🍪
`fr.example.com` requesting `fr.example.com/remote-checkout/amazonpay/payment-session` ✅ 🍪
`it.example.com` requesting `it.example.com/remote-checkout/amazonpay/payment-session` ✅ 🍪

## Testing / Proof
[Cart page video](https://drive.google.com/file/d/1N57dlBNPLIvm6-XuDbDsSdh859eYB4IY/view?usp=sharing)
[Checkout page video](https://drive.google.com/file/d/1cRfU1e4WR9exULFAWpgA5qRotSuiRFPk/view?usp=sharing)

## Depends on
👉 https://github.com/bigcommerce/bigcommerce/pull/46325

@bigcommerce/checkout @bigcommerce/payments
