### PR TITLE
feat(payment): INT-6407 AmazonPayV2: Add the new `estimatedOrderAmount` parameter

### DIFF
--- a/packages/core/src/payment/create-payment-strategy-registry.spec.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.spec.ts
@@ -13,6 +13,7 @@ import { AdyenV3PaymentStrategy } from './strategies/adyenv3';
 import { AffirmPaymentStrategy } from './strategies/affirm';
 import { AfterpayPaymentStrategy } from './strategies/afterpay';
 import { AmazonPayPaymentStrategy } from './strategies/amazon-pay';
+import { AmazonPayV2PaymentStrategy } from './strategies/amazon-pay-v2';
 import { BarclaysPaymentStrategy } from './strategies/barclays';
 import { BlueSnapV2PaymentStrategy } from './strategies/bluesnapv2';
 import { BraintreeCreditCardPaymentStrategy, BraintreePaypalPaymentStrategy, BraintreeVisaCheckoutPaymentStrategy } from './strategies/braintree';
@@ -89,6 +90,11 @@ describe('CreatePaymentStrategyRegistry', () => {
     it('can instantiate amazon', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.AMAZON);
         expect(paymentStrategy).toBeInstanceOf(AmazonPayPaymentStrategy);
+    });
+
+    it('can instantiate amazonpay', () => {
+        const paymentStrategy = registry.get(PaymentStrategyType.AMAZONPAYV2);
+        expect(paymentStrategy).toBeInstanceOf(AmazonPayV2PaymentStrategy);
     });
 
     it('can instantiate afterpay', () => {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -36,6 +36,10 @@ export function getAmazonPayV2Ph4ButtonParamsMock(): AmazonPayV2ButtonParameters
         productType: AmazonPayV2PayOptions.PayAndShip,
         placement: AmazonPayV2Placement.Checkout,
         buttonColor: AmazonPayV2ButtonColor.Gold,
+        estimatedOrderAmount: {
+            amount: '190',
+            currencyCode: 'USD',
+        },
         createCheckoutSessionConfig: {
             payloadJSON: 'payload',
             signature: 'xxxx',

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -90,6 +90,14 @@ export interface AmazonPayV2NewButtonParams extends AmazonPayV2ButtonConfig {
     publicKeyId?: string;
 
     /**
+     * It does not have to match the final order amount if the buyer updates
+     * their order after starting checkout. Amazon Pay will use this value to
+     * assess transaction risk and prevent buyers from selecting payment methods
+     * that can't be used to process the order.
+     */
+    estimatedOrderAmount?: AmazonPayV2Price;
+
+    /**
      * Create Checkout Session configuration.
      */
     createCheckoutSessionConfig: AmazonPayV2CheckoutSessionConfig;
@@ -128,6 +136,18 @@ export interface AmazonPayV2CheckoutSessionConfig {
      * if your `publicKeyId` has an environment prefix.
      */
     publicKeyId?: string;
+}
+
+export interface AmazonPayV2Price {
+    /**
+     * Transaction amount.
+     */
+    amount: string;
+
+    /**
+     * Transaction currency code in ISO 4217 format. Example: USD.
+     */
+    currencyCode: string;
 }
 
 export type AmazonPayV2ChangeActionType = 'changeAddress' | 'changePayment';

--- a/packages/core/src/payment/strategies/amazon-pay-v2/create-amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/create-amazon-pay-v2-payment-processor.spec.ts
@@ -1,0 +1,22 @@
+import createAmazonPayV2PaymentProcessor from "./create-amazon-pay-v2-payment-processor";
+import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
+
+import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
+
+jest.mock('./amazon-pay-v2-payment-processor');
+
+beforeEach(() => {
+    (AmazonPayV2PaymentProcessor as jest.Mock<AmazonPayV2PaymentProcessor>).mockClear();
+});
+
+describe('createAmazonPayV2PaymentProcessor()', () => {
+    it('returns an instance of AmazonPayV2PaymentProcessor', () => {
+        const processor = createAmazonPayV2PaymentProcessor();
+
+        expect(processor).toBeInstanceOf(AmazonPayV2PaymentProcessor);
+        expect(AmazonPayV2PaymentProcessor).toHaveBeenNthCalledWith(
+            1,
+            expect.any(AmazonPayV2ScriptLoader)
+        );
+    });
+});


### PR DESCRIPTION
## What? [INT-6407](https://bigcommercecloud.atlassian.net/browse/INT-6407)
1. Add the new `estimatedOrderAmount` parameter.
2. Add some missing tests.

## Why?
1. Because Amazon Pay will use this value to assess transaction risk and prevent buyers from selecting payment methods that can't be used to process the order.
2. To increase code coverage.

## Testing / Proof
Amazon Pay script logs the result:
<img width="1401" alt="estimatedOrderAmount" src="https://user-images.githubusercontent.com/4843328/184194259-b6c1fdc4-ee85-464d-b360-a4700fa50ed7.png">

@bigcommerce/apex-integrations  @bigcommerce/checkout @bigcommerce/payments
