### PR TITLE
feat(payment): PAYPAL-1690 added default height value for PayPal buttons if height is not provided

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.spec.ts
@@ -104,6 +104,21 @@ describe('#getValidButtonStyle()', () => {
         expect(getValidButtonStyle(stylesMock)).toEqual(expects);
     });
 
+    it('returns styles with default height if height value not provided', () => {
+        const stylesMock = {
+            color: StyleButtonColor.silver,
+            height: undefined,
+            shape: StyleButtonShape.rect,
+        };
+
+        const expects = {
+            ...stylesMock,
+            height: 40,
+        };
+
+        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
+    });
+
     it('returns styles without tagline for vertical layout', () => {
         const stylesMock = {
             color: StyleButtonColor.silver,

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.ts
@@ -42,10 +42,15 @@ function getValidTagline(tagline?: boolean, layout?: string): boolean | undefine
 }
 
 function getValidHeight(height?: number): number {
+    const defaultHeight = 40;
     const minHeight = 25;
     const maxHeight = 55;
 
-    if (typeof height !== 'number' || height > maxHeight) {
+    if (!height || typeof height !== 'number') {
+        return defaultHeight;
+    }
+
+    if (height > maxHeight) {
         return maxHeight;
     }
 


### PR DESCRIPTION
## What?
Added default height value for PayPal buttons if height is not provided

## Why?
To avoid issues with PayPal size when height is not provided from BE

## Testing / Proof
Manual tests
Unit tests
