### PR TITLE
feat(payment): INT-6443 Hide payPal onDigital River behind an experiment

### DIFF
--- a/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -231,9 +231,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
 
             this._submitFormEvent = this._getDigitalRiverInitializeOptions().onSubmitForm;
 
-            const disabledPaymentMethods: string[] = [
-                features['PROJECT-4802.digital_river_paypal_support'] ? null : 'payPal'
-            ].filter((x): x is string => x !== null);
+            const disabledPaymentMethods: string[] = features['PROJECT-4802.digital_river_paypal_support'] ? [] : ['payPal'];
 
             const digitalRiverConfiguration = {
                 sessionId: this._digitalRiverCheckoutData.sessionId,

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver-payment-strategy.ts
@@ -212,7 +212,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
             const state = await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(options.methodId));
             const billing = state.billingAddress.getBillingAddressOrThrow();
             const customer = state.customer.getCustomerOrThrow();
-            const {features} = state.config.getStoreConfigOrThrow().checkoutSettings;
+            const { features } = state.config.getStoreConfigOrThrow().checkoutSettings;
             const {paymentMethodConfiguration} = this._getDigitalRiverInitializeOptions().configuration;
             const {containerId, configuration} = this._getDigitalRiverInitializeOptions();
             const {clientToken} = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
@@ -231,7 +231,7 @@ export default class DigitalRiverPaymentStrategy implements PaymentStrategy {
 
             this._submitFormEvent = this._getDigitalRiverInitializeOptions().onSubmitForm;
 
-            const disabledPaymentMethods: string[] = features['PROJECT-4802.digital_river_paypal_support'] ? [] : ['payPal'];
+            const disabledPaymentMethods = features['PROJECT-4802.digital_river_paypal_support'] ? [] : ['payPal'];
 
             const digitalRiverConfiguration = {
                 sessionId: this._digitalRiverCheckoutData.sessionId,

--- a/packages/core/src/payment/strategies/digitalriver/digitalriver.ts
+++ b/packages/core/src/payment/strategies/digitalriver/digitalriver.ts
@@ -234,6 +234,10 @@ interface BaseElementOptions {
      * Set custom class names on the container DOM element when the Digital River element is in a particular state.
      */
     classes?: DigitalRiverElementClasses;
+    /**
+     * Use disabledPaymentMethods to disable specific payment methods.
+     */
+    disabledPaymentMethods?: string[];
 }
 
 /**


### PR DESCRIPTION
## What? [INT-6443](https://bigcommercecloud.atlassian.net/browse/INT-6443)
Implementation on Digital River of the availability/hide for PayPay APM using the 'disabledPaymentMethods'  behind the the experiment 'PROJECT-4802.digital_river_paypal_support'.

This implement a way to control the "disabledPaymentMethods" on the checkout strategy for Digital River.
When the experiment is on (true) PayPal will be disabled in the checkout for Digital River.
There is no side effect since it only controls the availability for PayPal on the checkout with Digital River.

## Why?
This is needed to control the availability of the PayPal flow on Digital River as requested.

## Testing / Proof
[Video Proof](https://drive.google.com/file/d/1a2pYhHrAywUL2QFRoMPnU4XATrTvSIyV/view?usp=sharing)


## Depends on
[feat(payment): INT-6443 experiment creation: 'PROJECT-4802.digital_river_paypal_support'](https://github.com/bigcommerce/bigcommerce/pull/49116)

## How can this change be undone in case of failure?
Revert PR

@bigcommerce/checkout @bigcommerce/payments
