### PR TITLE
fix(payment): PAYPAL-0000 updated paypal button rendering implementation in PayPalCommerceCreditButtonStrategy

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
@@ -94,7 +94,6 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
         jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce').mockReturnValue(paypalSdkMock);
         jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
 
-        jest.spyOn(paypalSdkMock, 'isFundingEligible').mockImplementation(() => true);
         jest.spyOn(paypalSdkMock, 'Buttons')
             .mockImplementation((options: ButtonsOptions) => {
                 eventEmitter.on('createOrder', () => {
@@ -111,6 +110,7 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
 
                 return {
                     render: jest.fn(),
+                    isEligible: jest.fn(() => true),
                 };
             });
 
@@ -190,11 +190,16 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
                 });
             });
 
-            it('initializes PayPal Credit button to render', async () => {
-                jest.spyOn(paypalSdkMock, 'isFundingEligible')
-                    .mockImplementation((fundingSource: string) => {
-                        return fundingSource === 'credit';
-                    })
+            it('initializes PayPal Credit button to render if PayPal PayLater is not eligible', async () => {
+                jest.spyOn(paypalSdkMock, 'Buttons')
+                    .mockImplementation((options: ButtonsOptions) => {
+                        return {
+                            render: jest.fn(),
+                            isEligible: jest.fn(() => {
+                                return options.fundingSource === paypalSdkMock.FUNDING.CREDIT;
+                            }),
+                        };
+                    });
 
                 await strategy.initialize(initializationOptions);
 
@@ -212,6 +217,7 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
                 jest.spyOn(paypalSdkMock, 'Buttons')
                     .mockImplementation(() => ({
                         render: paypalCommerceSdkRenderMock,
+                        isEligible: jest.fn(() => true),
                     }));
 
                 await strategy.initialize(initializationOptions);
@@ -222,12 +228,10 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
             it('removes PayPal Commerce Credit button container if the funding sources are not eligible', async () => {
                 const paypalCommerceSdkRenderMock = jest.fn();
 
-                jest.spyOn(paypalSdkMock, 'isFundingEligible')
-                    .mockImplementation(() => false);
-
                 jest.spyOn(paypalSdkMock, 'Buttons')
                     .mockImplementation(() => ({
                         render: paypalCommerceSdkRenderMock,
+                        isEligible: jest.fn(() => false),
                     }));
 
                 await strategy.initialize(initializationOptions);
@@ -284,6 +288,7 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
 
                         return {
                             render: jest.fn(),
+                            isEligible: jest.fn(() => true),
                         };
                     });
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -87,7 +87,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -108,7 +108,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'EUR',
             intent: 'capture',
         }
@@ -130,7 +130,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -157,7 +157,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'venmo'],
             'enable-funding': ['credit', 'paylater'],
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -184,7 +184,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -211,7 +211,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater'],
             'enable-funding': ['venmo'],
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -238,7 +238,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -266,7 +266,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo', 'mybank', 'sofort', 'sepa'],
             'enable-funding': ['bancontact', 'giropay', 'ideal'],
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -288,7 +288,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: true,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }
@@ -307,7 +307,7 @@ describe('PaypalCommerceScriptLoader', () => {
             'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
             'enable-funding': undefined,
             commit: false,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: 'USD',
             intent: 'capture',
         }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -96,7 +96,7 @@ export default class PaypalCommerceScriptLoader {
             'enable-funding': enableFunding.length > 0 ? enableFunding : undefined,
             'disable-funding': disableFunding.length > 0 ? disableFunding : undefined,
             commit,
-            components: ['buttons', 'funding-eligibility', 'hosted-fields', 'messages', 'payment-fields'],
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: currencyCode,
             intent,
         };

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -214,7 +214,6 @@ export interface PaypalCommerceSDK {
     Buttons(params: ButtonsOptions): PaypalCommerceButtons;
     PaymentFields(params: FieldsOptions): PaypalCommerceFields;
     Messages(params: MessagesOptions): PaypalCommerceMessages;
-    isFundingEligible(fundingSource: string): boolean;
 }
 
 export interface PaypalCommerceHostWindow extends Window {

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce.mock.ts
@@ -8,7 +8,6 @@ export function getPaypalCommerceMock(): PaypalCommerceSDK {
         PaymentFields: () => ({
             render: jest.fn(),
         }),
-        isFundingEligible: jest.fn(),
         FUNDING: {
             PAYPAL: 'paypal',
             CREDIT: 'credit',


### PR DESCRIPTION
## What?
Updated paypal button rendering implementation in PayPalCommerceCreditButtonStrategy by by changing funding source eligibility check to configured button eligibility check.

## Why?
Because `isFundingEligible` method is not suitable for our needs. We should check configured button eligibility instead

## Testing / Proof
Unit tests
Manual tests
