### PR TITLE
fix(payment): INT-6478 SquareV2 - Fail Gracefully when payment provider unavailable

### DIFF
--- a/packages/core/src/payment/strategies/square/square-script-loader.ts
+++ b/packages/core/src/payment/strategies/square/square-script-loader.ts
@@ -2,7 +2,7 @@ import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '../../errors';
 
-import { SquareFormOptions, SquareScriptCallBack } from './square-form';
+import SquarePaymentForm, { SquareFormOptions, SquareScriptCallBack } from './square-form';
 import SquareWindow from './square-window';
 
 export default class SquareScriptLoader {
@@ -23,7 +23,7 @@ export default class SquareScriptLoader {
                 '//js.squareupsandbox.com/v2/paymentform' :
                 '//js.squareup.com/v2/paymentform');
 
-        return (options: SquareFormOptions) => {
+        return (options: SquareFormOptions): SquarePaymentForm => {
             if (!this._isSquareWindow(this._window)) {
                 throw new PaymentMethodClientUnavailableError();
             }


### PR DESCRIPTION
## JIRA: [INT-6478](https://bigcommercecloud.atlassian.net/browse/INT-6478)

## What?
Added a try/catch with a reject msg and refactored it to return an error if the provider scripts path fails.

## Why?
Square is having degraded performance on their API and it is causing all checkouts to fail if a store has square enabled.

## Testing / Proof
https://drive.google.com/file/d/1rbZXSOWFunQXrnk07fGcP06YOFA1KV9w/view?usp=sharing

## Linked to this [PR](https://github.com/bigcommerce/checkout-js/pull/1047) of Checkout JS

@bigcommerce/checkout @bigcommerce/payments
