### PR TITLE
fix(payment): CHECKOUT-6790 Pass phone number as part of billing address for apple pay wallet buttons

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
@@ -373,10 +373,15 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
         const transformedBillingAddress = this._transformContactToAddress(billingContact);
         const transformedShippingAddress = this._transformContactToAddress(shippingContact);
         const emailAddress = shippingContact?.emailAddress;
+        const phone = shippingContact?.phoneNumber;
 
         try {
             await this._store.dispatch(
-                this._billingAddressActionCreator.updateAddress({ ...transformedBillingAddress, email: emailAddress })
+                this._billingAddressActionCreator.updateAddress({
+                    ...transformedBillingAddress,
+                    email: emailAddress,
+                    phone,
+                })
             );
 
             if (requiresShipping) {

--- a/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -407,10 +407,15 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         const transformedBillingAddress = this._transformContactToAddress(billingContact);
         const transformedShippingAddress = this._transformContactToAddress(shippingContact);
         const emailAddress = shippingContact?.emailAddress;
+        const phone = shippingContact?.phoneNumber;
 
         try {
             await this._store.dispatch(
-                this._billingAddressActionCreator.updateAddress({ ...transformedBillingAddress, email: emailAddress })
+                this._billingAddressActionCreator.updateAddress({
+                    ...transformedBillingAddress,
+                    email: emailAddress,
+                    phone,
+                })
             );
 
             if (requiresShipping) {


### PR DESCRIPTION
## What?
Apple Pay order initiated from Cart are missing phone number on billing address

## Why?
Support received calls around billing address phone number missing for apple pay orders created initiated from cart.

## Testing / Proof
- tests

@bigcommerce/checkout
