### PR TITLE
fix(order): CHECKOUT-000 Update order consignments interface

### DIFF
--- a/packages/core/src/order/order.ts
+++ b/packages/core/src/order/order.ts
@@ -11,7 +11,7 @@ export default interface Order {
     billingAddress: BillingAddress;
     cartId: string;
     coupons: Coupon[];
-    consignments: OrderConsignment[];
+    consignments: OrderConsignment;
     currency: Currency;
     customerCanBeCreated: boolean;
     customerId: number;

--- a/packages/core/src/order/orders.mock.ts
+++ b/packages/core/src/order/orders.mock.ts
@@ -13,7 +13,7 @@ export function getOrder(): Order {
         baseAmount: 200,
         billingAddress: getBillingAddress(),
         cartId: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
-        consignments: [getOrderConsignment()],
+        consignments: getOrderConsignment(),
         coupons: [
             getCoupon(),
             getShippingCoupon(),

--- a/packages/payment-integration/src/order/order.ts
+++ b/packages/payment-integration/src/order/order.ts
@@ -11,7 +11,7 @@ export default interface Order {
     billingAddress: BillingAddress;
     cartId: string;
     coupons: Coupon[];
-    consignments: OrderConsignment[];
+    consignments: OrderConsignment;
     currency: Currency;
     customerCanBeCreated: boolean;
     customerId: number;


### PR DESCRIPTION
## What?
Update order consignment interface

## Why?
The interface for order response is outdated. Have updated it as per https://developer.bigcommerce.com/api-reference/f40f1f75f3e00-get-order 

Issue - https://github.com/bigcommerce/checkout-sdk-js/issues/1547

## Testing / Proof
- Circle

@bigcommerce/checkout
