### PR TITLE
Fix(payment): STRIPE-53 Give more information on payment authentication with 3ds failure error message

### DIFF
--- a/packages/core/src/payment/strategies/stripev3/stripev3-error.spec.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-error.spec.ts
@@ -1,0 +1,9 @@
+import StripeV3Error, { StripeV3ErrorType } from './stripev3-error';
+
+describe('StripeV3Error', () => {
+    it('returns error name, type and message', () => {
+        const error = new StripeV3Error(StripeV3ErrorType.AuthFailure);
+
+        expect(error.type).toEqual('User did not authenticate');
+    });
+});

--- a/packages/core/src/payment/strategies/stripev3/stripev3-error.spec.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-error.spec.ts
@@ -1,9 +1,10 @@
 import StripeV3Error, { StripeV3ErrorType } from './stripev3-error';
 
 describe('StripeV3Error', () => {
-    it('returns error name, type and message', () => {
+    it('returns the error type and subtype asigned in this class', () => {
         const error = new StripeV3Error(StripeV3ErrorType.AuthFailure);
 
-        expect(error.type).toEqual('User did not authenticate');
+        expect(error.type).toEqual('stripev3_error');
+        expect(error.subtype).toEqual('auth_failure');
     });
 });

--- a/packages/core/src/payment/strategies/stripev3/stripev3-error.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-error.ts
@@ -1,6 +1,6 @@
 import { StandardError } from '../../../common/error/errors';
 
-const defaultMessage: string = 'There was an error while processing your payment. Please try again or contact us.';
+const defaultMessage = 'There was an error while processing your payment. Please try again or contact us.';
 
 export enum StripeV3ErrorType {
     AuthFailure = 'auth-failure',

--- a/packages/core/src/payment/strategies/stripev3/stripev3-error.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-error.ts
@@ -1,0 +1,24 @@
+import { StandardError } from '../../../common/error/errors';
+
+const defaultMessage: string = 'There was an error while processing your payment. Please try again or contact us.';
+
+export enum StripeV3ErrorType {
+    AuthFailure = 'auth-failure',
+}
+
+export default class StripeV3Error extends StandardError {
+    constructor(type: StripeV3ErrorType) {
+        super(getErrorMessage(type) || defaultMessage);
+
+        this.type = type;
+    }
+}
+
+function getErrorMessage(type: StripeV3ErrorType){
+    switch (type) {
+        case StripeV3ErrorType.AuthFailure:
+            return `User did not authenticate`;
+        default:
+            return 'There was an error while processing your payment. Please try again or contact us.';
+    }
+}

--- a/packages/core/src/payment/strategies/stripev3/stripev3-error.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-error.ts
@@ -1,16 +1,17 @@
 import { StandardError } from '../../../common/error/errors';
 
-const defaultMessage = 'There was an error while processing your payment. Please try again or contact us.';
-
 export enum StripeV3ErrorType {
-    AuthFailure = 'auth-failure',
+    AuthFailure = 'auth_failure',
 }
 
 export default class StripeV3Error extends StandardError {
-    constructor(type: StripeV3ErrorType) {
-        super(getErrorMessage(type) || defaultMessage);
+    subtype: string;
 
-        this.type = type;
+    constructor(subtype: StripeV3ErrorType) {
+        super(getErrorMessage(subtype));
+
+        this.type = 'stripev3_error';
+        this.subtype = subtype;
     }
 }
 

--- a/packages/core/src/payment/strategies/stripev3/stripev3-initialize-options.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-initialize-options.ts
@@ -2,8 +2,6 @@ import { HostedFormOptions } from '../../../hosted-form';
 
 import { IndividualCardElementOptions, StripeElementOptions } from './stripev3';
 
-import Stripev3Error from './stripev3-error';
-
 /**
  * A set of options that are required to initialize the Stripe payment method.
  *
@@ -61,9 +59,4 @@ export default interface StripeV3PaymentInitializeOptions {
      * Hosted Form Validation Options
      */
     form?: HostedFormOptions;
-
-    /**
-     * 3ds Authentication Error
-     */
-    stripev3AuthError?: Stripev3Error;
 }

--- a/packages/core/src/payment/strategies/stripev3/stripev3-initialize-options.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-initialize-options.ts
@@ -2,6 +2,8 @@ import { HostedFormOptions } from '../../../hosted-form';
 
 import { IndividualCardElementOptions, StripeElementOptions } from './stripev3';
 
+import Stripev3Error from './stripev3-error';
+
 /**
  * A set of options that are required to initialize the Stripe payment method.
  *
@@ -59,4 +61,9 @@ export default interface StripeV3PaymentInitializeOptions {
      * Hosted Form Validation Options
      */
     form?: HostedFormOptions;
+
+    /**
+     * 3ds Authentication Error
+     */
+    stripev3AuthError?: Stripev3Error;
 }

--- a/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -785,19 +785,11 @@ describe('StripeV3PaymentStrategy', () => {
                             token: 'token',
                         },
                     }));
-                    const authenticationFailErrorResponse = new RequestError(getResponse({
-                        ...getErrorPaymentResponseBody(),
-                        errors: [
-                            { code: 'payment_intent_authentication_failure' },
-                        ],
-                    }));
-                    const stripeErrorMessage = 'Stripe error message.';
 
                     jest.spyOn(paymentActionCreator, 'submitPayment')
-                        .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, threeDSecureRequiredErrorResponse)))
-                        .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, authenticationFailErrorResponse)));
+                        .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, threeDSecureRequiredErrorResponse)));
 
-                    stripeV3JsMock.confirmCardPayment = jest.fn(() => Promise.resolve({ error: { payment_intent: { last_payment_error: { message : stripeErrorMessage } }, code: 'payment_intent_authentication_failure' } }));
+                    stripeV3JsMock.confirmCardPayment = jest.fn(() => Promise.resolve({ error: { payment_intent: { last_payment_error: { message : 'Stripe error message.' } }, code: 'payment_intent_authentication_failure' } }));
 
                     await strategy.initialize(options);
 

--- a/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -19,6 +19,7 @@ import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-r
 import PaymentStrategy from '../payment-strategy';
 
 import isIndividualCardElementOptions, { PaymentIntent, PaymentMethod as StripePaymentMethod, StripeAdditionalAction, StripeAddress, StripeBillingDetails, StripeCardElements, StripeConfirmIdealPaymentData, StripeConfirmPaymentData, StripeConfirmSepaPaymentData, StripeElement, StripeElements, StripeElementOptions, StripeElementType, StripeError, StripePaymentMethodType, StripeV3Client } from './stripev3';
+import StripeV3Error, { StripeV3ErrorType } from './stripev3-error';
 import StripeV3PaymentInitializeOptions from './stripev3-initialize-options';
 import StripeV3ScriptLoader from './stripev3-script-loader';
 
@@ -158,6 +159,10 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
 
     private _isCancellationError(stripeError: StripeError | undefined) {
         return stripeError && stripeError.payment_intent.last_payment_error?.message?.indexOf('canceled') !== -1;
+    }
+
+    private _isAuthError(stripeError: StripeError | undefined){
+        return stripeError?.code  === 'payment_intent_authentication_failure'
     }
 
     private _isCreditCard(methodId: string): boolean {
@@ -485,6 +490,11 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
                 if (this._isCancellationError(result.error)) {
                     throw new PaymentMethodCancelledError();
                 }
+
+                if (this._isAuthError(result.error)) {
+                    throw new StripeV3Error(StripeV3ErrorType.AuthFailure);
+                }
+
                 throw new Error(result.error.message);
             }
 

--- a/packages/core/src/payment/strategies/stripev3/stripev3.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3.ts
@@ -91,6 +91,11 @@ export interface StripeError {
      * The PaymentIntent object.
      */
     payment_intent: PaymentIntent;
+
+    /**
+     * A human-readable code for the error obtained
+     */
+    code?: string;
 }
 
 /**


### PR DESCRIPTION
## What? [STRIPE-53](https://bigcommercecloud.atlassian.net/browse/STRIPE-53)
Alteration of error message when stripe 3DS auth fails

## Why?
To give more information to the user about the failure

## Testing / Proof
<img width="801" alt="Screen Shot 2022-07-04 at 11 38 23" src="https://user-images.githubusercontent.com/106765049/177193507-7f6b55ff-79d7-42ee-86e9-c1ea5e085653.png">

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 

## Depends on 
https://github.com/bigcommerce/checkout-js/pull/940