### PR TITLE
feat(payment): INT-3926 StripeV3: Google Pay: Add BOPIS support

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.spec.ts
@@ -1,3 +1,5 @@
+import { getConsignment } from '../../../shipping/consignments.mock';
+
 import GooglePayStripeInitializer from './googlepay-stripe-initializer';
 import { getCheckoutMock, getStripePaymentDataMock, getStripePaymentDataRequest, getStripePaymentMethodMock, getStripeTokenizedPayload } from './googlepay.mock';
 
@@ -21,6 +23,34 @@ describe('GooglePayStripeInitializer', () => {
             );
 
             expect(initialize).toEqual(getStripePaymentDataRequest());
+        });
+
+        it('should not require shipping address when BOPIS is enabled', async () => {
+            const checkout = {
+                ...getCheckoutMock(),
+                consignments: [{
+                    ...getConsignment(),
+                    selectedShippingOption: undefined,
+                    selectedPickupOption: {
+                        pickupMethodId: 1,
+                    },
+                }],
+            };
+            const paymentMethod = getStripePaymentMethodMock();
+            paymentMethod.initializationData = {
+                ...paymentMethod.initializationData,
+                bopis: {
+                    enabled: true,
+                    requiredAddress: 'none',
+                },
+            };
+
+            const initialize = await googlePayInitializer.initialize(checkout, paymentMethod, false);
+
+            expect(initialize).toEqual({
+                ...getStripePaymentDataRequest(),
+                shippingAddressRequired: false,
+            });
         });
     });
 

--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
@@ -50,6 +50,7 @@ export default class GooglePayStripeInitializer implements GooglePayInitializer 
             cart: {
                 currency: { code: currencyCode },
             },
+            consignments,
         } = checkout;
 
         const {
@@ -60,9 +61,12 @@ export default class GooglePayStripeInitializer implements GooglePayInitializer 
                 stripeVersion,
                 stripePublishableKey,
                 stripeConnectedAccount,
+                bopis,
             },
             supportedCards,
         } = paymentMethod;
+
+        const isPickup = consignments?.every(consignment => consignment.selectedPickupOption);
 
         return {
             apiVersion: 2,
@@ -98,7 +102,9 @@ export default class GooglePayStripeInitializer implements GooglePayInitializer 
                 totalPrice: round(outstandingBalance, 2).toFixed(2),
             },
             emailRequired: true,
-            shippingAddressRequired: !hasShippingAddress,
+            shippingAddressRequired: bopis?.enabled && isPickup && bopis?.requiredAddress === 'none'
+                ? false
+                : !hasShippingAddress,
             shippingAddressParameters: {
                 phoneNumberRequired: true,
             },


### PR DESCRIPTION
## What? [INT-3926](https://bigcommercecloud.atlassian.net/browse/INT-3926)
Set the [`PaymentDataRequest.shippingAddressRequired`](https://developers.google.com/pay/api/web/reference/request-objects#PaymentDataRequest) property to `false` to support BOPIS on Google Pay through StripeV3.

## Why?
To avoid the Google Pay payment sheet to display shipping address options.

## Testing / Proof
<img width="1312" alt="Screen Shot 2022-06-29 at 7 27 44 PM" src="https://user-images.githubusercontent.com/4843328/176567631-31706bb3-51e1-4a45-985d-081b3429b693.png">
<img width="716" alt="Screen Shot 2022-06-29 at 7 04 36 PM" src="https://user-images.githubusercontent.com/4843328/176567463-f536acd8-b643-4308-9b0b-51b227777c76.png">

## Sibling PR
👉 https://github.com/bigcommerce/bigcommerce/pull/47101

@bigcommerce/checkout @bigcommerce/payments
