### PR TITLE
feat(payment): ADYEN-539 added vaulting card validation

### DIFF
--- a/packages/core/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
+++ b/packages/core/src/payment/strategies/adyenv2/adyenv2-initialize-options.ts
@@ -1,6 +1,6 @@
 import { Omit } from '../../../common/types';
 
-import { AdyenComponentState } from '.';
+import { AdyenV2ValidationState } from '.';
 import { AdyenAdditionalActionOptions, AdyenCreditCardComponentOptions, AdyenIdealComponentOptions, AdyenThreeDS2Options } from './adyenv2';
 
 /**
@@ -105,5 +105,5 @@ export default interface AdyenV2PaymentInitializeOptions {
 
     shouldShowNumberField?: boolean;
 
-    validateCardFields(componentState: AdyenComponentState): void;
+    validateCardFields(validateState: AdyenV2ValidationState): void;
 }

--- a/packages/core/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/adyenv2/adyenv2-payment-strategy.ts
@@ -270,20 +270,9 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
             if (adyenv2.cardVerificationContainerId) {
                 cardVerificationComponent = adyenClient.create(AdyenComponentType.SecuredFields, {
                     ...adyenv2.options,
-                    styles: {
-                        error: {
-                            color: 'red',
-                        },
-                        validated: {
-                            color: 'green',
-                        },
-                    },
                     onChange: componentState => this._updateComponentState(componentState),
-                    onError: componentState => {
-                        this._updateComponentState(componentState);
-                        adyenv2.validateCardFields(componentState);
-                    },
-                    onFieldValid: componentState => adyenv2.validateCardFields(componentState),
+                    onError: validateState => adyenv2.validateCardFields(validateState),
+                    onFieldValid: validateState => adyenv2.validateCardFields(validateState),
                 });
 
                 try {
@@ -403,35 +392,11 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
             return;
         }
 
-        adyenv2.hasVaultedInstruments ?
-            adyenv2.validateCardFields(cardComponent.state) :
-            cardComponent.componentRef.showValidation();
+        cardComponent.componentRef.showValidation();
 
-        if ( Object.keys(cardComponent.state).length === 0 || !this._isFieldsValid(cardComponent, adyenv2) ) {
+        if ( Object.keys(cardComponent.state).length === 0 || !cardComponent.state?.isValid ) {
             throw new PaymentInvalidFormError( this._mapCardErrors(cardComponent?.state?.errors) );
         }
-    }
-
-    private _isFieldsValid(cardComponent: AdyenComponent, adyenv2: AdyenV2PaymentInitializeOptions): boolean {
-        return adyenv2.hasVaultedInstruments ? this._isInstrumentValid(cardComponent, adyenv2) : !!cardComponent.state?.isValid;
-    }
-
-    private _isInstrumentValid(cardComponent: AdyenComponent, adyenv2: AdyenV2PaymentInitializeOptions): boolean {
-        if (adyenv2.shouldShowNumberField) {
-            return !!cardComponent.state?.isValid;
-        }
-
-        let isValid = true;
-        const fieldsValidationState = cardComponent?.state?.valid || {};
-
-        for (const fieldKey in fieldsValidationState) {
-            if (fieldKey !== 'encryptedCardNumber' && !fieldsValidationState[fieldKey]) {
-                isValid = false;
-                break;
-            }
-        }
-
-        return isValid;
     }
 
     private _mapCardErrors(cardStateErrors: CardStateErrors = {}): PaymentInvalidFormErrorDetails {

--- a/packages/core/src/payment/strategies/adyenv2/adyenv2.ts
+++ b/packages/core/src/payment/strategies/adyenv2/adyenv2.ts
@@ -182,9 +182,9 @@ export interface AdyenComponentEvents {
      * Called in case of an invalid card number, invalid expiry date, or
      *  incomplete field. Called again when errors are cleared.
      */
-    onError?(state: AdyenComponentState, component: AdyenComponent): void;
+    onError?(state: AdyenV2ValidationState, component: AdyenComponent): void;
 
-    onFieldValid?(state: AdyenComponentState, component: AdyenComponent): void;
+    onFieldValid?(state: AdyenV2ValidationState, component: AdyenComponent): void;
 }
 
 export interface AdyenClient {
@@ -832,6 +832,22 @@ export interface ThreeDS2DeviceFingerprintComponentOptions {
 export type AdyenComponentState = (
     CardState | WechatState
 );
+
+export interface AdyenV2ValidationState {
+    valid: boolean;
+    fieldType?: AdyenV2CardFields;
+    endDigits?: string;
+    encryptedFieldName?: string;
+    i18n?: string;
+    error?: string;
+    errorKey?: string;
+};
+
+export enum AdyenV2CardFields {
+    CardNumber = 'encryptedCardNumber',
+    SecurityCode = 'encryptedSecurityCode',
+    ExpiryDate = 'encryptedExpiryDate',
+}
 
 export type AdyenComponentOptions = (
     AdyenCreditCardComponentOptions | AdyenIdealComponentOptions | AdyenCustomCardComponentOptions

--- a/packages/core/src/payment/strategies/adyenv3/adyenv3-initialize-options.ts
+++ b/packages/core/src/payment/strategies/adyenv3/adyenv3-initialize-options.ts
@@ -1,6 +1,6 @@
 import { Omit } from '../../../common/types';
 
-import { AdyenV3ComponentState } from '.';
+import { AdyenV3ValidationState } from '.';
 import { AdyenAdditionalActionOptions, AdyenV3CreditCardComponentOptions } from './adyenv3';
 
 /**
@@ -87,5 +87,5 @@ export default interface AdyenV3PaymentInitializeOptions {
 
     shouldShowNumberField?: boolean;
 
-    validateCardFields(componentState: AdyenV3ComponentState): void;
+    validateCardFields(validateState: AdyenV3ValidationState): void;
 }

--- a/packages/core/src/payment/strategies/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -85,7 +85,7 @@ describe('AdyenV3PaymentStrategy', () => {
         let cardVerificationComponent: AdyenComponent;
 
         beforeEach(() => {
-            let handleOnError: (componentState: AdyenV3ComponentState) => {};
+            let handleOnChange: (componentState: AdyenV3ComponentState) => {};
 
             options = getInitializeOptions();
 
@@ -99,7 +99,7 @@ describe('AdyenV3PaymentStrategy', () => {
 
             cardVerificationComponent = {
                 mount: jest.fn(() => {
-                    handleOnError(getComponentState(false));
+                    handleOnChange(getComponentState());
 
                     return;
                 }),
@@ -115,8 +115,8 @@ describe('AdyenV3PaymentStrategy', () => {
                     return paymentComponent;
                 }))
                 .mockImplementationOnce(jest.fn((_method, options) => {
-                    const { onError } = options;
-                    handleOnError = onError;
+                    const { onChange } = options;
+                    handleOnChange = onChange;
 
                     return cardVerificationComponent;
                 }));

--- a/packages/core/src/payment/strategies/adyenv3/adyenv3.ts
+++ b/packages/core/src/payment/strategies/adyenv3/adyenv3.ts
@@ -178,9 +178,9 @@ export interface AdyenComponentEvents {
      * Called in case of an invalid card number, invalid expiry date, or
      *  incomplete field. Called again when errors are cleared.
      */
-    onError?(state: AdyenV3ComponentState, component: AdyenComponent): void;
+    onError?(state: AdyenV3ValidationState, component: AdyenComponent): void;
 
-    onFieldValid?(state: AdyenV3ComponentState, component: AdyenComponent): void;
+    onFieldValid?(state: AdyenV3ValidationState, component: AdyenComponent): void;
 }
 
 export interface AdyenClient {
@@ -816,6 +816,22 @@ export interface ThreeDS2ChallengeComponentOptions {
 export interface ThreeDS2DeviceFingerprintComponentOptions {
     onAdditionalDetails?(state: AdyenAdditionalActionState, component?: AdyenComponent): void;
     onError(error: AdyenError): void;
+}
+
+export interface AdyenV3ValidationState {
+    valid: boolean;
+    fieldType?: AdyenV3CardFields;
+    endDigits?: string;
+    encryptedFieldName?: string;
+    i18n?: string;
+    error?: string;
+    errorKey?: string;
+};
+
+export enum AdyenV3CardFields {
+    CardNumber = 'encryptedCardNumber',
+    SecurityCode = 'encryptedSecurityCode',
+    ExpiryDate = 'encryptedExpiryDate',
 }
 
 export type AdyenV3ComponentState = CardState | WechatState;


### PR DESCRIPTION
## What?
Added custom Adyen validation for saved card validation, comparison of last 4 symbols entered and saved card.
checkout-js pr: https://github.com/bigcommerce/checkout-js/pull/935
## Why?
Due to the https://bigcommercecloud.atlassian.net/browse/ADYEN-539

## Testing / Proof

https://user-images.githubusercontent.com/79574476/180739964-1cdbb97a-4202-4b7c-a161-944cd86818bc.mov


@bigcommerce/checkout 
