### PR TITLE
feat(checkout): CHECKOUT-6860 Use numeric keypad

### DIFF
--- a/packages/core/src/hosted-form/iframe-content/hosted-input.spec.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input.spec.ts
@@ -122,7 +122,7 @@ describe('HostedInput', () => {
     it('configures input with expected attributes', () => {
         input.attach();
 
-        // tslint:disable-next-line:no-non-null-assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const element = container.querySelector('input')!;
 
         expect(element.id)
@@ -133,6 +133,32 @@ describe('HostedInput', () => {
             .toEqual('cc-name');
         expect(element.getAttribute('aria-label'))
             .toEqual('Cardholder name');
+        expect(element.inputMode)
+            .toEqual('text');
+    });
+
+    it('configures card number input with numeric inputmode', () => {
+        const cardNumberInput = new HostedInput(
+            HostedFieldType.CardNumber,
+            container,
+            'Full name',
+            'Cardholder name',
+            'cc-name',
+            styles,
+            fontUrls,
+            eventListener as IframeEventListener<HostedFieldEventMap>,
+            eventPoster as IframeEventPoster<HostedInputEvent>,
+            inputAggregator as HostedInputAggregator,
+            inputValidator as HostedInputValidator,
+            paymentHandler as HostedInputPaymentHandler
+        );
+        cardNumberInput.attach();
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(container.querySelector('input')!.inputMode)
+            .toEqual('numeric');
+
+        cardNumberInput.detach();
     });
 
     it('sets target for event poster', () => {
@@ -152,7 +178,7 @@ describe('HostedInput', () => {
     it('applies default styles to input', () => {
         input.attach();
 
-        // tslint:disable-next-line:no-non-null-assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const element = container.querySelector('input')!;
 
         expect(element.style.color)
@@ -184,7 +210,7 @@ describe('HostedInput', () => {
 
         input.attach();
 
-        // tslint:disable-next-line:no-non-null-assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const element = container.querySelector('input')!;
 
         element.value = '123';
@@ -204,7 +230,7 @@ describe('HostedInput', () => {
 
         input.attach();
 
-        // tslint:disable-next-line:no-non-null-assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const element = container.querySelector('input')!;
 
         element.dispatchEvent(new Event('focus', { bubbles: true }));
@@ -223,7 +249,7 @@ describe('HostedInput', () => {
 
         input.attach();
 
-        // tslint:disable-next-line:no-non-null-assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const element = container.querySelector('input')!;
 
         element.dispatchEvent(new Event('blur', { bubbles: true }));
@@ -240,7 +266,7 @@ describe('HostedInput', () => {
     it('validates form when input loses focus', () => {
         input.attach();
 
-        // tslint:disable-next-line:no-non-null-assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const element = container.querySelector('input')!;
 
         element.dispatchEvent(new Event('blur', { bubbles: true }));

--- a/packages/core/src/hosted-form/iframe-content/hosted-input.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input.ts
@@ -122,6 +122,21 @@ export default class HostedInput {
         this._input.setAttribute('aria-label', this._accessibilityLabel);
 
         this._applyStyles(this._styles.default);
+
+        switch (this._input.id) {
+            case 'card-code':
+            case 'card-expiry':
+            case 'card-number':
+                this._input.type = 'text';
+                this._input.inputMode = 'numeric';
+                this._input.pattern = "[0-9]*";
+                break;
+            case 'card-name':
+                this._input.type = 'text';
+                this._input.inputMode = 'text';
+                break;
+        }
+
     }
 
     private _applyStyles(styles: HostedInputStyles = {}): void {


### PR DESCRIPTION
## What?
Using a numeric keypad to enter numbers.

## Why?
Speed up the checkout.

## Testing / Proof
Before:
<img width="300" src="https://user-images.githubusercontent.com/88361607/189790379-6753f0eb-eca6-44c4-96dc-6a8db94ea133.png" />

After:
Copied the newly generated html code, then made a static page for testing on mobile. Page source code:
```
Card number:<br>
<input id="card-number" placeholder="" autocomplete="cc-number" aria-label="Credit Card Number" inputmode="numeric" pattern="[0-9]*" value=""><br>
Name:<br>
<input id="card-name" placeholder="" autocomplete="cc-name" aria-label="Name on Card" inputmode="text" value="">
```

https://user-images.githubusercontent.com/88361607/189790937-d5ba8968-97f7-4385-a121-55955c1993e7.mov

