### PR TITLE
feat(payment): PAYPAL-1627 added Buy Now implementation for PayPalCommerceVenmo button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -293,6 +293,7 @@ export default function createCheckoutButtonRegistry(
         new PaypalCommerceVenmoButtonStrategy(
             store,
             checkoutActionCreator,
+            cartRequestSender,
             formPoster,
             paypalScriptLoader,
             paypalCommerceRequestSender

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-options.ts
@@ -1,3 +1,4 @@
+import { BuyNowCartRequestBody } from '../../../cart';
 import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
 
 export interface PaypalCommerceVenmoButtonInitializeOptions {
@@ -10,4 +11,16 @@ export interface PaypalCommerceVenmoButtonInitializeOptions {
      * Flag which helps to detect that the strategy initializes on Checkout page
      */
     initializesOnCheckoutPage?: boolean;
+
+    /**
+     * The option that used to initialize a PayPal script with provided currency code.
+     */
+    currencyCode?: string;
+
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    }
 }


### PR DESCRIPTION
## What?
Added Buy Now functionality to PayPalCommerceVenmo button strategy

## Why?
Due the task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1627

## Testing / Proof
Manual tests
Unit tests

<img width="1273" alt="Screenshot 2022-09-28 at 19 30 44" src="https://user-images.githubusercontent.com/25133454/192838226-13d75067-2047-4e7a-81a9-46c19a9c5ce9.png">
