### PR TITLE
feat(payment): INT-6128 AmazonPayV2: Introduce the new API V2 config

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
@@ -1,6 +1,6 @@
-import { AmazonPayV2ButtonParams } from '../../../payment/strategies/amazon-pay-v2';
+import { AmazonPayV2ButtonParameters } from '../../../payment/strategies/amazon-pay-v2';
 
 /**
  * The required config to render the AmazonPayV2 buttton.
  */
-export type AmazonPayV2ButtonInitializeOptions = AmazonPayV2ButtonParams;
+export type AmazonPayV2ButtonInitializeOptions = AmazonPayV2ButtonParameters;

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -7,7 +7,7 @@ import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfig } from '../../../config/configs.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
-import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
+import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor, AmazonPayV2Placement, AmazonPayV2ButtonParams } from '../../../payment/strategies/amazon-pay-v2';
 import { getAmazonPayV2ButtonParamsMock } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
@@ -87,14 +87,14 @@ describe('AmazonPayV2ButtonStrategy', () => {
         });
 
         it('creates the button', async () => {
-            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            const expectedOptions = getAmazonPayV2ButtonParamsMock() as AmazonPayV2ButtonParams;
             expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
             expectedOptions.placement = AmazonPayV2Placement.Cart;
 
             await strategy.initialize(checkoutButtonOptions);
 
             expect(paymentProcessor.createButton).toHaveBeenCalledWith(
-                '#amazonpayCheckoutButton',
+                'amazonpayCheckoutButton',
                 expectedOptions
             );
         });

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -1,30 +1,26 @@
-import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
-import { getConfig, getConfigState } from '../../../config/configs.mock';
+import { getConfig } from '../../../config/configs.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
-import { getAmazonPayV2, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
-import { getAmazonPayV2ButtonParamsMock, getPaymentMethodMockUndefinedMerchant } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
+import { getAmazonPayV2ButtonParamsMock } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
 import AmazonPayV2ButtonStrategy from './amazon-pay-v2-button-strategy';
 import { getAmazonPayV2CheckoutButtonOptions, Mode } from './amazon-pay-v2-button.mock';
 
 describe('AmazonPayV2ButtonStrategy', () => {
-    let container: HTMLDivElement;
-    let formPoster: FormPoster;
     let checkoutButtonOptions: CheckoutButtonInitializeOptions;
     let paymentProcessor: AmazonPayV2PaymentProcessor;
     let checkoutActionCreator: CheckoutActionCreator;
     let requestSender: RequestSender;
     let store: CheckoutStore;
     let strategy: AmazonPayV2ButtonStrategy;
-    let walletButton: HTMLAnchorElement;
 
     beforeEach(() => {
         store = createCheckoutStore(getCheckoutStoreState());
@@ -39,216 +35,107 @@ describe('AmazonPayV2ButtonStrategy', () => {
 
         paymentProcessor = createAmazonPayV2PaymentProcessor();
 
-        formPoster = createFormPoster();
-
         strategy = new AmazonPayV2ButtonStrategy(
             store,
             checkoutActionCreator,
             paymentProcessor
         );
 
-        jest.spyOn(store, 'dispatch')
-            .mockReturnValue(Promise.resolve(store.getState()));
+        checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
 
         jest.spyOn(paymentProcessor, 'initialize')
             .mockReturnValue(Promise.resolve());
 
-        jest.spyOn(formPoster, 'postForm')
-            .mockReturnValue(Promise.resolve());
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout')
+            .mockResolvedValue(store.getState());
 
-        container = document.createElement('div');
-        container.setAttribute('id', 'amazonpayCheckoutButton');
-        walletButton = document.createElement('a');
-        walletButton.setAttribute('id', 'mockButton');
+        const buttonContainer = document.createElement('div');
+        buttonContainer.setAttribute('id', 'amazonpayCheckoutButton');
+        document.body.appendChild(buttonContainer);
 
         jest.spyOn(paymentProcessor, 'createButton')
-            .mockReturnValue(walletButton);
-
-        container.appendChild(walletButton);
-        document.body.appendChild(container);
+            .mockReturnValue(document.createElement('button'));
     });
 
     afterEach(() => {
-        document.body.removeChild(container);
+        const buttonContainer = document.getElementById('amazonpayCheckoutButton');
+
+        if (buttonContainer) {
+            document.body.removeChild(buttonContainer);
+        }
     });
 
     describe('#initialize()', () => {
-        it('creates the button', async () => {
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
-
-            await strategy.initialize(checkoutButtonOptions);
-
-            expect(paymentProcessor.createButton).toHaveBeenCalledWith(
-                '#amazonpayCheckoutButton',
-                getAmazonPayV2ButtonParamsMock()
-            );
-        });
-
-        it('creates the button and validates if cart contains physical items', async () => {
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
-            jest.spyOn(store.getState().cart, 'getCart')
-                .mockReturnValue({...store.getState().cart.getCart(), lineItems : {physicalItems: []}});
-
-            await strategy.initialize(checkoutButtonOptions);
-
-            expect(paymentProcessor.createButton).toHaveBeenCalledWith(
-                '#amazonpayCheckoutButton',
-                getAmazonPayV2ButtonParamsMock()
-            );
-        });
-
-        it('fails to initialize the strategy if there is no payment method data', async () => {
-            const paymentMethods = { ...getPaymentMethodsState(), data: undefined };
-            const state = { ...getCheckoutStoreState(), paymentMethods };
-            store = createCheckoutStore(state);
-            strategy = new AmazonPayV2ButtonStrategy(
-                store,
-                checkoutActionCreator,
-                paymentProcessor
-            );
-
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
-
-            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(MissingDataError);
-        });
-
-        it('fails to create button if there is no store config data', async () => {
-            const config = { ...getConfigState(), data: undefined };
-            const state = { ...getCheckoutStoreState(), config };
-            store = createCheckoutStore(state);
-
-            jest.spyOn(store, 'dispatch')
-                .mockReturnValue(Promise.resolve(store.getState()));
-
-            strategy = new AmazonPayV2ButtonStrategy(
-                store,
-                checkoutActionCreator,
-                paymentProcessor
-            );
-
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
-
-            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(MissingDataError);
-        });
-
-        it('fails to create button if merchantId is not provided', async () => {
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(getPaymentMethodMockUndefinedMerchant());
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
-
-            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(MissingDataError);
-        });
-
         it('initialises the payment processor once', async () => {
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
-
             await strategy.initialize(checkoutButtonOptions);
 
             expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
         });
 
-        it('fails to initialize the strategy if containerId is not provided', async () => {
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedContainer);
+        it('loads the checkout if AmazonPayV2ButtonInitializeOptions is not provided', async () => {
+            await strategy.initialize(checkoutButtonOptions);
 
-            await expect( strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalledTimes(1);
         });
 
-        it('fails to create button if not a valid containerId is provided', async () => {
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.InvalidContainer);
+        it('does not load the checkout if AmazonPayV2ButtonInitializeOptions is provided', async () => {
+            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
 
-            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(checkoutActionCreator.loadDefaultCheckout).not.toHaveBeenCalled();
         });
 
-        it('loads the checkout and creates the button if AmazonPayV2ButtonInitializeOptions is not provided', async () => {
+        it('creates the button', async () => {
             const expectedOptions = getAmazonPayV2ButtonParamsMock();
             expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
             expectedOptions.placement = AmazonPayV2Placement.Cart;
 
-            jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout');
-
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
-
             await strategy.initialize(checkoutButtonOptions);
 
-            expect(checkoutActionCreator.loadDefaultCheckout).toBeCalled();
-            expect(paymentProcessor.createButton).toHaveBeenCalledWith('#amazonpayCheckoutButton', expectedOptions);
+            expect(paymentProcessor.createButton).toHaveBeenCalledWith(
+                '#amazonpayCheckoutButton',
+                expectedOptions
+            );
         });
 
-        it('creates the button with a realtive url if AmazonPayV2ButtonInitializeOptions is not provided', async () => {
-            const config = getConfig();
+        describe('should fail...', () => {
+            test('if methodId is not provided', async () => {
+                checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedMethodId);
 
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow')
-                .mockReturnValue({
-                    ...config.storeConfig,
-                    checkoutSettings: {
-                        ...config.storeConfig.checkoutSettings,
-                        features: {
-                            'INT-5826.amazon_relative_url': true,
-                        },
-                    },
-                });
+                await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+            });
 
-            const expectedOptions = getAmazonPayV2ButtonParamsMock();
-            expectedOptions.createCheckoutSession.url = `/remote-checkout/amazonpay/payment-session`;
-            expectedOptions.placement = AmazonPayV2Placement.Cart;
+            test('if containerId is not provided', async () => {
+                checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedContainer);
 
-            jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout');
+                await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+            });
 
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
+            test('if there is no payment method data', async () => {
+                const paymentMethods = { ...getPaymentMethodsState(), data: undefined };
+                const state = { ...getCheckoutStoreState(), paymentMethods };
+                store = createCheckoutStore(state);
+                strategy = new AmazonPayV2ButtonStrategy(
+                    store,
+                    checkoutActionCreator,
+                    paymentProcessor
+                );
 
-            await strategy.initialize(checkoutButtonOptions);
-
-            expect(checkoutActionCreator.loadDefaultCheckout).toBeCalled();
-            expect(paymentProcessor.createButton).toHaveBeenCalledWith('#amazonpayCheckoutButton', expectedOptions);
+                await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(MissingDataError);
+            });
         });
 
-        it('fails to initialize the strategy if methodId is not provided', async () => {
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedMethodId);
-
-            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
-        });
-
-        it('fails to create button if ledgerCurrency is not provided', async () => {
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
-                .mockReturnValue({ ...getAmazonPayV2(), initializationData: { ledgerCurrency: '' } });
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
-
-            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(MissingDataError);
-        });
-
-        it('fails to create button if shopPath is not provided', async () => {
-            const storeConfig = getConfig().storeConfig;
-            storeConfig.storeProfile.shopPath = '';
-            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow')
-                .mockReturnValue(storeConfig);
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
-
-            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(MissingDataError);
-        });
     });
 
     describe('#deinitialize()', () => {
-        let checkoutButtonOptions: CheckoutButtonInitializeOptions;
-
-        beforeEach(() => {
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.Full);
-            container = document.createElement('div');
-        });
-
-        afterEach(() => {
-            document.body.appendChild(container);
-        });
-
         it('succesfully deinitializes the strategy', async () => {
             await strategy.initialize(checkoutButtonOptions);
-
             await strategy.deinitialize();
-            const button = document.getElementById(checkoutButtonOptions.containerId);
 
-            expect(button).toBe(null);
-        });
+            const buttonContainer = document.getElementById(checkoutButtonOptions.containerId);
 
-        it('run deinitializes without calling initialize', async () => {
-            await expect(strategy.deinitialize()).resolves.toBe(undefined);
+            expect(buttonContainer).toBeNull();
         });
     });
 });

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -1,12 +1,8 @@
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
-import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { PaymentMethod } from '../../../payment';
-import { AmazonPayV2ButtonParams, AmazonPayV2PaymentProcessor, AmazonPayV2PayOptions, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
-import { getShippableItemsCount } from '../../../shipping';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { AmazonPayV2PaymentProcessor, AmazonPayV2Placement } from '../../../payment/strategies/amazon-pay-v2';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
-
-import { AmazonPayV2ButtonInitializeOptions } from './amazon-pay-v2-button-options';
 
 export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy {
     private _walletButton?: HTMLElement;
@@ -18,16 +14,27 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
     ) { }
 
     async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
-        const { containerId, methodId, amazonpay } = options;
+        const { methodId, containerId, amazonpay } = options;
 
-        if (!containerId || !methodId) {
-            throw new InvalidArgumentError('Unable to proceed because "containerId" or "methodId" argument is not provided.');
+        if (!methodId || !containerId) {
+            throw new InvalidArgumentError('Unable to proceed because "methodId" or "containerId" argument is not provided.');
         }
 
-        const paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(methodId);
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
 
-        await this._amazonPayV2PaymentProcessor.initialize(paymentMethod);
-        this._walletButton = await this._createSignInButton(containerId, paymentMethod, amazonpay);
+        await this._amazonPayV2PaymentProcessor.initialize(getPaymentMethodOrThrow(methodId));
+
+        if (!amazonpay) {
+            await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        }
+
+        this._walletButton = this._amazonPayV2PaymentProcessor.renderAmazonPayButton(
+            containerId,
+            this._store.getState(),
+            methodId,
+            AmazonPayV2Placement.Cart,
+            amazonpay
+        );
     }
 
     deinitialize(): Promise<void> {
@@ -37,61 +44,5 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
         }
 
         return Promise.resolve();
-    }
-
-    private async _createSignInButton(containerId: string, paymentMethod: PaymentMethod, options?: AmazonPayV2ButtonInitializeOptions): Promise<HTMLElement> {
-        const container = document.getElementById(containerId);
-
-        if (!container) {
-            throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
-        }
-
-        const amazonButtonOptions = options ?? await this._getAmazonPayV2ButtonOptions(paymentMethod);
-
-        this._amazonPayV2PaymentProcessor.createButton(`#${containerId}`, amazonButtonOptions);
-
-        return container;
-    }
-
-    private async _getAmazonPayV2ButtonOptions(paymentMethod: PaymentMethod): Promise<AmazonPayV2ButtonParams> {
-        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
-        const cart = state.cart.getCart();
-        const { storeProfile: { shopPath }, checkoutSettings: { features } } = state.config.getStoreConfigOrThrow();
-
-        const {
-            config: {
-                merchantId,
-                testMode,
-            },
-            initializationData: {
-                checkoutLanguage,
-                ledgerCurrency,
-                checkoutSessionMethod,
-                extractAmazonCheckoutSessionId,
-            },
-        } = paymentMethod;
-
-        if (!merchantId || !ledgerCurrency || !shopPath) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
-
-        return {
-            merchantId,
-            createCheckoutSession: {
-                // tslint:disable-next-line: no-string-literal
-                url: features['INT-5826.amazon_relative_url']
-                    ? `/remote-checkout/${paymentMethod.id}/payment-session`
-                    : `${shopPath}/remote-checkout/${paymentMethod.id}/payment-session`,
-                method: checkoutSessionMethod,
-                extractAmazonCheckoutSessionId,
-            },
-            sandbox: !!testMode,
-            ledgerCurrency,
-            checkoutLanguage,
-            productType: cart && getShippableItemsCount(cart) === 0 ?
-                AmazonPayV2PayOptions.PayOnly :
-                AmazonPayV2PayOptions.PayAndShip,
-            placement: AmazonPayV2Placement.Cart,
-        };
     }
 }

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
@@ -10,7 +10,7 @@ import { getConfig } from '../../../config/configs.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
-import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor } from '../../../payment/strategies/amazon-pay-v2';
+import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor, AmazonPayV2ButtonParams } from '../../../payment/strategies/amazon-pay-v2';
 import { getAmazonPayV2ButtonParamsMock } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { CustomerInitializeOptions } from '../../customer-request-options';
@@ -93,13 +93,13 @@ describe('AmazonPayV2CustomerStrategy', () => {
         });
 
         it('creates the button', async () => {
-            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            const expectedOptions = getAmazonPayV2ButtonParamsMock() as AmazonPayV2ButtonParams;
             expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
 
             await strategy.initialize(customerInitializeOptions);
 
             expect(paymentProcessor.createButton).toHaveBeenCalledWith(
-                '#amazonpayCheckoutButton',
+                'amazonpayCheckoutButton',
                 expectedOptions
             );
         });

--- a/packages/core/src/payment/payment-methods.mock.ts
+++ b/packages/core/src/payment/payment-methods.mock.ts
@@ -312,8 +312,13 @@ export function getAmazonPayV2(region = 'us'): PaymentMethod {
             buttonColor: 'Gold',
             checkoutLanguage: 'en_US',
             checkoutSessionMethod: 'GET',
+            createCheckoutSessionConfig: {
+                payloadJSON: 'payload',
+                signature: 'xxxx',
+            },
             extractAmazonCheckoutSessionId: 'token',
             ledgerCurrency: 'USD',
+            publicKeyId: 'SANDBOX-XXXXXXXX',
             region,
         },
         logoUrl: '',

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -1,12 +1,16 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { NotInitializedError } from '../../../common/error/errors';
-import { getAmazonPayV2 } from '../../payment-methods.mock';
+import { getConfig, getConfigState } from '../../../../src/config/configs.mock';
+import { getCart } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../../common/error/errors';
+import { getAmazonPayV2, getPaymentMethodsState } from '../../payment-methods.mock';
 
-import { AmazonPayV2ButtonParams, AmazonPayV2SDK } from './amazon-pay-v2';
+import { AmazonPayV2ButtonParams, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
 import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
-import { getAmazonPayV2ButtonParamsMock, getAmazonPayV2SDKMock } from './amazon-pay-v2.mock';
+import { getAmazonPayV2ButtonParamsMock, getAmazonPayV2SDKMock, getPaymentMethodMockUndefinedLedgerCurrency, getPaymentMethodMockUndefinedMerchant } from './amazon-pay-v2.mock';
 
 describe('AmazonPayV2PaymentProcessor', () => {
     let amazonPayV2ScriptLoader: AmazonPayV2ScriptLoader;
@@ -15,29 +19,40 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
     beforeEach(() => {
         amazonPayV2ScriptLoader = new AmazonPayV2ScriptLoader(createScriptLoader());
+
         processor = new AmazonPayV2PaymentProcessor(
             amazonPayV2ScriptLoader
         );
+
         amazonPayV2SDKMock = getAmazonPayV2SDKMock();
 
-        jest.spyOn(amazonPayV2ScriptLoader, 'load').mockResolvedValue(amazonPayV2SDKMock);
+        jest.spyOn(amazonPayV2ScriptLoader, 'load')
+            .mockResolvedValue(amazonPayV2SDKMock);
+    });
+
+    it('creates an instance of AmazonPayV2PaymentProcessor', () => {
+        expect(processor).toBeInstanceOf(AmazonPayV2PaymentProcessor);
     });
 
     describe('#initialize', () => {
-        it('creates an instance of AmazonPayV2PaymentProcessor', () => {
-            expect(processor).toBeInstanceOf(AmazonPayV2PaymentProcessor);
-        });
-
         it('initializes processor successfully', async () => {
-            await processor.initialize(getAmazonPayV2());
+            const amazonMock = getAmazonPayV2();
 
-            expect(amazonPayV2ScriptLoader.load).toHaveBeenCalled();
+            await processor.initialize(amazonMock);
+
+            expect(amazonPayV2ScriptLoader.load).toHaveBeenCalledWith(amazonMock);
         });
     });
 
     describe('#deinitialize', () => {
-        it('deinitializes processor successfully', () => {
-            expect(processor.deinitialize()).toBeTruthy();
+        it('deinitializes processor successfully', async () => {
+            const renderButton = () => processor.createButton('foo', getAmazonPayV2ButtonParamsMock());
+
+            await processor.initialize(getAmazonPayV2());
+            expect(renderButton).not.toThrow();
+
+            await processor.deinitialize();
+            expect(renderButton).toThrowError(NotInitializedError);
         });
     });
 
@@ -89,6 +104,111 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
         it('throws an error when amazonPayV2SDK is not initialized', () => {
             expect(() => processor.createButton(containerId, amazonPayV2ButtonParams)).toThrow(NotInitializedError);
+        });
+    });
+
+    describe('#renderAmazonPayButton', () => {
+        let store: CheckoutStore;
+
+        beforeAll(() => {
+            const container = document.createElement('div');
+            container.id = 'foo';
+            document.body.appendChild(container);
+        });
+
+        beforeEach(() => {
+            store = createCheckoutStore(getCheckoutStoreState());
+        });
+
+        it('should render an Amazon Pay button and validate if cart contains physical items', async () => {
+            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
+            expectedOptions.productType = AmazonPayV2PayOptions.PayOnly;
+
+            const cartMock = getCart();
+            cartMock.lineItems.physicalItems = [];
+
+            jest.spyOn(store.getState().cart, 'getCart')
+                .mockReturnValueOnce(cartMock);
+
+            await processor.initialize(getAmazonPayV2());
+            processor.renderAmazonPayButton('foo', store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout);
+
+            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+        });
+
+        it('should provide a relative URL to create a checkout session', async () => {
+            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            expectedOptions.createCheckoutSession.url = `/remote-checkout/amazonpay/payment-session`;
+
+            const storeConfigMock = getConfig().storeConfig;
+            storeConfigMock.checkoutSettings.features = {
+                'INT-5826.amazon_relative_url': true,
+            };
+
+            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow')
+                .mockReturnValueOnce(storeConfigMock);
+
+            await processor.initialize(getAmazonPayV2());
+            processor.renderAmazonPayButton('foo', store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout);
+
+            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+        });
+
+        describe('should fail...', () => {
+            test('if an invalid containerId is provided', async () => {
+                await processor.initialize(getAmazonPayV2());
+                const renderAmazonPayButton = () => processor.renderAmazonPayButton('bar', store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout);
+
+                expect(renderAmazonPayButton).toThrowError(InvalidArgumentError);
+                expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
+            });
+
+            test('if there is no payment methods data', async () => {
+                const paymentMethods = { ...getPaymentMethodsState(), data: undefined };
+                const state = { ...getCheckoutStoreState(), paymentMethods };
+                store = createCheckoutStore(state);
+
+                await processor.initialize(getAmazonPayV2());
+                const renderAmazonPayButton = () => processor.renderAmazonPayButton('foo', store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout);
+
+                expect(renderAmazonPayButton).toThrowError(MissingDataError);
+                expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
+            });
+
+            test('if there is no store config data', async () => {
+                const config = { ...getConfigState(), data: undefined };
+                const state = { ...getCheckoutStoreState(), config };
+                store = createCheckoutStore(state);
+
+                await processor.initialize(getAmazonPayV2());
+                const renderAmazonPayButton = () => processor.renderAmazonPayButton('foo', store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout);
+
+                expect(renderAmazonPayButton).toThrowError(MissingDataError);
+                expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
+            });
+
+            test('if merchantId is undefined', async () => {
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValue(getPaymentMethodMockUndefinedMerchant());
+
+                await processor.initialize(getAmazonPayV2());
+                const renderAmazonPayButton = () => processor.renderAmazonPayButton('foo', store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout);
+
+                expect(renderAmazonPayButton).toThrowError(MissingDataError);
+                expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
+            });
+
+            test('if ledgerCurrency is undefined', async () => {
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValue(getPaymentMethodMockUndefinedLedgerCurrency());
+
+                await processor.initialize(getAmazonPayV2());
+                const renderAmazonPayButton = () => processor.renderAmazonPayButton('foo', store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout);
+
+                expect(renderAmazonPayButton).toThrowError(MissingDataError);
+                expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -1,8 +1,10 @@
 import { PaymentMethod } from '../..';
+import { InternalCheckoutSelectors } from '../../../../../core/src/checkout';
+import { getShippableItemsCount } from '../../../../../core/src/shipping';
 import { AmazonPayV2ButtonInitializeOptions } from '../../../checkout-buttons/strategies/amazon-pay-v2';
-import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 
-import { AmazonPayV2ChangeActionType, AmazonPayV2SDK } from './amazon-pay-v2';
+import { AmazonPayV2ButtonColor, AmazonPayV2ChangeActionType, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 
 export default class AmazonPayV2PaymentProcessor {
@@ -39,6 +41,85 @@ export default class AmazonPayV2PaymentProcessor {
         }
 
         return Promise.resolve();
+    }
+
+    renderAmazonPayButton(
+        containerId: string,
+        checkoutState: InternalCheckoutSelectors,
+        methodId: string,
+        placement: AmazonPayV2Placement,
+        options?: AmazonPayV2ButtonInitializeOptions
+    ): HTMLElement {
+        const container = document.getElementById(containerId);
+
+        if (!container) {
+            throw new InvalidArgumentError('Unable to render the Amazon Pay button to an invalid HTML container element.');
+        }
+
+        const amazonPayV2ButtonOptions = options ?? this._getAmazonPayV2ButtonOptions(checkoutState, methodId, placement);
+
+        this.createButton(`#${containerId}`, amazonPayV2ButtonOptions);
+
+        return container;
+    }
+
+    private _getAmazonPayV2ButtonOptions(
+        {
+            paymentMethods: { getPaymentMethodOrThrow },
+            config: { getStoreConfigOrThrow },
+            cart: { getCart },
+        }: InternalCheckoutSelectors,
+        methodId: string,
+        placement: AmazonPayV2Placement
+    ): AmazonPayV2ButtonInitializeOptions {
+        const {
+            config: {
+                merchantId,
+                testMode,
+            },
+            initializationData: {
+                checkoutLanguage,
+                ledgerCurrency,
+                checkoutSessionMethod,
+                extractAmazonCheckoutSessionId,
+            },
+        } = getPaymentMethodOrThrow(methodId);
+
+        const {
+            checkoutSettings: { features },
+            storeProfile: { shopPath },
+        } = getStoreConfigOrThrow();
+
+        const cart = getCart();
+
+        if (!merchantId || !ledgerCurrency) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const buttonBaseConfig = {
+            merchantId,
+            ledgerCurrency,
+            checkoutLanguage,
+            productType: cart && getShippableItemsCount(cart) === 0 ?
+                AmazonPayV2PayOptions.PayOnly :
+                AmazonPayV2PayOptions.PayAndShip,
+            placement,
+            buttonColor: AmazonPayV2ButtonColor.Gold,
+        };
+
+        const createCheckoutSession = {
+            method: checkoutSessionMethod,
+            url: features['INT-5826.amazon_relative_url']
+                ? `/remote-checkout/${methodId}/payment-session`
+                : `${shopPath}/remote-checkout/${methodId}/payment-session`,
+            extractAmazonCheckoutSessionId,
+        };
+
+        return {
+            ...buttonBaseConfig,
+            createCheckoutSession,
+            sandbox: !!testMode,
+        };
     }
 
     private _getAmazonPayV2SDK(): AmazonPayV2SDK {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
@@ -32,6 +32,7 @@ import AmazonPayV2PaymentInitializeOptions from './amazon-pay-v2-payment-initial
 import AmazonPayV2PaymentStrategy from './amazon-pay-v2-payment-strategy';
 import { getAmazonPayV2ButtonParamsMock } from './amazon-pay-v2.mock';
 import createAmazonPayV2PaymentProcessor from './create-amazon-pay-v2-payment-processor';
+import { AmazonPayV2ButtonParams } from './amazon-pay-v2';
 
 describe('AmazonPayV2PaymentStrategy', () => {
     let amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor;
@@ -177,14 +178,14 @@ describe('AmazonPayV2PaymentStrategy', () => {
         });
 
         it('creates the signin button if no paymentToken is present on initializationData', async () => {
-            const expectedOptions = getAmazonPayV2ButtonParamsMock();
+            const expectedOptions = getAmazonPayV2ButtonParamsMock() as AmazonPayV2ButtonParams;
             expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
 
             await strategy.initialize(initializeOptions);
 
             expect(amazonPayV2PaymentProcessor.bindButton).not.toHaveBeenCalled();
             expect(amazonPayV2PaymentProcessor.initialize).toHaveBeenCalledWith(paymentMethodMock);
-            expect(amazonPayV2PaymentProcessor.createButton).toHaveBeenCalledWith(`#AmazonPayButton`, expectedOptions);
+            expect(amazonPayV2PaymentProcessor.createButton).toHaveBeenCalledWith(`AmazonPayButton`, expectedOptions);
         });
 
         it('dispatches widgetInteraction when clicking previously binded edit method button if region not US', async () => {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -1,7 +1,7 @@
 import PaymentMethod from '../../payment-method';
 import { getAmazonPayV2 } from '../../payment-methods.mock';
 
-import { AmazonPayV2ButtonParams, AmazonPayV2CheckoutLanguage, AmazonPayV2LedgerCurrency, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
+import { AmazonPayV2ButtonColor, AmazonPayV2ButtonParams, AmazonPayV2CheckoutLanguage, AmazonPayV2LedgerCurrency, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
 
 export function getAmazonPayV2SDKMock(): AmazonPayV2SDK {
     return {
@@ -14,21 +14,32 @@ export function getAmazonPayV2SDKMock(): AmazonPayV2SDK {
 }
 
 export function getPaymentMethodMockUndefinedMerchant(): PaymentMethod {
-    return { ...getAmazonPayV2(), config: { merchantId: undefined } };
+    const amazonMock = getAmazonPayV2();
+    amazonMock.config.merchantId = undefined;
+
+    return amazonMock;
+}
+
+export function getPaymentMethodMockUndefinedLedgerCurrency(): PaymentMethod {
+    const amazonMock = getAmazonPayV2();
+    amazonMock.initializationData.ledgerCurrency = undefined;
+
+    return amazonMock;
 }
 
 export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParams {
     return {
-        checkoutLanguage: 'en_US' as AmazonPayV2CheckoutLanguage,
+        buttonColor: AmazonPayV2ButtonColor.Gold,
+        checkoutLanguage: AmazonPayV2CheckoutLanguage.en_US,
         createCheckoutSession: {
             url: 'https://my-dev-store.store.bcdev/remote-checkout/amazonpay/payment-session',
             method: 'GET',
             extractAmazonCheckoutSessionId: 'token',
         },
-        ledgerCurrency: 'USD' as AmazonPayV2LedgerCurrency,
+        ledgerCurrency: AmazonPayV2LedgerCurrency.USD,
         merchantId: 'checkout_amazonpay',
-        placement: 'Checkout' as AmazonPayV2Placement,
-        productType: 'PayAndShip' as AmazonPayV2PayOptions,
+        placement: AmazonPayV2Placement.Checkout,
+        productType: AmazonPayV2PayOptions.PayAndShip,
         sandbox: true,
     };
 }

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -1,7 +1,7 @@
 import PaymentMethod from '../../payment-method';
 import { getAmazonPayV2 } from '../../payment-methods.mock';
 
-import { AmazonPayV2ButtonColor, AmazonPayV2ButtonParams, AmazonPayV2CheckoutLanguage, AmazonPayV2LedgerCurrency, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
+import { AmazonPayV2ButtonColor, AmazonPayV2CheckoutLanguage, AmazonPayV2LedgerCurrency, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK, AmazonPayV2ButtonParameters } from './amazon-pay-v2';
 
 export function getAmazonPayV2SDKMock(): AmazonPayV2SDK {
     return {
@@ -27,7 +27,23 @@ export function getPaymentMethodMockUndefinedLedgerCurrency(): PaymentMethod {
     return amazonMock;
 }
 
-export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParams {
+export function getAmazonPayV2Ph4ButtonParamsMock(): AmazonPayV2ButtonParameters {
+    return {
+        merchantId: 'checkout_amazonpay',
+        publicKeyId: 'SANDBOX-XXXXXXXX',
+        ledgerCurrency: AmazonPayV2LedgerCurrency.USD,
+        checkoutLanguage: AmazonPayV2CheckoutLanguage.en_US,
+        productType: AmazonPayV2PayOptions.PayAndShip,
+        placement: AmazonPayV2Placement.Checkout,
+        buttonColor: AmazonPayV2ButtonColor.Gold,
+        createCheckoutSessionConfig: {
+            payloadJSON: 'payload',
+            signature: 'xxxx',
+        },
+    };
+}
+
+export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParameters {
     return {
         buttonColor: AmazonPayV2ButtonColor.Gold,
         checkoutLanguage: AmazonPayV2CheckoutLanguage.en_US,

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -8,6 +8,8 @@ export interface AmazonPayV2SDK {
     Pay: AmazonPayV2Client;
 }
 
+export type AmazonPayV2ButtonParameters = AmazonPayV2ButtonParams | AmazonPayV2NewButtonParams;
+
 export interface AmazonPayV2Client {
     /**
      * Render the Amazon Pay button to a HTML container element.
@@ -15,7 +17,7 @@ export interface AmazonPayV2Client {
      * @param containerId - HTML element id.
      * @param params - Button rendering params.
      */
-    renderButton(containerId: string, params: AmazonPayV2ButtonParams): HTMLElement;
+    renderButton(containerId: string, params: AmazonPayV2ButtonParameters): HTMLElement;
 
     /**
      * Bind click events to HTML elements, so that when the element is clicked, the buyer can select a different shipping address or payment method.
@@ -35,16 +37,11 @@ export interface AmazonPayV2HostWindow extends Window {
     amazon?: AmazonPayV2SDK;
 }
 
-export interface AmazonPayV2ButtonParams {
+interface AmazonPayV2ButtonConfig {
     /**
      * Amazon Pay merchant account identifier.
      */
     merchantId: string;
-
-    /**
-     * Configuration for calling the endpoint to Create Checkout Session.
-     */
-    createCheckoutSession: AmazonPayV2CheckoutSession;
 
     /**
      * Placement of the Amazon Pay button on your website.
@@ -72,9 +69,30 @@ export interface AmazonPayV2ButtonParams {
     checkoutLanguage?: AmazonPayV2CheckoutLanguage;
 
     /**
-     * Sets button to Sandbox environment. Default is false.
+     * Sets button to Sandbox environment. You do not have to set this parameter
+     * if your `publicKeyId` has an environment prefix. Default is false.
      */
     sandbox?: boolean;
+}
+
+export interface AmazonPayV2ButtonParams extends AmazonPayV2ButtonConfig {
+    /**
+     * Configuration for calling the endpoint to Create Checkout Session.
+     */
+    createCheckoutSession: AmazonPayV2CheckoutSession;
+}
+
+export interface AmazonPayV2NewButtonParams extends AmazonPayV2ButtonConfig {
+    /**
+     * Credential provided by Amazon Pay. You must also set the `sandbox`
+     * parameter if your `publicKeyId` does not have an environment prefix.
+     */
+    publicKeyId?: string;
+
+    /**
+     * Create Checkout Session configuration.
+     */
+    createCheckoutSessionConfig: AmazonPayV2CheckoutSessionConfig;
 }
 
 export interface AmazonPayV2CheckoutSession {
@@ -92,6 +110,24 @@ export interface AmazonPayV2CheckoutSession {
      * Checkout Session ID parameter in the response. Default is 'checkoutSessionId'.
      */
     extractAmazonCheckoutSessionId?: string;
+}
+
+export interface AmazonPayV2CheckoutSessionConfig {
+    /**
+     * A payload that Amazon Pay will use to create a Checkout Session object.
+     */
+    payloadJSON: string;
+
+    /**
+     * Payload's signature.
+     */
+    signature: string;
+
+    /**
+     * Credential provided by Amazon Pay. You do not have to set this parameter
+     * if your `publicKeyId` has an environment prefix.
+     */
+    publicKeyId?: string;
 }
 
 export type AmazonPayV2ChangeActionType = 'changeAddress' | 'changePayment';

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -62,6 +62,11 @@ export interface AmazonPayV2ButtonParams {
     productType?: AmazonPayV2PayOptions;
 
     /**
+     * Color of the Amazon Pay button.
+     */
+    buttonColor?: AmazonPayV2ButtonColor;
+
+    /**
      * Language used to render the button and text on Amazon Pay hosted pages.
      */
     checkoutLanguage?: AmazonPayV2CheckoutLanguage;
@@ -150,4 +155,10 @@ export enum AmazonPayV2PayOptions {
 
     /** Select this product type if you do not need the buyer's shipping details. */
     PayOnly = 'PayOnly',
+}
+
+export enum AmazonPayV2ButtonColor {
+    Gold = 'Gold',
+    LightGray = 'LightGray',
+    DarkGray = 'DarkGray',
 }


### PR DESCRIPTION
## What? [INT-6128](https://bigcommercecloud.atlassian.net/browse/INT-6128)

1. Refactored duplicated blocks of code.
2. Upgrade to the new Amazon Pay Checkout version.

<img width="1517" alt="Comparison" src="https://user-images.githubusercontent.com/4843328/180506098-fdfa152d-9cad-449f-bf96-dfe8b1134bc1.png">

#### API v2 Flavors:

<img width="1633" alt="v2 Flavors" src="https://user-images.githubusercontent.com/4843328/180506088-43f30791-063c-4856-a1f6-f3336671f2fd.png">

## Why?
The button should now render faster because our `/payment-session` endpoint is not called anymore to create the checkout session.

## Testing / Proof
🎬🍿 [>>video<<](https://drive.google.com/file/d/11ZneWUspg65cm7DNFMScr1ft0nIMRb0C/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments
