### PR TITLE
chore(common): CHECKOUT-6855 Load customer strategies from V2 as priority

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -13,7 +13,8 @@ import { ResolveIdRegistry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { getConfig } from '../config/configs.mock';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
-import { createCustomerStrategyRegistry, CustomerActionCreator, CustomerRequestSender, CustomerStrategyActionCreator } from '../customer';
+import { createCustomerStrategyRegistry, createCustomerStrategyRegistryV2, CustomerActionCreator, CustomerRequestSender, CustomerStrategyActionCreator } from '../customer';
+import CustomerStrategyRegistryV2 from '../customer/customer-strategy-registry-v2';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { getAddressFormFields, getFormFields } from '../form/form.mock';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
@@ -74,6 +75,7 @@ describe('CheckoutService', () => {
     let paymentStrategyActionCreator: PaymentStrategyActionCreator;
     let paymentStrategyRegistry: PaymentStrategyRegistry;
     let paymentStrategyRegistryV2: ResolveIdRegistry<PaymentStrategyV2, PaymentStrategyResolveId>;
+    let customerRegistryV2: CustomerStrategyRegistryV2;
     let shippingStrategyActionCreator: ShippingStrategyActionCreator;
     let shippingCountryRequestSender: ShippingCountryRequestSender;
     let signInEmailActionCreator: SignInEmailActionCreator;
@@ -151,6 +153,7 @@ describe('CheckoutService', () => {
         paymentStrategyRegistry = new PaymentStrategyRegistry(store);
         const paymentIntegrationService = createPaymentIntegrationService(store);
         paymentStrategyRegistryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
+        customerRegistryV2 = createCustomerStrategyRegistryV2(paymentIntegrationService);
 
         jest.spyOn(paymentStrategyRegistry, 'getByMethod').mockReturnValue(paymentStrategy);
 
@@ -229,7 +232,8 @@ describe('CheckoutService', () => {
         consignmentActionCreator = new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender);
 
         customerStrategyActionCreator = new CustomerStrategyActionCreator(
-            createCustomerStrategyRegistry(store, paymentClient, requestSender, locale)
+            createCustomerStrategyRegistry(store, paymentClient, requestSender, locale),
+            customerRegistryV2
         );
 
         instrumentActionCreator = new InstrumentActionCreator(instrumentRequestSender);

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -7,7 +7,7 @@ import { getDefaultLogger } from '../common/log';
 import { getEnvironment } from '../common/utility';
 import { ConfigActionCreator, ConfigRequestSender, ConfigState, ConfigWindow } from '../config';
 import { CouponActionCreator, CouponRequestSender, GiftCertificateActionCreator, GiftCertificateRequestSender } from '../coupon';
-import { createCustomerStrategyRegistry, CustomerActionCreator, CustomerRequestSender, CustomerStrategyActionCreator } from '../customer';
+import { createCustomerStrategyRegistry, createCustomerStrategyRegistryV2, CustomerActionCreator, CustomerRequestSender, CustomerStrategyActionCreator } from '../customer';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
@@ -81,6 +81,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
     const checkoutActionCreator = new CheckoutActionCreator(checkoutRequestSender, configActionCreator, formFieldsActionCreator);
     const paymentIntegrationService = createPaymentIntegrationService(store);
     const registryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
+    const customerRegistryV2 = createCustomerStrategyRegistryV2(paymentIntegrationService);
 
     return new CheckoutService(
         store,
@@ -98,7 +99,10 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new ConsignmentActionCreator(new ConsignmentRequestSender(requestSender), checkoutRequestSender),
         new CountryActionCreator(new CountryRequestSender(requestSender, { locale })),
         new CouponActionCreator(new CouponRequestSender(requestSender)),
-        new CustomerStrategyActionCreator(createCustomerStrategyRegistry(store, paymentClient, requestSender, locale)),
+        new CustomerStrategyActionCreator(
+            createCustomerStrategyRegistry(store, paymentClient, requestSender, locale),
+            customerRegistryV2
+        ),
         new ErrorActionCreator(),
         new GiftCertificateActionCreator(new GiftCertificateRequestSender(requestSender)),
         new InstrumentActionCreator(new InstrumentRequestSender(paymentClient, requestSender)),

--- a/packages/core/src/customer/create-customer-strategy-registry.ts
+++ b/packages/core/src/customer/create-customer-strategy-registry.ts
@@ -9,6 +9,7 @@ import { ConfigActionCreator, ConfigRequestSender } from '../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import { PaymentActionCreator, PaymentMethodActionCreator, PaymentMethodRequestSender, PaymentRequestSender, PaymentRequestTransformer } from '../payment';
+import { createPaymentIntegrationService } from '../payment-integration';
 import { AmazonPayScriptLoader } from '../payment/strategies/amazon-pay';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { ApplePaySessionFactory } from '../payment/strategies/apple-pay';
@@ -21,6 +22,7 @@ import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../rem
 import { ConsignmentActionCreator, ConsignmentRequestSender } from '../shipping';
 import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../spam-protection';
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subscription';
+import createCustomerStrategyRegistryV2 from './create-customer-strategy-registry-v2';
 
 import CustomerActionCreator from './customer-action-creator';
 import CustomerRequestSender from './customer-request-sender';
@@ -64,6 +66,9 @@ export default function createCustomerStrategyRegistry(
         checkoutActionCreator,
         spamProtectionActionCreator
     );
+
+    const paymentIntegrationService = createPaymentIntegrationService(store);
+    const customerRegistryV2 = createCustomerStrategyRegistryV2(paymentIntegrationService);
 
     registry.register('googlepayadyenv2', () =>
         new GooglePayCustomerStrategy(
@@ -113,7 +118,7 @@ export default function createCustomerStrategyRegistry(
             store,
             checkoutActionCreator,
             paymentMethodActionCreator,
-            new CustomerStrategyActionCreator(registry),
+            new CustomerStrategyActionCreator(registry, customerRegistryV2),
             remoteCheckoutActionCreator,
             createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender),
             new VisaCheckoutScriptLoader(scriptLoader),

--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -32,6 +32,8 @@ export interface CustomerRequestOptions extends RequestOptions {
  * information in order to initialize the customer step of checkout.
  */
 export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
+    [key: string]: unknown;
+
     /**
      * The options that are required to initialize the customer step of checkout
      * when using Amazon Pay.

--- a/packages/core/src/customer/customer-strategy-action-creator.ts
+++ b/packages/core/src/customer/customer-strategy-action-creator.ts
@@ -24,19 +24,7 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.SignInRequested, undefined, meta));
 
-            let strategy: CustomerStrategy | CustomerStrategyV2;
-
-            if (!methodId) {
-                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-            }
-
-            try {
-                strategy = this._strategyRegistryV2.get({ id: methodId });
-            } catch {
-                strategy = this._strategyRegistry.get(methodId)
-            }
-
-            let promise: Promise<InternalCheckoutSelectors | void> = strategy.signIn(credentials, options);
+            const promise: Promise<InternalCheckoutSelectors | void> = this._getStrategy(methodId).signIn(credentials, options);
 
             promise.then(() => {
                 observer.next(createAction(CustomerStrategyActionType.SignInSucceeded, undefined, meta));
@@ -55,19 +43,7 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.SignOutRequested, undefined, meta));
 
-            let strategy: CustomerStrategy | CustomerStrategyV2;
-
-            if (!methodId) {
-                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-            }
-
-            try {
-                strategy = this._strategyRegistryV2.get({ id: methodId });
-            } catch {
-                strategy = this._strategyRegistry.get(methodId)
-            }
-
-            let promise: Promise<InternalCheckoutSelectors | void> = strategy.signOut(options);
+            const promise: Promise<InternalCheckoutSelectors | void> = this._getStrategy(methodId).signOut(options);
 
             promise
                 .then(() => {
@@ -87,19 +63,7 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.ExecutePaymentMethodCheckoutRequested, undefined, meta));
 
-            let strategy: CustomerStrategy | CustomerStrategyV2;
-
-            if (!methodId) {
-                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-            }
-
-            try {
-                strategy = this._strategyRegistryV2.get({ id: methodId });
-            } catch {
-                strategy = this._strategyRegistry.get(methodId)
-            }
-
-            let promise: Promise<InternalCheckoutSelectors | void> = strategy.executePaymentMethodCheckout(options);
+            const promise: Promise<InternalCheckoutSelectors | void> = this._getStrategy(methodId).executePaymentMethodCheckout(options);
 
             promise
                 .then(() => {
@@ -124,19 +88,7 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.InitializeRequested, undefined, meta));
 
-            let strategy: CustomerStrategy | CustomerStrategyV2;
-
-            if (!methodId) {
-                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-            }
-
-            try {
-                strategy = this._strategyRegistryV2.get({ id: methodId });
-            } catch {
-                strategy = this._strategyRegistry.get(methodId)
-            }
-
-            let promise: Promise<InternalCheckoutSelectors | void> = strategy.initialize(options);
+            const promise: Promise<InternalCheckoutSelectors | void> = this._getStrategy(methodId).initialize(options);
 
             promise
                 .then(() => {
@@ -161,19 +113,7 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.DeinitializeRequested, undefined, meta));
 
-            let strategy: CustomerStrategy | CustomerStrategyV2;
-
-            if (!methodId) {
-                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-            }
-
-            try {
-                strategy = this._strategyRegistryV2.get({ id: methodId });
-            } catch {
-                strategy = this._strategyRegistry.get(methodId)
-            }
-
-            let promise: Promise<InternalCheckoutSelectors | void> = strategy.deinitialize(options);
+            const promise: Promise<InternalCheckoutSelectors | void> = this._getStrategy(methodId).deinitialize(options);
 
             promise
                 .then(() => {
@@ -201,5 +141,20 @@ export default class CustomerStrategyActionCreator {
                 observer.error(createErrorAction(CustomerStrategyActionType.WidgetInteractionFailed, error, meta));
             });
         });
+    }
+
+    private _getStrategy(methodId?: string): CustomerStrategy | CustomerStrategyV2 {
+        if (!methodId) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+        let strategy: CustomerStrategy | CustomerStrategyV2;
+
+        try {
+            strategy = this._strategyRegistryV2.get({ id: methodId });
+        } catch {
+            strategy = this._strategyRegistry.get(methodId)
+        }
+
+        return strategy;
     }
 }

--- a/packages/core/src/customer/customer-strategy-action-creator.ts
+++ b/packages/core/src/customer/customer-strategy-action-creator.ts
@@ -1,5 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
-import { CustomerStrategy as CustomerStrategyV2, MissingDataError, MissingDataErrorType } from '@bigcommerce/checkout-sdk/payment-integration';
+import { CustomerStrategy as CustomerStrategyV2 } from '@bigcommerce/checkout-sdk/payment-integration';
 import { Observable, Observer } from 'rxjs';
 
 import { InternalCheckoutSelectors } from '../checkout';
@@ -144,13 +144,10 @@ export default class CustomerStrategyActionCreator {
     }
 
     private _getStrategy(methodId?: string): CustomerStrategy | CustomerStrategyV2 {
-        if (!methodId) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
         let strategy: CustomerStrategy | CustomerStrategyV2;
 
         try {
-            strategy = this._strategyRegistryV2.get({ id: methodId });
+            strategy = this._strategyRegistryV2.get({ id: methodId || '' });
         } catch {
             strategy = this._strategyRegistry.get(methodId)
         }

--- a/packages/core/src/customer/customer-strategy-action-creator.ts
+++ b/packages/core/src/customer/customer-strategy-action-creator.ts
@@ -1,4 +1,5 @@
 import { createAction, createErrorAction, ThunkAction } from '@bigcommerce/data-store';
+import { CustomerStrategy as CustomerStrategyV2, MissingDataError, MissingDataErrorType } from '@bigcommerce/checkout-sdk/payment-integration';
 import { Observable, Observer } from 'rxjs';
 
 import { InternalCheckoutSelectors } from '../checkout';
@@ -7,11 +8,13 @@ import { Registry } from '../common/registry';
 import CustomerCredentials from './customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from './customer-request-options';
 import { CustomerStrategyActionType, CustomerStrategyDeinitializeAction, CustomerStrategyExecutePaymentMethodCheckoutAction, CustomerStrategyInitializeAction, CustomerStrategySignInAction, CustomerStrategySignOutAction, CustomerStrategyWidgetAction } from './customer-strategy-actions';
+import CustomerStrategyRegistryV2 from './customer-strategy-registry-v2';
 import { CustomerStrategy } from './strategies';
 
 export default class CustomerStrategyActionCreator {
     constructor(
-        private _strategyRegistry: Registry<CustomerStrategy>
+        private _strategyRegistry: Registry<CustomerStrategy>,
+        private _strategyRegistryV2: CustomerStrategyRegistryV2
     ) {}
 
     signIn(credentials: CustomerCredentials, options?: CustomerRequestOptions): Observable<CustomerStrategySignInAction> {
@@ -21,15 +24,27 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.SignInRequested, undefined, meta));
 
-            this._strategyRegistry.get(methodId)
-                .signIn(credentials, options)
-                .then(() => {
-                    observer.next(createAction(CustomerStrategyActionType.SignInSucceeded, undefined, meta));
-                    observer.complete();
-                })
-                .catch(error => {
-                    observer.error(createErrorAction(CustomerStrategyActionType.SignInFailed, error, meta));
-                });
+            let strategy: CustomerStrategy | CustomerStrategyV2;
+
+            if (!methodId) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            try {
+                strategy = this._strategyRegistryV2.get({ id: methodId });
+            } catch {
+                strategy = this._strategyRegistry.get(methodId)
+            }
+
+            let promise: Promise<InternalCheckoutSelectors | void> = strategy.signIn(credentials, options);
+
+            promise.then(() => {
+                observer.next(createAction(CustomerStrategyActionType.SignInSucceeded, undefined, meta));
+                observer.complete();
+            })
+            .catch(error => {
+                observer.error(createErrorAction(CustomerStrategyActionType.SignInFailed, error, meta));
+            });
         });
     }
 
@@ -40,8 +55,21 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.SignOutRequested, undefined, meta));
 
-            this._strategyRegistry.get(methodId)
-                .signOut(options)
+            let strategy: CustomerStrategy | CustomerStrategyV2;
+
+            if (!methodId) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            try {
+                strategy = this._strategyRegistryV2.get({ id: methodId });
+            } catch {
+                strategy = this._strategyRegistry.get(methodId)
+            }
+
+            let promise: Promise<InternalCheckoutSelectors | void> = strategy.signOut(options);
+
+            promise
                 .then(() => {
                     observer.next(createAction(CustomerStrategyActionType.SignOutSucceeded, undefined, meta));
                     observer.complete();
@@ -59,8 +87,21 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.ExecutePaymentMethodCheckoutRequested, undefined, meta));
 
-            this._strategyRegistry.get(methodId)
-                .executePaymentMethodCheckout(options)
+            let strategy: CustomerStrategy | CustomerStrategyV2;
+
+            if (!methodId) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            try {
+                strategy = this._strategyRegistryV2.get({ id: methodId });
+            } catch {
+                strategy = this._strategyRegistry.get(methodId)
+            }
+
+            let promise: Promise<InternalCheckoutSelectors | void> = strategy.executePaymentMethodCheckout(options);
+
+            promise
                 .then(() => {
                     observer.next(createAction(CustomerStrategyActionType.ExecutePaymentMethodCheckoutSucceeded, undefined, meta));
                     observer.complete();
@@ -83,8 +124,21 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.InitializeRequested, undefined, meta));
 
-            this._strategyRegistry.get(methodId)
-                .initialize(options)
+            let strategy: CustomerStrategy | CustomerStrategyV2;
+
+            if (!methodId) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            try {
+                strategy = this._strategyRegistryV2.get({ id: methodId });
+            } catch {
+                strategy = this._strategyRegistry.get(methodId)
+            }
+
+            let promise: Promise<InternalCheckoutSelectors | void> = strategy.initialize(options);
+
+            promise
                 .then(() => {
                     observer.next(createAction(CustomerStrategyActionType.InitializeSucceeded, undefined, meta));
                     observer.complete();
@@ -107,8 +161,21 @@ export default class CustomerStrategyActionCreator {
 
             observer.next(createAction(CustomerStrategyActionType.DeinitializeRequested, undefined, meta));
 
-            this._strategyRegistry.get(methodId)
-                .deinitialize(options)
+            let strategy: CustomerStrategy | CustomerStrategyV2;
+
+            if (!methodId) {
+                throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+            }
+
+            try {
+                strategy = this._strategyRegistryV2.get({ id: methodId });
+            } catch {
+                strategy = this._strategyRegistry.get(methodId)
+            }
+
+            let promise: Promise<InternalCheckoutSelectors | void> = strategy.deinitialize(options);
+
+            promise
                 .then(() => {
                     observer.next(createAction(CustomerStrategyActionType.DeinitializeSucceeded, undefined, meta));
                     observer.complete();

--- a/packages/core/src/customer/customer-strategy-registry-v2.ts
+++ b/packages/core/src/customer/customer-strategy-registry-v2.ts
@@ -1,0 +1,6 @@
+import { CustomerStrategy, CustomerStrategyResolveId } from '@bigcommerce/checkout-sdk/payment-integration';
+import { ResolveIdRegistry } from '../common/registry';
+
+type CustomerStrategyRegistry = ResolveIdRegistry<CustomerStrategy, CustomerStrategyResolveId>;
+
+export default CustomerStrategyRegistry;

--- a/packages/core/src/customer/index.ts
+++ b/packages/core/src/customer/index.ts
@@ -4,6 +4,7 @@ export { default as InternalCustomer } from './internal-customer';
 export { default as Customer, CustomerAddress } from './customer';
 
 export { default as createCustomerStrategyRegistry } from './create-customer-strategy-registry';
+export { default as createCustomerStrategyRegistryV2 } from './create-customer-strategy-registry-v2';
 export { CustomerAction, CustomerActionType } from './customer-actions';
 export { default as customerReducer } from './customer-reducer';
 export { default as CustomerAccountRequestBody, CustomerAddressRequestBody } from './customer-account';

--- a/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
@@ -4,6 +4,7 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
+import { createPaymentIntegrationService } from '../../../payment-integration';
 import { of } from 'rxjs';
 
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
@@ -17,6 +18,7 @@ import { createBraintreeVisaCheckoutPaymentProcessor, BraintreeVisaCheckoutPayme
 import { RemoteCheckoutActionCreator, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 import createCustomerStrategyRegistry from '../../create-customer-strategy-registry';
+import createCustomerStrategyRegistryV2 from '../../create-customer-strategy-registry-v2';
 import { CustomerInitializeOptions } from '../../customer-request-options';
 import CustomerStrategyActionCreator from '../../customer-strategy-action-creator';
 import { CustomerStrategyActionType } from '../../customer-strategy-actions';
@@ -68,6 +70,8 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         formPoster = createFormPoster();
 
         const registry = createCustomerStrategyRegistry(store, paymentClient, requestSender, '');
+        const paymentIntegrationService = createPaymentIntegrationService(store);
+        const customerRegistryV2 = createCustomerStrategyRegistryV2(paymentIntegrationService);
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
@@ -76,7 +80,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         );
 
         paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
-        customerStrategyActionCreator = new CustomerStrategyActionCreator(registry);
+        customerStrategyActionCreator = new CustomerStrategyActionCreator(registry, customerRegistryV2);
 
         strategy = new BraintreeVisaCheckoutCustomerStrategy(
             store,


### PR DESCRIPTION
## What?
Load customer methods from automatic v2 strategy registry as priority and use v1 as fallback

## Why?
As we move towards customer strategy packages, we want to register strategies as part of build process.

## Testing / Proof
- circle

@bigcommerce/checkout
