### PR TITLE
feat(payment): PAYPAL-1549 added script options configuration method for PayPalCommerce

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -44,8 +44,8 @@ describe('PaypalCommerceButtonStrategy', () => {
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());
         requestSender = createRequestSender();
-        paymentMethod = { ...getPaypalCommerce() };
-        cart = { ...getCart() };
+        paymentMethod = getPaypalCommerce();
+        cart = getCart();
         formPoster = createFormPoster();
 
         checkoutActionCreator = new CheckoutActionCreator(
@@ -135,135 +135,6 @@ describe('PaypalCommerceButtonStrategy', () => {
         if (paypalOptions.messagingContainer != null && document.getElementById(paypalOptions.messagingContainer)) {
                 document.body.removeChild(messageContainer);
         }
-    });
-
-    it('initializes PaypalCommerce and PayPal credit disabled & messaging enabled', async () => {
-        await strategy.initialize(options);
-
-        const obj = {
-            'client-id': 'abc',
-            commit: false,
-            currency: 'USD',
-            intent: 'capture',
-            components: ['buttons', 'messages'],
-            'disable-funding': [
-                'card',
-                'credit',
-                'paylater',
-                'venmo',
-            ],
-        };
-
-        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, undefined);
-    });
-
-    it('initializes PaypalCommerce and PayPal credit enabled & messaging enabled', async () => {
-        paymentMethod.initializationData.isPayPalCreditAvailable = true;
-        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
-
-        await strategy.initialize(options);
-
-        const obj = {
-                'client-id': 'abc',
-                commit: false,
-                currency: 'USD',
-                intent: 'capture',
-                components: ['buttons', 'messages'],
-                'disable-funding': [
-                    'card',
-                    'venmo',
-                ],
-                'enable-funding': [
-                    'credit',
-                    'paylater',
-                ],
-        };
-
-        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, undefined);
-    });
-
-    it('initializes PaypalCommerce with enabled Venmo', async () => {
-        paymentMethod.initializationData.isVenmoEnabled = true;
-        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
-
-        await strategy.initialize(options);
-
-        const obj = {
-            'client-id': 'abc',
-            commit: false,
-            currency: 'USD',
-            intent: 'capture',
-            components: ['buttons', 'messages'],
-            'disable-funding': [
-                'card',
-                'credit',
-                'paylater',
-            ],
-            'enable-funding': [
-                'venmo',
-            ],
-        };
-
-        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, true);
-    });
-
-    it('initializes PaypalCommerce with enabled APMs', async () => {
-
-        paymentMethod.initializationData.availableAlternativePaymentMethods = ['sepa', 'venmo', 'sofort', 'mybank'];
-        paymentMethod.initializationData.enabledAlternativePaymentMethods = ['sofort', 'mybank'];
-        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
-
-        await strategy.initialize(options);
-
-        const obj = {
-                'client-id': 'abc',
-                commit: false,
-                currency: 'USD',
-                intent: 'capture',
-                components: ['buttons', 'messages'],
-                'disable-funding': [
-                    'card',
-                    'sepa',
-                    'venmo',
-                    'credit',
-                    'paylater',
-                    'venmo',
-                ],
-                'enable-funding': [
-                    'sofort',
-                    'mybank',
-                ],
-        };
-
-        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, undefined);
-    });
-
-    it('initializes PaypalCommerce with disabled APMs', async () => {
-        paymentMethod.initializationData.availableAlternativePaymentMethods = ['sepa', 'venmo', 'sofort', 'mybank'];
-        paymentMethod.initializationData.enabledAlternativePaymentMethods = [];
-        await store.dispatch(of(createAction(PaymentMethodActionType.LoadPaymentMethodsSucceeded, [paymentMethod])));
-
-        await strategy.initialize(options);
-
-        const obj = {
-                'client-id': 'abc',
-                commit: false,
-                currency: 'USD',
-                intent: 'capture',
-                components: ['buttons', 'messages'],
-                'disable-funding': [
-                    'card',
-                    'sepa',
-                    'venmo',
-                    'sofort',
-                    'mybank',
-                    'credit',
-                    'paylater',
-                    'venmo',
-                ],
-        };
-
-        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(obj, undefined, undefined);
     });
 
     it('render PayPal buttons', async () => {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
@@ -155,16 +155,6 @@ describe('PaypalCommerceVenmoButtonStrategy', () => {
             }
         });
 
-        it('throws error if client id is missing', async () => {
-            paymentMethodMock.initializationData.clientId = undefined;
-
-            try {
-                await strategy.initialize(initializationOptions);
-            } catch (error) {
-                expect(error).toBeInstanceOf(MissingDataError);
-            }
-        });
-
         it('loads paypal commerce sdk script', async () => {
             await strategy.initialize(initializationOptions);
 

--- a/packages/core/src/payment/payment-method.ts
+++ b/packages/core/src/payment/payment-method.ts
@@ -1,7 +1,7 @@
 import PaymentMethodConfig from './payment-method-config';
 import InitializationStrategy from './payment-method-initialization-strategy';
 
-export default interface PaymentMethod {
+export default interface PaymentMethod<T = any> {
     id: string;
     config: PaymentMethodConfig;
     method: string;
@@ -11,7 +11,7 @@ export default interface PaymentMethod {
     gateway?: string;
     logoUrl?: string;
     nonce?: string;
-    initializationData?: any;
+    initializationData?: T;
     returnUrl?: string;
     initializationStrategy?: InitializationStrategy;
 }

--- a/packages/core/src/payment/payment-methods.mock.ts
+++ b/packages/core/src/payment/payment-methods.mock.ts
@@ -94,6 +94,7 @@ export function getPaypalCommerce(): PaymentMethod {
         logoUrl: '',
         method: 'paypal',
         supportedCards: [],
+        clientToken: 'asdcvY7XFSQasd',
         config: {
             testMode: true,
             merchantId: 'JTS4DY7XFSQZE',
@@ -105,9 +106,13 @@ export function getPaypalCommerce(): PaymentMethod {
                 label: 'pay',
             },
             clientId: 'abc',
+            merchantId: 'JTS4DY7XFSQZE',
             orderId: '3U4171152W1482642',
+            attributionId: '1123JLKJASD12',
             intent: 'capture',
             isPayPalCreditAvailable: false,
+            isVenmoEnabled: false,
+            shouldRenderFields: true,
         },
         type: 'PAYMENT_TYPE_API',
     };

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
@@ -3,12 +3,17 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { of, Observable } from 'rxjs';
 
+import { Cart } from '../../../cart';
+import { getCart } from '../../../cart/carts.mock';
 import { createCheckoutStore, CheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { OrderActionCreator, OrderActionType } from '../../../order';
+import { PaymentMethod } from '../../../payment';
 import { PaymentInvalidFormError, PaymentMethodFailedError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
+import { getPaypalCommerce } from '../../payment-methods.mock';
+
 
 import { PaypalCommerceFormOptions, PaypalCommerceHostedForm, PaypalCommercePaymentProcessor, PaypalCommerceRequestSender, PaypalCommerceScriptLoader } from './index';
 
@@ -17,11 +22,13 @@ describe('PaypalCommerceHostedForm', () => {
     let hostedForm: PaypalCommerceHostedForm;
     let requestSender: RequestSender;
     let paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor;
+    let cart: Cart;
     let containers: HTMLElement[];
     let orderId: string;
     let store: CheckoutStore;
     let orderActionCreator: OrderActionCreator;
     let paymentActionCreator: PaymentActionCreator;
+    let paymentMethodMock: PaymentMethod;
     let submitOrderAction: Observable<Action>;
     let submitPaymentAction: Observable<Action>;
 
@@ -58,7 +65,9 @@ describe('PaypalCommerceHostedForm', () => {
             paymentActionCreator
         );
         requestSender = createRequestSender();
+        cart = getCart();
         orderId = 'orderId';
+        paymentMethodMock = getPaypalCommerce();
 
         formOptions = {
             fields: {
@@ -104,16 +113,16 @@ describe('PaypalCommerceHostedForm', () => {
     });
 
     it('initialize paypalCommercePaymentProcessor', async () => {
-        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
+        await hostedForm.initialize(formOptions, cart, paymentMethodMock.initializationData);
 
-        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith({ 'client-id': '' });
+        expect(paypalCommercePaymentProcessor.initialize).toHaveBeenCalledWith(paymentMethodMock.initializationData, cart.currency.code);
     });
 
     it('render hosted fields with form fields', async () => {
-        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
+        await hostedForm.initialize(formOptions, cart, paymentMethodMock.initializationData);
 
         expect(paypalCommercePaymentProcessor.renderHostedFields)
-            .toHaveBeenCalledWith('123', {
+            .toHaveBeenCalledWith(cart.id, {
                 fields: {
                     cvv: { selector: '#cardCode', placeholder: 'Card code' },
                     expirationDate: { selector: '#cardExpiry', placeholder: 'Card expiry' },
@@ -142,10 +151,10 @@ describe('PaypalCommerceHostedForm', () => {
                     instrumentId: 'foobar_instrument_id',
                 },
             },
-        }, '123', { 'client-id': '' });
+        }, cart, paymentMethodMock.initializationData);
 
         expect(paypalCommercePaymentProcessor.renderHostedFields)
-            .toHaveBeenCalledWith('123', {
+            .toHaveBeenCalledWith(cart.id, {
                 fields: {
                     cvv: { selector: '#cardCode', placeholder: 'Card code' },
                     number: { selector: '#cardNumber', placeholder: 'Card number' },
@@ -159,21 +168,21 @@ describe('PaypalCommerceHostedForm', () => {
     });
 
     it('submit hosted form should return orderId', async () => {
-        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
+        await hostedForm.initialize(formOptions, cart, paymentMethodMock.initializationData);
         const result = await hostedForm.submit();
 
         expect(result.orderId).toEqual(orderId);
     });
 
     it('submit hosted form should call submitHostedFields of paypalCommercePaymentProcessor', async () => {
-        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
+        await hostedForm.initialize(formOptions, cart, paymentMethodMock.initializationData);
         await hostedForm.submit();
 
         expect(paypalCommercePaymentProcessor.submitHostedFields).toHaveBeenCalled();
     });
 
     it('submit hosted form should call submitHostedFields with 3ds of paypalCommercePaymentProcessor', async () => {
-        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
+        await hostedForm.initialize(formOptions, cart, paymentMethodMock.initializationData);
         await hostedForm.submit(true);
 
         expect(paypalCommercePaymentProcessor.submitHostedFields).toHaveBeenCalledWith({
@@ -186,7 +195,7 @@ describe('PaypalCommerceHostedForm', () => {
         jest.spyOn(paypalCommercePaymentProcessor, 'submitHostedFields')
             .mockReturnValue(Promise.resolve({ orderId, liabilityShift: 'NO' }));
 
-        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
+        await hostedForm.initialize(formOptions, cart, paymentMethodMock.initializationData);
 
         await expect(hostedForm.submit(true)).rejects.toThrow(PaymentMethodFailedError);
     });
@@ -195,7 +204,7 @@ describe('PaypalCommerceHostedForm', () => {
         jest.spyOn(paypalCommercePaymentProcessor, 'getHostedFieldsValidationState')
             .mockReturnValue({ isValid: false, fields: {} });
 
-        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
+        await hostedForm.initialize(formOptions, cart, paymentMethodMock.initializationData);
 
         await expect(hostedForm.submit()).rejects.toThrow(PaymentInvalidFormError);
     });
@@ -217,7 +226,7 @@ describe('PaypalCommerceHostedForm', () => {
             cardNumber: [{ fieldType: 'cardNumber', message: 'Invalid card number', type: 'invalid_card_number' }],
         };
 
-        await hostedForm.initialize(formOptions, '123', { 'client-id': '' });
+        await hostedForm.initialize(formOptions, cart, paymentMethodMock.initializationData);
 
         try {
             await hostedForm.submit();

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
@@ -1,8 +1,10 @@
 import { isNil, kebabCase, omitBy } from 'lodash';
 
+import { Cart } from '../../../cart';
+import { PaymentMethod } from '../../../payment';
 import { PaymentInvalidFormError, PaymentInvalidFormErrorDetails, PaymentMethodFailedError } from '../../errors';
 
-import { PaypalCommerceFormFieldStyles, PaypalCommerceFormFieldStylesMap, PaypalCommerceFormFieldType, PaypalCommerceFormFieldValidateErrorData, PaypalCommerceFormFieldValidateEventData, PaypalCommerceFormOptions, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceHostedFieldsSubmitOptions, PaypalCommercePaymentProcessor, PaypalCommerceRegularField, PaypalCommerceScriptParams } from './index';
+import { PaypalCommerceFormFieldStyles, PaypalCommerceFormFieldStylesMap, PaypalCommerceFormFieldType, PaypalCommerceFormFieldValidateErrorData, PaypalCommerceFormFieldValidateEventData, PaypalCommerceFormOptions, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceHostedFieldsSubmitOptions, PaypalCommerceInitializationData, PaypalCommercePaymentProcessor, PaypalCommerceRegularField } from './index';
 import { PaypalCommerceFormFieldsMap, PaypalCommerceStoredCardFieldsMap } from './paypal-commerce-payment-initialize-options';
 
 enum PaypalCommerceHostedFormType {
@@ -17,11 +19,10 @@ export default class PaypalCommerceHostedForm {
 
     constructor(
         private _paypalCommercePaymentProcessor: PaypalCommercePaymentProcessor
-    ) {
-    }
+    ) {}
 
-    async initialize(options: PaypalCommerceFormOptions, cartId: string, paramsScript: PaypalCommerceScriptParams) {
-        await this._paypalCommercePaymentProcessor.initialize(paramsScript);
+    async initialize(options: PaypalCommerceFormOptions, cart: Cart, paymentMethod: PaymentMethod<PaypalCommerceInitializationData>) {
+        await this._paypalCommercePaymentProcessor.initialize(paymentMethod, cart.currency.code);
 
         this._formOptions = options;
         this._type = this._isPaypalCommerceFormFieldsMap(options.fields) ?
@@ -39,7 +40,7 @@ export default class PaypalCommerceHostedForm {
             inputSubmitRequest: this._handleInputSubmitRequest,
         };
 
-        await this._paypalCommercePaymentProcessor.renderHostedFields(cartId, params, events);
+        await this._paypalCommercePaymentProcessor.renderHostedFields(cart.id, params, events);
 
         if (this._isPaypalCommerceFormFieldsMap(options.fields)) {
             this._cardNameField = new PaypalCommerceRegularField(
@@ -244,5 +245,4 @@ export default class PaypalCommerceHostedForm {
             errors: this._mapValidationErrors(event.fields),
         });
     };
-
 }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -3,11 +3,12 @@ import { isNil, omitBy } from 'lodash';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { NotImplementedError, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 import { OrderActionCreator } from '../../../order';
+import { PaymentMethod } from '../../../payment';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentStrategyType from '../../payment-strategy-type';
 
-import { ButtonsOptions, FieldsOptions, NON_INSTANT_PAYMENT_METHODS, ParamsForProvider, PaypalButtonStyleOptions, PaypalCommerceButtons, PaypalCommerceFields, PaypalCommerceHostedFields, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceHostedFieldsSubmitOptions, PaypalCommerceMessages, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceScriptParams, PaypalCommerceSDK, PaypalCommerceSDKFunding, PaypalFieldsStyleOptions, StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape } from './index';
+import { ButtonsOptions, FieldsOptions, NON_INSTANT_PAYMENT_METHODS, ParamsForProvider, PaypalButtonStyleOptions, PaypalCommerceButtons, PaypalCommerceFields, PaypalCommerceHostedFields, PaypalCommerceHostedFieldsApprove, PaypalCommerceHostedFieldsRenderOptions, PaypalCommerceHostedFieldsState, PaypalCommerceHostedFieldsSubmitOptions, PaypalCommerceInitializationData, PaypalCommerceMessages, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, PaypalCommerceSDKFunding, PaypalFieldsStyleOptions, StyleButtonColor, StyleButtonLabel, StyleButtonLayout, StyleButtonShape } from './index';
 
 export interface OptionalParamsRenderButtons {
     paramsForProvider?: ParamsForProvider;
@@ -55,10 +56,10 @@ export default class PaypalCommercePaymentProcessor {
         private _paymentActionCreator: PaymentActionCreator
     ) {}
 
-    async initialize(paramsScript: PaypalCommerceScriptParams, gatewayId?: string, isVenmoEnabled?: boolean): Promise<PaypalCommerceSDK> {
-        this._paypal = await this._paypalScriptLoader.loadPaypalCommerce(paramsScript);
-        this._gatewayId = gatewayId;
-        this._isVenmoEnabled = isVenmoEnabled;
+    async initialize(paymentMethod: PaymentMethod<PaypalCommerceInitializationData>, currencyCode: string): Promise<PaypalCommerceSDK> {
+        this._paypal = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currencyCode);
+        this._gatewayId = paymentMethod.gateway;
+        this._isVenmoEnabled = paymentMethod.initializationData?.isVenmoEnabled;
 
         return this._paypal;
     }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -1,9 +1,11 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
+import { isNil, omitBy } from 'lodash';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { PaymentMethod } from '../../../payment';
 
-import { InvalidArgumentError } from '../../../common/error/errors';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
-import { PaypalCommerceHostWindow, PaypalCommerceScriptParams, PaypalCommerceSDK } from './paypal-commerce-sdk';
+import { FundingType, PaypalCommerceHostWindow, PaypalCommerceInitializationData, PaypalCommerceScriptParams, PaypalCommerceSDK } from './paypal-commerce-sdk';
 
 export default class PaypalCommerceScriptLoader {
     private _window: PaypalCommerceHostWindow;
@@ -14,46 +16,92 @@ export default class PaypalCommerceScriptLoader {
         this._window = window;
     }
 
-    async loadPaypalCommerce(params: PaypalCommerceScriptParams): Promise<PaypalCommerceSDK> {
-        if (!this._window.paypal) {
-            this._validateParams(params);
+    async loadPaypalCommerce(
+        paymentMethod: PaymentMethod<PaypalCommerceInitializationData>,
+        currency: string,
+        initializesOnCheckoutPage?: boolean,
+    ): Promise<PaypalCommerceSDK> {
+        const paypalSdkScriptConfig = this._getPayPalSdkScriptConfigOrThrow(paymentMethod, currency, initializesOnCheckoutPage);
+
+        if (!this._window.paypalLoadScript) {
+            const PAYPAL_SDK_VERSION = '5.0.5';
+            const scriptSrc = `https://unpkg.com/@paypal/paypal-js@${PAYPAL_SDK_VERSION}/dist/iife/paypal-js.min.js`;
+
+            await this._scriptLoader.loadScript(scriptSrc, { async: true, attributes: {} });
 
             if (!this._window.paypalLoadScript) {
-                const PAYPAL_SDK_VERSION = '5.0.5';
-                const scriptSrc = `https://unpkg.com/@paypal/paypal-js@${PAYPAL_SDK_VERSION}/dist/iife/paypal-js.min.js`;
-
-                await this._scriptLoader.loadScript(scriptSrc, { async: true, attributes: {} });
-
-                if (!this._window.paypalLoadScript) {
-                    throw new PaymentMethodClientUnavailableError();
-                }
-            }
-
-            await this._window.paypalLoadScript(params);
-
-            if (!this._window.paypal) {
                 throw new PaymentMethodClientUnavailableError();
             }
+        }
+
+        await this._window.paypalLoadScript(paypalSdkScriptConfig);
+
+        if (!this._window.paypal) {
+            throw new PaymentMethodClientUnavailableError();
         }
 
         return this._window.paypal;
     }
 
-    private _validateParams(options: PaypalCommerceScriptParams): void {
-        const CLIENT_ID = 'client-id';
-        const MERCHANT_ID = 'merchant-id';
-        let param;
+    private _getPayPalSdkScriptConfigOrThrow(
+        paymentMethod: PaymentMethod<PaypalCommerceInitializationData>,
+        currency: string,
+        initializesOnCheckoutPage = true,
+    ): PaypalCommerceScriptParams {
+        const { id, clientToken, initializationData } = paymentMethod;
 
-        if (!options) {
-            param = 'options';
-        } else if (!options[CLIENT_ID]) {
-            param = CLIENT_ID;
-        } else if (!options[MERCHANT_ID]) {
-            param = MERCHANT_ID;
+        if (!initializationData?.clientId) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        if (param) {
-            throw new InvalidArgumentError(`Unable to proceed because "${param}" argument in PayPal script is not provided.`);
+        const {
+            intent,
+            clientId,
+            merchantId,
+            attributionId,
+            isVenmoEnabled,
+            isHostedCheckoutEnabled,
+            isInlineCheckoutEnabled,
+            isPayPalCreditAvailable,
+            availableAlternativePaymentMethods = [],
+            enabledAlternativePaymentMethods = [],
+        } = initializationData;
+
+        const shouldShowInlineCheckout = !initializesOnCheckoutPage && isInlineCheckoutEnabled;
+
+        const commit = shouldShowInlineCheckout || isHostedCheckoutEnabled || initializesOnCheckoutPage;
+
+        const shouldEnableCard = shouldShowInlineCheckout || id === 'paypalcommercecreditcards';
+        const enableCardFunding = shouldEnableCard ? ['card'] : [];
+        const disableCardFunding = !shouldEnableCard ? ['card'] : [];
+
+        const enableCreditFunding = isPayPalCreditAvailable ? ['credit', 'paylater'] : [];
+        const disableCreditFunding = !isPayPalCreditAvailable ? ['credit', 'paylater'] : [];
+
+        const shouldEnableAPMs = !shouldShowInlineCheckout && !isHostedCheckoutEnabled; // should disable APMs if Inline Checkout or Shipping Options feature enabled
+        const enableVenmoFunding = shouldEnableAPMs && isVenmoEnabled ? ['venmo'] : [];
+        const disableVenmoFunding = !shouldEnableAPMs || !isVenmoEnabled ? ['venmo'] : [];
+        const enableAPMsFunding = shouldEnableAPMs ? enabledAlternativePaymentMethods : [];
+        const disableAPMsFunding = shouldEnableAPMs
+            ? availableAlternativePaymentMethods.filter((apm: string) => !enabledAlternativePaymentMethods.includes(apm))
+            : availableAlternativePaymentMethods;
+
+        const disableFunding: FundingType = [...disableCardFunding, ...disableCreditFunding, ...disableVenmoFunding, ...disableAPMsFunding];
+        const enableFunding: FundingType = [...enableCardFunding, ...enableCreditFunding, ...enableVenmoFunding, ...enableAPMsFunding];
+
+        const scriptConfiguretion: PaypalCommerceScriptParams = {
+            'client-id': clientId,
+            'data-partner-attribution-id': attributionId,
+            'data-client-token': clientToken,
+            'merchant-id': merchantId,
+            'enable-funding': enableFunding,
+            'disable-funding': disableFunding,
+            commit,
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            currency,
+            intent,
         }
+
+        return omitBy(scriptConfiguretion, isNil);
     }
 }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -230,6 +230,8 @@ export interface PaypalCommerceInitializationData {
     buyerCountry?: string;
     isDeveloperModeApplicable?: boolean;
     intent?: 'capture' | 'authorize';
+    isHostedCheckoutEnabled?: boolean;
+    isInlineCheckoutEnabled?: boolean;
     isPayPalCreditAvailable?: boolean;
     availableAlternativePaymentMethods: FundingType;
     enabledAlternativePaymentMethods: FundingType;
@@ -241,7 +243,7 @@ export interface PaypalCommerceInitializationData {
 export type ComponentsScriptType = Array<'buttons' | 'messages' | 'hosted-fields' | 'payment-fields'>;
 
 export interface PaypalCommerceScriptParams  {
-    'client-id': string;
+    'client-id'?: string;
     'merchant-id'?: string;
     'buyer-country'?: string;
     'disable-funding'?: FundingType;


### PR DESCRIPTION
## What?
Added script options configuration method for PayPalCommerce to have only place where contain the logic with PayPal SDK configuration.

## Why?
It might help us to avoid unnecessary extra script loading with different configuration, what sometimes causes some errors

## Testing / Proof
Unit tests
Manual tests
