### PR TITLE
feat(payment): PAYPAL-1628 added Buy Now implementation for PayPalCommerce alternative methods button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -270,6 +270,7 @@ export default function createCheckoutButtonRegistry(
         new PaypalCommerceAlternativeMethodsButtonStrategy(
             store,
             checkoutActionCreator,
+            cartRequestSender,
             formPoster,
             paypalScriptLoader,
             paypalCommerceRequestSender

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-options.ts
@@ -1,3 +1,4 @@
+import { BuyNowCartRequestBody } from '../../../cart';
 import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
 
 export interface PaypalCommerceAlternativeMethodsButtonOptions {
@@ -15,4 +16,16 @@ export interface PaypalCommerceAlternativeMethodsButtonOptions {
      * A set of styling options for the checkout button.
      */
     style?: PaypalButtonStyleOptions;
+
+    /**
+     * The option that used to initialize a PayPal script with provided currency code.
+     */
+    currencyCode?: string;
+
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    }
 }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -3,8 +3,9 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
-import { Cart } from '../../../cart';
+import { BuyNowCartRequestBody, Cart, CartRequestSender } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
+import { BuyNowCartCreationError } from '../../../cart/errors';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
@@ -22,6 +23,7 @@ import PaypalCommerceAlternativeMethodsButtonStrategy from './paypal-commerce-al
 
 describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
     let cartMock: Cart;
+    let cartRequestSender: CartRequestSender;
     let checkoutActionCreator: CheckoutActionCreator;
     let eventEmitter: EventEmitter;
     let formPoster: FormPoster;
@@ -51,6 +53,36 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
         paypalcommercealternativemethods: paypalCommerceAlternativeMethodsOptions,
     };
 
+    const buyNowCartMock = {
+        ...getCart(),
+        id: 999,
+        source: 'BUY_NOW',
+    };
+
+    const buyNowCartRequestBody: BuyNowCartRequestBody = {
+        source: 'BUY_NOW',
+        lineItems: [{
+            productId: 1,
+            quantity: 2,
+            optionSelections: {
+                optionId: 11,
+                optionValue: 11,
+            },
+        }],
+    };
+
+    const buyNowInitializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.PAYPALCOMMERCE_APMS,
+        containerId: defaultButtonContainerId,
+        paypalcommercealternativemethods: {
+            ...paypalCommerceAlternativeMethodsOptions,
+            currencyCode: 'USD',
+            buyNowInitializeOptions: {
+                getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
+            },
+        }
+    };
+
     beforeEach(() => {
         cartMock = getCart();
         eventEmitter = new EventEmitter();
@@ -60,6 +92,7 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
         store = createCheckoutStore(getCheckoutStoreState());
         requestSender = createRequestSender();
         formPoster = createFormPoster();
+        cartRequestSender = new CartRequestSender(requestSender);
         paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
         paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());
 
@@ -72,6 +105,7 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
         strategy = new PaypalCommerceAlternativeMethodsButtonStrategy(
             store,
             checkoutActionCreator,
+            cartRequestSender,
             formPoster,
             paypalScriptLoader,
             paypalCommerceRequestSender,
@@ -82,6 +116,7 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
         document.body.appendChild(paypalCommerceAlternativeMethodsButtonElement);
 
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout').mockImplementation(() => {});
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethodMock);
         jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdkMock);
         jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
@@ -91,6 +126,28 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
                 eventEmitter.on('createOrder', () => {
                     if (options.createOrder) {
                         options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('onClick', async (jestSuccessExpectationsCallback, jestFailureExpectationsCallback) => {
+                    try {
+                        if (options.onClick) {
+                            await options.onClick(
+                                { fundingSource: 'sepa' },
+                                {
+                                    reject: jest.fn(),
+                                    resolve: jest.fn(),
+                                },
+                            );
+
+                            if (jestSuccessExpectationsCallback && typeof jestSuccessExpectationsCallback === 'function') {
+                                jestSuccessExpectationsCallback();
+                            }
+                        }
+                    } catch (error) {
+                        if (jestFailureExpectationsCallback && typeof jestFailureExpectationsCallback === 'function') {
+                            jestFailureExpectationsCallback(error);
+                        }
                     }
                 });
 
@@ -171,10 +228,36 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
             }
         });
 
+        it('loads default checkout', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalled();
+        });
+
+        it ('does not load default checkout for Buy Now flow', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(checkoutActionCreator.loadDefaultCheckout).not.toHaveBeenCalled();
+        });
+
         it('loads paypal commerce sdk script', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalled();
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethodMock,
+                cartMock.currency.code,
+                initializationOptions.paypalcommercealternativemethods?.initializesOnCheckoutPage
+            );
+        });
+
+        it('loads paypal commerce sdk script with provided currency code (Buy Now flow)', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethodMock,
+                buyNowInitializationOptions.paypalcommercealternativemethods?.currencyCode,
+                buyNowInitializationOptions.paypalcommercealternativemethods?.initializesOnCheckoutPage
+            );
         });
 
         it('initializes APM button to render', async () => {
@@ -184,7 +267,8 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
                 fundingSource: paypalCommerceAlternativeMethodsOptions.apm,
                 style: paypalCommerceAlternativeMethodsOptions.style,
                 createOrder: expect.any(Function),
-                onApprove: expect.any(Function)
+                onApprove: expect.any(Function),
+                onClick: expect.any(Function),
             });
         });
 
@@ -249,6 +333,54 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
             expect(document.getElementById(defaultButtonContainerId)).toBeNull();
         });
 
+        it('throws an error if buy now cart request body data is not provided on button click (Buy Now flow)', async () => {
+            const buyNowInitializationOptionsMock = {
+                ...buyNowInitializationOptions,
+                paypalcommercealternativemethods: {
+                    ...buyNowInitializationOptions.paypalcommercealternativemethods,
+                    apm: paypalCommerceAlternativeMethodsOptions.apm,
+                    buyNowInitializeOptions: {
+                        getBuyNowCartRequestBody: jest.fn().mockReturnValue(undefined),
+                    },
+                },
+            };
+
+            await strategy.initialize(buyNowInitializationOptionsMock);
+            eventEmitter.emit(
+                'onClick',
+                undefined,
+                (error: Error) => {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                },
+            );
+        });
+
+        it('creates buy now cart (Buy Now Flow)', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({ body: buyNowCartMock });
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit(
+                'onClick',
+                () => {
+                    expect(cartRequestSender.createBuyNowCart).toHaveBeenCalledWith(buyNowCartRequestBody);
+                },
+            );
+        });
+
+        it('throws an error if failed to create buy now cart (Buy Now Flow)', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockImplementation(() => Promise.reject());
+
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit(
+                'onClick',
+                undefined,
+                (error: Error) => {
+                    expect(error).toBeInstanceOf(BuyNowCartCreationError);
+                }
+            );
+        });
+
         it('creates an order with paypalcommercealternativemethod as provider id if its initializes outside checkout page', async () => {
             jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
 
@@ -279,6 +411,23 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
             await new Promise(resolve => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, 'paypalcommercealternativemethodscheckout');
+        });
+
+        it('creates order with Buy Now cart id (Buy Now flow)', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({ body: buyNowCartMock });
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(buyNowCartMock.id, 'paypalcommercealternativemethod');
         });
 
         it('throws an error if orderId is not provided by PayPal on approve', async () => {
@@ -322,6 +471,29 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
                 order_id: approveDataOrderId,
                 payment_type: 'paypal',
                 provider: paymentMethodMock.id,
+            }));
+        });
+
+        it('provides buy now cart_id on payment tokenization on paypal approve', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({ body: buyNowCartMock });
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('111');
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                cart_id: buyNowCartMock.id,
             }));
         });
     });

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
@@ -1,4 +1,6 @@
 import { FormPoster } from '@bigcommerce/form-poster';
+import { CartRequestSender } from '../../../cart';
+import { BuyNowCartCreationError } from '../../../cart/errors';
 
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, } from '../../../common/error/errors';
@@ -8,13 +10,16 @@ import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 import getValidButtonStyle from './get-valid-button-style';
+import { PaypalCommerceAlternativeMethodsButtonOptions } from './paypal-commerce-alternative-methods-button-options';
 
 export default class PaypalCommerceAlternativeMethodsButtonStrategy implements CheckoutButtonStrategy {
+    private _buyNowCartId?: string;
     private _paypalCommerceSdk?: PaypalCommerceSDK;
 
     constructor(
         private _store: CheckoutStore,
         private _checkoutActionCreator: CheckoutActionCreator,
+        private _cartRequestSender: CartRequestSender,
         private _formPoster: FormPoster,
         private _paypalScriptLoader: PaypalCommerceScriptLoader,
         private _paypalCommerceRequestSender: PaypalCommerceRequestSender
@@ -22,7 +27,6 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy implements C
 
     async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
         const { paypalcommercealternativemethods, containerId, methodId } = options;
-        const { apm, initializesOnCheckoutPage, style } = paypalcommercealternativemethods || {};
 
         if (!methodId) {
             throw new InvalidArgumentError('Unable to initialize payment because "options.methodId" argument is not provided.');
@@ -36,16 +40,30 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy implements C
             throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommercealternativemethods" argument is not provided.`);
         }
 
-        if (!apm) {
+        if (!paypalcommercealternativemethods.apm) {
             throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommercealternativemethods.apm" argument is not provided.`);
         }
 
-        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
-        const currency = state.cart.getCartOrThrow().currency.code;
-        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currency, initializesOnCheckoutPage);
+        const { buyNowInitializeOptions, currencyCode, initializesOnCheckoutPage } = paypalcommercealternativemethods;
 
-        this._renderButton(apm, methodId, containerId, initializesOnCheckoutPage, style);
+        if (buyNowInitializeOptions) {
+            const state = this._store.getState();
+            const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+            if (!currencyCode) {
+                throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommercealternativemethods.currencyCode" argument is not provided.`);
+            }
+
+            this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, currencyCode, initializesOnCheckoutPage);
+        } else {
+            const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+            const cart = state.cart.getCartOrThrow();
+            const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+            this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(paymentMethod, cart.currency.code, initializesOnCheckoutPage);
+        }
+
+        this._renderButton(methodId, containerId, paypalcommercealternativemethods);
     }
 
     deinitialize(): Promise<void> {
@@ -53,12 +71,12 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy implements C
     }
 
     private _renderButton(
-        apm: string,
         methodId: string,
         containerId: string,
-        initializesOnCheckoutPage?: boolean,
-        style?: PaypalButtonStyleOptions
+        paypalcommercealternativemethods: PaypalCommerceAlternativeMethodsButtonOptions,
     ): void {
+        const { apm, buyNowInitializeOptions, initializesOnCheckoutPage, style } = paypalcommercealternativemethods;
+
         const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
         const isAvailableFundingSource = Object.values(paypalCommerceSdk.FUNDING).includes(apm);
 
@@ -71,6 +89,7 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy implements C
         const buttonRenderOptions: ButtonsOptions = {
             fundingSource: apm,
             style: validButtonStyle,
+            onClick: () => this._handleClick(buyNowInitializeOptions),
             createOrder: () => this._createOrder(initializesOnCheckoutPage),
             onApprove: ({ orderID }: ApproveDataOptions) => this._tokenizePayment(methodId, orderID),
         };
@@ -84,13 +103,32 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy implements C
         }
     }
 
+    private async _handleClick(
+        buyNowInitializeOptions: PaypalCommerceAlternativeMethodsButtonOptions['buyNowInitializeOptions'],
+    ): Promise<void> {
+        if (buyNowInitializeOptions && typeof buyNowInitializeOptions.getBuyNowCartRequestBody === 'function') {
+            const cartRequestBody = buyNowInitializeOptions.getBuyNowCartRequestBody();
+
+            if (!cartRequestBody) {
+                throw new MissingDataError(MissingDataErrorType.MissingCart);
+            }
+
+            try {
+                const { body: cart } = await this._cartRequestSender.createBuyNowCart(cartRequestBody);
+
+                this._buyNowCartId = cart.id;
+            } catch (error) {
+                throw new BuyNowCartCreationError();
+            }
+        }
+    }
+
     private async _createOrder(initializesOnCheckoutPage?: boolean): Promise<string> {
-        const state = this._store.getState();
-        const cart = state.cart.getCartOrThrow();
+        const cartId = this._buyNowCartId || this._store.getState().cart.getCartOrThrow().id;
 
         const providerId = initializesOnCheckoutPage ? 'paypalcommercealternativemethodscheckout' : 'paypalcommercealternativemethod';
 
-        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cart.id, providerId);
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cartId, providerId);
 
         return orderId;
     }
@@ -105,6 +143,7 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy implements C
             action: 'set_external_checkout',
             provider: methodId,
             order_id: orderId,
+            ...this._buyNowCartId && { cart_id: this._buyNowCartId },
         });
     }
 


### PR DESCRIPTION
## What?
Added Buy Now implementation for PayPalCommerce alternative methods button strategy

## Why?
Due the task: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1628

## Testing / Proof
Manual tests
Unit tests
