### PR TITLE
fix(payment) INT-6328 Bluesnap open a new tab insted of using iframe to complete order

### DIFF
--- a/packages/core/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/bluesnapv2/bluesnapv2-payment-strategy.ts
@@ -39,13 +39,13 @@ export default class BlueSnapV2PaymentStrategy implements PaymentStrategy {
             );
         }
 
-        await this._store.dispatch(this._orderActionCreator.submitOrder(orderRequest, options));
-
         const { onLoad, style } = this._initializeOptions;
         const frame = this._createIframe(IFRAME_NAME, style);
         const promise = new CancellablePromise<undefined>(new Promise(noop));
 
         onLoad(frame, () => promise.cancel(new PaymentMethodCancelledError()));
+
+        await this._store.dispatch(this._orderActionCreator.submitOrder(orderRequest, options));
 
         return this._store.dispatch(this._paymentActionCreator.initializeOffsitePayment({
             methodId: payment.methodId,
@@ -80,9 +80,9 @@ export default class BlueSnapV2PaymentStrategy implements PaymentStrategy {
 
     private _createIframe(name: string, style?: BlueSnapV2StyleProps): HTMLIFrameElement {
         const iframe = document.createElement('iframe');
+        iframe.setAttribute("sandbox", "allow-top-navigation allow-scripts allow-forms allow-same-origin");
 
         iframe.name = name;
-
         if (style) {
             const { border, height, width } = style;
 


### PR DESCRIPTION
## What?[INT-6328](https://bigcommercecloud.atlassian.net/browse/INT-6328)
Complete the order inside iframe.


## Why?
We notice the following behavior related with Bluesnap,
After select a payment method for Bluesnap (Credit cards or any other APMs) and click on continue, now Bluesnap opens a new tab and the tab where originally was generating the purchase keeps loading and display a blank iframe. 

To clarify, you are able to complete the order on new tab displayed, but the fact that process left a tab loading a blank iframe seems like bad user experience.

The behavior was tested on store of Integrations and Staging. And were tested on different browsers (Chrome, Safari, Firefox) to see this is not related with browser configuration, but for all of them happens the same.

## Testing / Proof

Before:
<img width="1344" alt="Screen Shot 2022-08-23 at 9 28 42" src="https://user-images.githubusercontent.com/107939414/186185235-7d279eb5-a2b0-498f-9e1e-ff6c519f5ebb.png">
<img width="1344" alt="Screen Shot 2022-08-23 at 9 28 45" src="https://user-images.githubusercontent.com/107939414/186185443-ded18e59-7ede-48a0-a8e8-00394c47b345.png">

After:
<img width="1344" alt="image" src="https://user-images.githubusercontent.com/107939414/186216003-b5a69223-9617-4869-b0c9-bc1654ec5e80.png">

ping @bigcommerce/payments @bigcommerce/apex-integrations 
