### PR TITLE
feat(payment): PAYPAL-1465 added extra check for braintree 3DS verification

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -394,6 +394,21 @@ describe('BraintreePaymentProcessor', () => {
             expect(verifiedCard).toEqual({ nonce: 'three_ds_nonce' });
         });
 
+        it('verifies credit card with hosted form using 3DS if the card is unavailable', async () => {
+            jest.spyOn(braintreeHostedForm, 'tokenizeWith3DSRegulationCheck')
+                .mockReturnValue({
+                    authenticationInsight: {
+                        regulationEnvironment: 'unavailable',
+                    },
+                    nonce: 'tokenized_nonce',
+                });
+
+            const verifiedCard = await braintreePaymentProcessor.verifyCardWithHostedFormAnd3DSCheck(getBillingAddress(), 122, merchantAccountIdMock);
+            expect(braintreePaymentProcessor.challenge3DSVerification).toHaveBeenCalledWith('tokenized_nonce', 122);
+            expect(braintreeHostedForm.tokenizeWith3DSRegulationCheck).toHaveBeenCalledWith(getBillingAddress(), merchantAccountIdMock);
+            expect(verifiedCard).toEqual({ nonce: 'three_ds_nonce' });
+        });
+
         it('only tokenizes credit card with hosted form using 3DS if the card is unregulated', async () => {
             jest.spyOn(braintreeHostedForm, 'tokenizeWith3DSRegulationCheck')
                 .mockReturnValue({

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -130,8 +130,9 @@ export default class BraintreePaymentProcessor {
 
     async verifyCardWithHostedFormAnd3DSCheck(billingAddress: Address, amount: number, merchantAccountId: string): Promise<NonceInstrument> {
         const { authenticationInsight, nonce } = await this._braintreeHostedForm.tokenizeWith3DSRegulationCheck(billingAddress, merchantAccountId);
+        const { regulationEnvironment } = authenticationInsight || {};
 
-        if (authenticationInsight?.regulationEnvironment === 'psd2') {
+        if (regulationEnvironment === 'psd2' || regulationEnvironment === 'unavailable') {
             return this.challenge3DSVerification(nonce, amount);
         }
 


### PR DESCRIPTION
## What?
Added extra check on 'unavailable' authenticationInsight to trigger braintree 3DS for this type of transactions.

## Why?
Because some of the transactions with 'unavailable' authenticationInsight can require 3DS verification

## Testing / Proof
Unit tests

