### PR TITLE
fix(payment): INT-5854 [Mollie] Klarna is not available if cart contains digital products

### DIFF
--- a/packages/core/src/payment/strategies/mollie/mollie-initialize-options.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-initialize-options.ts
@@ -61,4 +61,8 @@ export default interface MolliePaymentInitializeOptions {
      * Hosted Form Validation Options
      */
     form?: HostedFormOptions;
+
+    unsupportedMethodMessage: string;
+
+    disableButton(): void;
 }

--- a/packages/core/src/payment/strategies/mollie/mollie-initialize-options.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-initialize-options.ts
@@ -62,7 +62,7 @@ export default interface MolliePaymentInitializeOptions {
      */
     form?: HostedFormOptions;
 
-    unsupportedMethodMessage: string;
+    unsupportedMethodMessage?: string;
 
     disableButton(): void;
 }

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -7,7 +7,7 @@ import { of, Observable } from 'rxjs';
 import { PaymentActionCreator } from '../..';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { InvalidArgumentError } from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { HostedForm, HostedFormFactory } from '../../../hosted-form';
 import { FinalizeOrderAction, LoadOrderSucceededAction, OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { getOrder } from '../../../order/orders.mock';
@@ -23,6 +23,7 @@ import {  MollieClient, MollieElement, MollieHostWindow } from './mollie';
 import MolliePaymentStrategy from './mollie-payment-strategy';
 import MollieScriptLoader from './mollie-script-loader';
 import { getHostedFormInitializeOptions, getInitializeOptions, getMollieClient, getOrderRequestBodyAPMs, getOrderRequestBodyVaultedCC, getOrderRequestBodyVaultAPMs, getOrderRequestBodyVaultCC, getOrderRequestBodyWithoutPayment, getOrderRequestBodyWithCreditCard } from './mollie.mock';
+import {getCart} from "../../../cart/carts.mock";
 
 describe('MolliePaymentStrategy', () => {
     let orderRequestSender: OrderRequestSender;
@@ -110,6 +111,10 @@ describe('MolliePaymentStrategy', () => {
                 .mockReturnValue({ storeProfile: { storeLanguage:  'en_US' } });
         });
 
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
         describe('Initialize', () => {
             it('does not load Mollie if initialization options are not provided', () => {
                 options.mollie = undefined;
@@ -136,6 +141,144 @@ describe('MolliePaymentStrategy', () => {
                 jest.runAllTimers();
                 expect(mollieClient.createComponent).toBeCalledTimes(4);
                 expect(mollieElement.mount).toBeCalledTimes(4);
+            });
+
+            it('does render a message when the cart contain digital items',  async () => {
+                const disableButtonMock = jest.fn();
+                const optionsMock = {
+                    ...getInitializeOptions(),
+                    methodId: 'klarnapaylater',
+                    mollie: {
+                        containerId: 'mollie-element',
+                        cardCvcId: 'mollie-card-cvc-component-field',
+                        cardExpiryId: 'mollie-card-expiry-component-field',
+                        cardHolderId: 'mollie-card-holder-component-field',
+                        cardNumberId: 'mollie-card-number-component-field',
+                        styles: {valid: '#0f0'},
+                        unsupportedMethodMessage: 'This payment method is not supported',
+                        disableButton: disableButtonMock,
+                    }
+                }
+
+                const cartMock = getCart();
+                const container = {
+                    appendChild: jest.fn(),
+                }
+                const paragraph = {
+                    innerText: '',
+                }
+
+                const mollieMethod = {
+                    ...getMollie(),
+                    config: {
+                        ...getMollie().config,
+                        isHostedFormEnabled : false,
+                    }
+                }
+
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValue( mollieMethod);
+                jest.spyOn(store.getState().cart, 'getCart')
+                    .mockReturnValue(cartMock);
+                jest.spyOn(document, 'createElement').mockReturnValue(paragraph);
+                jest.spyOn(document, 'getElementById').mockReturnValue(container);
+
+                await strategy.initialize(optionsMock);
+
+                expect(store.getState().cart.getCart).toHaveBeenCalled();
+                expect(document.getElementById).toHaveBeenCalledWith(options.mollie?.containerId);
+                expect(document.createElement).toHaveBeenCalledWith('p');
+                expect(container.appendChild).toHaveBeenCalled();
+                expect(disableButtonMock).toHaveBeenCalled();
+            });
+
+            it('does not display a message when the cart contains no digital items',  async () => {
+                const disableButtonMock = jest.fn();
+
+                const optionsMock = {
+                    ...getInitializeOptions(),
+                    methodId: 'klarnapaylater',
+                    mollie: {
+                        containerId: 'mollie-element',
+                        cardCvcId: 'mollie-card-cvc-component-field',
+                        cardExpiryId: 'mollie-card-expiry-component-field',
+                        cardHolderId: 'mollie-card-holder-component-field',
+                        cardNumberId: 'mollie-card-number-component-field',
+                        styles: {valid: '#0f0'},
+                        unsupportedMethodMessage: 'This payment method is not supported',
+                        disableButton: disableButtonMock,
+                    }
+                }
+
+                const cartMock = {
+                    ...getCart(),
+                    lineItems: {
+                        ...getCart().lineItems,
+                        digitalItems: []
+                    }
+                }
+
+                const mollieMethod = {
+                    ...getMollie(),
+                    config: {
+                        ...getMollie().config,
+                        isHostedFormEnabled : false,
+                    }
+                }
+
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValue( mollieMethod);
+                jest.spyOn(store.getState().cart, 'getCart').mockReturnValue(cartMock);
+                jest.spyOn(document, 'createElement');
+                jest.spyOn(document, 'getElementById');
+
+                await strategy.initialize(optionsMock);
+
+                expect(store.getState().cart.getCart).toHaveBeenCalled();
+                expect(document.getElementById).not.toHaveBeenCalledWith('mollie-element');
+                expect(document.createElement).not.toHaveBeenCalledWith('p');
+                expect(disableButtonMock).not.toHaveBeenCalled();
+            });
+
+            it('throws MissingDataError when the state.cart is not available',  () => {
+                const disableButtonMock = jest.fn();
+
+                const optionsMock = {
+                    ...getInitializeOptions(),
+                    methodId: 'klarnapaylater',
+                    mollie: {
+                        containerId: 'mollie-element',
+                        cardCvcId: 'mollie-card-cvc-component-field',
+                        cardExpiryId: 'mollie-card-expiry-component-field',
+                        cardHolderId: 'mollie-card-holder-component-field',
+                        cardNumberId: 'mollie-card-number-component-field',
+                        styles: {valid: '#0f0'},
+                        unsupportedMethodMessage: 'This payment method is not supported',
+                        disableButton: disableButtonMock,
+                    }
+                }
+
+                const mollieMethod = {
+                    ...getMollie(),
+                    config: {
+                        ...getMollie().config,
+                        isHostedFormEnabled : false,
+                    }
+                }
+
+                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
+                    .mockReturnValue( mollieMethod);
+                jest.spyOn(store.getState().cart, 'getCart').mockReturnValue(null);
+                jest.spyOn(document, 'createElement');
+                jest.spyOn(document, 'getElementById');
+
+                const response = strategy.initialize(optionsMock)
+
+                expect(response).rejects.toThrowError(new MissingDataError(MissingDataErrorType.MissingCart));
+                expect(store.getState().cart.getCart).toHaveBeenCalled();
+                expect(document.getElementById).not.toHaveBeenCalledWith('mollie-element');
+                expect(document.createElement).not.toHaveBeenCalledWith('p');
+                expect(disableButtonMock).not.toHaveBeenCalled();
             });
         });
 

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -23,7 +23,7 @@ import {  MollieClient, MollieElement, MollieHostWindow } from './mollie';
 import MolliePaymentStrategy from './mollie-payment-strategy';
 import MollieScriptLoader from './mollie-script-loader';
 import { getHostedFormInitializeOptions, getInitializeOptions, getMollieClient, getOrderRequestBodyAPMs, getOrderRequestBodyVaultedCC, getOrderRequestBodyVaultAPMs, getOrderRequestBodyVaultCC, getOrderRequestBodyWithoutPayment, getOrderRequestBodyWithCreditCard } from './mollie.mock';
-import {getCart} from "../../../cart/carts.mock";
+import { getCart } from "../../../cart/carts.mock";
 
 describe('MolliePaymentStrategy', () => {
     let orderRequestSender: OrderRequestSender;

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -178,14 +178,14 @@ describe('MolliePaymentStrategy', () => {
 
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValue( mollieMethod);
-                jest.spyOn(store.getState().cart, 'getCart')
+                jest.spyOn(store.getState().cart, 'getCartOrThrow')
                     .mockReturnValue(cartMock);
                 jest.spyOn(document, 'createElement').mockReturnValue(paragraph);
                 jest.spyOn(document, 'getElementById').mockReturnValue(container);
 
                 await strategy.initialize(optionsMock);
 
-                expect(store.getState().cart.getCart).toHaveBeenCalled();
+                expect(store.getState().cart.getCartOrThrow).toHaveBeenCalled();
                 expect(document.getElementById).toHaveBeenCalledWith(options.mollie?.containerId);
                 expect(document.createElement).toHaveBeenCalledWith('p');
                 expect(container.appendChild).toHaveBeenCalled();
@@ -228,13 +228,13 @@ describe('MolliePaymentStrategy', () => {
 
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValue( mollieMethod);
-                jest.spyOn(store.getState().cart, 'getCart').mockReturnValue(cartMock);
+                jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cartMock);
                 jest.spyOn(document, 'createElement');
                 jest.spyOn(document, 'getElementById');
 
                 await strategy.initialize(optionsMock);
 
-                expect(store.getState().cart.getCart).toHaveBeenCalled();
+                expect(store.getState().cart.getCartOrThrow).toHaveBeenCalled();
                 expect(document.getElementById).not.toHaveBeenCalledWith('mollie-element');
                 expect(document.createElement).not.toHaveBeenCalledWith('p');
                 expect(disableButtonMock).not.toHaveBeenCalled();
@@ -268,14 +268,14 @@ describe('MolliePaymentStrategy', () => {
 
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValue( mollieMethod);
-                jest.spyOn(store.getState().cart, 'getCart').mockReturnValue(null);
+                jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(null);
                 jest.spyOn(document, 'createElement');
                 jest.spyOn(document, 'getElementById');
 
                 const response = strategy.initialize(optionsMock)
 
                 expect(response).rejects.toThrowError(new MissingDataError(MissingDataErrorType.MissingCart));
-                expect(store.getState().cart.getCart).toHaveBeenCalled();
+                expect(store.getState().cart.getCartOrThrow).toHaveBeenCalled();
                 expect(document.getElementById).not.toHaveBeenCalledWith('mollie-element');
                 expect(document.createElement).not.toHaveBeenCalledWith('p');
                 expect(disableButtonMock).not.toHaveBeenCalled();

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -85,27 +85,24 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             this._mountElements();
         }
 
-        if(methodsNotAllowedWhenDigitalOrder.includes(methodId)) {
-            const cart = state.cart.getCart();
-
-            if (!cart) {
-                throw new MissingDataError(MissingDataErrorType.MissingCart);
-            }
-
+        if (methodsNotAllowedWhenDigitalOrder.includes(methodId)) {
+            const cart = state.cart.getCartOrThrow();
             const cartDigitalItems = cart.lineItems.digitalItems;
 
-            if(cartDigitalItems && cartDigitalItems.length > 0){
+            if (cartDigitalItems && cartDigitalItems.length > 0) {
                 const { containerId } = this._getInitializeOptions();
 
                 if (containerId) {
                     const container = document.getElementById(containerId);
 
-                    if(container){
+                    if (container) {
                         const paragraph = document.createElement('p') ;
-                        paragraph.innerText = mollie.unsupportedMethodMessage;
-                        container.appendChild(paragraph);
 
-                        mollie.disableButton();
+                        if (mollie.unsupportedMethodMessage) {
+                            paragraph.innerText = mollie.unsupportedMethodMessage;
+                            container.appendChild(paragraph);
+                            mollie.disableButton();
+                        }
                     }
                 }
             }

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -20,6 +20,11 @@ export enum MolliePaymentMethodType {
     creditcard = 'credit_card',
 }
 
+const methodsNotAllowedWhenDigitalOrder = [
+    'klarnapaylater',
+    'klarnasliceit'
+]
+
 export default class MolliePaymentStrategy implements PaymentStrategy {
     private _initializeOptions?: MolliePaymentInitializeOptions;
     private _mollieClient?: MollieClient;
@@ -78,6 +83,32 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         } else if (this.isCreditCard(methodId)) {
             this._mollieClient = await this._loadMollieJs(merchantId, storeConfig.storeProfile.storeLanguage, testMode);
             this._mountElements();
+        }
+
+        if(methodsNotAllowedWhenDigitalOrder.includes(methodId)) {
+            const cart = state.cart.getCart();
+
+            if (!cart) {
+                throw new MissingDataError(MissingDataErrorType.MissingCart);
+            }
+
+            const cartDigitalItems = cart.lineItems.digitalItems;
+
+            if(cartDigitalItems && cartDigitalItems.length > 0){
+                const { containerId } = this._getInitializeOptions();
+
+                if (containerId) {
+                    const container = document.getElementById(containerId);
+
+                    if(container){
+                        const paragraph = document.createElement('p') ;
+                        paragraph.innerText = mollie.unsupportedMethodMessage;
+                        container.appendChild(paragraph);
+
+                        mollie.disableButton();
+                    }
+                }
+            }
         }
 
         return Promise.resolve(this._store.getState());

--- a/packages/core/src/payment/strategies/mollie/mollie.mock.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie.mock.ts
@@ -15,6 +15,8 @@ export function getInitializeOptions(): PaymentInitializeOptions {
             cardHolderId: 'mollie-card-holder-component-field',
             cardNumberId: 'mollie-card-number-component-field',
             styles: {valid: '#0f0'},
+            unsupportedMethodMessage: 'This payment method is not supported',
+            disableButton: jest.fn(),
         },
     };
 }
@@ -37,6 +39,8 @@ export function getHostedFormInitializeOptions(): PaymentInitializeOptions {
                     [HostedFieldType.CardName]: { containerId: 'card-name' },
                 },
             },
+            unsupportedMethodMessage: 'This payment method is not supported',
+            disableButton: jest.fn(),
         },
     };
 }


### PR DESCRIPTION
## What? [INT-5854](https://bigcommercecloud.atlassian.net/browse/INT-5854)
I want to hide any Klarna Pay Later and Klarna Slice It from shoppers if their cart contains digital products

## Why?
So that I can prevent shoppers from trying to pay for an ineligible cart and getting an error

## Testing / Proof

Before
https://user-images.githubusercontent.com/104527753/180102690-63e27651-3e1d-466b-bc3d-24f71aaf2b78.mov

After
https://user-images.githubusercontent.com/104527753/180099759-592b8826-6aea-4258-a53c-4835332259d4.mov



@bigcommerce/checkout @bigcommerce/apex-integrations 
