### PR TITLE
refactor(payment): PAYPAL-1742 removed Fake data implementation due to BE changes

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
@@ -334,36 +334,6 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
     });
 
     describe('#_createOrder button callback', () => {
-        it('resets customers data before creating PayPal order', async () => {
-            const emptyAddress = {
-                firstName: '',
-                lastName: '',
-                email: '',
-                phone: '',
-                company: '',
-                address1: '',
-                address2: '',
-                city: '',
-                countryCode: '',
-                postalCode: '',
-                stateOrProvince: '',
-                stateOrProvinceCode: '',
-                customFields: [],
-            };
-
-            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue({ orderID: paypalOrderId });
-
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('createOrder');
-
-            await new Promise(resolve => process.nextTick(resolve));
-
-            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(emptyAddress);
-            expect(consignmentActionCreator.updateAddress).toHaveBeenCalledWith(emptyAddress);
-            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(cartMock.id, initializationOptions.methodId);
-        });
-
         it('creates PayPal order', async () => {
             jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue({ orderID: paypalOrderId });
 
@@ -380,12 +350,12 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
     describe('#_onShippingAddressChange button callback', () => {
         it('updates billing and consignment address with data returned from PayPal', async () => {
             const providedAddress = {
-                firstName: 'Fake',
-                lastName: 'Fake',
-                email: 'fake@fake.fake',
+                firstName: '',
+                lastName: '',
+                email: '',
                 phone: '',
                 company: '',
-                address1: 'Fake street',
+                address1: '',
                 address2: '',
                 city: paypalShippingAddressPayloadMock.city,
                 countryCode: paypalShippingAddressPayloadMock.country_code,


### PR DESCRIPTION
## What?
We used some 'Fake' data to fill all required empty fields to make an ability to create paypal order. We removed 'Fake' data implementation in this PR.

## Why?
We found a way how to avoid using 'Fake' data in Checkout SDK.

## Testing / Proof
Unit tests
Manual tests
