### PR TITLE
feat(payment): PAYPAL-1381 added braintreevenmo checkout button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -3,7 +3,7 @@ import { RequestOptions } from '../common/http-request';
 import { CheckoutButtonMethodType } from './strategies';
 import { AmazonPayV2ButtonInitializeOptions } from './strategies/amazon-pay-v2';
 import { ApplePayButtonInitializeOptions } from './strategies/apple-pay';
-import { BraintreePaypalCreditButtonInitializeOptions, BraintreePaypalV1ButtonInitializeOptions } from './strategies/braintree';
+import { BraintreePaypalCreditButtonInitializeOptions, BraintreePaypalV1ButtonInitializeOptions, BraintreeVenmoButtonInitializeOptions } from './strategies/braintree';
 import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
 import { PaypalCommerceButtonInitializeOptions } from './strategies/paypal-commerce';
@@ -48,6 +48,12 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * omitted unless you need to support Braintree Credit.
      */
     braintreepaypalcreditv2?: BraintreePaypalCreditButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate Braintree Venmo. They can be
+     * omitted unless you need to support Braintree Venmo.
+     */
+    braintreevenmo?: BraintreeVenmoButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate PayPal. They can be omitted

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -9,7 +9,7 @@ import createCheckoutButtonRegistry from './create-checkout-button-registry';
 import { CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
-import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
+import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreePaypalV1ButtonStrategy, BraintreeVenmoButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 
 describe('createCheckoutButtonRegistry', () => {
@@ -39,6 +39,10 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with Braintree PayPal Credit V2 registered', () => {
         expect(registry.get('braintreepaypalcreditv2')).toEqual(expect.any(BraintreePaypalCreditButtonStrategy));
+    });
+
+    it('returns registry with Braintree Venmo registered', () => {
+        expect(registry.get('braintreevenmo')).toEqual(expect.any(BraintreeVenmoButtonStrategy));
     });
 
     it('returns registry with GooglePay on Adyen Credit registered', () => {

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -24,7 +24,7 @@ import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subsc
 import { CheckoutButtonMethodType, CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
-import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
+import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreeVenmoButtonStrategy, BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 import { MasterpassButtonStrategy } from './strategies/masterpass';
 import { PaypalButtonStrategy } from './strategies/paypal';
@@ -131,6 +131,15 @@ export default function createCheckoutButtonRegistry(
             braintreeSdkCreator,
             formPoster,
             window
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.BRAINTREE_VENMO, () =>
+        new BraintreeVenmoButtonStrategy(
+            store,
+            paymentMethodActionCreator,
+            braintreeSdkCreator,
+            formPoster
         )
     );
 

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-options.ts
@@ -1,0 +1,11 @@
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+
+export interface BraintreeVenmoButtonInitializeOptions {
+    /**
+     * A callback that gets called on any error.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: BraintreeError | StandardError): void;
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
@@ -1,0 +1,392 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
+import { getBraintree } from '../../../payment/payment-methods.mock';
+import { BraintreeScriptLoader, BraintreeSDKCreator, BraintreeVenmoCheckout, BraintreeVenmoCheckoutCreator } from '../../../payment/strategies/braintree';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+
+import BraintreeVenmoButtonStrategy from './braintree-venmo-button-strategy';
+
+describe('BraintreeVenmoButtonStrategy', () => {
+    let braintreeSDKCreator: BraintreeSDKCreator;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let braintreeVenmoCheckoutMock: BraintreeVenmoCheckout;
+    let braintreeVenmoCheckoutCreatorMock: BraintreeVenmoCheckoutCreator;
+    let formPoster: FormPoster;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let venmoButtonElement: HTMLDivElement;
+    let store: CheckoutStore;
+    let strategy: BraintreeVenmoButtonStrategy;
+
+    const defaultContainerId = 'braintree-venmo-button-mock-id';
+
+    const getBraintreeVenmoButtonOptionsMock = () => ({
+        methodId: CheckoutButtonMethodType.BRAINTREE_VENMO,
+        containerId: defaultContainerId,
+        braintreevenmo: {
+            onError: jest.fn(),
+        },
+    });
+
+    const billingAddressPayload = {
+        line1: 'line1',
+        line2: 'line2',
+        city: 'city',
+        state: 'state',
+        postalCode: 'postalCode',
+        countryCode: 'countryCode',
+    };
+
+    const shippingAddressPayload = {
+        ...billingAddressPayload,
+        recipientName: 'John Doe',
+    };
+
+    const expectedAddress = {
+        email: 'test@test.com',
+        first_name: 'John',
+        last_name: 'Doe',
+        phone_number: '123456789',
+        address_line_1: 'line1',
+        address_line_2: 'line2',
+        city: 'city',
+        state: 'state',
+        country_code: 'countryCode',
+        postal_code: 'postalCode',
+    };
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader());
+        braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        formPoster = createFormPoster();
+
+        strategy = new BraintreeVenmoButtonStrategy(
+            store,
+            paymentMethodActionCreator,
+            braintreeSDKCreator,
+            formPoster
+        );
+
+        paymentMethodMock = {
+            ...getBraintree(),
+            clientToken: 'myToken',
+            initializationData: {
+                merchantAccountId: '100000',
+            },
+        };
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+        jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(paymentMethodMock.clientToken);
+        jest.spyOn(braintreeSDKCreator, 'getDataCollector').mockReturnValue({ deviceData: { device: 'something' } });
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+
+        venmoButtonElement = document.createElement('div');
+        venmoButtonElement.id = defaultContainerId;
+        document.body.appendChild(venmoButtonElement);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        if (document.getElementById(defaultContainerId)) {
+            document.body.removeChild(venmoButtonElement);
+        }
+    });
+
+    it('creates an instance of the braintree venmo checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(BraintreeVenmoButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = { containerId: 'braintree-venmo-button-mock-id' } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if client token is missing', async () => {
+            paymentMethodMock.clientToken = undefined;
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = { methodId: CheckoutButtonMethodType.BRAINTREE_VENMO } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('initializes braintree sdk creator', async () => {
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getVenmoCheckout = jest.fn();
+
+            await strategy.initialize(options);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+        });
+
+        it('initializes the braintree venmo checkout', async () => {
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getVenmoCheckout = jest.fn();
+
+            await strategy.initialize(options);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+            expect(braintreeSDKCreator.getVenmoCheckout).toHaveBeenCalled();
+        });
+
+        it('calls braintree venmo checkout create method', async () => {
+            braintreeVenmoCheckoutCreatorMock = { create: jest.fn() };
+
+            jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(paymentMethodMock.clientToken);
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            await strategy.initialize(options);
+
+            expect(braintreeVenmoCheckoutCreatorMock.create).toHaveBeenCalled();
+        });
+
+        it('calls onError callback option if the error was caught on braintree venmo checkout creation', async () => {
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(new Error('test'), undefined)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const onErrorCallback = jest.fn();
+
+            const options = {
+                ...getBraintreeVenmoButtonOptionsMock(),
+                braintreevenmo: {
+                    onError: onErrorCallback,
+                },
+            };
+
+            await strategy.initialize(options);
+            expect(onErrorCallback).toHaveBeenCalled();
+        });
+
+        it('calls onError callback option if customer browser is not supported', async () => {
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(false),
+                teardown: jest.fn(),
+                tokenize: jest.fn(),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const onErrorCallback = jest.fn();
+
+            const options = {
+                ...getBraintreeVenmoButtonOptionsMock(),
+                braintreevenmo: {
+                    onError: onErrorCallback,
+                },
+            };
+
+            await strategy.initialize(options);
+            expect(onErrorCallback).toHaveBeenCalled();
+        });
+
+        it('successfully renders braintree venmo button', async () => {
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+            const venmoButton = document.getElementById(options.containerId);
+
+            await strategy.initialize(options);
+
+            expect(venmoButton).toBeInstanceOf(HTMLDivElement);
+        });
+
+        it('successfully tokenize braintreeVenmoCheckout on venmo button click', async () => {
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+            const venmoButton = document.getElementById(options.containerId);
+
+            await strategy.initialize(options);
+
+            if (venmoButton) {
+                venmoButton.click();
+
+                expect(braintreeVenmoCheckoutMock.tokenize).toHaveBeenCalled();
+            }
+        });
+
+        it('successfully sends data through formPoster on venmo button click', async () => {
+            const tokenizationPayload = {
+                nonce: 'tokenization_nonce',
+                type: 'VenmoAccount',
+                details: {
+                    email: 'test@test.com',
+                    firstName: 'John',
+                    lastName: 'Doe',
+                    phone: '123456789',
+                    billingAddress: billingAddressPayload,
+                    shippingAddress: shippingAddressPayload,
+                },
+            };
+
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(callback => callback(undefined, tokenizationPayload)),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+            const venmoButton = document.getElementById(options.containerId);
+
+            await strategy.initialize(options);
+
+            if (venmoButton) {
+                venmoButton.click();
+
+                expect(braintreeVenmoCheckoutMock.tokenize).toHaveBeenCalled();
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', {
+                    action: 'set_external_checkout',
+                    device_data: { device: 'something' },
+                    nonce: 'tokenization_nonce',
+                    payment_type: 'paypal',
+                    provider: 'braintreevenmo',
+                    billing_address: JSON.stringify(expectedAddress),
+                    shipping_address: JSON.stringify(expectedAddress),
+                });
+            }
+        });
+
+        it('successfully sends data through formPoster on venmo button click with shipping data if billing data is not provided', async () => {
+            const tokenizationPayload = {
+                nonce: 'tokenization_nonce',
+                type: 'VenmoAccount',
+                details: {
+                    email: 'test@test.com',
+                    firstName: 'John',
+                    lastName: 'Doe',
+                    phone: '123456789',
+                    shippingAddress: shippingAddressPayload,
+                },
+            };
+
+            braintreeVenmoCheckoutMock = {
+                isBrowserSupported: jest.fn().mockReturnValue(true),
+                teardown: jest.fn(),
+                tokenize: jest.fn(callback => callback(undefined, tokenizationPayload)),
+            };
+
+            braintreeVenmoCheckoutCreatorMock = {
+                create: jest.fn((_config, callback) => callback(undefined, braintreeVenmoCheckoutMock)),
+            };
+
+            jest.spyOn(braintreeScriptLoader, 'loadVenmoCheckout').mockReturnValue(braintreeVenmoCheckoutCreatorMock);
+
+            const options = getBraintreeVenmoButtonOptionsMock();
+            const venmoButton = document.getElementById(options.containerId);
+
+            await strategy.initialize(options);
+
+            if (venmoButton) {
+                venmoButton.click();
+
+                expect(braintreeVenmoCheckoutMock.tokenize).toHaveBeenCalled();
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', {
+                    action: 'set_external_checkout',
+                    device_data: {
+                        device: 'something',
+                    },
+                    nonce: 'tokenization_nonce',
+                    payment_type: 'paypal',
+                    provider: 'braintreevenmo',
+                    billing_address: JSON.stringify(expectedAddress),
+                    shipping_address: JSON.stringify(expectedAddress),
+                });
+            }
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('teardowns braintree sdk creator on strategy deinitialize', async () => {
+            const options = getBraintreeVenmoButtonOptionsMock();
+
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getVenmoCheckout = jest.fn();
+            braintreeSDKCreator.teardown = jest.fn();
+
+            await strategy.initialize(options);
+            await strategy.deinitialize();
+
+            expect(braintreeSDKCreator.teardown).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
@@ -1,0 +1,148 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { noop } from 'lodash';
+
+import { CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, UnsupportedBrowserError } from '../../../common/error/errors';
+import { PaymentMethodActionCreator } from '../../../payment';
+import { BraintreeError, BraintreeSDKCreator, BraintreeTokenizePayload, BraintreeVenmoCheckout } from '../../../payment/strategies/braintree';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+import { CheckoutButtonMethodType } from '../index';
+
+import mapToLegacyBillingAddress from './map-to-legacy-billing-address';
+import mapToLegacyShippingAddress from './map-to-legacy-shipping-address';
+
+const venmoButtonStyle = {
+    backgroundColor: '#3D95CE',
+    backgroundPosition: '50% 50%',
+    backgroundSize: '80px auto',
+    backgroundImage: 'url("/app/assets/img/payment-providers/venmo-logo-white.svg")',
+    backgroundRepeat: 'no-repeat',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    transition: '0.2s ease',
+    minHeight: '40px',
+    minWidth: '150px',
+    height: '100%',
+    width: '100%',
+};
+
+const venmoButtonStyleHover = {
+    backgroundColor: '#0a7fc2',
+};
+
+export default class BraintreeVenmoButtonStrategy implements CheckoutButtonStrategy {
+    private _onError = noop;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _braintreeSDKCreator: BraintreeSDKCreator,
+        private _formPoster: FormPoster
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { braintreevenmo, containerId, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
+        }
+
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        if (!paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
+        }
+
+        this._onError = braintreevenmo?.onError || this._handleError;
+
+        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        await this._braintreeSDKCreator.getVenmoCheckout(
+            braintreeVenmoCheckout => this._handleInitializationVenmoSuccess(braintreeVenmoCheckout, containerId),
+            error => this._handleInitializationVenmoError(error, containerId)
+        );
+    }
+
+    deinitialize(): Promise<void> {
+        this._braintreeSDKCreator.teardown();
+
+        return Promise.resolve();
+    }
+
+    private _handleError(error: BraintreeError) {
+        throw new Error(error.message);
+    }
+
+    private _handleInitializationVenmoSuccess(braintreeVenmoCheckout: BraintreeVenmoCheckout, parentContainerId: string): void {
+        return this._renderVenmoButton(braintreeVenmoCheckout, parentContainerId);
+    }
+
+    private _handleInitializationVenmoError(error: BraintreeError | UnsupportedBrowserError, containerId: string): void {
+        this._removeVenmoContainer(containerId);
+
+        return this._onError(error);
+    }
+
+    private _removeVenmoContainer(containerId: string): void {
+        const buttonContainer = document.getElementById(containerId);
+
+        if (buttonContainer) {
+            buttonContainer.remove();
+        }
+    }
+
+    private _renderVenmoButton(braintreeVenmoCheckout: BraintreeVenmoCheckout, containerId: string): void {
+        const venmoButton = document.getElementById(containerId);
+
+        if (!venmoButton) {
+            throw new InvalidArgumentError('Unable to create wallet button without valid container ID.');
+        }
+
+        venmoButton.setAttribute('aria-label', 'Venmo');
+        Object.assign(venmoButton.style, venmoButtonStyle);
+
+        venmoButton.addEventListener('click', () =>  {
+            venmoButton.setAttribute('disabled', 'true');
+
+            if (braintreeVenmoCheckout.tokenize) {
+                braintreeVenmoCheckout.tokenize(async (error: BraintreeError, payload: BraintreeTokenizePayload) => {
+                    venmoButton.removeAttribute('disabled');
+
+                    if (error) {
+                        return this._onError(error);
+                    }
+
+                    await this._handlePostForm(payload);
+                });
+            }
+        });
+
+        venmoButton.addEventListener('mouseenter', () => {
+            venmoButton.style.backgroundColor = venmoButtonStyleHover.backgroundColor;
+        });
+
+        venmoButton.addEventListener('mouseleave', () => {
+            venmoButton.style.backgroundColor = venmoButtonStyle.backgroundColor;
+        });
+    }
+
+    private async _handlePostForm(payload: BraintreeTokenizePayload): Promise<void> {
+        const { deviceData } = await this._braintreeSDKCreator.getDataCollector();
+        const { nonce, details } = payload;
+
+        this._formPoster.postForm('/checkout.php', {
+            nonce,
+            provider: CheckoutButtonMethodType.BRAINTREE_VENMO,
+            payment_type: 'paypal',
+            device_data: deviceData,
+            action: 'set_external_checkout',
+            billing_address: JSON.stringify(mapToLegacyBillingAddress(details)),
+            shipping_address: JSON.stringify(mapToLegacyShippingAddress(details)),
+        });
+    }
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/index.ts
@@ -11,3 +11,7 @@ export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-butto
 // Braintree PayPal Credit (Credit / PayLater)
 export { default as BraintreePaypalCreditButtonStrategy } from './braintree-paypal-credit-button-strategy';
 export { BraintreePaypalCreditButtonInitializeOptions } from './braintree-paypal-credit-button-options';
+
+// Braintree Venmo
+export { default as BraintreeVenmoButtonStrategy } from './braintree-venmo-button-strategy';
+export { BraintreeVenmoButtonInitializeOptions } from './braintree-venmo-button-options';


### PR DESCRIPTION
## What?
Added braintreevenmo checkout button strategy

## Why?
To separate braintree venmo functionality from braintreepaypal strategy to its own.

## Testing / Proof
Manual tests
Unit tests 

<img width="1224" alt="Screenshot 2022-05-12 at 12 55 08" src="https://user-images.githubusercontent.com/25133454/168338645-cc79db6a-c793-4982-9780-bd973d610049.png">

<img width="1224" alt="Screenshot 2022-05-12 at 12 55 16" src="https://user-images.githubusercontent.com/25133454/168338652-6ed5e253-31f1-4959-bd99-ae49c1d8497e.png">

<img width="450" alt="Screenshot 2022-05-12 at 12 55 32" src="https://user-images.githubusercontent.com/25133454/168338665-2c9d6ac5-b606-43b6-a08c-a0ec154e4afb.png">
