### PR TITLE
fix(payment): INT-6772 WorldpayAcces supported in firefox

### DIFF
--- a/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.spec.ts
@@ -262,7 +262,7 @@ describe('WorldpayaccessPaymetStrategy', () => {
                 .toHaveBeenCalledTimes(2);
         })
 
-        it('throws error when url in hidden ifreme is invalid', async () => {
+        it('throws error when url in hidden iframe is invalid', async () => {
             window.fetch = jest.fn(() => Promise.resolve({ok: false}));
 
             jest.spyOn(orderActionCreator, 'loadCurrentOrder')

--- a/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/worldpayaccess/worldpayaccess-payment-strategy.ts
@@ -151,7 +151,11 @@ export default class WorldpayaccessPaymetStrategy extends CreditCardPaymentStrat
         button.id = 'btnsubmit';
         form.appendChild(button);
 
-        iframe.contentWindow.document.body.appendChild(form);
+        if (navigator.userAgent.match('Firefox')) {
+            iframe.srcdoc = form.outerHTML
+        } else {
+            iframe.contentWindow.document.body.appendChild(form)
+        }
 
         const script = document.createElement('script');
         script.innerHTML = `


### PR DESCRIPTION
## What? [INT-6772](https://bigcommercecloud.atlassian.net/browse/INT-6772)

**worldpayaccess-payment-strategy.ts**
- Insert form in the hidden iframe with the script 

## Why?
Payments with WorldpayAccess were not working on Firefox due to an iframe not being injected properly.
This iframe contains a hidden form needed to retrieve device data requested by Worldpay's 3DS verification. Due to this error, the payment can not be processed

## Testing / Proof
[Video](https://drive.google.com/file/d/1sWq1uNEbLiWfF6wTVk_6xVc0lOIgQTZb/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
