### PR TITLE
refactor(checkout): STRF-10042 Incapsulate BODL event names into public methods

### DIFF
--- a/packages/core/src/bodl/bodl-emitter-service.ts
+++ b/packages/core/src/bodl/bodl-emitter-service.ts
@@ -49,7 +49,7 @@ export default class BodlEmitterService implements BodlService {
             },
         } = checkout;
 
-        this.bodlEvents.emit('create_checkout_begin', {
+        this.bodlEvents.emitCheckoutBeginEvent({
             id,
             currency: currency.code,
             cart_value: cartAmount,
@@ -82,7 +82,7 @@ export default class BodlEmitterService implements BodlService {
             return;
         }
 
-        this.bodlEvents.emit('create_order_purchased', {
+        this.bodlEvents.emitOrderPurchasedEvent({
             id: cartId,
             currency: currency.code,
             transaction_id: orderId,

--- a/packages/core/src/bodl/bodl-events-service.spec.ts
+++ b/packages/core/src/bodl/bodl-events-service.spec.ts
@@ -14,7 +14,8 @@ describe('BodlEmitterService', () => {
 
     beforeEach(() => {
         bodlEvents = {
-            emit: jest.fn(),
+            emitOrderPurchasedEvent: jest.fn(),
+            emitCheckoutBeginEvent: jest.fn(),
         };
 
         checkoutService = createCheckoutService();
@@ -44,12 +45,11 @@ describe('BodlEmitterService', () => {
             bodlEmitterService.checkoutBegin();
             bodlEmitterService.checkoutBegin();
 
-            expect(bodlEvents.emit).toBeCalledTimes(1);
+            expect(bodlEvents.emitCheckoutBeginEvent).toBeCalledTimes(1);
         });
 
         it('tracks the id', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_checkout_begin',
+            expect(bodlEvents.emitCheckoutBeginEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 })
@@ -57,8 +57,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks the currency', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_checkout_begin',
+            expect(bodlEvents.emitCheckoutBeginEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     currency: 'USD',
                 })
@@ -66,8 +65,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks the cart value', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_checkout_begin',
+            expect(bodlEvents.emitCheckoutBeginEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     cart_value: 190,
                 })
@@ -75,8 +73,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks the coupon string', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_checkout_begin',
+            expect(bodlEvents.emitCheckoutBeginEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     coupon: 'SAVEBIG2015,279F507D817E3E7',
                 })
@@ -84,8 +81,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks products', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_checkout_begin',
+            expect(bodlEvents.emitCheckoutBeginEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     coupon: 'SAVEBIG2015,279F507D817E3E7',
                     cart_value: 190,
@@ -138,8 +134,7 @@ describe('BodlEmitterService', () => {
 
 
         it('tracks the id', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_order_purchased',
+            expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 })
@@ -147,8 +142,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks the currency', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_order_purchased',
+            expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     currency: 'USD',
                 })
@@ -156,8 +150,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks the transaction id', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_order_purchased',
+            expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     transaction_id: 295,
                 })
@@ -165,8 +158,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks the cart amount', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_order_purchased',
+            expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     cart_value: 190,
                 })
@@ -174,8 +166,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks the coupon amount, single field, comma separated', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_order_purchased',
+            expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     coupon: 'SAVEBIG2015,279F507D817E3E7',
                 })
@@ -183,8 +174,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks the shipping cost', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_order_purchased',
+            expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     shipping_cost: 15,
                 })
@@ -192,8 +182,7 @@ describe('BodlEmitterService', () => {
         });
 
         it('tracks products', () => {
-            expect(bodlEvents.emit).toHaveBeenCalledWith(
-                'create_order_purchased',
+            expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
                     line_items: [{
                         product_id: 103,

--- a/packages/core/src/bodl/bodl-window.ts
+++ b/packages/core/src/bodl/bodl-window.ts
@@ -41,7 +41,8 @@ export interface OrderPurchasedData {
 }
 
 export interface BodlEventsCheckout { 
-    emit(eventName: string , data: CheckoutBeginData | OrderPurchasedData): boolean;
+    emitCheckoutBeginEvent(data: CheckoutBeginData): boolean;
+    emitOrderPurchasedEvent(data: OrderPurchasedData): boolean;
 }
 
 export interface BodlEvents {


### PR DESCRIPTION
## What?

Changed usage of BODL event names directly to public methods on the library.

## Why?

To avoid discrepancy on event names between clients of the library.
https://github.com/bigcommerce/bodl-events/pull/25/files#diff-ea794abbd2f1d06c91f25f33458480aac092e4448178a154e7f50cdd6019528fR14

## Testing / Proof

<img width="1659" alt="Screenshot 2022-09-29 at 18 57 39" src="https://user-images.githubusercontent.com/68893868/193092905-5e2f3048-15b0-4e05-b294-c805733d43e0.png">

@bigcommerce/checkout @bigcommerce/payments
