### PR TITLE
chore(common): CHECKOUT-000 Update ts loader for packages in webpack

### DIFF
--- a/package-loader-rule.js
+++ b/package-loader-rule.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+const packages = [
+    'core',
+    'apple-pay',
+    'payment-integration',
+];
+
+const getPackagesWithPath = packages.map(package => {
+    const packageSrcPath =  path.join(__dirname, `packages/${package}/src`);
+
+    return {
+        test: /\.[tj]s$/,
+        include: packageSrcPath,
+        loader: 'ts-loader',
+    };
+});
+
+module.exports = getPackagesWithPath;

--- a/package-loader-rule.js
+++ b/package-loader-rule.js
@@ -1,15 +1,10 @@
 const path = require('path');
 const { projects } = require('./workspace.json');
 
-const packages = [
-    'core',
-    'apple-pay',
-    'payment-integration',
-];
-
 const tsSrcPackages = [];
+const aliasMap = {};
 
-for (const [, packagePath] of Object.entries(projects)) {
+for (const [packageName, packagePath] of Object.entries(projects)) {
     const packageSrcPath =  path.join(__dirname, `${packagePath}/src`);
 
     tsSrcPackages.push({
@@ -17,6 +12,11 @@ for (const [, packagePath] of Object.entries(projects)) {
         include: packageSrcPath,
         loader: 'ts-loader',
     });
+
+    aliasMap[`@bigcommerce/checkout-sdk/${packageName}`] = packageSrcPath;
 }
 
-module.exports = tsSrcPackages;
+module.exports = {
+    aliasMap,
+    tsSrcPackages
+};

--- a/package-loader-rule.js
+++ b/package-loader-rule.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { projects } = require('./workspace.json');
 
 const packages = [
     'core',
@@ -6,14 +7,16 @@ const packages = [
     'payment-integration',
 ];
 
-const getPackagesWithPath = packages.map(package => {
-    const packageSrcPath =  path.join(__dirname, `packages/${package}/src`);
+const tsSrcPackages = [];
 
-    return {
+for (const [, packagePath] of Object.entries(projects)) {
+    const packageSrcPath =  path.join(__dirname, `${packagePath}/src`);
+
+    tsSrcPackages.push({
         test: /\.[tj]s$/,
         include: packageSrcPath,
         loader: 'ts-loader',
-    };
-});
+    });
+}
 
-module.exports = getPackagesWithPath;
+module.exports = tsSrcPackages;

--- a/scripts/webpack/index.js
+++ b/scripts/webpack/index.js
@@ -1,4 +1,5 @@
 module.exports = {
     getNextVersion: require('./get-next-version'),
     transformManifest: require('./transform-manifest'),
+    packageLoaderRules: require('./package-loader-rule'),
 };

--- a/scripts/webpack/package-loader-rule.js
+++ b/scripts/webpack/package-loader-rule.js
@@ -1,11 +1,13 @@
 const path = require('path');
-const { projects } = require('./workspace.json');
+const { projects } = require('../../workspace.json');
+
+console.log('projects',projects);
 
 const tsSrcPackages = [];
 const aliasMap = {};
 
 for (const [packageName, packagePath] of Object.entries(projects)) {
-    const packageSrcPath =  path.join(__dirname, `${packagePath}/src`);
+    const packageSrcPath =  path.join(__dirname, '../../', `${packagePath}/src`);
 
     tsSrcPackages.push({
         test: /\.[tj]s$/,

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const { DefinePlugin } = require('webpack');
 
 const { getNextVersion } = require('./scripts/webpack');
-const packages = require('./package-loader-rule');
+const { aliasMap: alias, tsSrcPackages } = require('./package-loader-rule');
 
 const libraryName = 'checkoutKit';
 
@@ -26,11 +26,7 @@ async function getBaseConfig() {
         mode: 'production',
         resolve: {
             extensions: ['.ts', '.js'],
-            alias: {
-                '@bigcommerce/checkout-sdk/payment-integration': path.resolve(__dirname, '/packages/payment-integration/src'),
-                '@bigcommerce/checkout-sdk/apple-pay': path.resolve(__dirname, '/packages/apple-pay/src'),
-                '@bigcommerce/checkout-sdk/test-utils': path.resolve(__dirname, '/packages/test-utils/src'),
-            }
+            alias,
         },
         module: {
             rules: [
@@ -44,7 +40,7 @@ async function getBaseConfig() {
                     enforce: 'pre',
                     loader: require.resolve('source-map-loader'),
                 },
-                ...packages
+                ...tsSrcPackages
             ],
         },
         plugins: [

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -1,8 +1,7 @@
 const path = require('path');
 const { DefinePlugin } = require('webpack');
 
-const { getNextVersion } = require('./scripts/webpack');
-const { aliasMap: alias, tsSrcPackages } = require('./package-loader-rule');
+const { getNextVersion, packageLoaderRules : { aliasMap: alias, tsSrcPackages } } = require('./scripts/webpack');
 
 const libraryName = 'checkoutKit';
 

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -2,12 +2,11 @@ const path = require('path');
 const { DefinePlugin } = require('webpack');
 
 const { getNextVersion } = require('./scripts/webpack');
-
-const coreSrcPath = path.join(__dirname, 'packages/core/src');
-const appleSrcPath = path.join(__dirname, 'packages/apple-pay/src');
-const paymentIntegrationSrcPath = path.join(__dirname, 'packages/payment-integration/src');
+const packages = require('./package-loader-rule');
 
 const libraryName = 'checkoutKit';
+
+const coreSrcPath = path.join(__dirname, 'packages/core/src');
 
 const libraryEntries = {
     'checkout-sdk': path.join(coreSrcPath, 'bundles', 'checkout-sdk.ts'),
@@ -45,21 +44,7 @@ async function getBaseConfig() {
                     enforce: 'pre',
                     loader: require.resolve('source-map-loader'),
                 },
-                {
-                    test: /\.[tj]s$/,
-                    include: coreSrcPath,
-                    loader: 'ts-loader',                    
-                },
-                {
-                    test: /\.[tj]s$/,
-                    include: appleSrcPath,
-                    loader: 'ts-loader',
-                },
-                {
-                    test: /\.[tj]s$/,
-                    include: paymentIntegrationSrcPath,
-                    loader: 'ts-loader',
-                },
+                ...packages
             ],
         },
         plugins: [


### PR DESCRIPTION
## What?
Move webpack package loader definition to a separate file.

## Why?
At the moment for every package we need to add a rule object with a path in webpack config. 

This PR eases that process by updating package list with package name.

## Testing / Proof
- build

@bigcommerce/checkout @bigcommerce/payments
