### PR TITLE
CHECKOUT-6781: Point to interfaces extracted from integration packages

### DIFF
--- a/packages/apple-pay/src/apple-pay-customer-initialize-options.ts
+++ b/packages/apple-pay/src/apple-pay-customer-initialize-options.ts
@@ -36,5 +36,9 @@ export default interface ApplePayCustomerInitializeOptions {
 }
 
 export interface WithApplePayCustomerInitializeOptions {
+    /**
+     * The options that are required to initialize the customer step of checkout
+     * when using ApplePay.
+     */
     applepay?: ApplePayCustomerInitializeOptions;
 }

--- a/packages/apple-pay/src/apple-pay-payment-initialize-options.ts
+++ b/packages/apple-pay/src/apple-pay-payment-initialize-options.ts
@@ -26,5 +26,9 @@ export default interface ApplePayPaymentInitializeOptions {
 }
 
 export interface WithApplePayPaymentInitializeOptions {
+    /**
+     * The options that are required to initialize the Apple Pay payment
+     * method. They can be omitted unless you need to support Apple Pay.
+     */
     applepay?: ApplePayPaymentInitializeOptions;
 }

--- a/packages/core/extend-interface.config.json
+++ b/packages/core/extend-interface.config.json
@@ -3,23 +3,26 @@
         {
             "inputPath": "packages/*/src/index.ts",
             "outputPath": "packages/core/src/generated/payment-initialize-options.ts",
+            "outputMemberName": "PaymentInitializeOptions",
             "memberPattern": "^With.+PaymentInitializeOptions$",
-            "targetPath": "packages/payment-integration/src/index.ts",
-            "targetMemberName": "PaymentInitializeOptions"
+            "targetPath": "packages/core/src/payment/index.ts",
+            "targetMemberName": "BasePaymentInitializeOptions"
         },
         {
             "inputPath": "packages/*/src/index.ts",
             "outputPath": "packages/core/src/generated/customer-initialize-options.ts",
+            "outputMemberName": "CustomerInitializeOptions",
             "memberPattern": "^With.+CustomerInitializeOptions$",
-            "targetPath": "packages/payment-integration/src/index.ts",
-            "targetMemberName": "CustomerInitializeOptions"
+            "targetPath": "packages/core/src/customer/index.ts",
+            "targetMemberName": "BaseCustomerInitializeOptions"
         },
         {
             "inputPath": "packages/*/src/index.ts",
             "outputPath": "packages/core/src/generated/checkout-button-initialize-options.ts",
+            "outputMemberName": "CheckoutButtonInitializeOptions",
             "memberPattern": "^With.+ButtonInitializeOptions$",
-            "targetPath": "packages/payment-integration/src/index.ts",
-            "targetMemberName": "CheckoutButtonInitializeOptions"
+            "targetPath": "packages/core/src/checkout-buttons/index.ts",
+            "targetMemberName": "BaseCheckoutButtonInitializeOptions"
         }
     ]
 }

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -61,7 +61,7 @@
                 "cwd": "packages/core",
                 "parallel": false,
                 "commands": [
-                    "tsc --outDir ../../temp --declaration",
+                    "tsc --outDir ../../temp --declaration --emitDeclarationOnly",
                     "api-extractor run --config api-extractor/checkout-sdk.json & api-extractor run --config api-extractor/checkout-button.json & api-extractor run --config api-extractor/embedded-checkout.json & api-extractor run --config api-extractor/internal-mappers.json",
                     "rm -rf ../../temp"
                 ]

--- a/packages/core/src/checkout-buttons/checkout-button-options-v2.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options-v2.ts
@@ -1,5 +1,0 @@
-import { CheckoutButtonInitializeOptions as CheckoutButtonInitializeOptionsV2 } from '../generated/checkout-button-initialize-options'
-
-import { CheckoutButtonInitializeOptions as CheckoutButtonInitializeOptionsV1 } from './checkout-button-options';
-
-export type CheckoutButtonInitializeOptions = CheckoutButtonInitializeOptionsV2 & CheckoutButtonInitializeOptionsV1;

--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -8,6 +8,8 @@ import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
 import { PaypalCommerceAlternativeMethodsButtonOptions, PaypalCommerceButtonInitializeOptions, PaypalCommerceVenmoButtonInitializeOptions } from './strategies/paypal-commerce';
 
+export { CheckoutButtonInitializeOptions } from '../generated/checkout-button-initialize-options';
+
 /**
  * The set of options for configuring the checkout button.
  */
@@ -18,7 +20,7 @@ export interface CheckoutButtonOptions extends RequestOptions {
     methodId: CheckoutButtonMethodType;
 }
 
-export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
+export interface BaseCheckoutButtonInitializeOptions extends CheckoutButtonOptions {
     /**
      * The options that are required to initialize the ApplePay payment method.
      * They can be omitted unless you need to support ApplePay in cart.

--- a/packages/core/src/checkout-buttons/index.ts
+++ b/packages/core/src/checkout-buttons/index.ts
@@ -3,5 +3,4 @@ export { default as checkoutButtonReducer } from './checkout-button-reducer';
 export { default as CheckoutButtonSelector, CheckoutButtonSelectorFactory, createCheckoutButtonSelectorFactory } from './checkout-button-selector';
 export { default as CheckoutButtonState } from './checkout-button-state';
 export { CheckoutButtonStrategy, CheckoutButtonMethodType } from './strategies';
-export { CheckoutButtonOptions, CheckoutButtonInitializeOptions } from './checkout-button-options';
-export { CheckoutButtonInitializeOptions as CheckoutButtonInitializeOptionsV2 } from './checkout-button-options-v2';
+export { BaseCheckoutButtonInitializeOptions, CheckoutButtonOptions, CheckoutButtonInitializeOptions } from './checkout-button-options';

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -1,5 +1,6 @@
-enum CheckoutButtonMethodType {
-    APPLEPAY = 'applepay',
+export { default as default } from '../../generated/checkout-button-method-type';
+
+export enum BaseCheckoutButtonMethodType {
     AMAZON_PAY_V2 = 'amazonpay',
     BRAINTREE_PAYPAL = 'braintreepaypal',
     BRAINTREE_VENMO = 'braintreevenmo',
@@ -19,5 +20,3 @@ enum CheckoutButtonMethodType {
     PAYPALCOMMERCE_APMS = 'paypalcommercealternativemethods',
     PAYPALCOMMERCE_VENMO = 'paypalcommercevenmo',
 }
-
-export default CheckoutButtonMethodType;

--- a/packages/core/src/customer/customer-request-options-v2.ts
+++ b/packages/core/src/customer/customer-request-options-v2.ts
@@ -1,5 +1,0 @@
-import { CustomerInitializeOptions as CustomerInitializeOptionsV2 } from '../generated/customer-initialize-options'
-
-import { CustomerInitializeOptions as CustomerInitializeOptionsV1 } from './customer-request-options';
-
-export type CustomerInitializeOptions = CustomerInitializeOptionsV2 & CustomerInitializeOptionsV1;

--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -2,12 +2,13 @@ import { RequestOptions } from '../common/http-request';
 
 import { AmazonPayCustomerInitializeOptions } from './strategies/amazon';
 import { AmazonPayV2CustomerInitializeOptions } from './strategies/amazon-pay-v2';
-import { ApplePayCustomerInitializeOptions } from './strategies/apple-pay';
 import { BoltCustomerInitializeOptions } from './strategies/bolt';
 import { BraintreeVisaCheckoutCustomerInitializeOptions } from './strategies/braintree';
 import { ChasePayCustomerInitializeOptions } from './strategies/chasepay';
 import { GooglePayCustomerInitializeOptions } from './strategies/googlepay';
 import { MasterpassCustomerInitializeOptions } from './strategies/masterpass';
+
+export { CustomerInitializeOptions } from '../generated/customer-initialize-options';
 
 /**
  * A set of options for configuring any requests related to the customer step of
@@ -30,7 +31,7 @@ export interface CustomerRequestOptions extends RequestOptions {
  * using their sign-in button. As a result, you may need to provide additional
  * information in order to initialize the customer step of checkout.
  */
-export interface CustomerInitializeOptions extends CustomerRequestOptions {
+export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
     /**
      * The options that are required to initialize the customer step of checkout
      * when using Amazon Pay.
@@ -42,12 +43,6 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
      * when using AmazonPayV2.
      */
     amazonpay?: AmazonPayV2CustomerInitializeOptions;
-
-    /**
-     * The options that are required to initialize the customer step of checkout
-     * when using ApplePay.
-     */
-     applepay?: ApplePayCustomerInitializeOptions;
 
     /**
      * The options that are required to initialize the customer step of checkout

--- a/packages/core/src/customer/index.ts
+++ b/packages/core/src/customer/index.ts
@@ -1,4 +1,4 @@
-export * from './customer-request-options';
+export { BaseCustomerInitializeOptions, CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from './customer-request-options';
 
 export { default as InternalCustomer } from './internal-customer';
 export { default as Customer, CustomerAddress } from './customer';
@@ -17,6 +17,5 @@ export { default as CustomerStrategySelector, CustomerStrategySelectorFactory, c
 export { default as CustomerStrategyState } from './customer-strategy-state';
 export { default as customerStrategyReducer } from './customer-strategy-reducer';
 export { default as GuestCredentials } from './guest-credentials';
-export { CustomerInitializeOptions as CustomerInitializeOptionsV2 } from './customer-request-options-v2';
 
 export { default as mapToInternalCustomer } from './map-to-internal-customer';

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -1,4 +1,4 @@
-export * from './payment-request-options';
+export { BasePaymentInitializeOptions, PaymentInitializeOptions, PaymentRequestOptions } from './payment-request-options';
 export * from './payment-method-actions';
 export * from './payment-method-types';
 export * from './payment-status-types';
@@ -55,4 +55,3 @@ export { default as PaymentStrategySelector, PaymentStrategySelectorFactory, cre
 export { default as PaymentStrategyState } from './payment-strategy-state';
 export { default as PaymentStrategyType } from './payment-strategy-type';
 export { default as StorefrontPaymentRequestSender } from './storefront-payment-request-sender';
-export { PaymentInitializeOptions as PaymentInitializeOptionsV2 } from './payment-request-options-v2';

--- a/packages/core/src/payment/payment-request-options-v2.ts
+++ b/packages/core/src/payment/payment-request-options-v2.ts
@@ -1,5 +1,0 @@
-import { PaymentInitializeOptions as PaymentInitializeOptionsV2 } from '../generated/payment-initialize-options'
-
-import { PaymentInitializeOptions as PaymentInitializeOptionsV1 } from './payment-request-options';
-
-export type PaymentInitializeOptions = PaymentInitializeOptionsV2 & PaymentInitializeOptionsV1;

--- a/packages/core/src/payment/payment-request-options.ts
+++ b/packages/core/src/payment/payment-request-options.ts
@@ -4,7 +4,6 @@ import { AdyenV2PaymentInitializeOptions } from './strategies/adyenv2';
 import { AdyenV3PaymentInitializeOptions } from './strategies/adyenv3';
 import { AmazonPayPaymentInitializeOptions } from './strategies/amazon-pay';
 import { AmazonPayV2PaymentInitializeOptions } from './strategies/amazon-pay-v2';
-import { ApplePayPaymentInitializeOptions } from './strategies/apple-pay';
 import { BlueSnapV2PaymentInitializeOptions } from './strategies/bluesnapv2';
 import { BoltPaymentInitializeOptions } from './strategies/bolt';
 import { BraintreePaymentInitializeOptions, BraintreeVisaCheckoutPaymentInitializeOptions } from './strategies/braintree';
@@ -24,6 +23,8 @@ import { SquarePaymentInitializeOptions } from './strategies/square';
 import { StripeUPEPaymentInitializeOptions } from './strategies/stripe-upe';
 import { StripeV3PaymentInitializeOptions } from './strategies/stripev3';
 import { WorldpayPaymentInitializeOptions } from './strategies/worldpay';
+
+export { PaymentInitializeOptions } from '../generated/payment-initialize-options';
 
 /**
  * The set of options for configuring any requests related to the payment step of
@@ -47,7 +48,7 @@ export interface PaymentRequestOptions extends RequestOptions {
  * A set of options that are required to initialize the payment step of the
  * current checkout flow.
  */
-export interface PaymentInitializeOptions extends PaymentRequestOptions {
+export interface BasePaymentInitializeOptions extends PaymentRequestOptions {
     /**
      * @alpha
      * Please note that this option is currently in an early stage of
@@ -73,12 +74,6 @@ export interface PaymentInitializeOptions extends PaymentRequestOptions {
      * method. They can be omitted unless you need to support AmazonPay.
      */
     amazon?: AmazonPayPaymentInitializeOptions;
-
-    /**
-     * The options that are required to initialize the Apple Pay payment
-     * method. They can be omitted unless you need to support AmazonPay.
-     */
-    applepay?: ApplePayPaymentInitializeOptions;
 
     /**
      * The options that are required to initialize the AmazonPayV2 payment

--- a/packages/workspace-tools/src/generators/extend-interface/__fixtures__/foobar-interface/foobar-interface.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/__fixtures__/foobar-interface/foobar-interface.ts
@@ -1,0 +1,3 @@
+export default interface FoobarInterface {
+    foobar: string;
+}

--- a/packages/workspace-tools/src/generators/extend-interface/__fixtures__/foobar-interface/index.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/__fixtures__/foobar-interface/index.ts
@@ -1,0 +1,1 @@
+export { default as FoobarInterface } from './foobar-interface';

--- a/packages/workspace-tools/src/generators/extend-interface/__fixtures__/interface-a/index.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/__fixtures__/interface-a/index.ts
@@ -1,0 +1,1 @@
+export { default as InterfaceA } from './interface-a';

--- a/packages/workspace-tools/src/generators/extend-interface/__fixtures__/interface-a/interface-a.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/__fixtures__/interface-a/interface-a.ts
@@ -1,0 +1,3 @@
+export default interface InterfaceA {
+    a: string;
+}

--- a/packages/workspace-tools/src/generators/extend-interface/__fixtures__/interface-b/index.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/__fixtures__/interface-b/index.ts
@@ -1,0 +1,1 @@
+export { default as InterfaceB } from './interface-b';

--- a/packages/workspace-tools/src/generators/extend-interface/__fixtures__/interface-b/interface-b.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/__fixtures__/interface-b/interface-b.ts
@@ -1,0 +1,3 @@
+export default interface InterfaceB {
+    b: string;
+}

--- a/packages/workspace-tools/src/generators/extend-interface/__snapshots__/extend-interface.spec.ts.snap
+++ b/packages/workspace-tools/src/generators/extend-interface/__snapshots__/extend-interface.spec.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`extendInterface extends interface with other matching interfaces 1`] = `
+"import { FoobarInterface } from '../__fixtures__/foobar-interface';
+import { InterfaceA } from '../__fixtures__/interface-a';
+import { InterfaceB } from '../__fixtures__/interface-b';
+export type ExtendedInterface = FoobarInterface & InterfaceA & InterfaceB;
+"
+`;
+
+exports[`extendInterface handles scenario where no matching interface is found 1`] = `
+"import { FoobarInterface } from '../__fixtures__/foobar-interface';
+export type ExtendedDummyInterface = FoobarInterface;
+"
+`;

--- a/packages/workspace-tools/src/generators/extend-interface/extend-interface-config.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/extend-interface-config.ts
@@ -5,6 +5,7 @@ export default interface ExtendInterfaceConfig {
 export interface ExtendInterfaceConfigEntry {
     inputPath: string;
     outputPath: string;
+    outputMemberName: string;
     memberPattern: string;
     targetPath: string;
     targetMemberName: string;

--- a/packages/workspace-tools/src/generators/extend-interface/extend-interface.spec.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/extend-interface.spec.ts
@@ -1,0 +1,33 @@
+import path from 'path';
+
+import extendInterface from './extend-interface';
+
+describe('extendInterface', () => {
+    it('extends interface with other matching interfaces', async () => {
+        const options = {
+            inputPath: path.join(__dirname, '/__fixtures__/**/index.ts'),
+            outputPath: path.join(__dirname, '/__temp__/output.ts'),
+            outputMemberName: 'ExtendedInterface',
+            memberPattern: '^Interface.$',
+            targetPath: path.join(__dirname, '/__fixtures__/foobar-interface/index.ts'),
+            targetMemberName: 'FoobarInterface',
+        };
+
+        expect(await extendInterface(options))
+            .toMatchSnapshot();
+    });
+
+    it('handles scenario where no matching interface is found', async () => {
+        const options = {
+            inputPath: path.join(__dirname, '/__fixtures__/**/index.ts'),
+            outputPath: path.join(__dirname, '/__temp__/output.ts'),
+            outputMemberName: 'ExtendedDummyInterface',
+            memberPattern: '^DummyInterface.$',
+            targetPath: path.join(__dirname, '/__fixtures__/foobar-interface/index.ts'),
+            targetMemberName: 'FoobarInterface',
+        };
+
+        expect(await extendInterface(options))
+            .toMatchSnapshot();
+    });
+});

--- a/packages/workspace-tools/src/generators/extend-interface/is-extend-interface-config.ts
+++ b/packages/workspace-tools/src/generators/extend-interface/is-extend-interface-config.ts
@@ -22,6 +22,10 @@ export default function isExtendInterfaceConfig(config: unknown): config is Exte
             return false;
         }
 
+        if (!hasKey(entry, 'outputMemberName') || typeof entry['outputMemberName'] !== 'string') {
+            return false;
+        }
+
         if (!hasKey(entry, 'memberPattern') || typeof entry['memberPattern'] !== 'string') {
             return false;
         }


### PR DESCRIPTION
## What?
Use interfaces extracted from various payment integration packages.

## Why?
This is the second attempt. We reverted the [last attempt](https://github.com/bigcommerce/checkout-sdk-js/pull/1526) because the generated types ended up clashing with the hand-written types. As a result, we ended up exporting multiple types with the same name, and they were automatically renamed with numeric suffixes (e.g.: `_2`, `_3`) when they were rolled up into a single `.d.ts` file. This attempt addresses the name collision so we can safely export the generated types.

## Testing / Proof
CircleCI + Manual

|initializeButton|initializeCustomer|initializePayment|
|---|---|---|
|<img width="799" alt="Screen Shot 2022-08-03 at 10 35 34 AM" src="https://user-images.githubusercontent.com/667603/182499751-79559b6a-2e05-4971-a193-c0b38e23ca42.png">|<img width="701" alt="Screen Shot 2022-08-03 at 10 35 54 AM" src="https://user-images.githubusercontent.com/667603/182499758-a8bb99ee-a575-4b2b-8e31-e5ef0eaf5fa9.png">|<img width="720" alt="Screen Shot 2022-08-03 at 10 36 11 AM" src="https://user-images.githubusercontent.com/667603/182499767-38269742-f2f7-4663-9468-aaa442b784fc.png">|

@bigcommerce/checkout @bigcommerce/payments
