### PR TITLE
fix(payment): ADYEN-540 fixed adyen 3ds2 challenge on googlepay

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-adyenv2-payment-processor.ts
@@ -36,7 +36,7 @@ export default class GooglePayAdyenV2PaymentProcessor implements GooglePayProvid
         }
 
         this._adyenClient = await this._scriptLoader.load({
-            environment: paymentMethod.config.testMode ? 'TEST' : ' PRODUCTION',
+            environment: paymentMethod.config.testMode ? 'test' : 'live',
             locale: storeConfig.storeProfile.storeLanguage,
             [clientSideAuthentication.key]: clientSideAuthentication.value,
             paymentMethodsResponse: paymentMethod.initializationData.paymentMethodsResponse,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-adyenv3-payment-processor.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-adyenv3-payment-processor.ts
@@ -23,7 +23,7 @@ export default class GooglePayAdyenV3PaymentProcessor implements GooglePayProvid
         }
 
         this._adyenClient = await this._scriptLoader.load({
-            environment: paymentMethod.config.testMode ? 'TEST' : ' PRODUCTION',
+            environment: paymentMethod.config.testMode ? 'test' : 'live',
             locale: storeConfig.storeProfile.storeLanguage,
             clientKey: paymentMethod.initializationData.clientKey,
             paymentMethodsResponse: paymentMethod.initializationData.paymentMethodsResponse,


### PR DESCRIPTION
## What?
Fixed Adyen 3ds2 challenge on googlepay

## Why?
Due to the https://bigcommercecloud.atlassian.net/browse/ADYEN-540

## Testing / Proof
There was a problem with adyen script load on live mode due to the wrong name of mode. Instead of test/live, was used TEST/PRODUCTION

**Now script loads without any errors:** 

<img width="746" alt="image" src="https://user-images.githubusercontent.com/79574476/189838826-1aff3c2b-9822-4088-826c-af0edab82d87.png">


@bigcommerce/checkout @bigcommerce/payments
