### PR TITLE
feat(payment): PAYPAL-1508 removed authentication insight to force trigger 3DS check on Braintree

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -283,54 +283,6 @@ describe('BraintreeHostedForm', () => {
         });
     });
 
-    describe('#tokenizeWith3DSRegulationCheck', () => {
-        it('tokenizes data with 3DS regulation check through hosted fields for credit card verification', async () => {
-            await subject.initialize(formOptions);
-
-            const merchantAccountIdMock = '1000000';
-            const billingAddress = getBillingAddress();
-            const cardNameInput = document.querySelector('#cardName input') as HTMLInputElement;
-
-            cardNameInput.value = 'Foobar';
-
-            await subject.tokenizeWith3DSRegulationCheck(billingAddress, merchantAccountIdMock);
-
-            expect(cardFields.tokenize)
-                .toHaveBeenCalledWith({
-                    authenticationInsight: {
-                        merchantAccountId: merchantAccountIdMock,
-                    },
-                    billingAddress: {
-                        countryName: billingAddress.country,
-                        postalCode: billingAddress.postalCode,
-                        streetAddress: billingAddress.address1,
-                    },
-                    cardholderName: 'Foobar',
-                });
-        });
-
-        it('returns invalid form error when tokenizing with invalid form data', async () => {
-            await subject.initialize(formOptions);
-
-            jest.spyOn(cardFields, 'tokenize')
-                .mockRejectedValue({ code: 'HOSTED_FIELDS_FIELDS_EMPTY' });
-
-            try {
-                await subject.tokenizeWith3DSRegulationCheck(getBillingAddress(), '100000');
-            } catch (error) {
-                expect(error).toBeInstanceOf(PaymentInvalidFormError);
-            }
-        });
-
-        it('throws error if trying to tokenize before initialization', async () => {
-            try {
-                await subject.tokenizeWith3DSRegulationCheck(getBillingAddress(), '100000');
-            } catch (error) {
-                expect(error).toBeInstanceOf(NotInitializedError);
-            }
-        });
-    });
-
     describe('card fields events notifications', () => {
         let handleFocus: jest.Mock;
         let handleBlur: jest.Mock;

--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -5,7 +5,7 @@ import { NotInitializedError, NotInitializedErrorType } from '../../../common/er
 import { PaymentInvalidFormError, PaymentInvalidFormErrorDetails } from '../../errors';
 import { NonceInstrument } from '../../payment';
 
-import { BraintreeAuthenticationInsight, BraintreeBillingAddressRequestData, BraintreeHostedFields, BraintreeHostedFieldsCreatorConfig, BraintreeHostedFieldsState, BraintreeHostedFormError } from './braintree';
+import { BraintreeBillingAddressRequestData, BraintreeHostedFields, BraintreeHostedFieldsCreatorConfig, BraintreeHostedFieldsState, BraintreeHostedFormError } from './braintree';
 import { BraintreeFormFieldsMap, BraintreeFormFieldStyles, BraintreeFormFieldStylesMap, BraintreeFormFieldType, BraintreeFormFieldValidateErrorData, BraintreeFormFieldValidateEventData, BraintreeFormOptions, BraintreeStoredCardFieldsMap } from './braintree-payment-options';
 import BraintreeRegularField from './braintree-regular-field';
 import BraintreeSDKCreator from './braintree-sdk-creator';
@@ -126,47 +126,6 @@ export default class BraintreeHostedForm {
             });
 
             return { nonce };
-        } catch (error) {
-            const errors = this._mapTokenizeError(error);
-
-            if (errors) {
-                this._formOptions?.onValidate?.({
-                    isValid: false,
-                    errors,
-                });
-
-                throw new PaymentInvalidFormError(errors as PaymentInvalidFormErrorDetails);
-            }
-
-            throw error;
-        }
-    }
-
-    async tokenizeWith3DSRegulationCheck(billingAddress: Address, merchantAccountId: string): Promise<BraintreeAuthenticationInsight & NonceInstrument> {
-        if (!this._cardFields) {
-            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-        }
-
-        try {
-            const tokenizationOptions = omitBy(
-                {
-                    authenticationInsight: {
-                        merchantAccountId,
-                    },
-                    billingAddress: billingAddress && this._mapBillingAddress(billingAddress),
-                    cardholderName: this._cardNameField?.getValue(),
-                },
-                isNil
-            );
-
-            const { authenticationInsight, nonce } = await this._cardFields.tokenize(tokenizationOptions);
-
-            this._formOptions?.onValidate?.({
-                isValid: true,
-                errors: {},
-            });
-
-            return { authenticationInsight, nonce };
         } catch (error) {
             const errors = this._mapTokenizeError(error);
 

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -374,67 +374,6 @@ describe('BraintreePaymentProcessor', () => {
         });
     });
 
-    describe('#verifyCardWithHostedFormAnd3DSCheck', () => {
-        let braintreePaymentProcessor: BraintreePaymentProcessor;
-        let merchantAccountIdMock: string;
-
-        beforeEach(() => {
-            merchantAccountIdMock = '100000';
-
-            braintreePaymentProcessor = new BraintreePaymentProcessor(braintreeSDKCreator, braintreeHostedForm, overlay);
-
-            braintreeHostedForm.tokenizeWith3DSRegulationCheck = jest.fn();
-
-            jest.spyOn(braintreePaymentProcessor, 'challenge3DSVerification')
-                .mockReturnValue({ nonce: 'three_ds_nonce' });
-        });
-
-        it('verifies credit card with hosted form using 3DS if the card is regulated', async () => {
-            jest.spyOn(braintreeHostedForm, 'tokenizeWith3DSRegulationCheck')
-                .mockReturnValue({
-                    authenticationInsight: {
-                        regulationEnvironment: 'psd2',
-                    },
-                    nonce: 'tokenized_nonce',
-                });
-
-            const verifiedCard = await braintreePaymentProcessor.verifyCardWithHostedFormAnd3DSCheck(getBillingAddress(), 122, merchantAccountIdMock);
-            expect(braintreePaymentProcessor.challenge3DSVerification).toHaveBeenCalledWith('tokenized_nonce', 122);
-            expect(braintreeHostedForm.tokenizeWith3DSRegulationCheck).toHaveBeenCalledWith(getBillingAddress(), merchantAccountIdMock);
-            expect(verifiedCard).toEqual({ nonce: 'three_ds_nonce' });
-        });
-
-        it('verifies credit card with hosted form using 3DS if the card is unavailable', async () => {
-            jest.spyOn(braintreeHostedForm, 'tokenizeWith3DSRegulationCheck')
-                .mockReturnValue({
-                    authenticationInsight: {
-                        regulationEnvironment: 'unavailable',
-                    },
-                    nonce: 'tokenized_nonce',
-                });
-
-            const verifiedCard = await braintreePaymentProcessor.verifyCardWithHostedFormAnd3DSCheck(getBillingAddress(), 122, merchantAccountIdMock);
-            expect(braintreePaymentProcessor.challenge3DSVerification).toHaveBeenCalledWith('tokenized_nonce', 122);
-            expect(braintreeHostedForm.tokenizeWith3DSRegulationCheck).toHaveBeenCalledWith(getBillingAddress(), merchantAccountIdMock);
-            expect(verifiedCard).toEqual({ nonce: 'three_ds_nonce' });
-        });
-
-        it('only tokenizes credit card with hosted form using 3DS if the card is unregulated', async () => {
-            jest.spyOn(braintreeHostedForm, 'tokenizeWith3DSRegulationCheck')
-                .mockReturnValue({
-                    authenticationInsight: {
-                        regulationEnvironment: 'unregulated',
-                    },
-                    nonce: 'tokenized_nonce',
-                });
-
-            const verifiedCard = await braintreePaymentProcessor.verifyCardWithHostedFormAnd3DSCheck(getBillingAddress(), 122, merchantAccountIdMock);
-            expect(braintreePaymentProcessor.challenge3DSVerification).not.toHaveBeenCalled();
-            expect(braintreeHostedForm.tokenizeWith3DSRegulationCheck).toHaveBeenCalledWith(getBillingAddress(), merchantAccountIdMock);
-            expect(verifiedCard).toEqual({ nonce: 'tokenized_nonce' });
-        });
-    });
-
     describe('#challenge3DSVerification()', () => {
         let clientMock: BraintreeClient;
         let threeDSecureMock: BraintreeThreeDSecure;

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -142,17 +142,6 @@ export default class BraintreePaymentProcessor {
         return this.challenge3DSVerification(nonce, amount);
     }
 
-    async verifyCardWithHostedFormAnd3DSCheck(billingAddress: Address, amount: number, merchantAccountId: string): Promise<NonceInstrument> {
-        const { authenticationInsight, nonce } = await this._braintreeHostedForm.tokenizeWith3DSRegulationCheck(billingAddress, merchantAccountId);
-        const { regulationEnvironment } = authenticationInsight || {};
-
-        if (regulationEnvironment === 'psd2' || regulationEnvironment === 'unavailable') {
-            return this.challenge3DSVerification(nonce, amount);
-        }
-
-        return { nonce };
-    }
-
     async challenge3DSVerification(nonce: string, amount: number): Promise<NonceInstrument> {
         const threeDSecure = await this._braintreeSDKCreator.get3DS();
 

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -283,23 +283,12 @@ export interface BraintreeHostedFieldsFieldData {
 
 export interface BraintreeHostedFieldsTokenizeOptions {
     vault?: boolean;
-    authenticationInsight?: {
-        merchantAccountId: string;
-    };
     fieldsToTokenize?: string[];
     cardholderName?: string;
     billingAddress?: BraintreeBillingAddressRequestData;
 }
 
-export interface BraintreeAuthenticationInsight {
-    authenticationInsight?: BraintreeRegulationEnvironment;
-}
-
-export interface BraintreeRegulationEnvironment {
-    regulationEnvironment: 'psd2' | 'unregulated' | 'unavailable';
-}
-
-export interface BraintreeHostedFieldsTokenizePayload extends BraintreeAuthenticationInsight {
+export interface BraintreeHostedFieldsTokenizePayload {
     nonce: string;
     details: {
         bin: string;


### PR DESCRIPTION
## What?
Removed authentication insight 3DS pre check on Braintree

## Why?
It should help us to reduce issues with 3DS verification on Braintree, because we will challenge 3DS verification for all transaction (accept 'unregulated') if 3DS is enabled in Braintree settings form on CP

## Testing / Proof
Unit tests
Manual tests
