### PR TITLE
refactor(payment): PAYPAL-1541 remove unnecessaru paypal commerce button strategy code

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -119,13 +119,6 @@ export interface BaseCheckoutButtonInitializeOptions extends CheckoutButtonOptio
     paypal?: PaypalButtonInitializeOptions;
 
     /**
-     * The options that are required to facilitate PayPal Commerce. They can be omitted
-     * unless you need to support Paypal.
-     */
-    // TODO: should be removed when PAYPAL-1539 hits Tier3
-    paypalCommerce?: PaypalCommerceButtonInitializeOptions;
-
-    /**
      * The options that are required to facilitate PayPal Commerce V2. They can be omitted
      * unless you need to support Paypal Commerce.
      */

--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -20,16 +20,6 @@ import {
 import CheckoutButtonRegistryV2 from "./checkout-button-strategy-registry-v2";
 import { CheckoutButtonMethodType, CheckoutButtonStrategy } from "./strategies";
 
-// TODO: should be removed when PAYPAL-1539 hits Tier3
-const methodMap: { [key: string]: CheckoutButtonMethodType | undefined } = {
-    [CheckoutButtonMethodType.PAYPALCOMMERCEV2]: CheckoutButtonMethodType.PAYPALCOMMERCE,
-};
-
-// TODO: should be removed when PAYPAL-1539 hits Tier3
-const mapCheckoutButtonMethodId = (methodId: CheckoutButtonMethodType) => {
-    return methodMap[methodId] || methodId;
-};
-
 export default class CheckoutButtonStrategyActionCreator {
     constructor(
         private _registry: Registry<CheckoutButtonStrategy>,
@@ -66,7 +56,7 @@ export default class CheckoutButtonStrategyActionCreator {
                     )
                 ),
                 this._paymentMethodActionCreator.loadPaymentMethod(
-                    mapCheckoutButtonMethodId(options.methodId), // TODO: the line should be updated with 'options.methodId,' when PAYPAL-1539 hits Tier3
+                    options.methodId,
                     { timeout: options.timeout, useCache: true }
                 )(store),
                 defer(() =>

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.spec.ts
@@ -78,11 +78,6 @@ describe('createCheckoutButtonRegistry', () => {
         expect(registry.get('paypalcommerce')).toEqual(expect.any(PaypalCommerceButtonStrategy));
     });
 
-    // TODO: should be removed when PAYPAL-1539 hits Tier3
-    it('returns registry with PayPal Commerce V2 registered', () => {
-        expect(registry.get('paypalcommercev2')).toEqual(expect.any(PaypalCommerceButtonStrategy));
-    });
-
     it('returns registry with PayPal Commerce Venmo registered', () => {
         expect(registry.get('paypalcommercevenmo')).toEqual(expect.any(PaypalCommerceVenmoButtonStrategy));
     });

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -253,17 +253,6 @@ export default function createCheckoutButtonRegistry(
         )
     );
 
-    // TODO: should be removed when PAYPAL-1539 hits Tier3
-    registry.register(CheckoutButtonMethodType.PAYPALCOMMERCEV2, () =>
-        new PaypalCommerceButtonStrategy(
-            store,
-            checkoutActionCreator,
-            formPoster,
-            paypalScriptLoader,
-            paypalCommerceRequestSender
-        )
-    );
-
     registry.register(CheckoutButtonMethodType.PAYPALCOMMERCE_CREDIT, () =>
         new PaypalCommerceCreditButtonStrategy(
             store,

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -17,7 +17,6 @@ export enum BaseCheckoutButtonMethodType {
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',
     PAYPALCOMMERCE = 'paypalcommerce',
-    PAYPALCOMMERCEV2 = 'paypalcommercev2', // TODO: should be removed when PAYPAL-1539 hits Tier3
     PAYPALCOMMERCE_CREDIT = 'paypalcommercecredit',
     PAYPALCOMMERCE_APMS = 'paypalcommercealternativemethods',
     PAYPALCOMMERCE_INLINE = 'paypalcommerceinline',

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -45,7 +45,7 @@ describe('PaypalCommerceButtonStrategy', () => {
     };
 
     const initializationOptions: CheckoutButtonInitializeOptions = {
-        methodId: CheckoutButtonMethodType.PAYPALCOMMERCEV2,
+        methodId: CheckoutButtonMethodType.PAYPALCOMMERCE,
         containerId: defaultButtonContainerId,
         paypalcommerce: paypalCommerceOptions,
     };
@@ -53,7 +53,7 @@ describe('PaypalCommerceButtonStrategy', () => {
     beforeEach(() => {
         cartMock = getCart();
         eventEmitter = new EventEmitter();
-        paymentMethodMock = { ...getPaypalCommerce(), id: 'paypalcommercev2' }; // TODO: remove paypalcommercev2 id when the strategy will be removed to PayPalCommerceButtonStrategy
+        paymentMethodMock = getPaypalCommerce();
         paypalSdkMock = getPaypalCommerceMock();
 
         store = createCheckoutStore(getCheckoutStoreState());
@@ -133,7 +133,7 @@ describe('PaypalCommerceButtonStrategy', () => {
         });
 
         it('throws an error if containerId is not provided', async () => {
-            const options = { methodId: CheckoutButtonMethodType.PAYPALCOMMERCEV2 } as CheckoutButtonInitializeOptions;
+            const options = { methodId: CheckoutButtonMethodType.PAYPALCOMMERCE } as CheckoutButtonInitializeOptions;
 
             try {
                 await strategy.initialize(options);
@@ -145,7 +145,7 @@ describe('PaypalCommerceButtonStrategy', () => {
         it('throws an error if paypalcommerce is not provided', async () => {
             const options = {
                 containerId: defaultButtonContainerId,
-                methodId: CheckoutButtonMethodType.PAYPALCOMMERCEV2,
+                methodId: CheckoutButtonMethodType.PAYPALCOMMERCE,
             } as CheckoutButtonInitializeOptions;
 
             try {
@@ -286,8 +286,7 @@ describe('PaypalCommerceButtonStrategy', () => {
                 action: 'set_external_checkout',
                 order_id: approveDataOrderId,
                 payment_type: 'paypal',
-                // provider: paymentMethodMock.id,
-                provider: 'paypalcommerce', // TODO: should be updated to paymentMethodMock.id when 'paypalcommercev2' will be updated with 'paypalcommerce'
+                provider: paymentMethodMock.id,
             }));
         });
     });

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -37,19 +37,12 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
 
         const { initializesOnCheckoutPage, style } = paypalcommerce;
 
-        // Info: it's a temporary decision until we have v1 and v2 version methodIds.
-        // TODO: should be removed when PAYPAL-1539 hits Tier3
-        const updatedMethodId = methodId === 'paypalcommercev2' ? 'paypalcommerce' : methodId;
-
         const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         const currencyCode = state.cart.getCartOrThrow().currency.code;
-
-        // TODO: should be updated when PAYPAL-1539 hits Tier3
-        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(updatedMethodId);
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currencyCode, initializesOnCheckoutPage);
 
-        // TODO: should be updated when PAYPAL-1539 hits Tier3
-        this._renderButton(containerId, updatedMethodId, initializesOnCheckoutPage, style);
+        this._renderButton(containerId, methodId, initializesOnCheckoutPage, style);
     }
 
     deinitialize(): Promise<void> {


### PR DESCRIPTION
## What?
Removed unnecessary paypal commerce V2 button strategy code, that left as a part of paypal commerce button strategies separation

## Why?
It is a final step of paypal commerce button strategies separation.

## Testing / Proof
Unit tests
CI tests

@bigcommerce/checkout @bigcommerce/payments
