### PR TITLE
feat(storefront): STRF-9858 Bodl Service: Checkout Begin and Order Purchased

### DIFF
--- a/packages/core/src/bodl/bodl-emitter-service.ts
+++ b/packages/core/src/bodl/bodl-emitter-service.ts
@@ -1,0 +1,152 @@
+import { LineItemMap } from '../cart';
+import { CheckoutSelectors, CheckoutStoreSelector } from '../checkout';
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+
+import BodlService from "./bodl-service";
+import { BodlEventsCheckout, BODLProduct } from './bodl-window';
+
+export default class BodlEmitterService implements BodlService {
+    private _checkoutStarted = false;
+    private state?: CheckoutStoreSelector;
+
+    constructor(
+        private subscribe: (subscriber: (state: CheckoutSelectors) => void) => void,
+        private bodlEvents: BodlEventsCheckout
+    ) {
+        this.subscribe(state => {
+            this.setState(state.data);
+
+            const config = this.state?.getConfig();
+
+            if (!config) {
+                throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
+            }
+        });
+    }
+
+    setState(state: CheckoutStoreSelector) {
+        this.state = state;
+    }
+
+    checkoutBegin(): void {
+        if (this._checkoutStarted) {
+            return;
+        }
+
+        const checkout = this.state?.getCheckout();
+
+        if (!checkout) {
+            return;
+        }
+
+        const {
+            cart: {
+                cartAmount,
+                currency,
+                lineItems,
+                id,
+                coupons
+            },
+        } = checkout;
+
+        this.bodlEvents.emit('create_checkout_begin', {
+            id,
+            currency: currency.code,
+            cart_value: cartAmount,
+            coupon: coupons.map(coupon => coupon.code.toUpperCase()).join(','),
+            line_items: this.getProducts(lineItems, currency.code)
+        });
+
+        this._checkoutStarted = true;
+    }
+
+    orderPurchased(): void {
+        const order = this.state?.getOrder();
+
+        if (!order) {
+            return;
+        }
+
+        const {
+            currency,
+            isComplete,
+            orderId,
+            orderAmount,
+            shippingCostTotal,
+            lineItems,
+            cartId,
+            coupons
+        } = order;
+
+        if (!isComplete) {
+            return;
+        }
+
+        this.bodlEvents.emit('create_order_purchased', {
+            id: cartId,
+            currency: currency.code,
+            transaction_id: orderId,
+            cart_value: orderAmount,
+            coupon: coupons.map(coupon => coupon.code.toUpperCase()).join(','),
+            shipping_cost: shippingCostTotal,
+            line_items: this.getProducts(lineItems, currency.code),
+        });
+    }
+
+    private getProducts(lineItems: LineItemMap, currencyCode: string): BODLProduct[] {
+        const customItems: BODLProduct[] = (lineItems.customItems || []).map(item => ({
+            product_id: item.id,
+            product_sku: item.sku,
+            price: item.listPrice,
+            quantity: item.quantity,
+            product_name: item.name,
+            currency: currencyCode,
+        }));
+
+        const giftCertificateItems: BODLProduct[] = lineItems.giftCertificates.map(item => {
+            return {
+                product_id: item.id,
+                gift_certificate_id: item.id,
+                price: item.amount,
+                product_name: item.name,
+                gift_certificate_name: item.name,
+                gift_certificate_theme: item.theme,
+                quantity: 1,
+                currency: currencyCode,
+            };
+        });
+
+        const physicalAndDigitalItems: BODLProduct[] = [
+            ...lineItems.physicalItems,
+            ...lineItems.digitalItems,
+        ].map(item => {
+            let itemAttributes;
+
+            if (item.options && item.options.length) {
+                itemAttributes = item.options.map(option => `${option.name}:${option.value}`);
+                itemAttributes.sort();
+            }
+
+            return {
+                product_id: item.productId,
+                quantity: item.quantity,
+                product_name: item.name,
+                price: item.salePrice,
+                product_sku: item.sku,
+                variant_id: item.variantId,
+                discount: item.discountAmount,
+                brand_name: item.brand,
+                currency: currencyCode,
+                category_name: item.categoryNames ? item.categoryNames.join(', ') : '',
+            };
+        });
+
+        return [
+            ...customItems,
+            ...physicalAndDigitalItems,
+            ...giftCertificateItems,
+        ];
+    }
+
+}
+

--- a/packages/core/src/bodl/bodl-events-service.spec.ts
+++ b/packages/core/src/bodl/bodl-events-service.spec.ts
@@ -1,0 +1,224 @@
+import { createCheckoutService, CheckoutService, CheckoutSelectors } from '../checkout';
+import { getCheckoutWithCoupons } from '../checkout/checkouts.mock';
+import { getConfig } from '../config/configs.mock';
+import { getOrder } from '../order/orders.mock';
+
+import BodlEmitterService from './bodl-emitter-service';
+import { BodlEventsCheckout } from './bodl-window';
+
+describe('BodlEmitterService', () => {
+    let checkoutService: CheckoutService;
+    let bodlEmitterService: BodlEmitterService;
+    let bodlEvents: BodlEventsCheckout;
+    let subscriber: (subscriber: (state: CheckoutSelectors) => void) => void;
+
+    beforeEach(() => {
+        bodlEvents = {
+            emit: jest.fn(),
+        };
+
+        checkoutService = createCheckoutService();
+
+        subscriber = (cb) => {
+            cb(checkoutService.getState());
+        };
+
+        jest.spyOn(checkoutService.getState().data, 'getCheckout')
+            .mockReturnValue(getCheckoutWithCoupons());
+
+        jest.spyOn(checkoutService.getState().data, 'getConfig')
+            .mockReturnValue(getConfig().storeConfig);
+    
+        bodlEmitterService = new BodlEmitterService(
+            subscriber,
+            bodlEvents
+        );
+    });
+
+    describe('#checkoutBegin()', () => {
+        beforeEach(() => {
+            bodlEmitterService.checkoutBegin();
+        });
+
+        it('only tracks event once', () => {
+            bodlEmitterService.checkoutBegin();
+            bodlEmitterService.checkoutBegin();
+
+            expect(bodlEvents.emit).toBeCalledTimes(1);
+        });
+
+        it('tracks the id', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_checkout_begin',
+                expect.objectContaining({
+                    id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                })
+            );
+        });
+
+        it('tracks the currency', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_checkout_begin',
+                expect.objectContaining({
+                    currency: 'USD',
+                })
+            );
+        });
+
+        it('tracks the cart value', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_checkout_begin',
+                expect.objectContaining({
+                    cart_value: 190,
+                })
+            );
+        });
+
+        it('tracks the coupon string', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_checkout_begin',
+                expect.objectContaining({
+                    coupon: 'SAVEBIG2015,279F507D817E3E7',
+                })
+            );
+        });
+
+        it('tracks products', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_checkout_begin',
+                expect.objectContaining({
+                    coupon: 'SAVEBIG2015,279F507D817E3E7',
+                    cart_value: 190,
+                    currency: 'USD',
+                    id: "b20deef40f9699e48671bbc3fef6ca44dc80e3c7",
+                    line_items: [{
+                        product_id: 103,
+                        product_sku: 'CLC',
+                        product_name: 'Canvas Laundry Cart',
+                        price: 190,
+                        quantity: 1,
+                        brand_name: 'OFS',
+                        discount: 10,
+                        category_name: 'Cat 1',
+                        variant_id: 71,
+                        currency: 'USD'
+                    }, {
+                        product_id: 104,
+                        product_sku: 'CLX',
+                        product_name: 'Digital Book',
+                        price: 200,
+                        quantity: 1,
+                        discount: 0,
+                        brand_name: 'Digitalia',
+                        category_name: 'Ebooks, Audio Books',
+                        variant_id: 72,
+                        currency: 'USD'
+                    }, {
+                        gift_certificate_id: "bd391ead-8c58-4105-b00e-d75d233b429a",
+                        gift_certificate_name: "$100 Gift Certificate",
+                        gift_certificate_theme: "General",
+                        product_name: '$100 Gift Certificate',
+                        price: 100,
+                        product_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                        quantity: 1,
+                        currency: 'USD'
+                    }],
+                })
+            );
+        });
+    });
+
+    describe('#orderPurchased()', () => {
+        beforeEach(() => {
+            jest.spyOn(checkoutService.getState().data, 'getOrder')
+                .mockReturnValue(getOrder());
+
+            bodlEmitterService.orderPurchased();
+        });
+
+
+        it('tracks the id', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_order_purchased',
+                expect.objectContaining({
+                    id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                })
+            );
+        });
+
+        it('tracks the currency', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_order_purchased',
+                expect.objectContaining({
+                    currency: 'USD',
+                })
+            );
+        });
+
+        it('tracks the transaction id', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_order_purchased',
+                expect.objectContaining({
+                    transaction_id: 295,
+                })
+            );
+        });
+
+        it('tracks the cart amount', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_order_purchased',
+                expect.objectContaining({
+                    cart_value: 190,
+                })
+            );
+        });
+
+        it('tracks the coupon amount, single field, comma separated', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_order_purchased',
+                expect.objectContaining({
+                    coupon: 'SAVEBIG2015,279F507D817E3E7',
+                })
+            );
+        });
+
+        it('tracks the shipping cost', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_order_purchased',
+                expect.objectContaining({
+                    shipping_cost: 15,
+                })
+            );
+        });
+
+        it('tracks products', () => {
+            expect(bodlEvents.emit).toHaveBeenCalledWith(
+                'create_order_purchased',
+                expect.objectContaining({
+                    line_items: [{
+                        product_id: 103,
+                        product_sku: 'CLC',
+                        product_name: 'Canvas Laundry Cart',
+                        price: 190,
+                        quantity: 1,
+                        brand_name: 'OFS',
+                        discount: 10,
+                        category_name: 'Cat 1',
+                        variant_id: 71,
+                        currency: 'USD'
+                    }, {
+                        gift_certificate_id: "bd391ead-8c58-4105-b00e-d75d233b429a",
+                        gift_certificate_name: "$100 Gift Certificate",
+                        gift_certificate_theme: "General",
+                        product_name: '$100 Gift Certificate',
+                        price: 100,
+                        product_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                        quantity: 1,
+                        currency: 'USD'
+                    }],
+                })
+            );
+        });
+    });
+});
+

--- a/packages/core/src/bodl/bodl-service.ts
+++ b/packages/core/src/bodl/bodl-service.ts
@@ -1,0 +1,4 @@
+export default interface BodlService {
+    checkoutBegin(): void;
+    orderPurchased(): void;
+}

--- a/packages/core/src/bodl/bodl-window.ts
+++ b/packages/core/src/bodl/bodl-window.ts
@@ -1,0 +1,53 @@
+export interface BODLProduct {
+    product_id: string | number;
+    product_name: string;
+    product_sku?: string;
+    variant_id?: number;
+    variant_sku?: string;
+    gift_certificate_id?: string | number;
+    gift_certificate_name?: string;
+    gift_certificate_theme?: string;
+    price: number;
+    sale_price?: number;
+    base_price?: number;
+    retail_price?: number;
+    quantity: number;
+    discount?: number;
+    index?: number;
+    brand_name?: string;
+    category_name?: string;
+    currency?: string;
+}
+
+
+export interface CheckoutBeginData {
+    id: string
+    currency: string,
+    cart_value: number,
+    coupon: string,
+    line_items: BODLProduct[]
+}
+
+
+export interface OrderPurchasedData {
+    id: string
+    currency: string,
+    transaction_id: number,
+    cart_value: number,
+    coupon: string,
+    shipping_cost: number,
+    line_items: BODLProduct[]
+
+}
+
+export interface BodlEventsCheckout { 
+    emit(eventName: string , data: CheckoutBeginData | OrderPurchasedData): boolean;
+}
+
+export interface BodlEvents {
+    checkout: BodlEventsCheckout;
+}
+
+export default interface BodlEventsWindow extends Window {
+    bodlEvents: BodlEvents;
+}

--- a/packages/core/src/bodl/create-bodl-service.spec.ts
+++ b/packages/core/src/bodl/create-bodl-service.spec.ts
@@ -1,0 +1,38 @@
+import { CheckoutSelectors, CheckoutService, createCheckoutService } from '../checkout';
+import BodlEmitterService from "./bodl-emitter-service";
+import BodlEventsWindow, { BodlEvents } from './bodl-window';
+import createBodlService from './create-bodl-service';
+import NoopBodlService from './noop-bodl-service';
+
+declare let window: BodlEventsWindow;
+
+describe('createBodl', () => {
+    let checkoutService: CheckoutService;
+    let subscriber: (subscriber: (state: CheckoutSelectors) => void) => void;
+
+    beforeEach(() => {
+        checkoutService = createCheckoutService();
+
+        subscriber = (() => {
+            return checkoutService.getState();
+        });
+    });
+
+    describe('#createBodlService()', () => {
+        describe('when window.bodlEvents is undefined', () => {
+            it('returns instance of noop logger', () => {
+                expect(createBodlService(subscriber)).toBeInstanceOf(NoopBodlService);
+            });
+        });
+
+        describe('when window.bodlEvents is defined', () => {
+            beforeEach(() => {
+                window.bodlEvents = {} as BodlEvents;
+            });
+
+            it('returns instance of BodlService', () => {
+                expect(createBodlService(subscriber)).toBeInstanceOf(BodlEmitterService);
+            });
+        });
+    });
+});

--- a/packages/core/src/bodl/create-bodl-service.ts
+++ b/packages/core/src/bodl/create-bodl-service.ts
@@ -1,0 +1,32 @@
+import BodlService from "./bodl-service";
+import NoopBodlService from "./noop-bodl-service";
+import BodlEmitterService from "./bodl-emitter-service";
+import { isBodlEnabled } from "./is-bodl-enabled";
+import { CheckoutSelectors } from "../checkout";
+
+/**
+ * Creates an instance of `BodlService`.
+ *
+ * @remarks
+ * 
+ * ```js
+ * const bodlService = BodlService();
+ * bodlService.checkoutBegin();
+ * 
+ * ```
+ *
+ * @param {CheckoutService} checkoutService - An instance of CheckoutService
+ * @returns an instance of `BodlService`.
+ */
+export default function createBodlService(
+    subscribe: (subscriber: (state: CheckoutSelectors) => void) => void,
+): BodlService {
+    if (isBodlEnabled(window)) {
+        return new BodlEmitterService(
+            subscribe,
+            window.bodlEvents.checkout
+        );
+    }
+
+    return new NoopBodlService();
+}

--- a/packages/core/src/bodl/index.ts
+++ b/packages/core/src/bodl/index.ts
@@ -1,0 +1,2 @@
+export { default as createBodlService } from './create-bodl-service';
+export { default as BodlService } from './bodl-service';

--- a/packages/core/src/bodl/is-bodl-enabled.ts
+++ b/packages/core/src/bodl/is-bodl-enabled.ts
@@ -1,0 +1,5 @@
+import BodlEventsWindow from './bodl-window';
+
+export function isBodlEnabled(window: Window): window is BodlEventsWindow {
+    return 'bodlEvents' in window;
+}

--- a/packages/core/src/bodl/noop-bodl-service.ts
+++ b/packages/core/src/bodl/noop-bodl-service.ts
@@ -1,0 +1,11 @@
+import BodlService from "./bodl-service";
+
+export default class NoopBodlService implements BodlService {
+    checkoutBegin(): void {
+        return;
+    }
+
+    orderPurchased(): void {
+        return;
+    }
+}

--- a/packages/core/src/bundles/checkout-sdk.ts
+++ b/packages/core/src/bundles/checkout-sdk.ts
@@ -7,3 +7,4 @@ export { createEmbeddedCheckoutMessenger } from '../embedded-checkout/iframe-con
 export { createLanguageService } from '../locale';
 export { createCurrencyService } from '../currency';
 export { createStepTracker } from '../analytics';
+export { createBodlService } from '../bodl';


### PR DESCRIPTION
## What?

Added Bodl Events Service, that triggers 2 events: Checkout Begin and Order Purchased 

## Why?

1) Storefront will inject bodl events library (EventEmitter) into DOM, that will an interface to emit events and subscribe on events. This part is for emitting events.
2) had to update tslib, had an issue with VSCode interfaces 
more: https://stackoverflow.com/questions/58329178/the-syntax-requires-an-imported-helper-named-spreadarrays

## Testing / Proof

unit

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/storefront-team 
