### PR TITLE
feat(payment): PAYPAL-1383 added PayPalCommerce Venmo button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -6,7 +6,7 @@ import { ApplePayButtonInitializeOptions } from './strategies/apple-pay';
 import { BraintreePaypalButtonInitializeOptions, BraintreePaypalCreditButtonInitializeOptions, BraintreeVenmoButtonInitializeOptions } from './strategies/braintree';
 import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
-import { PaypalCommerceButtonInitializeOptions } from './strategies/paypal-commerce';
+import { PaypalCommerceButtonInitializeOptions, PaypalCommerceVenmoButtonInitializeOptions } from './strategies/paypal-commerce';
 
 /**
  * The set of options for configuring the checkout button.
@@ -50,18 +50,6 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
     braintreevenmo?: BraintreeVenmoButtonInitializeOptions;
 
     /**
-     * The options that are required to facilitate PayPal. They can be omitted
-     * unless you need to support Paypal.
-     */
-    paypal?: PaypalButtonInitializeOptions;
-
-    /**
-     * The options that are required to facilitate PayPal Commerce. They can be omitted
-     * unless you need to support Paypal.
-     */
-    paypalCommerce?: PaypalCommerceButtonInitializeOptions;
-
-    /**
      * The ID of a container which the checkout button should be inserted.
      */
     containerId: string;
@@ -70,13 +58,13 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * The options that are required to initialize the GooglePay payment method.
      * They can be omitted unless you need to support adyenv2 GooglePay.
      */
-     googlepayadyenv2?: GooglePayButtonInitializeOptions;
+    googlepayadyenv2?: GooglePayButtonInitializeOptions;
 
     /**
      * The options that are required to initialize the GooglePay payment method.
      * They can be omitted unless you need to support adyenv2 GooglePay.
      */
-      googlepayadyenv3?: GooglePayButtonInitializeOptions;
+    googlepayadyenv3?: GooglePayButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate Braintree GooglePay. They can be
@@ -100,7 +88,7 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * The options that are required to facilitate Orbital GooglePay. They can be
      * omitted unless you need to support Orbital GooglePay.
      */
-     googlepayorbital?: GooglePayButtonInitializeOptions;
+    googlepayorbital?: GooglePayButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate Stripe GooglePay. They can be
@@ -119,4 +107,22 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * They can be omitted unless you need to support Authorize.Net GooglePay.
      */
     googlepayauthorizenet?: GooglePayButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate PayPal. They can be omitted
+     * unless you need to support Paypal.
+     */
+    paypal?: PaypalButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate PayPal Commerce. They can be omitted
+     * unless you need to support Paypal.
+     */
+    paypalCommerce?: PaypalCommerceButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate PayPal Commerce Venmo. They can be omitted
+     * unless you need to support PayPal Commerce Venmo.
+     */
+    paypalcommercevenmo?: PaypalCommerceVenmoButtonInitializeOptions;
 }

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -11,6 +11,7 @@ import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
 import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, BraintreeVenmoButtonStrategy } from './strategies/braintree';
 import { GooglePayButtonStrategy } from './strategies/googlepay';
+import { PaypalCommerceButtonStrategy, PaypalCommerceVenmoButtonStrategy } from './strategies/paypal-commerce';
 
 describe('createCheckoutButtonRegistry', () => {
     let registry: Registry<CheckoutButtonStrategy>;
@@ -23,6 +24,10 @@ describe('createCheckoutButtonRegistry', () => {
 
     it('returns registry with ApplePay registered', () => {
         expect(registry.get('applepay')).toEqual(expect.any(ApplePayButtonStrategy));
+    });
+
+    it('returns registry with AmazonPayV2 registered', () => {
+        expect(registry.get('amazonpay')).toEqual(expect.any(AmazonPayV2ButtonStrategy));
     });
 
     it('returns registry with Braintree PayPal registered', () => {
@@ -69,7 +74,11 @@ describe('createCheckoutButtonRegistry', () => {
         expect(registry.get('googlepaystripeupe')).toEqual(expect.any(GooglePayButtonStrategy));
     });
 
-    it('returns registry with AmazonPayV2 registered', () => {
-        expect(registry.get('amazonpay')).toEqual(expect.any(AmazonPayV2ButtonStrategy));
+    it('returns registry with PayPal Commerce registered', () => {
+        expect(registry.get('paypalcommerce')).toEqual(expect.any(PaypalCommerceButtonStrategy));
+    });
+
+    it('returns registry with PayPal Commerce Venmo registered', () => {
+        expect(registry.get('paypalcommercevenmo')).toEqual(expect.any(PaypalCommerceVenmoButtonStrategy));
     });
 });

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -16,6 +16,7 @@ enum CheckoutButtonMethodType {
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',
     PAYPALCOMMERCE = 'paypalcommerce',
+    PAYPALCOMMERCE_VENMO = 'paypalcommercevenmo',
 }
 
 export default CheckoutButtonMethodType;

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.spec.ts
@@ -1,0 +1,139 @@
+import { StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape } from '../../../payment/strategies/paypal-commerce';
+
+import getValidButtonStyle from './get-valid-button-style';
+
+describe('#getValidButtonStyle()', () => {
+    it('returns valid button style', () => {
+        const stylesMock = {
+            color: StyleButtonColor.silver,
+            height: 55,
+            shape: StyleButtonShape.rect,
+        };
+
+        const expects = {
+            ...stylesMock,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns button style without shape if shape is not valid', () => {
+        const stylesMock = {
+            color: StyleButtonColor.silver,
+            height: 55,
+            shape: 'ellipse' as StyleButtonShape,
+        };
+
+        const expects = {
+            ...stylesMock,
+            shape: undefined,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns button style without color if color is not valid', () => {
+        const stylesMock = {
+            color: 'red' as StyleButtonColor,
+            height: 55,
+        };
+
+        const expects = {
+            ...stylesMock,
+            color: undefined,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns button style without label if label is not valid', () => {
+        const stylesMock = {
+            height: 55,
+            label: 'label' as StyleButtonLabel,
+        };
+
+        const expects = {
+            ...stylesMock,
+            label: undefined,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns button style without layout if layout is not valid', () => {
+        const stylesMock = {
+            height: 55,
+            layout: 'layout' as StyleButtonLayout,
+        };
+
+        const expects = {
+            ...stylesMock,
+            layout: undefined,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns styles with updated height if height value is bigger than expected', () => {
+        const stylesMock = {
+            color: StyleButtonColor.silver,
+            height: 110,
+            shape: StyleButtonShape.rect,
+        };
+
+        const expects = {
+            ...stylesMock,
+            height: 55,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns styles with updated height if height value is less than expected', () => {
+        const stylesMock = {
+            color: StyleButtonColor.silver,
+            height: 10,
+            shape: StyleButtonShape.rect,
+        };
+
+        const expects = {
+            ...stylesMock,
+            height: 25,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns styles without tagline for vertical layout', () => {
+        const stylesMock = {
+            color: StyleButtonColor.silver,
+            height: 55,
+            shape: StyleButtonShape.rect,
+            layout: StyleButtonLayout.vertical,
+            tagline: true,
+        };
+
+        const expects = {
+            ...stylesMock,
+            tagline: undefined,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
+    it('returns styles with tagline if the layout is horizontal', () => {
+        const stylesMock = {
+            color: StyleButtonColor.silver,
+            height: 55,
+            shape: StyleButtonShape.rect,
+            layout: StyleButtonLayout.horizontal,
+            tagline: true,
+        };
+
+        const expects = {
+            ...stylesMock,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.ts
@@ -1,0 +1,57 @@
+import { isNil, omitBy } from 'lodash';
+
+import { StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape, PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+
+export default function getValidButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+    const { label, color, layout, shape, height, tagline } = style;
+
+    const validStyles = {
+        color: getValidColor(color),
+        height: getValidHeight(height),
+        label: getValidLabel(label),
+        layout: getValidLayout(layout),
+        shape: getValidShape(shape),
+        tagline: getValidTagline(tagline, layout),
+    };
+
+    return omitBy(validStyles, isNil);
+}
+
+function getValidColor(color?: StyleButtonColor): StyleButtonColor | undefined {
+    return color && StyleButtonColor[color] ? color : undefined;
+}
+
+function getValidLabel(label?: StyleButtonLabel): StyleButtonLabel | undefined {
+    return label && StyleButtonLabel[label] ? label : undefined
+}
+
+function getValidLayout(layout?: StyleButtonLayout): StyleButtonLayout | undefined {
+    return layout && StyleButtonLayout[layout] ? layout : undefined
+}
+
+function getValidShape(shape?: StyleButtonShape): StyleButtonShape | undefined {
+    return shape && StyleButtonShape[shape] ? shape : undefined
+}
+
+function getValidTagline(tagline?: boolean, layout?: string): boolean | undefined {
+    if (tagline && typeof tagline === 'boolean' && layout === StyleButtonLayout[StyleButtonLayout.horizontal]) {
+        return tagline;
+    }
+
+    return undefined;
+}
+
+function getValidHeight(height?: number): number {
+    const minHeight = 25;
+    const maxHeight = 55;
+
+    if (typeof height !== 'number' || height > maxHeight) {
+        return maxHeight;
+    }
+
+    if (height < minHeight) {
+        return minHeight;
+    }
+
+    return height;
+}

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/index.ts
@@ -1,2 +1,12 @@
+/**
+ * Common PayPal Commerce strategy what contains the logic for all PayPal Commerce modules (paypal, credit, paylater, venmo and all APMs)
+ * TODO: we should find a way how to separate PayPal Commerce modules with their own strategies
+ */
 export { PaypalCommerceButtonInitializeOptions } from './paypal-commerce-button-options';
 export { default as PaypalCommerceButtonStrategy } from './paypal-commerce-button-strategy';
+
+/**
+ * PayPal Commerce Venmo
+ */
+export { PaypalCommerceVenmoButtonInitializeOptions } from './paypal-commerce-venmo-button-options';
+export { default as PaypalCommerceVenmoButtonStrategy } from './paypal-commerce-venmo-button-strategy';

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-options.ts
@@ -1,0 +1,13 @@
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+
+export interface PaypalCommerceVenmoButtonInitializeOptions {
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: PaypalButtonStyleOptions;
+
+    /**
+     * Flag which helps to detect that the strategy initializes on Checkout page
+     */
+    initializesOnCheckoutPage?: boolean;
+}

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
@@ -1,0 +1,303 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+
+import { Cart } from '../../../cart';
+import { getCart } from '../../../cart/carts.mock';
+import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod } from '../../../payment';
+import { getPaypalCommerce } from '../../../payment/payment-methods.mock';
+import { PaypalHostWindow } from '../../../payment/strategies/paypal';
+import { ButtonsOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK } from '../../../payment/strategies/paypal-commerce';
+import { getPaypalCommerceMock } from '../../../payment/strategies/paypal-commerce/paypal-commerce.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+import { PaypalCommerceVenmoButtonInitializeOptions } from './paypal-commerce-venmo-button-options';
+import PaypalCommerceVenmoButtonStrategy from './paypal-commerce-venmo-button-strategy';
+
+describe('PaypalCommerceVenmoButtonStrategy', () => {
+    let cartMock: Cart;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let requestSender: RequestSender;
+    let paymentMethodMock: PaymentMethod;
+    let paypalCommerceRequestSender: PaypalCommerceRequestSender;
+    let paypalScriptLoader: PaypalCommerceScriptLoader;
+    let store: CheckoutStore;
+    let strategy: PaypalCommerceVenmoButtonStrategy;
+    let paypalSdkMock: PaypalCommerceSDK;
+    let paypalVenmoButtonElement: HTMLDivElement;
+
+    const defaultButtonContainerId = 'paypal-commerce-venmo-button-mock-id';
+    const approveDataOrderId = 'ORDER_ID';
+
+    const paypalCommerceVenmoOptions: PaypalCommerceVenmoButtonInitializeOptions = {
+        initializesOnCheckoutPage: false,
+        style: {
+            height: 45,
+        },
+    };
+
+    const initializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_VENMO,
+        containerId: defaultButtonContainerId,
+        paypalcommercevenmo: paypalCommerceVenmoOptions,
+    };
+
+    beforeEach(() => {
+        cartMock = { ...getCart() };
+        eventEmitter = new EventEmitter();
+        paymentMethodMock = { ...getPaypalCommerce(), id: 'paypalcommercevenmo' };
+        paypalSdkMock = getPaypalCommerceMock();
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = createRequestSender();
+        formPoster = createFormPoster();
+        paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
+        paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());
+
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
+        strategy = new PaypalCommerceVenmoButtonStrategy(
+            store,
+            checkoutActionCreator,
+            formPoster,
+            paypalScriptLoader,
+            paypalCommerceRequestSender,
+        );
+
+        paypalVenmoButtonElement = document.createElement('div');
+        paypalVenmoButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalVenmoButtonElement);
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce').mockReturnValue(paypalSdkMock);
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+
+
+        jest.spyOn(paypalSdkMock, 'Buttons')
+            .mockImplementation((options: ButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ orderID: approveDataOrderId });
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                };
+            });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PaypalHostWindow).paypal;
+
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalVenmoButtonElement);
+        }
+    });
+
+    it('creates an instance of the PayPal Commerce Venmo checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(PaypalCommerceVenmoButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = { containerId: defaultButtonContainerId } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = { methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_VENMO } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommercevenmo is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+                methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_VENMO,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if client id is missing', async () => {
+            paymentMethodMock.initializationData.clientId = undefined;
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('loads paypal commerce sdk script', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalScriptLoader.loadPaypalCommerce).toHaveBeenCalled();
+        });
+
+        it('initializes Venmo button to render', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdkMock.FUNDING.VENMO,
+                style: paypalCommerceVenmoOptions.style,
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function)
+            });
+        });
+
+        it('renders Venmo button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation(() => ({
+                    isEligible: jest.fn(() => true),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+        });
+
+        it('does not render Venmo button if it is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation(() => ({
+                    isEligible: jest.fn(() => false),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
+        it('removes Venmo button container if the button has not rendered', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation(() => ({
+                    isEligible: jest.fn(() => false),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(document.getElementById(defaultButtonContainerId)).toBeNull();
+        });
+
+        it('creates an order with paypalcommercevenmo as provider id if its initializes outside checkout page', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, 'paypalcommercevenmo');
+        });
+
+        it('creates an order with paypalcommercevenmocheckout as provider id if its initializes on checkout page', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            const updatedIntializationOptions = {
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    ...initializationOptions.paypalcommercevenmo,
+                    initializesOnCheckoutPage: true,
+                },
+            };
+
+            await strategy.initialize(updatedIntializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, 'paypalcommercevenmocheckout');
+        });
+
+        it('throws an error if orderId is not provided by PayPal on approve', async () => {
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation((options: ButtonsOptions) => {
+                    eventEmitter.on('createOrder', () => {
+                        if (options.createOrder) {
+                            options.createOrder().catch(() => {});
+                        }
+                    });
+
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove({ orderID: undefined });
+                        }
+                    });
+
+                    return {
+                        isEligible: jest.fn(() => true),
+                        render: jest.fn(),
+                    };
+                });
+
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onApprove');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('tokenizes payment on paypal approve', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                action: 'set_external_checkout',
+                order_id: approveDataOrderId,
+                payment_type: 'paypal',
+                provider: paymentMethodMock.id,
+            }));
+        });
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.ts
@@ -1,0 +1,155 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, } from '../../../common/error/errors';
+import { PaymentMethod } from '../../../payment';
+import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
+import { ApproveDataOptions, ButtonsOptions, PaypalButtonStyleOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceScriptParams, PaypalCommerceSDK } from '../../../payment/strategies/paypal-commerce';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+import getValidButtonStyle from './get-valid-button-style';
+
+export default class PaypalCommerceVenmoButtonStrategy implements CheckoutButtonStrategy {
+    private _paypalCommerceSdk?: PaypalCommerceSDK;
+    private _paymentMethod?: PaymentMethod;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _formPoster: FormPoster,
+        private _paypalScriptLoader: PaypalCommerceScriptLoader,
+        private _paypalCommerceRequestSender: PaypalCommerceRequestSender
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { paypalcommercevenmo, containerId, methodId } = options;
+        const { style, initializesOnCheckoutPage } = paypalcommercevenmo || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
+        }
+
+        if (!paypalcommercevenmo) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommercevenmo" argument is not provided.`);
+        }
+
+        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        if (!this._paymentMethod.initializationData.clientId) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const paypalSdkScriptParams = this._getScriptParams(initializesOnCheckoutPage);
+        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paypalSdkScriptParams);
+
+        this._renderButton(containerId, initializesOnCheckoutPage, style);
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private _getScriptParams(initializesOnCheckoutPage?: boolean): PaypalCommerceScriptParams {
+        const state = this._store.getState();
+        const currency = state.cart.getCartOrThrow().currency.code;
+
+        const { initializationData } = this._getPaymentMethodOrThrow();
+        const { attributionId, clientId, intent, merchantId } = initializationData;
+
+        return {
+            'client-id': clientId,
+            'data-partner-attribution-id': attributionId,
+            'merchant-id': merchantId,
+            commit: !!initializesOnCheckoutPage,
+            components: ['buttons', 'messages'],
+            'enable-funding': ['venmo'],
+            currency,
+            intent,
+        };
+    }
+
+    private _renderButton(containerId: string, initializesOnCheckoutPage?: boolean, style?: PaypalButtonStyleOptions): void {
+        const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
+        const fundingSource = paypalCommerceSdk.FUNDING.VENMO;
+
+        const validButtonStyle = style ? this._getVenmoButtonStyle(style) : {};
+
+        const buttonRenderOptions: ButtonsOptions = {
+            fundingSource,
+            style: validButtonStyle,
+            createOrder: () => this._createOrder(initializesOnCheckoutPage),
+            onApprove: ({ orderID }: ApproveDataOptions) => this._tokenizePayment(orderID),
+        };
+
+        const paypalButtonRender = paypalCommerceSdk.Buttons(buttonRenderOptions);
+
+        if (paypalButtonRender.isEligible()) {
+            paypalButtonRender.render(`#${containerId}`);
+        } else {
+            this._removeElement(containerId);
+        }
+    }
+
+    private async _createOrder(initializesOnCheckoutPage?: boolean): Promise<string> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+
+        const providerId = initializesOnCheckoutPage ? 'paypalcommercevenmocheckout': 'paypalcommercevenmo';
+
+
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cart.id, providerId);
+
+        return orderId;
+    }
+
+    private _tokenizePayment(orderId?: string): void {
+        const paymentMethod = this._getPaymentMethodOrThrow();
+
+        if (!orderId) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        return this._formPoster.postForm('/checkout.php', {
+            payment_type: 'paypal',
+            action: 'set_external_checkout',
+            provider: paymentMethod.id,
+            order_id: orderId,
+        });
+    }
+
+    private _getPayPalCommerceSdkOrThrow(): PaypalCommerceSDK {
+        if (!this._paypalCommerceSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this._paypalCommerceSdk;
+    }
+
+    private _getPaymentMethodOrThrow(): PaymentMethod {
+        if (!this._paymentMethod) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return this._paymentMethod;
+    }
+
+    private _getVenmoButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+        const { height, label, layout, shape } = getValidButtonStyle(style);
+
+        return { height, label, layout, shape };
+    }
+
+    private _removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+}

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -17,6 +17,8 @@ export default class PaypalCommerceRequestSender {
         private _requestSender: RequestSender
     ) {}
 
+    // TODO: this method should be removed when provider will be passed as an argument
+    // (to prevent containing unnecessary provider detecting logic inside)
     async setupPayment(cartId: string, params: ParamsForProvider = {}): Promise<OrderData> {
         const { isCredit, isCheckout, isCreditCard, isAPM, isVenmo} = params;
         let provider = 'paypalcommerce';
@@ -36,7 +38,11 @@ export default class PaypalCommerceRequestSender {
             provider = 'paypalcommercealternativemethodscheckout';
         }
 
-        const url = `/api/storefront/payment/${provider}`;
+        return this.createOrder(cartId, provider);
+    }
+
+    async createOrder(cartId: string, providerId: string): Promise<OrderData> {
+        const url = `/api/storefront/payment/${providerId}`;
         const body = { cartId };
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
@@ -44,9 +50,9 @@ export default class PaypalCommerceRequestSender {
             ...SDK_VERSION_HEADERS,
         };
 
-        const res = await this._requestSender.post(url, { headers, body });
+        const res = await this._requestSender.post<OrderData>(url, { headers, body });
 
-        return res.body as OrderData;
+        return res.body;
     }
 
     async getOrderStatus() {

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -33,6 +33,7 @@ describe('PaypalCommerceScriptLoader', () => {
     });
 
     afterEach(() => {
+        (window as PaypalCommerceHostWindow).paypal = undefined;
         (window as PaypalCommerceHostWindow).paypalLoadScript = undefined;
     });
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -15,28 +15,31 @@ export default class PaypalCommerceScriptLoader {
     }
 
     async loadPaypalCommerce(params: PaypalCommerceScriptParams): Promise<PaypalCommerceSDK> {
-        this._validateParams(params);
-
-        if (!this._window.paypalLoadScript) {
-            const scriptSrc = 'https://unpkg.com/@paypal/paypal-js@5.0.5/dist/iife/paypal-js.min.js';
-
-            await this._scriptLoader.loadScript(scriptSrc, {async: true, attributes: {}});
+        if (!this._window.paypal) {
+            this._validateParams(params);
 
             if (!this._window.paypalLoadScript) {
+                const PAYPAL_SDK_VERSION = '5.0.5';
+                const scriptSrc = `https://unpkg.com/@paypal/paypal-js@${PAYPAL_SDK_VERSION}/dist/iife/paypal-js.min.js`;
+
+                await this._scriptLoader.loadScript(scriptSrc, { async: true, attributes: {} });
+
+                if (!this._window.paypalLoadScript) {
+                    throw new PaymentMethodClientUnavailableError();
+                }
+            }
+
+            await this._window.paypalLoadScript(params);
+
+            if (!this._window.paypal) {
                 throw new PaymentMethodClientUnavailableError();
             }
-        }
-
-        await this._window.paypalLoadScript(params);
-
-        if (!this._window.paypal) {
-            throw new PaymentMethodClientUnavailableError();
         }
 
         return this._window.paypal;
     }
 
-    _validateParams(options: PaypalCommerceScriptParams): void {
+    private _validateParams(options: PaypalCommerceScriptParams): void {
         const CLIENT_ID = 'client-id';
         const MERCHANT_ID = 'merchant-id';
         let param;

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -51,7 +51,7 @@ export interface PaypalButtonStyleOptions {
     layout?: StyleButtonLayout;
     color?: StyleButtonColor;
     shape?: StyleButtonShape;
-    height?: 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 | 40 | 41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 | 51 | 52 | 53 | 54 | 55;
+    height?: number;
     label?: StyleButtonLabel;
     tagline?: boolean;
 }
@@ -59,7 +59,7 @@ export interface PaypalButtonStyleOptions {
 export interface ButtonsOptions {
     style?: PaypalButtonStyleOptions;
     fundingSource?: string;
-    createOrder?(): Promise<string>;
+    createOrder?(): Promise<string | void>; // TODO: this method should return only Promise<void>
     onApprove?(data: ApproveDataOptions): void;
     onClick?(data: ClickDataOptions, actions: ClickActions): void;
     onCancel?(): void;


### PR DESCRIPTION
## What?
Added PayPalCommerce Venmo button strategy

## Why?
It is a part of PayPalCommerce button strategy separation what we need to initialise and render PayPalCommerce buttons separately in different containers.

## Testing / Proof
Unit tests
