### PR TITLE
fix(payment): INT-6392 [Mollie] Klarna shopper are able to place orders with digital items through klarna pay later and slice it when them are added via coupon

### DIFF
--- a/packages/core/src/payment/strategies/mollie/mollie-initialize-options.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-initialize-options.ts
@@ -65,5 +65,5 @@ export default interface MolliePaymentInitializeOptions {
 
     unsupportedMethodMessage?: string;
 
-    disableButton(): void;
+    disableButton(disabled: boolean): void;
 }

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -36,6 +36,8 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
 
     private _hostedForm?: HostedForm;
 
+    private _unsubscribe?: (() => void);
+
     constructor(
         private _hostedFormFactory: HostedFormFactory,
         private _store: CheckoutStore,
@@ -85,28 +87,36 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             this._mountElements();
         }
 
-        if (methodsNotAllowedWhenDigitalOrder.includes(methodId)) {
-            const cart = state.cart.getCartOrThrow();
-            const cartDigitalItems = cart.lineItems.digitalItems;
+        this._unsubscribe = this._store.subscribe(
+            async state => {
+                if (state.paymentStrategies.isInitialized(methodId)) {
 
-            if (cartDigitalItems && cartDigitalItems.length > 0) {
-                const { containerId } = this._getInitializeOptions();
+                    if (methodId && gatewayId && mollie) {
+                        const element = document.getElementById(`${gatewayId}-${methodId}-paragraph`);
 
-                if (containerId) {
-                    const container = document.getElementById(containerId);
-
-                    if (container) {
-                        const paragraph = document.createElement('p') ;
-
-                        if (mollie.unsupportedMethodMessage) {
-                            paragraph.innerText = mollie.unsupportedMethodMessage;
-                            container.appendChild(paragraph);
-                            mollie.disableButton();
+                        if (element) {
+                            element.remove();
                         }
+
+                        mollie.disableButton(false);
                     }
+
+                    await this._validateDigitalOrder(mollie, methodId, gatewayId, state);
                 }
+            },
+            state => {
+                const checkout = state.checkout.getCheckout();
+
+                return checkout && checkout.outstandingBalance;
+            },
+            state => {
+                const checkout = state.checkout.getCheckout();
+
+                return checkout && checkout.coupons;
             }
-        }
+        );
+
+        await this._validateDigitalOrder(mollie, methodId, gatewayId, state);
 
         return Promise.resolve(this._store.getState());
     }
@@ -142,6 +152,10 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
     }
 
     deinitialize(options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        if (this._unsubscribe) {
+            this._unsubscribe();
+        }
+
         if (this._hostedForm) {
             this._hostedForm.detach();
         }
@@ -340,5 +354,31 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
                 this._expiryDateElement.mount(`#${cardExpiryId}`);
             }
         }, 0);
+    }
+
+    private async _validateDigitalOrder(mollie: MolliePaymentInitializeOptions, methodId: string, gatewayId: string, state: InternalCheckoutSelectors){
+        if (methodsNotAllowedWhenDigitalOrder.includes(methodId)) {
+            const cart = state.cart.getCartOrThrow();
+            const cartDigitalItems = cart.lineItems.digitalItems;
+
+            if (cartDigitalItems && cartDigitalItems.length > 0) {
+                const { containerId } = this._getInitializeOptions();
+
+                if (containerId) {
+                    const container = document.getElementById(containerId);
+
+                    if (container) {
+                        const paragraph = document.createElement('p') ;
+                        paragraph.setAttribute("id",`${gatewayId}-${methodId}-paragraph`)
+
+                        if (mollie.unsupportedMethodMessage) {
+                            paragraph.innerText = mollie.unsupportedMethodMessage;
+                            container.appendChild(paragraph);
+                            mollie.disableButton(true);
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -101,7 +101,7 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
                         mollie.disableButton(false);
                     }
 
-                    await this._validateDigitalOrder(mollie, methodId, gatewayId, state);
+                    await this._loadPaymentMethodsAllowed(mollie, methodId, gatewayId, state);
                 }
             },
             state => {
@@ -116,9 +116,7 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             }
         );
 
-        await this._validateDigitalOrder(mollie, methodId, gatewayId, state);
-
-        return Promise.resolve(this._store.getState());
+        return this._loadPaymentMethodsAllowed(mollie, methodId, gatewayId, state);
     }
 
     async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
@@ -356,7 +354,7 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         }, 0);
     }
 
-    private async _validateDigitalOrder(mollie: MolliePaymentInitializeOptions, methodId: string, gatewayId: string, state: InternalCheckoutSelectors){
+    private async _loadPaymentMethodsAllowed(mollie: MolliePaymentInitializeOptions, methodId: string, gatewayId: string, state: InternalCheckoutSelectors){
         if (methodsNotAllowedWhenDigitalOrder.includes(methodId)) {
             const cart = state.cart.getCartOrThrow();
             const cartDigitalItems = cart.lineItems.digitalItems;
@@ -380,5 +378,7 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
                 }
             }
         }
+
+        return state;
     }
 }

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -90,18 +90,15 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         this._unsubscribe = this._store.subscribe(
             async state => {
                 if (state.paymentStrategies.isInitialized(methodId)) {
+                    const element = document.getElementById(`${gatewayId}-${methodId}-paragraph`);
 
-                    if (methodId && gatewayId && mollie) {
-                        const element = document.getElementById(`${gatewayId}-${methodId}-paragraph`);
-
-                        if (element) {
-                            element.remove();
-                        }
-
-                        mollie.disableButton(false);
+                    if (element) {
+                        element.remove();
                     }
 
-                    await this._loadPaymentMethodsAllowed(mollie, methodId, gatewayId, state);
+                    mollie.disableButton(false);
+
+                    this._loadPaymentMethodsAllowed(mollie, methodId, gatewayId, state);
                 }
             },
             state => {
@@ -116,7 +113,8 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             }
         );
 
-        return this._loadPaymentMethodsAllowed(mollie, methodId, gatewayId, state);
+        this._loadPaymentMethodsAllowed(mollie, methodId, gatewayId, state);
+        return Promise.resolve(this._store.getState());
     }
 
     async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
@@ -354,7 +352,7 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
         }, 0);
     }
 
-    private async _loadPaymentMethodsAllowed(mollie: MolliePaymentInitializeOptions, methodId: string, gatewayId: string, state: InternalCheckoutSelectors){
+    private _loadPaymentMethodsAllowed(mollie: MolliePaymentInitializeOptions, methodId: string, gatewayId: string, state: InternalCheckoutSelectors){
         if (methodsNotAllowedWhenDigitalOrder.includes(methodId)) {
             const cart = state.cart.getCartOrThrow();
             const cartDigitalItems = cart.lineItems.digitalItems;
@@ -378,7 +376,5 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
                 }
             }
         }
-
-        return state;
     }
 }


### PR DESCRIPTION
## What? [INT-6392](https://bigcommercecloud.atlassian.net/browse/INT-6392)
Shopper are able to place orders with Digital items through Klarna Pay Later and Slice it when them are added via coupon

## Why?
Shopper should not be able to place orders with Digital items through Klarna Pay Later and Slice it event if those items are added via coupon.

## Testing / Proof

### Before

https://user-images.githubusercontent.com/104527753/184431432-6138953a-6d01-4577-9f43-af9617637cc8.mov


### After

https://user-images.githubusercontent.com/104527753/184400785-50bd4249-f2d4-4556-8a45-d07c7de171c7.mov




@bigcommerce/checkout @bigcommerce/apex-integrations 
