### PR TITLE
feat(payment): PAYPAL-1382 added braintreepaypalcredit checkout button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -3,7 +3,7 @@ import { RequestOptions } from '../common/http-request';
 import { CheckoutButtonMethodType } from './strategies';
 import { AmazonPayV2ButtonInitializeOptions } from './strategies/amazon-pay-v2';
 import { ApplePayButtonInitializeOptions } from './strategies/apple-pay';
-import { BraintreePaypalV1ButtonInitializeOptions } from './strategies/braintree';
+import { BraintreePaypalCreditButtonInitializeOptions, BraintreePaypalV1ButtonInitializeOptions } from './strategies/braintree';
 import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
 import { PaypalCommerceButtonInitializeOptions } from './strategies/paypal-commerce';
@@ -42,6 +42,12 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * omitted unless you need to support Braintree Credit.
      */
     braintreepaypalcredit?: BraintreePaypalV1ButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate Braintree Credit. They can be
+     * omitted unless you need to support Braintree Credit.
+     */
+    braintreepaypalcreditv2?: BraintreePaypalCreditButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate PayPal. They can be omitted

--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -9,7 +9,16 @@ import { PaymentMethodActionCreator } from '../payment';
 
 import { CheckoutButtonActionType, DeinitializeButtonAction, InitializeButtonAction } from './checkout-button-actions';
 import { CheckoutButtonInitializeOptions, CheckoutButtonOptions } from './checkout-button-options';
-import { CheckoutButtonStrategy } from './strategies';
+import { CheckoutButtonMethodType, CheckoutButtonStrategy } from './strategies';
+
+// TODO: should be removed when BRAINTREE_PAYPAL_CREDITV2 registries will be removed
+const mapCheckoutButtonMethodId = (methodId: CheckoutButtonMethodType) => {
+    if (methodId === CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDITV2) {
+        return CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT;
+    }
+
+    return methodId;
+};
 
 export default class CheckoutButtonStrategyActionCreator {
     constructor(
@@ -27,7 +36,7 @@ export default class CheckoutButtonStrategyActionCreator {
 
             return concat(
                 of(createAction(CheckoutButtonActionType.InitializeButtonRequested, undefined, meta)),
-                this._paymentMethodActionCreator.loadPaymentMethod(options.methodId, { timeout: options.timeout, useCache: true }),
+                this._paymentMethodActionCreator.loadPaymentMethod(mapCheckoutButtonMethodId(options.methodId), { timeout: options.timeout, useCache: true }),
                 defer(() => this._registry.get(options.methodId).initialize(options)
                     .then(() => createAction(CheckoutButtonActionType.InitializeButtonSucceeded, undefined, meta)))
             ).pipe(

--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -11,13 +11,12 @@ import { CheckoutButtonActionType, DeinitializeButtonAction, InitializeButtonAct
 import { CheckoutButtonInitializeOptions, CheckoutButtonOptions } from './checkout-button-options';
 import { CheckoutButtonMethodType, CheckoutButtonStrategy } from './strategies';
 
-// TODO: should be removed when BRAINTREE_PAYPAL_CREDITV2 registries will be removed
-const mapCheckoutButtonMethodId = (methodId: CheckoutButtonMethodType) => {
-    if (methodId === CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDITV2) {
-        return CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT;
-    }
+const methodMap: { [key: string]: CheckoutButtonMethodType | undefined } = {
+    [CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDITV2]: CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT, // TODO: should be removed when BRAINTREE_PAYPAL_CREDITV2 registries will be removed
+};
 
-    return methodId;
+const mapCheckoutButtonMethodId = (methodId: CheckoutButtonMethodType) => {
+    return methodMap[methodId] || methodId;
 };
 
 export default class CheckoutButtonStrategyActionCreator {

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -9,7 +9,7 @@ import createCheckoutButtonRegistry from './create-checkout-button-registry';
 import { CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
-import { BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
+import { BraintreePaypalCreditButtonStrategy, BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 
 describe('createCheckoutButtonRegistry', () => {
@@ -31,6 +31,10 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with Braintree PayPal Credit registered', () => {
         expect(registry.get('braintreepaypalcredit')).toEqual(expect.any(BraintreePaypalV1ButtonStrategy));
+    });
+
+    it('returns registry with Braintree PayPal Credit V2 registered', () => {
+        expect(registry.get('braintreepaypalcreditv2')).toEqual(expect.any(BraintreePaypalCreditButtonStrategy));
     });
 
     it('returns registry with GooglePay on Adyen Credit registered', () => {

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
@@ -1,0 +1,44 @@
+import { Address } from '../../../address';
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
+
+export interface BraintreePaypalCreditButtonInitializeOptions {
+    /**
+     * @internal
+     * This is an internal property and therefore subject to change. DO NOT USE.
+     */
+    shouldProcessPayment?: boolean;
+
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: Pick<PaypalButtonStyleOptions, 'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons' | 'height'>;
+
+    /**
+     * Address to be used for shipping.
+     * If not provided, it will use the first saved address from the active customer.
+     */
+    shippingAddress?: Address | null;
+
+    /**
+     * A callback that gets called if unable to authorize and tokenize payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onAuthorizeError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * A callback that gets called if unable to submit payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onPaymentError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * A callback that gets called on any error instead of submit payment or authorization errors.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: BraintreeError | StandardError): void;
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -126,7 +126,9 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
 
         delete (window as PaypalHostWindow).paypal;
 
-        document.body.removeChild(paypalButtonElement);
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalButtonElement);
+        }
     });
 
     it('creates an instance of the braintree paypal credit checkout button strategy', () => {

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -1,0 +1,530 @@
+import { createAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+import { from } from 'rxjs';
+
+import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfig } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod } from '../../../payment';
+import { getBraintree } from '../../../payment/payment-methods.mock';
+import { BraintreeDataCollector, BraintreePaypalCheckout, BraintreePaypalCheckoutCreator, BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
+import { getDataCollectorMock, getPaypalCheckoutMock, getPayPalCheckoutCreatorMock } from '../../../payment/strategies/braintree/braintree.mock';
+import { PaypalButtonOptions, PaypalHostWindow, PaypalSDK } from '../../../payment/strategies/paypal';
+import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+
+import { BraintreePaypalCreditButtonInitializeOptions } from './braintree-paypal-credit-button-options';
+import BraintreePaypalCreditButtonStrategy from './braintree-paypal-credit-button-strategy';
+
+describe('BraintreePaypalCreditButtonStrategy', () => {
+    let braintreeSDKCreator: BraintreeSDKCreator;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let braintreePaypalCheckoutCreatorMock: BraintreePaypalCheckoutCreator;
+    let braintreePaypalCheckoutMock: BraintreePaypalCheckout;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let dataCollector: BraintreeDataCollector;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let paymentMethodMock: PaymentMethod;
+    let paypalButtonElement: HTMLDivElement;
+    let paypalSdkMock: PaypalSDK;
+    let store: CheckoutStore;
+    let strategy: BraintreePaypalCreditButtonStrategy;
+
+    const defaultButtonContainerId = 'braintree-paypal-button-mock-id';
+
+    const braintreePaypalCreditOptions: BraintreePaypalCreditButtonInitializeOptions = {
+        style: {
+            height: 45,
+        },
+        onAuthorizeError: jest.fn(),
+        onPaymentError: jest.fn(),
+        onError: jest.fn(),
+    };
+
+    const initializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT,
+        containerId: defaultButtonContainerId,
+        braintreepaypalcredit: braintreePaypalCreditOptions,
+    };
+
+    beforeEach(() => {
+        braintreePaypalCheckoutMock = getPaypalCheckoutMock();
+        braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(braintreePaypalCheckoutMock, false);
+        dataCollector = getDataCollectorMock();
+        paypalSdkMock = getPaypalMock();
+        eventEmitter = new EventEmitter();
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(createRequestSender()),
+            new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+        );
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader());
+        braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        formPoster = createFormPoster();
+
+        (window as PaypalHostWindow).paypal = paypalSdkMock;
+
+        strategy = new BraintreePaypalCreditButtonStrategy(
+            store,
+            checkoutActionCreator,
+            braintreeSDKCreator,
+            formPoster,
+            window
+        );
+
+        paymentMethodMock = {
+            ...getBraintree(),
+            clientToken: 'myToken',
+        };
+
+        paypalButtonElement = document.createElement('div');
+        paypalButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalButtonElement);
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(getConfig().storeConfig);
+        jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(paymentMethodMock.clientToken);
+        jest.spyOn(braintreeSDKCreator, 'getDataCollector').mockReturnValue(dataCollector);
+        jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(braintreePaypalCheckoutCreatorMock);
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+
+        jest.spyOn(paypalSdkMock, 'Buttons')
+            .mockImplementation((options: PaypalButtonOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('approve', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {});
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                };
+            });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PaypalHostWindow).paypal;
+
+        document.body.removeChild(paypalButtonElement);
+    });
+
+    it('creates an instance of the braintree paypal credit checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(BraintreePaypalCreditButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = { containerId: defaultButtonContainerId } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = { methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if braintreepaypalcredit is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+                methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if client token is missing', async () => {
+            paymentMethodMock.clientToken = undefined;
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('initializes braintree sdk creator', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+        });
+
+        it('initializes braintree paypal checkout', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+            expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
+        });
+
+        it('calls braintree paypal checkout create method', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreePaypalCheckoutCreatorMock.create).toHaveBeenCalled();
+        });
+
+        it('calls onError callback option if the error was caught on paypal checkout creation', async () => {
+            braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(undefined, true);
+
+            jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(braintreePaypalCheckoutCreatorMock);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(initializationOptions.braintreepaypalcredit?.onError).toHaveBeenCalled();
+        });
+
+        it('renders braintree paylater button', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.PAYLATER,
+                onApprove: expect.any(Function),
+                style: {
+                    shape: 'rect',
+                    height: 45,
+                },
+            });
+
+            expect(paypalSdkMock.Buttons).not.toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.CREDIT,
+                onApprove: expect.any(Function),
+                style: {
+                    label: 'credit',
+                    shape: 'rect',
+                    height: 45,
+                },
+            });
+        });
+
+        it('renders braintree credit button if paylater is not eligible', async () => {
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementationOnce(() => {
+                    return {
+                        isEligible: jest.fn(() => false),
+                    };
+                });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.PAYLATER,
+                onApprove: expect.any(Function),
+                style: {
+                    shape: 'rect',
+                    height: 45,
+                },
+            });
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.CREDIT,
+                onApprove: expect.any(Function),
+                style: {
+                    label: 'credit',
+                    shape: 'rect',
+                    height: 45,
+                },
+            });
+        });
+
+        it('renders braintree checkout button in production environment if payment method is in test mode', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith(
+                expect.objectContaining({ env: 'production' })
+            );
+        });
+
+        it('loads checkout details when customer is ready to pay', async () => {
+            jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout')
+                .mockReturnValue(() => from([
+                    createAction(CheckoutActionType.LoadCheckoutRequested),
+                    createAction(CheckoutActionType.LoadCheckoutSucceeded, getCheckout()),
+                ]));
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalledTimes(2);
+        });
+
+        it('sets up PayPal payment flow with provided address', async () => {
+            jest.spyOn(store.getState().checkout, 'getCheckoutOrThrow').mockReturnValue({ outstandingBalance: 22 });
+
+            await strategy.initialize({
+                ...initializationOptions,
+                braintreepaypalcredit: {
+                    ...initializationOptions.braintreepaypalcredit,
+                    shippingAddress: {
+                        ...getShippingAddress(),
+                        address1: 'a1',
+                        address2: 'a2',
+                        city: 'c',
+                        countryCode: 'AU',
+                        phone: '0123456',
+                        postalCode: '2000',
+                        stateOrProvinceCode: 'NSW',
+                        firstName: 'foo',
+                        lastName: 'bar',
+                    },
+                },
+            });
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith(expect.objectContaining({
+                shippingAddressOverride: {
+                    city: 'c',
+                    countryCode: 'AU',
+                    line1: 'a1',
+                    line2: 'a2',
+                    phone: '0123456',
+                    postalCode: '2000',
+                    recipientName: 'foo bar',
+                    state: 'NSW',
+                },
+            }));
+        });
+
+        it('sets up PayPal payment flow with no address when null is passed', async () => {
+            jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(undefined);
+
+            await strategy.initialize({
+                ...initializationOptions,
+                braintreepaypalcredit: {
+                    ...initializationOptions.braintreepaypalcredit,
+                    shippingAddress: null,
+                },
+            });
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith(expect.objectContaining({
+                shippingAddressOverride: undefined,
+            }));
+        });
+
+        it('sets up PayPal payment flow with current checkout details when customer is ready to pay', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith({
+                amount: 190,
+                currency: 'USD',
+                enableShippingAddress: true,
+                flow: 'checkout',
+                offerCredit: true,
+                shippingAddressEditable: false,
+                shippingAddressOverride: {
+                    city: 'Some City',
+                    countryCode: 'US',
+                    line1: '12345 Testing Way',
+                    line2: '',
+                    phone: '555-555-5555',
+                    postalCode: '95555',
+                    recipientName: 'Test Tester',
+                    state: 'CA',
+                },
+            });
+        });
+
+        it('triggers error callback if unable to set up payment flow', async () => {
+            const expectedError = new Error('Unable to set up payment flow');
+
+            jest.spyOn(braintreePaypalCheckoutMock, 'createPayment')
+                .mockImplementation(() => Promise.reject(expectedError));
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCreditOptions.onPaymentError).toHaveBeenCalledWith(expectedError);
+        });
+
+        it('tokenizes PayPal payment details when authorization event is triggered', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.tokenizePayment).toHaveBeenCalledWith({ payerId: 'PAYER_ID' });
+        });
+
+        it('posts payment details to server to set checkout data when PayPal payment details are tokenized', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                payment_type: 'paypal',
+                provider: 'braintreepaypalcredit',
+                action: 'set_external_checkout',
+                device_data: dataCollector.deviceData,
+                nonce: 'NONCE',
+                billing_address: JSON.stringify({
+                    email: 'foo@bar.com',
+                    first_name: 'Foo',
+                    last_name: 'Bar',
+                    address_line_1: '56789 Testing Way',
+                    address_line_2: 'Level 2',
+                    city: 'Some Other City',
+                    state: 'Arizona',
+                    country_code: 'US',
+                    postal_code: '96666',
+                }),
+                shipping_address: JSON.stringify({
+                    email: 'foo@bar.com',
+                    first_name: 'Hello',
+                    last_name: 'World',
+                    address_line_1: '12345 Testing Way',
+                    address_line_2: 'Level 1',
+                    city: 'Some City',
+                    state: 'California',
+                    country_code: 'US',
+                    postal_code: '95555',
+                }),
+            }));
+        });
+
+        it('posts payment details to server to process payment if `shouldProcessPayment` is passed when PayPal payment details are tokenized', async () => {
+            const options = {
+                ...initializationOptions,
+                braintreepaypalcredit: {
+                    ...braintreePaypalCreditOptions,
+                    shouldProcessPayment: true,
+                },
+            };
+
+            await strategy.initialize(options);
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                payment_type: 'paypal',
+                provider: 'braintreepaypalcredit',
+                action: 'process_payment',
+                device_data: dataCollector.deviceData,
+                nonce: 'NONCE',
+                billing_address: JSON.stringify({
+                    email: 'foo@bar.com',
+                    first_name: 'Foo',
+                    last_name: 'Bar',
+                    address_line_1: '56789 Testing Way',
+                    address_line_2: 'Level 2',
+                    city: 'Some Other City',
+                    state: 'Arizona',
+                    country_code: 'US',
+                    postal_code: '96666',
+                }),
+                shipping_address: JSON.stringify({
+                    email: 'foo@bar.com',
+                    first_name: 'Hello',
+                    last_name: 'World',
+                    address_line_1: '12345 Testing Way',
+                    address_line_2: 'Level 1',
+                    city: 'Some City',
+                    state: 'California',
+                    country_code: 'US',
+                    postal_code: '95555',
+                }),
+            }));
+        });
+
+        it('triggers error callback if unable to tokenize payment', async () => {
+            const expectedError = new Error('Unable to tokenize');
+
+            jest.spyOn(braintreePaypalCheckoutMock, 'tokenizePayment')
+                .mockReturnValue(Promise.reject(expectedError));
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCreditOptions.onAuthorizeError).toHaveBeenCalledWith(expectedError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('teardowns braintree sdk creator on strategy deinitialize', async () => {
+            braintreeSDKCreator.teardown = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+            await strategy.deinitialize();
+
+            expect(braintreeSDKCreator.teardown).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -47,7 +47,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
 
         const paypalCheckoutOptions = { currency };
         const paypalCheckoutCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) =>
-            this._renderPayPalComponent(
+            this._renderPayPalButton(
                 braintreePaypalCheckout,
                 braintreepaypalcredit,
                 containerId,
@@ -71,28 +71,6 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         return Promise.resolve();
     }
 
-    private _renderPayPalComponent(
-        braintreePaypalCheckout: BraintreePaypalCheckout,
-        braintreepaypalcredit: BraintreePaypalCreditButtonInitializeOptions,
-        containerId: string,
-        methodId: string,
-        testMode: boolean
-    ) {
-        const { paypal } = this._window;
-
-        if (paypal) {
-            this._renderPayPalButton(
-                braintreePaypalCheckout,
-                braintreepaypalcredit,
-                containerId,
-                methodId,
-                testMode
-            );
-        } else {
-            this._hideElement(containerId);
-        }
-    }
-
     private _renderPayPalButton(
         braintreePaypalCheckout: BraintreePaypalCheckout,
         braintreepaypalcredit: BraintreePaypalCreditButtonInitializeOptions,
@@ -103,9 +81,9 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         const { style, shippingAddress, shouldProcessPayment, onAuthorizeError, onPaymentError } = braintreepaypalcredit;
         const { paypal } = this._window;
 
-        if (paypal) {
-            let hasRenderedSmartButton = false;
+        let hasRenderedSmartButton = false;
 
+        if (paypal) {
             const fundingSources = [paypal.FUNDING.PAYLATER, paypal.FUNDING.CREDIT];
             const commonButtonStyle = style ? getValidButtonStyle(style) : {};
 
@@ -114,7 +92,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
                     ? { label: PaypalButtonStyleLabelOption.CREDIT, ...commonButtonStyle }
                     : commonButtonStyle;
 
-                if (!hasRenderedSmartButton && fundingSource) {
+                if (!hasRenderedSmartButton) {
                     const paypalButtonRender = paypal.Buttons({
                         env: testMode ? 'sandbox' : 'production',
                         commit: false,
@@ -131,10 +109,10 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
                     }
                 }
             });
+        }
 
-            if (!hasRenderedSmartButton) {
-                this._hideElement(containerId);
-            }
+        if (!paypal || !hasRenderedSmartButton) {
+            this._hideElement(containerId);
         }
     }
 

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -112,7 +112,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         }
 
         if (!paypal || !hasRenderedSmartButton) {
-            this._hideElement(containerId);
+            this._removeElement(containerId);
         }
     }
 
@@ -186,18 +186,18 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         containerId: string,
         onErrorCallback?: (error: BraintreeError) => void
     ): void {
-        this._hideElement(containerId);
+        this._removeElement(containerId);
 
         if (onErrorCallback) {
             onErrorCallback(error);
         }
     }
 
-    private _hideElement(elementId?: string): void {
+    private _removeElement(elementId?: string): void {
         const element = elementId && document.getElementById(elementId);
 
         if (element) {
-            Object.assign(element.style, { display: 'none' });
+            element.remove();
         }
     }
 }

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -1,0 +1,225 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { Address } from '../../../address';
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, StandardError } from '../../../common/error/errors';
+import { mapToBraintreeShippingAddressOverride, BraintreeError, BraintreePaypalCheckout, BraintreeSDKCreator, BraintreeTokenizePayload } from '../../../payment/strategies/braintree';
+import { PaypalAuthorizeData, PaypalButtonStyleLabelOption, PaypalHostWindow } from '../../../payment/strategies/paypal';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+import { BraintreePaypalCreditButtonInitializeOptions } from './braintree-paypal-credit-button-options';
+import getValidButtonStyle from './get-valid-button-style';
+import mapToLegacyBillingAddress from './map-to-legacy-billing-address';
+import mapToLegacyShippingAddress from './map-to-legacy-shipping-address';
+
+export default class BraintreePaypalCreditButtonStrategy implements CheckoutButtonStrategy {
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _braintreeSDKCreator: BraintreeSDKCreator,
+        private _formPoster: FormPoster,
+        private _window: PaypalHostWindow
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { braintreepaypalcredit, containerId, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
+        }
+
+        if (!braintreepaypalcredit) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.braintreepaypalcredit" argument is not provided.`);
+        }
+
+        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
+        const currency = state.cart.getCartOrThrow()?.currency.code;
+
+        if (!paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const paypalCheckoutOptions = { currency };
+        const paypalCheckoutCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) =>
+            this._renderPayPalComponent(
+                braintreePaypalCheckout,
+                braintreepaypalcredit,
+                containerId,
+                methodId,
+                Boolean(paymentMethod.config.testMode)
+            );
+        const paypalCheckoutErrorCallback = (error: BraintreeError) =>
+            this._handleError(error, containerId, braintreepaypalcredit.onError);
+
+        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        await this._braintreeSDKCreator.getPaypalCheckout(
+            paypalCheckoutOptions,
+            paypalCheckoutCallback,
+            paypalCheckoutErrorCallback
+        );
+    }
+
+    deinitialize(): Promise<void> {
+        this._braintreeSDKCreator.teardown();
+
+        return Promise.resolve();
+    }
+
+    private _renderPayPalComponent(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypalcredit: BraintreePaypalCreditButtonInitializeOptions,
+        containerId: string,
+        methodId: string,
+        testMode: boolean
+    ) {
+        const { paypal } = this._window;
+
+        if (paypal) {
+            this._renderPayPalButton(
+                braintreePaypalCheckout,
+                braintreepaypalcredit,
+                containerId,
+                methodId,
+                testMode
+            );
+        } else {
+            this._hideElement(containerId);
+        }
+    }
+
+    private _renderPayPalButton(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypalcredit: BraintreePaypalCreditButtonInitializeOptions,
+        containerId: string,
+        methodId: string,
+        testMode: boolean
+    ): void {
+        const { style, shippingAddress, shouldProcessPayment, onAuthorizeError, onPaymentError } = braintreepaypalcredit;
+        const { paypal } = this._window;
+
+        if (paypal) {
+            let hasRenderedSmartButton = false;
+
+            const fundingSources = [paypal.FUNDING.PAYLATER, paypal.FUNDING.CREDIT];
+            const commonButtonStyle = style ? getValidButtonStyle(style) : {};
+
+            fundingSources.forEach(fundingSource => {
+                const buttonStyle = fundingSource === paypal.FUNDING.CREDIT
+                    ? { label: PaypalButtonStyleLabelOption.CREDIT, ...commonButtonStyle }
+                    : commonButtonStyle;
+
+                if (!hasRenderedSmartButton && fundingSource) {
+                    const paypalButtonRender = paypal.Buttons({
+                        env: testMode ? 'sandbox' : 'production',
+                        commit: false,
+                        fundingSource,
+                        style: buttonStyle,
+                        createOrder: () => this._setupPayment(braintreePaypalCheckout, shippingAddress, onPaymentError),
+                        onApprove: (authorizeData: PaypalAuthorizeData) =>
+                            this._tokenizePayment(authorizeData, braintreePaypalCheckout, methodId, shouldProcessPayment, onAuthorizeError),
+                    });
+
+                    if (paypalButtonRender.isEligible()) {
+                        paypalButtonRender.render(`#${containerId}`);
+                        hasRenderedSmartButton = true;
+                    }
+                }
+            });
+
+            if (!hasRenderedSmartButton) {
+                this._hideElement(containerId);
+            }
+        }
+    }
+
+    private async _setupPayment(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        shippingAddress?: Address | null,
+        onError?: (error: BraintreeError | StandardError) => void
+    ): Promise<string> {
+        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+
+        try {
+            const checkout = state.checkout.getCheckoutOrThrow();
+            const config = state.config.getStoreConfigOrThrow();
+            const customer = state.customer.getCustomer();
+
+            const address = shippingAddress || customer?.addresses?.[0];
+            const shippingAddressOverride = address ? mapToBraintreeShippingAddressOverride(address) : undefined;
+
+            return await braintreePaypalCheckout.createPayment({
+                flow: 'checkout',
+                enableShippingAddress: true,
+                shippingAddressEditable: false,
+                shippingAddressOverride,
+                amount: checkout.outstandingBalance,
+                currency: config.currency.code,
+                offerCredit: true,
+            });
+        } catch (error) {
+            if (onError) {
+                onError(error);
+            }
+
+            throw error;
+        }
+    }
+
+    private async _tokenizePayment(
+        authorizeData: PaypalAuthorizeData,
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        methodId: string,
+        shouldProcessPayment?: boolean,
+        onError?: (error: BraintreeError | StandardError) => void
+    ): Promise<BraintreeTokenizePayload> {
+        try {
+            const { deviceData } = await this._braintreeSDKCreator.getDataCollector({ paypal: true });
+            const tokenizePayload = await braintreePaypalCheckout.tokenizePayment(authorizeData);
+            const { details, nonce } = tokenizePayload;
+
+            this._formPoster.postForm('/checkout.php', {
+                payment_type: 'paypal',
+                provider: methodId,
+                action: shouldProcessPayment ? 'process_payment' : 'set_external_checkout',
+                nonce,
+                device_data: deviceData,
+                billing_address: JSON.stringify(mapToLegacyBillingAddress(details)),
+                shipping_address: JSON.stringify(mapToLegacyShippingAddress(details)),
+            });
+
+            return tokenizePayload;
+        } catch (error) {
+            if (onError) {
+                onError(error);
+            }
+
+            throw error;
+        }
+    }
+
+    private _handleError(
+        error: BraintreeError,
+        containerId: string,
+        onErrorCallback?: (error: BraintreeError) => void
+    ): void {
+        this._hideElement(containerId);
+
+        if (onErrorCallback) {
+            onErrorCallback(error);
+        }
+    }
+
+    private _hideElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            Object.assign(element.style, { display: 'none' });
+        }
+    }
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -29,6 +29,9 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
             throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
         }
 
+        // TODO: this line should be removed when registry will contain braintreepaypalcredit only
+        const updatedMethodId = methodId === 'braintreepaypalcreditv2' ? 'braintreepaypalcredit' : methodId;
+
         if (!containerId) {
             throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
         }
@@ -38,7 +41,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         }
 
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
-        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(updatedMethodId);
         const currency = state.cart.getCartOrThrow()?.currency.code;
 
         if (!paymentMethod.clientToken) {
@@ -51,7 +54,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
                 braintreePaypalCheckout,
                 braintreepaypalcredit,
                 containerId,
-                methodId,
+                updatedMethodId,
                 Boolean(paymentMethod.config.testMode)
             );
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>

--- a/packages/core/src/checkout-buttons/strategies/braintree/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/index.ts
@@ -3,3 +3,7 @@
 // TODO: Should be removed after BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy and BraintreeVenmoButtonStrategy strategies creation
 export { default as BraintreePaypalV1ButtonStrategy } from './braintree-paypal-v1-button-strategy';
 export { BraintreePaypalV1ButtonInitializeOptions } from './braintree-paypal-v1-button-options';
+
+// Braintree PayPal Credit (Credit / PayLater)
+export { default as BraintreePaypalCreditButtonStrategy } from './braintree-paypal-credit-button-strategy';
+export { BraintreePaypalCreditButtonInitializeOptions } from './braintree-paypal-credit-button-options';

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -4,6 +4,7 @@ enum CheckoutButtonMethodType {
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_VENMO = 'braintreevenmo',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',
+    BRAINTREE_PAYPAL_CREDITV2 = 'braintreepaypalcreditv2',
     GOOGLEPAY_ADYENV2 = 'googlepayadyenv2',
     GOOGLEPAY_ADYENV3 = 'googlepayadyenv3',
     GOOGLEPAY_AUTHORIZENET = 'googlepayauthorizenet',


### PR DESCRIPTION
## What?
Added braintreepaypalcredit checkout button strategy

## Why?
To separate Braintree PayPal Credit/Paylater functionality from braintreepaypal strategy to its own.

## Testing / Proof
Unit tests
Manual tests

<img width="313" alt="Screenshot 2022-06-02 at 15 38 30" src="https://user-images.githubusercontent.com/25133454/171633791-74314778-3564-48ab-acbd-591201775be7.png">
