### PR TITLE
fix(provider): INT-6217 [CYBSV2] submit referenceId field for 3DS V2

### DIFF
--- a/packages/core/src/payment/payment.ts
+++ b/packages/core/src/payment/payment.ts
@@ -128,6 +128,11 @@ export interface ThreeDSecureToken {
     token: string;
 }
 
+export interface ThreeDSecureData {
+    token: string;
+    reference_id?: string;
+}
+
 export interface HostedInstrument {
     shouldSaveInstrument?: boolean;
     shouldSetAsDefaultInstrument?: boolean;

--- a/packages/core/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.ts
+++ b/packages/core/src/payment/strategies/cardinal/cardinal-three-d-secure-flow-v2.ts
@@ -40,7 +40,8 @@ export default class CardinalThreeDSecureFlowV2 {
             return await execute(payload, options);
         } catch (error) {
             if (error instanceof RequestError && error.body.status === 'additional_action_required') {
-                const token = error.body.additional_action_required?.data?.token;
+                const additionalActionData = error.body.additional_action_required?.data;
+                const { token, reference_id } = additionalActionData;
                 const xid = error.body.three_ds_result?.payer_auth_request;
 
                 await this._cardinalClient.configure(token);
@@ -52,7 +53,7 @@ export default class CardinalThreeDSecureFlowV2 {
                 }
 
                 try {
-                    return await this._submitPayment(payment, { xid }, hostedForm);
+                    return await this._submitPayment(payment, { xid, reference_id }, hostedForm);
                 } catch (error) {
                     if (error instanceof RequestError && some(error.body.errors, {code: 'three_d_secure_required'})) {
                         const threeDsResult = error.body.three_ds_result;

--- a/packages/core/src/payment/strategies/cardinal/cardinal.ts
+++ b/packages/core/src/payment/strategies/cardinal/cardinal.ts
@@ -1,4 +1,4 @@
-import { ThreeDSecure, ThreeDSecureToken } from '../../payment';
+import { ThreeDSecure, ThreeDSecureData, ThreeDSecureToken } from '../../payment';
 
 export const CardinalSignatureValidationErrors = [100004, 1010, 1011, 1020];
 
@@ -180,4 +180,4 @@ export enum CardinalSignatureVerification {
     No = 'N',
 }
 
-export type CardinalThreeDSecureToken = Pick<ThreeDSecure, 'xid'> | ThreeDSecureToken;
+export type CardinalThreeDSecureToken = Pick<ThreeDSecure, 'xid'> | ThreeDSecureToken | ThreeDSecureData;


### PR DESCRIPTION
## What? [INT-6217](https://bigcommercecloud.atlassian.net/browse/INT-6217)
Add the missing field `consumerAuthenticationInformation.referenceId` to the payload for CyberSourceV2
We are bouncing this field from the `CyberSource::PayerAuthenticationApi.payer_auth_setup` to the FE and then back to BigPay to include it in the next `CyberSource::PaymentsApi.create_payment call`

## Why?
This field was causing transactions to fallback to 3DS v1 instead of using the 3DS v2
BNZ and CYBSV2 noticed this issue while running tests for the upcoming BNZ integration

## Testing / Proof
Version displayed on cybersource CP before the changes
![image](https://user-images.githubusercontent.com/64860381/179611685-6db3324c-6fc8-4813-8212-3b2c4252440e.png)

Version displayed on cybersource CP after the changes
![image](https://user-images.githubusercontent.com/64860381/179611532-77fc50e4-3787-4b7a-9e3f-23b339747236.png)

## Dependency of
https://github.com/bigcommerce/bigpay/pull/5689

@bigcommerce/apex-integrations @bigcommerce/payments @bigcommerce/checkout 