### PR TITLE
CHECKOUT-6780: Add missing dependency for CDN build

### DIFF
--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -42,6 +42,10 @@
             },
             "dependsOn": [
                 {
+                    "target": "generate",
+                    "projects": "self"
+                },
+                {
                     "target": "build",
                     "projects": "dependencies"
                 }


### PR DESCRIPTION
## What?
Run `npx nx run core:generate` before running `build-cdn` command.

## Why?
Otherwise, the build will fail as it won't have the generated files to build with.

## Testing / Proof
<img width="420" alt="Screen Shot 2022-07-26 at 2 15 43 PM" src="https://user-images.githubusercontent.com/667603/180921735-2234e64e-c36d-4f36-9b2a-82760102a9c2.png">

@bigcommerce/checkout @bigcommerce/payments
