### PR TITLE
feat(payment): BOLT-386 Add BODL analytics tracking events

### DIFF
--- a/packages/core/src/bodl/analytics-steps.ts
+++ b/packages/core/src/bodl/analytics-steps.ts
@@ -1,0 +1,13 @@
+export enum AnalyticStepType {
+    CUSTOMER = 'customer',
+    SHIPPING = 'shipping',
+    BILLING = 'billing',
+    PAYMENT = 'payment',
+}
+
+export const AnalyticStepOrder: AnalyticStepType[] = [
+    AnalyticStepType.CUSTOMER,
+    AnalyticStepType.SHIPPING,
+    AnalyticStepType.BILLING,
+    AnalyticStepType.PAYMENT
+];

--- a/packages/core/src/bodl/bodl-service.ts
+++ b/packages/core/src/bodl/bodl-service.ts
@@ -1,4 +1,16 @@
+import { BodlEventsPayload } from './bodl-window';
+
 export default interface BodlService {
     checkoutBegin(): void;
     orderPurchased(): void;
+    stepCompleted(step?: string): void;
+    customerEmailEntry(email?: string): void;
+    customerSuggestionExecute(): void;
+    customerPaymentMethodExecuted(payload?: BodlEventsPayload): void;
+    showShippingMethods(): void;
+    selectedPaymentMethod(methodName?: string): void;
+    clickPayButton(payload?: BodlEventsPayload): void;
+    paymentRejected(): void;
+    paymentComplete(): void;
+    exitCheckout(): void;
 }

--- a/packages/core/src/bodl/bodl-window.ts
+++ b/packages/core/src/bodl/bodl-window.ts
@@ -41,9 +41,14 @@ export interface OrderPurchasedData {
 
 }
 
-export interface BodlEventsCheckout { 
+export interface BodlEventsCheckout {
     emitCheckoutBeginEvent(data: CheckoutBeginData): boolean;
     emitOrderPurchasedEvent(data: OrderPurchasedData): boolean;
+    emit(name: string, data?: BodlEventsPayload): void;
+}
+
+export interface BodlEventsPayload {
+    [key: string]: unknown
 }
 
 export interface BodlEvents {

--- a/packages/core/src/bodl/create-bodl-service.ts
+++ b/packages/core/src/bodl/create-bodl-service.ts
@@ -8,11 +8,11 @@ import { CheckoutSelectors } from "../checkout";
  * Creates an instance of `BodlService`.
  *
  * @remarks
- * 
+ *
  * ```js
  * const bodlService = BodlService();
  * bodlService.checkoutBegin();
- * 
+ *
  * ```
  *
  * @param {CheckoutService} checkoutService - An instance of CheckoutService

--- a/packages/core/src/bodl/noop-bodl-service.ts
+++ b/packages/core/src/bodl/noop-bodl-service.ts
@@ -1,11 +1,27 @@
 import BodlService from "./bodl-service";
 
 export default class NoopBodlService implements BodlService {
-    checkoutBegin(): void {
-        return;
-    }
+    checkoutBegin(): void {}
 
-    orderPurchased(): void {
-        return;
-    }
+    orderPurchased(): void {}
+
+    stepCompleted(): void {}
+
+    customerEmailEntry(): void {}
+
+    customerSuggestionExecute(): void {};
+
+    customerPaymentMethodExecuted(): void {}
+
+    showShippingMethods(): void {}
+
+    selectedPaymentMethod(): void {}
+
+    clickPayButton(): void {}
+
+    paymentRejected(): void {};
+
+    paymentComplete(): void {};
+
+    exitCheckout(): void {};
 }

--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -150,5 +150,10 @@ export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
  *
  */
 export interface ExecutePaymentMethodCheckoutOptions extends CustomerRequestOptions {
+    checkoutPaymentMethodExecuted?(data?: CheckoutPaymentMethodExecutedOptions): void;
     continueWithCheckoutCallback?(): void;
+}
+
+export interface CheckoutPaymentMethodExecutedOptions {
+    hasBoltAccount?: boolean;
 }

--- a/packages/core/src/customer/strategies/bolt/bolt-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/bolt/bolt-customer-strategy.spec.ts
@@ -155,7 +155,7 @@ describe('BoltCustomerStrategy', () => {
         it('fails to execute payment method checkout if provided continueWithCheckoutCallback is not a function', async () => {
             try {
                 /* eslint-disable @typescript-eslint/ban-ts-comment */
-                // @ts-ignore 
+                // @ts-ignore
                 await strategy.executePaymentMethodCheckout({ methodId: 'bolt', continueWithCheckoutCallback: 'string' });
             } catch (error) {
                 expect(error).toBeInstanceOf(InvalidArgumentError);


### PR DESCRIPTION
## What?
Add additional BODL analytics events emitors to checkout.
Checkout-js PR: [https://github.com/bigcommerce/checkout-js/pull/1024](https://github.com/bigcommerce/checkout-js/pull/1024)

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-386](https://bigcommercecloud.atlassian.net/browse/BOLT-386)

## Testing / Proof
Manual tested
<img width="404" alt="Screenshot 2022-10-22 at 13 20 39" src="https://user-images.githubusercontent.com/9430298/197334178-23cc4684-2f76-4f9d-8823-345f4c98094e.png">

@bigcommerce/checkout @bigcommerce/payments
