### PR TITLE
feat(checkout): CHECKOUT-6765 pass checkout Id to checkout settings api as query string

### DIFF
--- a/packages/core/src/checkout/checkout-action-creator.ts
+++ b/packages/core/src/checkout/checkout-action-creator.ts
@@ -24,7 +24,7 @@ export default class CheckoutActionCreator {
         return concat(
             of(createAction(CheckoutActionType.LoadCheckoutRequested)),
             merge(
-                this._configActionCreator.loadConfig({ ...options, useCache: true }),
+                this._configActionCreator.loadConfig({ ...options, useCache: true, params: {...options?.params, checkoutId: id} }),
                 this._formFieldsActionCreator.loadFormFields({ ...options, useCache: true }),
                 defer(() => this._checkoutRequestSender.loadCheckout(id, options)
                     .then(({ body }) => createAction(CheckoutActionType.LoadCheckoutSucceeded, body)))

--- a/packages/core/src/config/config-request-sender.spec.ts
+++ b/packages/core/src/config/config-request-sender.spec.ts
@@ -54,6 +54,21 @@ describe('ConfigRequestSender', () => {
             });
         });
 
+        it('loads config with checkout ID', async () => {
+            const options = { params: { checkoutId: 'dummy' } };
+            const output = await configRequestSender.loadConfig(options);
+
+            expect(output).toEqual(response);
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/checkout-settings', {
+                ...options,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                    'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_VERSION_HEADERS,
+                },
+            });
+        });
+
         it('throws a CheckoutNotAvailable error when it encounters a client error(400-499)', async () => {
             jest.spyOn(requestSender, 'get').mockRejectedValue(getErrorResponse(undefined, undefined, 404));
 

--- a/packages/core/src/config/config-request-sender.ts
+++ b/packages/core/src/config/config-request-sender.ts
@@ -10,7 +10,7 @@ export default class ConfigRequestSender {
         private _requestSender: RequestSender
     ) {}
 
-    loadConfig({ timeout }: RequestOptions = {}): Promise<Response<Config>> {
+    loadConfig({ timeout, params }: RequestOptions = {}): Promise<Response<Config>> {
         const url = '/api/storefront/checkout-settings';
 
         return this._requestSender.get<Config>(url, {
@@ -20,6 +20,7 @@ export default class ConfigRequestSender {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 ...SDK_VERSION_HEADERS,
             },
+            params,
         }).catch(error => {
             if (error.status >= 400 && error.status < 500) {
                 throw new CheckoutNotAvailableError(error);


### PR DESCRIPTION
## What?

pass checkout Id to checkout settings api as query string in the checkout loading action: `/api/storefront/checkout-settings?checkoutId=<cart_id>`

> didn't change `loadDefaultCheckout` action, since buy-now cart checkout never use it.

## Related PR:

storefront checkout settings changes to allow passing cart id:
https://github.com/bigcommerce/bigcommerce/pull/46795

## Why?

to support buy-now cart checkout, to get checkout settings of buy-now cart.

## Testing / Proof

- [x] unit test: added test case and passed
- [x] manual test

1) checkout page with buy-now cart id in page url `/checkout/b316955c-2e73-40a4-92d4-50541331aa34`
<img width="1731" alt="Screen Shot 2022-06-21 at 9 23 56 am" src="https://user-images.githubusercontent.com/94653751/174688374-c587f120-0db5-4831-a788-e08c3fa966fb.png">

call checkout settings with buy-now cart id in query string: `/api/storefront/checkout-settings?checkoutId=b316955c-2e73-40a4-92d4-50541331aa34&include=cart.lineItems.physicalItems.categoryNames&include=cart.lineItems.digitalItems.categoryNames`

2) checkout page without cart id
<img width="1731" alt="Screen Shot 2022-06-21 at 9 27 50 am" src="https://user-images.githubusercontent.com/94653751/174688592-a6cb0e91-c086-44cc-90fe-d2e17487b034.png">

call checkout settings with primary cart id in query string: `/api/storefront/checkout-settings?checkoutId=1893ac08-5cb6-4e21-abd3-370261fd91b6&include=cart.lineItems.physicalItems.categoryNames&include=cart.lineItems.digitalItems.categoryNames`

3) checkout page with primary cart id in page url `/checkout/893ac08-5cb6-4e21-abd3-370261fd91b6`
same result as 2)

@bigcommerce/checkout
