### PR TITLE
docs(payment): INT-0000: Add missing backticks

### DIFF
--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-initialize-options.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-initialize-options.ts
@@ -18,6 +18,7 @@
  *         editButtonId: 'edit-button',
  *     },
  * });
+ * ```
  */
 export default interface AmazonPayV2PaymentInitializeOptions {
     /**

--- a/packages/core/src/payment/strategies/bluesnapv2/bluesnapv2-payment-options.ts
+++ b/packages/core/src/payment/strategies/bluesnapv2/bluesnapv2-payment-options.ts
@@ -30,6 +30,7 @@ import { BlueSnapV2StyleProps } from './bluesnapv2';
  *         },
  *     },
  * });
+ * ```
  */
 export interface BlueSnapV2PaymentInitializeOptions {
     /**

--- a/packages/core/src/payment/strategies/mollie/mollie-initialize-options.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-initialize-options.ts
@@ -23,6 +23,7 @@ import { HostedFormOptions } from '../../../hosted-form';
  *          }
  *      }
  * });
+ * ```
  */
 export default interface MolliePaymentInitializeOptions {
     /**


### PR DESCRIPTION
## What?
Fix JS syntax highlighting for some payment strategies.

## Why?
The final MD files are messed up.

## Testing / Proof
<img width="547" alt="Screen Shot 2022-08-11 at 12 49 05 PM" src="https://user-images.githubusercontent.com/4843328/184200334-dbda5741-899e-4665-811e-576f38d94650.png">

@bigcommerce/apex-integrations  @bigcommerce/checkout @bigcommerce/payments
