### PR TITLE
feat(payment): STRIPE-25 Stripe Link State

### DIFF
--- a/packages/core/src/customer/customer-actions.ts
+++ b/packages/core/src/customer/customer-actions.ts
@@ -22,6 +22,8 @@ export enum CustomerActionType {
     CreateCustomerAddressRequested = 'CREATE_CUSTOMER_ADDRESS_REQUESTED',
     CreateCustomerAddressSucceeded = 'CREATE_CUSTOMER_ADDRESS_SUCCEEDED',
     CreateCustomerAddressFailed = 'CREATE_CUSTOMER_ADDRESS_FAILED',
+
+    StripeLinkAuthenticated = 'STRIPE_LINK_AUTHENTICATED',
 }
 
 export type CustomerAction =
@@ -57,6 +59,10 @@ export type SignOutCustomerAction =
 
 export interface SignInCustomerRequestedAction extends Action {
     type: CustomerActionType.SignInCustomerRequested;
+}
+
+export interface StripeLinkAuthenticatedAction extends Action {
+    type: CustomerActionType.StripeLinkAuthenticated;
 }
 
 export interface SignInCustomerSucceededAction extends Action<InternalCustomerResponseData> {

--- a/packages/core/src/customer/customer-reducer.spec.ts
+++ b/packages/core/src/customer/customer-reducer.spec.ts
@@ -1,6 +1,6 @@
 import { createErrorAction } from '@bigcommerce/data-store';
 
-import { CreateCustomerAction, CreateCustomerAddressAction, CustomerActionType } from './customer-actions';
+import { CreateCustomerAction, CreateCustomerAddressAction, CustomerActionType, StripeLinkAuthenticatedAction } from './customer-actions';
 import customerReducer from './customer-reducer';
 import CustomerState, { DEFAULT_STATE } from './customer-state';
 
@@ -74,6 +74,17 @@ describe('customerReducer()', () => {
         expect(customerReducer(initialState, action)).toEqual(expect.objectContaining({
             statuses: { isCreatingAddress: false },
             errors: { createAddressError: action.payload },
+        }));
+    });
+
+    it('returns is stripe link authenticated value when succeeded', () => {
+        const action: StripeLinkAuthenticatedAction = {
+            type: CustomerActionType.StripeLinkAuthenticated,
+            payload: true
+        };
+
+        expect(customerReducer(initialState, action)).toEqual(expect.objectContaining({
+            data: { isStripeLinkAuthenticated: action.payload },
         }));
     });
 });

--- a/packages/core/src/customer/customer-reducer.ts
+++ b/packages/core/src/customer/customer-reducer.ts
@@ -6,14 +6,16 @@ import { clearErrorReducer } from '../common/error';
 import { objectMerge, objectSet } from '../common/utility';
 
 import Customer from './customer';
-import { CustomerAction, CustomerActionType } from './customer-actions';
+import { CustomerAction, CustomerActionType, StripeLinkAuthenticatedAction } from './customer-actions';
 import CustomerState, { CustomerErrorsState, CustomerStatusesState, DEFAULT_STATE } from './customer-state';
+
+type ReducerActionType = CheckoutAction | ContinueAsGuestAction | CustomerAction | StripeLinkAuthenticatedAction;
 
 export default function customerReducer(
     state: CustomerState = DEFAULT_STATE,
-    action: CheckoutAction | ContinueAsGuestAction | CustomerAction
+    action: ReducerActionType
 ): CustomerState {
-    const reducer = combineReducers<CustomerState, CheckoutAction | CustomerAction | ContinueAsGuestAction>({
+    const reducer = combineReducers<CustomerState, ReducerActionType>({
         data: dataReducer,
         errors: composeReducers(errorsReducer, clearErrorReducer),
         statuses: statusesReducer,
@@ -24,7 +26,7 @@ export default function customerReducer(
 
 function dataReducer(
     data: Customer | undefined,
-    action: CheckoutAction | ContinueAsGuestAction | CustomerAction
+    action: ReducerActionType
 ): Customer | undefined {
     switch (action.type) {
     case BillingAddressActionType.ContinueAsGuestSucceeded:
@@ -33,6 +35,8 @@ function dataReducer(
 
     case CustomerActionType.CreateCustomerAddressSucceeded:
             return objectMerge(data, action.payload);
+    case CustomerActionType.StripeLinkAuthenticated:
+            return objectSet(data, 'isStripeLinkAuthenticated', action.payload);
 
     default:
         return data;
@@ -41,7 +45,7 @@ function dataReducer(
 
 function errorsReducer(
     errors: CustomerErrorsState = DEFAULT_STATE.errors,
-    action: CheckoutAction | ContinueAsGuestAction | CustomerAction
+    action: ReducerActionType
 ): CustomerErrorsState {
     switch (action.type) {
     case CustomerActionType.CreateCustomerRequested:
@@ -65,7 +69,7 @@ function errorsReducer(
 
 function statusesReducer(
     statuses: CustomerStatusesState = DEFAULT_STATE.statuses,
-    action: CheckoutAction | ContinueAsGuestAction | CustomerAction
+    action: ReducerActionType
 ): CustomerStatusesState {
     switch (action.type) {
     case CustomerActionType.CreateCustomerRequested:

--- a/packages/core/src/customer/customer.ts
+++ b/packages/core/src/customer/customer.ts
@@ -18,6 +18,7 @@ export default interface Customer {
      * Note: You need to enable "Prompt existing accounts to sign in" in your Checkout Settings.
      */
     shouldEncourageSignIn: boolean;
+    isStripeLinkAuthenticated?: boolean;
     customerGroup?: CustomerGroup;
 }
 

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -1,8 +1,10 @@
+import { createAction } from '@bigcommerce/data-store';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { PaymentMethodActionCreator } from '../../../payment';
 import { StripeElements, StripeElementType, StripeScriptLoader, StripeUPEClient, StripeEventType, StripeUPEAppearanceOptions } from '../../../payment/strategies/stripe-upe';
 import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerActionType } from '../../customer-actions';
 import CustomerCredentials from '../../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
@@ -84,7 +86,7 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
                 if (!('authenticated' in event)) {
                     throw new MissingDataError(MissingDataErrorType.MissingCustomer);
                 }
-
+                this._store.dispatch(createAction(CustomerActionType.StripeLinkAuthenticated, event.authenticated));
                 event.complete ? onEmailChange(event.authenticated, event.value.email) : onEmailChange(false, '');
 
                 if (isLoading) {

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer.mock.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer.mock.ts
@@ -1,7 +1,7 @@
-import { StripeUPEClient } from '../../../payment/strategies/stripe-upe';
+import { StripeElement, StripeUPEClient } from '../../../payment/strategies/stripe-upe';
 import { CustomerInitializeOptions } from '../../customer-request-options';
 
-export function getCustomerStripeUPEJsMock(): StripeUPEClient {
+export function getCustomerStripeUPEJsMock(returnElement?: StripeElement): StripeUPEClient {
     return {
         elements: jest.fn(() => ({
             create: jest.fn(() => ({
@@ -9,7 +9,7 @@ export function getCustomerStripeUPEJsMock(): StripeUPEClient {
                 unmount: jest.fn(),
                 on: jest.fn(),
             })),
-            getElement: jest.fn().mockReturnValue(null),
+            getElement: jest.fn(() => returnElement),
             update: jest.fn(),
             fetchUpdates: jest.fn(),
         })),

--- a/packages/core/src/customer/strategies/stripe-upe/stripeupe-customer-initialize-options.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripeupe-customer-initialize-options.ts
@@ -34,6 +34,6 @@ export default interface StripeUPECustomerInitializeOptions {
      */
     getStyles?(): {
         [key: string]: string;
-    };
+    } | undefined;
 
 }


### PR DESCRIPTION
## What? [STRIPE-25](https://bigcommercecloud.atlassian.net/browse/STRIPE-25)
- Add `stripeLinkAuthenticated` to the customer's data state and its corresponding actions to update it.
- Also add `| undefined ` to StripeUPE `getStyles` function.

## Why?
- It was suggested to move this state to the `checkout-sdk` from `checkout-js` to avoid adding more states handled by the checkout component.
- `getStyles` function may also  have to return `undefined` on newer implementations of the function due to additional validations.

## Dependency Of
https://github.com/bigcommerce/checkout-js/pull/1017

## Testing / Proof
### Without Link Authenticated
<img width="523" alt="image (9)" src="https://user-images.githubusercontent.com/35502707/192863344-85e3dad2-899e-4e37-b439-f9c02e7a4280.png">

<img width="766" alt="image (10)" src="https://user-images.githubusercontent.com/35502707/192863341-6b1a0ec1-7b27-4ed6-b566-8ff6c181b925.png">

### With Link Authenticated
<img width="739" alt="image (11)" src="https://user-images.githubusercontent.com/35502707/192863335-d004bacd-ab28-450b-afbd-506b01ba5909.png">
<img width="769" alt="image (12)" src="https://user-images.githubusercontent.com/35502707/192863332-8ac12d42-272a-4135-891f-a525e66bc956.png">

### Without Link Enabled
<img width="885" alt="image (13)" src="https://user-images.githubusercontent.com/35502707/192863326-a30145d6-f247-44a3-a9d0-511d72b5de45.png">


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
