### PR TITLE
fix(payment): STRIPE-130 Stripe UPE making postal code not always required to make purchase

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -525,6 +525,23 @@ describe('StripeUPEPaymentStrategy', () => {
                         expect(response).toBe(store.getState());
                     });
 
+                    it('with a guest user without postal code', async () => {
+                        jest.spyOn(store.getState().customer, 'getCustomer')
+                            .mockReturnValue(undefined);
+                        jest.spyOn(store.getState().shippingAddress, 'getShippingAddress')
+                            .mockReturnValue({
+                                ...getShippingAddress(),
+                                postalCode: '',
+                            });
+
+                        const response = await strategy.execute(getStripeUPEOrderRequestBodyMock());
+
+                        expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+                        expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalled();
+                        expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                        expect(response).toBe(store.getState());
+                    });
+
                     it('without shipping address if there is not physical items in cart', async () => {
                         jest.spyOn(store.getState().cart, 'getCart')
                             .mockReturnValue({

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -263,7 +263,6 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                         email: StripeStringConstants.NEVER,
                         address: {
                             country: StripeStringConstants.NEVER,
-                            postalCode: StripeStringConstants.NEVER,
                             city: StripeStringConstants.NEVER,
                         },
                     },
@@ -359,10 +358,9 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             const {
                 city,
                 countryCode: country,
-                postalCode,
             } = address;
 
-            return { city, country, postal_code: postalCode };
+            return { city, country };
         }
 
         throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
@@ -378,7 +376,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
         }
 
-        if (!email || !address || !address.city || !address.country || !address.postal_code) {
+        if (!email || !address || !address.city || !address.country) {
             throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);
         }
 


### PR DESCRIPTION
## What? [STRIPE-130](https://bigcommercecloud.atlassian.net/browse/STRIPE-130)
StripeUPE always requires to get a postal code and in some countries is not needed so i deleted the validation in the _mapStripePaymentData function

## Why?
StripeUPE unable to process payments for billing address where no zip/postal code is required

## Testing / Proof

Before change:
<img width="812" alt="Screen Shot 2022-08-15 at 15 20 27" src="https://user-images.githubusercontent.com/106765049/184711501-4ba781c6-620b-44a1-8817-aff8a02c42be.png">
 
After change:
<img width="827" alt="Screen Shot 2022-08-15 at 15 21 03" src="https://user-images.githubusercontent.com/106765049/184711583-e85dc058-9d49-4ff3-9a8d-d64d041def3d.png">

Proof of other payment methods working

<img width="701" alt="Screen Shot 2022-08-16 at 13 01 33" src="https://user-images.githubusercontent.com/106765049/184981240-af9711e2-1f8d-4908-9fb7-65bab3cae4f0.png">

<img width="637" alt="Screen Shot 2022-08-16 at 13 06 22" src="https://user-images.githubusercontent.com/106765049/184981252-06debe6b-0dfb-4be2-99d1-e17fcef42311.png">

<img width="1243" alt="Screen Shot 2022-08-16 at 13 16 27" src="https://user-images.githubusercontent.com/106765049/184981274-098d07f0-d1dd-4fd4-a545-af91f9154429.png">

<img width="1130" alt="Screen Shot 2022-08-16 at 13 20 50" src="https://user-images.githubusercontent.com/106765049/184981290-f5d392ab-f249-4c5c-8abe-17597032f933.png">

<img width="1325" alt="Screen Shot 2022-08-16 at 15 26 06" src="https://user-images.githubusercontent.com/106765049/184981303-d62cce43-3ae9-4d1c-83cb-561023728f2b.png">


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
