### PR TITLE
feat(checkout): STRF-9829 Add hidePriceFromGuests to StoreConfig interface

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -11,6 +11,7 @@ export interface StoreConfig {
     checkoutSettings: CheckoutSettings;
     currency: StoreCurrency;
     displayDateFormat: string;
+    displaySettings: DisplaySettings;
     inputDateFormat: string;
 
     /**
@@ -138,4 +139,8 @@ export interface ContextConfig {
         formId?: string;
         token?: string;
     };
+}
+
+export interface DisplaySettings {
+    hidePriceFromGuests: boolean;
 }

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -60,6 +60,9 @@ export function getConfig(): Config {
                 thousandsSeparator: ',',
             },
             displayDateFormat: 'dd/MM/yyyy',
+            displaySettings: {
+                hidePriceFromGuests: false,
+            },
             inputDateFormat: 'dd/MM/yyyy',
             formFields: getFormFields(),
             links: {


### PR DESCRIPTION
### JIRA: [STRF-9829](https://bigcommercecloud.atlassian.net/browse/STRF-9829)

### Depends on: 
- https://github.com/bigcommerce/bigcommerce/pull/47777

## What?
Added **hidePriceFromGuests** to StoreConfig interface for checkouts.

## Why?
STRF-9829 will move the "Hide price for guests" functionality to BigCommerce instead of themes, so we should ensure that this value is available to the Checkout SDK since it will now be returned by the **checkout-settings** endpoint.

This setting needs to be exposed so that if a user signs out mid-checkout while prices are restricted to login, they will be redirected to the cart page.

## Testing / Proof
**note: screenshot is outdated slightly. Variable has changed to hidePriceFromGuests**
![Screen Shot 2022-07-26 at 3 57 40 PM](https://user-images.githubusercontent.com/19815878/181110672-78b35b14-b004-499d-98c0-b0b2f0da8e5a.png)


@bigcommerce/checkout @bigcommerce/payments
