### PR TITLE
feat(payment): PAYPAL-1626 added Buy Now functionality to PayPalCommerceCredit button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -260,6 +260,7 @@ export default function createCheckoutButtonRegistry(
         new PaypalCommerceCreditButtonStrategy(
             store,
             checkoutActionCreator,
+            cartRequestSender,
             formPoster,
             paypalScriptLoader,
             paypalCommerceRequestSender

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -45,7 +45,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
 
             if (!paypalcommerce.currencyCode) {
-                throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommerce.currency" argument is not provided.`);
+                throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommerce.currencyCode" argument is not provided.`);
             }
 
             this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, paypalcommerce.currencyCode, paypalcommerce.initializesOnCheckoutPage);

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-options.ts
@@ -1,3 +1,4 @@
+import { BuyNowCartRequestBody } from '../../../cart';
 import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
 
 export interface PaypalCommerceCreditButtonInitializeOptions {
@@ -15,4 +16,16 @@ export interface PaypalCommerceCreditButtonInitializeOptions {
      * A set of styling options for the checkout button.
      */
     style?: PaypalButtonStyleOptions;
+
+    /**
+     * The option that used to initialize a PayPal script with provided currency code.
+     */
+    currencyCode?: string;
+
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    }
 }


### PR DESCRIPTION
## What?
Added Buy Now functionality to PayPalCommerceCredit button strategy

## Why?
Due the task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1626

## Testing / Proof
Unit tests
Manual tests