### PR TITLE
feat(payment): STRIPE-9 [Stripe UPE] Add support for Klarna

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -26,6 +26,7 @@ const APM_REDIRECT = [
   StripePaymentMethodType.IDEAL,
   StripePaymentMethodType.GIROPAY,
   StripePaymentMethodType.ALIPAY,
+  StripePaymentMethodType.KLARNA,
 ];
 
 export default class StripeUPEPaymentStrategy implements PaymentStrategy {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -226,6 +226,7 @@ export enum StripePaymentMethodType {
     IDEAL = 'ideal',
     GIROPAY = 'giropay',
     ALIPAY = 'alipay',
+    KLARNA = 'klarna',
 }
 
 type AutoOrNever = StripeStringConstants.AUTO | StripeStringConstants.NEVER;


### PR DESCRIPTION
## What? [STRIPE-9](https://bigcommercecloud.atlassian.net/browse/STRIPE-9)
Add support for Klarna as a payment method on StripeUPE.

## Why?
To enable and use Klarna with Stripe UPE.

As a Merchant, I want to be able to enable or disable Klarna within the Stripe configuration settings page so that I can control whether Klarna is available to my shoppers or not.

## Testing / Proof

- [Authorize Only](https://drive.google.com/file/d/1QTni4ZiwHSKCOwgodiYBbLIlA87SoJbC/view?usp=sharing)
- [Purchase](https://drive.google.com/file/d/1Y-6b6MlE2Y8FJfOhPlr8vkQ3u_nLyXJl/view?usp=sharing)
- [Capture](https://drive.google.com/file/d/1HH-O7eKoWN1mfULEdxXKF99b7vtnuo8M/view?usp=sharing)
- [Refund](https://drive.google.com/file/d/1n8PBKG6MEvXndZkmYHcBpuqquDWqq0_m/view?usp=sharing)
- [Void](https://drive.google.com/file/d/1eg8qTgDgvEMntF9-0W_3fIJ4p95Jn4pr/view?usp=sharing)


![Screen Shot 2022-06-02 at 5 52 43 PM](https://user-images.githubusercontent.com/69487174/171751153-ad055fd8-6251-4e02-8e44-9da770b70118.png)

![Screen Shot 2022-06-02 at 4 46 40 PM](https://user-images.githubusercontent.com/69487174/171751177-7772d2f8-75b6-46d8-8c41-005b14b36325.png)


![Screen Shot 2022-06-09 at 11 18 04 AM](https://user-images.githubusercontent.com/69487174/172911051-3198d9c1-b8fb-4199-bc09-466a43395e7f.png)

ping @bigcommerce/payments @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team 
