### PR TITLE
feat(payment): BOLT-105 Send 'create_bolt_account: false' for shoppers with registered Bolt account

### DIFF
--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -542,6 +542,44 @@ describe('BoltPaymentStrategy', () => {
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(submitPaymentOptions);
         });
 
+        it('succesfully executes the bolt strategy with bolt embedded (with already exist account)', async () => {
+            const submitPaymentOptions = {
+                methodId: 'bolt',
+                paymentData: {
+                    formattedPayload: {
+                        credit_card_token: {
+                            token: 'token',
+                            last_four_digits: '1111',
+                            iin: '1111',
+                            expiration_month: 11,
+                            expiration_year: 2022,
+                        },
+                        provider_data: {
+                            create_account: false,
+                            embedded_checkout: true,
+                        },
+                    },
+                },
+            };
+
+            const boltEmbeddedPayload = {
+                payment: {
+                    methodId: 'bolt',
+                    paymentData: {
+                        shouldCreateAccount: true,
+                    },
+                },
+            };
+
+            jest.spyOn(boltClient, 'hasBoltAccount').mockImplementation(() => true);
+            paymentMethodMock.initializationData.embeddedOneClickEnabled = true;
+            await strategy.initialize(boltEmbeddedScriptInitializationOptions);
+            await strategy.execute(boltEmbeddedPayload);
+            expect(boltEmbeddedField.tokenize).toHaveBeenCalled();
+            expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(submitPaymentOptions);
+        });
+
     });
 
     describe('#deinitialize()', () => {

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -221,7 +221,7 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
                         expiration_year: +tokenizeResult.expiration.split('-')[0],
                     },
                     provider_data: {
-                        create_account: paymentData.shouldCreateAccount || false,
+                        create_account: await this._shouldCreateAccount(paymentData.shouldCreateAccount),
                         embedded_checkout: true,
                     },
                 },
@@ -350,5 +350,9 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
         ) {
             throw new PaymentArgumentInvalidError();
         }
+    }
+
+    private async _shouldCreateAccount(shouldCreateAccount = false): Promise<boolean> {
+        return (await this._hasBoltAccount()) ? false : shouldCreateAccount;
     }
 }


### PR DESCRIPTION
## What?
Send 'create_bolt_account: false' for shoppers with registered Bolt account

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-105](https://bigcommercecloud.atlassian.net/browse/BOLT-105)

## Testing / Proof
<img width="698" alt="Screenshot 2022-07-18 at 21 34 21" src="https://user-images.githubusercontent.com/9430298/179579482-e3e31918-83dc-4bdc-ac8d-b6654babdce7.png">



@bigcommerce/checkout @bigcommerce/payments
