### PR TITLE
refactor(common): CHECKOUT-6752 Refactor payment strategies to pass method as params

### DIFF
--- a/packages/core/src/payment/payment-method-request-sender.spec.ts
+++ b/packages/core/src/payment/payment-method-request-sender.spec.ts
@@ -97,5 +97,22 @@ describe('PaymentMethodRequestSender', () => {
                 },
             });
         });
+
+        it('loads payment method with params', async () => {
+            const options = { params: { method: 'method-id' } };
+
+            jest.spyOn(requestSender, 'get')
+                .mockReturnValue(Promise.resolve(response));
+
+            expect(await paymentMethodRequestSender.loadPaymentMethod('afterpay', options)).toEqual(response);
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/payments/afterpay', {
+                ...options,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                    'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_VERSION_HEADERS,
+                },
+            });
+        });
     });
 });

--- a/packages/core/src/payment/payment-method-request-sender.ts
+++ b/packages/core/src/payment/payment-method-request-sender.ts
@@ -22,7 +22,7 @@ export default class PaymentMethodRequestSender {
         });
     }
 
-    loadPaymentMethod(methodId: string, { timeout }: RequestOptions = {}): Promise<Response<PaymentMethod>> {
+    loadPaymentMethod(methodId: string, { timeout, params }: RequestOptions = {}): Promise<Response<PaymentMethod>> {
         const url = `/api/storefront/payments/${methodId}`;
 
         return this._requestSender.get(url, {
@@ -32,6 +32,7 @@ export default class PaymentMethodRequestSender {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 ...SDK_VERSION_HEADERS,
             },
+            params,
         });
     }
 }

--- a/packages/core/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/afterpay/afterpay-payment-strategy.spec.ts
@@ -229,7 +229,7 @@ describe('AfterpayPaymentStrategy', () => {
         });
 
         it('loads payment client token', () => {
-            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(`${paymentMethod.gateway}?method=${paymentMethod.id}`, undefined);
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(paymentMethod.gateway, { params: { method: paymentMethod.id } });
             expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
         });
     });

--- a/packages/core/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/afterpay/afterpay-payment-strategy.ts
@@ -136,7 +136,7 @@ export default class AfterpayPaymentStrategy implements PaymentStrategy {
     private async _loadPaymentMethod(gatewayId: string, methodId: string, options?: RequestOptions): Promise<InternalCheckoutSelectors> {
         try {
             return await this._store.dispatch(
-                this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}?method=${methodId}`, options)
+                this._paymentMethodActionCreator.loadPaymentMethod(gatewayId, { ...options, params: { ...options?.params, method: methodId } })
             );
         } catch (error) {
             if (error instanceof RequestError && error?.body?.status === 422) {

--- a/packages/core/src/payment/strategies/clearpay/clearpay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/clearpay/clearpay-payment-strategy.spec.ts
@@ -221,7 +221,7 @@ describe('ClearpayPaymentStrategy', () => {
 
         it('loads payment client token', () => {
             expect(paymentMethodActionCreator.loadPaymentMethod)
-                .toHaveBeenCalledWith(`${paymentMethod.gateway}?method=${paymentMethod.id}`, undefined);
+                .toHaveBeenCalledWith(paymentMethod.gateway, { params: { method: paymentMethod.id } });
             expect(store.dispatch).toHaveBeenCalledWith(loadPaymentMethodAction);
         });
 

--- a/packages/core/src/payment/strategies/clearpay/clearpay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/clearpay/clearpay-payment-strategy.ts
@@ -122,7 +122,7 @@ export default class ClearpayPaymentStrategy implements PaymentStrategy {
     private async _loadPaymentMethod(gatewayId: string, methodId: string, options?: RequestOptions): Promise<InternalCheckoutSelectors> {
         try {
             return await this._store.dispatch(
-                this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}?method=${methodId}`, options)
+                this._paymentMethodActionCreator.loadPaymentMethod(gatewayId, { ...options, params: { ...options?.params, method: methodId } })
             );
         } catch (error) {
             if (error instanceof RequestError && error?.body?.status === 422) {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -58,7 +58,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                 const payment = this._stripeElements?.getElement(StripeStringConstants.PAYMENT);
                 if (payment) {
                     let error;
-                    await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}?method=${methodId}`)).catch(err => error = err);
+                    await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(gatewayId, { params: { method: methodId } })).catch(err => error = err);
                     if (error) {
                         if (this._isMounted) {
                             payment.unmount();
@@ -216,7 +216,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
     }
 
     private async _loadStripeElement(containerId: string, style: { [key: string]: string } | undefined, gatewayId: string, methodId: string) {
-        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}?method=${methodId}`));
+        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(gatewayId, { params: { method: methodId } }));
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         const { initializationData: { stripePublishableKey, stripeConnectedAccount, shopperLanguage } } = paymentMethod;
 

--- a/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -100,7 +100,7 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                 return await this._executeWithVaulted(payment, instrumentId, shouldSetAsDefaultInstrument);
             }
 
-            const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}?method=${methodId}`));
+            const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(`${gatewayId}`, { params: { method: methodId } }));
             const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
             const result = await this._confirmStripePayment(paymentMethod);
             const { clientToken, method } = paymentMethod;


### PR DESCRIPTION
## What?
To pass `method` as params, instead of as bundle string of gatewayId like this `${gatewayId}?method=${methodId}`

## Why?
For adding additional parameter when calling loadPaymentMethod in the future.   

## Testing / Proof
- [x] unit test

@bigcommerce/checkout @bigcommerce/payments @josesonora @BC-AOrtiz 
