### PR TITLE
feat(checkout): INT-5963 Check for feature flag when loading threeDS Script

### DIFF
--- a/src/payment/payment-methods.mock.ts
+++ b/src/payment/payment-methods.mock.ts
@@ -905,6 +905,7 @@ export function getCBAMPGS(): PaymentMethod {
         },
         type: 'PAYMENT_TYPE_API',
         initializationData: {
+            isTestModeFlagEnabled: false,
             merchantId: 'ABC123',
         },
     };

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.spec.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.spec.ts
@@ -150,6 +150,36 @@ describe('CBAMPGSPaymentStrategy', () => {
             expect(threeDSjs.isConfigured).toHaveBeenCalled();
         });
 
+        it('should initialize the strategy and load ThreeDSjs in production mode if `isTestModeFlagEnabled` is false', async () => {
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(cbaMPGSScriptLoader.load).toHaveBeenCalledWith(false);
+        });
+
+        it('should initialize the strategy and load ThreeDSjs in sandbox mode if `isTestModeFlagEnabled` is true', async () => {
+            paymentMethod.initializationData.isTestModeFlagEnabled = true;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(cbaMPGSScriptLoader.load).toHaveBeenCalledWith(true);
+        });
+
+        it('should initialize the strategy and load ThreeDSjs in production mode if `isTestModeFlagEnabled` is undefined', async () => {
+            paymentMethod.initializationData.isTestModeFlagEnabled = undefined;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(cbaMPGSScriptLoader.load).toHaveBeenCalledWith(false);
+        });
+
+        it('should initialize the strategy and load ThreeDSjs in production mode if `isTestModeFlagEnabled` is not present', async () => {
+            delete paymentMethod.initializationData.isTestModeFlagEnabled;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(cbaMPGSScriptLoader.load).toHaveBeenCalledWith(false);
+        });
+
         it('should fail to initialize strategy if the script loader fails to load the script', () => {
             jest.spyOn(cbaMPGSScriptLoader, 'load')
                 .mockResolvedValue(undefined);

--- a/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.ts
+++ b/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.ts
@@ -43,10 +43,10 @@ export default class CBAMPGSPaymentStrategy extends CreditCardPaymentStrategy {
 
         const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        const { clientToken, initializationData: { merchantId }, config: { is3dsEnabled, testMode } } = paymentMethod;
+        const { clientToken, initializationData: { isTestModeFlagEnabled = false, merchantId }, config: { is3dsEnabled } } = paymentMethod;
 
         if (is3dsEnabled) {
-            this._threeDSjs = await this._CBAMGPSScriptLoader.load(testMode);
+            this._threeDSjs = await this._CBAMGPSScriptLoader.load(isTestModeFlagEnabled);
 
             if (!this._threeDSjs) {
                 throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);


### PR DESCRIPTION
## What?
Use the feature flag value to decide which version of ThreeDS script to load instead of `testMode`

## Why?
To stop dependency in testMode, so `test` transaction can be made using the production environment script.

## Testing / Proof
- [x] Unit Testing
- [x] Manual Testing
  - [With the feature flag off ](https://drive.google.com/file/d/1kPYKZf6t6Mxrv0Q5Ylt09kw9b3EMflmw/view?usp=sharing)
  - [With the feature flag on](https://drive.google.com/file/d/1s1Fm0i0VrT_uG6gzXon9oWsDl-1-pXNM/view?usp=sharing)
 
@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
