### PR TITLE
feat(payment): INT-6675 [Digital River] Update billingAddress from paypal

### DIFF
--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -549,7 +549,8 @@ export default function createPaymentStrategyRegistry(
             orderActionCreator,
             paymentActionCreator,
             storeCreditActionCreator,
-            new DigitalRiverScriptLoader(scriptLoader, getStylesheetLoader())
+            new DigitalRiverScriptLoader(scriptLoader, getStylesheetLoader()),
+            billingAddressActionCreator
         )
     );
 

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -25,12 +25,13 @@ import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import { getVaultedInstrument } from '../../payments.mock';
-import { getAdditionalActionError, getClientMock, getDigitalRiverJSMock, getDigitalRiverPaymentMethodMock, getInitializeOptionsMock, getOrderRequestBodyWithVaultedInstrument } from '../digitalriver/digitalriver.mock';
+import { getAdditionalActionError, getClientMock, getDigitalRiverJSMock, getDigitalRiverPaymentMethodMock, getInitializeOptionsMock, getOrderRequestBodyWithVaultedInstrument } from '../digitalriver/digitalriver.mock'
 
 import { AuthenticationSourceStatus, OnCancelOrErrorResponse, OnSuccessResponse } from './digitalriver';
 import DigitalRiverError from './digitalriver-error';
 import DigitalRiverPaymentStrategy from './digitalriver-payment-strategy';
 import DigitalRiverScriptLoader from './digitalriver-script-loader';
+import { BillingAddressActionCreator } from '../../../billing';
 
 describe('DigitalRiverPaymentStrategy', () => {
     let paymentMethodActionCreator: PaymentMethodActionCreator;
@@ -48,6 +49,7 @@ describe('DigitalRiverPaymentStrategy', () => {
     let submitPaymentAction: Observable<SubmitPaymentAction>;
     let storeCreditActionCreator: StoreCreditActionCreator;
     let applyStoreCreditAction: Observable<Action>;
+    let billingAddressActionCreator: BillingAddressActionCreator;
 
     beforeEach(() => {
         const scriptLoader = createScriptLoader();
@@ -108,7 +110,8 @@ describe('DigitalRiverPaymentStrategy', () => {
             orderActionCreator,
             paymentActionCreator,
             storeCreditActionCreator,
-            digitalRiverScriptLoader
+            digitalRiverScriptLoader,
+            billingAddressActionCreator
         );
 
     });

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -425,6 +425,21 @@ describe('DigitalRiverPaymentStrategy', () => {
                     methodId: 'paypal'
                 }
             }
+
+            const owner = {
+                address: {
+                    city: "Minnetonka",
+                    country: "US",
+                    line1: "10380 Bren Road W",
+                    postalCode: "55343",
+                    state: "MN"
+                },
+                email: "test@digitalriver.com",
+                firstName: "John",
+                lastName: "Doe",
+                phoneNumber: "000-000-0000"
+            };
+
             jest.spyOn(digitalRiverLoadResponse, 'createDropin').mockImplementation(configuration => {
                 onSuccessCallback = configuration.onSuccess;
 
@@ -436,19 +451,7 @@ describe('DigitalRiverPaymentStrategy', () => {
                 source: {
                     id: '1',
                     reusable: false,
-                    owner: {
-                        address: {
-                            city: "Minnetonka",
-                            country: "US",
-                            line1: "10380 Bren Road W",
-                            postalCode: "55343",
-                            state: "MN"
-                        },
-                        email: "test@digitalriver.com",
-                        firstName: "John",
-                        lastName: "Doe",
-                        phoneNumber: "000-000-0000"
-                    }
+                    owner: owner,
                 },
                 readyForStorage: true,
             });
@@ -471,19 +474,7 @@ describe('DigitalRiverPaymentStrategy', () => {
                                         source: {
                                             id: '1',
                                             reusable: false,
-                                            owner: {
-                                                address: {
-                                                    city: "Minnetonka",
-                                                    country: "US",
-                                                    line1: "10380 Bren Road W",
-                                                    postalCode: "55343",
-                                                    state: "MN"
-                                                },
-                                                email: "test@digitalriver.com",
-                                                firstName: "John",
-                                                lastName: "Doe",
-                                                phoneNumber: "000-000-0000"
-                                            }
+                                            owner: owner,
                                         },
                                         readyForStorage: true,
                                     },

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.spec.ts
@@ -25,7 +25,7 @@ import { PaymentInitializeOptions } from '../../payment-request-options';
 import PaymentRequestSender from '../../payment-request-sender';
 import PaymentRequestTransformer from '../../payment-request-transformer';
 import { getVaultedInstrument } from '../../payments.mock';
-import { getAdditionalActionError, getClientMock, getDigitalRiverJSMock, getDigitalRiverPaymentMethodMock, getInitializeOptionsMock, getOrderRequestBodyWithVaultedInstrument } from '../digitalriver/digitalriver.mock'
+import { getAdditionalActionError, getClientMock, getDigitalRiverJSMock, getDigitalRiverPaymentMethodMock, getInitializeOptionsMock, getOrderRequestBodyWithVaultedInstrument } from '../digitalriver/digitalriver.mock';
 
 import { AuthenticationSourceStatus, OnCancelOrErrorResponse, OnSuccessResponse } from './digitalriver';
 import DigitalRiverError from './digitalriver-error';

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -11,7 +11,7 @@ import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
-import { BillingAddressActionCreator } from '@bigcommerce/checkout-sdk/core';
+import { BillingAddressActionCreator } from '../../../billing';
 
 import DigitalRiverJS, { AuthenticationSourceStatus, DigitalRiverAdditionalProviderData, DigitalRiverAuthenticateSourceResponse, DigitalRiverDropIn, DigitalRiverElementOptions, DigitalRiverInitializeToken, OnCancelOrErrorResponse, OnReadyResponse, OnSuccessResponse } from './digitalriver';
 import DigitalRiverError from './digitalriver-error';
@@ -169,43 +169,43 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
     private _onSuccessResponse(data?: OnSuccessResponse): Promise<void> {
         const error = new InvalidArgumentError('Unable to initialize payment because success argument is not provided.');
 
-        return new Promise(async (resolve, reject) => {
+        return new Promise( (resolve, reject) => {
             if (data && this._submitFormEvent) {
                 const { browserInfo, owner } = data.source;
 
-                const billingAddressPayPal = {
-                    firstName: owner.firstName,
-                    lastName: owner.lastName,
-                    city: owner.address.city,
-                    company: '',
-                    address1: owner.address.line1,
-                    address2: '',
-                    postalCode: owner.address.postalCode,
-                    countryCode: owner.address.country,
-                    phone: owner.phoneNumber,
-                    stateOrProvince: owner.address.state,
-                    stateOrProvinceCode: owner.address.country,
-                    customFields: [],
-                    email: owner.email || owner.email,
-                };
+                if (owner) {
+                    const billingAddressPayPal = {
+                        firstName: owner.firstName,
+                        lastName: owner.lastName,
+                        city: owner.address.city,
+                        company: '',
+                        address1: owner.address.line1,
+                        address2: '',
+                        postalCode: owner.address.postalCode,
+                        countryCode: owner.address.country,
+                        phone: owner.phoneNumber,
+                        stateOrProvince: owner.address.state,
+                        stateOrProvinceCode: owner.address.country,
+                        customFields: [],
+                        email: owner.email || owner.email,
+                    };
 
-                await this._store.dispatch(
-                    this._billingAddressActionCreator.updateAddress(billingAddressPayPal)
-                );
+                    this._store.dispatch(this._billingAddressActionCreator.updateAddress(billingAddressPayPal)).then();
+                }
 
                 this._loadSuccessResponse = browserInfo ? {
                     source: {
                         id: data.source.id,
                         reusable: data.source.reusable,
                         ...browserInfo,
-                        owner: data.source.owner
+                        ...owner
                     },
                     readyForStorage: data.readyForStorage,
                 } : {
                     source: {
                         id: data.source.id,
                         reusable: data.source.reusable,
-                        owner: data.source.owner
+                        ...owner
                     },
                     readyForStorage: data.readyForStorage,
                 };

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -7,11 +7,11 @@ import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { StoreCreditActionCreator } from '../../../store-credit';
 import { PaymentArgumentInvalidError } from '../../errors';
 import { isVaultedInstrument, HostedInstrument } from '../../index';
+import { BillingAddressActionCreator } from '../../../billing';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategy from '../payment-strategy';
-import { BillingAddressActionCreator } from '../../../billing';
 
 import DigitalRiverJS, { AuthenticationSourceStatus, DigitalRiverAdditionalProviderData, DigitalRiverAuthenticateSourceResponse, DigitalRiverDropIn, DigitalRiverElementOptions, DigitalRiverInitializeToken, OnCancelOrErrorResponse, OnReadyResponse, OnSuccessResponse } from './digitalriver';
 import DigitalRiverError from './digitalriver-error';

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -169,9 +169,24 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
     private _onSuccessResponse(data?: OnSuccessResponse): Promise<void> {
         const error = new InvalidArgumentError('Unable to initialize payment because success argument is not provided.');
 
-        return new Promise( (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             if (data && this._submitFormEvent) {
                 const { browserInfo, owner } = data.source;
+
+                this._loadSuccessResponse = browserInfo ? {
+                    source: {
+                        id: data.source.id,
+                        reusable: data.source.reusable,
+                        ...browserInfo,
+                    },
+                    readyForStorage: data.readyForStorage,
+                } : {
+                    source: {
+                        id: data.source.id,
+                        reusable: data.source.reusable,
+                    },
+                    readyForStorage: data.readyForStorage,
+                };
 
                 if (owner) {
                     const billingAddressPayPal = {
@@ -189,26 +204,10 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
                         customFields: [],
                         email: owner.email || owner.email,
                     };
-
+                    this._loadSuccessResponse.source.owner = data.source.owner;
                     this._store.dispatch(this._billingAddressActionCreator.updateAddress(billingAddressPayPal)).then();
                 }
 
-                this._loadSuccessResponse = browserInfo ? {
-                    source: {
-                        id: data.source.id,
-                        reusable: data.source.reusable,
-                        ...browserInfo,
-                        ...owner
-                    },
-                    readyForStorage: data.readyForStorage,
-                } : {
-                    source: {
-                        id: data.source.id,
-                        reusable: data.source.reusable,
-                        ...owner
-                    },
-                    readyForStorage: data.readyForStorage,
-                };
                 resolve();
                 this._submitFormEvent();
             } else {

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver.ts
@@ -202,7 +202,7 @@ export interface OnSuccessResponse {
         browserInfo?: {
             browserIp?: string;
         };
-        owner: {
+        owner?: {
             email: string;
             firstName: string;
             lastName: string;

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver.ts
@@ -202,7 +202,20 @@ export interface OnSuccessResponse {
         browserInfo?: {
             browserIp?: string;
         };
-    };
+        owner: {
+            email: string;
+            firstName: string;
+            lastName: string;
+            phoneNumber: string;
+            address: {
+                city: string;
+                country: string;
+                line1: string;
+                postalCode: string;
+                state: string;
+            }
+        }
+    }
 
     /**
      * Indicates whether the source has been enabled for future use.


### PR DESCRIPTION
## What?
Support PayPal as APM for Digital River

## Why?
As a merchant using Digital River, I want to be able to accept payment with PayPal.
AC:
When enabled on Digital River account, PayPal displays within the DR drop-in component on my checkout page.

Shopper can pay with PayPal.
Merchant can void PayPal transaction from CP.
Merchant can capture PayPal transaction from CP.
Merchant can fully refund PayPal transaction from CP.
Merchant can partially refund PayPal transaction from CP.
reflect the correct billing address on the order in BC (if Paypal address is different from what was entered on the checkout form)
For a digital order , the tax must be calculated based on the billing address on the PayPal account

## Testing / Proof
https://user-images.githubusercontent.com/104527753/195113173-aafd0cf8-9b59-4073-9a25-6c067f723265.mov



@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
