### PR TITLE
fix(payment): PAYPAL-1730 fixed the issue with passing onComplete method for non hosted paypal flows

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -59,7 +59,7 @@ describe('PaypalCommerceButtonStrategy', () => {
         style: {
             height: 45,
         },
-        onComplete: () => {}
+        onComplete: () => {},
     };
 
     const initializationOptions: CheckoutButtonInitializeOptions = {
@@ -327,6 +327,52 @@ describe('PaypalCommerceButtonStrategy', () => {
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
             });
+        });
+
+        it('does not throw an error if onComplete method is not provided for default flow', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isHostedCheckoutEnabled: false,
+                },
+            });
+
+            const options = {
+                ...initializationOptions,
+                paypalcommerce: {
+                    ...initializationOptions.paypalcommerce,
+                    onComplete: undefined,
+                },
+            };
+
+            await strategy.initialize(options);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalled();
+        });
+
+        it('throws an error if onComplete method is not provided for shippingOptions flow', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            });
+
+            const options = {
+                ...initializationOptions,
+                paypalcommerce: {
+                    ...initializationOptions.paypalcommerce,
+                    onComplete: undefined,
+                },
+            };
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
         });
 
         it('renders PayPal button if it is eligible', async () => {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -73,12 +73,14 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
 
     private _renderButton(containerId: string, methodId: string, paypalcommerce: PaypalCommerceButtonInitializeOptions): void {
         const { buyNowInitializeOptions, initializesOnCheckoutPage, style, onComplete } = paypalcommerce;
+
+        const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
+
         const state = this._store.getState();
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
-        const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
 
-        if (!onComplete || typeof onComplete !== 'function') {
+        if (isHostedCheckoutEnabled && (!onComplete || typeof onComplete !== 'function')) {
             throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommerce.onComplete" argument is not provided or it is not a function.`);
         }
 
@@ -159,7 +161,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         data: ApproveCallbackPayload,
         actions: ApproveCallbackActions,
         methodId: string,
-        onComplete: () => void
+        onComplete?: () => void
     ): Promise<boolean> {
         const state = this._store.getState();
         const cart = state.cart.getCartOrThrow();
@@ -191,7 +193,10 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
 
             await this._store.dispatch(this._orderActionCreator.submitOrder({}, { params: { methodId } }));
             await this._submitPayment(methodId, data.orderID);
-            onComplete();
+
+            if (onComplete) {
+                onComplete();
+            }
 
             return true;
         } catch (error) {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
@@ -77,14 +77,15 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
     private _renderButton(containerId: string, methodId: string, paypalcommercecredit: PaypalCommerceCreditButtonInitializeOptions): void {
         const { buyNowInitializeOptions, initializesOnCheckoutPage, style, onComplete } = paypalcommercecredit;
 
-        if (!onComplete || typeof onComplete !== 'function') {
-            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommerce.onComplete" argument is not provided or it is not a function.`);
-        }
-
         const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
+
         const state = this._store.getState();
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-        const { initializationData: { isHostedCheckoutEnabled } } = paymentMethod;
+        const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
+
+        if (isHostedCheckoutEnabled && (!onComplete || typeof onComplete !== 'function')) {
+            throw new InvalidArgumentError(`Unable to initialize payment because "options.paypalcommercecredit.onComplete" argument is not provided or it is not a function.`);
+        }
 
         const hostedCheckoutCallbacks = {
             onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) => this._onShippingAddressChange(data),
@@ -96,6 +97,7 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
         const regularCallbacks = {
             onApprove: ({ orderID }: ApproveCallbackPayload) => this._tokenizePayment(methodId, orderID),
         };
+
         const paypalCallbacks = isHostedCheckoutEnabled ? hostedCheckoutCallbacks : regularCallbacks;
 
         const fundingSources = [paypalCommerceSdk.FUNDING.PAYLATER, paypalCommerceSdk.FUNDING.CREDIT];
@@ -151,7 +153,7 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
         data: ApproveCallbackPayload,
         actions: ApproveCallbackActions,
         methodId: string,
-        onComplete: () => void
+        onComplete?: () => void
     ): Promise<boolean> {
         const state = this._store.getState();
         const cart = state.cart.getCartOrThrow();
@@ -179,7 +181,10 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
 
         await this._store.dispatch(this._orderActionCreator.submitOrder({}, { params: { methodId } }));
         await this._submitPayment(methodId, data.orderID);
-        onComplete();
+
+        if (onComplete) {
+            onComplete();
+        }
 
         return true;
     }

--- a/packages/core/src/payment/payment-methods.mock.ts
+++ b/packages/core/src/payment/payment-methods.mock.ts
@@ -113,6 +113,7 @@ export function getPaypalCommerce(): PaymentMethod {
             isPayPalCreditAvailable: false,
             isVenmoEnabled: false,
             shouldRenderFields: true,
+            isHostedCheckoutEnabled: false,
         },
         type: 'PAYMENT_TYPE_API',
     };


### PR DESCRIPTION
## What?
Fixed the issue with passing onComplete method for non hosted PayPal flows

## Why?
The default PayPal buttons did not work without passing onComplete methods because of the thrown error

## Testing / Proof
Unit tests
Manual tests

Before:
<img width="1792" alt="Screenshot 2022-10-18 at 13 19 36" src="https://user-images.githubusercontent.com/25133454/196422830-7b8864f2-d546-4369-8ec6-6d4eebf1eeaa.png">

After: 
<img width="1792" alt="Screenshot 2022-10-18 at 13 24 54" src="https://user-images.githubusercontent.com/25133454/196422866-02a0eeea-deb4-4895-8faa-750c7bfe8a39.png">

