### PR TITLE
fix(payment): PAYPAL-1639 fixed paypal commerce zoid issue

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -83,7 +83,7 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
 
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
-        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce').mockReturnValue(paypalSdkMock);
+        jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdkMock);
         jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
 
         jest.spyOn(paypalSdkMock, 'Buttons')
@@ -174,7 +174,7 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
         it('loads paypal commerce sdk script', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalScriptLoader.loadPaypalCommerce).toHaveBeenCalled();
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalled();
         });
 
         it('initializes APM button to render', async () => {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
@@ -43,7 +43,7 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy implements C
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         const currency = state.cart.getCartOrThrow().currency.code;
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currency, initializesOnCheckoutPage);
+        this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currency, initializesOnCheckoutPage);
 
         this._renderButton(apm, methodId, containerId, initializesOnCheckoutPage, style);
     }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
@@ -91,7 +91,7 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
         jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cartMock);
 
-        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce').mockReturnValue(paypalSdkMock);
+        jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdkMock);
         jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
 
         jest.spyOn(paypalSdkMock, 'Buttons')
@@ -175,7 +175,7 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
         it('loads paypal commerce sdk script', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalScriptLoader.loadPaypalCommerce).toHaveBeenCalled();
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalled();
         });
 
         describe('PayPal Commerce Credit buttons logic', () => {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
@@ -39,7 +39,7 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         const currencyCode = state.cart.getCartOrThrow().currency.code;
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currencyCode, initializesOnCheckoutPage);
+        this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currencyCode, initializesOnCheckoutPage);
 
         this._renderButton(containerId, methodId, initializesOnCheckoutPage, style);
         this._renderMessages(messagingContainerId);

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-v2-button-strategy.spec.ts
@@ -82,7 +82,7 @@ describe('PaypalCommerceV2ButtonStrategy', () => {
 
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
-        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce').mockReturnValue(paypalSdkMock);
+        jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdkMock);
         jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
 
 
@@ -158,7 +158,7 @@ describe('PaypalCommerceV2ButtonStrategy', () => {
         it('loads paypal commerce sdk script', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalScriptLoader.loadPaypalCommerce).toHaveBeenCalled();
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalled();
         });
 
         it('initializes PayPal button to render', async () => {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-v2-button-strategy.ts
@@ -43,7 +43,7 @@ export default class PaypalCommerceV2ButtonStrategy implements CheckoutButtonStr
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         const currencyCode = state.cart.getCartOrThrow().currency.code;
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(updatedMethodId);
-        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currencyCode, initializesOnCheckoutPage);
+        this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currencyCode, initializesOnCheckoutPage);
 
         this._renderButton(containerId, updatedMethodId, initializesOnCheckoutPage, style);
     }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
@@ -82,7 +82,7 @@ describe('PaypalCommerceVenmoButtonStrategy', () => {
 
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
-        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce').mockReturnValue(paypalSdkMock);
+        jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdkMock);
         jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
 
 
@@ -158,7 +158,7 @@ describe('PaypalCommerceVenmoButtonStrategy', () => {
         it('loads paypal commerce sdk script', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalScriptLoader.loadPaypalCommerce).toHaveBeenCalled();
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalled();
         });
 
         it('initializes Venmo button to render', async () => {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.ts
@@ -39,7 +39,7 @@ export default class PaypalCommerceVenmoButtonStrategy implements CheckoutButton
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         const currency = state.cart.getCartOrThrow().currency.code;
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        this._paypalCommerceSdk = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currency, initializesOnCheckoutPage);
+        this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currency, initializesOnCheckoutPage);
 
         this._renderButton(containerId, methodId, initializesOnCheckoutPage, style);
     }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-credit-card-payment-strategy.spec.ts
@@ -73,7 +73,7 @@ describe('PaypalCommerceCreditCardPaymentStrategy', () => {
         paymentActionCreator = {} as PaymentActionCreator;
         paymentActionCreator.submitPayment = jest.fn(() => submitPaymentAction);
 
-        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce')
+        jest.spyOn(paypalScriptLoader, 'getPayPalSDK')
             .mockReturnValue(Promise.resolve(paypal));
 
         jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod')

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.spec.ts
@@ -119,7 +119,7 @@ describe('PaypalCommercePaymentProcessor', () => {
                 };
             });
 
-        jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce')
+        jest.spyOn(paypalScriptLoader, 'getPayPalSDK')
             .mockReturnValue(Promise.resolve(paypal));
 
         hostedFormOptions = {
@@ -176,13 +176,13 @@ describe('PaypalCommercePaymentProcessor', () => {
         it('initializes PaypalCommerce and PayPal JS clients', async () => {
             await paypalCommercePaymentProcessor.initialize(paymentMethodMock, 'USD');
 
-            expect(paypalScriptLoader.loadPaypalCommerce).toHaveBeenCalledWith(paymentMethodMock, 'USD', undefined);
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalledWith(paymentMethodMock, 'USD', undefined);
         });
 
         it('throws error if unable to initialize PaypalCommerce or PayPal JS client', async () => {
             const expectedError = new Error('Unable to load JS client');
 
-            jest.spyOn(paypalScriptLoader, 'loadPaypalCommerce')
+            jest.spyOn(paypalScriptLoader, 'getPayPalSDK')
                 .mockReturnValue(Promise.reject(expectedError));
 
             try {

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -57,7 +57,7 @@ export default class PaypalCommercePaymentProcessor {
     ) {}
 
     async initialize(paymentMethod: PaymentMethod<PaypalCommerceInitializationData>, currencyCode: string, initializesOnCheckoutPage?: boolean): Promise<PaypalCommerceSDK> {
-        this._paypal = await this._paypalScriptLoader.loadPaypalCommerce(paymentMethod, currencyCode, initializesOnCheckoutPage);
+        this._paypal = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currencyCode, initializesOnCheckoutPage);
         this._gatewayId = paymentMethod.gateway;
         this._isVenmoEnabled = paymentMethod.initializationData?.isVenmoEnabled;
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -54,7 +54,7 @@ describe('PaypalCommerceScriptLoader', () => {
         };
 
         try {
-            await paypalLoader.loadPaypalCommerce(paymentMethodProp, 'USD');
+            await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD');
         } catch (error) {
             expect(error).toBeInstanceOf(MissingDataError);
         }
@@ -70,14 +70,14 @@ describe('PaypalCommerceScriptLoader', () => {
         };
 
         try {
-            await paypalLoader.loadPaypalCommerce(paymentMethodProp, 'USD');
+            await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD');
         } catch (error) {
             expect(error).toBeInstanceOf(MissingDataError);
         }
     });
 
     it('loads PayPalSDK script with default configuration', async () => {
-        const output = await paypalLoader.loadPaypalCommerce(paymentMethod, 'USD');
+        const output = await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -97,8 +97,21 @@ describe('PaypalCommerceScriptLoader', () => {
         expect(output).toEqual(paypalSdk);
     });
 
+    it('loads PayPalSDK script only once even if it calls couple times', async () => {
+        const paypalCommerceCreditPaymentMethod = {
+            ...paymentMethod,
+            id: 'paypalcommercecredit',
+        };
+
+        await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
+        await paypalLoader.getPayPalSDK(paypalCommerceCreditPaymentMethod, 'USD');
+
+        expect(loader.loadScript).toHaveBeenCalledTimes(1);
+        expect(paypalLoadScript).toHaveBeenCalledTimes(1);
+    });
+
     it('loads PayPalSDK script with EUR currency', async () => {
-        await paypalLoader.loadPaypalCommerce(paymentMethod, 'EUR');
+        await paypalLoader.getPayPalSDK(paymentMethod, 'EUR');
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -120,7 +133,7 @@ describe('PaypalCommerceScriptLoader', () => {
     // it('loads PayPalCommerce script with enabled card funding', async () => {});
 
     it('loads PayPalCommerce script with disabled card funding', async () => {
-        await paypalLoader.loadPaypalCommerce(paymentMethod, 'USD');
+        await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -147,7 +160,7 @@ describe('PaypalCommerceScriptLoader', () => {
             },
         };
 
-        await paypalLoader.loadPaypalCommerce(paymentMethodProp, 'USD');
+        await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD');
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -174,7 +187,7 @@ describe('PaypalCommerceScriptLoader', () => {
             },
         };
 
-        await paypalLoader.loadPaypalCommerce(paymentMethodProp, 'USD');
+        await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD');
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -201,7 +214,7 @@ describe('PaypalCommerceScriptLoader', () => {
             },
         };
 
-        await paypalLoader.loadPaypalCommerce(paymentMethodProp, 'USD');
+        await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD');
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -228,7 +241,7 @@ describe('PaypalCommerceScriptLoader', () => {
             },
         };
 
-        await paypalLoader.loadPaypalCommerce(paymentMethodProp, 'USD');
+        await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD');
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -256,7 +269,7 @@ describe('PaypalCommerceScriptLoader', () => {
             },
         };
 
-        await paypalLoader.loadPaypalCommerce(paymentMethodProp, 'USD');
+        await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD');
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -278,7 +291,7 @@ describe('PaypalCommerceScriptLoader', () => {
     // it('loads PayPalCommerce script with disabled all APMs', async () => {});
 
     it('loads PayPalSDK script with commit flag as true', async () => {
-        await paypalLoader.loadPaypalCommerce(paymentMethod, 'USD', true);
+        await paypalLoader.getPayPalSDK(paymentMethod, 'USD', true);
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -297,7 +310,7 @@ describe('PaypalCommerceScriptLoader', () => {
     });
 
     it('loads PayPalSDK script with commit flag as false', async () => {
-        await paypalLoader.loadPaypalCommerce(paymentMethod, 'USD', false);
+        await paypalLoader.getPayPalSDK(paymentMethod, 'USD', false);
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,
@@ -326,7 +339,7 @@ describe('PaypalCommerceScriptLoader', () => {
         });
 
         try {
-            await paypalLoader.loadPaypalCommerce(paymentMethod, 'USD');
+            await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
         } catch (error) {
             expect(error).toEqual(expectedError);
         }
@@ -341,7 +354,7 @@ describe('PaypalCommerceScriptLoader', () => {
             });
 
         try {
-            await paypalLoader.loadPaypalCommerce(paymentMethod, 'USD');
+            await paypalLoader.getPayPalSDK(paymentMethod, 'USD');
         } catch (error) {
             expect(error).toEqual(new PaymentMethodClientUnavailableError());
         }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -8,6 +8,7 @@ import { FundingType, PaypalCommerceHostWindow, PaypalCommerceInitializationData
 
 export default class PaypalCommerceScriptLoader {
     private _window: PaypalCommerceHostWindow;
+    private _paypalSdk?: Promise<PaypalCommerceSDK>;
 
     constructor(
         private _scriptLoader: ScriptLoader
@@ -15,13 +16,21 @@ export default class PaypalCommerceScriptLoader {
         this._window = window;
     }
 
-    async loadPaypalCommerce(
+    async getPayPalSDK(
         paymentMethod: PaymentMethod<PaypalCommerceInitializationData>,
         currencyCode: string,
         initializesOnCheckoutPage?: boolean,
     ): Promise<PaypalCommerceSDK> {
-        const paypalSdkScriptConfig = this._getPayPalSdkScriptConfigOrThrow(paymentMethod, currencyCode, initializesOnCheckoutPage);
+        if (!this._paypalSdk) {
+            this._paypalSdk = this.loadPayPalSDK(
+                this._getPayPalSdkScriptConfigOrThrow(paymentMethod, currencyCode, initializesOnCheckoutPage)
+            );
+        }
 
+        return this._paypalSdk;
+    }
+
+    private async loadPayPalSDK(paypalSdkScriptConfig: PaypalCommerceScriptParams): Promise<PaypalCommerceSDK> {
         if (!this._window.paypalLoadScript) {
             const PAYPAL_SDK_VERSION = '5.0.5';
             const scriptSrc = `https://unpkg.com/@paypal/paypal-js@${PAYPAL_SDK_VERSION}/dist/iife/paypal-js.min.js`;


### PR DESCRIPTION
## What?
Fixed PayPalCommerce zoid issue.
Zoid issue - is an implementation (or a bug) on PayPal side, what destroys all paypal components on the page if the script was loaded couple times in the same time.

It should help us to avoid a lot of Sentry issues with 'Zoid destroyed all components' message.

## Why?
To avoid an issue when PayPal removes its own components.

## Testing / Proof
Unit tests
Manual tests
