### PR TITLE
feat(customer): INT-6023 Resize VCO button for Discover cards

### DIFF
--- a/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
@@ -152,7 +152,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
     }
 
     private _insertVisaCheckoutButton(container: Element, buttonClass: string): HTMLElement {
-        const buttonSource = 'https://secure.checkout.visa.com/wallet-services-web/xo/button.png?acceptCanadianVisaDebit=false&cobrand=true&size=154';
+        const buttonSource = 'https://secure.checkout.visa.com/wallet-services-web/xo/button.png?acceptCanadianVisaDebit=false&cobrand=true&height=34&width=178';
         const buttonTemplate = `
             <img
                 alt="Visa Checkout"


### PR DESCRIPTION
## What? [INT-6023](https://bigcommercecloud.atlassian.net/browse/INT-6023)
Change VCO button size from `154` to `178x32`

## Why?
To allow the discover card icon to be displayed, and to be consistent with other similar checkout buttons

## Testing / Proof
### Before:
<img width="633" alt="Screen Shot 2022-07-12 at 4 43 19 PM" src="https://user-images.githubusercontent.com/35502707/178600679-da1a1b9d-b46b-49c0-84ef-e887f367d3c7.png">

### After: (White button is VCO)
<img width="709" alt="Screen Shot 2022-07-12 at 4 36 52 PM" src="https://user-images.githubusercontent.com/35502707/178600373-e4aa9c4d-51af-49d1-9c70-15449cab6741.png">


bigcommerce/checkout bigcommerce/payments bigcommerce/apex-integrations 
