### PR TITLE
feat(payment): INT-6092 AmazonPayV2: Add an additional payment button…

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -28,13 +28,14 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
             await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         }
 
-        this._walletButton = this._amazonPayV2PaymentProcessor.renderAmazonPayButton(
-            containerId,
-            this._store.getState(),
-            methodId,
-            AmazonPayV2Placement.Cart,
-            amazonpay
-        );
+        this._walletButton =
+            this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
+                checkoutState: this._store.getState(),
+                containerId,
+                methodId,
+                options: amazonpay,
+                placement: AmazonPayV2Placement.Cart,
+            });
     }
 
     deinitialize(): Promise<void> {

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
@@ -32,12 +32,12 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
         await this._amazonPayV2PaymentProcessor.initialize(getPaymentMethodOrThrow(methodId));
 
         this._walletButton =
-            this._amazonPayV2PaymentProcessor.renderAmazonPayButton(
-                amazonpay.container,
-                this._store.getState(),
+            this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
+                checkoutState: this._store.getState(),
+                containerId: amazonpay.container,
                 methodId,
-                AmazonPayV2Placement.Checkout
-            );
+                placement: AmazonPayV2Placement.Checkout,
+            });
 
         return this._store.getState();
     }

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -219,7 +219,6 @@ export default function createPaymentStrategyRegistry(
         new AmazonPayV2PaymentStrategy(
             store,
             paymentStrategyActionCreator,
-            paymentMethodActionCreator,
             orderActionCreator,
             paymentActionCreator,
             createAmazonPayV2PaymentProcessor()

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -176,7 +176,13 @@ describe('AmazonPayV2PaymentProcessor', () => {
     describe('#renderAmazonPayButton', () => {
         const CONTAINER_ID = 'foo';
         const renderAmazonPayButton = (containerId = CONTAINER_ID, decoupleCheckoutInitiation = false) => {
-            processor.renderAmazonPayButton(containerId, store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout, undefined, decoupleCheckoutInitiation);
+            processor.renderAmazonPayButton({
+                checkoutState: store.getState(),
+                containerId,
+                decoupleCheckoutInitiation,
+                methodId: 'amazonpay',
+                placement: AmazonPayV2Placement.Checkout,
+            });
         };
 
         let store: CheckoutStore;

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -7,7 +7,7 @@ import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../../common/error/errors';
 import { getAmazonPayV2, getPaymentMethodsState } from '../../payment-methods.mock';
 
-import { AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK, AmazonPayV2ButtonParameters, AmazonPayV2NewButtonParams, AmazonPayV2ButtonParams } from './amazon-pay-v2';
+import { AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK, AmazonPayV2ButtonParameters, AmazonPayV2NewButtonParams, AmazonPayV2ButtonParams, AmazonPayV2CheckoutSessionConfig, AmazonPayV2Button } from './amazon-pay-v2';
 import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 import { getAmazonPayV2ButtonParamsMock, getAmazonPayV2Ph4ButtonParamsMock, getAmazonPayV2SDKMock, getPaymentMethodMockUndefinedLedgerCurrency, getPaymentMethodMockUndefinedMerchant } from './amazon-pay-v2.mock';
@@ -107,10 +107,76 @@ describe('AmazonPayV2PaymentProcessor', () => {
         });
     });
 
+    describe('#prepareCheckout', () => {
+        const containerId = 'amazonpay-container';
+        let amazonPayV2ButtonParams: Required<AmazonPayV2NewButtonParams>;
+        let createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>;
+
+        beforeEach(async () => {
+            amazonPayV2ButtonParams = getAmazonPayV2Ph4ButtonParamsMock() as Required<AmazonPayV2NewButtonParams>;
+            const { publicKeyId, createCheckoutSessionConfig: signedPayload } = amazonPayV2ButtonParams;
+
+            createCheckoutSessionConfig = {
+                publicKeyId,
+                ...signedPayload,
+            };
+        });
+
+        describe('should initiate checkout successfully:', () => {
+            beforeEach(async () => {
+                await processor.initialize(getAmazonPayV2());
+                processor.createButton(containerId, amazonPayV2ButtonParams);
+            });
+
+            test('onClick is called to define custom actions', () => {
+                processor.prepareCheckout(createCheckoutSessionConfig);
+
+                const amazonPayV2Button: AmazonPayV2Button = (amazonPayV2SDKMock.Pay.renderButton as jest.Mock).mock.results[0].value;
+
+                expect(amazonPayV2Button.onClick).toHaveBeenCalledTimes(1);
+            })
+
+            test('config does not include publicKeyId because it has an environment prefix', () => {
+                const expectedConfig = {
+                    createCheckoutSessionConfig: amazonPayV2ButtonParams.createCheckoutSessionConfig,
+                };
+
+                processor.prepareCheckout(createCheckoutSessionConfig);
+
+                const amazonPayV2Button: AmazonPayV2Button = (amazonPayV2SDKMock.Pay.renderButton as jest.Mock).mock.results[0].value;
+                const customActions = (amazonPayV2Button.onClick as jest.Mock).mock.calls[0][0];
+
+                customActions();
+
+                expect(amazonPayV2Button.initCheckout).toHaveBeenNthCalledWith(1, expectedConfig);
+            });
+
+            test('config includes publicKeyId because it does not have an environment prefix', async () => {
+                const expectedConfig = {
+                    createCheckoutSessionConfig,
+                };
+
+                createCheckoutSessionConfig.publicKeyId = 'foo';
+                processor.prepareCheckout(createCheckoutSessionConfig);
+
+                const amazonPayV2Button: AmazonPayV2Button = (amazonPayV2SDKMock.Pay.renderButton as jest.Mock).mock.results[0].value;
+                const customActions = (amazonPayV2Button.onClick as jest.Mock).mock.calls[0][0];
+
+                customActions();
+
+                expect(amazonPayV2Button.initCheckout).toHaveBeenNthCalledWith(1, expectedConfig);
+            });
+        });
+
+        it('throws an error when amazonPayV2Button is not initialized', () => {
+            expect(() => processor.prepareCheckout(createCheckoutSessionConfig)).toThrow(NotInitializedError);
+        });
+    });
+
     describe('#renderAmazonPayButton', () => {
         const CONTAINER_ID = 'foo';
-        const renderAmazonPayButton = (containerId = CONTAINER_ID) => {
-            processor.renderAmazonPayButton(containerId, store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout);
+        const renderAmazonPayButton = (containerId = CONTAINER_ID, decoupleCheckoutInitiation = false) => {
+            processor.renderAmazonPayButton(containerId, store.getState(), 'amazonpay', AmazonPayV2Placement.Checkout, undefined, decoupleCheckoutInitiation);
         };
 
         let store: CheckoutStore;
@@ -180,10 +246,11 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
             test('publicKeyId does not have an environment prefix', () => {
                 const expectedOptions = getAmazonPayV2Ph4ButtonParamsMock() as AmazonPayV2NewButtonParams;
+                const createCheckoutSessionConfig = expectedOptions.createCheckoutSessionConfig as Required<AmazonPayV2NewButtonParams>['createCheckoutSessionConfig'];
                 delete expectedOptions.publicKeyId;
                 expectedOptions.sandbox = true;
                 expectedOptions.createCheckoutSessionConfig = {
-                    ...expectedOptions.createCheckoutSessionConfig,
+                    ...createCheckoutSessionConfig,
                     publicKeyId: 'foo',
                 };
 
@@ -218,6 +285,15 @@ describe('AmazonPayV2PaymentProcessor', () => {
                     .mockReturnValueOnce(undefined);
 
                 renderAmazonPayButton();
+
+                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+            });
+
+            test('createCheckoutSessionConfig is not set if decoupleCheckoutInitiation is true', () => {
+                const expectedOptions = getAmazonPayV2Ph4ButtonParamsMock() as AmazonPayV2NewButtonParams;
+                delete expectedOptions.createCheckoutSessionConfig;
+
+                renderAmazonPayButton(CONTAINER_ID, true);
 
                 expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
             });

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -3,7 +3,7 @@ import { InternalCheckoutSelectors } from '../../../../../core/src/checkout';
 import { getShippableItemsCount } from '../../../../../core/src/shipping';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 
-import { AmazonPayV2ButtonColor, AmazonPayV2ChangeActionType, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK, AmazonPayV2ButtonParameters, AmazonPayV2Button, AmazonPayV2NewButtonParams, AmazonPayV2CheckoutSessionConfig } from './amazon-pay-v2';
+import { AmazonPayV2ButtonColor, AmazonPayV2ChangeActionType, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK, AmazonPayV2ButtonParameters, AmazonPayV2Button, AmazonPayV2NewButtonParams, AmazonPayV2CheckoutSessionConfig, AmazonPayV2ButtonRenderingOptions } from './amazon-pay-v2';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 
 import { guard } from '../../../../src/common/utility';
@@ -59,15 +59,15 @@ export default class AmazonPayV2PaymentProcessor {
         return Promise.resolve();
     }
 
-    renderAmazonPayButton(
-        containerId: string,
-        checkoutState: InternalCheckoutSelectors,
-        methodId: string,
-        placement: AmazonPayV2Placement,
-        options?: AmazonPayV2ButtonParameters,
-        decoupleCheckoutInitiation = false
-    ): HTMLElement {
-        const container = document.getElementById(containerId);
+    renderAmazonPayButton({
+        checkoutState,
+        containerId,
+        decoupleCheckoutInitiation = false,
+        methodId,
+        options,
+        placement,
+    }: AmazonPayV2ButtonRenderingOptions): HTMLElement {
+        const container = document.querySelector<HTMLElement>(`#${containerId}`);
 
         if (!container) {
             throw new InvalidArgumentError('Unable to render the Amazon Pay button to an invalid HTML container element.');

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
@@ -13,7 +13,7 @@ import PaymentStrategy from '../payment-strategy';
 import { AmazonPayV2ChangeActionType, AmazonPayV2PaymentProcessor, AmazonPayV2Placement } from '.';
 
 import { guard } from '../../../../src/common/utility';
-import { CheckoutSettings } from '../../../config/config';
+import { CheckoutSettings } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
 
@@ -46,14 +46,14 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
             const { id: containerId } = this._createContainer();
 
             this._walletButton =
-                this._amazonPayV2PaymentProcessor.renderAmazonPayButton(
+                this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
+                    checkoutState: this._store.getState(),
                     containerId,
-                    this._store.getState(),
+                    decoupleCheckoutInitiation:
+                        this._isOneTimeTransaction(features),
                     methodId,
-                    AmazonPayV2Placement.Checkout,
-                    undefined,
-                    this._isOneTimeTransaction(features)
-                );
+                    placement: AmazonPayV2Placement.Checkout,
+                });
         }
 
         return this._store.getState();

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
@@ -6,12 +6,14 @@ import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
-import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
 import PaymentStrategy from '../payment-strategy';
 
 import { AmazonPayV2ChangeActionType, AmazonPayV2PaymentProcessor, AmazonPayV2Placement } from '.';
+
+import { guard } from '../../../../src/common/utility';
+import { CheckoutSettings } from '../../../config/config';
 
 export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
 
@@ -20,7 +22,6 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
     constructor(
         private _store: CheckoutStore,
         private _paymentStrategyActionCreator: PaymentStrategyActionCreator,
-        private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _orderActionCreator: OrderActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
         private _amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor
@@ -33,37 +34,33 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
             throw new InvalidArgumentError('Unable to proceed because "methodId" argument is not provided.');
         }
 
-        const {
-            paymentMethods: { getPaymentMethodOrThrow },
-        } = await this._store.dispatch(
-            this._paymentMethodActionCreator.loadPaymentMethod(methodId)
-        );
-        const paymentMethod = getPaymentMethodOrThrow(methodId);
+        const { features } = this._store.getState().config.getStoreConfigOrThrow().checkoutSettings;
+        const paymentMethod = this._store.getState().paymentMethods.getPaymentMethodOrThrow(methodId);
         const { initializationData: { paymentToken, region } } = paymentMethod;
 
         await this._amazonPayV2PaymentProcessor.initialize(paymentMethod);
 
-        if (paymentToken && amazonpay?.editButtonId) {
+        if (this._isReadyToPay(features, paymentToken) && amazonpay?.editButtonId) {
             this._bindEditButton(amazonpay.editButtonId, paymentToken, 'changePayment', this._isModalFlow(region));
+        } else {
+            const { id: containerId } = this._createContainer();
 
-            return this._store.getState();
+            this._walletButton =
+                this._amazonPayV2PaymentProcessor.renderAmazonPayButton(
+                    containerId,
+                    this._store.getState(),
+                    methodId,
+                    AmazonPayV2Placement.Checkout,
+                    undefined,
+                    this._isOneTimeTransaction(features)
+                );
         }
-
-        const { id: containerId } = this._createContainer();
-
-        this._walletButton =
-            this._amazonPayV2PaymentProcessor.renderAmazonPayButton(
-                containerId,
-                this._store.getState(),
-                methodId,
-                AmazonPayV2Placement.Checkout
-            );
 
         return this._store.getState();
     }
 
-    async execute(orderRequest: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
-        const { payment } = orderRequest;
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<InternalCheckoutSelectors> {
+        const { payment } = payload;
 
         if (!payment) {
             throw new PaymentArgumentInvalidError(['payment']);
@@ -71,37 +68,35 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
 
         const { methodId } = payment;
 
-        const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
-        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const { features } = this._store.getState().config.getStoreConfigOrThrow().checkoutSettings;
+        const { region, paymentToken } = this._store.getState().paymentMethods.getPaymentMethodOrThrow(methodId).initializationData;
 
-        const { paymentToken, region } = paymentMethod.initializationData;
-
-        if (paymentToken) {
+        if (this._isReadyToPay(features, paymentToken) || this._isOneTimeTransaction(features)) {
             const paymentPayload = {
                 methodId,
-                paymentData: { nonce: paymentToken },
+                paymentData: { nonce: paymentToken || 'apb' },
             };
 
-            await this._store.dispatch(this._orderActionCreator.submitOrder(orderRequest, options));
+            await this._store.dispatch(this._orderActionCreator.submitOrder(payload, options));
 
             try {
                 return await this._store.dispatch(this._paymentActionCreator.submitPayment(paymentPayload));
             } catch (error) {
                 if (error instanceof RequestError && error.body.status === 'additional_action_required') {
-                    return new Promise(() => {
-                        window.location.replace(error.body.additional_action_required.data.redirect_url);
-                    });
-                }
+                    if (paymentToken) {
+                        return new Promise(() =>
+                            window.location.assign(error.body.additional_action_required.data.redirect_url)
+                        );
+                    }
 
-                throw error;
+                    this._amazonPayV2PaymentProcessor.prepareCheckout(JSON.parse(error.body.additional_action_required.data.redirect_url));
+                } else {
+                    throw error;
+                }
             }
         }
 
-        if (!this._walletButton) {
-            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
-        }
-
-        this._walletButton.click();
+        this._getWalletButton().click();
 
         // Focus of parent window used to try and detect the user cancelling the Amazon log in modal
         // Should be refactored if/when Amazon add a modal close hook to their SDK
@@ -174,5 +169,21 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
         container.style.display = 'none';
 
         return document.body.appendChild(container);
+    }
+
+    private _getWalletButton() {
+        return guard(this._walletButton, () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+    }
+
+    private _isOneTimeTransaction(features: CheckoutSettings['features']): boolean {
+        return features['PROJECT-3483.amazon_pay_ph4'] && features['INT-6399.amazon_pay_apb'];
+    }
+
+    private _isStandardIntegration(features: CheckoutSettings['features']): boolean {
+        return !this._isOneTimeTransaction(features);
+    }
+
+    private _isReadyToPay(features: CheckoutSettings['features'], paymentToken?: string): boolean {
+        return this._isStandardIntegration(features) && !!paymentToken;
     }
 }

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -6,7 +6,10 @@ import { AmazonPayV2ButtonColor, AmazonPayV2CheckoutLanguage, AmazonPayV2LedgerC
 export function getAmazonPayV2SDKMock(): AmazonPayV2SDK {
     return {
         Pay: {
-            renderButton: jest.fn(),
+            renderButton: jest.fn().mockReturnValue({
+                onClick: jest.fn(),
+                initCheckout: jest.fn(),
+            }),
             bindChangeAction: jest.fn(),
             signout: jest.fn(),
         },

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -1,3 +1,5 @@
+import { InternalCheckoutSelectors } from '../../../../../core/src/checkout';
+
 export type EnvironmentType = 'PRODUCTION' | 'TEST';
 
 export interface AmazonPayV2Options {
@@ -229,4 +231,13 @@ export enum AmazonPayV2ButtonColor {
     Gold = 'Gold',
     LightGray = 'LightGray',
     DarkGray = 'DarkGray',
+}
+
+export interface AmazonPayV2ButtonRenderingOptions {
+    checkoutState: InternalCheckoutSelectors;
+    containerId: string;
+    decoupleCheckoutInitiation?: boolean;
+    methodId: string;
+    options?: AmazonPayV2ButtonParameters;
+    placement: AmazonPayV2Placement;
 }

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -8,6 +8,18 @@ export interface AmazonPayV2SDK {
     Pay: AmazonPayV2Client;
 }
 
+export interface AmazonPayV2Button {
+    /**
+     * Allows you to define custom actions.
+     */
+    onClick: (callback: () => void) => void;
+
+    /**
+     * Initiates the Amazon Pay checkout.
+     */
+    initCheckout(requestConfig: { createCheckoutSessionConfig: AmazonPayV2CheckoutSessionConfig }): void;
+}
+
 export type AmazonPayV2ButtonParameters = AmazonPayV2ButtonParams | AmazonPayV2NewButtonParams;
 
 export interface AmazonPayV2Client {
@@ -17,7 +29,7 @@ export interface AmazonPayV2Client {
      * @param containerId - HTML element id.
      * @param params - Button rendering params.
      */
-    renderButton(containerId: string, params: AmazonPayV2ButtonParameters): HTMLElement;
+    renderButton(containerId: string, params: AmazonPayV2ButtonParameters): AmazonPayV2Button;
 
     /**
      * Bind click events to HTML elements, so that when the element is clicked, the buyer can select a different shipping address or payment method.
@@ -100,7 +112,7 @@ export interface AmazonPayV2NewButtonParams extends AmazonPayV2ButtonConfig {
     /**
      * Create Checkout Session configuration.
      */
-    createCheckoutSessionConfig: AmazonPayV2CheckoutSessionConfig;
+    createCheckoutSessionConfig?: AmazonPayV2CheckoutSessionConfig;
 }
 
 export interface AmazonPayV2CheckoutSession {

--- a/packages/payment-integration-api/src/config/index.ts
+++ b/packages/payment-integration-api/src/config/index.ts
@@ -1,1 +1,1 @@
-export { default as Config, StoreConfig } from "./config";
+export { default as Config, StoreConfig, CheckoutSettings } from "./config";

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -8,7 +8,7 @@ export {
 } from "./checkout-buttons";
 export { Cart, DigitalItem, GiftCertificateItem, PhysicalItem } from "./cart";
 export { Checkout } from "./checkout";
-export { Config, StoreConfig } from "./config";
+export { Config, StoreConfig, CheckoutSettings } from "./config";
 export { Coupon } from "./coupon";
 export { Currency } from "./currency";
 export {


### PR DESCRIPTION
… for one-time transactions

## What? [INT-6092](https://bigcommercecloud.atlassian.net/browse/INT-6092)
Add an additional payment button for one-time transactions at the 4th step of the checkout page.

## Why?
To decrease cart abandonment by reducing manual input at the checkout step. This new behavior is under experiments `PROJECT-3483` and `INT-6399`, and most of the flow is done on the Amazon Pay Hosted Page, so it basically behaves like an external payment flow.

## Testing / Proof
https://user-images.githubusercontent.com/4843328/192050254-97b136bf-5d98-419b-83fb-d93e1b0eaab7.mov

## Depends on:
👉 https://github.com/bigcommerce/bigpay/pull/5997 as long as `INT-6399.amazon_pay_apb` is on.

@bigcommerce/checkout @bigcommerce/payments
