### PR TITLE
chore(payment): PAYPAL-1463 Bump PPCP PayPal JS SDK version to the la…

### DIFF
--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -49,7 +49,7 @@ describe('PaypalCommerceScriptLoader', () => {
             await paypalLoader.loadPaypalCommerce(params);
 
             expect(loader.loadScript).toHaveBeenCalledWith(
-                'https://unpkg.com/@paypal/paypal-js@1.0.2/dist/paypal.browser.min.js',
+                'https://unpkg.com/@paypal/paypal-js@5.0.5/dist/iife/paypal-js.min.js',
                 { async: true, attributes: {} }
             );
         });

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -18,7 +18,7 @@ export default class PaypalCommerceScriptLoader {
         this._validateParams(params, isProgressiveOnboardingAvailable);
 
         if (!this._window.paypalLoadScript) {
-            const scriptSrc = 'https://unpkg.com/@paypal/paypal-js@1.0.2/dist/paypal.browser.min.js';
+            const scriptSrc = 'https://unpkg.com/@paypal/paypal-js@5.0.5/dist/iife/paypal-js.min.js';
 
             await this._scriptLoader.loadScript(scriptSrc, {async: true, attributes: {}});
 


### PR DESCRIPTION
…test

## What?
Bump PPCP PayPal JS SDK version to the latest

## Why?
We need to use the latest version of the PayPal JS SDK to be able to implement  the inline checkout

## Testing / Proof
manual tests

@bigcommerce/checkout @bigcommerce/payments
