### PR TITLE
feat(payment): PAYPAL-1386 added PayPalCommerceCredit checkout button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -6,7 +6,7 @@ import { ApplePayButtonInitializeOptions } from './strategies/apple-pay';
 import { BraintreePaypalButtonInitializeOptions, BraintreePaypalCreditButtonInitializeOptions, BraintreeVenmoButtonInitializeOptions } from './strategies/braintree';
 import { GooglePayButtonInitializeOptions } from './strategies/googlepay';
 import { PaypalButtonInitializeOptions } from './strategies/paypal';
-import { PaypalCommerceAlternativeMethodsButtonOptions, PaypalCommerceButtonInitializeOptions, PaypalCommerceVenmoButtonInitializeOptions } from './strategies/paypal-commerce';
+import { PaypalCommerceAlternativeMethodsButtonOptions, PaypalCommerceButtonInitializeOptions, PaypalCommerceCreditButtonInitializeOptions, PaypalCommerceVenmoButtonInitializeOptions } from './strategies/paypal-commerce';
 
 export { CheckoutButtonInitializeOptions } from '../generated/checkout-button-initialize-options';
 
@@ -123,6 +123,12 @@ export interface BaseCheckoutButtonInitializeOptions extends CheckoutButtonOptio
      * unless you need to support Paypal.
      */
     paypalCommerce?: PaypalCommerceButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate PayPal Commerce. They can be omitted
+     * unless you need to support PayPal Commerce Credit / PayLater.
+     */
+    paypalcommercecredit?: PaypalCommerceCreditButtonInitializeOptions;
 
     /**
      * The options that are required to facilitate PayPal Commerce. They can be omitted

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -28,7 +28,7 @@ import { BraintreePaypalButtonStrategy, BraintreePaypalCreditButtonStrategy, Bra
 import { GooglePayButtonStrategy } from './strategies/googlepay';
 import { MasterpassButtonStrategy } from './strategies/masterpass';
 import { PaypalButtonStrategy } from './strategies/paypal';
-import { PaypalCommerceAlternativeMethodsButtonStrategy, PaypalCommerceButtonStrategy, PaypalCommerceVenmoButtonStrategy } from './strategies/paypal-commerce';
+import { PaypalCommerceAlternativeMethodsButtonStrategy, PaypalCommerceButtonStrategy, PaypalCommerceCreditButtonStrategy, PaypalCommerceVenmoButtonStrategy } from './strategies/paypal-commerce';
 
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
@@ -263,6 +263,16 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             formPoster,
             paypalCommercePaymentProcessor
+        )
+    );
+
+    registry.register(CheckoutButtonMethodType.PAYPALCOMMERCE_CREDIT, () =>
+        new PaypalCommerceCreditButtonStrategy(
+            store,
+            checkoutActionCreator,
+            formPoster,
+            paypalScriptLoader,
+            paypalCommerceRequestSender
         )
     );
 

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -17,6 +17,7 @@ export enum BaseCheckoutButtonMethodType {
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',
     PAYPALCOMMERCE = 'paypalcommerce',
+    PAYPALCOMMERCE_CREDIT = 'paypalcommercecredit',
     PAYPALCOMMERCE_APMS = 'paypalcommercealternativemethods',
     PAYPALCOMMERCE_VENMO = 'paypalcommercevenmo',
 }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/index.ts
@@ -6,6 +6,12 @@ export { PaypalCommerceButtonInitializeOptions } from './paypal-commerce-button-
 export { default as PaypalCommerceButtonStrategy } from './paypal-commerce-button-strategy';
 
 /**
+ * PayPal Commerce Credit Payment Methods
+ */
+export { PaypalCommerceCreditButtonInitializeOptions } from './paypal-commerce-credit-button-options';
+export { default as PaypalCommerceCreditButtonStrategy } from './paypal-commerce-credit-button-strategy';
+
+/**
  * PayPal Commerce Alternative Payment Methods
  */
  export { PaypalCommerceAlternativeMethodsButtonOptions } from './paypal-commerce-alternative-methods-button-options';

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-options.ts
@@ -1,0 +1,18 @@
+import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+
+export interface PaypalCommerceCreditButtonInitializeOptions {
+    /**
+     * Flag which helps to detect that the strategy initializes on Checkout page
+     */
+    initializesOnCheckoutPage?: boolean;
+
+    /**
+     * The ID of a container which the messaging should be inserted.
+     */
+    messagingContainerId?: string;
+
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: PaypalButtonStyleOptions;
+}

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
@@ -1,0 +1,341 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+
+import { Cart } from '../../../cart';
+import { getCart } from '../../../cart/carts.mock';
+import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod } from '../../../payment';
+import { getPaypalCommerce } from '../../../payment/payment-methods.mock';
+import { PaypalHostWindow } from '../../../payment/strategies/paypal';
+import { ButtonsOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK } from '../../../payment/strategies/paypal-commerce';
+import { getPaypalCommerceMock } from '../../../payment/strategies/paypal-commerce/paypal-commerce.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+import { PaypalCommerceCreditButtonInitializeOptions } from './paypal-commerce-credit-button-options';
+import PaypalCommerceCreditButtonStrategy from './paypal-commerce-credit-button-strategy';
+
+describe('PaypalCommerceCreditButtonStrategy', () => {
+    let cartMock: Cart;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let requestSender: RequestSender;
+    let paymentMethodMock: PaymentMethod;
+    let paypalCommerceRequestSender: PaypalCommerceRequestSender;
+    let paypalScriptLoader: PaypalCommerceScriptLoader;
+    let store: CheckoutStore;
+    let strategy: PaypalCommerceCreditButtonStrategy;
+    let paypalSdkMock: PaypalCommerceSDK;
+    let paypalCommerceCreditButtonElement: HTMLDivElement;
+    let paypalCommerceCreditMessageElement: HTMLDivElement;
+
+    const defaultButtonContainerId = 'paypal-commerce-credit-button-mock-id';
+    const defaultMessageContainerId = 'paypal-commerce-credit-message-mock-id';
+    const approveDataOrderId = 'ORDER_ID';
+
+    const paypalCommerceCreditOptions: PaypalCommerceCreditButtonInitializeOptions = {
+        initializesOnCheckoutPage: false,
+        messagingContainerId: defaultMessageContainerId,
+        style: {
+            height: 45,
+        },
+    };
+
+    const initializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_CREDIT,
+        containerId: defaultButtonContainerId,
+        paypalcommercecredit: paypalCommerceCreditOptions,
+    };
+
+    beforeEach(() => {
+        cartMock = getCart();
+        eventEmitter = new EventEmitter();
+        paymentMethodMock = { ...getPaypalCommerce(), id: 'paypalcommercecredit' };
+        paypalSdkMock = getPaypalCommerceMock();
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = createRequestSender();
+        formPoster = createFormPoster();
+        paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
+        paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());
+
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
+        );
+
+        strategy = new PaypalCommerceCreditButtonStrategy(
+            store,
+            checkoutActionCreator,
+            formPoster,
+            paypalScriptLoader,
+            paypalCommerceRequestSender,
+        );
+
+        paypalCommerceCreditButtonElement = document.createElement('div');
+        paypalCommerceCreditButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalCommerceCreditButtonElement);
+
+        paypalCommerceCreditMessageElement = document.createElement('div');
+        paypalCommerceCreditMessageElement.id = defaultMessageContainerId;
+        document.body.appendChild(paypalCommerceCreditMessageElement);
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
+        jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cartMock);
+
+        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce').mockReturnValue(paypalSdkMock);
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+
+        jest.spyOn(paypalSdkMock, 'isFundingEligible').mockImplementation(() => true);
+        jest.spyOn(paypalSdkMock, 'Buttons')
+            .mockImplementation((options: ButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ orderID: approveDataOrderId });
+                    }
+                });
+
+                return {
+                    render: jest.fn(),
+                };
+            });
+
+        jest.spyOn(paypalSdkMock, 'Messages')
+            .mockImplementation(() => ({
+                render: jest.fn(),
+            }));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PaypalHostWindow).paypal;
+
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalCommerceCreditButtonElement);
+        }
+
+        if (document.getElementById(defaultMessageContainerId)) {
+            document.body.removeChild(paypalCommerceCreditMessageElement);
+        }
+    });
+
+    it('creates an instance of the PayPal Commerce Credit checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(PaypalCommerceCreditButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = { containerId: defaultButtonContainerId } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = { methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_CREDIT } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommercecredit is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+                methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_CREDIT,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('loads paypal commerce sdk script', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalScriptLoader.loadPaypalCommerce).toHaveBeenCalled();
+        });
+
+        describe('PayPal Commerce Credit buttons logic', () => {
+            it('initializes PayPal PayLater button to render', async () => {
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                    fundingSource: paypalSdkMock.FUNDING.PAYLATER,
+                    style: paypalCommerceCreditOptions.style,
+                    createOrder: expect.any(Function),
+                    onApprove: expect.any(Function)
+                });
+            });
+
+            it('initializes PayPal Credit button to render', async () => {
+                jest.spyOn(paypalSdkMock, 'isFundingEligible')
+                    .mockImplementation((fundingSource: string) => {
+                        return fundingSource === 'credit';
+                    })
+
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                    fundingSource: paypalSdkMock.FUNDING.CREDIT,
+                    style: paypalCommerceCreditOptions.style,
+                    createOrder: expect.any(Function),
+                    onApprove: expect.any(Function)
+                });
+            });
+
+            it('renders PayPal button', async () => {
+                const paypalCommerceSdkRenderMock = jest.fn();
+
+                jest.spyOn(paypalSdkMock, 'Buttons')
+                    .mockImplementation(() => ({
+                        render: paypalCommerceSdkRenderMock,
+                    }));
+
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalCommerceSdkRenderMock).toHaveBeenCalledWith(`#${defaultButtonContainerId}`);
+            });
+
+            it('removes PayPal Commerce Credit button container if the funding sources are not eligible', async () => {
+                const paypalCommerceSdkRenderMock = jest.fn();
+
+                jest.spyOn(paypalSdkMock, 'isFundingEligible')
+                    .mockImplementation(() => false);
+
+                jest.spyOn(paypalSdkMock, 'Buttons')
+                    .mockImplementation(() => ({
+                        render: paypalCommerceSdkRenderMock,
+                    }));
+
+                await strategy.initialize(initializationOptions);
+
+                expect(document.getElementById(defaultButtonContainerId)).toBeNull();
+            });
+
+            it('creates an order with paypalcommercecredit as provider id if its initializes outside checkout page', async () => {
+                jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('createOrder');
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, 'paypalcommercecredit');
+            });
+
+            it('creates an order with paypalcommercecreditcheckout as provider id if its initializes on checkout page', async () => {
+                jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+                const updatedIntializationOptions = {
+                    ...initializationOptions,
+                    paypalcommercecredit: {
+                        ...initializationOptions.paypalcommercecredit,
+                        initializesOnCheckoutPage: true,
+                    },
+                };
+
+                await strategy.initialize(updatedIntializationOptions);
+
+                eventEmitter.emit('createOrder');
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, 'paypalcommercecreditcheckout');
+            });
+
+            it('throws an error if orderId is not provided by PayPal on approve', async () => {
+                jest.spyOn(paypalSdkMock, 'Buttons')
+                    .mockImplementation((options: ButtonsOptions) => {
+                        eventEmitter.on('createOrder', () => {
+                            if (options.createOrder) {
+                                options.createOrder().catch(() => {});
+                            }
+                        });
+
+                        eventEmitter.on('onApprove', () => {
+                            if (options.onApprove) {
+                                options.onApprove({ orderID: undefined });
+                            }
+                        });
+
+                        return {
+                            render: jest.fn(),
+                        };
+                    });
+
+                try {
+                    await strategy.initialize(initializationOptions);
+                    eventEmitter.emit('onApprove');
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('tokenizes payment on paypal approve', async () => {
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                    action: 'set_external_checkout',
+                    order_id: approveDataOrderId,
+                    payment_type: 'paypal',
+                    provider: paymentMethodMock.id,
+                }));
+            });
+        });
+
+        describe('PayPal Commerce Credit messages logic', () => {
+            it('initializes PayPal Messages component', async () => {
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalSdkMock.Messages).toHaveBeenCalledWith({
+                    amount: cartMock.cartAmount,
+                    placement: 'cart',
+                    style: {
+                        layout: 'text',
+                    },
+                });
+            });
+
+            it('renders PayPal message', async () => {
+                const paypalCommerceSdkRenderMock = jest.fn();
+
+                jest.spyOn(paypalSdkMock, 'Messages')
+                    .mockImplementation(() => ({
+                        render: paypalCommerceSdkRenderMock,
+                    }));
+
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalCommerceSdkRenderMock).toHaveBeenCalledWith(`#${defaultMessageContainerId}`);
+            });
+        });
+    });
+});

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
@@ -37,9 +37,9 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
         }
 
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
-        const currency = state.cart.getCartOrThrow().currency.code;
+        const currencyCode = state.cart.getCartOrThrow().currency.code;
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currency, initializesOnCheckoutPage);
+        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currencyCode, initializesOnCheckoutPage);
 
         this._renderButton(containerId, methodId, initializesOnCheckoutPage, style);
         this._renderMessages(messagingContainerId);

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
@@ -1,0 +1,145 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType, } from '../../../common/error/errors';
+import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
+import { ApproveDataOptions, ButtonsOptions, PaypalButtonStyleOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK } from '../../../payment/strategies/paypal-commerce';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+import getValidButtonStyle from './get-valid-button-style';
+
+export default class PaypalCommerceCreditButtonStrategy implements CheckoutButtonStrategy {
+    private _paypalCommerceSdk?: PaypalCommerceSDK;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _formPoster: FormPoster,
+        private _paypalScriptLoader: PaypalCommerceScriptLoader,
+        private _paypalCommerceRequestSender: PaypalCommerceRequestSender
+    ) {}
+
+    async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        const { paypalcommercecredit, containerId, methodId } = options;
+        const { initializesOnCheckoutPage, messagingContainerId, style } = paypalcommercecredit || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.containerId" argument is not provided.`);
+        }
+
+        if (!paypalcommercecredit) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommercecredit" argument is not provided.`);
+        }
+
+        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        const currency = state.cart.getCartOrThrow().currency.code;
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currency, initializesOnCheckoutPage);
+
+        this._renderButton(containerId, methodId, initializesOnCheckoutPage, style);
+        this._renderMessages(messagingContainerId);
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private _renderButton(containerId: string, methodId: string, initializesOnCheckoutPage?: boolean, style?: PaypalButtonStyleOptions): void {
+        const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
+        const primaryFundingSource = paypalCommerceSdk.FUNDING.PAYLATER;
+        const secondaryFundingSource = paypalCommerceSdk.FUNDING.CREDIT;
+
+        if (!paypalCommerceSdk.isFundingEligible(primaryFundingSource) && !paypalCommerceSdk.isFundingEligible(secondaryFundingSource)) {
+            this._removeElement(containerId);
+        }
+
+        const fundingSource = paypalCommerceSdk.isFundingEligible(primaryFundingSource)
+            ? primaryFundingSource
+            : secondaryFundingSource;
+
+        const buttonRenderOptions: ButtonsOptions = {
+            fundingSource,
+            style: style ? this._getButtonStyle(style) : {},
+            createOrder: () => this._createOrder(initializesOnCheckoutPage),
+            onApprove: ({ orderID }: ApproveDataOptions) => this._tokenizePayment(methodId, orderID),
+        };
+
+        const paypalButton = paypalCommerceSdk.Buttons(buttonRenderOptions);
+
+        paypalButton.render(`#${containerId}`);
+    }
+
+    private _renderMessages(messagingContainerId?: string): void {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+
+        const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
+
+        const isMessagesAvailable = Boolean(messagingContainerId && document.getElementById(messagingContainerId));
+
+        if (isMessagesAvailable) {
+            const paypalMessagesOptions = {
+                amount: cart.cartAmount,
+                placement: 'cart',
+                style: {
+                    layout: 'text',
+                },
+            };
+
+            const paypalMessages = paypalCommerceSdk.Messages(paypalMessagesOptions);
+
+            paypalMessages.render(`#${messagingContainerId}`);
+        }
+    }
+
+    private async _createOrder(initializesOnCheckoutPage?: boolean): Promise<string> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+
+        const providerId = initializesOnCheckoutPage ? 'paypalcommercecreditcheckout': 'paypalcommercecredit';
+
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cart.id, providerId);
+
+        return orderId;
+    }
+
+    private _tokenizePayment(methodId: string, orderId?: string): void {
+        if (!orderId) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        return this._formPoster.postForm('/checkout.php', {
+            payment_type: 'paypal',
+            action: 'set_external_checkout',
+            provider: methodId,
+            order_id: orderId,
+        });
+    }
+
+    private _getPayPalCommerceSdkOrThrow(): PaypalCommerceSDK {
+        if (!this._paypalCommerceSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this._paypalCommerceSdk;
+    }
+
+    private _getButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+        const { color, height, label, layout, shape } = getValidButtonStyle(style);
+
+        return { color, height, label, layout, shape };
+    }
+
+    private _removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+}

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -87,7 +87,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -108,7 +108,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'EUR',
             intent: 'capture',
         }
@@ -130,7 +130,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -157,7 +157,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'venmo'],
             'enable-funding': ['credit', 'paylater'],
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -184,7 +184,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -211,7 +211,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater'],
             'enable-funding': ['venmo'],
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -238,7 +238,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -266,7 +266,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo', 'mybank', 'sofort', 'sepa'],
             'enable-funding': ['bancontact', 'giropay', 'ideal'],
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -288,7 +288,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -307,7 +307,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: false,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -96,7 +96,7 @@ export default class PaypalCommerceScriptLoader {
             'enable-funding': enableFunding.length > 0 ? enableFunding : undefined,
             'disable-funding': disableFunding.length > 0 ? disableFunding : undefined,
             commit,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
             currency,
             intent,
         };

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -17,10 +17,10 @@ export default class PaypalCommerceScriptLoader {
 
     async loadPaypalCommerce(
         paymentMethod: PaymentMethod<PaypalCommerceInitializationData>,
-        currency: string,
+        currencyCode: string,
         initializesOnCheckoutPage?: boolean,
     ): Promise<PaypalCommerceSDK> {
-        const paypalSdkScriptConfig = this._getPayPalSdkScriptConfigOrThrow(paymentMethod, currency, initializesOnCheckoutPage);
+        const paypalSdkScriptConfig = this._getPayPalSdkScriptConfigOrThrow(paymentMethod, currencyCode, initializesOnCheckoutPage);
 
         if (!this._window.paypalLoadScript) {
             const PAYPAL_SDK_VERSION = '5.0.5';
@@ -44,7 +44,7 @@ export default class PaypalCommerceScriptLoader {
 
     private _getPayPalSdkScriptConfigOrThrow(
         paymentMethod: PaymentMethod<PaypalCommerceInitializationData>,
-        currency: string,
+        currencyCode: string,
         initializesOnCheckoutPage = true,
     ): PaypalCommerceScriptParams {
         const { id, clientToken, initializationData } = paymentMethod;
@@ -97,7 +97,7 @@ export default class PaypalCommerceScriptLoader {
             'disable-funding': disableFunding.length > 0 ? disableFunding : undefined,
             commit,
             components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
-            currency,
+            currency: currencyCode,
             intent,
         };
     }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -214,6 +214,7 @@ export interface PaypalCommerceSDK {
     Buttons(params: ButtonsOptions): PaypalCommerceButtons;
     PaymentFields(params: FieldsOptions): PaypalCommerceFields;
     Messages(params: MessagesOptions): PaypalCommerceMessages;
+    isFundingEligible(fundingSource: string): boolean;
 }
 
 export interface PaypalCommerceHostWindow extends Window {
@@ -240,7 +241,7 @@ export interface PaypalCommerceInitializationData {
     isVenmoEnabled?: boolean;
 }
 
-export type ComponentsScriptType = Array<'buttons' | 'messages' | 'hosted-fields' | 'payment-fields'>;
+export type ComponentsScriptType = Array<'buttons' | 'funding-eligibility' | 'hosted-fields' | 'messages' | 'payment-fields'>;
 
 export interface PaypalCommerceScriptParams  {
     'client-id'?: string;

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
@@ -8,6 +8,7 @@ export function getPaypalCommerceMock(): PaypalCommerceSDK {
         PaymentFields: () => ({
             render: jest.fn(),
         }),
+        isFundingEligible: jest.fn(),
         FUNDING: {
             PAYPAL: 'paypal',
             CREDIT: 'credit',


### PR DESCRIPTION
## What?
Added PayPalCommerceCredit checkout button strategy

## Why?
It is a part of PayPalCommerce button strategy separation. We as developers want to have clearer vision of whats functionality related for current feature.

## Testing / Proof
Unit tests
Manual tests

Screenshot of the result:
<img width="1403" alt="Screenshot 2022-08-12 at 11 46 05" src="https://user-images.githubusercontent.com/25133454/184345307-e1aee3f5-a83d-4976-bc83-615545d09393.png">
