### PR TITLE
feat(payment): INT-6115 Worldpay - 3DS support for Access Worldpay

### DIFF
--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -74,6 +74,7 @@ import { SquarePaymentStrategy, SquareScriptLoader } from './strategies/square';
 import { StripeScriptLoader as StripeUPEScriptLoader, StripeUPEPaymentStrategy } from './strategies/stripe-upe';
 import { StripeScriptLoader as StripeV3ScriptLoader, StripeV3PaymentStrategy } from './strategies/stripev3';
 import { WepayPaymentStrategy, WepayRiskClient } from './strategies/wepay';
+import { WorldpayaccessPaymetStrategy } from './strategies/worldpayaccess';
 import { ZipPaymentStrategy } from './strategies/zip';
 
 export default function createPaymentStrategyRegistry(
@@ -827,6 +828,15 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             hostedFormFactory,
             new WepayRiskClient(scriptLoader)
+        )
+    );
+
+    registry.register(PaymentStrategyType.WORLDPAYACCESS, () =>
+        new WorldpayaccessPaymetStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
         )
     );
 

--- a/packages/core/src/payment/payment-request-options.ts
+++ b/packages/core/src/payment/payment-request-options.ts
@@ -22,7 +22,7 @@ import { PaypalCommerceInitializeOptions } from './strategies/paypal-commerce';
 import { SquarePaymentInitializeOptions } from './strategies/square';
 import { StripeUPEPaymentInitializeOptions } from './strategies/stripe-upe';
 import { StripeV3PaymentInitializeOptions } from './strategies/stripev3';
-import { WorldpayPaymentInitializeOptions } from './strategies/worldpay';
+import { WorldpayAccessPaymentInitializeOptions } from './strategies/worldpayaccess';
 
 export { PaymentInitializeOptions } from '../generated/payment-initialize-options';
 
@@ -242,5 +242,5 @@ export interface BasePaymentInitializeOptions extends PaymentRequestOptions {
      * The options that are required to initialize the Worldpay payment method.
      * They can be omitted unless you need to support Worldpay.
      */
-    worldpay?: WorldpayPaymentInitializeOptions;
+    worldpay?: WorldpayAccessPaymentInitializeOptions;
 }

--- a/packages/core/src/payment/payment-strategy-type.ts
+++ b/packages/core/src/payment/payment-strategy-type.ts
@@ -61,6 +61,7 @@ enum PaymentStrategyType {
     BRAINTREE_GOOGLE_PAY = 'googlepaybraintree',
     CHASE_PAY = 'chasepay',
     WE_PAY = 'wepay',
+    WORLDPAYACCESS = 'worldpayaccess',
     MASTERPASS = 'masterpass',
     STRIPE_GOOGLE_PAY = 'googlepaystripe',
     SEZZLE = 'sezzle',

--- a/packages/core/src/payment/strategies/worldpay/index.ts
+++ b/packages/core/src/payment/strategies/worldpay/index.ts
@@ -1,1 +1,0 @@
-export { WorldpayPaymentInitializeOptions } from './worldpay-payment-options';

--- a/packages/core/src/payment/strategies/worldpayaccess/index.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/index.ts
@@ -1,0 +1,2 @@
+export { WorldpayAccessPaymentInitializeOptions } from './worldpayaccess-payment-options';
+export { default as WorldpayaccessPaymetStrategy } from './worldpayaccess-payment-strategy';

--- a/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-options.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-options.ts
@@ -1,4 +1,22 @@
-export interface WorldpayPaymentInitializeOptions {
+export interface WorldpayAccessAdditionalAction {
+    additional_action_required: {
+        data: {
+            redirect_url: string
+        }
+    };
+    provider_data: {
+        data: string;
+        source_id: string
+    }
+}
+
+export interface WorldpayAccess3DSOptions {
+    acs_url: string,
+    merchant_data: string,
+    payer_auth_request: string
+}
+
+export interface WorldpayAccessPaymentInitializeOptions {
     /**
      * A callback that gets called when the iframe is ready to be added to the
      * current page. It is responsible for determining where the iframe should
@@ -11,3 +29,4 @@ export interface WorldpayPaymentInitializeOptions {
      */
     onLoad(iframe: HTMLIFrameElement, cancel: () => void): void;
 }
+

--- a/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.spec.ts
@@ -1,0 +1,311 @@
+import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client';
+import { createAction, createErrorAction, Action } from '@bigcommerce/data-store';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+import { merge, omit } from 'lodash';
+import { of, Observable } from 'rxjs';
+
+import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../hosted-form';
+import { LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import { getOrder } from '../../../order/orders.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType } from '../../payment-actions';
+import { getPaymentMethod } from '../../payment-methods.mock';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentRequestSender from '../../payment-request-sender';
+import PaymentRequestTransformer from '../../payment-request-transformer';
+
+import WorldpayaccessPaymetStrategy from './worldpayaccess-payment-strategy';
+
+import { getResponse } from '../../../common/http-request/responses.mock';
+import { getErrorPaymentResponseBody } from '../../payments.mock';
+import { RequestError } from '../../../common/error/errors';
+
+describe('WorldpayaccessPaymetStrategy', () => {
+    let formFactory: HostedFormFactory;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let store: CheckoutStore;
+    let strategy: WorldpayaccessPaymetStrategy;
+    let submitOrderAction: Observable<Action>;
+    let submitPaymentAction: Observable<Action>;
+
+    beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(createPaymentClient()),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()))
+        );
+
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+
+        orderActionCreator = new OrderActionCreator(
+            new OrderRequestSender(createRequestSender()),
+            new CheckoutValidator(new CheckoutRequestSender(createRequestSender()))
+        );
+
+        formFactory = new HostedFormFactory(store);
+
+        strategy = new WorldpayaccessPaymetStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            formFactory
+        );
+
+        jest.spyOn(store, 'dispatch');
+
+        jest.spyOn(orderActionCreator, 'submitOrder')
+            .mockReturnValue(submitOrderAction);
+
+        jest.spyOn(paymentActionCreator, 'submitPayment')
+            .mockReturnValue(submitPaymentAction);
+    });
+
+    it('submits order without payment data', async () => {
+        const payload = getOrderRequestBody();
+
+        await strategy.execute(payload);
+
+        expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(omit(payload, 'payment'), undefined);
+        expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+    });
+
+    it('submits payment separately', async () => {
+        const payload = getOrderRequestBody();
+
+        await strategy.execute(payload);
+
+        expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payload.payment);
+        expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+    });
+
+    it('returns checkout state', async () => {
+        const output = await strategy.execute(getOrderRequestBody());
+
+        expect(output).toEqual(store.getState());
+    });
+
+    it('throws error to inform that order finalization is not required', async () => {
+        try {
+            await strategy.finalize();
+        } catch (error) {
+            expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+        }
+    });
+
+    describe('when hosted form is enabled', () => {
+        let form: Pick<HostedForm, 'attach' | 'submit' | 'validate'>;
+        let initializeOptions: PaymentInitializeOptions;
+        let loadOrderAction: Observable<LoadOrderSucceededAction>;
+        let state: InternalCheckoutSelectors;
+
+        beforeEach(() => {
+            form = {
+                attach: jest.fn(() => Promise.resolve()),
+                submit: jest.fn(() => Promise.resolve()),
+                validate: jest.fn(() => Promise.resolve()),
+            };
+            initializeOptions = {
+                creditCard: {
+                    form: {
+                        fields: {
+                            [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                            [HostedFieldType.CardName]: { containerId: 'card-name' },
+                            [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                        },
+                    },
+                },
+                methodId: 'worldpayaccess',
+                worldpay: {
+                    onLoad: jest.fn()
+                }
+            };
+
+            loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
+            state = store.getState();
+
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(merge(
+                    getPaymentMethod(),
+                    { config: { isHostedFormEnabled: true } }
+                ));
+
+            jest.spyOn(orderActionCreator, 'loadCurrentOrder')
+                .mockReturnValue(loadOrderAction);
+
+            jest.spyOn(formFactory, 'create')
+                .mockReturnValue(form);
+        });
+
+        it('creates hosted form', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(formFactory.create)
+                .toHaveBeenCalledWith(
+                    'https://bigpay.integration.zone',
+                    // tslint:disable-next-line:no-non-null-assertion
+                    initializeOptions.creditCard!.form!
+                );
+        });
+
+        it('attaches hosted form to container', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(form.attach)
+                .toHaveBeenCalled();
+        });
+
+        it('submits payment data with hosted form', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(form.submit)
+                .toHaveBeenCalledWith(payload.payment);
+        });
+
+        it('validates user input before submitting data', async () => {
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(getOrderRequestBody());
+
+            expect(form.validate)
+                .toHaveBeenCalled();
+        });
+
+        it('does not submit payment data with hosted form if validation fails', async () => {
+            jest.spyOn(form, 'validate')
+                .mockRejectedValue(new Error());
+
+            try {
+                await strategy.initialize(initializeOptions);
+                await strategy.execute(getOrderRequestBody());
+            } catch (error) {
+                expect(form.submit)
+                    .not.toHaveBeenCalled();
+            }
+        });
+
+        it('loads current order after payment submission', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(store.dispatch)
+                .toHaveBeenCalledWith(loadOrderAction);
+        });
+    });
+
+    describe('when hosted form is enabled but hosted fields are not present for rendering', () => {
+        let form: Pick<HostedForm, 'attach' | 'submit' | 'validate'>;
+        let initializeOptions: PaymentInitializeOptions;
+        let loadOrderAction: Observable<LoadOrderSucceededAction>;
+        let state: InternalCheckoutSelectors;
+
+        const errorResponse = new RequestError(getResponse({
+            ...getErrorPaymentResponseBody(),
+            errors: [
+                { code: 'additional_action_required' },
+            ],
+            additional_action_required: {
+                type: 'unknown_action',
+                data: {
+                    redirect_url: 'http://url.com'
+                }
+            },
+            provider_data: {
+                source_id: '5313',
+                data: 'jwt_token'
+            },
+            status: 'error',
+        }));
+
+        const onLoad = jest.fn()
+
+        beforeEach(() => {
+            form = {
+                attach: jest.fn(() => Promise.resolve()),
+                submit: jest.fn(() => Promise.resolve()),
+                validate: jest.fn(() => Promise.resolve()),
+            };
+            initializeOptions = {
+                creditCard: {
+                    form: {
+                        fields: {},
+                    },
+                },
+                methodId: 'worldpayaccess',
+                worldpay: {
+                    onLoad: onLoad
+                }
+            };
+            loadOrderAction = of(createAction(OrderActionType.LoadOrderSucceeded, getOrder()));
+            state = store.getState();
+
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockReturnValue(merge(
+                    getPaymentMethod(),
+                    { config: { isHostedFormEnabled: true } }
+                ));
+
+            jest.spyOn(orderActionCreator, 'loadCurrentOrder')
+                .mockReturnValue(loadOrderAction);
+
+            jest.spyOn(formFactory, 'create')
+                .mockReturnValue(form);
+        });
+
+        it('does not create hosted form', async () => {
+            await strategy.initialize(initializeOptions);
+
+            expect(formFactory.create)
+                .not.toHaveBeenCalled();
+        });
+
+        it('does not submit with hosted form', async () => {
+            const payload = getOrderRequestBody();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(form.submit)
+                .not.toHaveBeenCalled();
+        });
+
+        it('submit with collection data required', async () => {
+            HTMLFormElement.prototype.submit = () => window.parent.postMessage('{"MessageType":"profile.completed","SessionId":"token","Status":true}', '*');
+            window.fetch = jest.fn(() => Promise.resolve({ok: true}));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, errorResponse)));
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(getOrderRequestBody());
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expect.objectContaining({
+                paymentData: expect.objectContaining({threeDSecure: expect.objectContaining({token: 'token'})})
+            }));
+        })
+
+        it('rejects error with collection data required with the url', async () => {
+            window.fetch = jest.fn(() => Promise.resolve({ok: false}));
+
+            jest.spyOn(paymentActionCreator, 'submitPayment')
+                .mockReturnValueOnce(of(createErrorAction(PaymentActionType.SubmitPaymentFailed, errorResponse)));
+
+            await strategy.initialize(initializeOptions);
+            await expect(strategy.execute(getOrderRequestBody())).rejects.toThrowError('Payment cannot continue');
+        })
+    });
+});

--- a/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.spec.ts
@@ -5,6 +5,7 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge, omit } from 'lodash';
 import { of, Observable } from 'rxjs';
 
+import { NotInitializedError } from '../../../common/error/errors';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { HostedFieldType, HostedForm, HostedFormFactory } from '../../../hosted-form';
@@ -282,6 +283,19 @@ describe('WorldpayaccessPaymetStrategy', () => {
             expect(form.submit)
                 .not.toHaveBeenCalled();
         });
+
+        it('submit with collection data required', async () => {
+            initializeOptions = {
+                creditCard: {
+                    form: {
+                        fields: {},
+                    },
+                },
+                methodId: 'worldpayaccess'
+            };
+
+            await expect(strategy.initialize(initializeOptions)).rejects.toThrowError(NotInitializedError);
+        })
 
         it('submit with collection data required', async () => {
             HTMLFormElement.prototype.submit = () => window.parent.postMessage('{"MessageType":"profile.completed","SessionId":"token","Status":true}', '*');

--- a/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.ts
@@ -1,0 +1,179 @@
+import { merge, some } from 'lodash';
+import { InternalCheckoutSelectors } from '../../../checkout';
+import { NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
+import { OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
+import { PaymentArgumentInvalidError } from '../../errors';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import { CreditCardPaymentStrategy } from '../credit-card';
+import { WorldpayAccess3DSOptions, WorldpayAccessAdditionalAction, WorldpayAccessPaymentInitializeOptions } from './worldpayaccess-payment-options';
+
+const IFRAME_NAME = 'worldpay_hosted_payment_page';
+const IFRAME_HIDDEN_NAME = 'worldpay_hosted_hidden_payment_page';
+const INVALID_URL = 'invalid url';
+
+export default class WorldpayaccessPaymetStrategy extends CreditCardPaymentStrategy {
+
+    private _initializeOptions?: WorldpayAccessPaymentInitializeOptions;
+
+    async initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        this._initializeOptions = options && options.worldpay;
+
+        return super.initialize(options);
+    }
+
+    async execute(orderRequest: OrderRequestBody, options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { payment } = orderRequest;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        try {
+            return await super.execute(orderRequest, options);
+        } catch(error){
+            return await this._processAdditionalAction(error, payment);
+        }
+    }
+
+    private async _processAdditionalAction(error: unknown, payment: OrderPaymentRequestBody): Promise<InternalCheckoutSelectors> {
+        if (!(error instanceof RequestError) || !some(error.body.errors, {code: 'additional_action_required'})) {
+            return Promise.reject(error);
+        }
+
+        const iframe = this._createHiddenIframe(error.body);
+        return new Promise((resolve, reject) => {
+            const message_event = async (event: MessageEvent) => {
+                window.removeEventListener('message', message_event);
+
+                if (iframe) {
+                    iframe.remove();
+                }
+
+                if (typeof event.data !== 'string' || event.data === INVALID_URL) {
+                    reject(new Error('Payment cannot continue'));
+                }
+
+                const data = JSON.parse(event.data);
+                const paymentPayload = merge({}, payment, { paymentData: { threeDSecure: { token: data.SessionId } } });
+
+                try {
+                    return resolve(await this._store.dispatch(this._paymentActionCreator.submitPayment( paymentPayload )));
+                } catch (error) {
+                    if (!(error instanceof RequestError) || !some(error.body.errors, {code: 'three_d_secure_required'})) {
+                        return reject(error);
+                    }
+
+                    this._3dsrequired(error.body.three_ds_result, reject);
+                }
+
+            }
+
+            window.addEventListener('message', message_event);
+        });
+    }
+
+    private _3dsrequired(data: WorldpayAccess3DSOptions, reject: Function):void {
+        if (!this._initializeOptions) {
+            throw new NotInitializedError(
+                NotInitializedErrorType.PaymentNotInitialized
+            );
+        }
+
+        const { onLoad } = this._initializeOptions;
+        const frame = this._createIframe(data);
+        onLoad(frame, () => reject());
+    }
+
+    private _createHiddenIframe(body: WorldpayAccessAdditionalAction): HTMLIFrameElement {
+        const iframe = document.createElement('iframe');
+        iframe.id = IFRAME_HIDDEN_NAME;
+        iframe.height = '0px';
+        iframe.width = '0px';
+        document.body.appendChild(iframe);
+
+        const form = document.createElement('form');
+        const formId = 'collectionForm';
+        form.id = formId;
+        form.name = 'devicedata';
+        form.method = 'post';
+        const url = body.additional_action_required.data.redirect_url;
+        form.action = url;
+
+        const inputBin = document.createElement('input');
+        inputBin.name = 'Bin';
+        inputBin.type = 'hidden';
+        inputBin.value = body.provider_data.source_id;
+        form.appendChild(inputBin);
+
+        const inputJWT = document.createElement('input');
+        inputJWT.name = 'JWT';
+        inputJWT.type = 'hidden';
+        inputJWT.value = body.provider_data.data;
+        form.appendChild(inputJWT);
+
+        const button = document.createElement('button');
+        button.type = 'submit';
+        button.id = 'btnsubmit';
+        form.appendChild(button);
+
+        iframe.contentWindow?.document.body.appendChild(form);
+
+        const script = document.createElement('script');
+        script.innerHTML = `
+            const data = new URLSearchParams()
+            data.append('Bin', '${body.provider_data.source_id}');
+            data.append('JWT', '${body.provider_data.data}');
+
+            window.parent.fetch('${url}', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: data
+            })
+            .then((response) => {
+                if(!response.ok) {
+                    window.parent.postMessage('${INVALID_URL}', '*')
+                }
+
+                document.getElementById('${formId}').submit();
+            })
+            .catch((error) =>  {
+                window.parent.postMessage('${INVALID_URL}', '*')
+            })
+        `;
+        iframe.contentWindow?.document.body.appendChild(script);
+
+        return iframe;
+    }
+
+
+    private _createIframe(data: WorldpayAccess3DSOptions): HTMLIFrameElement {
+        const form = document.createElement('form');
+        form.id = 'challengeForm';
+        form.method = 'POST';
+        form.action = data.acs_url;
+
+        const inputJWT = document.createElement('input');
+        inputJWT.name = 'JWT';
+        inputJWT.type = 'hidden';
+        inputJWT.value = data.payer_auth_request;
+        form.appendChild(inputJWT);
+
+        const merchant = document.createElement('input');
+        merchant.name = 'MD';
+        merchant.type = 'hidden';
+        merchant.value = 'merchantSessionId=' + data.merchant_data;
+        form.appendChild(merchant);
+
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.innerHTML = "window.onload = function() { document.getElementById('challengeForm').submit(); }"
+
+        const iframe = document.createElement('iframe');
+        iframe.name = IFRAME_NAME;
+        iframe.height = '400';
+        iframe.width = '100%';
+        iframe.srcdoc = `${form.outerHTML} ${script.outerHTML}`;
+
+        return iframe;
+    }
+}

--- a/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.ts
@@ -16,7 +16,13 @@ export default class WorldpayaccessPaymetStrategy extends CreditCardPaymentStrat
     private _initializeOptions?: WorldpayAccessPaymentInitializeOptions;
 
     async initialize(options?: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
-        this._initializeOptions = options && options.worldpay;
+        if (!options?.worldpay) {
+            throw new NotInitializedError(
+                NotInitializedErrorType.PaymentNotInitialized
+            );
+        }
+
+        this._initializeOptions = options.worldpay;
 
         return super.initialize(options);
     }


### PR DESCRIPTION
## What? [INT-6115](https://bigcommercecloud.atlassian.net/browse/INT-6115)
Added support to handle iFrames and collect device data for Access Worldpay

## Why?
In order to support 3DS1 and 3DS2 we need to use iframes to handle 3DS data collection and support frictionless and challenge verification.

## Testing / Proof
https://drive.google.com/file/d/1zfe8vvwITn2uoZ-RKOjXuabQcnK2fpcf/view?usp=sharing

@bigcommerce/checkout @bigcommerce/payments
