### PR TITLE
chore(common): CHECKOUT-6855 Load payment strategies from V2 as priority

### DIFF
--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -26,6 +26,10 @@
             },
             "dependsOn": [
                 {
+                    "target": "generate",
+                    "projects": "self"
+                },
+                {
                     "target": "build",
                     "projects": "dependencies"
                 }

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -619,14 +619,11 @@ describe('CheckoutService', () => {
         });
     });
 
-    describe.only('#finalizeOrderIfNeeded()', () => {
-        it.only('finds payment strategy', async () => {
+    describe('#finalizeOrderIfNeeded()', () => {
+        it('finds payment strategy', async () => {
             await checkoutService.loadCheckout();
-            console.log('loadCheckjout');
             await checkoutService.loadPaymentMethods();
-            console.log('loadPaymentMethods');
             await checkoutService.finalizeOrderIfNeeded();
-            console.log('finalizeOrderIfNeeded');
 
             expect(paymentStrategyRegistry.getByMethod).toHaveBeenCalledWith(getAuthorizenet());
         });

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -619,11 +619,14 @@ describe('CheckoutService', () => {
         });
     });
 
-    describe('#finalizeOrderIfNeeded()', () => {
-        it('finds payment strategy', async () => {
+    describe.only('#finalizeOrderIfNeeded()', () => {
+        it.only('finds payment strategy', async () => {
             await checkoutService.loadCheckout();
+            console.log('loadCheckjout');
             await checkoutService.loadPaymentMethods();
+            console.log('loadPaymentMethods');
             await checkoutService.finalizeOrderIfNeeded();
+            console.log('finalizeOrderIfNeeded');
 
             expect(paymentStrategyRegistry.getByMethod).toHaveBeenCalledWith(getAuthorizenet());
         });

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -11,7 +11,8 @@ import { createCustomerStrategyRegistry, CustomerActionCreator, CustomerRequestS
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
-import { createPaymentClient, createPaymentStrategyRegistry, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentStrategyActionCreator } from '../payment';
+import { createPaymentClient, createPaymentStrategyRegistry, createPaymentStrategyRegistryV2, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentStrategyActionCreator } from '../payment';
+import { createPaymentIntegrationService } from '../payment-integration';
 import { InstrumentActionCreator, InstrumentRequestSender } from '../payment/instrument';
 import { createShippingStrategyRegistry, ConsignmentActionCreator, ConsignmentRequestSender, PickupOptionActionCreator, PickupOptionRequestSender, ShippingCountryActionCreator, ShippingCountryRequestSender, ShippingStrategyActionCreator } from '../shipping';
 import { SignInEmailActionCreator, SignInEmailRequestSender } from '../signin-email';
@@ -78,6 +79,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     const subscriptionsActionCreator = new SubscriptionsActionCreator(new SubscriptionsRequestSender(requestSender));
     const formFieldsActionCreator = new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender));
     const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator, formFieldsActionCreator);
+    const paymentIntegrationService = createPaymentIntegrationService(store);
 
     return new CheckoutService(
         store,
@@ -103,6 +105,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
         new PaymentStrategyActionCreator(
             createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, locale),
+            createPaymentStrategyRegistryV2(paymentIntegrationService),
             orderActionCreator,
             spamProtectionActionCreator
         ),

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -1,11 +1,9 @@
-import { PaymentStrategy, PaymentStrategyResolveId } from '@bigcommerce/checkout-sdk/payment-integration';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { ErrorActionCreator } from '../common/error';
 import { getDefaultLogger } from '../common/log';
-import { ResolveIdRegistry } from '../common/registry';
 import { getEnvironment } from '../common/utility';
 import { ConfigActionCreator, ConfigRequestSender, ConfigState, ConfigWindow } from '../config';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
@@ -82,7 +80,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     const formFieldsActionCreator = new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender));
     const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator, formFieldsActionCreator);
     const paymentIntegrationService = createPaymentIntegrationService(store);
-    const registryV2: ResolveIdRegistry<PaymentStrategy, PaymentStrategyResolveId> = createPaymentStrategyRegistryV2(paymentIntegrationService);
+    const registryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
 
     return new CheckoutService(
         store,

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -1,9 +1,11 @@
+import { PaymentStrategy, PaymentStrategyResolveId } from '@bigcommerce/checkout-sdk/payment-integration';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { ErrorActionCreator } from '../common/error';
 import { getDefaultLogger } from '../common/log';
+import { ResolveIdRegistry } from '../common/registry';
 import { getEnvironment } from '../common/utility';
 import { ConfigActionCreator, ConfigRequestSender, ConfigState, ConfigWindow } from '../config';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
@@ -80,6 +82,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     const formFieldsActionCreator = new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender));
     const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator, formFieldsActionCreator);
     const paymentIntegrationService = createPaymentIntegrationService(store);
+    const registryV2: ResolveIdRegistry<PaymentStrategy, PaymentStrategyResolveId> = createPaymentStrategyRegistryV2(paymentIntegrationService);
 
     return new CheckoutService(
         store,
@@ -105,7 +108,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
         new PaymentStrategyActionCreator(
             createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, locale),
-            createPaymentStrategyRegistryV2(paymentIntegrationService),
+            registryV2,
             orderActionCreator,
             spamProtectionActionCreator
         ),

--- a/packages/core/src/payment/create-payment-strategy-registry.spec.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.spec.ts
@@ -13,7 +13,6 @@ import { AdyenV3PaymentStrategy } from './strategies/adyenv3';
 import { AffirmPaymentStrategy } from './strategies/affirm';
 import { AfterpayPaymentStrategy } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy } from './strategies/amazon-pay';
-import { ApplePayPaymentStrategy } from './strategies/apple-pay';
 import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy } from './strategies/braintree';
@@ -60,11 +59,6 @@ describe('CreatePaymentStrategyRegistry', () => {
 
     it('can create a payment strategy registry', () => {
         expect(registry).toEqual(expect.any(PaymentStrategyRegistry));
-    });
-
-    it('can instantiate Apple Pay', () => {
-        const paymentStrategy = registry.get(PaymentStrategyType.APPLEPAY);
-        expect(paymentStrategy).toBeInstanceOf(ApplePayPaymentStrategy);
     });
 
     it('can instantiate adyenv2', () => {

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -1,6 +1,7 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
 import { RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
+import { createApplePayPaymentStrategy } from '@bigcommerce/checkout-sdk/apple-pay';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
@@ -109,6 +110,8 @@ export default function createPaymentStrategyRegistry(
     const stepHandler = createStepHandler(formPoster, paymentHumanVerificationHandler);
     const hostedFormFactory = new HostedFormFactory(store);
     const storefrontPaymentRequestSender = new StorefrontPaymentRequestSender(requestSender);
+
+    console.log(createApplePayPaymentStrategy);
 
     registry.register(PaymentStrategyType.ADYENV2, () =>
         new AdyenV2PaymentStrategy(

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -32,7 +32,6 @@ import { AffirmPaymentStrategy, AffirmScriptLoader } from './strategies/affirm';
 import { AfterpayPaymentStrategy, AfterpayScriptLoader } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy, AmazonPayScriptLoader } from './strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentStrategy } from './strategies/amazon-pay-v2';
-import { ApplePayPaymentStrategy, ApplePaySessionFactory } from './strategies/apple-pay';
 import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BoltPaymentStrategy, BoltScriptLoader } from './strategies/bolt';
@@ -849,17 +848,6 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             storefrontPaymentRequestSender,
             paymentActionCreator
-        )
-    );
-
-    registry.register(PaymentStrategyType.APPLEPAY, () =>
-        new ApplePayPaymentStrategy(
-            store,
-            requestSender,
-            orderActionCreator,
-            paymentMethodActionCreator,
-            paymentActionCreator,
-            new ApplePaySessionFactory()
         )
     );
 

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -6,6 +6,7 @@ export * from './payment-status-types';
 export { default as PaymentAdditionalAction, CardingProtectionActionData } from './payment-additional-action';
 export { default as createPaymentClient } from './create-payment-client';
 export { default as createPaymentStrategyRegistry } from './create-payment-strategy-registry';
+export { default as createPaymentStrategyRegistryV2 } from './create-payment-strategy-registry-v2';
 export { default as isHostedInstrumentLike } from './is-hosted-intrument-like';
 export { default as isNonceLike } from './is-nonce-like';
 export { default as isVaultedInstrument } from './is-vaulted-instrument';

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -83,15 +83,11 @@ export default class PaymentStrategyActionCreator {
 
                 let strategy: PaymentStrategy | PaymentStrategyV2;
 
-                console.log('this gets triggered?');
-
                 try {
                     strategy = this._strategyRegistryV2.get({ id: method.id });
                 } catch {
                     strategy = this._strategyRegistry.getByMethod(method)
                 }
-
-                console.log('Does it get here?');
 
                 await strategy.finalize({ ...options, methodId: method.id, gatewayId: method.gateway });
 
@@ -155,6 +151,7 @@ export default class PaymentStrategyActionCreator {
             if (methodId && !state.paymentStrategies.isInitialized(methodId)) {
                 return empty();
             }
+
             let strategy: PaymentStrategy | PaymentStrategyV2;
 
             try {
@@ -163,7 +160,7 @@ export default class PaymentStrategyActionCreator {
                 strategy = this._strategyRegistry.getByMethod(method)
             }
 
-            const promise: Promise<InternalCheckoutSelectors | void> = strategy.initialize({ ...options, methodId, gatewayId });
+            const promise: Promise<InternalCheckoutSelectors | void> = strategy.deinitialize({ ...options, methodId, gatewayId });
 
             return concat(
                 of(createAction(PaymentStrategyActionType.DeinitializeRequested, undefined, { methodId })),

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -19,6 +19,7 @@ import { PaymentStrategy } from './strategies';
 export default class PaymentStrategyActionCreator {
     constructor(
         private _strategyRegistry: PaymentStrategyRegistry,
+        private _strategyRegistryV2: any,
         private _orderActionCreator: OrderActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator
     ) {}
@@ -45,6 +46,8 @@ export default class PaymentStrategyActionCreator {
                         if (!method) {
                             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                         }
+
+                        console.log(this._strategyRegistryV2);
 
                         strategy = this._strategyRegistry.getByMethod(method);
                     } else {

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -49,9 +49,11 @@ export default class PaymentStrategyActionCreator {
                             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                         }
 
-                        strategy = this._strategyRegistryV2.get({ id: method.id }) ?
-                            this._strategyRegistryV2.get({ id: method.id }) :
-                            this._strategyRegistry.getByMethod(method);
+                        try {
+                            strategy = this._strategyRegistryV2.get({ id: method.id });
+                        } catch {
+                            strategy = this._strategyRegistry.getByMethod(method)
+                        }
                     } else {
                         strategy = this._strategyRegistry.get(PaymentStrategyType.NO_PAYMENT_DATA_REQUIRED);
                     }
@@ -79,9 +81,17 @@ export default class PaymentStrategyActionCreator {
                     throw new OrderFinalizationNotRequiredError();
                 }
 
-                const strategy = this._strategyRegistryV2.get({ id: method.id }) ?
-                    this._strategyRegistryV2.get({ id: method.id }) :
-                    this._strategyRegistry.getByMethod(method);
+                let strategy: PaymentStrategy | PaymentStrategyV2;
+
+                console.log('this gets triggered?');
+
+                try {
+                    strategy = this._strategyRegistryV2.get({ id: method.id });
+                } catch {
+                    strategy = this._strategyRegistry.getByMethod(method)
+                }
+
+                console.log('Does it get here?');
 
                 await strategy.finalize({ ...options, methodId: method.id, gatewayId: method.gateway });
 
@@ -112,9 +122,13 @@ export default class PaymentStrategyActionCreator {
                 return empty();
             }
 
-            const strategy = this._strategyRegistryV2.get({ id: method.id }) ?
-                this._strategyRegistryV2.get({ id: method.id }) :
-                this._strategyRegistry.getByMethod(method);
+            let strategy: PaymentStrategy | PaymentStrategyV2;
+
+            try {
+                strategy = this._strategyRegistryV2.get({ id: method.id });
+            } catch {
+                strategy = this._strategyRegistry.getByMethod(method)
+            }
 
             const promise: Promise<InternalCheckoutSelectors | void> = strategy.initialize({ ...options, methodId, gatewayId });
 
@@ -141,10 +155,13 @@ export default class PaymentStrategyActionCreator {
             if (methodId && !state.paymentStrategies.isInitialized(methodId)) {
                 return empty();
             }
+            let strategy: PaymentStrategy | PaymentStrategyV2;
 
-            const strategy = this._strategyRegistryV2.get({ id: method.id }) ?
-                this._strategyRegistryV2.get({ id: method.id }) :
-                this._strategyRegistry.getByMethod(method);
+            try {
+                strategy = this._strategyRegistryV2.get({ id: method.id });
+            } catch {
+                strategy = this._strategyRegistry.getByMethod(method)
+            }
 
             const promise: Promise<InternalCheckoutSelectors | void> = strategy.initialize({ ...options, methodId, gatewayId });
 

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -1,4 +1,4 @@
-import { PaymentStrategy as PaymentStrategyV2, PaymentStrategyResolveId } from '@bigcommerce/checkout-sdk/payment-integration';
+import { PaymentStrategy as PaymentStrategyV2 } from '@bigcommerce/checkout-sdk/payment-integration';
 import { createAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat, defer, empty, of, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -7,7 +7,6 @@ import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
-import { ResolveIdRegistry } from '../common/registry';
 import { LoadOrderPaymentsAction, OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../order';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 import { SpamProtectionAction, SpamProtectionActionCreator } from '../spam-protection';
@@ -15,13 +14,14 @@ import { SpamProtectionAction, SpamProtectionActionCreator } from '../spam-prote
 import { PaymentInitializeOptions, PaymentRequestOptions } from './payment-request-options';
 import { PaymentStrategyActionType, PaymentStrategyDeinitializeAction, PaymentStrategyExecuteAction, PaymentStrategyFinalizeAction, PaymentStrategyInitializeAction, PaymentStrategyWidgetAction } from './payment-strategy-actions';
 import PaymentStrategyRegistry from './payment-strategy-registry';
+import PaymentStrategyRegistryV2 from './payment-strategy-registry-v2';
 import PaymentStrategyType from './payment-strategy-type';
 import { PaymentStrategy } from './strategies';
 
 export default class PaymentStrategyActionCreator {
     constructor(
         private _strategyRegistry: PaymentStrategyRegistry,
-        private _strategyRegistryV2: ResolveIdRegistry<PaymentStrategyV2, PaymentStrategyResolveId>,
+        private _strategyRegistryV2: PaymentStrategyRegistryV2,
         private _orderActionCreator: OrderActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator
     ) {}

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -1,3 +1,4 @@
+import { PaymentStrategy as PaymentStrategyV2, PaymentStrategyResolveId } from '@bigcommerce/checkout-sdk/payment-integration';
 import { createAction, ThunkAction } from '@bigcommerce/data-store';
 import { concat, defer, empty, of, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -6,6 +7,7 @@ import { InternalCheckoutSelectors, ReadableCheckoutStore } from '../checkout';
 import { throwErrorAction } from '../common/error';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { RequestOptions } from '../common/http-request';
+import { ResolveIdRegistry } from '../common/registry';
 import { LoadOrderPaymentsAction, OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../order';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 import { SpamProtectionAction, SpamProtectionActionCreator } from '../spam-protection';
@@ -19,7 +21,7 @@ import { PaymentStrategy } from './strategies';
 export default class PaymentStrategyActionCreator {
     constructor(
         private _strategyRegistry: PaymentStrategyRegistry,
-        private _strategyRegistryV2: any,
+        private _strategyRegistryV2: ResolveIdRegistry<PaymentStrategyV2, PaymentStrategyResolveId>,
         private _orderActionCreator: OrderActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator
     ) {}
@@ -47,7 +49,7 @@ export default class PaymentStrategyActionCreator {
                             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                         }
 
-                        console.log(this._strategyRegistryV2);
+                        console.log('lolol does this log', this._strategyRegistryV2);
 
                         strategy = this._strategyRegistry.getByMethod(method);
                     } else {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
@@ -5,7 +5,7 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { of, Observable } from 'rxjs';
 
-import { createPaymentStrategyRegistry, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../..';
+import { createPaymentStrategyRegistry, createPaymentStrategyRegistryV2, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../..';
 import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError, RequestError } from '../../../common/error/errors';
@@ -32,6 +32,7 @@ import AmazonPayV2PaymentInitializeOptions from './amazon-pay-v2-payment-initial
 import AmazonPayV2PaymentStrategy from './amazon-pay-v2-payment-strategy';
 import { getAmazonPayV2ButtonParamsMock, getPaymentMethodMockUndefinedMerchant } from './amazon-pay-v2.mock';
 import createAmazonPayV2PaymentProcessor from './create-amazon-pay-v2-payment-processor';
+import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 
 describe('AmazonPayV2PaymentStrategy', () => {
     let amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor;
@@ -58,6 +59,8 @@ describe('AmazonPayV2PaymentStrategy', () => {
         const paymentClient = createPaymentClient(store);
         const spamProtection = createSpamProtection(createScriptLoader());
         const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, 'en_US');
+        const paymentIntegrationService = createPaymentIntegrationService(store);
+        const registryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
         const paymentMethodRequestSender: PaymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
         const widgetInteractionAction = of(createAction(PaymentStrategyActionType.WidgetInteractionStarted));
         const submitPaymentAction: Observable<SubmitPaymentAction> = of(createAction(PaymentActionType.SubmitPaymentRequested));;
@@ -71,6 +74,7 @@ describe('AmazonPayV2PaymentStrategy', () => {
 
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             registry,
+            registryV2,
             orderActionCreator,
             new SpamProtectionActionCreator(spamProtection, new SpamProtectionRequestSender(requestSender))
         );

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
@@ -15,6 +15,7 @@ import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestB
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { createPaymentIntegrationService } from '../../../payment-integration';
 import { PaymentArgumentInvalidError } from '../../errors';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
@@ -32,7 +33,6 @@ import AmazonPayV2PaymentInitializeOptions from './amazon-pay-v2-payment-initial
 import AmazonPayV2PaymentStrategy from './amazon-pay-v2-payment-strategy';
 import { getAmazonPayV2ButtonParamsMock, getPaymentMethodMockUndefinedMerchant } from './amazon-pay-v2.mock';
 import createAmazonPayV2PaymentProcessor from './create-amazon-pay-v2-payment-processor';
-import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 
 describe('AmazonPayV2PaymentStrategy', () => {
     let amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor;

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -1,7 +1,6 @@
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 import { of, Observable } from 'rxjs';
 
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
@@ -15,6 +14,7 @@ import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { createPaymentIntegrationService } from '../../../payment-integration';
 import createPaymentClient from '../../create-payment-client';
 import createPaymentStrategyRegistry from '../../create-payment-strategy-registry';
 import createPaymentStrategyRegistryV2 from '../../create-payment-strategy-registry-v2';

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -1,6 +1,7 @@
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 import { of, Observable } from 'rxjs';
 
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
@@ -16,6 +17,7 @@ import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
 import createPaymentClient from '../../create-payment-client';
 import createPaymentStrategyRegistry from '../../create-payment-strategy-registry';
+import createPaymentStrategyRegistryV2 from '../../create-payment-strategy-registry-v2';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';
@@ -72,6 +74,8 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
         const paymentClient = createPaymentClient(store);
         const spamProtection = createSpamProtection(createScriptLoader());
         const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, 'en_US');
+        const paymentIntegrationService = createPaymentIntegrationService(store);
+        const registryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
         const checkoutRequestSender = new CheckoutRequestSender(createRequestSender());
         const checkoutValidator = new CheckoutValidator(checkoutRequestSender);
 
@@ -87,6 +91,7 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(createRequestSender()));
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             registry,
+            registryV2,
             orderActionCreator,
             new SpamProtectionActionCreator(spamProtection, new SpamProtectionRequestSender(requestSender))
         );

--- a/packages/core/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
@@ -2,6 +2,7 @@ import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { noop } from 'lodash';
+import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 import { of, Observable } from 'rxjs';
 
 import { getCartState } from '../../../cart/carts.mock';
@@ -16,7 +17,7 @@ import { getFormFieldsState } from '../../../form/form.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
-import { createPaymentClient, createPaymentStrategyRegistry, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
+import { createPaymentClient, createPaymentStrategyRegistry, createPaymentStrategyRegistryV2, PaymentActionCreator, PaymentMethod, PaymentMethodActionCreator } from '../../../payment';
 import { getChasePay, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { ChasePayEventType, ChasePayScriptLoader, JPMC } from '../../../payment/strategies/chasepay';
 import { getChasePayScriptMock } from '../../../payment/strategies/chasepay/chasepay.mock';
@@ -94,6 +95,8 @@ describe('ChasePayPaymentStrategy', () => {
         const paymentClient = createPaymentClient(store);
         const spamProtection = createSpamProtection(createScriptLoader());
         const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, 'en_US');
+        const paymentIntegrationService = createPaymentIntegrationService(store);
+        const registryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
         const _requestSender: PaymentMethodRequestSender = new PaymentMethodRequestSender(requestSender);
 
         paymentMethodActionCreator = new PaymentMethodActionCreator(_requestSender);
@@ -114,6 +117,7 @@ describe('ChasePayPaymentStrategy', () => {
         );
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             registry,
+            registryV2,
             orderActionCreator,
             new SpamProtectionActionCreator(spamProtection, new SpamProtectionRequestSender(requestSender))
         );

--- a/packages/core/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/chasepay/chasepay-payment-strategy.spec.ts
@@ -2,7 +2,6 @@ import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { noop } from 'lodash';
-import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 import { of, Observable } from 'rxjs';
 
 import { getCartState } from '../../../cart/carts.mock';
@@ -22,6 +21,7 @@ import { getChasePay, getPaymentMethodsState } from '../../../payment/payment-me
 import { ChasePayEventType, ChasePayScriptLoader, JPMC } from '../../../payment/strategies/chasepay';
 import { getChasePayScriptMock } from '../../../payment/strategies/chasepay/chasepay.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { createPaymentIntegrationService } from '../../../payment-integration';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethodRequestSender from '../../payment-method-request-sender';
 import { PaymentInitializeOptions } from '../../payment-request-options';

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -2,6 +2,7 @@ import { createErrorAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
 import { noop } from 'lodash';
+import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 import { of } from 'rxjs';
 
 import { getCartState } from '../../../cart/carts.mock';
@@ -16,7 +17,7 @@ import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form'
 import { OrderActionCreator } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrder } from '../../../order/orders.mock';
-import { createPaymentClient, createPaymentStrategyRegistry, PaymentActionCreator, PaymentInitializeOptions, PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentStrategyActionCreator } from '../../../payment';
+import { createPaymentClient, createPaymentStrategyRegistry, createPaymentStrategyRegistryV2, PaymentActionCreator, PaymentInitializeOptions, PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentStrategyActionCreator } from '../../../payment';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
 import { PaymentActionType } from '../../payment-actions';
 import { getGooglePay, getPaymentMethodsState } from '../../payment-methods.mock';
@@ -75,6 +76,8 @@ describe('GooglePayPaymentStrategy', () => {
         const paymentClient = createPaymentClient(store);
         const spamProtection = createSpamProtection(scriptLoader);
         const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, 'en_US');
+        const paymentIntegrationService = createPaymentIntegrationService(store);
+        const registryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
@@ -90,6 +93,7 @@ describe('GooglePayPaymentStrategy', () => {
         );
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             registry,
+            registryV2,
             orderActionCreator,
             new SpamProtectionActionCreator(spamProtection, new SpamProtectionRequestSender(requestSender))
         );

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -2,7 +2,6 @@ import { createErrorAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
 import { noop } from 'lodash';
-import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 import { of } from 'rxjs';
 
 import { getCartState } from '../../../cart/carts.mock';
@@ -19,6 +18,7 @@ import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrder } from '../../../order/orders.mock';
 import { createPaymentClient, createPaymentStrategyRegistry, createPaymentStrategyRegistryV2, PaymentActionCreator, PaymentInitializeOptions, PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentStrategyActionCreator } from '../../../payment';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
+import { createPaymentIntegrationService } from '../../../payment-integration';
 import { PaymentActionType } from '../../payment-actions';
 import { getGooglePay, getPaymentMethodsState } from '../../payment-methods.mock';
 import PaymentRequestTransformer from '../../payment-request-transformer';

--- a/packages/core/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -2,7 +2,6 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
@@ -16,6 +15,7 @@ import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../.
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { createPaymentStrategyRegistry, createPaymentStrategyRegistryV2, PaymentActionCreator, PaymentInitializeOptions, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentStrategyActionCreator } from '../../../payment';
 import { getPaymentMethodsState, getSquare } from '../../../payment/payment-methods.mock';
+import { createPaymentIntegrationService } from '../../../payment-integration';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';

--- a/packages/core/src/payment/strategies/square/square-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/square/square-payment-strategy.spec.ts
@@ -2,6 +2,7 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
+import { createPaymentIntegrationService } from 'packages/core/src/payment-integration';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator, InternalCheckoutSelectors } from '../../../checkout';
@@ -13,7 +14,7 @@ import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form'
 import { getFormFieldsState } from '../../../form/form.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestSender } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { createPaymentStrategyRegistry, PaymentActionCreator, PaymentInitializeOptions, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentStrategyActionCreator } from '../../../payment';
+import { createPaymentStrategyRegistry, createPaymentStrategyRegistryV2, PaymentActionCreator, PaymentInitializeOptions, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentStrategyActionCreator } from '../../../payment';
 import { getPaymentMethodsState, getSquare } from '../../../payment/payment-methods.mock';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
 import { PaymentActionType } from '../../payment-actions';
@@ -88,6 +89,8 @@ describe('SquarePaymentStrategy', () => {
         const paymentClient = createPaymentClient(store);
         const spamProtection = createSpamProtection(createScriptLoader());
         const registry = createPaymentStrategyRegistry(store, paymentClient, requestSender, spamProtection, 'en_US');
+        const paymentIntegrationService = createPaymentIntegrationService(store);
+        const registryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
         const storeConfig = getConfig().storeConfig;
 
         orderActionCreator = new OrderActionCreator(
@@ -105,6 +108,7 @@ describe('SquarePaymentStrategy', () => {
             new PaymentMethodRequestSender(requestSender));
         paymentStrategyActionCreator = new PaymentStrategyActionCreator(
             registry,
+            registryV2,
             orderActionCreator,
             new SpamProtectionActionCreator(spamProtection, new SpamProtectionRequestSender(requestSender))
         );

--- a/webpack-cdn.config.js
+++ b/webpack-cdn.config.js
@@ -5,7 +5,7 @@ const { DefinePlugin } = require('webpack');
 const WebpackAssetsManifest = require('webpack-assets-manifest');
 
 const { getNextVersion, transformManifest } = require('./scripts/webpack');
-const { babelLoaderRules, getBaseConfig, libraryEntries, libraryName, srcPath } = require('./webpack-common.config');
+const { babelLoaderRules, getBaseConfig, libraryEntries, libraryName, coreSrcPath } = require('./webpack-common.config');
 
 const baseOutputPath = path.join(__dirname, 'dist-cdn');
 
@@ -52,7 +52,7 @@ async function getCdnLoaderConfig(options, argv) {
         ...baseConfig,
         name: 'umd-loader',
         entry: {
-            loader: path.join(srcPath, 'loader-cdn.ts'),
+            loader: path.join(coreSrcPath, 'loader-cdn.ts'),
         },
         output: {
             filename: `[name]-v${version}.js`,

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -3,16 +3,18 @@ const { DefinePlugin } = require('webpack');
 
 const { getNextVersion } = require('./scripts/webpack');
 
-const srcPath = path.join(__dirname, 'packages/core/src');
+const coreSrcPath = path.join(__dirname, 'packages/core/src');
+const appleSrcPath = path.join(__dirname, 'packages/apple-pay/src');
+const paymentIntegrationSrcPath = path.join(__dirname, 'packages/payment-integration/src');
 
 const libraryName = 'checkoutKit';
 
 const libraryEntries = {
-    'checkout-sdk': path.join(srcPath, 'bundles', 'checkout-sdk.ts'),
-    'checkout-button': path.join(srcPath, 'bundles', 'checkout-button.ts'),
-    'embedded-checkout': path.join(srcPath, 'bundles', 'embedded-checkout.ts'),
-    'hosted-form': path.join(srcPath, 'bundles', 'hosted-form.ts'),
-    'internal-mappers': path.join(srcPath, 'bundles', 'internal-mappers.ts'),
+    'checkout-sdk': path.join(coreSrcPath, 'bundles', 'checkout-sdk.ts'),
+    'checkout-button': path.join(coreSrcPath, 'bundles', 'checkout-button.ts'),
+    'embedded-checkout': path.join(coreSrcPath, 'bundles', 'embedded-checkout.ts'),
+    'hosted-form': path.join(coreSrcPath, 'bundles', 'hosted-form.ts'),
+    'internal-mappers': path.join(coreSrcPath, 'bundles', 'internal-mappers.ts'),
 };
 
 async function getBaseConfig() {
@@ -26,6 +28,7 @@ async function getBaseConfig() {
         resolve: {
             extensions: ['.ts', '.js'],
             alias: {
+                '@bigcommerce/checkout-sdk/payment-integration': path.resolve(__dirname, '/packages/payment-integration/src'),
                 '@bigcommerce/checkout-sdk/apple-pay': path.resolve(__dirname, '/packages/apple-pay/src'),
                 '@bigcommerce/checkout-sdk/test-utils': path.resolve(__dirname, '/packages/test-utils/src'),
             }
@@ -44,7 +47,17 @@ async function getBaseConfig() {
                 },
                 {
                     test: /\.[tj]s$/,
-                    include: srcPath,
+                    include: coreSrcPath,
+                    loader: 'ts-loader',                    
+                },
+                {
+                    test: /\.[tj]s$/,
+                    include: appleSrcPath,
+                    loader: 'ts-loader',
+                },
+                {
+                    test: /\.[tj]s$/,
+                    include: paymentIntegrationSrcPath,
                     loader: 'ts-loader',
                 },
             ],
@@ -73,7 +86,7 @@ const babelLoaderRules = [
     {
         test: /\.[tj]s$/,
         loader: 'babel-loader',
-        include: srcPath,
+        include: coreSrcPath,
         options: {
             presets: [
                 babelEnvPreset,
@@ -102,5 +115,5 @@ module.exports = {
     getBaseConfig,
     libraryEntries,
     libraryName,
-    srcPath,
+    coreSrcPath,
 };


### PR DESCRIPTION
## What?
- Load payment methods from automatic v2 strategy registry as priority and use v1 as fallback
- Update webpack config to process packages with ts-loader 

## Why?
As we move towards payment strategy packages, we want to register strategies as part of build process. 
Also process packages with ts-loader, we need to have a rule per package for now [issue](https://github.com/TypeStrong/ts-loader/issues/647). 

## Testing / Proof
- tests

@bigcommerce/checkout
