### PR TITLE
feat(checkout): CHECKOUT-6722 pass cart Id to SF/payments API endpoint

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.spec.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.spec.ts
@@ -42,7 +42,7 @@ describe('CheckoutButtonStrategyActionCreator', () => {
         registry.register(CheckoutButtonMethodType.BRAINTREE_PAYPAL, () => strategy);
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(from([
+            .mockReturnValue(() => from([
                 createAction(PaymentMethodActionType.LoadPaymentMethodRequested),
                 createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, { paymentMethod: getPaymentMethod() }),
             ]));
@@ -124,7 +124,7 @@ describe('CheckoutButtonStrategyActionCreator', () => {
         const expectedError = new Error('Unable to load payment method');
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(throwError(createErrorAction(PaymentMethodActionType.LoadPaymentMethodFailed, expectedError)));
+            .mockReturnValue(() => throwError(createErrorAction(PaymentMethodActionType.LoadPaymentMethodFailed, expectedError)));
 
         const errorHandler = jest.fn(action => of(action));
         const actions = await from(strategyActionCreator.initialize({ methodId, containerId })(store))

--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -36,7 +36,7 @@ export default class CheckoutButtonStrategyActionCreator {
 
             return concat(
                 of(createAction(CheckoutButtonActionType.InitializeButtonRequested, undefined, meta)),
-                this._paymentMethodActionCreator.loadPaymentMethod(mapCheckoutButtonMethodId(options.methodId), { timeout: options.timeout, useCache: true }),
+                this._paymentMethodActionCreator.loadPaymentMethod(mapCheckoutButtonMethodId(options.methodId), { timeout: options.timeout, useCache: true })(store),
                 defer(() => this._registry.get(options.methodId).initialize(options)
                     .then(() => createAction(CheckoutButtonActionType.InitializeButtonSucceeded, undefined, meta)))
             ).pipe(

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -647,13 +647,14 @@ describe('CheckoutService', () => {
 
     describe('#loadPaymentMethods()', () => {
         it('loads payment methods', async () => {
+            const options = { params: { cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7' } };
             await checkoutService.loadPaymentMethods();
 
-            expect(paymentMethodRequestSender.loadPaymentMethods).toHaveBeenCalledWith(undefined);
+            expect(paymentMethodRequestSender.loadPaymentMethods).toHaveBeenCalledWith(options);
         });
 
         it('loads payment methods with timeout', async () => {
-            const options = { timeout: createTimeout() };
+            const options = { timeout: createTimeout(), params: { cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7' } };
 
             await checkoutService.loadPaymentMethods(options);
 
@@ -671,7 +672,7 @@ describe('CheckoutService', () => {
 
             await checkoutService.loadPaymentMethods();
 
-            expect(store.dispatch).toHaveBeenCalledWith(expect.any(Observable), { queueId: 'paymentMethods' });
+            expect(store.dispatch).toHaveBeenCalledWith(expect.any(Function), { queueId: 'paymentMethods' });
         });
     });
 

--- a/packages/core/src/payment/payment-method-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-method-action-creator.spec.ts
@@ -1,7 +1,9 @@
 import { createRequestSender, createTimeout, Response } from '@bigcommerce/request-sender';
-import { merge, of } from 'rxjs';
+import { from, merge, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
+import { createCheckoutStore, CheckoutStore } from '../checkout';
+import { getCheckout, getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { ErrorResponseBody } from '../common/error';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
@@ -17,6 +19,7 @@ describe('PaymentMethodActionCreator', () => {
     let paymentMethodRequestSender: PaymentMethodRequestSender;
     let paymentMethodResponse: Response<PaymentMethod>;
     let paymentMethodsResponse: Response<PaymentMethod[]>;
+    let store: CheckoutStore;
 
     beforeEach(() => {
         errorResponse = getErrorResponse();
@@ -25,6 +28,7 @@ describe('PaymentMethodActionCreator', () => {
             'x-device-session-id': getPaymentMethodsMeta().deviceSessionId,
             'x-session-hash': getPaymentMethodsMeta().sessionHash,
         });
+        store = createCheckoutStore(getCheckoutStoreState());
 
         paymentMethodRequestSender = new PaymentMethodRequestSender(createRequestSender());
         paymentMethodActionCreator = new PaymentMethodActionCreator(paymentMethodRequestSender);
@@ -34,17 +38,20 @@ describe('PaymentMethodActionCreator', () => {
 
         jest.spyOn(paymentMethodRequestSender, 'loadPaymentMethods')
             .mockReturnValue(Promise.resolve(paymentMethodsResponse));
+
+        jest.spyOn(store.getState().cart, 'getCartOrThrow')
+            .mockReturnValue(getCheckout().cart);
     });
 
     describe('#loadPaymentMethods()', () => {
         it('sends a request to get a list of payment methods', async () => {
-            await paymentMethodActionCreator.loadPaymentMethods().toPromise();
+            await from(paymentMethodActionCreator.loadPaymentMethods()(store)).toPromise();
 
             expect(paymentMethodRequestSender.loadPaymentMethods).toHaveBeenCalled();
         });
 
         it('emits actions if able to load payment methods', async () => {
-            const actions = await paymentMethodActionCreator.loadPaymentMethods()
+            const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
                 .pipe(toArray())
                 .toPromise();
 
@@ -66,7 +73,7 @@ describe('PaymentMethodActionCreator', () => {
                 .mockReturnValue(Promise.reject(errorResponse));
 
             const errorHandler = jest.fn(action => of(action));
-            const actions = await paymentMethodActionCreator.loadPaymentMethods()
+            const actions = await from(paymentMethodActionCreator.loadPaymentMethods()(store))
                 .pipe(
                     catchError(errorHandler),
                     toArray()
@@ -84,24 +91,25 @@ describe('PaymentMethodActionCreator', () => {
     describe('#loadPaymentMethod()', () => {
         it('loads payment method data', async () => {
             const methodId = 'braintree';
+            const options = { params: {cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7'} };
 
-            await paymentMethodActionCreator.loadPaymentMethod(methodId).toPromise();
+            await from(paymentMethodActionCreator.loadPaymentMethod(methodId)(store)).toPromise();
 
-            expect(paymentMethodRequestSender.loadPaymentMethod).toHaveBeenCalledWith(methodId, undefined);
+            expect(paymentMethodRequestSender.loadPaymentMethod).toHaveBeenCalledWith(methodId, options);
         });
 
         it('loads payment method data with timeout', async () => {
             const methodId = 'braintree';
-            const options = { timeout: createTimeout() };
+            const options = { timeout: createTimeout(), params: {cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7'} };
 
-            await paymentMethodActionCreator.loadPaymentMethod(methodId, options).toPromise();
+            await from(paymentMethodActionCreator.loadPaymentMethod(methodId, options)(store)).toPromise();
 
             expect(paymentMethodRequestSender.loadPaymentMethod).toHaveBeenCalledWith(methodId, options);
         });
 
         it('emits actions if able to load payment method', async () => {
             const methodId = 'braintree';
-            const actions = await paymentMethodActionCreator.loadPaymentMethod(methodId)
+            const actions = await from(paymentMethodActionCreator.loadPaymentMethod(methodId)(store))
                 .pipe(toArray())
                 .toPromise();
 
@@ -115,8 +123,8 @@ describe('PaymentMethodActionCreator', () => {
             const methodId = 'braintree';
             const options = { useCache: true };
             const actions = await merge(
-                paymentMethodActionCreator.loadPaymentMethod(methodId, options),
-                paymentMethodActionCreator.loadPaymentMethod(methodId, options)
+                from(paymentMethodActionCreator.loadPaymentMethod(methodId, options)(store)),
+                from(paymentMethodActionCreator.loadPaymentMethod(methodId, options)(store))
             )
                 .pipe(toArray())
                 .toPromise();
@@ -136,7 +144,7 @@ describe('PaymentMethodActionCreator', () => {
 
             const methodId = 'braintree';
             const errorHandler = jest.fn(action => of(action));
-            const actions = await paymentMethodActionCreator.loadPaymentMethod(methodId)
+            const actions = await from(paymentMethodActionCreator.loadPaymentMethod(methodId)(store))
                 .pipe(
                     catchError(errorHandler),
                     toArray()

--- a/packages/core/src/payment/payment-method-action-creator.ts
+++ b/packages/core/src/payment/payment-method-action-creator.ts
@@ -47,11 +47,12 @@ export default class PaymentMethodActionCreator {
     loadPaymentMethod(methodId: string, options?: RequestOptions & ActionOptions): ThunkAction<LoadPaymentMethodAction, InternalCheckoutSelectors> {
         return store => Observable.create((observer: Observer<LoadPaymentMethodAction>) => {
             const state = store.getState();
-            const cart = state.cart.getCartOrThrow();
+            const cartId = state.cart.getCart()?.id;
+            const params = cartId ? { ...options?.params, cartId } : { ...options?.params };
 
             observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodRequested, undefined, { methodId }));
 
-            this._requestSender.loadPaymentMethod(methodId, { ...options, params: { ...options?.params, cartId: cart.id } })
+            this._requestSender.loadPaymentMethod(methodId, { ...options, params })
                 .then(response => {
                     observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, response.body, { methodId }));
                     observer.complete();

--- a/packages/core/src/payment/payment-method-action-creator.ts
+++ b/packages/core/src/payment/payment-method-action-creator.ts
@@ -1,7 +1,8 @@
-import { createAction, createErrorAction } from '@bigcommerce/data-store';
+import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
 import { filter } from 'lodash';
 import { Observable, Observer } from 'rxjs';
 
+import { InternalCheckoutSelectors } from '../checkout';
 import { cachableAction, ActionOptions } from '../common/data-store';
 import { RequestOptions } from '../common/http-request';
 
@@ -17,11 +18,14 @@ export default class PaymentMethodActionCreator {
         private _requestSender: PaymentMethodRequestSender
     ) {}
 
-    loadPaymentMethods(options?: RequestOptions): Observable<LoadPaymentMethodsAction> {
-        return Observable.create((observer: Observer<LoadPaymentMethodsAction>) => {
+    loadPaymentMethods(options?: RequestOptions): ThunkAction<LoadPaymentMethodsAction, InternalCheckoutSelectors> {
+        return store => Observable.create((observer: Observer<LoadPaymentMethodsAction>) => {
+            const state = store.getState();
+            const cart = state.cart.getCartOrThrow();
+
             observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodsRequested));
 
-            this._requestSender.loadPaymentMethods(options)
+            this._requestSender.loadPaymentMethods({ ...options, params: { ...options?.params, cartId: cart.id } })
                 .then(response => {
                     const meta = {
                         deviceSessionId: response.headers['x-device-session-id'],
@@ -40,11 +44,14 @@ export default class PaymentMethodActionCreator {
     }
 
     @cachableAction
-    loadPaymentMethod(methodId: string, options?: RequestOptions & ActionOptions): Observable<LoadPaymentMethodAction> {
-        return Observable.create((observer: Observer<LoadPaymentMethodAction>) => {
+    loadPaymentMethod(methodId: string, options?: RequestOptions & ActionOptions): ThunkAction<LoadPaymentMethodAction, InternalCheckoutSelectors> {
+        return store => Observable.create((observer: Observer<LoadPaymentMethodAction>) => {
+            const state = store.getState();
+            const cart = state.cart.getCartOrThrow();
+
             observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodRequested, undefined, { methodId }));
 
-            this._requestSender.loadPaymentMethod(methodId, options)
+            this._requestSender.loadPaymentMethod(methodId, { ...options, params: { ...options?.params, cartId: cart.id } })
                 .then(response => {
                     observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, response.body, { methodId }));
                     observer.complete();

--- a/packages/core/src/payment/payment-method-request-sender.spec.ts
+++ b/packages/core/src/payment/payment-method-request-sender.spec.ts
@@ -54,6 +54,23 @@ describe('PaymentMethodRequestSender', () => {
                 },
             });
         });
+
+        it('loads payment methods with params', async () => {
+            const options = { params: { method: 'method-id' } };
+
+            jest.spyOn(requestSender, 'get')
+                .mockReturnValue(Promise.resolve(response));
+
+            expect(await paymentMethodRequestSender.loadPaymentMethods(options)).toEqual(response);
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/payments', {
+                ...options,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                    'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                    ...SDK_VERSION_HEADERS,
+                },
+            });
+        });
     });
 
     describe('#loadPaymentMethod()', () => {

--- a/packages/core/src/payment/payment-method-request-sender.ts
+++ b/packages/core/src/payment/payment-method-request-sender.ts
@@ -9,7 +9,7 @@ export default class PaymentMethodRequestSender {
         private _requestSender: RequestSender
     ) {}
 
-    loadPaymentMethods({ timeout }: RequestOptions = {}): Promise<Response<PaymentMethod[]>> {
+    loadPaymentMethods({ timeout, params }: RequestOptions = {}): Promise<Response<PaymentMethod[]>> {
         const url = '/api/storefront/payments';
 
         return this._requestSender.get(url, {
@@ -19,6 +19,7 @@ export default class PaymentMethodRequestSender {
                 'X-API-INTERNAL': INTERNAL_USE_ONLY,
                 ...SDK_VERSION_HEADERS,
             },
+            params,
         });
     }
 

--- a/packages/core/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
@@ -166,7 +166,7 @@ export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
     }
 
     private async _updateOrder(gatewayId: string) {
-        await this._paymentMethodActionCreator.loadPaymentMethod(gatewayId).toPromise();
+        await this._paymentMethodActionCreator.loadPaymentMethod(gatewayId);
     }
 
     private _authorize(methodId: string): Promise<KlarnaAuthorizationResponse> {


### PR DESCRIPTION
## What?
Reopen revert PR https://github.com/bigcommerce/checkout-sdk-js/pull/1456 with fixed commit
* Fixed loadPaymentMethod in checkout-button-strategy-action-creator

## Why?
Wallet buttons didn't show on the cart page

## Testing / Proof
### Before
![image](https://user-images.githubusercontent.com/84553389/175190233-73a9ef18-7a12-4591-87a2-c9f9be1433dc.png)

### After
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/84553389/175178829-0e842b26-f345-4180-a0d5-0930aca409d9.png">


@bigcommerce/checkout 