### PR TITLE
feat(payment): BOLT-282 fixed analytics feature for Bolt Checkout

### DIFF
--- a/packages/core/src/analytics/analytics-extra-items-manager.ts
+++ b/packages/core/src/analytics/analytics-extra-items-manager.ts
@@ -1,0 +1,54 @@
+import { LineItemMap } from '../cart';
+import { ExtraItemsData } from './analytics-step-tracker';
+
+const ORDER_ITEMS_STORAGE_KEY = 'ORDER_ITEMS';
+
+export default class AnalyticsExtraItemsManager {
+    constructor(
+        private storage: StorageFallback,
+    ) {}
+
+    saveExtraItemsData(id: string, lineItems: LineItemMap): ExtraItemsData {
+        const data = [
+            ...lineItems.physicalItems,
+            ...lineItems.digitalItems,
+        ].reduce<ExtraItemsData>((result, item) => {
+            result[item.productId] = {
+                brand: item.brand ? item.brand : '',
+                category: item.categoryNames ? item.categoryNames.join(', ') : '',
+            };
+
+            return result;
+        }, {});
+
+        try {
+            this.storage.setItem(this.getStorageKey(id), JSON.stringify(data));
+
+            return data;
+        } catch (err) {
+            return {};
+        }
+    }
+
+    readExtraItemsData(id: string): ExtraItemsData | null {
+        try {
+            const item = this.storage.getItem(this.getStorageKey(id));
+
+            return item ? JSON.parse(item) : null;
+        } catch (err) {
+            return null;
+        }
+    }
+
+    clearExtraItemData(id: string): void {
+        try {
+            this.storage.removeItem(this.getStorageKey(id));
+        } catch (err) {
+            // silently ignore the failure
+        }
+    }
+
+    private getStorageKey(id: string): string {
+        return id ? `${ORDER_ITEMS_STORAGE_KEY}_${id}` : '';
+    }
+}

--- a/packages/core/src/analytics/analytics-step-tracker.spec.ts
+++ b/packages/core/src/analytics/analytics-step-tracker.spec.ts
@@ -1,5 +1,6 @@
 import { getGiftCertificateItem } from '../cart/line-items.mock';
 import { createCheckoutService, CheckoutService } from '../checkout';
+import AnalyticsExtraItemsManager from './analytics-extra-items-manager';
 import { getCheckoutWithCoupons } from '../checkout/checkouts.mock';
 import { InvalidArgumentError } from '../common/error/errors';
 import { ShopperCurrency } from '../config';
@@ -65,7 +66,7 @@ describe('AnalyticsStepTracker', () => {
 
         analyticsStepTracker = new AnalyticsStepTracker(
             checkoutService,
-            sessionStorage,
+            new AnalyticsExtraItemsManager(sessionStorage),
             analytics
         );
     });
@@ -357,7 +358,7 @@ describe('AnalyticsStepTracker', () => {
 
                 analyticsStepTracker = new AnalyticsStepTracker(
                     checkoutService,
-                    sessionStorage,
+                    new AnalyticsExtraItemsManager(sessionStorage),
                     analytics
                 );
 
@@ -398,7 +399,7 @@ describe('AnalyticsStepTracker', () => {
 
                 analyticsStepTracker = new AnalyticsStepTracker(
                     checkoutService,
-                    sessionStorage,
+                    new AnalyticsExtraItemsManager(sessionStorage),
                     analytics
                 );
 
@@ -460,7 +461,7 @@ describe('AnalyticsStepTracker', () => {
             beforeEach(() => {
                 analyticsStepTrackerCustomOrder = new AnalyticsStepTracker(
                     checkoutService,
-                    sessionStorage,
+                    new AnalyticsExtraItemsManager(sessionStorage),
                     analytics,
                     {
                         checkoutSteps: ['shipping', 'billing', 'payment', 'customer'],
@@ -491,7 +492,7 @@ describe('AnalyticsStepTracker', () => {
             beforeEach(() => {
                 analyticsStepTrackerNoBackfill = new AnalyticsStepTracker(
                     checkoutService,
-                    sessionStorage,
+                    new AnalyticsExtraItemsManager(sessionStorage),
                     analytics,
                     { checkoutSteps: [] }
                 );

--- a/packages/core/src/analytics/create-step-tracker.ts
+++ b/packages/core/src/analytics/create-step-tracker.ts
@@ -2,6 +2,7 @@ import localStorageFallback from 'local-storage-fallback';
 
 import { CheckoutService } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import AnalyticsExtraItemsManager from './analytics-extra-items-manager';
 
 import AnalyticsStepTracker, { StepTrackerConfig } from './analytics-step-tracker';
 import { isAnalyticsTrackerWindow } from './is-analytics-step-tracker-window';
@@ -40,7 +41,7 @@ export default function createStepTracker(
     if (isAnalyticsEnabled && isAnalyticsTrackerWindow(window)) {
         return new AnalyticsStepTracker(
             checkoutService,
-            localStorageFallback,
+            new AnalyticsExtraItemsManager(localStorageFallback),
             window.analytics,
             stepTrackerConfig
         );

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -1,6 +1,7 @@
 import { createFormPoster } from '@bigcommerce/form-poster';
 import { RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, getScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loader';
+import localStorageFallback from 'local-storage-fallback';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../checkout';
@@ -16,6 +17,7 @@ import { createSpamProtection, GoogleRecaptcha, PaymentHumanVerificationHandler,
 import { StoreCreditActionCreator, StoreCreditRequestSender } from '../store-credit';
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subscription';
 import createPaymentStrategyRegistryV2 from './create-payment-strategy-registry-v2';
+import AnalyticsExtraItemsManager from '../analytics/analytics-extra-items-manager';
 
 import PaymentActionCreator from './payment-action-creator';
 import PaymentMethodActionCreator from './payment-method-action-creator';
@@ -343,7 +345,8 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             paymentMethodActionCreator,
             storeCreditActionCreator,
-            new BoltScriptLoader(scriptLoader)
+            new BoltScriptLoader(scriptLoader),
+            new AnalyticsExtraItemsManager(localStorageFallback),
         )
     );
 

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -2,11 +2,13 @@ import { createClient as createPaymentClient } from '@bigcommerce/bigpay-client'
 import { createAction, Action } from '@bigcommerce/data-store';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
+import localStorageFallback from 'local-storage-fallback';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, Checkout, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
 import { getCheckout, getCheckoutStoreStateWithOrder } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../../common/error/errors';
+import AnalyticsExtraItemsManager from '../../../analytics/analytics-extra-items-manager';
 import { getConfig } from '../../../config/configs.mock';
 import { OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
@@ -165,7 +167,8 @@ describe('BoltPaymentStrategy', () => {
             paymentActionCreator,
             paymentMethodActionCreator,
             storeCreditActionCreator,
-            boltScriptLoader
+            boltScriptLoader,
+            new AnalyticsExtraItemsManager(localStorageFallback)
         );
     });
 


### PR DESCRIPTION
## What?
GA doesn't work with Bolt Checkout if we navigate to the confirmation page from any page other than the checkout page.
Added `_setExtraItemsForAnalytics()` method for set up extra data to LocalStorage for GA

## Why?
According to task [BOLT-282](https://bigcommercecloud.atlassian.net/browse/BOLT-282)

## Testing / Proof
Validation is not available in the test environment
Need to check in the production environment

@bigcommerce/checkout @bigcommerce/payments
