### PR TITLE
feat(payment): PAYPAL-1474 added PayPalCommerceInlineCheckoutButtonStrategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1389,9 +1389,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.19.0.tgz",
-      "integrity": "sha512-iP9ztuU7kET5ppkfeFYW4P5RlG2El7KC66NGhpFD8p3Ww7KAihcQncwRtodLL5cEh6ndf8GeP6+XAuCPNJ7NTg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.20.0.tgz",
+      "integrity": "sha512-O88thU+FGgUot4IVOgMcSO3PwH7ZgD3m5jtU6Mr6oORmafo2mYezVprgWoPbiNE2FGZngVvxDjzq6X0stn607w==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^27.4.6",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
-    "@bigcommerce/bigpay-client": "^5.19.0",
+    "@bigcommerce/bigpay-client": "^5.20.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -6,7 +6,7 @@ import { ApplePayButtonInitializeOptions } from './strategies/apple-pay';
 import { BraintreePaypalButtonInitializeOptions, BraintreePaypalCreditButtonInitializeOptions, BraintreeVenmoButtonInitializeOptions } from './strategies/braintree';
 import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
-import { PaypalCommerceAlternativeMethodsButtonOptions, PaypalCommerceButtonInitializeOptions, PaypalCommerceCreditButtonInitializeOptions, PaypalCommerceV2ButtonInitializeOptions, PaypalCommerceVenmoButtonInitializeOptions } from './strategies/paypal-commerce';
+import { PaypalCommerceAlternativeMethodsButtonOptions, PaypalCommerceButtonInitializeOptions, PaypalCommerceCreditButtonInitializeOptions, PaypalCommerceInlineCheckoutButtonInitializeOptions, PaypalCommerceV2ButtonInitializeOptions, PaypalCommerceVenmoButtonInitializeOptions } from './strategies/paypal-commerce';
 
 export { CheckoutButtonInitializeOptions } from '../generated/checkout-button-initialize-options';
 
@@ -141,6 +141,12 @@ export interface BaseCheckoutButtonInitializeOptions extends CheckoutButtonOptio
      * unless you need to support PayPal Commerce Alternative Payment Methods.
      */
     paypalcommercealternativemethods?: PaypalCommerceAlternativeMethodsButtonOptions;
+
+    /**
+     * The options that are required to facilitate PayPal Commerce Inline Checkout. They can be omitted
+     * unless you need to support PayPal Commerce Inline(Accelerated) Checkout.
+     */
+    paypalcommerceinline?: PaypalCommerceInlineCheckoutButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate PayPal Commerce Venmo. They can be omitted

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -20,5 +20,6 @@ export enum BaseCheckoutButtonMethodType {
     PAYPALCOMMERCEV2 = 'paypalcommercev2',
     PAYPALCOMMERCE_CREDIT = 'paypalcommercecredit',
     PAYPALCOMMERCE_APMS = 'paypalcommercealternativemethods',
+    PAYPALCOMMERCE_INLINE = 'paypalcommerceinline',
     PAYPALCOMMERCE_VENMO = 'paypalcommercevenmo',
 }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/index.ts
@@ -24,6 +24,12 @@ export { default as PaypalCommerceCreditButtonStrategy } from './paypal-commerce
  export { default as PaypalCommerceAlternativeMethodsButtonStrategy } from './paypal-commerce-alternative-methods-button-strategy';
 
 /**
+ * PayPal Commerce Inline Checkout
+ */
+export { PaypalCommerceInlineCheckoutButtonInitializeOptions } from './paypal-commerce-inline-checkout-button-options';
+export { default as PaypalCommerceInlineCheckoutButtonStrategy } from './paypal-commerce-inline-checkout-button-strategy';
+
+/**
  * PayPal Commerce Venmo
  */
 export { PaypalCommerceVenmoButtonInitializeOptions } from './paypal-commerce-venmo-button-options';

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-options.ts
@@ -1,0 +1,41 @@
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+
+export interface PaypalCommerceInlineCheckoutButtonInitializeOptions {
+    /**
+     * Accelerated Checkout Buttons container - is a generic container for all AC buttons
+     * Used as a container where the button will be rendered with its own container
+     * Example: 'data-cart-accelerated-checkout-buttons'
+     * Info: we are using data attributes as an identifier because the buttons can be rendered in several places on the page
+     */
+    acceleratedCheckoutContainerDataId: string;
+
+    /**
+     * A container identifier what used to add special class for container where the button will be generated in
+     * Example: 'data-paypal-commerce-inline-button'
+     * Info: we are using data attributes as an identifier because the buttons can be rendered in several places on the page
+     */
+    buttonContainerDataId: string;
+
+    /**
+     * A class name used to add special class for container where the button will be generated in
+     * Default: 'PaypalCommerceInlineButton'
+     */
+    buttonContainerClassName?: string;
+
+    /**
+     * Used by Accelerated Checkout strategy to hide primary action button before rendering PayPal inline checkout button
+     * Example: 'data-checkout-now-button'
+     * Info: we are using data attributes as an identifier because the buttons can be rendered in several places on the page
+     */
+    checkoutNowElementDataId: string;
+
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: PaypalButtonStyleOptions;
+
+    /**
+     * A callback that gets called when payment complete on paypal side.
+     */
+    onComplete(): void;
+}

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-options.ts
@@ -23,11 +23,11 @@ export interface PaypalCommerceInlineCheckoutButtonInitializeOptions {
     buttonContainerClassName?: string;
 
     /**
-     * Used by Accelerated Checkout strategy to hide primary action button before rendering PayPal inline checkout button
+     * Used by Accelerated Checkout strategy to hide native action button before rendering PayPal inline checkout button
      * Example: 'data-checkout-now-button'
      * Info: we are using data attributes as an identifier because the buttons can be rendered in several places on the page
      */
-    checkoutNowElementDataId: string;
+    nativeCheckoutButtonDataId: string;
 
     /**
      * A set of styling options for the checkout button.

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
@@ -38,6 +38,7 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
     let consignmentActionCreator: ConsignmentActionCreator;
     let eventEmitter: EventEmitter;
     let formPoster: FormPoster;
+    let nativeCheckoutElement: HTMLDivElement;
     let orderActionCreator: OrderActionCreator;
     let paymentActionCreator: PaymentActionCreator;
     let paymentHumanVerificationHandler: PaymentHumanVerificationHandler;
@@ -46,7 +47,6 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
     let paypalCommerceRequestSender: PaypalCommerceRequestSender;
     let paypalScriptLoader: PaypalCommerceScriptLoader;
     let paypalSdkMock: PaypalCommerceSDK;
-    let primaryCheckoutNowElement: HTMLDivElement;
     let requestSender: RequestSender;
     let store: CheckoutStore;
     let strategy: PaypalCommerceInlineCheckoutButtonStrategy;
@@ -54,7 +54,7 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
 
     const acceleratedCheckoutContainerDataId = 'data-ac-buttons-mock-id';
     const buttonContainerDataId = 'data-paypal-inline-button-mock-id';
-    const checkoutNowElementDataId = 'data-checkout-now-button-mock-id';
+    const nativeCheckoutButtonDataId = 'data-checkout-now-button-mock-id';
 
     const paypalOrderId = 'ORDER_ID';
 
@@ -70,7 +70,7 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
     const paypalCommerceInlineOptions: PaypalCommerceInlineCheckoutButtonInitializeOptions = {
         acceleratedCheckoutContainerDataId,
         buttonContainerDataId,
-        checkoutNowElementDataId,
+        nativeCheckoutButtonDataId,
         onComplete: jest.fn(),
         style: paypalCommerceButtonStyle,
     };
@@ -140,9 +140,9 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
         acceleratedButtonsContainer.setAttribute(acceleratedCheckoutContainerDataId, '');
         document.body.appendChild(acceleratedButtonsContainer);
 
-        primaryCheckoutNowElement = document.createElement('div');
-        primaryCheckoutNowElement.setAttribute(checkoutNowElementDataId, '');
-        document.body.appendChild(primaryCheckoutNowElement);
+        nativeCheckoutElement = document.createElement('div');
+        nativeCheckoutElement.setAttribute(nativeCheckoutButtonDataId, '');
+        document.body.appendChild(nativeCheckoutElement);
 
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
         jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cartMock);
@@ -221,8 +221,8 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
 
         delete (window as PaypalHostWindow).paypal;
 
-        if (document.querySelector(`[${checkoutNowElementDataId}]`)) {
-            document.body.removeChild(primaryCheckoutNowElement);
+        if (document.querySelector(`[${nativeCheckoutButtonDataId}]`)) {
+            document.body.removeChild(nativeCheckoutElement);
         }
 
         if (document.querySelector(`[${acceleratedCheckoutContainerDataId}]`)) {
@@ -245,11 +245,10 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
             }
         });
 
-        it('throws an error if options.paypalcommerceinline options are not provided', async () => {
+        it('throws an error if options.paypalcommerceinline option is not provided', async () => {
             const options = {
                 methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_INLINE,
                 containerId: `[${acceleratedCheckoutContainerDataId}]`,
-                paypalcommerceinline: {},
             } as CheckoutButtonInitializeOptions;
 
             try {
@@ -263,12 +262,6 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalled();
-        });
-
-        it('calls consignment action creator to load shipping options', async () => {
-            await strategy.initialize(initializationOptions);
-
-            expect(consignmentActionCreator.loadShippingOptions).toHaveBeenCalled();
         });
 
         it('loads paypal commerce sdk script', async () => {
@@ -308,7 +301,7 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
         it('hides primary action element if PayPal button is eligible', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(primaryCheckoutNowElement.style.display).toEqual('none');
+            expect(nativeCheckoutElement.style.display).toEqual('none');
         });
 
         it('renders PayPal button if it is eligible', async () => {
@@ -776,7 +769,7 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
                 await strategy.initialize(initializationOptions);
                 eventEmitter.emit('onError');
             } catch (_) {
-                expect(primaryCheckoutNowElement.style.display).toEqual('');
+                expect(nativeCheckoutElement.style.display).toEqual('');
             }
         });
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
@@ -1,0 +1,792 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
+import { Cart } from '../../../cart';
+import { getCart } from '../../../cart/carts.mock';
+import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator, createCheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { OrderActionCreator, OrderRequestSender } from '../../../order';
+import { PaymentActionCreator, PaymentMethod, PaymentRequestSender, PaymentRequestTransformer } from '../../../payment';
+import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
+import { getPaypalCommerce } from '../../../payment/payment-methods.mock';
+import { PaypalHostWindow } from '../../../payment/strategies/paypal';
+import { PayPalAddress, PaypalCheckoutButtonOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, PayPalOrderDetails, PayPalSelectedShippingOption } from '../../../payment/strategies/paypal-commerce';
+import { getPaypalCommerceMock } from '../../../payment/strategies/paypal-commerce/paypal-commerce.mock';
+import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
+import { getConsignment } from '../../../shipping/consignments.mock';
+import { getShippingOption } from '../../../shipping/shipping-options.mock';
+import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+import { PaypalCommerceInlineCheckoutButtonInitializeOptions } from './paypal-commerce-inline-checkout-button-options';
+import PaypalCommerceInlineCheckoutButtonStrategy from './paypal-commerce-inline-checkout-button-strategy';
+
+describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
+    let acceleratedButtonsContainer: HTMLDivElement;
+    let billingAddressActionCreator: BillingAddressActionCreator;
+    let cartMock: Cart;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let checkoutRequestSender: CheckoutRequestSender;
+    let checkoutValidator: CheckoutValidator;
+    let consignmentActionCreator: ConsignmentActionCreator;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let paymentHumanVerificationHandler: PaymentHumanVerificationHandler;
+    let paymentMethodMock: PaymentMethod;
+    let paymentRequestSender: PaymentRequestSender;
+    let paypalCommerceRequestSender: PaypalCommerceRequestSender;
+    let paypalScriptLoader: PaypalCommerceScriptLoader;
+    let paypalSdkMock: PaypalCommerceSDK;
+    let primaryCheckoutNowElement: HTMLDivElement;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: PaypalCommerceInlineCheckoutButtonStrategy;
+    let subscriptionsActionCreator: SubscriptionsActionCreator;
+
+    const acceleratedCheckoutContainerDataId = 'data-ac-buttons-mock-id';
+    const buttonContainerDataId = 'data-paypal-inline-button-mock-id';
+    const checkoutNowElementDataId = 'data-checkout-now-button-mock-id';
+
+    const paypalOrderId = 'ORDER_ID';
+
+    const paypalCommerceButtonStyle = {
+        custom: {
+            label: 'Checkout',
+            css: {
+                color: 'white',
+            },
+        },
+    };
+
+    const paypalCommerceInlineOptions: PaypalCommerceInlineCheckoutButtonInitializeOptions = {
+        acceleratedCheckoutContainerDataId,
+        buttonContainerDataId,
+        checkoutNowElementDataId,
+        onComplete: jest.fn(),
+        style: paypalCommerceButtonStyle,
+    };
+
+    const initializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_INLINE,
+        containerId: `[${acceleratedCheckoutContainerDataId}]`,
+        paypalcommerceinline: paypalCommerceInlineOptions,
+    };
+
+    const paypalShippingAddressPayloadMock: PayPalAddress = {
+        city: "San Jose",
+        state: "CA",
+        country_code: "US",
+        postal_code: "95131",
+    };
+
+    const paypalSelectedShippingOptionPayloadMock: PayPalSelectedShippingOption = {
+        id: '1',
+        type: 'SHIPPING',
+        label: 'FREE SHIPPING',
+        selected: false,
+        amount: {
+            currency_code: 'USD',
+            value: '0.00',
+        },
+    };
+
+    beforeEach(() => {
+        cartMock = getCart();
+        eventEmitter = new EventEmitter();
+        paymentMethodMock = { ...getPaypalCommerce(), id: 'paypalcommerceinline' };
+        paypalSdkMock = getPaypalCommerceMock();
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = createRequestSender();
+        formPoster = createFormPoster();
+
+        paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
+        paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+        checkoutRequestSender = new CheckoutRequestSender(requestSender);
+        checkoutValidator = new CheckoutValidator(checkoutRequestSender);
+        orderActionCreator = new OrderActionCreator(new OrderRequestSender(requestSender), checkoutValidator);
+        consignmentActionCreator = new ConsignmentActionCreator(new ConsignmentRequestSender(requestSender), checkoutRequestSender);
+        subscriptionsActionCreator = new SubscriptionsActionCreator(new SubscriptionsRequestSender(requestSender));
+        billingAddressActionCreator = new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender), subscriptionsActionCreator);
+        paymentRequestSender = new PaymentRequestSender(requestSender);
+        paymentHumanVerificationHandler = new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader()));
+        paymentActionCreator = new PaymentActionCreator(paymentRequestSender, orderActionCreator, new PaymentRequestTransformer(), paymentHumanVerificationHandler);
+
+        strategy = new PaypalCommerceInlineCheckoutButtonStrategy(
+            store,
+            checkoutActionCreator,
+            paypalScriptLoader,
+            paypalCommerceRequestSender,
+            orderActionCreator,
+            consignmentActionCreator,
+            billingAddressActionCreator,
+            paymentActionCreator
+        );
+
+        acceleratedButtonsContainer = document.createElement('div');
+        acceleratedButtonsContainer.setAttribute(acceleratedCheckoutContainerDataId, '');
+        document.body.appendChild(acceleratedButtonsContainer);
+
+        primaryCheckoutNowElement = document.createElement('div');
+        primaryCheckoutNowElement.setAttribute(checkoutNowElementDataId, '');
+        document.body.appendChild(primaryCheckoutNowElement);
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cartMock);
+        jest.spyOn(store.getState().consignments, 'getConsignmentsOrThrow').mockReturnValue([getConsignment()]);
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+
+        jest.spyOn(billingAddressActionCreator, 'updateAddress').mockReturnValue(true);
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout').mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'loadShippingOptions').mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'selectShippingOption').mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(true);
+        jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(true);
+        jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(true);
+        jest.spyOn(paypalCommerceRequestSender, 'updateOrder').mockReturnValue(true);
+
+        jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdkMock);
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+
+        jest.spyOn(paypalSdkMock, 'Buttons')
+            .mockImplementation((options: PaypalCheckoutButtonOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('onShippingAddressChange', () => {
+                    if (options.onShippingAddressChange) {
+                        options.onShippingAddressChange({
+                            orderId: paypalOrderId,
+                            shippingAddress: paypalShippingAddressPayloadMock,
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingOptionsChange', () => {
+                    if (options.onShippingOptionsChange) {
+                        options.onShippingOptionsChange({
+                            orderId: paypalOrderId,
+                            selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
+                        });
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ orderID: paypalOrderId }, {
+                            order: {
+                                get: jest.fn(),
+                            }
+                        });
+                    }
+                });
+
+                eventEmitter.on('onComplete', () => {
+                    if (options.onComplete) {
+                        options.onComplete({ intent: 'CAPTURE', orderID: paypalOrderId });
+                    }
+                });
+
+                eventEmitter.on('onError', () => {
+                    if (options.onError) {
+                        options.onError(new Error('Error message'));
+                    }
+                });
+
+                return {
+                    render: jest.fn(),
+                    isEligible: jest.fn(() => true),
+                };
+            });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PaypalHostWindow).paypal;
+
+        if (document.querySelector(`[${checkoutNowElementDataId}]`)) {
+            document.body.removeChild(primaryCheckoutNowElement);
+        }
+
+        if (document.querySelector(`[${acceleratedCheckoutContainerDataId}]`)) {
+            document.body.removeChild(acceleratedButtonsContainer);
+        }
+    });
+
+    it('creates an instance of the PaypalCommerceInlineCheckoutButtonStrategy', () => {
+        expect(strategy).toBeInstanceOf(PaypalCommerceInlineCheckoutButtonStrategy);
+    });
+
+    describe('#initialize', () => {
+        it('throws an error if methodId is not provided', async () => {
+            const options = { containerId: initializationOptions.containerId } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if options.paypalcommerceinline options are not provided', async () => {
+            const options = {
+                methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_INLINE,
+                containerId: `[${acceleratedCheckoutContainerDataId}]`,
+                paypalcommerceinline: {},
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('calls checkout action creator to load default checkout', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalled();
+        });
+
+        it('calls consignment action creator to load shipping options', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(consignmentActionCreator.loadShippingOptions).toHaveBeenCalled();
+        });
+
+        it('loads paypal commerce sdk script', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalled();
+        });
+
+        it('throws an error if paypal sdk is not loaded', async () => {
+            jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(undefined);
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
+            }
+        });
+    });
+
+    describe('#_renderButton', () => {
+        it('initializes PayPal button to render with provided options', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                experience: 'inline',
+                fundingSource: paypalSdkMock.FUNDING.CARD,
+                style: paypalCommerceButtonStyle,
+                createOrder: expect.any(Function),
+                onShippingAddressChange: expect.any(Function),
+                onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+                onComplete: expect.any(Function),
+                onError: expect.any(Function),
+            });
+        });
+
+        it('hides primary action element if PayPal button is eligible', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(primaryCheckoutNowElement.style.display).toEqual('none');
+        });
+
+        it('renders PayPal button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation(() => ({
+                    render: paypalCommerceSdkRenderMock,
+                    isEligible: jest.fn(() => true),
+                }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalledWith(`[${buttonContainerDataId}]`);
+        });
+
+        it('does not render PayPal button container if PayPal button is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation(() => ({
+                    render: paypalCommerceSdkRenderMock,
+                    isEligible: jest.fn(() => false),
+                }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(document.querySelector(`[${buttonContainerDataId}]`)).toBeNull();
+        });
+    });
+
+    describe('#_createOrder button callback', () => {
+        it('creates PayPal order', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue({ orderID: paypalOrderId });
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, initializationOptions.methodId);
+        });
+    });
+
+    describe('#_onShippingAddressChange button callback', () => {
+        it('updates billing and consignment address with data returned from PayPal', async () => {
+            const providedAddress = {
+                firstName: 'Fake',
+                lastName: 'Fake',
+                email: 'fake@fake.fake',
+                phone: '',
+                company: '',
+                address1: 'Fake street',
+                address2: '',
+                city: paypalShippingAddressPayloadMock.city,
+                countryCode: paypalShippingAddressPayloadMock.country_code,
+                postalCode: paypalShippingAddressPayloadMock.postal_code,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalShippingAddressPayloadMock.state,
+                customFields: [],
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(providedAddress);
+            expect(consignmentActionCreator.updateAddress).toHaveBeenCalledWith(providedAddress);
+        });
+
+        it('selects recommended shipping option if it was not selected earlier', async () => {
+            const recommendedShippingOption = {
+                ...getShippingOption(),
+                isRecommended: true,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [recommendedShippingOption],
+                selectedShippingOption: null
+            };
+
+            const updatedConsignment = {
+                ...consignment,
+                selectedShippingOption: recommendedShippingOption,
+            };
+
+            jest.spyOn(store.getState().consignments, 'getConsignmentsOrThrow')
+                .mockReturnValueOnce([consignment])
+                .mockReturnValue([updatedConsignment])
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(consignmentActionCreator.selectShippingOption).toHaveBeenCalledWith(recommendedShippingOption.id);
+        });
+
+        it('updates PayPal order', async () => {
+            const consignment = getConsignment();
+
+            // INFO: lets imagine that it is a state that we get after consignmentActionCreator.selectShippingOption call
+            jest.spyOn(store.getState().consignments, 'getConsignmentsOrThrow')
+                .mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalledWith({
+                availableShippingOptions: consignment.availableShippingOptions,
+                cartId: cartMock.id,
+                selectedShippingOption: consignment.selectedShippingOption,
+            });
+        });
+    });
+
+    describe('#_onShippingOptionsChange button callback', () => {
+        it('selects shipping option', async () => {
+            const recommendedShippingOption = getShippingOption();
+            const shippingOptionThatShouldBeSelected = {
+                ...getShippingOption(),
+                id: paypalSelectedShippingOptionPayloadMock.id,
+                isRecommended: false,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [recommendedShippingOption, shippingOptionThatShouldBeSelected],
+            };
+
+            jest.spyOn(store.getState().consignments, 'getConsignmentsOrThrow')
+                .mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(consignmentActionCreator.selectShippingOption).toHaveBeenCalledWith(shippingOptionThatShouldBeSelected.id);
+        });
+
+        it('selects recommended shipping option if there is no match with payload from paypal', async () => {
+            const recommendedShippingOption = getShippingOption();
+            const anotherShippingOption = {
+                ...getShippingOption(),
+                id: 'asdag123',
+                isRecommended: false,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [recommendedShippingOption, anotherShippingOption],
+            };
+
+            jest.spyOn(store.getState().consignments, 'getConsignmentsOrThrow')
+                .mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(consignmentActionCreator.selectShippingOption).not.toHaveBeenCalledWith(paypalSelectedShippingOptionPayloadMock.id);
+            expect(consignmentActionCreator.selectShippingOption).toHaveBeenCalledWith(recommendedShippingOption.id);
+        });
+
+        it('updates PayPal order', async () => {
+            const consignment = getConsignment();
+
+            // INFO: lets imagine that it is a state that we get after consignmentActionCreator.selectShippingOption call
+            jest.spyOn(store.getState().consignments, 'getConsignmentsOrThrow')
+                .mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalledWith({
+                availableShippingOptions: consignment.availableShippingOptions,
+                cartId: cartMock.id,
+                selectedShippingOption: consignment.selectedShippingOption,
+            });
+        });
+    });
+
+    describe('#_onApprove button callback', () => {
+        const paypalOrderDetails: PayPalOrderDetails = {
+            purchase_units: [
+                {
+                    shipping: {
+                        address: {
+                            address_line_1: "2 E 61st St",
+                            admin_area_2: "New York",
+                            admin_area_1: "NY",
+                            postal_code: "10065",
+                            country_code: "US"
+                        },
+                    },
+                },
+            ],
+            payer: {
+                name: {
+                    given_name: "John",
+                    surname: "Doe",
+                },
+                email_address: "john@doe.com",
+                address: {
+                    address_line_1: "1 Main St",
+                    admin_area_2: "San Jose",
+                    admin_area_1: "CA",
+                    postal_code: "95131",
+                    country_code: "US",
+                },
+            },
+        };
+
+        beforeEach(() => {
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation((options: PaypalCheckoutButtonOptions) => {
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove({ orderID: paypalOrderId }, {
+                                order: {
+                                    get: jest.fn(() => paypalOrderDetails),
+                                }
+                            });
+                        }
+                    });
+
+                    return {
+                        render: jest.fn(),
+                        isEligible: jest.fn(() => true),
+                    };
+                });
+        });
+
+        it('takes order details data from paypal', async () => {
+            const getOrderActionMock = jest.fn(() => paypalOrderDetails);
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation((options: PaypalCheckoutButtonOptions) => {
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove({ orderID: paypalOrderId }, {
+                                order: {
+                                    get: getOrderActionMock,
+                                }
+                            });
+                        }
+                    });
+
+                    return {
+                        render: jest.fn(),
+                        isEligible: jest.fn(() => true),
+                    };
+                });
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(getOrderActionMock).toHaveBeenCalled();
+            expect(getOrderActionMock).toReturnWith(paypalOrderDetails);
+        });
+
+        it('updates only billing address with valid customers data from order details if there is no shipping needed', async () => {
+            const defaultCart = getCart();
+            const cartWithoutShipping = {
+                ...defaultCart,
+                lineItems: {
+                    ...defaultCart.lineItems,
+                    physicalItems: [],
+                },
+            };
+
+            jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cartWithoutShipping);
+
+            const address = {
+                firstName: paypalOrderDetails.payer.name.given_name,
+                lastName: paypalOrderDetails.payer.name.surname,
+                email: paypalOrderDetails.payer.email_address,
+                phone: '',
+                company: '',
+                address1: paypalOrderDetails.payer.address.address_line_1,
+                address2: '',
+                city: paypalOrderDetails.payer.address.admin_area_2,
+                countryCode: paypalOrderDetails.payer.address.country_code,
+                postalCode: paypalOrderDetails.payer.address.postal_code,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalOrderDetails.payer.address.admin_area_1,
+                customFields: [],
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(address);
+        });
+
+        it('skips consignment address update with valid customer data from order details if there are no items what should be shipped', async () => {
+            const defaultCart = getCart();
+            const cartWithoutShipping = {
+                ...defaultCart,
+                lineItems: {
+                    ...defaultCart.lineItems,
+                    physicalItems: [],
+                },
+            };
+
+            jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cartWithoutShipping);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(consignmentActionCreator.updateAddress).not.toHaveBeenCalled();
+            expect(paypalCommerceRequestSender.updateOrder).not.toHaveBeenCalled();
+        });
+
+        it('updates order and updates address with valid customer data from order details', async () => {
+            const address = {
+                firstName: paypalOrderDetails.payer.name.given_name,
+                lastName: paypalOrderDetails.payer.name.surname,
+                email: paypalOrderDetails.payer.email_address,
+                phone: '',
+                company: '',
+                address1: paypalOrderDetails.purchase_units[0].shipping.address.address_line_1,
+                address2: '',
+                city: paypalOrderDetails.purchase_units[0].shipping.address.admin_area_2,
+                countryCode: paypalOrderDetails.purchase_units[0].shipping.address.country_code,
+                postalCode: paypalOrderDetails.purchase_units[0].shipping.address.postal_code,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalOrderDetails.purchase_units[0].shipping.address.admin_area_1,
+                customFields: [],
+            };
+
+            const consignment = getConsignment();
+
+            // INFO: lets imagine that it is a state that we get after consignmentActionCreator.updateAddress call
+            jest.spyOn(store.getState().consignments, 'getConsignmentsOrThrow')
+                .mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(address);
+            expect(consignmentActionCreator.updateAddress).toHaveBeenCalledWith(address);
+            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalledWith({
+                availableShippingOptions: consignment.availableShippingOptions,
+                cartId: cartMock.id,
+                selectedShippingOption: consignment.selectedShippingOption,
+            });
+        });
+
+        it('submits BC order with provided methodId', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(
+                {},
+                {
+                    params: {
+                        methodId: initializationOptions.methodId,
+                    },
+                },
+            );
+        });
+
+        it('submits BC payment to update BC order data', async () => {
+            const methodId = initializationOptions.methodId;
+            const paymentData =  {
+                formattedPayload: {
+                    vault_payment_instrument: null,
+                    set_as_default_stored_instrument: null,
+                    device_info: null,
+                    method_id: methodId,
+                    paypal_account: {
+                        order_id: paypalOrderId,
+                    },
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({ methodId, paymentData });
+        });
+    });
+
+    describe('#_onComplete button callback', () => {
+        it('submits payment', async () => {
+            const methodId = initializationOptions.methodId;
+            const paymentData =  {
+                formattedPayload: {
+                    vault_payment_instrument: null,
+                    set_as_default_stored_instrument: null,
+                    device_info: null,
+                    method_id: methodId,
+                    paypal_account: {
+                        order_id: paypalOrderId,
+                    },
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onComplete');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({ methodId, paymentData });
+        });
+
+        it('calls callback if its provided', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onComplete');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceInlineOptions.onComplete).toHaveBeenCalled();
+        });
+    });
+
+    describe('#_onError button callback', () => {
+        it('hides Inline Checkout container', async () => {
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onError');
+            } catch (_) {
+                expect(document.querySelector(`[${buttonContainerDataId}]`)).toBeNull();
+            }
+        });
+
+        it('shows primary action button if Inline checkout gets an error', async () => {
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onError');
+            } catch (_) {
+                expect(primaryCheckoutNowElement.style.display).toEqual('');
+            }
+        });
+
+        it('throws an error with message', async () => {
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onError');
+            } catch (error) {
+                expect(error.message).toBe('Error message');
+            }
+        });
+    });
+})

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
@@ -1,0 +1,334 @@
+import { BillingAddressActionCreator, BillingAddressRequestBody } from '../../../billing';
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { OrderActionCreator } from '../../../order';
+import { PaymentActionCreator } from '../../../payment';
+import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
+import { ConsignmentActionCreator, ShippingOption } from '../../../shipping';
+import { ApproveCallbackActions, ApproveCallbackPayload, CompleteCallbackDataPayload, PaypalButtonStyleOptions, PaypalCheckoutButtonOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, PayPalOrderAddress, PayPalOrderDetails, ShippingAddressChangeCallbackPayload, ShippingOptionChangeCallbackPayload } from '../../../payment/strategies/paypal-commerce';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+export default class PaypalCommerceInlineCheckoutButtonStrategy implements CheckoutButtonStrategy {
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _paypalScriptLoader: PaypalCommerceScriptLoader,
+        private _paypalCommerceRequestSender: PaypalCommerceRequestSender,
+        private _orderActionCreator: OrderActionCreator,
+        private _consignmentActionCreator: ConsignmentActionCreator,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _paymentActionCreator: PaymentActionCreator
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { methodId, paypalcommerceinline } = options;
+        const {
+            acceleratedCheckoutContainerDataId,
+            buttonContainerDataId,
+            buttonContainerClassName,
+            checkoutNowElementDataId,
+            style,
+            onComplete,
+        } = paypalcommerceinline || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
+        }
+
+        if (!acceleratedCheckoutContainerDataId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommerceinline.acceleratedCheckoutContainerDataId" argument is not provided.`);
+        }
+
+        if (!buttonContainerDataId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommerceinline.buttonContainerDataId" argument is not provided.`);
+        }
+
+        if (!checkoutNowElementDataId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommerceinline.checkoutNowElementDataId" argument is not provided.`);
+        }
+
+        if (!onComplete || typeof onComplete !== 'function') {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommerceinline.onComplete" argument is not provided or it is not a function.`);
+        }
+
+        await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        await this._store.dispatch(this._consignmentActionCreator.loadShippingOptions());
+
+        const state = this._store.getState();
+        const currency = state.cart.getCartOrThrow().currency.code;
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currency, false);
+
+        if (!paypalCommerceSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        this._renderButton(
+            methodId,
+            paypalCommerceSdk,
+            onComplete,
+            acceleratedCheckoutContainerDataId,
+            checkoutNowElementDataId,
+            buttonContainerDataId,
+            buttonContainerClassName,
+            style,
+        );
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private _renderButton(
+        methodId: string,
+        paypalCommerceSdk: PaypalCommerceSDK,
+        onComplete: () => void,
+        acceleratedCheckoutContainerDataId: string,
+        checkoutNowElementDataId: string,
+        buttonContainerDataId: string,
+        buttonContainerClassName?: string,
+        style?: PaypalButtonStyleOptions,
+    ): void {
+        const fundingSource = paypalCommerceSdk.FUNDING.CARD;
+
+        const buttonRenderOptions: PaypalCheckoutButtonOptions = {
+            experience: "inline",
+            fundingSource,
+            style,
+            createOrder: () => this._createOrder(methodId),
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) => this._onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) => this._onShippingOptionsChange(data),
+            onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) => this._onApprove(data, actions, methodId),
+            onComplete: (data: CompleteCallbackDataPayload) => this._onComplete(data, methodId, onComplete),
+            onError: (error: Error) => this._onError(error, buttonContainerDataId, checkoutNowElementDataId),
+        };
+
+        const paypalButtonRender = paypalCommerceSdk.Buttons(buttonRenderOptions);
+
+        if (paypalButtonRender.isEligible()) {
+            this._hideCheckoutNowButton(checkoutNowElementDataId);
+
+            this._createPayPalButtonContainer(acceleratedCheckoutContainerDataId, buttonContainerDataId, buttonContainerClassName);
+            paypalButtonRender.render(`[${buttonContainerDataId}]`);
+        }
+    }
+
+    private async _createOrder(methodId: string): Promise<string> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cart.id, methodId);
+
+        return orderId;
+    }
+
+    private async _onShippingAddressChange(data: ShippingAddressChangeCallbackPayload): Promise<void> {
+        const address = this._transformAddress({
+            city: data.shippingAddress.city,
+            countryCode: data.shippingAddress.country_code,
+            postalCode: data.shippingAddress.postal_code,
+            stateOrProvinceCode: data.shippingAddress.state,
+        });
+
+        // Info: we use the same address to fill billing and consignment addresses to have valid quota on BE for order updating process
+        // on this stage we don't have access to valid customer's address accept shipping data
+        await this._store.dispatch(this._billingAddressActionCreator.updateAddress(address));
+        await this._store.dispatch(this._consignmentActionCreator.updateAddress(address));
+
+        const shippingOption = this._getShippingOptionOrThrow();
+
+        await this._store.dispatch(this._consignmentActionCreator.selectShippingOption(shippingOption.id));
+        await this._updateOrder();
+    }
+
+    private async _onShippingOptionsChange(data: ShippingOptionChangeCallbackPayload): Promise<void> {
+        const shippingOption = this._getShippingOptionOrThrow(data.selectedShippingOption?.id);
+
+        await this._store.dispatch(this._consignmentActionCreator.selectShippingOption(shippingOption.id));
+        await this._updateOrder();
+    }
+
+    private async _onApprove(
+        data: ApproveCallbackPayload,
+        actions: ApproveCallbackActions,
+        methodId: string,
+    ): Promise<boolean> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const orderDetails = await actions.order.get();
+
+        if (cart.lineItems.physicalItems.length > 0) {
+            const address = this._getValidAddress(
+                orderDetails.payer.name,
+                orderDetails.payer.email_address,
+                orderDetails.purchase_units[0].shipping.address
+            );
+
+            await this._store.dispatch(this._billingAddressActionCreator.updateAddress(address));
+            await this._store.dispatch(this._consignmentActionCreator.updateAddress(address));
+            await this._updateOrder();
+        } else {
+            const address = this._getValidAddress(
+                orderDetails.payer.name,
+                orderDetails.payer.email_address,
+                orderDetails.payer.address
+            );
+
+            await this._store.dispatch(this._billingAddressActionCreator.updateAddress(address));
+        }
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder({}, { params: { methodId } }));
+        await this._submitPayment(methodId, data.orderID);
+
+        return true;
+    }
+
+    private async _onComplete(
+        data: CompleteCallbackDataPayload,
+        methodId: string,
+        callback?: () => void
+    ): Promise<void> {
+        await this._submitPayment(methodId, data.orderID);
+
+        if (callback) {
+            callback();
+        }
+    }
+
+    private _onError(error: Error, buttonContainerDataId: string, checkoutNowElementDataId: string): void {
+        this._removePayPalContainer(buttonContainerDataId);
+        this._showCheckoutNowButton(checkoutNowElementDataId);
+
+        throw new Error(error.message);
+    }
+
+    private async _updateOrder(): Promise<void> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const consignment = state.consignments.getConsignmentsOrThrow()[0];
+
+        await this._paypalCommerceRequestSender.updateOrder({
+            availableShippingOptions: consignment?.availableShippingOptions,
+            cartId: cart.id,
+            selectedShippingOption: consignment?.selectedShippingOption,
+        });
+    }
+
+    private async _submitPayment(methodId: string, orderId: string): Promise<void> {
+        const paymentData =  {
+            formattedPayload: {
+                vault_payment_instrument: null,
+                set_as_default_stored_instrument: null,
+                device_info: null,
+                method_id: methodId,
+                paypal_account: {
+                    order_id: orderId,
+                },
+            },
+        };
+
+        await this._store.dispatch(this._paymentActionCreator.submitPayment({ methodId, paymentData }));
+    }
+
+    private _getShippingOptionOrThrow(selectedShippingOptionId?: string): ShippingOption {
+        const state = this._store.getState();
+        const consignment = state.consignments.getConsignmentsOrThrow()[0];
+
+        const availableShippingOptions = consignment?.availableShippingOptions || [];
+
+        const recommendedShippingOption = availableShippingOptions.find(option => option.isRecommended);
+        const selectedShippingOption = selectedShippingOptionId
+            ? availableShippingOptions.find(option => option.id === selectedShippingOptionId)
+            : availableShippingOptions.find(option => option.id === consignment?.selectedShippingOption?.id);
+
+        const shippingOptionToSelect = selectedShippingOption || recommendedShippingOption;
+
+        if (!shippingOptionToSelect) {
+            throw new Error('Your order can\'t be shipped to this address');
+        }
+
+        return shippingOptionToSelect;
+    }
+
+    private _transformAddress(address?: Partial<BillingAddressRequestBody>): BillingAddressRequestBody {
+        return {
+            firstName: address?.firstName || 'Fake',
+            lastName: address?.lastName || 'Fake',
+            email: address?.email || 'fake@fake.fake',
+            phone: '',
+            company: '',
+            address1: address?.address1 || 'Fake street',
+            address2: '',
+            city: address?.city || '',
+            countryCode: address?.countryCode || '',
+            postalCode: address?.postalCode || '',
+            stateOrProvince: '',
+            stateOrProvinceCode: address?.stateOrProvinceCode || '',
+            customFields: [],
+        };
+    }
+
+    private _getValidAddress(
+        payerName: PayPalOrderDetails['payer']['name'],
+        email: string,
+        address: PayPalOrderAddress,
+    ) {
+        return this._transformAddress({
+            firstName: payerName.given_name,
+            lastName: payerName.surname,
+            email,
+            address1: address?.address_line_1,
+            city: address?.admin_area_2,
+            countryCode: address?.country_code,
+            postalCode: address?.postal_code,
+            stateOrProvinceCode: address?.admin_area_1,
+        });
+    }
+
+    private _getElementByDataId(dataId: string): HTMLElement | null {
+        return document.querySelector(`[${dataId}]`);
+    }
+
+    private _createPayPalButtonContainer(
+        acceleratedCheckoutContainerDataId: string,
+        buttonContainerDataId: string,
+        buttonContainerClassName = 'PaypalCommerceInlineButton',
+    ): void {
+        const paypalButtonContainer = document.createElement('div');
+        paypalButtonContainer.setAttribute('class', buttonContainerClassName);
+        paypalButtonContainer.setAttribute(buttonContainerDataId, '');
+
+        const container = this._getElementByDataId(acceleratedCheckoutContainerDataId);
+
+        if (container) {
+            container.innerHTML = "";
+            container.append(paypalButtonContainer);
+        }
+    }
+
+    private _showCheckoutNowButton(checkoutNowButtonDataId: string): void {
+        const checkoutNowButton = this._getElementByDataId(checkoutNowButtonDataId);
+
+        if (checkoutNowButton) {
+            checkoutNowButton.removeAttribute('style');
+        }
+    }
+
+    private _hideCheckoutNowButton(checkoutNowButtonDataId: string): void {
+        const checkoutNowButton = this._getElementByDataId(checkoutNowButtonDataId);
+
+        if (checkoutNowButton) {
+            checkoutNowButton.setAttribute('style', 'display: none');
+        }
+    }
+
+    private _removePayPalContainer(buttonContainerDataId: string): void {
+        const buttonContainer = this._getElementByDataId(buttonContainerDataId);
+
+        if (buttonContainer?.parentNode) {
+            buttonContainer.parentNode.removeChild(buttonContainer);
+        }
+    }
+}

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -2,7 +2,7 @@ import { RequestSender } from '@bigcommerce/request-sender';
 
 import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../../../common/http-request';
 
-import { OrderData, OrderStatus } from './paypal-commerce-sdk';
+import { OrderData, OrderStatus, UpdateOrderPayload } from './paypal-commerce-sdk';
 
 export interface ParamsForProvider {
     isCredit?: boolean;
@@ -64,6 +64,20 @@ export default class PaypalCommerceRequestSender {
         };
 
         const res = await this._requestSender.get<OrderStatus>(url, {headers});
+
+        return res.body;
+    }
+
+    async updateOrder(payload: UpdateOrderPayload) {
+        const url = `/api/storefront/initialization/paypalcommerce`;
+        const body = payload;
+        const headers = {
+            'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            'Content-Type': ContentType.Json,
+            ...SDK_VERSION_HEADERS,
+        };
+
+        const res = await this._requestSender.put(url, { headers, body });
 
         return res.body;
     }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -144,15 +144,15 @@ export interface ButtonsOptions {
 }
 
 export interface PaypalCheckoutButtonOptions {
-    experience?: string;
+    experience: string;
     style?: PaypalButtonStyleOptions;
-    fundingSource?: string;
-    createOrder?(): Promise<string>;
-    onError?(error: Error): void;
-    onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;
-    onShippingOptionsChange?(data: ShippingOptionChangeCallbackPayload): Promise<void>;
-    onApprove?(data: ApproveCallbackPayload, actions: ApproveCallbackActions): Promise<boolean>;
-    onComplete?(data: CompleteCallbackDataPayload): void;
+    fundingSource: string;
+    createOrder(): Promise<string>;
+    onError(error: Error): void;
+    onShippingAddressChange(data: ShippingAddressChangeCallbackPayload): Promise<void>;
+    onShippingOptionsChange(data: ShippingOptionChangeCallbackPayload): Promise<void>;
+    onApprove(data: ApproveCallbackPayload, actions: ApproveCallbackActions): Promise<boolean>;
+    onComplete(data: CompleteCallbackDataPayload): void;
 }
 
 export interface PaypalFieldsStyleOptions {

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -1,7 +1,4 @@
-
-export interface ApproveDataOptions {
-    orderID?: string;
-}
+import { ShippingOption } from '../../../shipping';
 
 export interface ClickDataOptions {
     fundingSource: string;
@@ -54,8 +51,88 @@ export interface PaypalButtonStyleOptions {
     height?: number;
     label?: StyleButtonLabel;
     tagline?: boolean;
+    custom?: {
+        label?: string;
+        css?: {
+            background?: string;
+            color?: string;
+            width?: string;
+        };
+    };
 }
 
+export interface PayPalAddress {
+    city: string;
+    country_code: string;
+    postal_code: string;
+    state: string;
+}
+
+export interface ShippingAddressChangeCallbackPayload {
+    orderId: string;
+    shippingAddress: PayPalAddress;
+}
+
+export interface PayPalSelectedShippingOption {
+    amount: {
+        currency_code: string;
+        value: string;
+    };
+    id: string;
+    label: string;
+    selected: boolean;
+    type: string;
+}
+
+export interface ShippingOptionChangeCallbackPayload {
+    orderId: string;
+    selectedShippingOption: PayPalSelectedShippingOption,
+}
+
+export interface ApproveDataOptions {
+    orderID?: string;
+}
+
+export interface ApproveCallbackPayload {
+    orderID: string;
+}
+
+export interface ApproveCallbackActions {
+    order: {
+        get: () => PayPalOrderDetails;
+    }
+}
+
+export interface CompleteCallbackDataPayload {
+    intent: string;
+    orderID: string;
+}
+
+export interface PayPalOrderAddress {
+    address_line_1: string;
+    admin_area_2: string;
+    admin_area_1?: string;
+    postal_code: string;
+    country_code: string;
+}
+
+export interface PayPalOrderDetails {
+    payer: {
+        name: {
+            given_name: string;
+            surname: string;
+        },
+        email_address: string;
+        address: PayPalOrderAddress;
+    };
+    purchase_units: Array<{
+        shipping: {
+            address: PayPalOrderAddress;
+        };
+    }>;
+}
+
+// TODO: this type should be merged with PayPalCheckoutButtonOptions in the future
 export interface ButtonsOptions {
     style?: PaypalButtonStyleOptions;
     fundingSource?: string;
@@ -64,6 +141,18 @@ export interface ButtonsOptions {
     onClick?(data: ClickDataOptions, actions: ClickActions): void;
     onCancel?(): void;
     onError?(error: Error): void;
+}
+
+export interface PaypalCheckoutButtonOptions {
+    experience?: string;
+    style?: PaypalButtonStyleOptions;
+    fundingSource?: string;
+    createOrder?(): Promise<string>;
+    onError?(error: Error): void;
+    onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;
+    onShippingOptionsChange?(data: ShippingOptionChangeCallbackPayload): Promise<void>;
+    onApprove?(data: ApproveCallbackPayload, actions: ApproveCallbackActions): Promise<boolean>;
+    onComplete?(data: CompleteCallbackDataPayload): void;
 }
 
 export interface PaypalFieldsStyleOptions {
@@ -185,6 +274,7 @@ export interface PaypalCommerceMessages {
 }
 
 export interface PaypalCommerceSDKFunding {
+    CARD: string;
     PAYPAL: string;
     CREDIT: string;
     PAYLATER: string;
@@ -211,7 +301,7 @@ export interface PaypalCommerceSDK {
         isEligible(): boolean;
         render(data: PaypalCommerceHostedFieldsRenderOptions): Promise<PaypalCommerceHostedFields>;
     };
-    Buttons(params: ButtonsOptions): PaypalCommerceButtons;
+    Buttons(params: ButtonsOptions | PaypalCheckoutButtonOptions): PaypalCommerceButtons;
     PaymentFields(params: FieldsOptions): PaypalCommerceFields;
     Messages(params: MessagesOptions): PaypalCommerceMessages;
 }
@@ -254,4 +344,10 @@ export interface PaypalCommerceScriptParams  {
     commit?: boolean;
     intent?: 'capture' | 'authorize';
     components?: ComponentsScriptType;
+}
+
+export interface UpdateOrderPayload {
+    availableShippingOptions?: ShippingOption[];
+    cartId: string;
+    selectedShippingOption?: ShippingOption;
 }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
@@ -9,6 +9,7 @@ export function getPaypalCommerceMock(): PaypalCommerceSDK {
             render: jest.fn(),
         }),
         FUNDING: {
+            CARD: 'card',
             PAYPAL: 'paypal',
             CREDIT: 'credit',
             PAYLATER: 'paylater',


### PR DESCRIPTION
## What?
Added PayPalCommerce inline checkout button strategy

## Why?
PayPal requested BC PayPal team to integrate their new feature Inline (Accelerated) Checkout.

Accelerated checkout button replaces out BC 'Check Out' button on the cart page and the customer goes trough PayPal checkout flow.

## Testing / Proof
Unit tests
Manual tests

Here are some screenshots of the result:
<img width="1137" alt="Screenshot 2022-09-06 at 12 24 01" src="https://user-images.githubusercontent.com/25133454/188600446-7ad3807f-cb81-4172-9979-b1bfe189ab8a.png">
<img width="303" alt="Screenshot 2022-09-06 at 12 24 13" src="https://user-images.githubusercontent.com/25133454/188600468-67b74eb1-0560-4474-aabe-3d70aa0eb96b.png">
<img width="1119" alt="Screenshot 2022-09-06 at 12 25 32" src="https://user-images.githubusercontent.com/25133454/188600484-843a9cdf-d922-40ae-ade5-dfdb2f09ffe7.png">


