### PR TITLE
chore(checkout): CHECKOUT-updated types for checkout StoreSetting

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -90,6 +90,7 @@ export interface StoreCurrency {
 
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
+    checkoutBillingSameAsShippingEnabled: boolean;
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/src/config/configs.mock.ts
+++ b/src/config/configs.mock.ts
@@ -20,6 +20,7 @@ export function getConfig(): Config {
             cdnPath: 'https://cdn.bcapp.dev/rHEAD',
             checkoutSettings: {
                 features: {},
+                checkoutBillingSameAsShippingEnabled: true,
                 enableOrderComments: true,
                 enableTermsAndConditions: false,
                 guestCheckoutEnabled: true,


### PR DESCRIPTION
## What?
Adds type of checkoutBillingSameAsShipping check for shopper during the checkout process

## Why?
Needs as part of Checkout JS so we can do checks for checkout store setting

## Testing / Proof
N/A

@bigcommerce/checkout @bigcommerce/payments
