### PR TITLE
feat(payment): BOLT-255 remove experiment for last four digits type

### DIFF
--- a/packages/core/src/payment/payment.ts
+++ b/packages/core/src/payment/payment.ts
@@ -146,8 +146,8 @@ export interface PaypalInstrument {
 interface BoltInstrument {
     credit_card_token: {
         token: string;
-        last_four_digits: string | number; // TODO: remove number type after Bolt-203 will be deployed and approved
-        iin: string | number; // TODO: remove number type after Bolt-203 will be deployed and approved
+        last_four_digits: string;
+        iin: string;
         expiration_month: number;
         expiration_year: number;
         brand?: string;

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -542,52 +542,6 @@ describe('BoltPaymentStrategy', () => {
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(submitPaymentOptions);
         });
 
-        it('check card number digits with disabled BOLT-203 experiment', async () => {
-            const config = getConfig();
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow')
-                .mockReturnValue({
-                    ...config.storeConfig,
-                    checkoutSettings: {
-                        ...config.storeConfig.checkoutSettings,
-                        features: {
-                            'BOLT-203.Bolt_string_type_of_token_card_data': false,
-                        },
-                    },
-                });
-
-            const submitPaymentOptions = {
-                methodId: 'bolt',
-                paymentData: {
-                    formattedPayload: {
-                        credit_card_token: {
-                            token: 'token',
-                            last_four_digits: 1111,
-                            iin: 1111,
-                            expiration_month: 11,
-                            expiration_year: 2022,
-                        },
-                        provider_data: {
-                            create_account: false,
-                            embedded_checkout: true,
-                        },
-                    },
-                },
-            };
-
-            const boltEmbeddedPayload = {
-                payment: {
-                    methodId: 'bolt',
-                    paymentData: {
-                        shouldCreateAccount: false,
-                    },
-                },
-            };
-
-            paymentMethodMock.initializationData.embeddedOneClickEnabled = true;
-            await strategy.initialize(boltEmbeddedScriptInitializationOptions);
-            await strategy.execute(boltEmbeddedPayload);
-            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(submitPaymentOptions);
-        });
     });
 
     describe('#deinitialize()', () => {

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -215,8 +215,8 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
                 formattedPayload: {
                     credit_card_token: {
                         token: tokenizeResult.token,
-                        last_four_digits: this._getCardDigitsData(tokenizeResult.last4), // TODO: leave origin data type (string) after Bolt-203 will be deployed and approved
-                        iin: this._getCardDigitsData(tokenizeResult.bin), // TODO: leave origin data type (string) after Bolt-203 will be deployed and approved
+                        last_four_digits: tokenizeResult.last4,
+                        iin: tokenizeResult.bin,
                         expiration_month: +tokenizeResult.expiration.split('-')[1],
                         expiration_year: +tokenizeResult.expiration.split('-')[0],
                     },
@@ -229,20 +229,6 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
         };
 
         return this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload));
-    }
-
-    /**
-     * The method get string data of card number digits and return it in different types based on experement result
-     * number - old type, this type has bug BOLT-203
-     * string - new type, this type will fix bug BOLT-203
-     * experiment 'BOLT-203.Bolt_string_type_of_token_card_data' was added to fast revert type changes on production if such will be found
-     * was added 04.04.2022 and should be removed after fix for BOLT-203 will be deployed and approved on Tier3
-     *
-     * @param data string
-     * @returns string | number
-     */
-    private _getCardDigitsData(data: string): string | number {
-        return this._store.getState().config.getStoreConfigOrThrow().checkoutSettings.features['BOLT-203.Bolt_string_type_of_token_card_data'] === true ? data : +data;
     }
 
     /**

--- a/packages/payment-integration/src/payment/payment.ts
+++ b/packages/payment-integration/src/payment/payment.ts
@@ -146,8 +146,8 @@ export interface PaypalInstrument {
 interface BoltInstrument {
     credit_card_token: {
         token: string;
-        last_four_digits: string | number; // TODO: remove number type after Bolt-203 will be deployed and approved
-        iin: string | number; // TODO: remove number type after Bolt-203 will be deployed and approved
+        last_four_digits: string;
+        iin: string;
         expiration_month: number;
         expiration_year: number;
         brand?: string;


### PR DESCRIPTION
## What?
Remove experiment `BOLT-203.Bolt_string_type_of_token_card_data` for last four digits type

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-255](https://bigcommercecloud.atlassian.net/browse/BOLT-255)

## Testing / Proof
<img width="749" alt="Screenshot 2022-07-11 at 17 57 34" src="https://user-images.githubusercontent.com/9430298/178294638-ae089de6-3255-4b16-b02c-4ef41d4a558e.png">

BCapp PR: https://github.com/bigcommerce/bigcommerce/pull/47329


@bigcommerce/checkout @bigcommerce/payments
