### PR TITLE
fix(payment): STRIPE-167 Adding Postal Code to stripe card element if not obtained in billing

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -514,6 +514,23 @@ describe('StripeUPEPaymentStrategy', () => {
                         expect(response).toBe(store.getState());
                     });
 
+                    it('with a guest user with postal code', async () => {
+                        jest.spyOn(store.getState().customer, 'getCustomer')
+                            .mockReturnValue(undefined);
+                        jest.spyOn(store.getState().shippingAddress, 'getShippingAddress')
+                            .mockReturnValue({
+                                ...getShippingAddress(),
+                                postalCode: '12345',
+                            });
+
+                        const response = await strategy.execute(getStripeUPEOrderRequestBodyMock());
+
+                        expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+                        expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalled();
+                        expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                        expect(response).toBe(store.getState());
+                    });
+
                     it('without shipping address if there is not physical items in cart', async () => {
                         jest.spyOn(store.getState().cart, 'getCart')
                             .mockReturnValue({

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -1,5 +1,4 @@
-import { includes, some } from 'lodash';
-
+import {includes, some} from 'lodash';
 import { isHostedInstrumentLike } from '../..';
 import { Address } from '../../../address';
 import { BillingAddressActionCreator } from '../../../billing';
@@ -12,11 +11,22 @@ import { PaymentArgumentInvalidError, PaymentMethodCancelledError, PaymentMethod
 import isVaultedInstrument from '../../is-vaulted-instrument';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
-import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import {PaymentInitializeOptions, PaymentRequestOptions} from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
 
 import formatLocale from './format-locale';
-import { AddressOptions, StripeConfirmPaymentData, StripeElement, StripeElements, StripeElementType, StripeError, StripePaymentMethodType, StripeStringConstants, StripeUPEAppearanceOptions, StripeUPEClient } from './stripe-upe';
+import {
+    AddressOptions,
+    StripeConfirmPaymentData,
+    StripeElement,
+    StripeElements,
+    StripeElementType,
+    StripeError,
+    StripePaymentMethodType,
+    StripeStringConstants,
+    StripeUPEAppearanceOptions,
+    StripeUPEClient
+} from './stripe-upe';
 import StripeUPEScriptLoader from './stripe-upe-script-loader';
 
 const APM_REDIRECT = [
@@ -284,6 +294,8 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             appearance,
         });
 
+        const { postalCode } = state.shippingAddress.getShippingAddressOrThrow();
+
         const stripeElement: StripeElement = this._stripeElements.getElement(StripeElementType.PAYMENT) || this._stripeElements.create(StripeElementType.PAYMENT,
             {
                 fields: {
@@ -292,6 +304,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                         address: {
                             country: StripeStringConstants.NEVER,
                             city: StripeStringConstants.NEVER,
+                            postalCode: postalCode ? StripeStringConstants.NEVER : StripeStringConstants.AUTO,
                         },
                     },
                 },
@@ -394,9 +407,10 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             const {
                 city,
                 countryCode: country,
+                postalCode,
             } = address;
 
-            return { city, country };
+            return { city, country, postalCode };
         }
 
         throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -82,7 +82,7 @@ export interface AddressOptions {
     city?: string;
     country?: string;
     state?: string;
-    postal_code?: string;
+    postalCode?: string;
     line1?: string;
     line2?: string;
 }


### PR DESCRIPTION
## What? [STRIPE-167](https://bigcommercecloud.atlassian.net/browse/STRIPE-167)
If the customer add postal code, we don't need to request in card

## Why?
Merchant reports that wants to hide the postal code field in the payment form

## Testing / Proof
<img width="836" alt="Screen Shot 2022-09-26 at 16 49 46" src="https://user-images.githubusercontent.com/106765049/192386975-5b0cbad5-470f-46e5-85c1-df67c20d94fa.png">

<img width="766" alt="Screen Shot 2022-09-26 at 16 51 23" src="https://user-images.githubusercontent.com/106765049/192387187-98238e5f-8224-42f3-8f57-84741008824c.png">

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
