### PR TITLE
feat(payment): PAYPAL-1532 added PayPalCommerceAlternativeMethods checkout button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -6,7 +6,7 @@ import { ApplePayButtonInitializeOptions } from './strategies/apple-pay';
 import { BraintreePaypalButtonInitializeOptions, BraintreePaypalCreditButtonInitializeOptions, BraintreeVenmoButtonInitializeOptions } from './strategies/braintree';
 import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
-import { PaypalCommerceButtonInitializeOptions, PaypalCommerceVenmoButtonInitializeOptions } from './strategies/paypal-commerce';
+import { PaypalCommerceAlternativeMethodsButtonOptions, PaypalCommerceButtonInitializeOptions, PaypalCommerceVenmoButtonInitializeOptions } from './strategies/paypal-commerce';
 
 /**
  * The set of options for configuring the checkout button.
@@ -119,6 +119,12 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * unless you need to support Paypal.
      */
     paypalCommerce?: PaypalCommerceButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate PayPal Commerce. They can be omitted
+     * unless you need to support PayPal Commerce Alternative Payment Methods.
+     */
+    paypalcommercealternativemethods?: PaypalCommerceAlternativeMethodsButtonOptions;
 
     /**
      * The options that are required to facilitate PayPal Commerce Venmo. They can be omitted

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -28,7 +28,7 @@ import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, Bra
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 import { MasterpassButtonStrategy } from './strategies/masterpass';
 import { PaypalButtonStrategy } from './strategies/paypal';
-import { PaypalCommerceButtonStrategy, PaypalCommerceVenmoButtonStrategy } from './strategies/paypal-commerce';
+import { PaypalCommerceAlternativeMethodsButtonStrategy, PaypalCommerceButtonStrategy, PaypalCommerceVenmoButtonStrategy } from './strategies/paypal-commerce';
 
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
@@ -263,6 +263,16 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             formPoster,
             paypalCommercePaymentProcessor
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.PAYPALCOMMERCE_APMS, () =>
+        new PaypalCommerceAlternativeMethodsButtonStrategy(
+            store,
+            checkoutActionCreator,
+            formPoster,
+            paypalScriptLoader,
+            paypalCommerceRequestSender
         )
     );
 

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -16,6 +16,7 @@ enum CheckoutButtonMethodType {
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',
     PAYPALCOMMERCE = 'paypalcommerce',
+    PAYPALCOMMERCE_APMS = 'paypalcommercealternativemethods',
     PAYPALCOMMERCE_VENMO = 'paypalcommercevenmo',
 }
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/index.ts
@@ -6,6 +6,12 @@ export { PaypalCommerceButtonInitializeOptions } from './paypal-commerce-button-
 export { default as PaypalCommerceButtonStrategy } from './paypal-commerce-button-strategy';
 
 /**
+ * PayPal Commerce Alternative Payment Methods
+ */
+ export { PaypalCommerceAlternativeMethodsButtonOptions } from './paypal-commerce-alternative-methods-button-options';
+ export { default as PaypalCommerceAlternativeMethodsButtonStrategy } from './paypal-commerce-alternative-methods-button-strategy';
+
+/**
  * PayPal Commerce Venmo
  */
 export { PaypalCommerceVenmoButtonInitializeOptions } from './paypal-commerce-venmo-button-options';

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-options.ts
@@ -1,0 +1,18 @@
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+
+export interface PaypalCommerceAlternativeMethodsButtonOptions {
+    /**
+     * Alternative payment method id what used for initialization PayPal button as funding source.
+     */
+    apm: string;
+
+    /**
+     * Flag which helps to detect that the strategy initializes on Checkout page.
+     */
+    initializesOnCheckoutPage?: boolean;
+
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: PaypalButtonStyleOptions;
+}

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -1,0 +1,328 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+
+import { Cart } from '../../../cart';
+import { getCart } from '../../../cart/carts.mock';
+import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod } from '../../../payment';
+import { getPaypalCommerce } from '../../../payment/payment-methods.mock';
+import { PaypalHostWindow } from '../../../payment/strategies/paypal';
+import { ButtonsOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK } from '../../../payment/strategies/paypal-commerce';
+import { getPaypalCommerceMock } from '../../../payment/strategies/paypal-commerce/paypal-commerce.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+import { PaypalCommerceAlternativeMethodsButtonOptions } from './paypal-commerce-alternative-methods-button-options';
+import PaypalCommerceAlternativeMethodsButtonStrategy from './paypal-commerce-alternative-methods-button-strategy';
+
+describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
+    let cartMock: Cart;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let requestSender: RequestSender;
+    let paymentMethodMock: PaymentMethod;
+    let paypalCommerceRequestSender: PaypalCommerceRequestSender;
+    let paypalScriptLoader: PaypalCommerceScriptLoader;
+    let store: CheckoutStore;
+    let strategy: PaypalCommerceAlternativeMethodsButtonStrategy;
+    let paypalSdkMock: PaypalCommerceSDK;
+    let paypalCommerceAlternativeMethodsButtonElement: HTMLDivElement;
+
+    const defaultButtonContainerId = 'paypal-commerce-alternative-methods-button-mock-id';
+    const approveDataOrderId = 'ORDER_ID';
+
+    const paypalCommerceAlternativeMethodsOptions: PaypalCommerceAlternativeMethodsButtonOptions = {
+        apm: 'sepa',
+        initializesOnCheckoutPage: false,
+        style: {
+            height: 45,
+        },
+    };
+
+    const initializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_APMS,
+        containerId: defaultButtonContainerId,
+        paypalcommercealternativemethods: paypalCommerceAlternativeMethodsOptions,
+    };
+
+    beforeEach(() => {
+        cartMock = getCart();
+        eventEmitter = new EventEmitter();
+        paymentMethodMock = { ...getPaypalCommerce(), id: 'paypalcommercealternativemethods' };
+        paypalSdkMock = getPaypalCommerceMock();
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = createRequestSender();
+        formPoster = createFormPoster();
+        paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
+        paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());
+
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
+        strategy = new PaypalCommerceAlternativeMethodsButtonStrategy(
+            store,
+            checkoutActionCreator,
+            formPoster,
+            paypalScriptLoader,
+            paypalCommerceRequestSender,
+        );
+
+        paypalCommerceAlternativeMethodsButtonElement = document.createElement('div');
+        paypalCommerceAlternativeMethodsButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalCommerceAlternativeMethodsButtonElement);
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce').mockReturnValue(paypalSdkMock);
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+
+        jest.spyOn(paypalSdkMock, 'Buttons')
+            .mockImplementation((options: ButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ orderID: approveDataOrderId });
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                };
+            });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PaypalHostWindow).paypal;
+
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalCommerceAlternativeMethodsButtonElement);
+        }
+    });
+
+    it('creates an instance of the PayPal Commerce APM checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(PaypalCommerceAlternativeMethodsButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = { containerId: defaultButtonContainerId } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = { methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_APMS } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommercealternativemethods option is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+                methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_APMS,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommercealternativemethods.apm option is not provided or falsy', async () => {
+            const options = {
+                ...initializationOptions,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    apm: '',
+                },
+            };
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('loads paypal commerce sdk script', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalScriptLoader.loadPaypalCommerce).toHaveBeenCalled();
+        });
+
+        it('initializes APM button to render', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalCommerceAlternativeMethodsOptions.apm,
+                style: paypalCommerceAlternativeMethodsOptions.style,
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function)
+            });
+        });
+
+        it('throws an error if provided apm is not a valid funding source', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            const options = {
+                ...initializationOptions,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    apm: 'not_valid_apm',
+                },
+            };
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+                expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+            }
+        });
+
+        it('renders APM button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation(() => ({
+                    isEligible: jest.fn(() => true),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+        });
+
+        it('does not render APM button if it is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation(() => ({
+                    isEligible: jest.fn(() => false),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
+        it('removes APM button container if the button has not rendered', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation(() => ({
+                    isEligible: jest.fn(() => false),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(document.getElementById(defaultButtonContainerId)).toBeNull();
+        });
+
+        it('creates an order with paypalcommercealternativemethod as provider id if its initializes outside checkout page', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, 'paypalcommercealternativemethod');
+        });
+
+        it('creates an order with paypalcommercealternativemethodscheckout as provider id if its initializes on checkout page', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            const updatedIntializationOptions = {
+                ...initializationOptions,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    initializesOnCheckoutPage: true,
+                },
+            };
+
+            await strategy.initialize(updatedIntializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, 'paypalcommercealternativemethodscheckout');
+        });
+
+        it('throws an error if orderId is not provided by PayPal on approve', async () => {
+            jest.spyOn(paypalSdkMock, 'Buttons')
+                .mockImplementation((options: ButtonsOptions) => {
+                    eventEmitter.on('createOrder', () => {
+                        if (options.createOrder) {
+                            options.createOrder().catch(() => {});
+                        }
+                    });
+
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove({ orderID: undefined });
+                        }
+                    });
+
+                    return {
+                        isEligible: jest.fn(() => true),
+                        render: jest.fn(),
+                    };
+                });
+
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onApprove');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('tokenizes payment on paypal approve', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                action: 'set_external_checkout',
+                order_id: approveDataOrderId,
+                payment_type: 'paypal',
+                provider: paymentMethodMock.id,
+            }));
+        });
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
@@ -1,0 +1,132 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
+import { ApproveDataOptions, ButtonsOptions, PaypalButtonStyleOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK } from '../../../payment/strategies/paypal-commerce';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+import getValidButtonStyle from './get-valid-button-style';
+
+export default class PaypalCommerceAlternativeMethodsButtonStrategy implements CheckoutButtonStrategy {
+    private _paypalCommerceSdk?: PaypalCommerceSDK;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _formPoster: FormPoster,
+        private _paypalScriptLoader: PaypalCommerceScriptLoader,
+        private _paypalCommerceRequestSender: PaypalCommerceRequestSender
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { paypalcommercealternativemethods, containerId, methodId } = options;
+        const { apm, initializesOnCheckoutPage, style } = paypalcommercealternativemethods || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
+        }
+
+        if (!paypalcommercealternativemethods) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommercealternativemethods" argument is not provided.`);
+        }
+
+        if (!apm) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommercealternativemethods.apm" argument is not provided.`);
+        }
+
+        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        const currency = state.cart.getCartOrThrow().currency.code;
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currency, initializesOnCheckoutPage);
+
+        this._renderButton(apm, methodId, containerId, initializesOnCheckoutPage, style);
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private _renderButton(
+        apm: string,
+        methodId: string,
+        containerId: string,
+        initializesOnCheckoutPage?: boolean,
+        style?: PaypalButtonStyleOptions
+    ): void {
+        const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
+        const isAvailableFundingSource = Object.values(paypalCommerceSdk.FUNDING).includes(apm);
+
+        if (!isAvailableFundingSource) {
+            throw new InvalidArgumentError(`Unable to initialize PayPal button because "options.paypalcommercealternativemethods.apm" argument is not valid funding source.`);
+        }
+
+        const validButtonStyle = style ? this._getButtonStyle(style) : {};
+
+        const buttonRenderOptions: ButtonsOptions = {
+            fundingSource: apm,
+            style: validButtonStyle,
+            createOrder: () => this._createOrder(initializesOnCheckoutPage),
+            onApprove: ({ orderID }: ApproveDataOptions) => this._tokenizePayment(methodId, orderID),
+        };
+
+        const paypalButtonRender = paypalCommerceSdk.Buttons(buttonRenderOptions);
+
+        if (paypalButtonRender.isEligible()) {
+            paypalButtonRender.render(`#${containerId}`);
+        } else {
+            this._removeElement(containerId);
+        }
+    }
+
+    private async _createOrder(initializesOnCheckoutPage?: boolean): Promise<string> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+
+        const providerId = initializesOnCheckoutPage ? 'paypalcommercealternativemethodscheckout' : 'paypalcommercealternativemethod';
+
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cart.id, providerId);
+
+        return orderId;
+    }
+
+    private _tokenizePayment(methodId: string, orderId?: string): void {
+        if (!orderId) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        return this._formPoster.postForm('/checkout.php', {
+            payment_type: 'paypal',
+            action: 'set_external_checkout',
+            provider: methodId,
+            order_id: orderId,
+        });
+    }
+
+    private _getPayPalCommerceSdkOrThrow(): PaypalCommerceSDK {
+        if (!this._paypalCommerceSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this._paypalCommerceSdk;
+    }
+
+    private _getButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+        const { height, label, layout, shape } = getValidButtonStyle(style);
+
+        return { height, label, layout, shape };
+    }
+
+    private _removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+}

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -35,7 +35,7 @@ export default class PaypalCommerceRequestSender {
         }
 
         if (isAPM) {
-            provider = 'paypalcommercealternativemethodscheckout';
+            provider = isCheckout ? 'paypalcommercealternativemethodscheckout' : 'paypalcommercealternativemethod';
         }
 
         return this.createOrder(cartId, provider);


### PR DESCRIPTION
## What?
Added new checkout button strategy for paypal commerce apms

## Why?
To separate APM functionality from PayPal Commerce common strategy and to make an ability to render PayPal APM buttons in their own containers

## Testing / Proof
Unit tests
