### PR TITLE
feat(payment): STRIPE-183 persisting stripe components when reloads the page

### DIFF
--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.spec.ts
@@ -5,6 +5,7 @@ import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { MutationObserverFactory } from '../../../common/dom';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
@@ -115,6 +116,16 @@ describe('StripeUpeCustomerStrategy', () => {
             expect(stripeUPEJsMock.elements).toHaveBeenCalledTimes(1);
         });
 
+        it('loads a single instance of StripeUPEClient and StripeElements when email is provided', async () => {
+            jest.spyOn(store.getState().billingAddress, 'getBillingAddress')
+                .mockReturnValue(getBillingAddress());
+
+            await expect(strategy.initialize(customerInitialization)).resolves.toBe(store.getState());
+
+            expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
+            expect(stripeUPEJsMock.elements).toHaveBeenCalledTimes(1);
+        });
+
         it('triggers onChange event callback, dispatches correct action and mounts component', async () => {
             const stripeMockElement: StripeElement = {
                 destroy: jest.fn(),
@@ -134,7 +145,7 @@ describe('StripeUpeCustomerStrategy', () => {
 
             expect(store.dispatch).toHaveBeenNthCalledWith(2, expectedAction);
             expect(customerInitialization.stripeupe?.onEmailChange).toHaveBeenCalledWith(true, 'foo@bar');
-            expect(customerInitialization.stripeupe?.isLoading).toHaveBeenCalled(), 
+            expect(customerInitialization.stripeupe?.isLoading).toHaveBeenCalled();
             expect(stripeMockElement.mount).toHaveBeenCalledWith(expect.any(String));
         });
 

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -2,7 +2,7 @@ import { createAction } from '@bigcommerce/data-store';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import { PaymentMethodActionCreator } from '../../../payment';
-import { StripeElements, StripeElementType, StripeScriptLoader, StripeUPEClient, StripeEventType, StripeUPEAppearanceOptions } from '../../../payment/strategies/stripe-upe';
+import { StripeElements, StripeElementType, StripeScriptLoader, StripeUPEClient, StripeEventType, StripeUPEAppearanceOptions, StripeSessionStorageKey } from '../../../payment/strategies/stripe-upe';
 import CustomerActionCreator from '../../customer-action-creator';
 import { CustomerActionType } from '../../customer-actions';
 import CustomerCredentials from '../../customer-credentials';
@@ -91,8 +91,8 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
                 }
                 if (event.complete) {
                     onEmailChange(event.authenticated, event.value.email);
-                    if (isStripeLinkAuthenticated === undefined && sessionStorage.getItem('stripeLink') != 'customerReloaded') {
-                        sessionStorage.setItem('stripeLink', 'customer');
+                    if (isStripeLinkAuthenticated === undefined && sessionStorage.getItem('stripeLink') != StripeSessionStorageKey.CUSTOMER_RELOADED) {
+                        sessionStorage.setItem('stripeLink', StripeSessionStorageKey.CUSTOMER);
                     }
                     this._store.dispatch(createAction(CustomerActionType.StripeLinkAuthenticated, event.authenticated));
                 } else {

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -91,7 +91,7 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
                 }
                 if (event.complete) {
                     onEmailChange(event.authenticated, event.value.email);
-                    if (isStripeLinkAuthenticated === undefined && sessionStorage.getItem('stripeLink') != StripeSessionStorageKey.CUSTOMER_RELOADED) {
+                    if (isStripeLinkAuthenticated === undefined && sessionStorage.getItem('stripeLink') !== StripeSessionStorageKey.CUSTOMER_RELOADED) {
                         sessionStorage.setItem('stripeLink', StripeSessionStorageKey.CUSTOMER);
                     }
                     this._store.dispatch(createAction(CustomerActionType.StripeLinkAuthenticated, event.authenticated));

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -81,7 +81,8 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
             });
 
             const billingAddress = this._store.getState().billingAddress.getBillingAddress();
-            const options = billingAddress?.email? { defaultValues: { email: billingAddress?.email } } : { } ;
+            const { email: billingEmail }  = billingAddress || {};
+            const options = billingEmail ? { defaultValues: { email: billingEmail } } : {};
             const linkAuthenticationElement = this._stripeElements.getElement(StripeElementType.AUTHENTICATION) ||
                 this._stripeElements.create(StripeElementType.AUTHENTICATION, options);
 

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -850,7 +850,8 @@ export default function createPaymentStrategyRegistry(
             paymentActionCreator,
             orderActionCreator,
             new StripeUPEScriptLoader(scriptLoader),
-            storeCreditActionCreator
+            storeCreditActionCreator,
+            billingAddressActionCreator
         )
     );
 

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
@@ -61,6 +61,18 @@ export function getStripeUPEOrderRequestBodyMock(stripePaymentMethodType: Stripe
     };
 }
 
+export function getStripeUPEWithLinkOrderRequestBodyMock(stripePaymentMethodType: StripePaymentMethodType = StripePaymentMethodType.CreditCard, shouldSaveInstrument = false): OrderRequestBody {
+    return {
+        payment: {
+            gatewayId: 'stripeupe',
+            methodId: stripePaymentMethodType,
+            paymentData: {
+                shouldSaveInstrument,
+            },
+        },
+    };
+}
+
 export function getStripeUPEOrderRequestBodyVaultMock(stripePaymentMethodType: StripePaymentMethodType = StripePaymentMethodType.CreditCard, shouldSetAsDefaultInstrument = false): OrderRequestBody {
     return {
         payment: {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -355,10 +355,3 @@ export enum StripeElementType {
     AUTHENTICATION = 'linkAuthentication',
     SHIPPING = 'shippingAddress',
 }
-
-export enum StripeSessionStorageKey {
-    CUSTOMER_RELOADED = 'customerReloaded',
-    CUSTOMER = 'customer',
-    SHIPPING = 'shipping',
-    SHIPPING_RELOADED = 'shippingReloaded',
-}

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -177,7 +177,24 @@ export interface WalletOptions {
 export interface StripeElementsCreateOptions {
     fields?: FieldsOptions;
     wallets?: WalletOptions;
-    allowedCountries?: any;
+    allowedCountries?: string[];
+    defaultValues?: ShippingDefaultValues | CustomerDefaultValues;
+}
+
+interface ShippingDefaultValues {
+    name: string;
+    address: {
+        line1: string;
+        line2: string;
+        city: string;
+        state: string;
+        postal_code: string;
+        country: string;
+    };
+}
+
+interface CustomerDefaultValues {
+    email: string;
 }
 
 export interface StripeElements {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -355,3 +355,10 @@ export enum StripeElementType {
     AUTHENTICATION = 'linkAuthentication',
     SHIPPING = 'shippingAddress',
 }
+
+export enum StripeSessionStorageKey {
+    CUSTOMER_RELOADED = 'customerReloaded',
+    CUSTOMER = 'customer',
+    SHIPPING = 'shipping',
+    SHIPPING_RELOADED = 'shippingReloaded',
+}

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-initialize-options.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-initialize-options.ts
@@ -41,4 +41,11 @@ export default interface StripeUPEShippingInitializeOptions {
     getStyles?(): {
         [key: string]: string;
     };
+
+    /**
+     * get the state code needed for shipping stripe element
+     * @param country
+     * @param state
+     */
+    getStripeState(country: string, state: string): string;
 }

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
@@ -17,7 +17,7 @@ import {
     PaymentMethodActionType, PaymentMethodRequestSender
 } from '../../../payment';
 import { getStripeUPE } from '../../../payment/payment-methods.mock';
-import { StripeScriptLoader, StripeUPEClient } from '../../../payment/strategies/stripe-upe';
+import { StripeHostWindow, StripeScriptLoader, StripeUPEClient } from '../../../payment/strategies/stripe-upe';
 import ConsignmentActionCreator from '../../consignment-action-creator';
 import { ConsignmentActionType } from '../../consignment-actions';
 import ConsignmentRequestSender from '../../consignment-request-sender';
@@ -79,10 +79,21 @@ describe('StripeUPEShippingStrategy', () => {
         });
 
         afterEach(() => {
+            delete (window as StripeHostWindow).bcStripeElements;
             jest.resetAllMocks();
         });
 
         it('loads a single instance of StripeUPEClient and StripeElements', async () => {
+            await expect(strategy.initialize(shippingInitialization)).resolves.toBe(store.getState());
+
+            expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
+            expect(stripeUPEJsMock.elements).toHaveBeenCalledTimes(1);
+        });
+
+        it('loads a single instance of StripeUPEClient and StripeElements when shipping data is provided', async () => {
+            jest.spyOn(store.getState().shippingAddress, 'getShippingAddress')
+                .mockReturnValue(getShippingAddress());
+
             await expect(strategy.initialize(shippingInitialization)).resolves.toBe(store.getState());
 
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -3,7 +3,7 @@ import { PaymentMethodActionCreator } from '../../../payment';
 import { AddressRequestBody } from '../../../address';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { StripeElements, StripeElementType, StripeEventType, StripeScriptLoader, StripeUPEAppearanceOptions, StripeUPEClient } from '../../../payment/strategies/stripe-upe';
+import { StripeElements, StripeElementType, StripeEventType, StripeScriptLoader, StripeSessionStorageKey, StripeUPEAppearanceOptions, StripeUPEClient } from '../../../payment/strategies/stripe-upe';
 import ConsignmentActionCreator from '../../consignment-action-creator';
 import { ShippingInitializeOptions, ShippingRequestOptions } from '../../shipping-request-options';
 import ShippingStrategy from '../shipping-strategy';
@@ -110,10 +110,10 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
             }
         };
 
-        if (shipping?.address1 && sessionStorage.getItem('stripeLink') == 'customerReloaded') {
-            sessionStorage.setItem('stripeLink', 'shippingReloaded');
+        if (shipping?.address1 && sessionStorage.getItem('stripeLink') == StripeSessionStorageKey.CUSTOMER_RELOADED) {
+            sessionStorage.setItem('stripeLink', StripeSessionStorageKey.SHIPPING_RELOADED);
         } else {
-            sessionStorage.setItem('stripeLink', 'shipping');
+            sessionStorage.setItem('stripeLink', StripeSessionStorageKey.SHIPPING);
         }
 
         const shippingAddressElement = this._stripeElements.getElement(StripeElementType.SHIPPING) ||

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -3,7 +3,7 @@ import { PaymentMethodActionCreator } from '../../../payment';
 import { AddressRequestBody } from '../../../address';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
-import { StripeElements, StripeElementType, StripeEventType, StripeScriptLoader, StripeSessionStorageKey, StripeUPEAppearanceOptions, StripeUPEClient } from '../../../payment/strategies/stripe-upe';
+import { StripeElements, StripeElementType, StripeEventType, StripeScriptLoader, StripeUPEAppearanceOptions, StripeUPEClient } from '../../../payment/strategies/stripe-upe';
 import ConsignmentActionCreator from '../../consignment-action-creator';
 import { ShippingInitializeOptions, ShippingRequestOptions } from '../../shipping-request-options';
 import ShippingStrategy from '../shipping-strategy';
@@ -109,12 +109,6 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
                 }
             }
         };
-
-        if (shipping?.address1 && sessionStorage.getItem('stripeLink') == StripeSessionStorageKey.CUSTOMER_RELOADED) {
-            sessionStorage.setItem('stripeLink', StripeSessionStorageKey.SHIPPING_RELOADED);
-        } else {
-            sessionStorage.setItem('stripeLink', StripeSessionStorageKey.SHIPPING);
-        }
 
         const shippingAddressElement = this._stripeElements.getElement(StripeElementType.SHIPPING) ||
             this._stripeElements.create(StripeElementType.SHIPPING, option);

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -98,7 +98,7 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
         const option = {
             allowedCountries: [availableCountries],
             defaultValues: {
-                name: shipping?.lastName? `${shipping.firstName} ${shipping.lastName}`: shipping?.firstName  || '',
+                name: shipping?.lastName ? `${shipping.firstName} ${shipping.lastName}`: shipping?.firstName  || '',
                 address: {
                     line1: shipping?.address1 || '',
                     line2: shipping?.address2  || '',

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
@@ -28,6 +28,7 @@ export function getStripeUPEShippingInitializeOptionsMock(): ShippingInitializeO
             onChangeShipping: jest.fn(),
             availableCountries: 'US,MX',
             getStyles: jest.fn(),
+            getStripeState: jest.fn()
         },
     };
 }


### PR DESCRIPTION
## What? [STRIPE-183](https://bigcommercecloud.atlassian.net/browse/STRIPE-183) & [STRIPE-195](https://bigcommercecloud.atlassian.net/browse/STRIPE-195)

Persisting data to use when checkout is reloaded, to achieve this we are forcing to load again shipping and customer steps on checkout to refill Stripe components and preserve Stripe behavior, in addition to improving the user experience, we make these steps auto-skip once it finishes loading

## Why?
For **STRIPE-183**, Link Enrollment Opt-In Disappears If Shopper Navigates Away From Checkout because the information is not persisting & for **STRIPE-195** I want to allow shoppers whose email address is both enrolled in Link and has a merchant registered account to skip the sign-in prompt if they successfully authenticate with Link so that they are not asked to authenticate with two different accounts 
## Testing / Proof
[VIDEO STRIPE-183](https://drive.google.com/file/d/1ccuz-hfTxp-3mSgfiJpM2V6CImRdA91P/view?usp=sharing)
[VIDEO STRIPE-195](https://drive.google.com/file/d/1RzP3klUD8DGnnRhc5Y9LUNk6q0iYIu8R/view?usp=sharing)

## Depends on 
https://github.com/bigcommerce/checkout-js/pull/1072

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
