### PR TITLE
fix(common): CHECKOUT-000 Remove token strings from test files

### DIFF
--- a/packages/core/src/hosted-form/hosted-form-order-data-transformer.spec.ts
+++ b/packages/core/src/hosted-form/hosted-form-order-data-transformer.spec.ts
@@ -12,11 +12,11 @@ describe('HostedFormOrderDataTransformer', () => {
         transformer = new HostedFormOrderDataTransformer(store);
 
         jest.spyOn(store.getState().payment, 'getPaymentToken')
-            .mockReturnValue('JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c');
+            .mockReturnValue('auth-token');
 
         jest.spyOn(store.getState().instruments, 'getInstrumentsMeta')
             .mockReturnValue({
-                vaultAccessToken: 'VAT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkZvbyBCYXIiLCJpYXQiOjE1MTYyMzkwMjJ9.ofV_rETulkW5agRmGt4wRs8QsU8WTdqDA3xjIaK4Yn8',
+                vaultAccessToken: 'vault-token',
             });
     });
 
@@ -46,7 +46,7 @@ describe('HostedFormOrderDataTransformer', () => {
         });
 
         expect(result.authToken)
-            .toEqual('JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c, VAT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkZvbyBCYXIiLCJpYXQiOjE1MTYyMzkwMjJ9.ofV_rETulkW5agRmGt4wRs8QsU8WTdqDA3xjIaK4Yn8');
+            .toEqual('auth-token, vault-token');
     });
 
     it('does not include vault access token if not paying with stored instrument', () => {
@@ -63,7 +63,7 @@ describe('HostedFormOrderDataTransformer', () => {
         });
 
         expect(result.authToken)
-            .toEqual('JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c');
+            .toEqual('auth-token');
     });
 
     it('returns AdditionalAction object within response if received as a parameter', () => {

--- a/packages/core/src/hosted-form/hosted-form-order-data.mock.ts
+++ b/packages/core/src/hosted-form/hosted-form-order-data.mock.ts
@@ -7,7 +7,7 @@ import HostedFormOrderData from './hosted-form-order-data';
 
 export function getHostedFormOrderData(): HostedFormOrderData {
     return {
-        authToken: 'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        authToken: 'auth-token',
         checkout: getCheckoutWithGiftCertificates(),
         config: getConfig(),
         order: getOrder(),

--- a/packages/core/src/order/internal-orders.mock.ts
+++ b/packages/core/src/order/internal-orders.mock.ts
@@ -249,7 +249,7 @@ export function getCompleteOrderResponseBody(): InternalOrderResponseBody {
 
 export function getSubmitOrderResponseHeaders(): { token: string } {
     return {
-        token: 'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        token: 'auth-token',
     };
 }
 

--- a/packages/core/src/payment/instrument/instrument-request-sender.spec.ts
+++ b/packages/core/src/payment/instrument/instrument-request-sender.spec.ts
@@ -60,7 +60,7 @@ describe('InstrumentRequestSender', () => {
             expect(output).toEqual({
                 ...response,
                 body: {
-                    vaultAccessToken: 'VAT f4k3v4ul74cc3sst0k3n',
+                    vaultAccessToken: 'vault-token',
                     vaultAccessExpiry: 1516097476098,
                 },
             });

--- a/packages/core/src/payment/instrument/instrument.mock.ts
+++ b/packages/core/src/payment/instrument/instrument.mock.ts
@@ -8,7 +8,7 @@ export function getInstrumentsMeta(): InstrumentMeta {
 
 export function getVaultAccessToken(): VaultAccessToken {
     return {
-        vaultAccessToken: 'VAT f4k3v4ul74cc3sst0k3n',
+        vaultAccessToken: 'vault-token',
         vaultAccessExpiry: 1516097476098,
     };
 }
@@ -124,7 +124,7 @@ export function getErrorInstrumentResponseBody(): InstrumentErrorResponseBody {
 export function getVaultAccessTokenResponseBody(): InternalVaultAccessTokenResponseBody {
     return {
         data: {
-            token: 'VAT f4k3v4ul74cc3sst0k3n',
+            token: 'vault-token',
             expires_at: 1516097476098,
         },
     };

--- a/packages/core/src/payment/payments.mock.ts
+++ b/packages/core/src/payment/payments.mock.ts
@@ -43,7 +43,7 @@ export function getVaultedInstrument(): VaultedInstrument {
 
 export function getPaymentRequestBody(): PaymentRequestBody {
     return {
-        authToken: 'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+        authToken: 'auth-token',
         billingAddress: mapToInternalAddress(getBillingAddress()),
         cart: mapToInternalCart(getCheckoutWithGiftCertificates()),
         customer: mapToInternalCustomer(getCustomer(), getBillingAddress()),


### PR DESCRIPTION
## What?
Remove hardcoded tokens from test/mock files

## Why?
Snyk code scanner has identified that we have some hardcoded secrets in test files, this replaces them with something simpler.

## Testing / Proof
- circle

@bigcommerce/checkout 
