### PR TITLE
feat(payment): PAYPAL-1631 BraintreePayPalCredit on PDP

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -104,6 +104,7 @@ export default function createCheckoutButtonRegistry(
         new BraintreePaypalCreditButtonStrategy(
             store,
             checkoutActionCreator,
+            cartRequestSender,
             braintreeSdkCreator,
             formPoster,
             window

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
@@ -1,4 +1,5 @@
 import { Address } from '../../../address';
+import { BuyNowCartRequestBody } from '../../../cart';
 import { StandardError } from '../../../common/error/errors';
 import { BraintreeError } from '../../../payment/strategies/braintree';
 import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
@@ -41,4 +42,16 @@ export interface BraintreePaypalCreditButtonInitializeOptions {
      * @param error - The error object describing the failure.
      */
     onError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * The option that used to initialize a PayPal script with provided currency code.
+     */
+    currencyCode?: string;
+
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    }
 }

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -1,13 +1,15 @@
-import { createAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
-import { createRequestSender } from '@bigcommerce/request-sender';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
+import { getCart } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 import { EventEmitter } from 'events';
-import { from } from 'rxjs';
 
-import { createCheckoutStore, CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
-import { getCheckout, getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { CartRequestSender } from '../../../cart';
+import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
+
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfig } from '../../../config/configs.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
@@ -25,6 +27,7 @@ import { BraintreePaypalCreditButtonInitializeOptions } from './braintree-paypal
 import BraintreePaypalCreditButtonStrategy from './braintree-paypal-credit-button-strategy';
 
 describe('BraintreePaypalCreditButtonStrategy', () => {
+    let cartRequestSender: CartRequestSender;
     let braintreeSDKCreator: BraintreeSDKCreator;
     let braintreeScriptLoader: BraintreeScriptLoader;
     let braintreePaypalCheckoutCreatorMock: BraintreePaypalCheckoutCreator;
@@ -33,6 +36,7 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
     let dataCollector: BraintreeDataCollector;
     let eventEmitter: EventEmitter;
     let formPoster: FormPoster;
+    let requestSender: RequestSender;
     let paymentMethodMock: PaymentMethod;
     let paypalButtonElement: HTMLDivElement;
     let paypalSdkMock: PaypalSDK;
@@ -56,6 +60,36 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
         braintreepaypalcredit: braintreePaypalCreditOptions,
     };
 
+    const buyNowCartMock = {
+        ...getCart(),
+        id: 999,
+        source: 'BUY_NOW',
+    };
+
+    const buyNowCartRequestBody: BuyNowCartRequestBody = {
+        source: 'BUY_NOW',
+        lineItems: [{
+            productId: 1,
+            quantity: 2,
+            optionSelections: {
+                optionId: 11,
+                optionValue: 11,
+            },
+        }],
+    };
+
+    const buyNowInitializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL_CREDIT,
+        containerId: defaultButtonContainerId,
+        braintreepaypalcredit: {
+            ...braintreePaypalCreditOptions,
+            currencyCode: 'USD',
+            buyNowInitializeOptions: {
+                getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
+            },
+        },
+    };
+
     beforeEach(() => {
         braintreePaypalCheckoutMock = getPaypalCheckoutMock();
         braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(braintreePaypalCheckoutMock, false);
@@ -64,11 +98,13 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
         eventEmitter = new EventEmitter();
 
         store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = createRequestSender();
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(createRequestSender()),
             new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
             new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender()))
         );
+        cartRequestSender = new CartRequestSender(requestSender);
         braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader());
         braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
         formPoster = createFormPoster();
@@ -78,6 +114,7 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
         strategy = new BraintreePaypalCreditButtonStrategy(
             store,
             checkoutActionCreator,
+            cartRequestSender,
             braintreeSDKCreator,
             formPoster,
             window
@@ -99,6 +136,7 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
         jest.spyOn(braintreeSDKCreator, 'getDataCollector').mockReturnValue(dataCollector);
         jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(braintreePaypalCheckoutCreatorMock);
         jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout').mockImplementation(() => {});
 
         jest.spyOn(paypalSdkMock, 'Buttons')
             .mockImplementation((options: PaypalButtonOptions) => {
@@ -214,6 +252,52 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
             expect(initializationOptions.braintreepaypalcredit?.onError).toHaveBeenCalled();
         });
 
+        it('does not load default checkout for BuyNowFlow', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(checkoutActionCreator.loadDefaultCheckout).not.toHaveBeenCalled();
+        });
+
+        it('throws an error if buy now cart request body data is not provided', async () => {
+            const buyNowInitializationOptions: CheckoutButtonInitializeOptions = {
+                methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL,
+                containerId: defaultButtonContainerId,
+                braintreepaypalcredit: {
+                    ...braintreePaypalCreditOptions,
+                    currencyCode: 'USD',
+                    buyNowInitializeOptions: {
+                        getBuyNowCartRequestBody: jest.fn().mockReturnValue(undefined),
+                    },
+                },
+            };
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(braintreePaypalCreditOptions.onPaymentError).toHaveBeenCalledWith(new MissingDataError(MissingDataErrorType.MissingCart));
+        });
+
+        it('creates order with Buy Now cart id (Buy Now flow)', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({ body: buyNowCartMock });
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            eventEmitter.emit('approve');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', expect.objectContaining({
+                cart_id: buyNowCartMock.id,
+            }));
+        });
+
         it('renders braintree paylater button', async () => {
             await strategy.initialize(initializationOptions);
 
@@ -292,12 +376,6 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
         });
 
         it('loads checkout details when customer is ready to pay', async () => {
-            jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout')
-                .mockReturnValue(() => from([
-                    createAction(CheckoutActionType.LoadCheckoutRequested),
-                    createAction(CheckoutActionType.LoadCheckoutSucceeded, getCheckout()),
-                ]));
-
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('createOrder');

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -1,8 +1,10 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 
-import { Address } from '../../../address';
-import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { CartRequestSender, Cart } from '../../../cart';
+import { BuyNowCartCreationError } from '../../../cart/errors';
+import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, StandardError } from '../../../common/error/errors';
+import PaymentMethod from '../../../payment/payment-method';
 import { mapToBraintreeShippingAddressOverride, BraintreeError, BraintreePaypalCheckout, BraintreeSDKCreator, BraintreeTokenizePayload } from '../../../payment/strategies/braintree';
 import { PaypalAuthorizeData, PaypalButtonStyleLabelOption, PaypalHostWindow } from '../../../payment/strategies/paypal';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
@@ -13,10 +15,15 @@ import getValidButtonStyle from './get-valid-button-style';
 import mapToLegacyBillingAddress from './map-to-legacy-billing-address';
 import mapToLegacyShippingAddress from './map-to-legacy-shipping-address';
 
+type BuyNowInitializeOptions = Pick<BraintreePaypalCreditButtonInitializeOptions, 'buyNowInitializeOptions'>;
+
 export default class BraintreePaypalCreditButtonStrategy implements CheckoutButtonStrategy {
+    private _buyNowCart?: Cart;
+
     constructor(
         private _store: CheckoutStore,
         private _checkoutActionCreator: CheckoutActionCreator,
+        private _cartRequestSender: CartRequestSender,
         private _braintreeSDKCreator: BraintreeSDKCreator,
         private _formPoster: FormPoster,
         private _window: PaypalHostWindow
@@ -37,15 +44,30 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
             throw new InvalidArgumentError(`Unable to initialize payment because "options.braintreepaypalcredit" argument is not provided.`);
         }
 
-        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
-        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        const currency = state.cart.getCartOrThrow()?.currency.code;
+        let state: InternalCheckoutSelectors;
+        let paymentMethod: PaymentMethod;
+        let currencyCode: string;
+
+        if (braintreepaypalcredit.buyNowInitializeOptions) {
+            state = this._store.getState();
+            paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+            if (!braintreepaypalcredit.currencyCode) {
+                throw new InvalidArgumentError(`Unable to initialize payment because "options.braintreepaypalcredit.currencyCode" argument is not provided.`);
+            }
+
+            currencyCode = braintreepaypalcredit.currencyCode;
+        } else {
+            state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+            paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+            currencyCode = state.cart.getCartOrThrow()?.currency.code;
+        }
 
         if (!paymentMethod.clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const paypalCheckoutOptions = { currency };
+        const paypalCheckoutOptions = { currency: currencyCode };
         const paypalCheckoutCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) =>
             this._renderPayPalButton(
                 braintreePaypalCheckout,
@@ -78,7 +100,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         methodId: string,
         testMode: boolean
     ): void {
-        const { style, shippingAddress, shouldProcessPayment, onAuthorizeError, onPaymentError } = braintreepaypalcredit;
+        const { style, shouldProcessPayment, onAuthorizeError } = braintreepaypalcredit;
         const { paypal } = this._window;
 
         let hasRenderedSmartButton = false;
@@ -98,7 +120,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
                         commit: false,
                         fundingSource,
                         style: buttonStyle,
-                        createOrder: () => this._setupPayment(braintreePaypalCheckout, shippingAddress, onPaymentError),
+                        createOrder: () => this._setupPayment(braintreePaypalCheckout, braintreepaypalcredit),
                         onApprove: (authorizeData: PaypalAuthorizeData) =>
                             this._tokenizePayment(authorizeData, braintreePaypalCheckout, methodId, shouldProcessPayment, onAuthorizeError),
                     });
@@ -118,15 +140,24 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
 
     private async _setupPayment(
         braintreePaypalCheckout: BraintreePaypalCheckout,
-        shippingAddress?: Address | null,
-        onError?: (error: BraintreeError | StandardError) => void
+        braintreepaypalcredit: BraintreePaypalCreditButtonInitializeOptions,
     ): Promise<string> {
-        const state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+        const { onPaymentError, shippingAddress, buyNowInitializeOptions } = braintreepaypalcredit;
+        let state: InternalCheckoutSelectors;
 
         try {
-            const checkout = state.checkout.getCheckoutOrThrow();
-            const config = state.config.getStoreConfigOrThrow();
+            this._buyNowCart = await this._createBuyNowCart({ buyNowInitializeOptions });
+
+            if (this._buyNowCart) {
+                state = this._store.getState();
+            } else {
+                state = await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
+            }
+
             const customer = state.customer.getCustomer();
+
+            const amount = this._buyNowCart ? this._buyNowCart?.cartAmount : state.checkout.getCheckoutOrThrow().outstandingBalance;
+            const currencyCode = braintreepaypalcredit.currencyCode ?? state.config.getStoreConfigOrThrow().currency.code;
 
             const address = shippingAddress || customer?.addresses?.[0];
             const shippingAddressOverride = address ? mapToBraintreeShippingAddressOverride(address) : undefined;
@@ -136,16 +167,34 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
                 enableShippingAddress: true,
                 shippingAddressEditable: false,
                 shippingAddressOverride,
-                amount: checkout.outstandingBalance,
-                currency: config.currency.code,
+                amount,
+                currency: currencyCode,
                 offerCredit: true,
             });
         } catch (error) {
-            if (onError) {
-                onError(error);
+            if (onPaymentError) {
+                onPaymentError(error);
             }
 
             throw error;
+        }
+    }
+
+    private async _createBuyNowCart({ buyNowInitializeOptions }: BuyNowInitializeOptions) {
+        if (typeof buyNowInitializeOptions?.getBuyNowCartRequestBody === 'function') {
+            const cartRequestBody = buyNowInitializeOptions.getBuyNowCartRequestBody();
+
+            if (!cartRequestBody) {
+                throw new MissingDataError(MissingDataErrorType.MissingCart);
+            }
+
+            try {
+                const { body: buyNowCart } = await this._cartRequestSender.createBuyNowCart(cartRequestBody);
+
+                return buyNowCart;
+            } catch (error) {
+                throw new BuyNowCartCreationError();
+            }
         }
     }
 
@@ -160,6 +209,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
             const { deviceData } = await this._braintreeSDKCreator.getDataCollector({ paypal: true });
             const tokenizePayload = await braintreePaypalCheckout.tokenizePayment(authorizeData);
             const { details, nonce } = tokenizePayload;
+            const buyNowCartId = this._buyNowCart?.id;
 
             this._formPoster.postForm('/checkout.php', {
                 payment_type: 'paypal',
@@ -169,6 +219,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
                 device_data: deviceData,
                 billing_address: JSON.stringify(mapToLegacyBillingAddress(details)),
                 shipping_address: JSON.stringify(mapToLegacyShippingAddress(details)),
+                ...buyNowCartId && { cart_id: buyNowCartId },
             });
 
             return tokenizePayload;


### PR DESCRIPTION
## What?
Quick payment button for BraintreePaypalCredit provider

## Why?

According to task [PAYPAL-1631](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1631)

## Testing / Proof

https://user-images.githubusercontent.com/99336044/197715660-511068ae-d7d6-4431-8b88-2f9890a449dd.mov







@bigcommerce/checkout @bigcommerce/payments
