### PR TITLE
feat(payment): BOLT-238 Card method swap

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -112,6 +112,7 @@ export interface CheckoutSettings {
     orderTermsAndConditionsType: string;
     privacyPolicyUrl: string;
     providerWithCustomCheckout: string | null;
+    paymentMethodsWithCreditCardConflicts: PaymentMethodsWithConflicts[] | null;
     shippingQuoteFailedMessage: string;
     realtimeShippingProviders: string[];
     requiresMarketingConsent: boolean;
@@ -138,4 +139,9 @@ export interface ContextConfig {
         formId?: string;
         token?: string;
     };
+}
+
+export interface PaymentMethodsWithConflicts {
+    methodId: string;
+    conflictMethodIds: string[];
 }

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -42,6 +42,7 @@ export function getConfig(): Config {
                 orderTermsAndConditionsType: '',
                 privacyPolicyUrl: '',
                 providerWithCustomCheckout: null,
+                paymentMethodsWithCreditCardConflicts: null,
                 shippingQuoteFailedMessage: 'Unfortunately one or more items in your cart can\'t be shipped to your location. Please choose a different delivery address.',
                 realtimeShippingProviders: [
                     'Fedex',


### PR DESCRIPTION
## What?
Interfaces update for new `paymentMethodsWithCreditCardConflicts` in `storeConfig`. This need for implementation new logic in checkpot-js: [https://github.com/bigcommerce/checkout-js/pull/877](https://github.com/bigcommerce/checkout-js/pull/877)

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-235](https://bigcommercecloud.atlassian.net/browse/BOLT-235)
For cases when merchant setup multiple payment providers and this providers has similar payment methods, we should hide this conflicts methods. 
For example:
Merchant setup Braintree and Bolt (with Braintree as payment system)
So customers will see two Credit card fields in payment section. And both of them will be processed by Braintree.
For this cases we need to hide similar fields and show only one Credit card field.
And we should keep workable all other payment methods for this providers, like embedded forms and other.
Video example of solution:

https://user-images.githubusercontent.com/9430298/169863639-332380e1-c125-45de-9d87-c101240ee023.mov

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments
