### PR TITLE
feat(checkout): CHECKOUT-6711 Update ApplePay for buy now cart

### DIFF
--- a/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.spec.ts
@@ -379,6 +379,8 @@ describe('ApplePayCustomerStrategy', () => {
         });
 
         it('submits payment when shopper authorises', async () => {
+            jest.spyOn(store.getState().order, 'getOrderOrThrow')
+                .mockReturnValue({orderId:100});
             const authEvent = {
                 payment: {
                     billingContact: getContactAddress(),
@@ -407,6 +409,8 @@ describe('ApplePayCustomerStrategy', () => {
         });
 
         it('returns an error if autorize payment fails', async () => {
+            jest.spyOn(store.getState().order, 'getOrderOrThrow')
+                .mockReturnValue({orderId:100});
             jest.spyOn(paymentActionCreator, 'submitPayment')
                 .mockRejectedValue(false);
             const authEvent = {

--- a/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -419,15 +419,20 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
                 );
             }
 
-            await this._store.dispatch(this._orderActionCreator.submitOrder(
+            const state = await this._store.dispatch(this._orderActionCreator.submitOrder(
                 {
                     useStoreCredit: false,
                 })
             );
+            const {
+                order: { getOrderOrThrow },
+            } = state;
+            const order = getOrderOrThrow();
+
             await this._store.dispatch(this._paymentActionCreator.submitPayment(payment));
             applePaySession.completePayment(ApplePaySession.STATUS_SUCCESS);
 
-            return this._onAuthorizeCallback();
+            return this._onAuthorizeCallback(window.location, order.orderId);
         } catch (error) {
             applePaySession.completePayment(ApplePaySession.STATUS_FAILURE);
 


### PR DESCRIPTION
## What?
When a checkout URL is a buy now cart URL,  `/checkout/:checkout-id`, its order confirmation page will put `orderId` in the URL, `/checkout/order-confirmation/:order-id`.

ApplePay is different form other payment methods. As a result, this PR is for changing ApplePay's callback behaviours.

## Why?
We can load the right information for a buy now cart checkout.

## Related PR
https://github.com/bigcommerce/checkout-js/pull/902

## Testing / Proof
I was unable to enable ApplePay testing env on my Mac. 