### PR TITLE
refactor(payment): PAYPAL-1756 removed 'Fake' data implementation from paypal commerce button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -192,12 +192,6 @@ describe('PaypalCommerceButtonStrategy', () => {
                     }
                 });
 
-                eventEmitter.on('onCancel', () => {
-                    if (options.onCancel) {
-                        options.onCancel();
-                    }
-                });
-
                 eventEmitter.on('onShippingAddressChange', () => {
                     if (options.onShippingAddressChange) {
                         options.onShippingAddressChange({
@@ -747,78 +741,6 @@ describe('PaypalCommerceButtonStrategy', () => {
             await new Promise(resolve => process.nextTick(resolve));
 
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({ methodId, paymentData });
-        });
-    });
-
-    describe('#_onCancel button callback', () => {
-        it('calls billingAddressActionCreator when isHostedCheckoutEnabled true', async () => {
-            const paymentMethod = {
-                ...paymentMethodMock,
-                initializationData: {
-                    ...paymentMethodMock.initializationData,
-                    isHostedCheckoutEnabled: true,
-                }
-
-            }
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethod);
-            await strategy.initialize(initializationOptions);
-            eventEmitter.emit('onClick');
-            await new Promise(resolve => process.nextTick(resolve));
-            eventEmitter.emit('onCancel');
-            await new Promise(resolve => process.nextTick(resolve));
-
-            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalled();
-        });
-
-        it('calls consignmentActionCreator when isHostedCheckoutEnabled true', async () => {
-            const paymentMethod = {
-                ...paymentMethodMock,
-                initializationData: {
-                    ...paymentMethodMock.initializationData,
-                    isHostedCheckoutEnabled: true,
-                }
-
-            }
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethod);
-            jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(Promise.resolve());
-            await strategy.initialize(initializationOptions);
-            eventEmitter.emit('onClick');
-            await new Promise(resolve => process.nextTick(resolve));
-            eventEmitter.emit('onCancel');
-            await new Promise(resolve => process.nextTick(resolve));
-
-            expect(consignmentActionCreator.updateAddress).toHaveBeenCalled();
-        });
-
-        it('calls paypalCommerceRequestSender updateOrder when isHostedCheckoutEnabled true', async () => {
-            const paymentMethod = {
-                ...paymentMethodMock,
-                initializationData: {
-                    ...paymentMethodMock.initializationData,
-                    isHostedCheckoutEnabled: true,
-                }
-
-            }
-            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethod);
-            jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(Promise.resolve());
-            await strategy.initialize(initializationOptions);
-            eventEmitter.emit('onClick');
-            await new Promise(resolve => process.nextTick(resolve));
-            eventEmitter.emit('onCancel');
-            await new Promise(resolve => process.nextTick(resolve));
-
-            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalled();
-        });
-
-        it('does not updateOrder when isHostedCheckoutEnabled false', async () => {
-            jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(Promise.resolve());
-            await strategy.initialize(initializationOptions);
-            eventEmitter.emit('onClick');
-            await new Promise(resolve => process.nextTick(resolve));
-            eventEmitter.emit('onCancel');
-            await new Promise(resolve => process.nextTick(resolve));
-
-            expect(paypalCommerceRequestSender.updateOrder).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## What?
Removed 'Fake' data implementation from PayPalCommerceButtonStrategy

## Why?
We used 'Fake' data to fill all required empty fields in onShippingAddressChange and onShippingOptionChange callbacks to create an order trough bigpay. But we don't need to mock the data for onShippingAddressChange and onShippingOptionChange to pass bigpay validation anymore, due to the bigpay mapper update

## Testing / Proof
Unit tests
Manual tests

https://user-images.githubusercontent.com/25133454/199940641-b1e8d3a2-db21-464d-82ae-e1d9d3d407bb.mov




