### PR TITLE
feat(payment): PAYPAL-1382 separated braintreepaypal and braintreepaypalcredit checkout buttons strategies

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -3,7 +3,7 @@ import { RequestOptions } from '../common/http-request';
 import { CheckoutButtonMethodType } from './strategies';
 import { AmazonPayV2ButtonInitializeOptions } from './strategies/amazon-pay-v2';
 import { ApplePayButtonInitializeOptions } from './strategies/apple-pay';
-import { BraintreePaypalButtonInitializeOptions } from './strategies/braintree';
+import { BraintreePaypalButtonInitializeOptions, BraintreePaypalCreditButtonInitializeOptions, BraintreeVenmoButtonInitializeOptions } from './strategies/braintree';
 import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
 import { PaypalCommerceButtonInitializeOptions } from './strategies/paypal-commerce';
@@ -41,7 +41,13 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * The options that are required to facilitate Braintree Credit. They can be
      * omitted unless you need to support Braintree Credit.
      */
-    braintreepaypalcredit?: BraintreePaypalButtonInitializeOptions;
+    braintreepaypalcredit?: BraintreePaypalCreditButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate Braintree Venmo. They can be
+     * omitted unless you need to support Braintree Venmo.
+     */
+    braintreevenmo?: BraintreeVenmoButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate PayPal. They can be omitted

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -9,7 +9,7 @@ import createCheckoutButtonRegistry from './create-checkout-button-registry';
 import { CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
-import { BraintreePaypalButtonStrategy } from './strategies/braintree';
+import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreeVenmoButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 
 describe('createCheckoutButtonRegistry', () => {
@@ -30,7 +30,11 @@ describe('createCheckoutButtonRegistry', () => {
     });
 
     it('returns registry with Braintree PayPal Credit registered', () => {
-        expect(registry.get('braintreepaypalcredit')).toEqual(expect.any(BraintreePaypalButtonStrategy));
+        expect(registry.get('braintreepaypalcredit')).toEqual(expect.any(BraintreePaypalCreditButtonStrategy));
+    });
+
+    it('returns registry with Braintree Venmo registered', () => {
+        expect(registry.get('braintreevenmo')).toEqual(expect.any(BraintreeVenmoButtonStrategy));
     });
 
     it('returns registry with GooglePay on Adyen Credit registered', () => {

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -8,11 +8,7 @@ import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { OrderActionCreator, OrderRequestSender } from '../order';
-import { PaymentActionCreator,
-    PaymentMethodActionCreator,
-    PaymentMethodRequestSender,
-    PaymentRequestSender,
-    PaymentRequestTransformer } from '../payment';
+import { PaymentActionCreator, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentRequestTransformer } from '../payment';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { ApplePaySessionFactory } from '../payment/strategies/apple-pay';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
@@ -28,7 +24,7 @@ import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subsc
 import { CheckoutButtonMethodType, CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
-import { BraintreePaypalButtonStrategy } from './strategies/braintree';
+import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreeVenmoButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 import { MasterpassButtonStrategy } from './strategies/masterpass';
 import { PaypalButtonStrategy } from './strategies/paypal';
@@ -101,19 +97,26 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
             formPoster,
-            undefined,
             window
         )
     );
 
     registry.register(CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT, () =>
-        new BraintreePaypalButtonStrategy(
+        new BraintreePaypalCreditButtonStrategy(
             store,
             checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
             formPoster,
-            true,
             window
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.BRAINTREE_VENMO, () =>
+        new BraintreeVenmoButtonStrategy(
+            store,
+            paymentMethodActionCreator,
+            new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
+            formPoster
         )
     );
 

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
@@ -3,17 +3,12 @@ import { StandardError } from '../../../common/error/errors';
 import { BraintreeError } from '../../../payment/strategies/braintree';
 import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
 
-export interface BraintreePaypalButtonInitializeOptions {
+export interface BraintreePaypalCreditButtonInitializeOptions {
     /**
      * @internal
      * This is an internal property and therefore subject to change. DO NOT USE.
      */
     shouldProcessPayment?: boolean;
-
-    /**
-     * The ID of a container which the messaging should be inserted.
-     */
-    messagingContainerId?: string;
 
     /**
      * A set of styling options for the checkout button.

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-old-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-old-button-options.ts
@@ -1,0 +1,47 @@
+import { Address } from '../../../address';
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
+
+export interface BraintreePaypalOldButtonInitializeOptions {
+    /**
+     * @internal
+     * This is an internal property and therefore subject to change. DO NOT USE.
+     */
+    shouldProcessPayment?: boolean;
+
+    /**
+     * The ID of a container which the messaging should be inserted.
+     */
+    messagingContainerId?: string;
+
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: Pick<PaypalButtonStyleOptions, 'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons' | 'height'>;
+
+    /**
+     * Whether or not to show a credit button.
+     */
+    allowCredit?: boolean;
+
+    /**
+     * Address to be used for shipping.
+     * If not provided, it will use the first saved address from the active customer.
+     */
+    shippingAddress?: Address | null;
+
+    /**
+     * A callback that gets called if unable to authorize and tokenize payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onAuthorizeError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * A callback that gets called if unable to submit payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onPaymentError?(error: BraintreeError | StandardError): void;
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-old-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-old-button-strategy.spec.ts
@@ -1,0 +1,581 @@
+import { createAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+import { merge } from 'lodash';
+import { from } from 'rxjs';
+
+import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { getBraintreePaypal } from '../../../payment/payment-methods.mock';
+import { BraintreeDataCollector, BraintreePaypalCheckout, BraintreeScriptLoader, BraintreeSDKCreator, VenmoInstance } from '../../../payment/strategies/braintree';
+import { getDataCollectorMock, getPaypalCheckoutMock, getVenmoCheckoutMock } from '../../../payment/strategies/braintree/braintree.mock';
+import { PaypalButtonOptions,
+    PaypalHostWindow,
+    PaypalScriptLoader,
+    PaypalSDK } from '../../../payment/strategies/paypal';
+import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+
+import { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+import BraintreePaypalOldButtonStrategy from './braintree-paypal-old-button-strategy';
+
+describe('BraintreePaypalOldButtonStrategy', () => {
+    let braintreeSDKCreator: BraintreeSDKCreator;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let dataCollector: BraintreeDataCollector;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let options: CheckoutButtonInitializeOptions;
+    let paypalOptions: BraintreePaypalButtonInitializeOptions;
+    let paypal: PaypalSDK;
+    let paypalCheckout: BraintreePaypalCheckout;
+    let venmoCheckout: VenmoInstance;
+    let paypalScriptLoader: PaypalScriptLoader;
+    let store: CheckoutStore;
+    let strategy: BraintreePaypalOldButtonStrategy;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(createRequestSender()),
+            new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+        );
+        braintreeSDKCreator = new BraintreeSDKCreator(new BraintreeScriptLoader(getScriptLoader()));
+        formPoster = createFormPoster();
+        paypalScriptLoader = new PaypalScriptLoader(getScriptLoader());
+
+        paypalOptions = {
+            onAuthorizeError: jest.fn(),
+            onPaymentError: jest.fn(),
+            style: {
+                height: 45,
+            },
+        };
+
+        options = {
+            methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL,
+            containerId: 'checkout-button',
+            braintreepaypal: paypalOptions,
+        };
+
+        eventEmitter = new EventEmitter();
+        dataCollector = getDataCollectorMock();
+        paypal = getPaypalMock();
+        paypalCheckout = getPaypalCheckoutMock();
+        venmoCheckout = getVenmoCheckoutMock();
+
+        jest.spyOn(paypal.Button, 'render')
+            .mockImplementation((options: PaypalButtonOptions) => {
+                eventEmitter.on('payment', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {
+                        });
+                    }
+                });
+
+                eventEmitter.on('approve', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {
+                        });
+                    }
+                });
+            });
+
+        jest.spyOn(paypal, 'Buttons')
+            .mockImplementation((options: PaypalButtonOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {
+                        });
+                    }
+                });
+
+                eventEmitter.on('approve', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {
+                        });
+                    }
+                });
+
+                return {
+                    render: jest.fn(),
+                    isEligible: jest.fn(),
+                };
+            });
+
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout')
+            .mockReturnValue(() => from([
+                createAction(CheckoutActionType.LoadCheckoutRequested),
+                createAction(CheckoutActionType.LoadCheckoutSucceeded, getCheckout()),
+            ]));
+
+        jest.spyOn(braintreeSDKCreator, 'getPaypalCheckout')
+            /* eslint-disable no-empty-pattern */
+            .mockImplementation(({}, callback) => {
+                callback(paypalCheckout);
+
+                return Promise.resolve(paypalCheckout);
+            });
+
+        jest.spyOn(braintreeSDKCreator, 'getVenmoCheckout').mockReturnValue(Promise.resolve(venmoCheckout));
+
+        jest.spyOn(braintreeSDKCreator, 'getDataCollector')
+            .mockReturnValue(Promise.resolve(dataCollector));
+
+        jest.spyOn(paypalScriptLoader, 'loadPaypal')
+            .mockReturnValue(Promise.resolve(paypal));
+
+        jest.spyOn(braintreeSDKCreator, 'getPaypal')
+            .mockReturnValue(Promise.resolve(paypal));
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockImplementation(() => {});
+
+        (window as PaypalHostWindow).paypal = paypal;
+
+        strategy = new BraintreePaypalButtonStrategy(
+            store,
+            checkoutActionCreator,
+            braintreeSDKCreator,
+            formPoster,
+            undefined,
+            window
+        );
+    });
+
+    afterEach(() => {
+        delete (window as PaypalHostWindow).paypal;
+    });
+
+    it('throws error if required data is not loaded', async () => {
+        try {
+            store = createCheckoutStore();
+            strategy = new BraintreePaypalButtonStrategy(
+                store,
+                checkoutActionCreator,
+                braintreeSDKCreator,
+                formPoster,
+                undefined,
+                window
+            );
+
+            await strategy.initialize(options);
+        } catch (error) {
+            expect(error).toBeInstanceOf(MissingDataError);
+        }
+    });
+
+    it('initializes Braintree and PayPal JS clients', async () => {
+        await strategy.initialize(options);
+
+        expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
+        expect(braintreeSDKCreator.getVenmoCheckout).toHaveBeenCalled();
+        expect(braintreeSDKCreator.getPaypal).toHaveBeenCalled();
+    });
+
+    it('throws error if unable to initialize Braintree or PayPal JS client', async () => {
+        const expectedError = new Error('Unable to load JS client');
+
+        jest.spyOn(braintreeSDKCreator, 'getPaypal')
+            .mockReturnValue(Promise.reject(expectedError));
+
+        try {
+            await strategy.initialize(options);
+        } catch (error) {
+            expect(error).toEqual(expectedError);
+        }
+    });
+
+    it('renders PayPal checkout button', async () => {
+        await strategy.initialize(options);
+
+        expect(paypal.Buttons).toHaveBeenCalledWith({
+            commit: false,
+            env: 'production',
+            onApprove: expect.any(Function),
+            createOrder: expect.any(Function),
+            style: {
+                label: undefined,
+                shape: 'rect',
+                height: 45,
+            },
+            fundingSource: paypal.FUNDING.PAYPAL,
+        });
+    });
+
+    it('customizes style of PayPal checkout button', async () => {
+        options = {
+            ...options,
+            braintreepaypal: {
+                ...paypalOptions,
+                style: {
+                    color: 'blue',
+                    shape: 'pill',
+                    size: 'responsive',
+                    layout: 'horizontal',
+                    label: 'paypal',
+                    tagline: true,
+                    fundingicons: false,
+                    height: 45,
+                },
+            },
+        };
+
+        await strategy.initialize(options);
+
+        expect(paypal.Buttons).toHaveBeenCalledWith(expect.objectContaining({
+            style: {
+                color: 'blue',
+                shape: 'pill',
+                size: 'responsive',
+                layout: 'horizontal',
+                label: 'paypal',
+                tagline: true,
+                fundingicons: false,
+                height: 45,
+            },
+        }));
+    });
+
+    it('throws error if unable to render PayPal button', async () => {
+        const expectedError = new Error('Unable to render PayPal button');
+        jest.spyOn(paypal, 'Buttons')
+            .mockImplementation(() => {
+                throw expectedError;
+            });
+
+        try {
+            await strategy.initialize(options);
+        } catch (error) {
+            expect(error).toEqual(expectedError);
+        }
+    });
+
+    it('renders PayPal checkout button in sandbox environment if payment method is in test mode', async () => {
+        store = createCheckoutStore(merge({}, getCheckoutStoreState(), {
+            paymentMethods: {
+                data: [
+                    merge({}, getBraintreePaypal(), { config: { testMode: true } }),
+                ],
+            },
+        }));
+
+        strategy = new BraintreePaypalButtonStrategy(
+            store,
+            checkoutActionCreator,
+            braintreeSDKCreator,
+            formPoster,
+            undefined,
+            window
+        );
+
+        await strategy.initialize(options);
+
+        expect(paypal.Buttons)
+            .toHaveBeenCalledWith(expect.objectContaining({ env: 'sandbox' }));
+    });
+
+    it('loads checkout details when customer is ready to pay', async () => {
+        jest.spyOn(store, 'dispatch');
+
+        await strategy.initialize(options);
+
+        eventEmitter.emit('createOrder');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalled();
+        expect(store.dispatch).toHaveBeenCalledWith(checkoutActionCreator.loadDefaultCheckout());
+    });
+
+    it('sets up PayPal payment flow with provided address', async () => {
+        await strategy.initialize({
+            ...options,
+            braintreepaypal: {
+                ...options.braintreepaypal,
+                shippingAddress: {
+                    ...getShippingAddress(),
+                    address1: 'a1',
+                    address2: 'a2',
+                    city: 'c',
+                    countryCode: 'AU',
+                    phone: '0123456',
+                    postalCode: '2000',
+                    stateOrProvinceCode: 'NSW',
+                    firstName: 'foo',
+                    lastName: 'bar',
+                },
+            },
+        });
+
+        eventEmitter.emit('createOrder');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(paypalCheckout.createPayment).toHaveBeenCalledWith(expect.objectContaining({
+            shippingAddressOverride: {
+                city: 'c',
+                countryCode: 'AU',
+                line1: 'a1',
+                line2: 'a2',
+                phone: '0123456',
+                postalCode: '2000',
+                recipientName: 'foo bar',
+                state: 'NSW',
+            },
+        }));
+    });
+
+    it('sets up PayPal payment flow with no address when null is passed', async () => {
+        await strategy.initialize({
+            ...options,
+            braintreepaypal: {
+                ...options.braintreepaypal,
+                shippingAddress: null,
+            },
+        });
+
+        eventEmitter.emit('createOrder');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(paypalCheckout.createPayment).toHaveBeenCalledWith(expect.objectContaining({
+            shippingAddressOverride: undefined,
+        }));
+    });
+
+    it('sets up PayPal payment flow with current checkout details when customer is ready to pay', async () => {
+        await strategy.initialize(options);
+
+        eventEmitter.emit('createOrder');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(paypalCheckout.createPayment).toHaveBeenCalledWith({
+            amount: 190,
+            currency: 'USD',
+            enableShippingAddress: true,
+            flow: 'checkout',
+            offerCredit: false,
+            shippingAddressEditable: false,
+            shippingAddressOverride: {
+                city: 'Some City',
+                countryCode: 'US',
+                line1: '12345 Testing Way',
+                line2: '',
+                phone: '555-555-5555',
+                postalCode: '95555',
+                recipientName: 'Test Tester',
+                state: 'CA',
+            },
+        });
+    });
+
+    it('tokenizes PayPal payment details when authorization event is triggered', async () => {
+        await strategy.initialize(options);
+
+        eventEmitter.emit('approve');
+
+        expect(paypalCheckout.tokenizePayment).toHaveBeenCalledWith({ payerId: 'PAYER_ID' });
+    });
+
+    it('posts payment details to server to set checkout data when PayPal payment details are tokenized', async () => {
+        await strategy.initialize(options);
+
+        eventEmitter.emit('approve');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+            payment_type: 'paypal',
+            provider: 'braintreepaypal',
+            action: 'set_external_checkout',
+            device_data: dataCollector.deviceData,
+            nonce: 'NONCE',
+            billing_address: JSON.stringify({
+                email: 'foo@bar.com',
+                first_name: 'Foo',
+                last_name: 'Bar',
+                address_line_1: '56789 Testing Way',
+                address_line_2: 'Level 2',
+                city: 'Some Other City',
+                state: 'Arizona',
+                country_code: 'US',
+                postal_code: '96666',
+            }),
+            shipping_address: JSON.stringify({
+                email: 'foo@bar.com',
+                first_name: 'Hello',
+                last_name: 'World',
+                address_line_1: '12345 Testing Way',
+                address_line_2: 'Level 1',
+                city: 'Some City',
+                state: 'California',
+                country_code: 'US',
+                postal_code: '95555',
+            }),
+        }));
+    });
+
+    it('posts payment details to server to process payment if `shouldProcessPayment` is passed when PayPal payment details are tokenized', async () => {
+        options = {
+            ...options,
+            braintreepaypal: {
+                ...paypalOptions,
+                shouldProcessPayment: true,
+            },
+        };
+
+        await strategy.initialize(options);
+
+        eventEmitter.emit('approve');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+            payment_type: 'paypal',
+            provider: 'braintreepaypal',
+            action: 'process_payment',
+            device_data: dataCollector.deviceData,
+            nonce: 'NONCE',
+            billing_address: JSON.stringify({
+                email: 'foo@bar.com',
+                first_name: 'Foo',
+                last_name: 'Bar',
+                address_line_1: '56789 Testing Way',
+                address_line_2: 'Level 2',
+                city: 'Some Other City',
+                state: 'Arizona',
+                country_code: 'US',
+                postal_code: '96666',
+            }),
+            shipping_address: JSON.stringify({
+                email: 'foo@bar.com',
+                first_name: 'Hello',
+                last_name: 'World',
+                address_line_1: '12345 Testing Way',
+                address_line_2: 'Level 1',
+                city: 'Some City',
+                state: 'California',
+                country_code: 'US',
+                postal_code: '95555',
+            }),
+        }));
+    });
+
+    it('triggers error callback if unable to set up payment flow', async () => {
+        const expectedError = new Error('Unable to set up payment flow');
+
+        jest.spyOn(paypalCheckout, 'createPayment')
+            .mockReturnValue(Promise.reject(expectedError));
+
+        await strategy.initialize(options);
+
+        eventEmitter.emit('createOrder');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(paypalOptions.onPaymentError).toHaveBeenCalledWith(expectedError);
+    });
+
+    it('triggers error callback if unable to tokenize payment', async () => {
+        const expectedError = new Error('Unable to tokenize');
+
+        jest.spyOn(paypalCheckout, 'tokenizePayment')
+            .mockReturnValue(Promise.reject(expectedError));
+
+        await strategy.initialize(options);
+
+        eventEmitter.emit('approve');
+
+        await new Promise(resolve => process.nextTick(resolve));
+
+        expect(paypalOptions.onAuthorizeError).toHaveBeenCalledWith(expectedError);
+    });
+
+    it('tears down Braintree setup when button is deinitialized', async () => {
+        jest.spyOn(braintreeSDKCreator, 'teardown');
+
+        await strategy.initialize(options);
+        await strategy.deinitialize();
+
+        expect(braintreeSDKCreator.teardown).toHaveBeenCalled();
+    });
+
+    describe('if PayPal Credit is offered', () => {
+        beforeEach(() => {
+            options = {
+                methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT,
+                containerId: 'checkout-button',
+                braintreepaypalcredit: {
+                    allowCredit: true,
+                    style: {
+                        label: 'credit',
+                        height: 45,
+                    },
+                },
+            };
+
+            strategy = new BraintreePaypalButtonStrategy(
+                store,
+                checkoutActionCreator,
+                braintreeSDKCreator,
+                formPoster,
+                true,
+                window
+            );
+        });
+
+        it('renders PayPal Credit checkout button', async () => {
+            await strategy.initialize(options);
+
+            expect(paypal.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                env: 'production',
+                onApprove: expect.any(Function),
+                createOrder: expect.any(Function),
+                style: {
+                    label: 'credit',
+                    shape: 'rect',
+                    height: 45,
+                },
+                fundingSource: paypal.FUNDING.PAYPAL,
+            });
+        });
+
+        it('sets up PayPal Credit payment flow with current checkout details when customer is ready to pay', async () => {
+            await strategy.initialize(options);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCheckout.createPayment).toHaveBeenCalledWith({
+                amount: 190,
+                currency: 'USD',
+                enableShippingAddress: true,
+                flow: 'checkout',
+                offerCredit: true,
+                shippingAddressEditable: false,
+                shippingAddressOverride: {
+                    city: 'Some City',
+                    countryCode: 'US',
+                    line1: '12345 Testing Way',
+                    line2: '',
+                    phone: '555-555-5555',
+                    postalCode: '95555',
+                    recipientName: 'Test Tester',
+                    state: 'CA',
+                },
+            });
+        });
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-old-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-old-button-strategy.ts
@@ -1,0 +1,326 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { Address, LegacyAddress } from '../../../address';
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError, UnsupportedBrowserError } from '../../../common/error/errors';
+import { PaymentMethod } from '../../../payment';
+import { BraintreeError, BraintreePaypalCheckout, BraintreeShippingAddressOverride, BraintreeSDKCreator, BraintreeTokenizePayload, BraintreeVenmoCheckout, RenderButtonsData } from '../../../payment/strategies/braintree';
+import { PaypalAuthorizeData, PaypalButtonStyleLabelOption, PaypalHostWindow } from '../../../payment/strategies/paypal';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+import { CheckoutButtonMethodType } from '../index';
+
+import getValidButtonStyle from './get-valid-button-style';
+
+export default class BraintreePaypalOldButtonStrategy implements CheckoutButtonStrategy {
+    private _paymentMethod?: PaymentMethod;
+    private _renderButtonsData?: RenderButtonsData;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _braintreeSDKCreator: BraintreeSDKCreator,
+        private _formPoster: FormPoster,
+        private _offerCredit: boolean = false,
+        private _window: PaypalHostWindow
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const paypalOptions = (this._offerCredit ? options.braintreepaypalcredit : options.braintreepaypal) || {};
+        const state = this._store.getState();
+        const paymentMethod = this._paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId);
+        const isVenmoEnabled = paymentMethod?.initializationData?.isBraintreeVenmoEnabled;
+        const storeState = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        const currency = storeState.cart.getCartOrThrow().currency.code;
+
+        if (!paymentMethod || !paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        const container = `#${options.containerId}`;
+        const messagingContainerId = options.braintreepaypal?.messagingContainerId;
+        const venmoParentContainer = options.containerId;
+
+        this._renderButtonsData = {
+            paymentMethod,
+            paypalOptions,
+            container,
+            messagingContainerId,
+            venmoParentContainer,
+        };
+
+        await this._braintreeSDKCreator.getPaypalCheckout(
+            { currency },
+            (braintreePaypalCheckout: BraintreePaypalCheckout) => this._renderButtons(braintreePaypalCheckout),
+            error => this._handleError(error)
+        );
+
+        await this._braintreeSDKCreator.getPaypal();
+
+        if (isVenmoEnabled) {
+            await this._braintreeSDKCreator.getVenmoCheckout(
+                braintreeVenmoCheckout => this._renderVenmoButton(braintreeVenmoCheckout),
+                error => this._handleError(error)
+            );
+        }
+    }
+
+    deinitialize(): Promise<void> {
+        this._paymentMethod = undefined;
+
+        this._braintreeSDKCreator.teardown();
+
+        return Promise.resolve();
+    }
+
+    private _renderButtons(braintreePaypalCheckout: BraintreePaypalCheckout) {
+        const { paypalOptions, paymentMethod, container, messagingContainerId } = this._renderButtonsData as RenderButtonsData;
+        const { style } = paypalOptions;
+        const { paypal } = this._window;
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const storeConfig = state.config.getStoreConfigOrThrow();
+        const isMessageContainerAvailable = Boolean(messagingContainerId && document.getElementById(messagingContainerId));
+        const ppsdkFeatureOn = storeConfig?.checkoutSettings.features['PAYPAL-1149.braintree-new-card-below-totals-banner-placement'];
+
+        if (paypal) {
+            const FUNDING_SOURCES = [];
+            for (const fundingKey in paypal.FUNDING) {
+                if (Object.prototype.hasOwnProperty.call(paypal.FUNDING, fundingKey)) {
+                    const skipCreditSource = (fundingKey === 'CREDIT' || fundingKey === 'PAYLATER') && !paypalOptions.allowCredit;
+                    if (fundingKey === 'CARD' || skipCreditSource) {
+                        continue;
+                    }
+                    FUNDING_SOURCES.push(fundingKey.toLowerCase());
+                }
+            }
+
+            const commonButtonStyle = style ? getValidButtonStyle(style) : {};
+
+            FUNDING_SOURCES.forEach(source => {
+                const buttonStyle =
+                    source === paypal.FUNDING.CREDIT && this._offerCredit
+                        ? { label: PaypalButtonStyleLabelOption.CREDIT, ...commonButtonStyle }
+                        : commonButtonStyle;
+
+                const button = paypal.Buttons({
+                    env: paymentMethod.config.testMode ? 'sandbox' : 'production',
+                    fundingSource: source,
+                    commit: false,
+                    style: buttonStyle,
+                    createOrder: () => this._setupPayment(braintreePaypalCheckout, paypalOptions.shippingAddress, paypalOptions.onPaymentError),
+                    onApprove: (data: PaypalAuthorizeData) => this._tokenizePayment(data, braintreePaypalCheckout, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),
+                });
+
+                if (button.isEligible()) {
+                    button.render(container);
+                }
+            });
+            if (isMessageContainerAvailable && ppsdkFeatureOn && messagingContainerId) {
+                this._renderMessages(cart.cartAmount, messagingContainerId);
+            }
+        }
+    }
+
+    private _renderVenmoButton(braintreeVenmoCheckout: BraintreeVenmoCheckout) {
+        const venmoContainer = this._renderButtonsData?.venmoParentContainer;
+        const venmoButton = document.createElement('div');
+        if (venmoContainer) {
+            const buttonContainer = document.getElementById(venmoContainer);
+            buttonContainer?.appendChild(venmoButton);
+            venmoButton.setAttribute('id', 'venmo-button');
+            venmoButton.addEventListener('click', () =>  {
+                venmoButton.setAttribute('disabled', 'true');
+                if (braintreeVenmoCheckout.tokenize) {
+                    braintreeVenmoCheckout.tokenize((error: BraintreeError, payload: BraintreeTokenizePayload) => {
+                        venmoButton.removeAttribute('disabled');
+                        if (error) {
+                            return  this._handleVenmoError(error);
+                        }
+
+                        return  this._handleSuccess(payload);
+                    });
+                }
+            });
+        }
+    }
+
+    private _handleSuccess(payload: BraintreeTokenizePayload) {
+        Promise.all([
+            this._braintreeSDKCreator.getDataCollector(),
+        ]).then(([{ deviceData }]) => {
+            this._formPoster.postForm('/checkout.php', {
+                payment_type: 'paypal',
+                provider: CheckoutButtonMethodType.BRAINTREE_VENMO,
+                action: 'set_external_checkout',
+                nonce: payload.nonce,
+                device_data: deviceData,
+                shipping_address: JSON.stringify(this._mapToLegacyShippingAddress(payload)),
+                billing_address: JSON.stringify(this._mapToLegacyBillingAddress(payload)),
+            });
+        });
+
+        return payload;
+    }
+
+    private _handleError(error: BraintreeError | UnsupportedBrowserError) {
+        throw new Error(error.message);
+    }
+
+    private _renderMessages(amount: number, containerId: string) {
+        const { paypal } = this._window;
+        if (!paypal?.Messages) {
+            return;
+        }
+
+        return paypal.Messages({
+            amount,
+            placement: 'cart',
+        }).render(`#${containerId}`);
+    }
+
+    private _setupPayment(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        address?: Address | null,
+        onError?: (error: BraintreeError | StandardError) => void
+    ): Promise<string> {
+        return this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout())
+            .then(state => {
+                const checkout = state.checkout.getCheckout();
+                const config = state.config.getStoreConfig();
+                const customer = state.customer.getCustomer();
+                const shippingAddress = address === undefined ?
+                    customer && customer.addresses && customer.addresses[0] :
+                    address;
+
+                if (!checkout) {
+                    throw new MissingDataError(MissingDataErrorType.MissingCheckout);
+                }
+
+                if (!config) {
+                    throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+                }
+
+                return braintreePaypalCheckout.createPayment({
+                    flow: 'checkout',
+                    enableShippingAddress: true,
+                    shippingAddressEditable: false,
+                    shippingAddressOverride: shippingAddress ? this._mapToBraintreeAddress(shippingAddress) : undefined,
+                    amount: checkout?.outstandingBalance,
+                    currency: config?.currency.code,
+                    offerCredit: this._offerCredit,
+                });
+            })
+            .catch(error => {
+                if (onError) {
+                    onError(error);
+                }
+
+                throw error;
+            });
+    }
+
+    private _tokenizePayment(
+        data: PaypalAuthorizeData,
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        shouldProcessPayment?: boolean,
+        onError?: (error: BraintreeError | StandardError) => void
+    ): Promise<BraintreeTokenizePayload> {
+        if (!this._paymentMethod || !braintreePaypalCheckout) {
+            throw new NotInitializedError(NotInitializedErrorType.CheckoutButtonNotInitialized);
+        }
+
+        const methodId = this._paymentMethod.id;
+
+        return Promise.all([
+            braintreePaypalCheckout.tokenizePayment(data),
+            this._braintreeSDKCreator.getDataCollector({ paypal: true }),
+        ])
+            .then(([payload, { deviceData }]) => {
+                this._formPoster.postForm('/checkout.php', {
+                    payment_type: 'paypal',
+                    provider: methodId,
+                    action: shouldProcessPayment ? 'process_payment' : 'set_external_checkout',
+                    nonce: payload.nonce,
+                    device_data: deviceData,
+                    shipping_address: JSON.stringify(this._mapToLegacyShippingAddress(payload)),
+                    billing_address: JSON.stringify(this._mapToLegacyBillingAddress(payload)),
+                });
+
+                return payload;
+            })
+            .catch(error => {
+                if (onError) {
+                    onError(error);
+                }
+
+                throw error;
+            });
+    }
+
+    private _mapToLegacyShippingAddress(payload: BraintreeTokenizePayload): Partial<LegacyAddress> {
+        const shippingAddress = payload.details.shippingAddress;
+        const recipientName = shippingAddress && shippingAddress.recipientName || '';
+        const [firstName, lastName] = recipientName.split(' ');
+
+        return {
+            email: payload.details.email,
+            first_name: firstName,
+            last_name: lastName,
+            phone_number: payload.details.phone,
+            address_line_1: shippingAddress && shippingAddress.line1,
+            address_line_2: shippingAddress && shippingAddress.line2,
+            city: shippingAddress && shippingAddress.city,
+            state: shippingAddress && shippingAddress.state,
+            country_code: shippingAddress && shippingAddress.countryCode,
+            postal_code: shippingAddress && shippingAddress.postalCode,
+        };
+    }
+
+    private _mapToLegacyBillingAddress(payload: BraintreeTokenizePayload): Partial<LegacyAddress> {
+        const billingAddress = payload.details.billingAddress;
+        const shippingAddress = payload.details.shippingAddress;
+
+        if (billingAddress) {
+            return {
+                email: payload.details.email,
+                first_name: payload.details.firstName,
+                last_name: payload.details.lastName,
+                phone_number: payload.details.phone,
+                address_line_1: billingAddress.line1,
+                address_line_2: billingAddress.line2,
+                city: billingAddress.city,
+                state: billingAddress.state,
+                country_code: billingAddress.countryCode,
+                postal_code: billingAddress.postalCode,
+            };
+        }
+
+        return {
+            email: payload.details.email,
+            first_name: payload.details.firstName,
+            last_name: payload.details.lastName,
+            phone_number: payload.details.phone,
+            address_line_1: shippingAddress && shippingAddress.line1,
+            address_line_2: shippingAddress && shippingAddress.line2,
+            city: shippingAddress && shippingAddress.city,
+            state: shippingAddress && shippingAddress.state,
+            country_code: shippingAddress && shippingAddress.countryCode,
+            postal_code: shippingAddress && shippingAddress.postalCode,
+        };
+    }
+
+    private _mapToBraintreeAddress(address: Address): BraintreeShippingAddressOverride {
+        return {
+            line1: address.address1,
+            line2: address.address2,
+            city: address.city,
+            state: address.stateOrProvinceCode,
+            postalCode: address.postalCode,
+            countryCode: address.countryCode,
+            phone: address.phone,
+            recipientName: `${address.firstName} ${address.lastName}`,
+        };
+    }
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-options.ts
@@ -1,0 +1,11 @@
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+
+export interface BraintreeVenmoButtonInitializeOptions {
+    /**
+     * A callback that gets called on any error.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: BraintreeError | StandardError): void;
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
@@ -1,0 +1,390 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
+import { getBraintree } from '../../../payment/payment-methods.mock';
+import { BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVenmoCheckout, BraintreeVenmoCheckoutCreator } from '../../../payment/strategies/braintree';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+
+import BraintreeVenmoButtonStrategy from './braintree-venmo-button-strategy';
+
+describe('BraintreeVenmoButtonStrategy', () => {
+    let braintreeSDKCreator: BraintreeSDKCreator;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let braintreeVenmoCheckoutMock: BraintreeVenmoCheckout;
+    let braintreeVenmoCheckoutCreatorMock: BraintreeVenmoCheckoutCreator;
+    let formPoster: FormPoster;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let venmoButtonElement: HTMLDivElement;
+    let store: CheckoutStore;
+    let strategy: BraintreeVenmoButtonStrategy;
+
+    const defaultContainerId = 'braintree-venmo-button-mock-id';
+
+    const getBraintreeVenmoButtonOptionsMock = () => ({
+        methodId: CheckoutButtonMethodType.BRAINTREE_VENMO,
+        containerId: defaultContainerId,
+    });
+
+    const billingAddressPayload = {
+        line1: 'line1',
+        line2: 'line2',
+        city: 'city',
+        state: 'state',
+        postalCode: 'postalCode',
+        countryCode: 'countryCode',
+    };
+
+    const shippingAddressPayload = {
+        ...billingAddressPayload,
+        recipientName: 'John Doe',
+    };
+
+    const expectedAddress = {
+        email: 'test@test.com',
+        first_name: 'John',
+        last_name: 'Doe',
+        phone_number: '123456789',
+        address_line_1: 'line1',
+        address_line_2: 'line2',
+        city: 'city',
+        state: 'state',
+        country_code: 'countryCode',
+        postal_code: 'postalCode',
+    };
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader());
+        braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        formPoster = createFormPoster();
+
+        strategy = new BraintreeVenmoButtonStrategy(
+            store,
+            paymentMethodActionCreator,
+            braintreeSDKCreator,
+            formPoster
+        );
+
+        paymentMethodMock = {
+            ...getBraintree(),
+            clientToken: 'myToken',
+            initializationData: {
+                merchantAccountId: '100000',
+            },
+        };
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+        jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(paymentMethodMock.clientToken);
+        jest.spyOn(braintreeSDKCreator, 'getDataCollector').mockReturnValue({ deviceData: { device: 'something' } });
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+
+        venmoButtonElement = document.createElement('div');
+        venmoButtonElement.id = defaultContainerId;
+        document.body.appendChild(venmoButtonElement);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        document.body.removeChild(venmoButtonElement);
+    });
+
+    it('creates an instance of the braintree venmo checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(BraintreeVenmoButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = { containerId: 'braintree-venmo-button-mock-id' } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if client token is missing', async () => {
+            paymentMethodMock.clientToken = undefined;
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = { methodId: CheckoutButtonMethodType.BRAINTREE_VENMO } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('initializes braintree sdk creator', async () => {
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getVenmoCheckout = jest.fn();
+
+            await strategy.initialize(options);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+        });
+
+        it('initializes the braintree venmo checkout', async () => {
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getVenmoCheckout = jest.fn();
+
+            await strategy.initialize(options);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+            expect(braintreeSDKCreator.getVenmoCheckout).toHaveBeenCalled();
+        });
+
+        it('calls braintree venmo checkout create method', async () => {
+            braintreeVenmoCheckoutCreatorMock = { create: jest.fn() };
+
+            jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(paymentMethodMock.clientToken);
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            await strategy.initialize(options);
+
+            expect(braintreeVenmoCheckoutCreatorMock.create).toHaveBeenCalled();
+        });
+
+        it('calls onError callback option if the error was caught on braintree venmo checkout creation', async () => {
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(new Error('test'), undefined)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const onErrorCallback = jest.fn();
+
+            const options = {
+                ...getBraintreeVenmoButtonOptionsMock(),
+                braintreevenmo: {
+                    onError: onErrorCallback,
+                },
+            };
+
+            await strategy.initialize(options);
+            expect(onErrorCallback).toHaveBeenCalled();
+        });
+
+        it('calls onError callback option if customer browser is not supported', async () => {
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(false),
+                teardown: jest.fn(),
+                tokenize: jest.fn(),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const onErrorCallback = jest.fn();
+
+            const options = {
+                ...getBraintreeVenmoButtonOptionsMock(),
+                braintreevenmo: {
+                    onError: onErrorCallback,
+                },
+            };
+
+            await strategy.initialize(options);
+            expect(onErrorCallback).toHaveBeenCalled();
+        });
+
+        it('successfully renders braintree venmo button', async () => {
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+            const venmoButton = document.getElementById(options.containerId);
+
+            await strategy.initialize(options);
+
+            expect(venmoButton).toBeInstanceOf(HTMLDivElement);
+        });
+
+        it('successfully tokenize braintreeVenmoCheckout on venmo button click', async () => {
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+            const venmoButton = document.getElementById(options.containerId);
+
+            await strategy.initialize(options);
+
+            if (venmoButton) {
+                venmoButton.click();
+
+                expect(braintreeVenmoCheckoutMock.tokenize).toHaveBeenCalled();
+            }
+        });
+
+        it('successfully sends data through formPoster on venmo button click', async () => {
+            const tokenizationPayload = {
+                nonce: 'tokenization_nonce',
+                type: 'VenmoAccount',
+                details: {
+                    email: 'test@test.com',
+                    firstName: 'John',
+                    lastName: 'Doe',
+                    phone: '123456789',
+                    billingAddress: billingAddressPayload,
+                    shippingAddress: shippingAddressPayload,
+                },
+            };
+
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(callback => callback(undefined, tokenizationPayload)),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+            const venmoButton = document.getElementById(options.containerId);
+
+            await strategy.initialize(options);
+
+            if (venmoButton) {
+                venmoButton.click();
+
+                expect(braintreeVenmoCheckoutMock.tokenize).toHaveBeenCalled();
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', {
+                    action: 'set_external_checkout',
+                    device_data: { device: 'something' },
+                    nonce: 'tokenization_nonce',
+                    payment_type: 'paypal',
+                    provider: 'braintreevenmo',
+                    billing_address: JSON.stringify(expectedAddress),
+                    shipping_address: JSON.stringify(expectedAddress),
+                });
+            }
+        });
+
+        it('successfully sends data through formPoster on venmo button click with shipping data if billing data is not provided', async () => {
+            const tokenizationPayload = {
+                nonce: 'tokenization_nonce',
+                type: 'VenmoAccount',
+                details: {
+                    email: 'test@test.com',
+                    firstName: 'John',
+                    lastName: 'Doe',
+                    phone: '123456789',
+                    shippingAddress: shippingAddressPayload,
+                },
+            };
+
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(callback => callback(undefined, tokenizationPayload)),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+            const venmoButton = document.getElementById(options.containerId);
+
+            await strategy.initialize(options);
+
+            if (venmoButton) {
+                venmoButton.click();
+
+                expect(braintreeVenmoCheckoutMock.tokenize).toHaveBeenCalled();
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', {
+                    action: 'set_external_checkout',
+                    device_data: {
+                        device: 'something',
+                    },
+                    nonce: 'tokenization_nonce',
+                    payment_type: 'paypal',
+                    provider: 'braintreevenmo',
+                    billing_address: JSON.stringify(expectedAddress),
+                    shipping_address: JSON.stringify(expectedAddress),
+                });
+            }
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('teardowns braintree sdk creator on strategy deinitialize', async () => {
+            const options = {
+                methodId: CheckoutButtonMethodType.BRAINTREE_VENMO,
+                containerId: defaultContainerId,
+            };
+
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getVenmoCheckout = jest.fn();
+            braintreeSDKCreator.teardown = jest.fn();
+
+            await strategy.initialize(options);
+            await strategy.deinitialize();
+
+            expect(braintreeSDKCreator.teardown).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
@@ -1,0 +1,145 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { noop } from 'lodash';
+
+import { CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, UnsupportedBrowserError } from '../../../common/error/errors';
+import { PaymentMethodActionCreator } from '../../../payment';
+import { BraintreeError, BraintreeSDKCreator, BraintreeTokenizePayload, BraintreeVenmoCheckout } from '../../../payment/strategies/braintree';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+import { CheckoutButtonMethodType } from '../index';
+
+import mapToLegacyBillingAddress from './map-to-legacy-billing-address';
+import mapToLegacyShippingAddress from './map-to-legacy-shipping-address';
+
+const venmoButtonStyle = {
+    backgroundColor: '#3D95CE',
+    backgroundPosition: '50% 50%',
+    backgroundSize: '80px auto',
+    backgroundImage: 'url("/app/assets/img/payment-providers/venmo-logo-white.svg")',
+    backgroundRepeat: 'no-repeat',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    transition: '0.2s ease',
+    minHeight: '40px',
+    minWidth: '150px',
+    height: '100%',
+    width: '100%',
+};
+
+const venmoButtonStyleHover = {
+    backgroundColor: '#0a7fc2',
+};
+
+export default class BraintreeVenmoButtonStrategy implements CheckoutButtonStrategy {
+    private _onError = noop;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _braintreeSDKCreator: BraintreeSDKCreator,
+        private _formPoster: FormPoster
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { braintreevenmo, containerId, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
+        }
+
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        if (!paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
+        }
+
+        this._onError = braintreevenmo?.onError || this._handleError;
+
+        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        await this._braintreeSDKCreator.getVenmoCheckout(
+            braintreeVenmoCheckout => this._handleInitializationVenmoSuccess(braintreeVenmoCheckout, containerId),
+            error => this._handleInitializationVenmoError(error, containerId)
+        );
+    }
+
+    deinitialize(): Promise<void> {
+        this._braintreeSDKCreator.teardown();
+
+        return Promise.resolve();
+    }
+
+    private _handleError(error: BraintreeError) {
+        throw new Error(error.message);
+    }
+
+    private _handleInitializationVenmoSuccess(braintreeVenmoCheckout: BraintreeVenmoCheckout, parentContainerId: string): void {
+        return this._renderVenmoButton(braintreeVenmoCheckout, parentContainerId);
+    }
+
+    private _handleInitializationVenmoError(error: BraintreeError | UnsupportedBrowserError, containerId: string): void {
+        this._hideVenmoContainer(containerId);
+
+        return this._onError(error);
+    }
+
+    private _hideVenmoContainer(containerId: string): void {
+        const buttonContainer = document.getElementById(containerId);
+        Object.assign(buttonContainer?.style, { display: 'none' });
+    }
+
+    private _renderVenmoButton(braintreeVenmoCheckout: BraintreeVenmoCheckout, containerId: string): void {
+        const venmoButton = document.getElementById(containerId);
+
+        if (!venmoButton) {
+            throw new InvalidArgumentError('Unable to create wallet button without valid container ID.');
+        }
+
+        venmoButton.setAttribute('aria-label', 'Venmo');
+        Object.assign(venmoButton.style, venmoButtonStyle);
+
+        venmoButton.addEventListener('click', () =>  {
+            venmoButton.setAttribute('disabled', 'true');
+
+            if (braintreeVenmoCheckout.tokenize) {
+                braintreeVenmoCheckout.tokenize(async (error: BraintreeError, payload: BraintreeTokenizePayload) => {
+                    venmoButton.removeAttribute('disabled');
+
+                    if (error) {
+                        return this._onError(error);
+                    }
+
+                    await this._handlePostForm(payload);
+                });
+            }
+        });
+
+        venmoButton.addEventListener('mouseenter', () => {
+            venmoButton.style.backgroundColor = venmoButtonStyleHover.backgroundColor;
+        });
+
+        venmoButton.addEventListener('mouseleave', () => {
+            venmoButton.style.backgroundColor = venmoButtonStyle.backgroundColor;
+        });
+    }
+
+    private async _handlePostForm(payload: BraintreeTokenizePayload): Promise<void> {
+        const { deviceData } = await this._braintreeSDKCreator.getDataCollector();
+        const { nonce, details } = payload;
+
+        this._formPoster.postForm('/checkout.php', {
+            nonce,
+            provider: CheckoutButtonMethodType.BRAINTREE_VENMO,
+            payment_type: 'paypal',
+            device_data: deviceData,
+            action: 'set_external_checkout',
+            billing_address: JSON.stringify(mapToLegacyBillingAddress(details)),
+            shipping_address: JSON.stringify(mapToLegacyShippingAddress(details)),
+        });
+    }
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/get-valid-button-style.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/get-valid-button-style.spec.ts
@@ -1,0 +1,80 @@
+import { PaypalButtonStyleColorOption, PaypalButtonStyleLayoutOption, PaypalButtonStyleShapeOption, PaypalButtonStyleSizeOption } from '../../../payment/strategies/paypal';
+
+import getValidButtonStyle from './get-valid-button-style';
+
+describe('#getValidButtonStyle()', () => {
+    it('returns valid button style', () => {
+        const stylesMock = {
+           color: PaypalButtonStyleColorOption.SIlVER,
+           fundingicons: true,
+           height: 55,
+           layout: PaypalButtonStyleLayoutOption.HORIZONTAL,
+           shape: PaypalButtonStyleShapeOption.RECT,
+           size: PaypalButtonStyleSizeOption.SMALL,
+           tagline: true,
+        };
+
+        const expects = {
+           ...stylesMock,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns button style with rect shape if shape is not provided', () => {
+        const stylesMock = {
+           color: PaypalButtonStyleColorOption.SIlVER,
+           fundingicons: true,
+           height: 55,
+           layout: PaypalButtonStyleLayoutOption.HORIZONTAL,
+           shape: undefined,
+           size: PaypalButtonStyleSizeOption.SMALL,
+           tagline: true,
+        };
+
+        const expects = {
+           ...stylesMock,
+           shape: PaypalButtonStyleShapeOption.RECT,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns styles with updated height if height value is bigger than expected', () => {
+        const stylesMock = {
+           color: PaypalButtonStyleColorOption.SIlVER,
+           fundingicons: true,
+           height: 110,
+           layout: PaypalButtonStyleLayoutOption.HORIZONTAL,
+           shape: PaypalButtonStyleShapeOption.RECT,
+           size: PaypalButtonStyleSizeOption.SMALL,
+           tagline: true,
+        };
+
+        const expects = {
+           ...stylesMock,
+           height: 55,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns styles with updated height if height value is less than expected', () => {
+        const stylesMock = {
+            color: PaypalButtonStyleColorOption.SIlVER,
+            fundingicons: true,
+            height: 10,
+            layout: PaypalButtonStyleLayoutOption.HORIZONTAL,
+            shape: PaypalButtonStyleShapeOption.RECT,
+            size: PaypalButtonStyleSizeOption.SMALL,
+            tagline: true,
+        };
+
+        const expects = {
+            ...stylesMock,
+            height: 25,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/braintree/get-valid-button-style.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/get-valid-button-style.ts
@@ -1,0 +1,32 @@
+import { isNil, omitBy } from 'lodash';
+
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
+
+export default function getValidButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+    const { color, fundingicons, height, layout, shape, size, tagline } = style;
+
+    const validStyles = {
+        color,
+        fundingicons,
+        height: validateHeight(height),
+        layout,
+        shape: shape || 'rect',
+        size,
+        tagline,
+    };
+
+    return omitBy(validStyles, isNil);
+}
+
+function validateHeight(height?: number): number | undefined {
+    const minHeight = 25;
+    const maxHeight = 55;
+
+    if (typeof height !== 'number') {
+        return undefined;
+    }
+
+    return (height < minHeight && minHeight)
+        || (height > maxHeight && maxHeight)
+        || height;
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/index.ts
@@ -1,2 +1,11 @@
+// Braintree PayPal
 export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
 export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+
+// Braintree PayPalCredit (PayLater)
+export { default as BraintreePaypalCreditButtonStrategy } from './braintree-paypal-credit-button-strategy';
+export { BraintreePaypalCreditButtonInitializeOptions } from './braintree-paypal-credit-button-options';
+
+// Braintree Venmo
+export { default as BraintreeVenmoButtonStrategy } from './braintree-venmo-button-strategy';
+export { BraintreeVenmoButtonInitializeOptions } from './braintree-venmo-button-options';

--- a/packages/core/src/checkout-buttons/strategies/braintree/map-to-legacy-billing-address.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/map-to-legacy-billing-address.spec.ts
@@ -1,0 +1,71 @@
+import mapToLegacyBillingAddress from './map-to-legacy-billing-address';
+
+describe('mapToLegacyBillingAddress()', () => {
+    const detailsMock = {
+        username: 'johndoe',
+        email: 'test@test.com',
+        payerId: '1122abc',
+        firstName: 'John',
+        lastName: 'Doe',
+        countryCode: 'US',
+        phone: '55555555555',
+        billingAddress: {
+            line1: 'billing_line1',
+            line2: 'billing_line2',
+            city: 'billing_city',
+            state: 'billing_state',
+            postalCode: '03444',
+            countryCode: 'US',
+        },
+        shippingAddress: {
+            recipientName: 'John Doe',
+            line1: 'shipping_line1',
+            line2: 'shipping_line2',
+            city: 'shipping_city',
+            state: 'shipping_state',
+            postalCode: '03444',
+            countryCode: 'US',
+        },
+    };
+
+    it('maps details to legacy billing address using billing details as main address', () => {
+        const props = detailsMock;
+
+        const expects = {
+            email: detailsMock.email,
+            first_name: detailsMock.firstName,
+            last_name: detailsMock.lastName,
+            phone_number: detailsMock.phone,
+            address_line_1: detailsMock.billingAddress.line1,
+            address_line_2: detailsMock.billingAddress.line2,
+            city: detailsMock.billingAddress.city,
+            state: detailsMock.billingAddress.state,
+            country_code: detailsMock.billingAddress.countryCode,
+            postal_code: detailsMock.billingAddress.postalCode,
+        };
+
+        expect(mapToLegacyBillingAddress(props)).toEqual(expects);
+    });
+
+    it('maps details to legacy billing address using shipping details as main address if billing details is not provided', () => {
+        const props = {
+            ...detailsMock,
+            billingAddress: undefined,
+        };
+
+        const expects = {
+            email: detailsMock.email,
+            first_name: detailsMock.firstName,
+            last_name: detailsMock.lastName,
+            phone_number: detailsMock.phone,
+            address_line_1: detailsMock.shippingAddress.line1,
+            address_line_2: detailsMock.shippingAddress.line2,
+            city: detailsMock.shippingAddress.city,
+            state: detailsMock.shippingAddress.state,
+            country_code: detailsMock.shippingAddress.countryCode,
+            postal_code: detailsMock.shippingAddress.postalCode,
+        };
+
+        expect(mapToLegacyBillingAddress(props)).toEqual(expects);
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/braintree/map-to-legacy-billing-address.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/map-to-legacy-billing-address.ts
@@ -1,0 +1,28 @@
+import { LegacyAddress } from '../../../address';
+import { BraintreeDetails } from '../../../payment/strategies/braintree';
+
+export default function mapToLegacyBillingAddress(details: BraintreeDetails): Partial<LegacyAddress> {
+    const {
+        billingAddress,
+        email,
+        firstName,
+        lastName,
+        phone,
+        shippingAddress,
+    } = details;
+
+    const address = billingAddress || shippingAddress;
+
+    return {
+        email,
+        first_name: firstName,
+        last_name: lastName,
+        phone_number: phone,
+        address_line_1: address?.line1,
+        address_line_2: address?.line2,
+        city: address?.city,
+        state: address?.state,
+        country_code: address?.countryCode,
+        postal_code: address?.postalCode,
+    };
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/map-to-legacy-shipping-address.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/map-to-legacy-shipping-address.spec.ts
@@ -1,0 +1,39 @@
+import mapToLegacyShippingAddress from './map-to-legacy-shipping-address';
+
+describe('mapToLegacyShippingAddress()', () => {
+    const detailsMock = {
+        email: 'test@test.com',
+        phone: '55555555555',
+        shippingAddress: {
+            recipientName: 'John Doe',
+            line1: 'shipping_line1',
+            line2: 'shipping_line2',
+            city: 'shipping_city',
+            state: 'shipping_state',
+            postalCode: '03444',
+            countryCode: 'US',
+        },
+    };
+
+    it('maps details to legacy shipping address', () => {
+        const props = {
+            ...detailsMock,
+            billingAddress: undefined,
+        };
+
+        const expects = {
+            email: detailsMock.email,
+            first_name: 'John',
+            last_name: 'Doe',
+            phone_number: detailsMock.phone,
+            address_line_1: detailsMock.shippingAddress.line1,
+            address_line_2: detailsMock.shippingAddress.line2,
+            city: detailsMock.shippingAddress.city,
+            state: detailsMock.shippingAddress.state,
+            country_code: detailsMock.shippingAddress.countryCode,
+            postal_code: detailsMock.shippingAddress.postalCode,
+        };
+
+        expect(mapToLegacyShippingAddress(props)).toEqual(expects);
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/braintree/map-to-legacy-shipping-address.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/map-to-legacy-shipping-address.ts
@@ -1,0 +1,22 @@
+import { LegacyAddress } from '../../../address';
+import { BraintreeDetails } from '../../../payment/strategies/braintree';
+
+export default function mapToLegacyShippingAddress(details: BraintreeDetails): Partial<LegacyAddress> {
+    const { email, phone, shippingAddress } = details;
+
+    const recipientName = shippingAddress?.recipientName || '';
+    const [firstName, lastName] = recipientName.split(' ');
+
+    return {
+        email,
+        first_name: firstName,
+        last_name: lastName,
+        phone_number: phone,
+        address_line_1: shippingAddress?.line1,
+        address_line_2: shippingAddress?.line2,
+        city: shippingAddress?.city,
+        state: shippingAddress?.state,
+        country_code: shippingAddress?.countryCode,
+        postal_code: shippingAddress?.postalCode,
+    };
+}

--- a/packages/core/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal/paypal-button-strategy.spec.ts
@@ -12,7 +12,7 @@ import { InvalidArgumentError, MissingDataError } from '../../../common/error/er
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaypalExpress } from '../../../payment/payment-methods.mock';
-import { PaypalActions, PaypalButtonOptions, PaypalScriptLoader, PaypalSDK } from '../../../payment/strategies/paypal';
+import { PaypalActions, PaypalButtonOptions, PaypalButtonStyleColorOption, PaypalButtonStyleShapeOption, PaypalButtonStyleSizeOption, PaypalScriptLoader, PaypalSDK } from '../../../payment/strategies/paypal';
 import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonMethodType from '../checkout-button-method-type';
@@ -204,9 +204,9 @@ describe('PaypalButtonStrategy', () => {
             paypal: {
                 ...paypalOptions,
                 style: {
-                    color: 'blue',
-                    shape: 'pill',
-                    size: 'responsive',
+                    color: PaypalButtonStyleColorOption.BLUE,
+                    shape: PaypalButtonStyleShapeOption.PILL,
+                    size: PaypalButtonStyleSizeOption.RESPONSIVE,
                 },
             },
         };

--- a/packages/core/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal/paypal-button-strategy.ts
@@ -5,7 +5,7 @@ import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType, StandardError } from '../../../common/error/errors';
 import { INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../../../common/http-request';
 import { PaymentMethod } from '../../../payment';
-import { PaypalActions, PaypalAuthorizeData, PaypalClientToken, PaypalScriptLoader } from '../../../payment/strategies/paypal';
+import { PaypalActions, PaypalAuthorizeData, PaypalButtonStyleShapeOption, PaypalButtonStyleSizeOption, PaypalClientToken, PaypalScriptLoader } from '../../../payment/strategies/paypal';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
@@ -43,14 +43,9 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
                 const env = paymentMethod.config.testMode ? 'sandbox' : 'production';
                 const clientToken: PaypalClientToken = { [env]: paypalOptions.clientId };
 
-                const allowedSources = [];
-                const disallowedSources = [];
-
-                if (paypalOptions.allowCredit) {
-                    allowedSources.push(paypal.FUNDING.CREDIT);
-                } else {
-                    disallowedSources.push(paypal.FUNDING.CREDIT);
-                }
+                const fundingCreditOption = paypal.FUNDING.CREDIT || 'credit';
+                const allowedSources = paypalOptions.allowCredit ? [fundingCreditOption] : [];
+                const disallowedSources = !paypalOptions.allowCredit ? [fundingCreditOption] : [];
 
                 return paypal.Button.render({
                     env,
@@ -61,9 +56,9 @@ export default class PaypalButtonStrategy implements CheckoutButtonStrategy {
                         disallowed: disallowedSources,
                     },
                     style: {
-                        shape: 'rect',
+                        shape: PaypalButtonStyleShapeOption.RECT,
                         ...pick(paypalOptions.style, 'layout', 'color', 'label', 'shape', 'tagline', 'fundingicons'),
-                        size: (paymentMethod.id === 'paypalexpress' && paypalOptions.style?.size === 'small') ? 'responsive' : paypalOptions.style?.size,
+                        size: (paymentMethod.id === 'paypalexpress' && paypalOptions.style?.size === 'small') ? PaypalButtonStyleSizeOption.RESPONSIVE : paypalOptions.style?.size,
                     },
                     payment: (_, actions) => this._setupPayment(merchantId, actions, paypalOptions.onPaymentError),
                     onAuthorize: (data, actions) => this._tokenizePayment(data, actions, paypalOptions.shouldProcessPayment, paypalOptions.onAuthorizeError),

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -161,9 +161,6 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
             expect(braintreePaymentProcessorMock.isInitializedHostedForm).toHaveBeenCalled();
             expect(braintreePaymentProcessorMock.getSessionId).toHaveBeenCalled();
         });
-
-        // throws BraintreeError
-        // throws another error
     });
 
     describe('#deinitialize()', () => {

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -3,7 +3,7 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 import { GooglePayCreator } from '../googlepay';
 
-import { BraintreeClientCreator, BraintreeDataCollectorCreator, BraintreeHostedFieldsCreator, BraintreeHostWindow, BraintreePaypalCheckoutCreator, BraintreePaypalCreator, BraintreeThreeDSecureCreator, BraintreeVisaCheckoutCreator } from './braintree';
+import { BraintreeClientCreator, BraintreeDataCollectorCreator, BraintreeHostedFieldsCreator, BraintreeHostWindow, BraintreePaypalCheckoutCreator, BraintreePaypalCreator, BraintreeThreeDSecureCreator, BraintreeVenmoCheckoutCreator, BraintreeVisaCheckoutCreator } from './braintree';
 
 const version = '3.81.0';
 
@@ -63,7 +63,6 @@ export default class BraintreeScriptLoader {
     }
 
     loadPaypalCheckout(): Promise<BraintreePaypalCheckoutCreator> {
-
         return this._scriptLoader
             .loadScript(`//js.braintreegateway.com/web/${version}/js/paypal-checkout.min.js`)
             .then(() => {
@@ -87,11 +86,11 @@ export default class BraintreeScriptLoader {
             });
     }
 
-    loadVenmoCheckout() {
+    loadVenmoCheckout(): Promise<BraintreeVenmoCheckoutCreator> {
         return this._scriptLoader
             .loadScript(`//js.braintreegateway.com/web/${version}/js/venmo.min.js`)
             .then(() => {
-                if (!this._window.braintree || !this._window.braintree.venmo) {
+                if (!this._window.braintree?.venmo) {
                     throw new PaymentMethodClientUnavailableError();
                 }
 

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -1,23 +1,7 @@
-import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { NotInitializedError, NotInitializedErrorType, UnsupportedBrowserError } from '../../../common/error/errors';
+import { PaypalHostWindow } from '../paypal';
 
-import { BraintreeClient,
-    BraintreeDataCollector,
-    BraintreeHostedFields,
-    BraintreeHostedFieldsCreatorConfig,
-    BraintreeModule,
-    BraintreePaypal,
-    BraintreePaypalCheckout,
-    BraintreeThreeDSecure,
-    BraintreeVisaCheckout,
-    GetPaypalConfig,
-    GetVenmoConfig,
-    GooglePayBraintreeSDK,
-    PaypalClientInstance,
-    PAYPAL_COMPONENTS,
-    RenderButtons,
-    RenderVenmoButtons,
-    VenmoCheckout,
-    VenmoInstance } from './braintree';
+import { BraintreeClient, BraintreeDataCollector, BraintreeError, BraintreeHostedFields, BraintreeHostedFieldsCreatorConfig, BraintreeModule, BraintreePaypal, BraintreePaypalCheckout, BraintreeThreeDSecure, BraintreeVenmoCheckout, BraintreeVisaCheckout, GooglePayBraintreeSDK, PAYPAL_COMPONENTS } from './braintree';
 import BraintreeScriptLoader from './braintree-script-loader';
 
 export default class BraintreeSDKCreator {
@@ -27,18 +11,19 @@ export default class BraintreeSDKCreator {
     private _paypalCheckout?: Promise<BraintreePaypalCheckout>;
     private _clientToken?: string;
     private _visaCheckout?: Promise<BraintreeVisaCheckout>;
+    private _venmoCheckout?: Promise<BraintreeVenmoCheckout>;
     private _dataCollectors: {
         default?: Promise<BraintreeDataCollector>;
         paypal?: Promise<BraintreeDataCollector>;
     } = {};
     private _googlePay?: Promise<GooglePayBraintreeSDK>;
-    private _paypalcheckoutInstance?: PaypalClientInstance;
-    private _venmoCheckoutInstance?: VenmoInstance;
-    private _venmoCheckout?: VenmoCheckout;
+    private _window: PaypalHostWindow;
 
     constructor(
         private _braintreeScriptLoader: BraintreeScriptLoader
-    ) {}
+    ) {
+        this._window = window;
+    }
 
     initialize(clientToken: string) {
         this._clientToken = clientToken;
@@ -69,52 +54,67 @@ export default class BraintreeSDKCreator {
         return this._paypal;
     }
 
-    getPaypalCheckout(config: GetPaypalConfig, renderButtonCallback: RenderButtons): Promise<BraintreePaypalCheckout> {
-        if (!this._paypalCheckout) {
-            this._paypalCheckout = Promise.all([
-                this.getClient(),
-                this._braintreeScriptLoader.loadPaypalCheckout(),
-            ])
-                .then(([client, paypalCheckout]) => paypalCheckout.create({ client }, (_error: string, instance: PaypalClientInstance) =>  {
-                    this._paypalcheckoutInstance = instance;
-                    instance.loadPayPalSDK({
-                        currency: config.currency,
-                        components: PAYPAL_COMPONENTS.toString(),
-                    }, () => {
-                        renderButtonCallback(instance);
-                    });
-                }));
-        } else if (this._paypalcheckoutInstance) {
-            renderButtonCallback(this._paypalcheckoutInstance);
-        }
+    async getPaypalCheckout(
+        config: { currency: string },
+        onSuccess: (instance: BraintreePaypalCheckout) => void,
+        onError: (error: BraintreeError) => void
+    ): Promise<BraintreePaypalCheckout> {
+        const client = await this.getClient();
+        const paypalCheckout = await this._braintreeScriptLoader.loadPaypalCheckout();
+
+        const paypalCheckoutConfig = { client };
+        const paypalCheckoutCallback = (error: BraintreeError, braintreePaypalCheckout: BraintreePaypalCheckout) => {
+            if (error) {
+                return onError(error);
+            }
+
+            const paypalSdkLoadCallback = () => onSuccess(braintreePaypalCheckout);
+            const paypalSdkLoadConfig = {
+                currency: config.currency,
+                components: PAYPAL_COMPONENTS.toString(),
+            };
+
+            if (!this._window.paypal) {
+                braintreePaypalCheckout.loadPayPalSDK(paypalSdkLoadConfig, paypalSdkLoadCallback);
+            } else {
+                onSuccess(braintreePaypalCheckout);
+            }
+        };
+
+        this._paypalCheckout = paypalCheckout.create(paypalCheckoutConfig, paypalCheckoutCallback);
 
         return this._paypalCheckout;
     }
 
-    getVenmoCheckout(config: GetVenmoConfig, getVenmoInstance: RenderVenmoButtons): Promise<void> {
-        if (!config.isBraintreeVenmoEnabled) {
-            return Promise.resolve();
+    async getVenmoCheckout(
+        onSuccess: (braintreeVenmoCheckout: BraintreeVenmoCheckout) => void,
+        onError: (error: BraintreeError | UnsupportedBrowserError) => void
+    ): Promise<BraintreeVenmoCheckout> {
+        if (!this._venmoCheckout) {
+            const client = await this.getClient();
+
+            const venmoCheckout = await this._braintreeScriptLoader.loadVenmoCheckout();
+
+            const venmoCheckoutConfig = {
+                client,
+                allowDesktop: true,
+                paymentMethodUsage: 'multi_use',
+            };
+
+            const venmoCheckoutCallback = (error: BraintreeError, braintreeVenmoCheckout: BraintreeVenmoCheckout): void => {
+                if (error) {
+                    return onError(error);
+                }
+
+                if (!braintreeVenmoCheckout.isBrowserSupported()) {
+                    return onError(new UnsupportedBrowserError());
+                }
+
+                onSuccess(braintreeVenmoCheckout);
+            };
+
+            this._venmoCheckout = venmoCheckout.create(venmoCheckoutConfig, venmoCheckoutCallback);
         }
-        this._venmoCheckout = Promise.all([
-            this.getClient(),
-            this._braintreeScriptLoader.loadVenmoCheckout(),
-        ])
-            .then(([client, venmoCheckout]) => venmoCheckout.create({
-                    client, allowDesktop: true,
-                    paymentMethodUsage: 'multi_use',
-                },
-                (venmoErr: string, venmoInstance: VenmoInstance) =>  {
-                    this._venmoCheckoutInstance = venmoInstance;
-                    getVenmoInstance(this._venmoCheckoutInstance);
-                    if (venmoErr) {
-                        return;
-                    }
-
-                    if (!venmoInstance.isBrowserSupported()) {
-
-                        return;
-                    }
-                }));
 
         return this._venmoCheckout;
     }
@@ -195,13 +195,17 @@ export default class BraintreeSDKCreator {
             this._teardown(this._3ds),
             this._teardown(this._dataCollectors.default),
             this._teardown(this._dataCollectors.paypal),
-            this._teardown(this._visaCheckout),
             this._teardown(this._googlePay),
+            this._teardown(this._paypalCheckout),
+            this._teardown(this._venmoCheckout),
+            this._teardown(this._visaCheckout),
         ]).then(() => {
             this._3ds = undefined;
-            this._visaCheckout = undefined;
             this._dataCollectors = {};
             this._googlePay = undefined;
+            this._paypalCheckout = undefined;
+            this._venmoCheckout = undefined;
+            this._visaCheckout = undefined;
         });
     }
 

--- a/packages/core/src/payment/strategies/braintree/braintree.mock.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.mock.ts
@@ -1,7 +1,7 @@
 import { OrderPaymentRequestBody } from '../../../order';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 
-import { BraintreeClient, BraintreeDataCollector, BraintreeHostedFields, BraintreeModule, BraintreeModuleCreator, BraintreePaypalCheckout, BraintreeRequestData, BraintreeShippingAddressOverride, BraintreeThreeDSecure, BraintreeTokenizePayload, BraintreeTokenizeResponse, BraintreeVerifyPayload, BraintreeVisaCheckout, GooglePayBraintreeSDK, VenmoInstance } from './braintree';
+import { BraintreeClient, BraintreeDataCollector, BraintreeHostedFields, BraintreeModule, BraintreeModuleCreator, BraintreePaypalCheckout, BraintreePaypalCheckoutCreator, BraintreeRequestData, BraintreeShippingAddressOverride, BraintreeThreeDSecure, BraintreeTokenizePayload, BraintreeTokenizeResponse, BraintreeVenmoCheckout, BraintreeVerifyPayload, BraintreeVisaCheckout, GooglePayBraintreeSDK } from './braintree';
 import { BraintreeThreeDSecureOptions } from './braintree-payment-options';
 
 export function getClientMock(): BraintreeClient {
@@ -40,15 +40,25 @@ export function getVisaCheckoutMock(): BraintreeVisaCheckout {
 
 export function getPaypalCheckoutMock(): BraintreePaypalCheckout {
     return {
+        loadPayPalSDK: jest.fn((_config, callback) => callback()),
         createPayment: jest.fn((() => Promise.resolve())),
         teardown: jest.fn(),
         tokenizePayment: jest.fn(() => Promise.resolve(getTokenizePayload())),
     };
 }
 
-export function getVenmoCheckoutMock(): VenmoInstance {
+export function getPayPalCheckoutCreatorMock(braintreePaypalCheckoutMock: BraintreePaypalCheckout | undefined, shouldThrowError: boolean): BraintreePaypalCheckoutCreator {
     return {
-        create: jest.fn((() => Promise.resolve())),
+        create: shouldThrowError
+            ? jest.fn((_config, callback) => callback(new Error('test'), undefined))
+            : jest.fn((_config, callback) => callback(undefined, braintreePaypalCheckoutMock)),
+    };
+}
+
+export function getVenmoCheckoutMock(): BraintreeVenmoCheckout {
+    return {
+        teardown: jest.fn((() => Promise.resolve())),
+        tokenize: jest.fn((() => Promise.resolve())),
         isBrowserSupported: jest.fn(),
     };
 }

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -1,3 +1,6 @@
+import { PaymentMethod } from '@bigcommerce/checkout-sdk/core';
+
+import { BraintreePaypalOldButtonInitializeOptions } from '../../../checkout-buttons/strategies/braintree/braintree-paypal-old-button-options';
 import { GooglePaymentData, GooglePayBraintreeDataRequest, GooglePayBraintreePaymentDataRequestV1, GooglePayCreator, TokenizePayload } from '../googlepay';
 import { PaypalAuthorizeData, PaypalButtonOptions, PaypalButtonRender, PaypalSDK } from '../paypal';
 
@@ -453,4 +456,13 @@ export interface BraintreeVisaCheckout extends BraintreeModule {
 export interface BraintreeHostWindow extends Window {
     braintree?: BraintreeSDK;
     paypal?: PaypalSDK;
+}
+
+// TODO: remove after braintree-paypal-old-button-strategy will be removed
+export interface RenderButtonsData {
+    paymentMethod: PaymentMethod;
+    paypalOptions: BraintreePaypalOldButtonInitializeOptions;
+    container: string;
+    venmoParentContainer: string;
+    messagingContainerId?: string;
 }

--- a/packages/core/src/payment/strategies/braintree/index.ts
+++ b/packages/core/src/payment/strategies/braintree/index.ts
@@ -13,3 +13,4 @@ export { default as createBraintreeVisaCheckoutPaymentProcessor } from './create
 export { default as VisaCheckoutScriptLoader } from './visacheckout-script-loader';
 export { default as BraintreeVisaCheckoutPaymentStrategy } from './braintree-visacheckout-payment-strategy';
 export { default as BraintreeVisaCheckoutPaymentInitializeOptions } from './braintree-visacheckout-payment-initialize-options';
+export { default as mapToBraintreeShippingAddressOverride } from './map-to-braintree-shipping-address-override';

--- a/packages/core/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal/paypal-sdk.ts
@@ -7,9 +7,10 @@ export interface PaypalSDK {
 }
 
 export interface PaypalFundingTypeList {
-    CARD: string;
-    CREDIT: string;
-    PAYPAL: string;
+    CARD?: string;
+    CREDIT?: string;
+    PAYPAL?: string;
+    PAYLATER?: string;
 }
 
 export interface PaypalButton {
@@ -54,12 +55,44 @@ export interface PaypalFundingType {
     disallowed?: string[];
 }
 
+export enum PaypalButtonStyleLayoutOption {
+    HORIZONTAL = 'horizontal',
+    VERTICAL = 'vertical',
+}
+
+export enum PaypalButtonStyleSizeOption {
+    SMALL = 'small',
+    MEDIUM = 'medium',
+    LARGE = 'large',
+    RESPONSIVE = 'responsive',
+}
+
+export enum PaypalButtonStyleColorOption {
+    GOLD = 'gold',
+    BLUE = 'blue',
+    SIlVER = 'silver',
+    BLACK = 'black',
+}
+
+export enum PaypalButtonStyleLabelOption {
+    CHECKOUT = 'checkout',
+    PAY = 'pay',
+    BUYNOW = 'buynow',
+    PAYPAL = 'paypal',
+    CREDIT = 'credit',
+}
+
+export enum PaypalButtonStyleShapeOption {
+    PILL = 'pill',
+    RECT = 'rect',
+}
+
 export interface PaypalButtonStyleOptions {
-    layout?: 'horizontal' | 'vertical';
-    size?: 'small' | 'medium' | 'large' | 'responsive';
-    color?: 'gold' | 'blue' | 'silver' | 'black';
-    label?: 'checkout' | 'pay' | 'buynow' | 'paypal' | 'credit';
-    shape?: 'pill' | 'rect';
+    layout?: PaypalButtonStyleLayoutOption;
+    size?: PaypalButtonStyleSizeOption;
+    color?: PaypalButtonStyleColorOption;
+    label?: PaypalButtonStyleLabelOption;
+    shape?: PaypalButtonStyleShapeOption;
     tagline?: boolean;
     fundingicons?: boolean;
     height?: number;

--- a/packages/core/src/payment/strategies/paypal/paypal.mock.ts
+++ b/packages/core/src/payment/strategies/paypal/paypal.mock.ts
@@ -5,6 +5,7 @@ export function getPaypalMock(): PaypalSDK {
         FUNDING: {
             CARD: 'card',
             CREDIT: 'credit',
+            PAYLATER: 'paylater',
             PAYPAL: 'paypal',
         },
         Button: {


### PR DESCRIPTION
## What?
Separated braintreepaypal and braintreepaypalcredit checkout buttons strategies

## Why?
Because it might be easier to render the buttons in their own containers and it's better to separate different providers (paypal / paypalcredit) into theirs own files.

## Testing / Proof
Unit tests
Manual tests

<img width="313" alt="Screenshot 2022-06-02 at 15 38 30" src="https://user-images.githubusercontent.com/25133454/171633791-74314778-3564-48ab-acbd-591201775be7.png">
