### PR TITLE
feat(payment): PAYPAL-1625 added Buy Now implementation for PayPalCommerceButtonStrategy

### DIFF
--- a/packages/core/src/cart/buy-now-cart-request-body.ts
+++ b/packages/core/src/cart/buy-now-cart-request-body.ts
@@ -1,0 +1,16 @@
+interface LineItem {
+    productId: number;
+    quantity: number;
+    optionSelections?: {
+        optionId: number;
+        optionValue: number | string;
+    };
+}
+
+/**
+ * An object that contains the information required for creating 'Buy now' cart.
+ */
+export default interface BuyNowCartRequestBody {
+    source: 'BUY_NOW';
+    lineItems: LineItem[];
+}

--- a/packages/core/src/cart/cart-request-sender.spec.ts
+++ b/packages/core/src/cart/cart-request-sender.spec.ts
@@ -1,0 +1,68 @@
+import { createRequestSender, createTimeout, RequestSender, Response } from '@bigcommerce/request-sender';
+import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
+import { getResponse } from '../common/http-request/responses.mock';
+import BuyNowCartRequestBody from './buy-now-cart-request-body';
+
+import Cart from './cart';
+import CartRequestSender from './cart-request-sender';
+import { getCart } from './carts.mock';
+
+describe('CartRequestSender', () => {
+    let cart: Cart;
+    let cartRequestSender: CartRequestSender;
+    let requestSender: RequestSender;
+    let response: Response<Cart>;
+
+    beforeEach(() => {
+        requestSender = createRequestSender();
+        cartRequestSender = new CartRequestSender(requestSender);
+    });
+
+    describe('#createBuyNowCart', () => {
+        const buyNowCartRequestBody: BuyNowCartRequestBody = {
+            source: 'BUY_NOW',
+            lineItems: [{
+                productId: 1,
+                quantity: 2,
+                optionSelections: {
+                    optionId: 11,
+                    optionValue: 11,
+                },
+            }],
+        };
+
+        beforeEach(() => {
+            cart = { ...getCart(), source: 'BUY_NOW' };
+            response = getResponse(cart);
+
+            jest.spyOn(requestSender, 'post').mockResolvedValue(response);
+        })
+
+        it('creates buy now cart', async () => {
+            await cartRequestSender.createBuyNowCart(buyNowCartRequestBody);
+
+            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/carts', {
+                body: buyNowCartRequestBody,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
+                },
+            });
+        });
+
+        it('creates buy now cart with timeout', async () => {
+            const options = { timeout: createTimeout() };
+
+            await cartRequestSender.createBuyNowCart(buyNowCartRequestBody, options);
+
+            expect(requestSender.post).toHaveBeenCalledWith('/api/storefront/carts', {
+                ...options,
+                body: buyNowCartRequestBody,
+                headers: {
+                    Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
+                },
+            });
+        });
+    })
+})

--- a/packages/core/src/cart/cart-request-sender.ts
+++ b/packages/core/src/cart/cart-request-sender.ts
@@ -1,0 +1,21 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
+import Cart from './cart';
+import BuyNowCartRequestBody from './buy-now-cart-request-body';
+
+export default class CartRequestSender {
+    constructor(
+        private _requestSender: RequestSender
+    ) {}
+
+    createBuyNowCart(body: BuyNowCartRequestBody, { timeout }: RequestOptions = {}): Promise<Response<Cart>> {
+        const url = '/api/storefront/carts';
+        const headers = {
+            Accept: ContentType.JsonV1,
+            ...SDK_VERSION_HEADERS,
+        };
+
+        return this._requestSender.post(url, { body, headers, timeout });
+    }
+}

--- a/packages/core/src/cart/cart.ts
+++ b/packages/core/src/cart/cart.ts
@@ -18,4 +18,5 @@ export default interface Cart {
     lineItems: LineItemMap;
     createdTime: string;
     updatedTime: string;
+    source?: 'BUY_NOW';
 }

--- a/packages/core/src/cart/errors/buy-now-cart-creation-error.ts
+++ b/packages/core/src/cart/errors/buy-now-cart-creation-error.ts
@@ -1,0 +1,14 @@
+import { StandardError } from '../../common/error/errors';
+
+/**
+ * This error should be thrown when a shopper tries to sign in as a guest but
+ * they are already signed in as a registered customer.
+ */
+export default class BuyNowCartCreationError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'An unexpected error has occurred during buy now cart creation process. Please try again later.');
+
+        this.name = 'BuyNowCartCreationError';
+        this.type = 'buy_now_cart_creation_error';
+    }
+}

--- a/packages/core/src/cart/errors/index.ts
+++ b/packages/core/src/cart/errors/index.ts
@@ -1,1 +1,2 @@
+export { default as BuyNowCartCreationError } from './buy-now-cart-creation-error';
 export { default as CartChangedError } from './cart-changed-error';

--- a/packages/core/src/cart/index.ts
+++ b/packages/core/src/cart/index.ts
@@ -1,3 +1,4 @@
+export { default as BuyNowCartRequestBody } from './buy-now-cart-request-body';
 export { default as Cart } from './cart';
 export { default as InternalCart } from './internal-cart';
 export { default as InternalLineItem } from './internal-line-item';
@@ -5,6 +6,7 @@ export { DigitalItem, GiftCertificateItem, LineItem, LineItemCategory, PhysicalI
 export { default as LineItemMap } from './line-item-map';
 
 export { default as CartComparator } from './cart-comparator';
+export { default as CartRequestSender } from './cart-request-sender';
 export { default as cartReducer } from './cart-reducer';
 export { default as CartSelector, CartSelectorFactory, createCartSelectorFactory } from './cart-selector';
 export { default as CartState } from './cart-state';

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -3,6 +3,7 @@ import { RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
+import { CartRequestSender } from '../cart';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
@@ -64,6 +65,7 @@ export default function createCheckoutButtonRegistry(
     const billingAddressActionCreator = new BillingAddressActionCreator(billingAddressRequestSender, subscriptionsActionCreator);
     const consignmentRequestSender = new ConsignmentRequestSender(requestSender);
     const consignmentActionCreator = new ConsignmentActionCreator(consignmentRequestSender, checkoutRequestSender);
+    const cartRequestSender = new CartRequestSender(requestSender);
 
     registry.register(CheckoutButtonMethodType.APPLEPAY, () =>
         new ApplePayButtonStrategy(
@@ -247,6 +249,7 @@ export default function createCheckoutButtonRegistry(
         new PaypalCommerceButtonStrategy(
             store,
             checkoutActionCreator,
+            cartRequestSender,
             formPoster,
             paypalScriptLoader,
             paypalCommerceRequestSender

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-options.ts
@@ -1,3 +1,5 @@
+import { BuyNowCartRequestBody } from '../../../cart';
+
 import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
 
 export interface PaypalCommerceButtonInitializeOptions {
@@ -7,7 +9,19 @@ export interface PaypalCommerceButtonInitializeOptions {
     style?: PaypalButtonStyleOptions;
 
     /**
-     * Flag which helps to detect that the strategy initializes on Checkout page
+     * Flag which helps to detect that the strategy initializes on Checkout page.
      */
     initializesOnCheckoutPage?: boolean;
+
+    /**
+     * The option that used to initialize a PayPal script with provided currency code.
+     */
+    currencyCode?: string;
+
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    }
 }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -3,8 +3,10 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
-import { Cart } from '../../../cart';
+import { Cart, CartRequestSender } from '../../../cart';
+import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
 import { getCart } from '../../../cart/carts.mock';
+import { BuyNowCartCreationError } from '../../../cart/errors';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
@@ -22,6 +24,7 @@ import PaypalCommerceButtonStrategy from './paypal-commerce-button-strategy';
 
 describe('PaypalCommerceButtonStrategy', () => {
     let cartMock: Cart;
+    let cartRequestSender: CartRequestSender;
     let checkoutActionCreator: CheckoutActionCreator;
     let eventEmitter: EventEmitter;
     let formPoster: FormPoster;
@@ -50,6 +53,36 @@ describe('PaypalCommerceButtonStrategy', () => {
         paypalcommerce: paypalCommerceOptions,
     };
 
+    const buyNowCartMock = {
+        ...getCart(),
+        id: 999,
+        source: 'BUY_NOW',
+    };
+
+    const buyNowCartRequestBody: BuyNowCartRequestBody = {
+        source: 'BUY_NOW',
+        lineItems: [{
+            productId: 1,
+            quantity: 2,
+            optionSelections: {
+                optionId: 11,
+                optionValue: 11,
+            },
+        }],
+    };
+
+    const buyNowInitializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.PAYPALCOMMERCE,
+        containerId: defaultButtonContainerId,
+        paypalcommerce: {
+            ...paypalCommerceOptions,
+            currencyCode: 'USD',
+            buyNowInitializeOptions: {
+                getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
+            },
+        },
+    };
+
     beforeEach(() => {
         cartMock = getCart();
         eventEmitter = new EventEmitter();
@@ -59,6 +92,7 @@ describe('PaypalCommerceButtonStrategy', () => {
         store = createCheckoutStore(getCheckoutStoreState());
         requestSender = createRequestSender();
         formPoster = createFormPoster();
+        cartRequestSender = new CartRequestSender(requestSender);
         paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
         paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());
 
@@ -71,6 +105,7 @@ describe('PaypalCommerceButtonStrategy', () => {
         strategy = new PaypalCommerceButtonStrategy(
             store,
             checkoutActionCreator,
+            cartRequestSender,
             formPoster,
             paypalScriptLoader,
             paypalCommerceRequestSender,
@@ -81,16 +116,38 @@ describe('PaypalCommerceButtonStrategy', () => {
         document.body.appendChild(paypalButtonElement);
 
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout').mockImplementation(() => {});
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
         jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdkMock);
         jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
-
 
         jest.spyOn(paypalSdkMock, 'Buttons')
             .mockImplementation((options: ButtonsOptions) => {
                 eventEmitter.on('createOrder', () => {
                     if (options.createOrder) {
                         options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('onClick', async (jestSuccessExpectationsCallback, jestFailureExpectationsCallback) => {
+                    try {
+                        if (options.onClick) {
+                            await options.onClick(
+                                { fundingSource: 'paypal' },
+                                {
+                                    reject: jest.fn(),
+                                    resolve: jest.fn(),
+                                },
+                            );
+
+                            if (jestSuccessExpectationsCallback && typeof jestSuccessExpectationsCallback === 'function') {
+                                jestSuccessExpectationsCallback();
+                            }
+                        }
+                    } catch (error) {
+                        if (jestFailureExpectationsCallback && typeof jestFailureExpectationsCallback === 'function') {
+                            jestFailureExpectationsCallback(error);
+                        }
                     }
                 });
 
@@ -155,10 +212,36 @@ describe('PaypalCommerceButtonStrategy', () => {
             }
         });
 
+        it('loads default checkout', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalled();
+        });
+
+        it ('does not load default checkout for Buy Now flow', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(checkoutActionCreator.loadDefaultCheckout).not.toHaveBeenCalled();
+        });
+
         it('loads paypal commerce sdk script', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalled();
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethodMock,
+                cartMock.currency.code,
+                initializationOptions.paypalcommerce?.initializesOnCheckoutPage
+            );
+        });
+
+        it('loads paypal commerce sdk script with provided currency code (Buy Now flow)', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethodMock,
+                buyNowInitializationOptions.paypalcommerce?.currencyCode,
+                buyNowInitializationOptions.paypalcommerce?.initializesOnCheckoutPage
+            );
         });
 
         it('initializes PayPal button to render', async () => {
@@ -168,7 +251,8 @@ describe('PaypalCommerceButtonStrategy', () => {
                 fundingSource: paypalSdkMock.FUNDING.PAYPAL,
                 style: paypalCommerceOptions.style,
                 createOrder: expect.any(Function),
-                onApprove: expect.any(Function)
+                onApprove: expect.any(Function),
+                onClick: expect.any(Function),
             });
         });
 
@@ -214,6 +298,53 @@ describe('PaypalCommerceButtonStrategy', () => {
             expect(document.getElementById(defaultButtonContainerId)).toBeNull();
         });
 
+        it('throws an error if buy now cart request body data is not provided on button click (Buy Now flow)', async () => {
+            const buyNowInitializationOptionsMock = {
+                ...buyNowInitializationOptions,
+                paypalcommerce: {
+                    ...buyNowInitializationOptions.paypalcommerce,
+                    buyNowInitializeOptions: {
+                        getBuyNowCartRequestBody: jest.fn().mockReturnValue(undefined),
+                    },
+                },
+            };
+
+            await strategy.initialize(buyNowInitializationOptionsMock);
+            eventEmitter.emit(
+                'onClick',
+                undefined,
+                (error: Error) => {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                },
+            );
+        });
+
+        it('creates buy now cart (Buy Now Flow)', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({ body: buyNowCartMock });
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit(
+                'onClick',
+                () => {
+                    expect(cartRequestSender.createBuyNowCart).toHaveBeenCalledWith(buyNowCartRequestBody);
+                },
+            );
+        });
+
+        it('throws an error if failed to create buy now cart (Buy Now Flow)', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockImplementation(() => Promise.reject());
+
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit(
+                'onClick',
+                undefined,
+                (error: Error) => {
+                    expect(error).toBeInstanceOf(BuyNowCartCreationError);
+                }
+            );
+        });
+
         it('creates an order with paypalcommerce as provider id if its initializes outside checkout page', async () => {
             jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
 
@@ -244,6 +375,23 @@ describe('PaypalCommerceButtonStrategy', () => {
             await new Promise(resolve => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, 'paypalcommercecheckout');
+        });
+
+        it('creates order with Buy Now cart id (Buy Now flow)', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({ body: buyNowCartMock });
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(buyNowCartMock.id, 'paypalcommerce');
         });
 
         it('throws an error if orderId is not provided by PayPal on approve', async () => {
@@ -287,6 +435,29 @@ describe('PaypalCommerceButtonStrategy', () => {
                 order_id: approveDataOrderId,
                 payment_type: 'paypal',
                 provider: paymentMethodMock.id,
+            }));
+        });
+
+        it('provides buy now cart_id on payment tokenization on paypal approve', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({ body: buyNowCartMock });
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('111');
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                cart_id: buyNowCartMock.id,
             }));
         });
     });

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -95,9 +95,9 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             }
 
             try {
-                const { body: card } = await this._cartRequestSender.createBuyNowCart(cartRequestBody);
+                const { body: cart } = await this._cartRequestSender.createBuyNowCart(cartRequestBody);
 
-                this._buyNowCartId = card.id;
+                this._buyNowCartId = cart.id;
             } catch (error) {
                 throw new BuyNowCartCreationError();
             }


### PR DESCRIPTION
## What?
Added Buy Now implementation for PayPalCommerceButtonStrategy

## Why?
Due the task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1625

## Testing / Proof
Unit tests
Manual tests

<img width="1166" alt="Screenshot 2022-09-19 at 13 18 35" src="https://user-images.githubusercontent.com/25133454/191509071-a7157144-e451-4f5c-a1cd-cb870b278afd.png">

<img width="1167" alt="Screenshot 2022-09-19 at 13 18 02" src="https://user-images.githubusercontent.com/25133454/191509089-a3384482-f38b-44d4-acf8-89cf60e85bfb.png">

