### PR TITLE
fix(payment): PAYPAL-1725 fixed the issue with passing fake data as customer address from last session in PayPalCommerceInlineCheckoutButtonStrategy

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
@@ -334,6 +334,36 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
     });
 
     describe('#_createOrder button callback', () => {
+        it('resets customers data before creating PayPal order', async () => {
+            const emptyAddress = {
+                firstName: '',
+                lastName: '',
+                email: '',
+                phone: '',
+                company: '',
+                address1: '',
+                address2: '',
+                city: '',
+                countryCode: '',
+                postalCode: '',
+                stateOrProvince: '',
+                stateOrProvinceCode: '',
+                customFields: [],
+            };
+
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue({ orderID: paypalOrderId });
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(emptyAddress);
+            expect(consignmentActionCreator.updateAddress).toHaveBeenCalledWith(emptyAddress);
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, initializationOptions.methodId);
+        });
+
         it('creates PayPal order', async () => {
             jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue({ orderID: paypalOrderId });
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
@@ -110,6 +110,8 @@ export default class PaypalCommerceInlineCheckoutButtonStrategy implements Check
         const state = this._store.getState();
         const cart = state.cart.getCartOrThrow();
 
+        await this._resetCustomersAddress();
+
         const { orderId } = await this._paypalCommerceRequestSender.createOrder(cart.id, methodId);
 
         return orderId;
@@ -243,6 +245,17 @@ export default class PaypalCommerceInlineCheckoutButtonStrategy implements Check
         return shippingOptionToSelect;
     }
 
+    private async _resetCustomersAddress(): Promise<void> {
+        const emptyAddress = this._getEmptyAddress();
+
+        try {
+            await this._store.dispatch(this._billingAddressActionCreator.updateAddress(emptyAddress));
+            await this._store.dispatch(this._consignmentActionCreator.updateAddress(emptyAddress));
+        } catch (error) {
+            throw new Error(error);
+        }
+    }
+
     private _transformAddress(address?: Partial<BillingAddressRequestBody>): BillingAddressRequestBody {
         return {
             firstName: address?.firstName || 'Fake',
@@ -276,6 +289,24 @@ export default class PaypalCommerceInlineCheckoutButtonStrategy implements Check
             postalCode: address?.postal_code,
             stateOrProvinceCode: address?.admin_area_1,
         });
+    }
+
+    private _getEmptyAddress(): BillingAddressRequestBody {
+        return {
+            firstName: '',
+            lastName: '',
+            email: '',
+            phone: '',
+            company: '',
+            address1: '',
+            address2: '',
+            city: '',
+            countryCode: '',
+            postalCode: '',
+            stateOrProvince: '',
+            stateOrProvinceCode: '',
+            customFields: [],
+        };
     }
 
     private _getElementByDataId(dataId: string): HTMLElement | null {


### PR DESCRIPTION
## What?
Fixed the issue with passing fake data as customer address from last session in PayPalCommerceInlineCheckoutButtonStrategy by clearing billing and consignment address before creating PayPal order

## Why?
Sometimes user can skip accelerated checkout in an unfinished state. In this case, fake data, that used to operate with shipping options before getting valid data from paypal, saves in checkout state. The user gets prev saved fake data from prev session in current one.

This code fixes this issue.

## Testing / Proof
Manual tests
Unit tests

Before:
Fake data can be found in shipping address section
<img width="1158" alt="Screenshot 2022-10-19 at 15 20 48" src="https://user-images.githubusercontent.com/25133454/196692030-71356c3a-ea21-4a08-8b79-c8d71705b5c6.png">

After:
The user sees prefilled shipping address from user's paypal account
<img width="1153" alt="Screenshot 2022-10-19 at 15 21 43" src="https://user-images.githubusercontent.com/25133454/196692147-0e18f196-6203-42d2-8ef4-6b715132ccd8.png">
