### PR TITLE
CHECKOUT-6781: Upgrade API extractor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3048,95 +3048,97 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-6.3.0.tgz",
-      "integrity": "sha512-rhC3Wc/Zaj44W8hJYJlaf+gFGxVwLvSEOnPslYUi3anFbtXBNZpK3ocF10SgtSaca2QfKA8UNN1rCIwXUCdz7g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.28.6.tgz",
+      "integrity": "sha512-RNUokJTlBGD0ax/Jo8xLPWv4s6IboqrYrcabEEh6rFadO/tVPoV/R5YHtEeZ2q4ubvwhHTtX3sRm+p4fJo/3Sg==",
       "dev": true,
       "requires": {
-        "@microsoft/node-core-library": "3.7.0",
-        "@microsoft/ts-command-line": "4.2.2",
-        "@microsoft/tsdoc": "0.12.2",
-        "@types/node": "8.5.8",
-        "@types/z-schema": "3.16.31",
+        "@microsoft/api-extractor-model": "7.22.1",
+        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "3.49.0",
+        "@rushstack/rig-package": "0.3.13",
+        "@rushstack/ts-command-line": "4.12.1",
         "colors": "~1.2.1",
-        "jju": "~1.3.0",
-        "lodash": "~4.17.5",
-        "resolve": "1.8.1",
-        "typescript": "~3.1.6",
-        "z-schema": "~3.18.3"
+        "lodash": "~4.17.15",
+        "resolve": "~1.17.0",
+        "semver": "~7.3.0",
+        "source-map": "~0.6.1",
+        "typescript": "~4.6.3"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "8.5.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
-          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
-          "dev": true
-        },
         "resolve": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "^1.0.6"
           }
         },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
         "typescript": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-          "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+          "version": "4.6.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
           "dev": true
         }
       }
     },
-    "@microsoft/node-core-library": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/node-core-library/-/node-core-library-3.7.0.tgz",
-      "integrity": "sha512-Mae+MFnlcrcEmd6cmNzSv7xG74jWtQRlcOVjIwi10lECwm2LJIaiCol/PrsyARnjroDzf1eDH3quXSY7dTxLaA==",
+    "@microsoft/api-extractor-model": {
+      "version": "7.22.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.22.1.tgz",
+      "integrity": "sha512-3Bx6VC8F4ti8XlhaOCynCpwGvdXGwHD2dGBpo2xpJT9gEmPQvpAL3Ni+5gaEX0eQ27zGILVTUZDqZSRYskk/Rw==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "5.0.4",
-        "@types/node": "8.5.8",
-        "@types/z-schema": "3.16.31",
-        "colors": "~1.2.1",
-        "fs-extra": "~7.0.1",
-        "jju": "~1.3.0",
-        "z-schema": "~3.18.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.5.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
-          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
-          "dev": true
-        }
-      }
-    },
-    "@microsoft/ts-command-line": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/ts-command-line/-/ts-command-line-4.2.2.tgz",
-      "integrity": "sha512-CLLVG+zWmUvD6jZD5oq7QCFYj3WOvrBSc3H6KejXCH6q2ntP5/ZHlmKVzQVvN1cEOSWP+jN9ml2AvUcDY/l6Tw==",
-      "dev": true,
-      "requires": {
-        "@types/argparse": "1.0.33",
-        "@types/node": "8.5.8",
-        "argparse": "~1.0.9",
-        "colors": "~1.2.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.5.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
-          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
-          "dev": true
-        }
+        "@microsoft/tsdoc": "0.14.1",
+        "@microsoft/tsdoc-config": "~0.16.1",
+        "@rushstack/node-core-library": "3.49.0"
       }
     },
     "@microsoft/tsdoc": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.2.tgz",
-      "integrity": "sha512-L/srhENhBtbZLUD9FfJ2ZQdnYv3A3MT3UI2EMbC06fHUzIxLjjbkomD6o42UrbsRMwlS9p1BtxExeaCdX73q2Q==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
+      "integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==",
       "dev": true
+    },
+    "@microsoft/tsdoc-config": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
+      "integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
+      "dev": true,
+      "requires": {
+        "@microsoft/tsdoc": "0.14.1",
+        "ajv": "~6.12.6",
+        "jju": "~1.4.0",
+        "resolve": "~1.19.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -12768,6 +12770,82 @@
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
       "dev": true
     },
+    "@rushstack/node-core-library": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.49.0.tgz",
+      "integrity": "sha512-yBJRzGgUNFwulVrwwBARhbGaHsxVMjsZ9JwU1uSBbqPYCdac+t2HYdzi4f4q/Zpgb0eNbwYj2yxgHYpJORNEaw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "12.20.24",
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.17.0",
+        "semver": "~7.3.0",
+        "timsort": "~0.3.0",
+        "z-schema": "~5.0.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@rushstack/rig-package": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.13.tgz",
+      "integrity": "sha512-4/2+yyA/uDl7LQvtYtFs1AkhSWuaIGEKhP9/KK2nNARqOVc5eCXmu1vyOqr5mPvNq7sHoIR+sG84vFbaKYGaDA==",
+      "dev": true,
+      "requires": {
+        "resolve": "~1.17.0",
+        "strip-json-comments": "~3.1.1"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "@rushstack/ts-command-line": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.12.1.tgz",
+      "integrity": "sha512-S1Nev6h/kNnamhHeGdp30WgxZTA+B76SJ/P721ctP7DrnC+rrjAc6h/R80I4V0cA2QuEEcMdVOQCtK2BTjsOiQ==",
+      "dev": true,
+      "requires": {
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "colors": "~1.2.1",
+        "string-argv": "~0.3.1"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -12996,9 +13074,9 @@
       "dev": true
     },
     "@types/argparse": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.33.tgz",
-      "integrity": "sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true
     },
     "@types/babel__core": {
@@ -13075,15 +13153,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
-    },
-    "@types/fs-extra": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
-      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/glob": {
       "version": "7.2.0",
@@ -13244,12 +13313,6 @@
       "version": "0.26.24",
       "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.24.tgz",
       "integrity": "sha512-x0bhHnYjH5mZit4HivUYbTMO4LouOTGwp/LLxSL1mbJYVwNJtHYESH0ed2bwM1lkI2yDmsoCDYJnWEgHeJDACg=="
-    },
-    "@types/z-schema": {
-      "version": "3.16.31",
-      "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz",
-      "integrity": "sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=",
-      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.26.0",
@@ -15188,9 +15251,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "optional": true
     },
@@ -19585,6 +19648,12 @@
         }
       }
     },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true
+    },
     "import-local": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
@@ -21988,9 +22057,9 @@
       }
     },
     "jju": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
     },
     "js-cookie": {
@@ -22216,7 +22285,7 @@
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -22409,7 +22478,7 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "dev": true
     },
     "lodash.ismatch": {
@@ -25601,6 +25670,12 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -26499,6 +26574,12 @@
         "xtend": "~4.0.1"
       }
     },
+    "timsort": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
+      "dev": true
+    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -27040,9 +27121,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unset-value": {
@@ -27182,9 +27263,9 @@
       }
     },
     "validator": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
-      "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "dev": true
     },
     "verror": {
@@ -28151,15 +28232,15 @@
       }
     },
     "z-schema": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
-      "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.3.tgz",
+      "integrity": "sha512-sGvEcBOTNum68x9jCpCVGPFJ6mWnkD0YxOcddDlJHRx3tKdB2q8pCHExMVZo/AV/6geuVJXG7hljDaWG8+5GDw==",
       "dev": true,
       "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^8.0.0"
+        "commander": "^2.20.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@babel/core": "^7.6.2",
     "@babel/preset-env": "^7.6.2",
     "@bigcommerce/eslint-config": "^1.0.1",
-    "@microsoft/api-extractor": "^6.3.0",
+    "@microsoft/api-extractor": "^7.28.6",
     "@nrwl/cli": "^13.10.3",
     "@nrwl/devkit": "^13.10.3",
     "@nrwl/eslint-plugin-nx": "^13.10.3",

--- a/packages/core/api-extractor/checkout-button.json
+++ b/packages/core/api-extractor/checkout-button.json
@@ -1,9 +1,7 @@
 {
     "extends": "./checkout-sdk.json",
-    "project": {
-        "entryPointSourceFile": "../../temp/core/src/bundles/checkout-button.d.ts"
-    },
+    "mainEntryPointFilePath": "<projectFolder>/temp/core/src/bundles/checkout-button.d.ts",
     "dtsRollup": {
-        "mainDtsRollupPath": "checkout-button.d.ts"
+        "publicTrimmedFilePath": "<projectFolder>/dist/checkout-button.d.ts"
     }
 }

--- a/packages/core/api-extractor/checkout-sdk.json
+++ b/packages/core/api-extractor/checkout-sdk.json
@@ -1,22 +1,51 @@
 {
     "compiler": {
-        "configType": "tsconfig",
-        "rootFolder": "."
+        "tsconfigFilePath": "../tsconfig.json"
     },
-    "project": {
-        "entryPointSourceFile": "../../temp/core/src/bundles/checkout-sdk.d.ts"
-    },
-    "validationRules": {
-        "missingReleaseTags": "allow"
-    },
-    "apiReviewFile": {
+    "projectFolder": "../../../",
+    "mainEntryPointFilePath": "<projectFolder>/temp/core/src/bundles/checkout-sdk.d.ts",
+    "newlineKind": "lf",
+    "docModel": {
         "enabled": false
     },
-    "apiJsonFile": {
+    "apiReport": {
         "enabled": false
+    },
+    "messages": {
+        "extractorMessageReporting": {
+            "default": {
+                "logLevel": "none"
+            },
+            "ae-forgotten-export": {
+                "logLevel": "none"
+            },
+            "ae-incompatible-release-tags": {
+                "logLevel": "none"
+            },
+            "ae-internal-missing-underscore": {
+                "logLevel": "none"
+            },
+            "ae-internal-mixed-release-tag": {
+                "logLevel": "none"
+            },
+            "ae-unresolved-inheritdoc-reference": {
+                "logLevel": "none"
+            },
+            "ae-unresolved-inheritdoc-base": {
+                "logLevel": "none"
+            },
+            "ae-wrong-input-file-type": {
+                "logLevel": "none"
+            }
+        },
+        "tsdocMessageReporting": {
+            "default": {
+                "logLevel": "none"
+            }
+        }
     },
     "dtsRollup": {
         "enabled": true,
-        "mainDtsRollupPath": "checkout-sdk.d.ts"
+        "publicTrimmedFilePath": "<projectFolder>/dist/checkout-sdk.d.ts"
     }
 }

--- a/packages/core/api-extractor/embedded-checkout.json
+++ b/packages/core/api-extractor/embedded-checkout.json
@@ -1,9 +1,7 @@
 {
     "extends": "./checkout-sdk.json",
-    "project": {
-        "entryPointSourceFile": "../../temp/core/src/bundles/embedded-checkout.d.ts"
-    },
+    "mainEntryPointFilePath": "<projectFolder>/temp/core/src/bundles/embedded-checkout.d.ts",
     "dtsRollup": {
-        "mainDtsRollupPath": "embedded-checkout.d.ts"
+        "publicTrimmedFilePath": "<projectFolder>/dist/embedded-checkout.d.ts"
     }
 }

--- a/packages/core/api-extractor/internal-mappers.json
+++ b/packages/core/api-extractor/internal-mappers.json
@@ -1,9 +1,7 @@
 {
     "extends": "./checkout-sdk.json",
-    "project": {
-        "entryPointSourceFile": "../../temp/core/src/bundles/internal-mappers.d.ts"
-    },
+    "mainEntryPointFilePath": "<projectFolder>/temp/core/src/bundles/internal-mappers.d.ts",
     "dtsRollup": {
-        "mainDtsRollupPath": "internal-mappers.d.ts"
+        "publicTrimmedFilePath": "<projectFolder>/dist/internal-mappers.d.ts"
     }
 }


### PR DESCRIPTION
## What?
Upgrade API extractor library from v6 to v7

## Why?
The new version has a couple of improvements. Please note that all the warnings are disabled at the moment because they need to be fixed individually.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
