### PR TITLE
fix(payment): PAYMENTS-8045 Fix form fields parameter name for PPSDK redirect

### DIFF
--- a/packages/core/src/payment/strategies/ppsdk/step-handler/continue-handler/redirect/redirect.spec.ts
+++ b/packages/core/src/payment/strategies/ppsdk/step-handler/continue-handler/redirect/redirect.spec.ts
@@ -17,7 +17,7 @@ describe('handleRedirect', () => {
     });
 
     describe('when there is not an already pending redirect', () => {
-        describe('when not passed formFields', () => {
+        describe('when not passed form_fields', () => {
             it('calls location assign with the url, never resolves or rejects', () => {
                 const resolveMock = jest.fn();
                 const rejectMock = jest.fn();
@@ -35,25 +35,25 @@ describe('handleRedirect', () => {
             });
         });
 
-        describe('with passed formFields', () => {
+        describe('with passed form_fields', () => {
             it('posts a form to the url along with fields, never resolves or rejects', () => {
                 const postFormSpy = jest.spyOn(formPoster, 'postForm').mockImplementation(jest.fn);
                 const resolveMock = jest.fn();
                 const rejectMock = jest.fn();
 
-                const formFields = {
+                const form_fields = {
                     someField: 'some-value',
                     anotherField: 'another-value',
                 };
 
                 const redirectContinueResponse = {
                     url: 'http://some-post-url.com',
-                    formFields,
+                    form_fields,
                 };
 
                 handleRedirect(redirectContinueResponse, formPoster).then(resolveMock).catch(rejectMock);
 
-                expect(postFormSpy).toHaveBeenCalledWith('http://some-post-url.com', formFields);
+                expect(postFormSpy).toHaveBeenCalledWith('http://some-post-url.com', form_fields);
                 expect(resolveMock).not.toHaveBeenCalled();
                 expect(rejectMock).not.toHaveBeenCalled();
             });
@@ -88,7 +88,7 @@ describe('isRedirect', () => {
             code: 'redirect',
             parameters: {
                 url: 'http://some-url.com',
-                formFields: {
+                form_fields: {
                     someField: 'some-value',
                     anotherField: 'another-value',
                 },

--- a/packages/core/src/payment/strategies/ppsdk/step-handler/continue-handler/redirect/redirect.ts
+++ b/packages/core/src/payment/strategies/ppsdk/step-handler/continue-handler/redirect/redirect.ts
@@ -8,7 +8,7 @@ import { RedirectionState } from './RedirectionState';
 
 interface Parameters {
     url: string;
-    formFields?: Record<string, string | number | boolean>;
+    form_fields?: Record<string, string | number | boolean>;
 }
 
 export interface Redirect {
@@ -18,7 +18,7 @@ export interface Redirect {
 }
 
 const isParameters = (x: unknown): x is Parameters => {
-    const formFields = get(x, 'formFields');
+    const formFields = get(x, 'form_fields');
 
     return (
         isString(get(x, 'url')) &&
@@ -32,7 +32,7 @@ export const isRedirect = (body: PaymentsAPIResponse['body']): body is Redirect 
     isParameters(get(body, 'parameters'))
 );
 
-export const handleRedirect = ({ url, formFields }: Parameters, formPoster: FormPoster): Promise<never> => {
+export const handleRedirect = ({ url, form_fields }: Parameters, formPoster: FormPoster): Promise<never> => {
     const redirectionState = new RedirectionState();
 
     if (redirectionState.isRedirecting()) {
@@ -43,8 +43,8 @@ export const handleRedirect = ({ url, formFields }: Parameters, formPoster: Form
 
     redirectionState.setRedirecting(true);
 
-    if (formFields) {
-        formPoster.postForm(url, formFields);
+    if (form_fields) {
+        formPoster.postForm(url, form_fields);
     } else {
         window.location.assign(url);
     }


### PR DESCRIPTION
## What?
Change `formFields` parameter name to `form_fields` in PPSDK redirect (offsite) payment method, so it executes correctly with the `POST` method.

## Why?
To fix the issue.

## Testing / Proof
Unit tests
Screenshots
**Before**
<img width="1668" alt="Screen Shot 2022-08-02 at 11 48 10 am" src="https://user-images.githubusercontent.com/36555311/182290635-76cf2545-fcb4-4c5e-8ced-4b546b10db80.png">

**After**
<img width="1226" alt="Screen Shot 2022-08-02 at 1 50 53 pm" src="https://user-images.githubusercontent.com/36555311/182290649-3ebba7c9-f50b-4aec-b380-c6c8588c85d5.png">

@bigcommerce/checkout @bigcommerce/payments
