### PR TITLE
feat(payment): INT-6342 fix klarna issue adding klarna v1 payment_method

### DIFF
--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -51,7 +51,7 @@ import { ExternalPaymentStrategy } from './strategies/external';
 import { createGooglePayPaymentProcessor, GooglePayAdyenV2Initializer, GooglePayAdyenV2PaymentProcessor, GooglePayAdyenV3Initializer, GooglePayAdyenV3PaymentProcessor, GooglePayAuthorizeNetInitializer, GooglePayBraintreeInitializer, GooglePayCheckoutcomInitializer, GooglePayCheckoutcomPaymentProcessor, GooglePayCybersourceV2Initializer, GooglePayOrbitalInitializer,  GooglePayPaymentStrategy, GooglePayStripeInitializer, GooglePayStripeUPEInitializer } from './strategies/googlepay';
 import { HummPaymentStrategy } from './strategies/humm';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
-import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader } from './strategies/klarnav2';
+import { KlarnaV2PaymentStrategy, KlarnaV2ScriptLoader, KlarnaV2TokenUpdater } from './strategies/klarnav2';
 import { LegacyPaymentStrategy } from './strategies/legacy';
 import { MasterpassPaymentStrategy, MasterpassScriptLoader } from './strategies/masterpass';
 import { MolliePaymentStrategy, MollieScriptLoader } from './strategies/mollie';
@@ -536,7 +536,7 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             remoteCheckoutActionCreator,
             new KlarnaV2ScriptLoader(scriptLoader),
-            new PaymentMethodRequestSender(requestSender)
+            new KlarnaV2TokenUpdater(requestSender)
         )
     );
 

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -534,9 +534,9 @@ export default function createPaymentStrategyRegistry(
         new KlarnaV2PaymentStrategy(
             store,
             orderActionCreator,
-            paymentMethodActionCreator,
             remoteCheckoutActionCreator,
-            new KlarnaV2ScriptLoader(scriptLoader)
+            new KlarnaV2ScriptLoader(scriptLoader),
+            new PaymentMethodRequestSender(requestSender)
         )
     );
 

--- a/packages/core/src/payment/strategies/klarnav2/index.ts
+++ b/packages/core/src/payment/strategies/klarnav2/index.ts
@@ -2,4 +2,5 @@ export { default as KlarnaV2PaymentStrategy } from './klarnav2-payment-strategy'
 export { default as KlarnaV2PaymentInitializeOptions } from './klarnav2-payment-initialize-options';
 export { default as KlarnaPayments, KlarnaLoadResponse } from './klarna-payments';
 export { default as KlarnaV2ScriptLoader } from './klarnav2-script-loader';
+export { default as KlarnaV2TokenUpdater } from './klarnav2-token-updater';
 export { supportedCountries, supportedCountriesRequiringStates } from './klarna-supported-countries';

--- a/packages/core/src/payment/strategies/klarnav2/klarnav2-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/klarnav2/klarnav2-payment-strategy.spec.ts
@@ -15,8 +15,6 @@ import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { PaymentMethodCancelledError, PaymentMethodInvalidError } from '../../errors';
 import PaymentMethod from '../../payment-method';
-import PaymentMethodActionCreator from '../../payment-method-action-creator';
-import { PaymentMethodActionType } from '../../payment-method-actions';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { getKlarna } from '../../payment-methods.mock';
 
@@ -24,16 +22,15 @@ import KlarnaPayments from './klarna-payments';
 import KlarnaV2PaymentStrategy from './klarnav2-payment-strategy';
 import KlarnaV2ScriptLoader from './klarnav2-script-loader';
 import { getEUBillingAddress, getEUBillingAddressWithNoPhone, getEUShippingAddress, getKlarnaV2UpdateSessionParams, getKlarnaV2UpdateSessionParamsForOC, getKlarnaV2UpdateSessionParamsPhone, getOCBillingAddress } from './klarnav2.mock';
+import { getResponse } from "../../../common/http-request/responses.mock";
 
 describe('KlarnaV2PaymentStrategy', () => {
     let checkoutActionCreator: CheckoutActionCreator;
     let initializePaymentAction: Observable<Action>;
     let klarnaPayments: KlarnaPayments;
-    let loadPaymentMethodAction: Observable<Action>;
     let payload: OrderRequestBody;
     let paymentMethod: PaymentMethod;
     let orderActionCreator: OrderActionCreator;
-    let paymentMethodActionCreator: PaymentMethodActionCreator;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let requestSender: RequestSender;
     let scriptLoader: KlarnaV2ScriptLoader;
@@ -41,6 +38,7 @@ describe('KlarnaV2PaymentStrategy', () => {
     let store: CheckoutStore;
     let strategy: KlarnaV2PaymentStrategy;
     let paymentMethodMock: PaymentMethod;
+    let paymentMethodRequestSender: PaymentMethodRequestSender
 
     beforeEach(() => {
         paymentMethodMock = { ...getKlarna(), id: 'pay_now', gateway: 'klarna'};
@@ -57,7 +55,6 @@ describe('KlarnaV2PaymentStrategy', () => {
             new OrderRequestSender(requestSender),
             new CheckoutValidator(new CheckoutRequestSender(requestSender))
         );
-        paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
@@ -69,12 +66,13 @@ describe('KlarnaV2PaymentStrategy', () => {
             checkoutActionCreator
         );
         scriptLoader = new KlarnaV2ScriptLoader(createScriptLoader());
+        paymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
         strategy = new KlarnaV2PaymentStrategy(
             store,
             orderActionCreator,
-            paymentMethodActionCreator,
             remoteCheckoutActionCreator,
-            scriptLoader
+            scriptLoader,
+            paymentMethodRequestSender
         );
 
         klarnaPayments = {
@@ -95,7 +93,6 @@ describe('KlarnaV2PaymentStrategy', () => {
             useStoreCredit: true,
         });
 
-        loadPaymentMethodAction = of(createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethod, { methodId: paymentMethod.id }));
         initializePaymentAction = of(createAction(RemoteCheckoutActionType.InitializeRemotePaymentRequested));
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
 
@@ -104,14 +101,14 @@ describe('KlarnaV2PaymentStrategy', () => {
         jest.spyOn(orderActionCreator, 'submitOrder')
             .mockReturnValue(submitOrderAction);
 
-        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')
-            .mockReturnValue(loadPaymentMethodAction);
-
         jest.spyOn(remoteCheckoutActionCreator, 'initializePayment')
             .mockReturnValue(initializePaymentAction);
 
         jest.spyOn(scriptLoader, 'load')
             .mockImplementation(() => Promise.resolve(klarnaPayments));
+
+        jest.spyOn(paymentMethodRequestSender, 'loadPaymentMethod')
+            .mockResolvedValue(getResponse(getKlarna()));
 
         jest.spyOn(store, 'subscribe');
     });
@@ -159,7 +156,8 @@ describe('KlarnaV2PaymentStrategy', () => {
             strategy.execute(payload);
             expect(klarnaPayments.authorize)
                 .toHaveBeenCalledWith({ payment_method_category: paymentMethod.id }, getKlarnaV2UpdateSessionParamsPhone(), expect.any(Function));
-            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(paymentMethod.gateway);
+            expect(paymentMethodRequestSender.loadPaymentMethod)
+                .toHaveBeenCalledWith(paymentMethod.gateway, { params: { params: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7'} });
         });
 
         it('loads widget in EU', async () => {
@@ -170,9 +168,9 @@ describe('KlarnaV2PaymentStrategy', () => {
             strategy = new KlarnaV2PaymentStrategy(
                 store,
                 orderActionCreator,
-                paymentMethodActionCreator,
                 remoteCheckoutActionCreator,
-                scriptLoader
+                scriptLoader,
+                paymentMethodRequestSender
             );
             jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
@@ -192,9 +190,9 @@ describe('KlarnaV2PaymentStrategy', () => {
             strategy = new KlarnaV2PaymentStrategy(
                 store,
                 orderActionCreator,
-                paymentMethodActionCreator,
                 remoteCheckoutActionCreator,
-                scriptLoader
+                scriptLoader,
+                paymentMethodRequestSender
             );
             jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
@@ -214,9 +212,9 @@ describe('KlarnaV2PaymentStrategy', () => {
             strategy = new KlarnaV2PaymentStrategy(
                 store,
                 orderActionCreator,
-                paymentMethodActionCreator,
                 remoteCheckoutActionCreator,
-                scriptLoader
+                scriptLoader,
+                paymentMethodRequestSender
             );
             jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
             jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
@@ -237,9 +235,9 @@ describe('KlarnaV2PaymentStrategy', () => {
             strategy = new KlarnaV2PaymentStrategy(
                 store,
                 orderActionCreator,
-                paymentMethodActionCreator,
                 remoteCheckoutActionCreator,
-                scriptLoader
+                scriptLoader,
+                paymentMethodRequestSender
             );
 
             strategy.initialize({ methodId: paymentMethod.id, gatewayId: paymentMethod.gateway, klarnav2: { container: '#container' } });

--- a/packages/core/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
@@ -14,7 +14,7 @@ import PaymentStrategy from '../payment-strategy';
 import KlarnaPayments, { KlarnaAddress, KlarnaAuthorizationResponse, KlarnaLoadResponse, KlarnaUpdateSessionParams } from './klarna-payments';
 import { supportedCountries, supportedCountriesRequiringStates } from './klarna-supported-countries';
 import KlarnaV2ScriptLoader from './klarnav2-script-loader';
-import PaymentMethodRequestSender from "../../payment-method-request-sender";
+import KlarnaV2TokenUpdater from './klarnav2-token-updater';
 
 export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
     private _klarnaPayments?: KlarnaPayments;
@@ -25,7 +25,7 @@ export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
         private _orderActionCreator: OrderActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
         private _klarnav2ScriptLoader: KlarnaV2ScriptLoader,
-        private _requestSender: PaymentMethodRequestSender
+        private _klarnav2TokenUpdater: KlarnaV2TokenUpdater
     ) {}
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -107,10 +107,10 @@ export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
         const cartId = state.cart.getCartOrThrow().id;
         const params = { 'params': cartId };
 
-        this._requestSender.loadPaymentMethod(gatewayId, { params })
+        await this._klarnav2TokenUpdater.updateClientToken(gatewayId, { params })
             .catch(() => {
-                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod)
-                });
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod)
+            });
 
         return new Promise<KlarnaLoadResponse>(resolve => {
             const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);

--- a/packages/core/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/klarnav2/klarnav2-payment-strategy.ts
@@ -8,13 +8,13 @@ import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { RemoteCheckoutActionCreator } from '../../../remote-checkout';
 import { PaymentMethodCancelledError, PaymentMethodInvalidError } from '../../errors';
-import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
 import KlarnaPayments, { KlarnaAddress, KlarnaAuthorizationResponse, KlarnaLoadResponse, KlarnaUpdateSessionParams } from './klarna-payments';
 import { supportedCountries, supportedCountriesRequiringStates } from './klarna-supported-countries';
 import KlarnaV2ScriptLoader from './klarnav2-script-loader';
+import PaymentMethodRequestSender from "../../payment-method-request-sender";
 
 export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
     private _klarnaPayments?: KlarnaPayments;
@@ -23,9 +23,9 @@ export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
     constructor(
         private _store: CheckoutStore,
         private _orderActionCreator: OrderActionCreator,
-        private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _remoteCheckoutActionCreator: RemoteCheckoutActionCreator,
-        private _klarnav2ScriptLoader: KlarnaV2ScriptLoader
+        private _klarnav2ScriptLoader: KlarnaV2ScriptLoader,
+        private _requestSender: PaymentMethodRequestSender
     ) {}
 
     initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
@@ -103,7 +103,14 @@ export default class KlarnaV2PaymentStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to proceed because "payload.payment.gatewayId" argument is not provided.');
         }
 
-        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(gatewayId));
+        const state = this._store.getState();
+        const cartId = state.cart.getCartOrThrow().id;
+        const params = { 'params': cartId };
+
+        this._requestSender.loadPaymentMethod(gatewayId, { params })
+            .catch(() => {
+                    throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod)
+                });
 
         return new Promise<KlarnaLoadResponse>(resolve => {
             const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);

--- a/packages/core/src/payment/strategies/klarnav2/klarnav2-token-updater.spec.ts
+++ b/packages/core/src/payment/strategies/klarnav2/klarnav2-token-updater.spec.ts
@@ -1,0 +1,49 @@
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import KlarnaV2TokenUpdater from './klarnav2-token-updater';
+
+describe('KlarnaV2TokenUpdater', () => {
+    const requestSender = createRequestSender();
+    const klarnaV2TokenUpdater = new KlarnaV2TokenUpdater(requestSender);
+
+    beforeEach(() => {
+        jest.spyOn(requestSender, 'get').mockReturnValue(Promise.resolve(true));
+    });
+
+    it('calls request sender to load payment method', async () => {
+        await klarnaV2TokenUpdater.updateClientToken('klarna', { params: 'cart' });
+
+        expect(requestSender.get).toHaveBeenCalledWith(
+            '/api/storefront/payments/klarna',
+            {
+                "headers": {
+                "Accept": "application/vnd.bc.v1+json",
+                     "X-API-INTERNAL": "This API endpoint is for internal use only and may change in the future",
+                     "X-Checkout-SDK-Version": "1.0.0",
+                },
+                "params": "cart",
+                "timeout": undefined,
+            }
+        );
+    });
+
+    it('throws an error when the request sender is unable to load payment method', () => {
+        jest.spyOn(requestSender, 'get')
+            .mockReturnValue(Promise.reject(new MissingDataError(MissingDataErrorType.MissingPaymentMethod)));
+
+        expect(klarnaV2TokenUpdater.updateClientToken('klarna', { params: 'cart' }))
+            .rejects.toThrow(MissingDataError);
+        expect(requestSender.get).toHaveBeenCalledWith(
+            '/api/storefront/payments/klarna',
+            {
+                "headers": {
+                    "Accept": "application/vnd.bc.v1+json",
+                    "X-API-INTERNAL": "This API endpoint is for internal use only and may change in the future",
+                    "X-Checkout-SDK-Version": "1.0.0",
+                },
+                "params": "cart",
+                "timeout": undefined,
+            }
+        );
+    });
+});

--- a/packages/core/src/payment/strategies/klarnav2/klarnav2-token-updater.ts
+++ b/packages/core/src/payment/strategies/klarnav2/klarnav2-token-updater.ts
@@ -1,0 +1,23 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+import { ContentType, INTERNAL_USE_ONLY, RequestOptions, SDK_VERSION_HEADERS } from '../../../common/http-request';
+import PaymentMethod from '../../payment-method';
+
+export default class KlarnaV2TokenUpdater {
+    constructor(
+        private _requestSender: RequestSender
+    ) {}
+
+    updateClientToken(gatewayId: string, { timeout, params }: RequestOptions = {}): Promise<Response<PaymentMethod>> {
+        const url = `/api/storefront/payments/${gatewayId}`;
+
+        return this._requestSender.get(url, {
+            timeout,
+            headers: {
+                Accept: ContentType.JsonV1,
+                'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                ...SDK_VERSION_HEADERS,
+            },
+            params,
+        });
+    }
+}


### PR DESCRIPTION
## What?
I switched to use PaymentMethodRequestSender.loadPaymentMethod function instead paymentMethodActionCreator.loadPaymentMethod(gateway_id) to avoid the klarnav1 payment method adding.

## Why?
we noticed that when we use loadPaymentMethod(gateway_id) function, load Klarna v1 payment_methods

## Testing / Proof
![image](https://user-images.githubusercontent.com/68653578/181863843-e57fdf4a-2d20-4b3a-99a8-841e4289e9c5.png)

![image](https://user-images.githubusercontent.com/68653578/181124836-127b10b0-5375-4cc0-b148-5b3fb649c85e.png)


@bigcommerce/checkout @bigcommerce/payments
