### PR TITLE
feat(payment): PAYPAL-1382 added braintreepaypal checkout button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -12,6 +12,7 @@ import { CheckoutButtonInitializeOptions, CheckoutButtonOptions } from './checko
 import { CheckoutButtonMethodType, CheckoutButtonStrategy } from './strategies';
 
 const methodMap: { [key: string]: CheckoutButtonMethodType | undefined } = {
+    [CheckoutButtonMethodType.BRAINTREE_PAYPALV2]: CheckoutButtonMethodType.BRAINTREE_PAYPAL, // TODO: should be removed when BRAINTREE_PAYPALV2 registries will be removed
     [CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDITV2]: CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT, // TODO: should be removed when BRAINTREE_PAYPAL_CREDITV2 registries will be removed
 };
 

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -9,7 +9,7 @@ import createCheckoutButtonRegistry from './create-checkout-button-registry';
 import { CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
-import { BraintreePaypalCreditButtonStrategy, BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
+import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 
 describe('createCheckoutButtonRegistry', () => {
@@ -27,6 +27,10 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with Braintree PayPal registered', () => {
         expect(registry.get('braintreepaypal')).toEqual(expect.any(BraintreePaypalV1ButtonStrategy));
+    });
+
+    it('returns registry with Braintree PayPal V2 registered', () => {
+        expect(registry.get('braintreepaypalv2')).toEqual(expect.any(BraintreePaypalButtonStrategy));
     });
 
     it('returns registry with Braintree PayPal Credit registered', () => {

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -8,11 +8,7 @@ import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { OrderActionCreator, OrderRequestSender } from '../order';
-import { PaymentActionCreator,
-    PaymentMethodActionCreator,
-    PaymentMethodRequestSender,
-    PaymentRequestSender,
-    PaymentRequestTransformer } from '../payment';
+import { PaymentActionCreator, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentRequestTransformer } from '../payment';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { ApplePaySessionFactory } from '../payment/strategies/apple-pay';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
@@ -28,7 +24,7 @@ import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subsc
 import { CheckoutButtonMethodType, CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
-import { BraintreePaypalCreditButtonStrategy, BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
+import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreePaypalV1ButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 import { MasterpassButtonStrategy } from './strategies/masterpass';
 import { PaypalButtonStrategy } from './strategies/paypal';
@@ -103,6 +99,16 @@ export default function createCheckoutButtonRegistry(
             braintreeSdkCreator,
             formPoster,
             undefined,
+            window
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.BRAINTREE_PAYPALV2, () =>
+        new BraintreePaypalButtonStrategy(
+            store,
+            checkoutActionCreator,
+            braintreeSdkCreator,
+            formPoster,
             window
         )
     );

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
@@ -1,0 +1,49 @@
+import { Address } from '../../../address';
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
+
+export interface BraintreePaypalButtonInitializeOptions {
+    /**
+     * @internal
+     * This is an internal property and therefore subject to change. DO NOT USE.
+     */
+    shouldProcessPayment?: boolean;
+
+    /**
+     * The ID of a container which the messaging should be inserted.
+     */
+    messagingContainerId?: string;
+
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: Pick<PaypalButtonStyleOptions, 'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons' | 'height'>;
+
+    /**
+     * Address to be used for shipping.
+     * If not provided, it will use the first saved address from the active customer.
+     */
+    shippingAddress?: Address | null;
+
+    /**
+     * A callback that gets called if unable to authorize and tokenize payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onAuthorizeError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * A callback that gets called if unable to submit payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onPaymentError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * A callback that gets called on any error instead of submit payment or authorization errors.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: BraintreeError | StandardError): void;
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -143,8 +143,13 @@ describe('BraintreePaypalButtonStrategy', () => {
 
         delete (window as PaypalHostWindow).paypal;
 
-        document.body.removeChild(paypalButtonElement);
-        document.body.removeChild(paypalMessageElement);
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalButtonElement);
+        }
+
+        if (document.getElementById(defaultMessageContainerId)) {
+            document.body.removeChild(paypalMessageElement);
+        }
     });
 
     it('creates an instance of the braintree paypal checkout button strategy', () => {

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -1,0 +1,515 @@
+import { createAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+import { from } from 'rxjs';
+
+import { getCart } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfig } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod } from '../../../payment';
+import { getBraintree } from '../../../payment/payment-methods.mock';
+import { BraintreeDataCollector, BraintreePaypalCheckout, BraintreePaypalCheckoutCreator, BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
+import { getDataCollectorMock, getPaypalCheckoutMock, getPayPalCheckoutCreatorMock } from '../../../payment/strategies/braintree/braintree.mock';
+import { PaypalButtonOptions, PaypalHostWindow, PaypalSDK } from '../../../payment/strategies/paypal';
+import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
+import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+
+import { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+import BraintreePaypalButtonStrategy from './braintree-paypal-button-strategy';
+
+describe('BraintreePaypalButtonStrategy', () => {
+    let braintreeSDKCreator: BraintreeSDKCreator;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let braintreePaypalCheckoutCreatorMock: BraintreePaypalCheckoutCreator;
+    let braintreePaypalCheckoutMock: BraintreePaypalCheckout;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let dataCollector: BraintreeDataCollector;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let paymentMethodMock: PaymentMethod;
+    let paypalButtonElement: HTMLDivElement;
+    let paypalMessageElement: HTMLDivElement;
+    let paypalSdkMock: PaypalSDK;
+    let store: CheckoutStore;
+    let strategy: BraintreePaypalButtonStrategy;
+
+    const defaultButtonContainerId = 'braintree-paypal-button-mock-id';
+    const defaultMessageContainerId = 'braintree-paypal-message-mock-id';
+
+    const braintreePaypalOptions: BraintreePaypalButtonInitializeOptions = {
+        messagingContainerId: defaultMessageContainerId,
+        style: {
+            height: 45,
+        },
+        onAuthorizeError: jest.fn(),
+        onPaymentError: jest.fn(),
+        onError: jest.fn(),
+    };
+
+    const initializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL,
+        containerId: defaultButtonContainerId,
+        braintreepaypal: braintreePaypalOptions,
+    };
+
+    beforeEach(() => {
+        const storeConfigMock = getConfig().storeConfig;
+        storeConfigMock.checkoutSettings.features = {
+            'PAYPAL-1149.braintree-new-card-below-totals-banner-placement': false,
+        };
+
+        braintreePaypalCheckoutMock = getPaypalCheckoutMock();
+        braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(braintreePaypalCheckoutMock, false);
+        dataCollector = getDataCollectorMock();
+        paypalSdkMock = getPaypalMock();
+        eventEmitter = new EventEmitter();
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(createRequestSender()),
+            new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
+        );
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader());
+        braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        formPoster = createFormPoster();
+
+        (window as PaypalHostWindow).paypal = paypalSdkMock;
+
+        strategy = new BraintreePaypalButtonStrategy(
+            store,
+            checkoutActionCreator,
+            braintreeSDKCreator,
+            formPoster,
+            window
+        );
+
+        paymentMethodMock = {
+            ...getBraintree(),
+            clientToken: 'myToken',
+        };
+
+        paypalButtonElement = document.createElement('div');
+        paypalButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalButtonElement);
+
+        paypalMessageElement = document.createElement('div');
+        paypalMessageElement.id = defaultMessageContainerId;
+        document.body.appendChild(paypalMessageElement);
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(storeConfigMock);
+        jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(paymentMethodMock.clientToken);
+        jest.spyOn(braintreeSDKCreator, 'getDataCollector').mockReturnValue(dataCollector);
+        jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(braintreePaypalCheckoutCreatorMock);
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+
+        jest.spyOn(paypalSdkMock, 'Buttons')
+            .mockImplementation((options: PaypalButtonOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('approve', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {});
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                };
+            });
+
+        jest.spyOn(paypalSdkMock, 'Messages').mockImplementation(() => ({
+            render: jest.fn(),
+        }));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PaypalHostWindow).paypal;
+
+        document.body.removeChild(paypalButtonElement);
+        document.body.removeChild(paypalMessageElement);
+    });
+
+    it('creates an instance of the braintree paypal checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(BraintreePaypalButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = { containerId: defaultButtonContainerId } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = { methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if braintreepaypal is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+                methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if client token is missing', async () => {
+            paymentMethodMock.clientToken = undefined;
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('initializes braintree sdk creator', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+        });
+
+        it('initializes braintree paypal checkout', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(paymentMethodMock.clientToken);
+            expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
+        });
+
+        it('calls braintree paypal checkout create method', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreePaypalCheckoutCreatorMock.create).toHaveBeenCalled();
+        });
+
+        it('calls onError callback option if the error was caught on paypal checkout creation', async () => {
+            braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(undefined, true);
+
+            jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(braintreePaypalCheckoutCreatorMock);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(initializationOptions.braintreepaypal?.onError).toHaveBeenCalled();
+        });
+
+        it('renders PayPal checkout message', async () => {
+            const cartMock = getCart();
+            const storeConfigMock = getConfig().storeConfig;
+            storeConfigMock.checkoutSettings.features = {
+                'PAYPAL-1149.braintree-new-card-below-totals-banner-placement': true,
+            };
+
+            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(storeConfigMock);
+            jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cartMock);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
+                amount: 190,
+                placement: 'cart',
+            });
+        });
+
+        it('renders PayPal checkout button', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.PAYPAL,
+                onApprove: expect.any(Function),
+                style: {
+                    shape: 'rect',
+                    height: 45,
+                },
+            });
+        });
+
+        it('renders PayPal checkout button in production environment if payment method is in test mode', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith(
+                expect.objectContaining({ env: 'production' })
+            );
+        });
+
+        it('loads checkout details when customer is ready to pay', async () => {
+            jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout')
+                .mockReturnValue(() => from([
+                    createAction(CheckoutActionType.LoadCheckoutRequested),
+                    createAction(CheckoutActionType.LoadCheckoutSucceeded, getCheckout()),
+                ]));
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalledTimes(2);
+        });
+
+        it('sets up PayPal payment flow with provided address', async () => {
+            jest.spyOn(store.getState().checkout, 'getCheckoutOrThrow').mockReturnValue({ outstandingBalance: 22 });
+
+            await strategy.initialize({
+                ...initializationOptions,
+                braintreepaypal: {
+                    ...initializationOptions.braintreepaypal,
+                    shippingAddress: {
+                        ...getShippingAddress(),
+                        address1: 'a1',
+                        address2: 'a2',
+                        city: 'c',
+                        countryCode: 'AU',
+                        phone: '0123456',
+                        postalCode: '2000',
+                        stateOrProvinceCode: 'NSW',
+                        firstName: 'foo',
+                        lastName: 'bar',
+                    },
+                },
+            });
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith(expect.objectContaining({
+                shippingAddressOverride: {
+                    city: 'c',
+                    countryCode: 'AU',
+                    line1: 'a1',
+                    line2: 'a2',
+                    phone: '0123456',
+                    postalCode: '2000',
+                    recipientName: 'foo bar',
+                    state: 'NSW',
+                },
+            }));
+        });
+
+        it('sets up PayPal payment flow with no address when null is passed', async () => {
+            jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(undefined);
+
+            await strategy.initialize({
+                ...initializationOptions,
+                braintreepaypal: {
+                    ...initializationOptions.braintreepaypal,
+                    shippingAddress: null,
+                },
+            });
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith(expect.objectContaining({
+                shippingAddressOverride: undefined,
+            }));
+        });
+
+        it('sets up PayPal payment flow with current checkout details when customer is ready to pay', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith({
+                amount: 190,
+                currency: 'USD',
+                enableShippingAddress: true,
+                flow: 'checkout',
+                offerCredit: false,
+                shippingAddressEditable: false,
+                shippingAddressOverride: {
+                    city: 'Some City',
+                    countryCode: 'US',
+                    line1: '12345 Testing Way',
+                    line2: '',
+                    phone: '555-555-5555',
+                    postalCode: '95555',
+                    recipientName: 'Test Tester',
+                    state: 'CA',
+                },
+            });
+        });
+
+        it('triggers error callback if unable to set up payment flow', async () => {
+            const expectedError = new Error('Unable to set up payment flow');
+
+            jest.spyOn(braintreePaypalCheckoutMock, 'createPayment')
+                .mockImplementation(() => Promise.reject(expectedError));
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalOptions.onPaymentError).toHaveBeenCalledWith(expectedError);
+        });
+
+        it('tokenizes PayPal payment details when authorization event is triggered', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.tokenizePayment).toHaveBeenCalledWith({ payerId: 'PAYER_ID' });
+        });
+
+        it('posts payment details to server to set checkout data when PayPal payment details are tokenized', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                payment_type: 'paypal',
+                provider: 'braintreepaypal',
+                action: 'set_external_checkout',
+                device_data: dataCollector.deviceData,
+                nonce: 'NONCE',
+                billing_address: JSON.stringify({
+                    email: 'foo@bar.com',
+                    first_name: 'Foo',
+                    last_name: 'Bar',
+                    address_line_1: '56789 Testing Way',
+                    address_line_2: 'Level 2',
+                    city: 'Some Other City',
+                    state: 'Arizona',
+                    country_code: 'US',
+                    postal_code: '96666',
+                }),
+                shipping_address: JSON.stringify({
+                    email: 'foo@bar.com',
+                    first_name: 'Hello',
+                    last_name: 'World',
+                    address_line_1: '12345 Testing Way',
+                    address_line_2: 'Level 1',
+                    city: 'Some City',
+                    state: 'California',
+                    country_code: 'US',
+                    postal_code: '95555',
+                }),
+            }));
+        });
+
+        it('posts payment details to server to process payment if `shouldProcessPayment` is passed when PayPal payment details are tokenized', async () => {
+            const options = {
+                ...initializationOptions,
+                braintreepaypal: {
+                    ...braintreePaypalOptions,
+                    shouldProcessPayment: true,
+                },
+            };
+
+            await strategy.initialize(options);
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                payment_type: 'paypal',
+                provider: 'braintreepaypal',
+                action: 'process_payment',
+                device_data: dataCollector.deviceData,
+                nonce: 'NONCE',
+                billing_address: JSON.stringify({
+                    email: 'foo@bar.com',
+                    first_name: 'Foo',
+                    last_name: 'Bar',
+                    address_line_1: '56789 Testing Way',
+                    address_line_2: 'Level 2',
+                    city: 'Some Other City',
+                    state: 'Arizona',
+                    country_code: 'US',
+                    postal_code: '96666',
+                }),
+                shipping_address: JSON.stringify({
+                    email: 'foo@bar.com',
+                    first_name: 'Hello',
+                    last_name: 'World',
+                    address_line_1: '12345 Testing Way',
+                    address_line_2: 'Level 1',
+                    city: 'Some City',
+                    state: 'California',
+                    country_code: 'US',
+                    postal_code: '95555',
+                }),
+            }));
+        });
+
+        it('triggers error callback if unable to tokenize payment', async () => {
+            const expectedError = new Error('Unable to tokenize');
+
+            jest.spyOn(braintreePaypalCheckoutMock, 'tokenizePayment')
+                .mockReturnValue(Promise.reject(expectedError));
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalOptions.onAuthorizeError).toHaveBeenCalledWith(expectedError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('teardowns braintree sdk creator on strategy deinitialize', async () => {
+            braintreeSDKCreator.teardown = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+            await strategy.deinitialize();
+
+            expect(braintreeSDKCreator.teardown).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -30,6 +30,9 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
             throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
         }
 
+        // TODO: this line should be removed with BraintreePayPalV1Button strategy
+        const updatedMethodId = methodId === 'braintreepaypalv2' ? 'braintreepaypal' : methodId;
+
         if (!containerId) {
             throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
         }
@@ -39,7 +42,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         }
 
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
-        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(updatedMethodId);
         const currency = state.cart.getCartOrThrow()?.currency.code;
 
         if (!paymentMethod.clientToken) {
@@ -52,7 +55,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
                 braintreePaypalCheckout,
                 braintreepaypal,
                 containerId,
-                methodId,
+                updatedMethodId,
                 Boolean(paymentMethod.config.testMode)
             );
         };

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -115,7 +115,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
                 paypalButtonRender.render(`#${containerId}`);
             }
         } else {
-            this._hideElement(containerId);
+            this._removeElement(containerId);
         }
     }
 
@@ -133,7 +133,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
             const paypalMessagesRender = paypal.Messages({ amount: cart.cartAmount, placement: 'cart' });
             paypalMessagesRender.render(`#${messagingContainerId}`);
         } else {
-            this._hideElement(messagingContainerId);
+            this._removeElement(messagingContainerId);
         }
     }
 
@@ -208,19 +208,19 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         messagingContainerId?: string,
         onErrorCallback?: (error: BraintreeError) => void
     ): void {
-        this._hideElement(buttonContainerId);
-        this._hideElement(messagingContainerId);
+        this._removeElement(buttonContainerId);
+        this._removeElement(messagingContainerId);
 
         if (onErrorCallback) {
             onErrorCallback(error);
         }
     }
 
-    private _hideElement(elementId?: string): void {
+    private _removeElement(elementId?: string): void {
         const element = elementId && document.getElementById(elementId);
 
         if (element) {
-            Object.assign(element.style, { display: 'none' });
+            element.remove();
         }
     }
 }

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -1,0 +1,226 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { Address } from '../../../address';
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, StandardError } from '../../../common/error/errors';
+import { mapToBraintreeShippingAddressOverride, BraintreeError, BraintreePaypalCheckout, BraintreeSDKCreator, BraintreeTokenizePayload } from '../../../payment/strategies/braintree';
+import { PaypalAuthorizeData, PaypalHostWindow } from '../../../payment/strategies/paypal';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+import { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+import getValidButtonStyle from './get-valid-button-style';
+import mapToLegacyBillingAddress from './map-to-legacy-billing-address';
+import mapToLegacyShippingAddress from './map-to-legacy-shipping-address';
+
+export default class BraintreePaypalButtonStrategy implements CheckoutButtonStrategy {
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _braintreeSDKCreator: BraintreeSDKCreator,
+        private _formPoster: FormPoster,
+        private _window: PaypalHostWindow
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { braintreepaypal, containerId, methodId } = options;
+        const { messagingContainerId, onError } = braintreepaypal || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
+        }
+
+        if (!braintreepaypal) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.braintreepaypal" argument is not provided.`);
+        }
+
+        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const currency = state.cart.getCartOrThrow()?.currency.code;
+
+        if (!paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const paypalCheckoutOptions = { currency };
+        const paypalCheckoutSuccessCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) => {
+            this._renderPayPalComponents(
+                braintreePaypalCheckout,
+                braintreepaypal,
+                containerId,
+                methodId,
+                Boolean(paymentMethod.config.testMode)
+            );
+        };
+        const paypalCheckoutErrorCallback = (error: BraintreeError) =>
+            this._handleError(error, containerId, messagingContainerId, onError);
+
+        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        await this._braintreeSDKCreator.getPaypalCheckout(
+            paypalCheckoutOptions,
+            paypalCheckoutSuccessCallback,
+            paypalCheckoutErrorCallback
+        );
+    }
+
+    deinitialize(): Promise<void> {
+        this._braintreeSDKCreator.teardown();
+
+        return Promise.resolve();
+    }
+
+    private _renderPayPalComponents(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypal: BraintreePaypalButtonInitializeOptions,
+        containerId: string,
+        methodId: string,
+        testMode: boolean
+    ): void {
+        const { messagingContainerId } = braintreepaypal;
+
+        this._renderPayPalMessages(messagingContainerId);
+        this._renderPayPalButton(braintreePaypalCheckout, braintreepaypal, containerId, methodId, testMode);
+    }
+
+    private _renderPayPalButton(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypal: BraintreePaypalButtonInitializeOptions,
+        containerId: string,
+        methodId: string,
+        testMode: boolean
+    ): void {
+        const { style, shippingAddress, shouldProcessPayment, onAuthorizeError, onPaymentError } = braintreepaypal;
+
+        const { paypal } = this._window;
+        const fundingSource = paypal?.FUNDING.PAYPAL;
+
+        if (paypal && fundingSource) {
+            const validButtonStyle = style ? getValidButtonStyle(style) : {};
+
+            const paypalButtonRender = paypal.Buttons({
+                env: testMode ? 'sandbox' : 'production',
+                commit: false,
+                fundingSource,
+                style: validButtonStyle,
+                createOrder: () => this._setupPayment(braintreePaypalCheckout, shippingAddress, onPaymentError),
+                onApprove: (authorizeData: PaypalAuthorizeData) =>
+                    this._tokenizePayment(authorizeData, braintreePaypalCheckout, methodId, shouldProcessPayment, onAuthorizeError),
+            });
+
+            if (paypalButtonRender.isEligible()) {
+                paypalButtonRender.render(`#${containerId}`);
+            }
+        } else {
+            this._hideElement(containerId);
+        }
+    }
+
+    private _renderPayPalMessages(messagingContainerId?: string): void {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const storeConfig = state.config.getStoreConfigOrThrow();
+
+        const isMessageContainerAvailable = messagingContainerId && !!document.getElementById(messagingContainerId);
+        const isMessagesRenderingFeatureOn = storeConfig.checkoutSettings.features['PAYPAL-1149.braintree-new-card-below-totals-banner-placement'];
+
+        const { paypal } = this._window;
+
+        if (paypal && isMessagesRenderingFeatureOn && messagingContainerId && isMessageContainerAvailable) {
+            const paypalMessagesRender = paypal.Messages({ amount: cart.cartAmount, placement: 'cart' });
+            paypalMessagesRender.render(`#${messagingContainerId}`);
+        } else {
+            this._hideElement(messagingContainerId);
+        }
+    }
+
+    private async _setupPayment(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        shippingAddress?: Address | null,
+        onError?: (error: BraintreeError | StandardError) => void
+    ): Promise<string> {
+        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+
+        try {
+            const checkout = state.checkout.getCheckoutOrThrow();
+            const config = state.config.getStoreConfigOrThrow();
+            const customer = state.customer.getCustomer();
+
+            const address = shippingAddress || customer?.addresses?.[0];
+            const shippingAddressOverride = address ? mapToBraintreeShippingAddressOverride(address) : undefined;
+
+            return await braintreePaypalCheckout.createPayment({
+                flow: 'checkout',
+                enableShippingAddress: true,
+                shippingAddressEditable: false,
+                shippingAddressOverride,
+                amount: checkout.outstandingBalance,
+                currency: config.currency.code,
+                offerCredit: false,
+            });
+        } catch (error) {
+            if (onError) {
+                onError(error);
+            }
+
+            throw error;
+        }
+    }
+
+    private async _tokenizePayment(
+        authorizeData: PaypalAuthorizeData,
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        methodId: string,
+        shouldProcessPayment?: boolean,
+        onError?: (error: BraintreeError | StandardError) => void
+    ): Promise<BraintreeTokenizePayload> {
+        try {
+            const { deviceData } = await this._braintreeSDKCreator.getDataCollector({ paypal: true });
+            const tokenizePayload = await braintreePaypalCheckout.tokenizePayment(authorizeData);
+            const { details, nonce } = tokenizePayload;
+
+            this._formPoster.postForm('/checkout.php', {
+                payment_type: 'paypal',
+                provider: methodId,
+                action: shouldProcessPayment ? 'process_payment' : 'set_external_checkout',
+                nonce,
+                device_data: deviceData,
+                billing_address: JSON.stringify(mapToLegacyBillingAddress(details)),
+                shipping_address: JSON.stringify(mapToLegacyShippingAddress(details)),
+            });
+
+            return tokenizePayload;
+        } catch (error) {
+            if (onError) {
+                onError(error);
+            }
+
+            throw error;
+        }
+    }
+
+    private _handleError(
+        error: BraintreeError,
+        buttonContainerId: string,
+        messagingContainerId?: string,
+        onErrorCallback?: (error: BraintreeError) => void
+    ): void {
+        this._hideElement(buttonContainerId);
+        this._hideElement(messagingContainerId);
+
+        if (onErrorCallback) {
+            onErrorCallback(error);
+        }
+    }
+
+    private _hideElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            Object.assign(element.style, { display: 'none' });
+        }
+    }
+}

--- a/packages/core/src/checkout-buttons/strategies/braintree/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/index.ts
@@ -4,6 +4,10 @@
 export { default as BraintreePaypalV1ButtonStrategy } from './braintree-paypal-v1-button-strategy';
 export { BraintreePaypalV1ButtonInitializeOptions } from './braintree-paypal-v1-button-options';
 
+// Braintree PayPal Button Strategy
+export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
+export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+
 // Braintree PayPal Credit (Credit / PayLater)
 export { default as BraintreePaypalCreditButtonStrategy } from './braintree-paypal-credit-button-strategy';
 export { BraintreePaypalCreditButtonInitializeOptions } from './braintree-paypal-credit-button-options';

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -2,6 +2,7 @@ enum CheckoutButtonMethodType {
     APPLEPAY = 'applepay',
     AMAZON_PAY_V2 = 'amazonpay',
     BRAINTREE_PAYPAL = 'braintreepaypal',
+    BRAINTREE_PAYPALV2 = 'braintreepaypalv2',
     BRAINTREE_VENMO = 'braintreevenmo',
     BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit',
     BRAINTREE_PAYPAL_CREDITV2 = 'braintreepaypalcreditv2',


### PR DESCRIPTION
## What?
Added braintreepaypal checkout button strategy

## Why?
To contain Braintree Paypal specific code in its own file.

## Testing / Proof
Unit tests
Manual tests 

<img width="575" alt="Screenshot 2022-06-06 at 17 31 12" src="https://user-images.githubusercontent.com/25133454/172181940-af824b71-32b7-4b8d-bb37-70ec045ab23d.png">
