### PR TITLE
feat(payment): PAYPAL-1673 updated 'experience' button option in PayPalCommerceInlineCheckoutButtonStrategy

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
@@ -286,7 +286,7 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
-                experience: 'inline',
+                experience: 'accelerated',
                 fundingSource: paypalSdkMock.FUNDING.CARD,
                 style: paypalCommerceButtonStyle,
                 createOrder: expect.any(Function),

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
@@ -85,7 +85,7 @@ export default class PaypalCommerceInlineCheckoutButtonStrategy implements Check
         const fundingSource = paypalCommerceSdk.FUNDING.CARD;
 
         const buttonRenderOptions: PaypalCheckoutButtonOptions = {
-            experience: "inline",
+            experience: 'accelerated',
             fundingSource,
             style,
             createOrder: () => this._createOrder(methodId),


### PR DESCRIPTION
## What?
Updated 'experience' button option in PayPalCommerceInlineCheckoutButtonStrategy

## Why?
PayPal requested to make this changes due to PayPal SDK update from their side. Accelerated checkout button doesn't work without this update.

## Testing / Proof
Unit tests
Manual tests

<img width="1153" alt="Screenshot 2022-09-19 at 18 52 04" src="https://user-images.githubusercontent.com/25133454/191064429-8156a891-b4d8-41bc-86b4-34aa57d1ea24.png">
