### PR TITLE
fix(payment): STRIPE-51 set a stored card as default during checkout

### DIFF
--- a/packages/core/src/payment/payment.ts
+++ b/packages/core/src/payment/payment.ts
@@ -18,7 +18,7 @@ export type PaymentInstrument = (
     CreditCardInstrument & WithCheckoutcomFawryInstrument |
     CreditCardInstrument & WithCheckoutcomSEPAInstrument |
     CryptogramInstrument |
-    FormattedPayload<AdyenV2Instrument | AppleInstrument | BoltInstrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | WithCheckoutcomiDealInstrument | WithCheckoutcomFawryInstrument | WithCheckoutcomSEPAInstrument | StripeV3Intent | StripeUPEIntent | WithMollieIssuerInstrument> |
+    FormattedPayload<AdyenV2Instrument | AppleInstrument | BoltInstrument | PaypalInstrument | FormattedHostedInstrument | FormattedVaultedInstrument | WithDocumentInstrument | WithCheckoutcomiDealInstrument | WithCheckoutcomFawryInstrument | WithCheckoutcomSEPAInstrument | StripeV3Intent | StripeUPEIntent | WithMollieIssuerInstrument | StripeV3FormattedPayload> |
     HostedInstrument |
     NonceInstrument |
     ThreeDSVaultedInstrument |
@@ -211,4 +211,17 @@ export interface FormattedVaultedInstrument {
 
 export interface FormattedPayload<T> {
     formattedPayload: T;
+}
+
+export interface StripeV3FormattedPayload {
+    credit_card_token?: {
+        token: string;
+    };
+    vault_payment_instrument?: boolean;
+    confirm: boolean;
+    set_as_default_stored_instrument?: boolean;
+    client_token?: string;
+    bigpay_token?: {
+        token: string;
+    }
 }

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -142,18 +142,20 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             return Promise.reject(error);
         }
 
+        const formattedPayload = {
+            credit_card_token: {
+                token,
+            },
+            vault_payment_instrument: shouldSaveInstrument,
+            set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
+            browser_info: getBrowserInfo(),
+            shopper_locale: this._getShopperLocale(),
+        }
+
         return await this._store.dispatch(this._paymentActionCreator.submitPayment({
             ...payment,
             paymentData: {
-                formattedPayload: {
-                    credit_card_token: {
-                        token,
-                    },
-                    vault_payment_instrument: shouldSaveInstrument,
-                    set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
-                    browser_info: getBrowserInfo(),
-                    shopper_locale: this._getShopperLocale(),
-                },
+                formattedPayload,
             },
         }));
     }

--- a/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -293,8 +293,8 @@ describe('StripeV3PaymentStrategy', () => {
                                 token: 'token',
                             },
                             confirm: true,
+                            set_as_default_stored_instrument: true,
                         },
-                        shouldSetAsDefaultInstrument: true,
                     }}
                 );
             });


### PR DESCRIPTION
## What?
Add `shouldSetAsDefaultInstrument` method to the `formattedPayload`  

## Why?
In order to have stored card as default during checkout.

## Testing / Proof

https://user-images.githubusercontent.com/67211919/178614708-732edf9e-226d-4438-8f2f-e3103c7bb617.mov



@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
