### PR TITLE
feat(payment): INT-6310 added bank of new zealand strategy

### DIFF
--- a/packages/core/src/payment/create-payment-strategy-registry.spec.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.spec.ts
@@ -14,6 +14,7 @@ import { AffirmPaymentStrategy } from './strategies/affirm';
 import { AfterpayPaymentStrategy } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy } from './strategies/amazon-pay';
 import { AmazonPayV2PaymentStrategy } from './strategies/amazon-pay-v2';
+import { BNZPaymentStrategy } from './strategies/bnz';
 import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy } from './strategies/braintree';
@@ -180,6 +181,11 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate cybersourcev2', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.CYBERSOURCEV2);
         expect(paymentStrategy).toBeInstanceOf(CyberSourceV2PaymentStrategy);
+    });
+
+    it('can instantiate bankofnewzealand', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.BNZ);
+        expect(paymentStrategy).toBeInstanceOf(BNZPaymentStrategy);
     });
 
     it('can instantiate digitalRiver', () => {

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -32,6 +32,7 @@ import { AffirmPaymentStrategy, AffirmScriptLoader } from './strategies/affirm';
 import { AfterpayPaymentStrategy, AfterpayScriptLoader } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy, AmazonPayScriptLoader } from './strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentStrategy } from './strategies/amazon-pay-v2';
+import { BNZPaymentStrategy } from './strategies/bnz';
 import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BoltPaymentStrategy, BoltScriptLoader } from './strategies/bolt';
@@ -407,6 +408,20 @@ export default function createPaymentStrategyRegistry(
 
     registry.register(PaymentStrategyType.CYBERSOURCEV2, () =>
         new CyberSourceV2PaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory,
+            new CardinalThreeDSecureFlowV2(
+                store,
+                paymentActionCreator,
+                new CardinalClient(new CardinalScriptLoader(scriptLoader))
+            )
+        )
+    );
+
+    registry.register(PaymentStrategyType.BNZ, () =>
+        new BNZPaymentStrategy(
             store,
             orderActionCreator,
             paymentActionCreator,

--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -93,6 +93,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'cybersourcev2',
         method: 'credit_card',
     },
+    bnz: {
+        provider: 'bnz',
+        method: 'credit_card',
+    },
     converge: {
         provider: 'converge',
         method: 'credit_card',

--- a/packages/core/src/payment/payment-strategy-type.ts
+++ b/packages/core/src/payment/payment-strategy-type.ts
@@ -24,6 +24,7 @@ enum PaymentStrategyType {
     CONVERGE = 'converge',
     CYBERSOURCE = 'cybersource',
     CYBERSOURCEV2 = 'cybersourcev2',
+    BNZ = 'bnz',
     DIGITALRIVER = 'digitalriver',
     CYBERSOURCEV2_GOOGLE_PAY = 'googlepaycybersourcev2',
     HUMM = 'humm',

--- a/packages/core/src/payment/strategies/bnz/bnz-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/bnz/bnz-payment-strategy.spec.ts
@@ -1,0 +1,159 @@
+import { merge } from 'lodash';
+import { of } from 'rxjs';
+
+import { createCheckoutStore, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethod from '../../payment-method';
+import { getCybersource } from '../../payment-methods.mock';
+import { CardinalThreeDSecureFlowV2 } from '../cardinal';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+import BNZPaymentStrategy from './bnz-payment-strategy';
+
+describe('BankOfNewZealandPaymentStrategy', () => {
+    let hostedFormFactory: HostedFormFactory;
+    let orderActionCreator: Pick<OrderActionCreator, 'submitOrder'>;
+    let paymentActionCreator: Pick<PaymentActionCreator, 'submitPayment'>;
+    let paymentMethod: PaymentMethod;
+    let state: InternalCheckoutSelectors;
+    let store: CheckoutStore;
+    let strategy: BNZPaymentStrategy;
+    let threeDSecureFlow: Pick<CardinalThreeDSecureFlowV2, 'prepare' | 'start'>;
+
+    beforeEach(() => {
+        paymentMethod = {
+            ...getCybersource(),
+            clientToken: 'foo',
+        };
+
+        store = createCheckoutStore();
+
+        orderActionCreator = {
+            submitOrder: jest.fn(() => of()),
+        };
+
+        paymentActionCreator = {
+            submitPayment: jest.fn(() => of()),
+        };
+
+        hostedFormFactory = {} as HostedFormFactory;
+
+        threeDSecureFlow = {
+            prepare: jest.fn(() => Promise.resolve()),
+            start: jest.fn(() => Promise.resolve()),
+        };
+
+        state = store.getState();
+
+        jest.spyOn(store, 'dispatch')
+            .mockResolvedValue(state);
+
+        jest.spyOn(store, 'getState')
+            .mockReturnValue(state);
+
+        jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+            .mockReturnValue(paymentMethod);
+
+        strategy = new BNZPaymentStrategy(
+            store,
+            orderActionCreator as OrderActionCreator,
+            paymentActionCreator as PaymentActionCreator,
+            hostedFormFactory,
+            threeDSecureFlow as CardinalThreeDSecureFlowV2
+        );
+    });
+
+    it('is special type of credit card strategy', () => {
+        expect(strategy)
+            .toBeInstanceOf(CreditCardPaymentStrategy);
+    });
+
+    describe('#initialize', () => {
+        it('throws error when payment method is not defined', async () => {
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockImplementation(() => { throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod); });
+
+            try {
+                await strategy.initialize({ methodId: paymentMethod.id });
+            } catch (error) {
+                expect(error)
+                    .toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('does not prepare 3DS flow when not enabled', async () => {
+            paymentMethod.config.is3dsEnabled = false;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(threeDSecureFlow.prepare)
+                .not.toHaveBeenCalled();
+        });
+
+        it('prepares 3DS flow when enabled', async () => {
+            paymentMethod.config.is3dsEnabled = true;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            expect(threeDSecureFlow.prepare)
+                .toHaveBeenCalled();
+        });
+    });
+
+    describe('#execute', () => {
+        let payload: OrderRequestBody;
+
+        beforeEach(() => {
+            payload = merge({}, getOrderRequestBody(), {
+                payment: {
+                    methodId: paymentMethod.id,
+                    gatewayId: paymentMethod.gateway,
+                },
+            });
+        });
+
+        it('throws error when payment method is not defined', async () => {
+            jest.spyOn(state.paymentMethods, 'getPaymentMethodOrThrow')
+                .mockImplementation(() => { throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod); });
+
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error)
+                    .toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('does not start 3DS flow when not enabled', async () => {
+            paymentMethod.config.is3dsEnabled = false;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            await strategy.execute(payload);
+
+            expect(threeDSecureFlow.prepare)
+                .not.toHaveBeenCalled();
+
+            expect(threeDSecureFlow.start)
+                .not.toHaveBeenCalled();
+        });
+
+        it('starts 3DS flow when enabled', async () => {
+            paymentMethod.config.is3dsEnabled = true;
+
+            await strategy.initialize({ methodId: paymentMethod.id });
+
+            await strategy.execute(payload);
+
+            expect(threeDSecureFlow.prepare)
+                .toHaveBeenCalled();
+
+            expect(threeDSecureFlow.start)
+                .toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/payment/strategies/bnz/bnz-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/bnz/bnz-payment-strategy.ts
@@ -1,0 +1,61 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { HostedFormFactory } from '../../../hosted-form';
+import { OrderActionCreator, OrderRequestBody } from '../../../order';
+import { PaymentArgumentInvalidError } from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import { CardinalThreeDSecureFlowV2 } from '../cardinal';
+import { CreditCardPaymentStrategy } from '../credit-card';
+
+export default class BNZPaymentStrategy extends CreditCardPaymentStrategy {
+    constructor(
+        store: CheckoutStore,
+        orderActionCreator: OrderActionCreator,
+        paymentActionCreator: PaymentActionCreator,
+        hostedFormFactory: HostedFormFactory,
+        private _threeDSecureFlow: CardinalThreeDSecureFlowV2
+    ) {
+        super(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            hostedFormFactory
+        );
+    }
+
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        await super.initialize(options);
+
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+        const paymentMethod = getPaymentMethodOrThrow(options.methodId);
+
+        if (paymentMethod.config.is3dsEnabled) {
+            await this._threeDSecureFlow.prepare(paymentMethod);
+        }
+
+        return this._store.getState();
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (!payload.payment) {
+            throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+        const { methodId } = payload.payment;
+
+        if (!methodId) {
+            throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+        const { paymentMethods: { getPaymentMethodOrThrow } } = this._store.getState();
+
+        if (getPaymentMethodOrThrow(methodId).config.is3dsEnabled) {
+            return this._threeDSecureFlow.start(
+                super.execute.bind(this),
+                payload,
+                options,
+                this._hostedForm
+            );
+        }
+
+        return super.execute(payload, options);
+    }
+}

--- a/packages/core/src/payment/strategies/bnz/index.ts
+++ b/packages/core/src/payment/strategies/bnz/index.ts
@@ -1,0 +1,1 @@
+export { default as BNZPaymentStrategy } from './bnz-payment-strategy';


### PR DESCRIPTION
## What? [INT-6310](https://bigcommercecloud.atlassian.net/browse/INT-6310)
Added bank of New Zealand payment strategy

## Why?
As a Merchant I want to be able to accept payments through Bank of New Zealand.

## Testing / Proof
![image](https://user-images.githubusercontent.com/87149598/182486787-f74f5e58-d954-4077-9afb-d2eef43798db.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/kyiv-payments-team 
