### PR TITLE
fix(payment): INT-6539 GooglePay: Pass `hostname` as param when loadi…

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -76,9 +76,11 @@ export default class GooglePayPaymentProcessor {
     }
 
     private _configureWallet(): Promise<void> {
+        const features = this._store.getState().config.getStoreConfig()?.checkoutSettings.features;
+        const options = features && features['INT-5826.google_hostname_alias'] ? { params: { origin: window.location.hostname } } : undefined;
         const methodId = this._getMethodId();
 
-        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
+        return this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId, options))
             .then(state => {
                 const paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
                 const checkout = state.checkout.getCheckout();


### PR DESCRIPTION
…ng googlepay

## What? [INT-6539](https://bigcommercecloud.atlassian.net/browse/INT-6539)
Pass `hostname` as param to SF/payments API endpoint when loading Google Pay.

## Why?
It's required to build the auth JWT.

## Testing / Proof
**_Before:_**
![Screen Shot 2022-09-20 at 3 34 29 PM](https://user-images.githubusercontent.com/4843328/191365153-498ac43c-9c93-4d3b-a929-d32523cc7798.png)

**_Now:_**
![Screen Shot 2022-09-20 at 3 35 35 PM](https://user-images.githubusercontent.com/4843328/191365156-b9707650-3062-4a39-b6f6-ce62b7bf08f1.png)

## Depends on:
👉 https://github.com/bigcommerce/bigcommerce/pull/48661

@bigcommerce/checkout @bigcommerce/payments
