### PR TITLE
fix(payment): INT-6848 AmazonPayV2: Render the button in a container created programmatically

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -4,11 +4,9 @@ import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, createChec
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
-import { getConfig } from '../../../config/configs.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
-import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
-import { AmazonPayV2ButtonParams, AmazonPayV2PaymentProcessor, AmazonPayV2Placement, createAmazonPayV2PaymentProcessor } from '../../../payment/strategies/amazon-pay-v2';
-import { getAmazonPayV2ButtonParamsMock } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
+import { getAmazonPayV2, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { AmazonPayV2PaymentProcessor, AmazonPayV2Placement, createAmazonPayV2PaymentProcessor } from '../../../payment/strategies/amazon-pay-v2';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
 import AmazonPayV2ButtonStrategy from './amazon-pay-v2-button-strategy';
@@ -23,6 +21,8 @@ describe('AmazonPayV2ButtonStrategy', () => {
     let strategy: AmazonPayV2ButtonStrategy;
 
     beforeEach(() => {
+        checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
+
         store = createCheckoutStore(getCheckoutStoreState());
 
         requestSender = createRequestSender();
@@ -33,83 +33,75 @@ describe('AmazonPayV2ButtonStrategy', () => {
             new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
         );
 
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout')
+            .mockResolvedValue(store.getState());
+
         paymentProcessor = createAmazonPayV2PaymentProcessor();
+
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockResolvedValue(undefined);
+
+        jest.spyOn(paymentProcessor, 'renderAmazonPayButton')
+            .mockResolvedValue('foo');
+
+        jest.spyOn(paymentProcessor, 'deinitialize')
+            .mockResolvedValue(undefined);
 
         strategy = new AmazonPayV2ButtonStrategy(
             store,
             checkoutActionCreator,
             paymentProcessor
         );
-
-        checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
-
-        jest.spyOn(paymentProcessor, 'initialize')
-            .mockReturnValue(Promise.resolve());
-
-        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout')
-            .mockResolvedValue(store.getState());
-
-        const buttonContainer = document.createElement('div');
-        buttonContainer.setAttribute('id', 'amazonpayCheckoutButton');
-        document.body.appendChild(buttonContainer);
-
-        jest.spyOn(paymentProcessor, 'createButton')
-            .mockReturnValue(document.createElement('button'));
     });
 
-    afterEach(() => {
-        const buttonContainer = document.getElementById('amazonpayCheckoutButton');
-
-        if (buttonContainer) {
-            document.body.removeChild(buttonContainer);
-        }
-    });
-
-    describe('#initialize()', () => {
-        it('initialises the payment processor once', async () => {
+    describe('#initialize', () => {
+        it('should initialize the processor', async () => {
             await strategy.initialize(checkoutButtonOptions);
 
-            expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(getAmazonPayV2());
         });
 
         it('loads the checkout if AmazonPayV2ButtonInitializeOptions is not provided', async () => {
+            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedAmazonPay);
+
             await strategy.initialize(checkoutButtonOptions);
 
-            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalledTimes(1);
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalled();
         });
 
         it('does not load the checkout if AmazonPayV2ButtonInitializeOptions is provided', async () => {
-            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
-
             await strategy.initialize(checkoutButtonOptions);
 
             expect(checkoutActionCreator.loadDefaultCheckout).not.toHaveBeenCalled();
         });
 
-        it('creates the button', async () => {
-            const expectedOptions = getAmazonPayV2ButtonParamsMock() as AmazonPayV2ButtonParams;
-            expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
-            expectedOptions.placement = AmazonPayV2Placement.Cart;
-
+        it('should render the button', async () => {
             await strategy.initialize(checkoutButtonOptions);
 
-            expect(paymentProcessor.createButton).toHaveBeenCalledWith(
-                'amazonpayCheckoutButton',
-                expectedOptions
-            );
+            expect(paymentProcessor.renderAmazonPayButton).toHaveBeenCalledWith({
+                checkoutState: store.getState(),
+                containerId: 'amazonpayCheckoutButton',
+                methodId: 'amazonpay',
+                options: checkoutButtonOptions.amazonpay,
+                placement: AmazonPayV2Placement.Cart,
+            });
         });
 
         describe('should fail...', () => {
             test('if methodId is not provided', async () => {
                 checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedMethodId);
 
-                await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+                const initialize = strategy.initialize(checkoutButtonOptions);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
             });
 
             test('if containerId is not provided', async () => {
                 checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.UndefinedContainer);
 
-                await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(InvalidArgumentError);
+                const initialize = strategy.initialize(checkoutButtonOptions);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
             });
 
             test('if there is no payment method data', async () => {
@@ -122,20 +114,18 @@ describe('AmazonPayV2ButtonStrategy', () => {
                     paymentProcessor
                 );
 
-                await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(MissingDataError);
+                const initialize = strategy.initialize(checkoutButtonOptions);
+
+                await expect(initialize).rejects.toThrow(MissingDataError);
             });
         });
-
     });
 
-    describe('#deinitialize()', () => {
+    describe('#deinitialize', () => {
         it('succesfully deinitializes the strategy', async () => {
-            await strategy.initialize(checkoutButtonOptions);
             await strategy.deinitialize();
 
-            const buttonContainer = document.getElementById(checkoutButtonOptions.containerId);
-
-            expect(buttonContainer).toBeNull();
+            expect(paymentProcessor.deinitialize).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -1,13 +1,13 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
-import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { getConfig } from '../../../config/configs.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
-import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor, AmazonPayV2Placement, AmazonPayV2ButtonParams } from '../../../payment/strategies/amazon-pay-v2';
+import { AmazonPayV2ButtonParams, AmazonPayV2PaymentProcessor, AmazonPayV2Placement, createAmazonPayV2PaymentProcessor } from '../../../payment/strategies/amazon-pay-v2';
 import { getAmazonPayV2ButtonParamsMock } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -5,8 +5,6 @@ import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy {
-    private _walletButton?: HTMLElement;
-
     constructor(
         private _store: CheckoutStore,
         private _checkoutActionCreator: CheckoutActionCreator,
@@ -28,22 +26,16 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
             await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         }
 
-        this._walletButton =
-            this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
-                checkoutState: this._store.getState(),
-                containerId,
-                methodId,
-                options: amazonpay,
-                placement: AmazonPayV2Placement.Cart,
-            });
+        this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
+            checkoutState: this._store.getState(),
+            containerId,
+            methodId,
+            options: amazonpay,
+            placement: AmazonPayV2Placement.Cart,
+        });
     }
 
     deinitialize(): Promise<void> {
-        if (this._walletButton && this._walletButton.parentNode) {
-            this._walletButton.parentNode.removeChild(this._walletButton);
-            this._walletButton = undefined;
-        }
-
-        return Promise.resolve();
+        return this._amazonPayV2PaymentProcessor.deinitialize();
     }
 }

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
@@ -2,7 +2,7 @@ import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { of } from 'rxjs';
 
-import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotImplementedError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
@@ -10,12 +10,12 @@ import { getConfig } from '../../../config/configs.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
-import { createAmazonPayV2PaymentProcessor, AmazonPayV2PaymentProcessor, AmazonPayV2ButtonParams } from '../../../payment/strategies/amazon-pay-v2';
+import { AmazonPayV2ButtonParams, AmazonPayV2PaymentProcessor, createAmazonPayV2PaymentProcessor } from '../../../payment/strategies/amazon-pay-v2';
 import { getAmazonPayV2ButtonParamsMock } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
 import { RemoteCheckoutActionCreator, RemoteCheckoutActionType, RemoteCheckoutRequestSender } from '../../../remote-checkout';
 import { CustomerInitializeOptions } from '../../customer-request-options';
 
-import { AmazonPayV2CustomerInitializeOptions } from '.';
+import AmazonPayV2CustomerInitializeOptions from './amazon-pay-v2-customer-initialize-options';
 import AmazonPayV2CustomerStrategy from './amazon-pay-v2-customer-strategy';
 import { getAmazonPayV2CustomerInitializeOptions, Mode } from './amazon-pay-v2-customer.mock';
 

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
@@ -7,8 +7,6 @@ import { CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethod
 import CustomerStrategy from '../customer-strategy';
 
 export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
-    private _walletButton?: HTMLElement;
-
     constructor(
         private _store: CheckoutStore,
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
@@ -31,24 +29,20 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
 
         await this._amazonPayV2PaymentProcessor.initialize(getPaymentMethodOrThrow(methodId));
 
-        this._walletButton =
-            this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
-                checkoutState: this._store.getState(),
-                containerId: amazonpay.container,
-                methodId,
-                placement: AmazonPayV2Placement.Checkout,
-            });
+        this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
+            checkoutState: this._store.getState(),
+            containerId: amazonpay.container,
+            methodId,
+            placement: AmazonPayV2Placement.Checkout,
+        });
 
         return this._store.getState();
     }
 
-    deinitialize(): Promise<InternalCheckoutSelectors> {
-        if (this._walletButton && this._walletButton.parentNode) {
-            this._walletButton.parentNode.removeChild(this._walletButton);
-            this._walletButton = undefined;
-        }
+    async deinitialize(): Promise<InternalCheckoutSelectors> {
+        await this._amazonPayV2PaymentProcessor.deinitialize();
 
-        return Promise.resolve(this._store.getState());
+        return this._store.getState();
     }
 
     signIn(): Promise<InternalCheckoutSelectors> {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -1,5 +1,6 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
+import { PaymentMethod } from '../../';
 import { getConfig, getConfigState } from '../../../../src/config/configs.mock';
 import { getCart } from '../../../cart/carts.mock';
 import { CheckoutStore, createCheckoutStore } from '../../../checkout';
@@ -16,6 +17,7 @@ describe('AmazonPayV2PaymentProcessor', () => {
     let amazonPayV2ScriptLoader: AmazonPayV2ScriptLoader;
     let processor: AmazonPayV2PaymentProcessor;
     let amazonPayV2SDKMock: AmazonPayV2SDK;
+    let amazonPayV2Mock: PaymentMethod
 
     beforeEach(() => {
         amazonPayV2ScriptLoader = new AmazonPayV2ScriptLoader(createScriptLoader());
@@ -28,6 +30,15 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
         jest.spyOn(amazonPayV2ScriptLoader, 'load')
             .mockResolvedValue(amazonPayV2SDKMock);
+
+        jest.spyOn(document, 'createElement');
+
+        amazonPayV2Mock = getAmazonPayV2();
+    });
+
+    afterEach(() => {
+        jest.spyOn(document, 'createElement')
+            .mockRestore();
     });
 
     it('creates an instance of AmazonPayV2PaymentProcessor', () => {
@@ -36,23 +47,41 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
     describe('#initialize', () => {
         it('initializes processor successfully', async () => {
-            const amazonMock = getAmazonPayV2();
+            await processor.initialize(amazonPayV2Mock);
 
-            await processor.initialize(amazonMock);
+            expect(amazonPayV2ScriptLoader.load).toHaveBeenCalledWith(amazonPayV2Mock);
+            expect(document.createElement).toHaveBeenCalledTimes(1);
+        });
 
-            expect(amazonPayV2ScriptLoader.load).toHaveBeenCalledWith(amazonMock);
+        it('should reuse already created container', async () => {
+            await processor.initialize(amazonPayV2Mock);
+            await processor.initialize(amazonPayV2Mock);
+
+            expect(document.createElement).toHaveBeenCalledTimes(1);
         });
     });
 
     describe('#deinitialize', () => {
         it('deinitializes processor successfully', async () => {
-            const renderButton = () => processor.createButton('foo', getAmazonPayV2ButtonParamsMock());
+            await processor.initialize(amazonPayV2Mock);
 
-            await processor.initialize(getAmazonPayV2());
-            expect(renderButton).not.toThrow();
+            const deinitialize = processor.deinitialize();
 
+            await expect(deinitialize).resolves.toBe(undefined);
+        });
+
+        it('should remove the button parent container from the DOM', async () => {
+            const grandparentContainer = document.createElement('div');
+            const parentContainer = grandparentContainer.appendChild(
+                document.createElement('div')
+            );
+            jest.spyOn(document, 'createElement')
+                .mockReturnValueOnce(parentContainer);
+
+            await processor.initialize(amazonPayV2Mock);
             await processor.deinitialize();
-            expect(renderButton).toThrowError(NotInitializedError);
+
+            expect(grandparentContainer.contains(parentContainer)).toBe(false);
         });
     });
 
@@ -66,21 +95,23 @@ describe('AmazonPayV2PaymentProcessor', () => {
                 changeAction: 'changePayment',
             };
 
-            await processor.initialize(getAmazonPayV2());
-
+            await processor.initialize(amazonPayV2Mock);
             processor.bindButton(buttonName, sessionId, 'changePayment');
 
             expect(amazonPayV2SDKMock.Pay.bindChangeAction).toHaveBeenCalledWith(`#${buttonName}`, bindOptions);
         });
 
-        it('does not bind the button if the processor is not initialized previously', () => {
-            expect(() => processor.bindButton(buttonName, sessionId, 'changePayment')).toThrow(NotInitializedError);
+        it('throws an error when amazonPayV2SDK is not initialized', () => {
+            const bindButton = () => processor.bindButton(buttonName, sessionId, 'changePayment');
+
+            expect(bindButton).toThrow(NotInitializedError);
         });
     });
 
     describe('#signOut', () => {
         it('signs out succesfully', async () => {
-            await processor.initialize(getAmazonPayV2());
+            await processor.initialize(amazonPayV2Mock);
+
             await processor.signout();
 
             expect(amazonPayV2SDKMock.Pay.signout).toHaveBeenCalled();
@@ -95,15 +126,18 @@ describe('AmazonPayV2PaymentProcessor', () => {
             amazonPayV2ButtonParams = getAmazonPayV2ButtonParamsMock();
         });
 
-        it('creates the html button element', async () => {
-            await processor.initialize(getAmazonPayV2());
+        it('should render the Amazon Pay button to an HTML container element', async () => {
+            await processor.initialize(amazonPayV2Mock);
+
             processor.createButton(containerId, amazonPayV2ButtonParams);
 
             expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(`#${containerId}`, amazonPayV2ButtonParams);
         });
 
         it('throws an error when amazonPayV2SDK is not initialized', () => {
-            expect(() => processor.createButton(containerId, amazonPayV2ButtonParams)).toThrow(NotInitializedError);
+            const createButton = () => processor.createButton(containerId, amazonPayV2ButtonParams);
+
+            expect(createButton).toThrow(NotInitializedError);
         });
     });
 
@@ -112,7 +146,7 @@ describe('AmazonPayV2PaymentProcessor', () => {
         let amazonPayV2ButtonParams: Required<AmazonPayV2NewButtonParams>;
         let createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>;
 
-        beforeEach(async () => {
+        beforeEach(() => {
             amazonPayV2ButtonParams = getAmazonPayV2Ph4ButtonParamsMock() as Required<AmazonPayV2NewButtonParams>;
             const { publicKeyId, createCheckoutSessionConfig: signedPayload } = amazonPayV2ButtonParams;
 
@@ -124,7 +158,7 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
         describe('should initiate checkout successfully:', () => {
             beforeEach(async () => {
-                await processor.initialize(getAmazonPayV2());
+                await processor.initialize(amazonPayV2Mock);
                 processor.createButton(containerId, amazonPayV2ButtonParams);
             });
 
@@ -151,7 +185,7 @@ describe('AmazonPayV2PaymentProcessor', () => {
                 expect(amazonPayV2Button.initCheckout).toHaveBeenNthCalledWith(1, expectedConfig);
             });
 
-            test('config includes publicKeyId because it does not have an environment prefix', async () => {
+            test('config includes publicKeyId because it does not have an environment prefix', () => {
                 const expectedConfig = {
                     createCheckoutSessionConfig,
                 };
@@ -169,12 +203,14 @@ describe('AmazonPayV2PaymentProcessor', () => {
         });
 
         it('throws an error when amazonPayV2Button is not initialized', () => {
-            expect(() => processor.prepareCheckout(createCheckoutSessionConfig)).toThrow(NotInitializedError);
+            const prepareCheckout = () => processor.prepareCheckout(createCheckoutSessionConfig);
+
+            expect(prepareCheckout).toThrow(NotInitializedError);
         });
     });
 
     describe('#renderAmazonPayButton', () => {
-        const CONTAINER_ID = 'foo';
+        const CONTAINER_ID = 'container_passed_by_the_client';
         const renderAmazonPayButton = (containerId = CONTAINER_ID, decoupleCheckoutInitiation = false) => {
             processor.renderAmazonPayButton({
                 checkoutState: store.getState(),
@@ -184,6 +220,7 @@ describe('AmazonPayV2PaymentProcessor', () => {
                 placement: AmazonPayV2Placement.Checkout,
             });
         };
+        const expectedContainerId = expect.stringMatching(/^#amazonpay_button_parent_container_[0-9a-f]{4}$/);
 
         let store: CheckoutStore;
 
@@ -193,12 +230,11 @@ describe('AmazonPayV2PaymentProcessor', () => {
             document.body.appendChild(container);
         });
 
-        beforeEach(async () => {
+        beforeEach(() => {
             store = createCheckoutStore(getCheckoutStoreState());
-            await processor.initialize(getAmazonPayV2());
         });
 
-        it('should render an Amazon Pay button and validate if cart contains physical items', () => {
+        it('should render an Amazon Pay button and validate if cart contains physical items', async () => {
             const expectedOptions = getAmazonPayV2ButtonParamsMock() as AmazonPayV2ButtonParams;
             expectedOptions.createCheckoutSession.url = `${getConfig().storeConfig.storeProfile.shopPath}/remote-checkout/amazonpay/payment-session`;
             expectedOptions.productType = AmazonPayV2PayOptions.PayOnly;
@@ -209,12 +245,13 @@ describe('AmazonPayV2PaymentProcessor', () => {
             jest.spyOn(store.getState().cart, 'getCart')
                 .mockReturnValueOnce(cartMock);
 
+            await processor.initialize(amazonPayV2Mock);
             renderAmazonPayButton();
 
-            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(expectedContainerId, expectedOptions);
         });
 
-        it('should provide a relative URL to create a checkout session', () => {
+        it('should provide a relative URL to create a checkout session', async () => {
             const expectedOptions = getAmazonPayV2ButtonParamsMock() as AmazonPayV2ButtonParams;
             expectedOptions.createCheckoutSession.url = `/remote-checkout/amazonpay/payment-session`;
 
@@ -226,9 +263,10 @@ describe('AmazonPayV2PaymentProcessor', () => {
             jest.spyOn(store.getState().config, 'getStoreConfigOrThrow')
                 .mockReturnValueOnce(storeConfigMock);
 
-            renderAmazonPayButton()
+            await processor.initialize(amazonPayV2Mock);
+            renderAmazonPayButton();
 
-            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+            expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(expectedContainerId, expectedOptions);
         });
 
         describe('should use the new button params from API Version 2:', () => {
@@ -242,15 +280,16 @@ describe('AmazonPayV2PaymentProcessor', () => {
                     .mockReturnValueOnce(storeConfigMock);
             });
 
-            test('publicKeyId has an environment prefix', () => {
+            test('publicKeyId has an environment prefix', async () => {
                 const expectedOptions = getAmazonPayV2Ph4ButtonParamsMock();
 
+                await processor.initialize(amazonPayV2Mock);
                 renderAmazonPayButton();
 
-                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(expectedContainerId, expectedOptions);
             });
 
-            test('publicKeyId does not have an environment prefix', () => {
+            test('publicKeyId does not have an environment prefix', async () => {
                 const expectedOptions = getAmazonPayV2Ph4ButtonParamsMock() as AmazonPayV2NewButtonParams;
                 const createCheckoutSessionConfig = expectedOptions.createCheckoutSessionConfig as Required<AmazonPayV2NewButtonParams>['createCheckoutSessionConfig'];
                 delete expectedOptions.publicKeyId;
@@ -266,82 +305,100 @@ describe('AmazonPayV2PaymentProcessor', () => {
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValueOnce(amazonPayV2Mock);
 
+                await processor.initialize(amazonPayV2Mock);
                 renderAmazonPayButton();
 
-                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(expectedContainerId, expectedOptions);
             });
 
-            test('estimatedOrderAmount is not set if there is no total', () => {
+            test('estimatedOrderAmount is not set if there is no total', async () => {
                 const expectedOptions = getAmazonPayV2Ph4ButtonParamsMock() as AmazonPayV2NewButtonParams;
                 delete expectedOptions.estimatedOrderAmount;
 
                 jest.spyOn(store.getState().checkout, 'getCheckout')
                     .mockReturnValueOnce(undefined);
 
+                await processor.initialize(amazonPayV2Mock);
                 renderAmazonPayButton();
 
-                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(expectedContainerId, expectedOptions);
             });
 
-            test('estimatedOrderAmount is not set if there is no currency code', () => {
+            test('estimatedOrderAmount is not set if there is no currency code', async () => {
                 const expectedOptions = getAmazonPayV2Ph4ButtonParamsMock() as AmazonPayV2NewButtonParams;
                 delete expectedOptions.estimatedOrderAmount;
 
                 jest.spyOn(store.getState().cart, 'getCart')
                     .mockReturnValueOnce(undefined);
 
+                await processor.initialize(amazonPayV2Mock);
                 renderAmazonPayButton();
 
-                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(expectedContainerId, expectedOptions);
             });
 
-            test('createCheckoutSessionConfig is not set if decoupleCheckoutInitiation is true', () => {
+            test('createCheckoutSessionConfig is not set if decoupleCheckoutInitiation is true', async () => {
                 const expectedOptions = getAmazonPayV2Ph4ButtonParamsMock() as AmazonPayV2NewButtonParams;
                 delete expectedOptions.createCheckoutSessionConfig;
 
+                await processor.initialize(amazonPayV2Mock);
                 renderAmazonPayButton(CONTAINER_ID, true);
 
-                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith('#foo', expectedOptions);
+                expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(expectedContainerId, expectedOptions);
             });
         });
 
         describe('should fail...', () => {
-            test('if an invalid containerId is provided', () => {
+            test('if an invalid containerId is provided', async () => {
                 const renderAmazonPayButtonToAnInvalidContainer = () => renderAmazonPayButton('bar');
+
+                await processor.initialize(amazonPayV2Mock);
 
                 expect(renderAmazonPayButtonToAnInvalidContainer).toThrowError(InvalidArgumentError);
                 expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
             });
 
-            test('if there is no payment methods data', () => {
+            test('if buttonParentContainer is not initialized', () => {
+                expect(renderAmazonPayButton).toThrowError(NotInitializedError);
+            });
+
+            test('if there is no payment methods data', async () => {
                 const paymentMethods = { ...getPaymentMethodsState(), data: undefined };
                 const state = { ...getCheckoutStoreState(), paymentMethods };
                 store = createCheckoutStore(state);
 
+                await processor.initialize(amazonPayV2Mock);
+
                 expect(renderAmazonPayButton).toThrowError(MissingDataError);
                 expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
             });
 
-            test('if there is no store config data', () => {
+            test('if there is no store config data', async () => {
                 const config = { ...getConfigState(), data: undefined };
                 const state = { ...getCheckoutStoreState(), config };
                 store = createCheckoutStore(state);
 
+                await processor.initialize(amazonPayV2Mock);
+
                 expect(renderAmazonPayButton).toThrowError(MissingDataError);
                 expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
             });
 
-            test('if merchantId is undefined', () => {
+            test('if merchantId is undefined', async () => {
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValue(getPaymentMethodMockUndefinedMerchant());
 
+                await processor.initialize(amazonPayV2Mock);
+
                 expect(renderAmazonPayButton).toThrowError(MissingDataError);
                 expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();
             });
 
-            test('if ledgerCurrency is undefined', () => {
+            test('if ledgerCurrency is undefined', async () => {
                 jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow')
                     .mockReturnValue(getPaymentMethodMockUndefinedLedgerCurrency());
+
+                await processor.initialize(amazonPayV2Mock);
 
                 expect(renderAmazonPayButton).toThrowError(MissingDataError);
                 expect(amazonPayV2SDKMock.Pay.renderButton).not.toHaveBeenCalled();

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -2,12 +2,12 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { getConfig, getConfigState } from '../../../../src/config/configs.mock';
 import { getCart } from '../../../cart/carts.mock';
-import { createCheckoutStore, CheckoutStore } from '../../../checkout';
+import { CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError } from '../../../common/error/errors';
 import { getAmazonPayV2, getPaymentMethodsState } from '../../payment-methods.mock';
 
-import { AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK, AmazonPayV2ButtonParameters, AmazonPayV2NewButtonParams, AmazonPayV2ButtonParams, AmazonPayV2CheckoutSessionConfig, AmazonPayV2Button } from './amazon-pay-v2';
+import { AmazonPayV2Button, AmazonPayV2ButtonParameters, AmazonPayV2ButtonParams, AmazonPayV2CheckoutSessionConfig, AmazonPayV2NewButtonParams, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
 import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 import { getAmazonPayV2ButtonParamsMock, getAmazonPayV2Ph4ButtonParamsMock, getAmazonPayV2SDKMock, getPaymentMethodMockUndefinedLedgerCurrency, getPaymentMethodMockUndefinedMerchant } from './amazon-pay-v2.mock';

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -9,6 +9,7 @@ import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 
 export default class AmazonPayV2PaymentProcessor {
     private _amazonPayV2SDK?: AmazonPayV2SDK;
+    private _buttonParentContainer?: HTMLDivElement;
     private _amazonPayV2Button?: AmazonPayV2Button;
 
     constructor(
@@ -17,9 +18,13 @@ export default class AmazonPayV2PaymentProcessor {
 
     async initialize(paymentMethod: PaymentMethod): Promise<void> {
         this._amazonPayV2SDK = await this._amazonPayV2ScriptLoader.load(paymentMethod);
+        this._buttonParentContainer = this._buttonParentContainer || this._createAmazonPayButtonParentContainer();
     }
 
     deinitialize(): Promise<void> {
+        this._amazonPayV2Button = undefined;
+        this._buttonParentContainer?.remove();
+        this._buttonParentContainer = undefined;
         this._amazonPayV2SDK = undefined;
 
         return Promise.resolve();
@@ -72,11 +77,23 @@ export default class AmazonPayV2PaymentProcessor {
             throw new InvalidArgumentError('Unable to render the Amazon Pay button to an invalid HTML container element.');
         }
 
+        const { id: parentContainerId } = container.appendChild(
+            this._getButtonParentContainer()
+        );
+
         const amazonPayV2ButtonOptions = options ?? this._getAmazonPayV2ButtonOptions(checkoutState, methodId, placement, decoupleCheckoutInitiation);
 
-        this.createButton(containerId, amazonPayV2ButtonOptions);
+        this.createButton(parentContainerId, amazonPayV2ButtonOptions);
 
         return container;
+    }
+
+    private _createAmazonPayButtonParentContainer(): HTMLDivElement {
+        const uid = Math.random().toString(16).substr(-4);
+        const parentContainer = document.createElement('div');
+        parentContainer.id = `amazonpay_button_parent_container_${uid}`;
+
+        return parentContainer;
     }
 
     private _getAmazonPayV2ButtonOptions(
@@ -170,6 +187,10 @@ export default class AmazonPayV2PaymentProcessor {
 
     private _getAmazonPayV2SDK(): AmazonPayV2SDK {
         return this._getOrThrow(this._amazonPayV2SDK);
+    }
+
+    private _getButtonParentContainer(): HTMLDivElement {
+        return this._getOrThrow(this._buttonParentContainer);
     }
 
     private _getAmazonPayV2Button(): AmazonPayV2Button {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -1,12 +1,11 @@
 import { PaymentMethod } from '../..';
 import { InternalCheckoutSelectors } from '../../../../../core/src/checkout';
 import { getShippableItemsCount } from '../../../../../core/src/shipping';
+import { guard } from '../../../../src/common/utility';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 
-import { AmazonPayV2ButtonColor, AmazonPayV2ChangeActionType, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK, AmazonPayV2ButtonParameters, AmazonPayV2Button, AmazonPayV2NewButtonParams, AmazonPayV2CheckoutSessionConfig, AmazonPayV2ButtonRenderingOptions } from './amazon-pay-v2';
+import { AmazonPayV2Button, AmazonPayV2ButtonColor, AmazonPayV2ButtonParameters, AmazonPayV2ButtonRenderingOptions, AmazonPayV2ChangeActionType, AmazonPayV2CheckoutSessionConfig, AmazonPayV2NewButtonParams, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
-
-import { guard } from '../../../../src/common/utility';
 
 export default class AmazonPayV2PaymentProcessor {
     private _amazonPayV2SDK?: AmazonPayV2SDK;

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.spec.ts
@@ -3,10 +3,10 @@ import { createAction, createErrorAction } from '@bigcommerce/data-store';
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
-import { of, Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import { createPaymentStrategyRegistry, createPaymentStrategyRegistryV2, PaymentActionCreator, PaymentMethod } from '../..';
-import { createCheckoutStore, CheckoutRequestSender, CheckoutStore, CheckoutValidator } from '../../../checkout';
+import { CheckoutRequestSender, CheckoutStore, CheckoutValidator, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError, NotInitializedError, RequestError } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
@@ -14,8 +14,8 @@ import { getConfig } from '../../../config/configs.mock';
 import { FinalizeOrderAction, OrderActionCreator, OrderActionType, OrderRequestBody, OrderRequestSender, SubmitOrderAction } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
-import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
 import { createPaymentIntegrationService } from '../../../payment-integration';
+import { createSpamProtection, PaymentHumanVerificationHandler, SpamProtectionActionCreator, SpamProtectionRequestSender } from '../../../spam-protection';
 import { PaymentArgumentInvalidError } from '../../errors';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import { getAmazonPayV2, getPaymentMethodsState } from '../../payment-methods.mock';
@@ -26,12 +26,12 @@ import PaymentStrategyActionCreator from '../../payment-strategy-action-creator'
 import { PaymentStrategyActionType } from '../../payment-strategy-actions';
 import { getErrorPaymentResponseBody } from '../../payments.mock';
 
-import { AmazonPayV2PaymentProcessor } from '.';
+import { AmazonPayV2ButtonParams, AmazonPayV2NewButtonParams } from './amazon-pay-v2';
 import AmazonPayV2PaymentInitializeOptions from './amazon-pay-v2-payment-initialize-options';
+import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 import AmazonPayV2PaymentStrategy from './amazon-pay-v2-payment-strategy';
 import { getAmazonPayV2ButtonParamsMock, getAmazonPayV2Ph4ButtonParamsMock } from './amazon-pay-v2.mock';
 import createAmazonPayV2PaymentProcessor from './create-amazon-pay-v2-payment-processor';
-import { AmazonPayV2ButtonParams, AmazonPayV2NewButtonParams } from './amazon-pay-v2';
 
 describe('AmazonPayV2PaymentStrategy', () => {
     let amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor;

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
@@ -1,5 +1,7 @@
+import { CheckoutSettings } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { noop } from 'lodash';
 
+import { guard } from '../../../../src/common/utility';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, NotInitializedError, NotInitializedErrorType, RequestError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
@@ -10,10 +12,8 @@ import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-r
 import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
 import PaymentStrategy from '../payment-strategy';
 
-import { AmazonPayV2ChangeActionType, AmazonPayV2PaymentProcessor, AmazonPayV2Placement } from '.';
-
-import { guard } from '../../../../src/common/utility';
-import { CheckoutSettings } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { AmazonPayV2ChangeActionType, AmazonPayV2Placement } from './amazon-pay-v2';
+import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 
 export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
 

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
@@ -16,8 +16,7 @@ import { AmazonPayV2ChangeActionType, AmazonPayV2Placement } from './amazon-pay-
 import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 
 export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
-
-    private _walletButton?: HTMLElement;
+    private _buttonContainer?: HTMLElement;
 
     constructor(
         private _store: CheckoutStore,
@@ -45,7 +44,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
         } else {
             const { id: containerId } = this._createContainer();
 
-            this._walletButton =
+            this._buttonContainer =
                 this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
                     checkoutState: this._store.getState(),
                     containerId,
@@ -96,7 +95,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
             }
         }
 
-        this._getWalletButton().click();
+        this._getButtonContainer().click();
 
         // Focus of parent window used to try and detect the user cancelling the Amazon log in modal
         // Should be refactored if/when Amazon add a modal close hook to their SDK
@@ -119,14 +118,11 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
     }
 
     async deinitialize(): Promise<InternalCheckoutSelectors> {
-        if (this._walletButton && this._walletButton.parentNode) {
-            this._walletButton.parentNode.removeChild(this._walletButton);
-            this._walletButton = undefined;
-        }
-
         await this._amazonPayV2PaymentProcessor.deinitialize();
 
-        return Promise.resolve(this._store.getState());
+        this._buttonContainer = undefined;
+
+        return this._store.getState();
     }
 
     private _bindEditButton(buttonId: string, sessionId: string, changeAction: AmazonPayV2ChangeActionType, isModalFlow: boolean): void {
@@ -171,8 +167,8 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
         return document.body.appendChild(container);
     }
 
-    private _getWalletButton() {
-        return guard(this._walletButton, () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+    private _getButtonContainer() {
+        return guard(this._buttonContainer, () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
     }
 
     private _isOneTimeTransaction(features: CheckoutSettings['features']): boolean {


### PR DESCRIPTION
## What? [INT-6848](https://bigcommercecloud.atlassian.net/browse/INT-6848)
Render the Amazon Pay button in a container created programmatically.

## Why?
To allow the Amazon Pay script to handle this new container instead of handling the container passed by the client. See issue #1652

## Testing / Proof
<img width="700" alt="Screen Shot 2022-10-24 at 4 56 31 PM" src="https://user-images.githubusercontent.com/4843328/197639386-a90f3006-f210-40ce-8f9a-2a5a740aa6f6.png">

@bigcommerce/checkout @bigcommerce/payments
