### PR TITLE
chore(analytics): DATA-10422 Rename fields for BODL events

### DIFF
--- a/packages/core/src/bodl/bodl-emitter-service.ts
+++ b/packages/core/src/bodl/bodl-emitter-service.ts
@@ -55,10 +55,10 @@ export default class BodlEmitterService implements BodlService {
         } = checkout;
 
         this.bodlEvents.emitCheckoutBeginEvent({
-            id,
+            event_id: id,
             currency: currency.code,
             cart_value: cartAmount,
-            coupon: coupons.map(coupon => coupon.code.toUpperCase()).join(','),
+            coupon_codes: coupons.map(coupon => coupon.code.toUpperCase()),
             line_items: this._getProducts(lineItems, currency.code),
             channel_id: channelId
         });
@@ -91,13 +91,13 @@ export default class BodlEmitterService implements BodlService {
         }
 
         this.bodlEvents.emitOrderPurchasedEvent({
-            id: cartId,
+            event_id: cartId,
             currency: currency.code,
-            transaction_id: orderId,
+            order_id: orderId,
             tax: taxTotal,
             channel_id: channelId,
             cart_value: orderAmount,
-            coupon: coupons.map(coupon => coupon.code.toUpperCase()).join(','),
+            coupon_codes: coupons.map(coupon => coupon.code.toUpperCase()),
             shipping_cost: shippingCostTotal,
             line_items: this._getProducts(lineItems, currency.code),
         });
@@ -213,7 +213,7 @@ export default class BodlEmitterService implements BodlService {
                 discount: item.discountAmount,
                 brand_name: item.brand,
                 currency: currencyCode,
-                category_name: item.categoryNames ? item.categoryNames.join(', ') : '',
+                category_names: item.categoryNames || [],
             };
         });
 

--- a/packages/core/src/bodl/bodl-events-service.spec.ts
+++ b/packages/core/src/bodl/bodl-events-service.spec.ts
@@ -50,10 +50,10 @@ describe('BodlEmitterService', () => {
             expect(bodlEvents.emitCheckoutBeginEvent).toBeCalledTimes(1);
         });
 
-        it('tracks the id', () => {
+        it('tracks the event id', () => {
             expect(bodlEvents.emitCheckoutBeginEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                    event_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 })
             );
         });
@@ -74,10 +74,10 @@ describe('BodlEmitterService', () => {
             );
         });
 
-        it('tracks the coupon string', () => {
+        it('tracks the coupon_codes array', () => {
             expect(bodlEvents.emitCheckoutBeginEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    coupon: 'SAVEBIG2015,279F507D817E3E7',
+                    coupon_codes: ['SAVEBIG2015', '279F507D817E3E7'],
                 })
             );
         });
@@ -93,10 +93,10 @@ describe('BodlEmitterService', () => {
         it('tracks products', () => {
             expect(bodlEvents.emitCheckoutBeginEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    coupon: 'SAVEBIG2015,279F507D817E3E7',
+                    coupon_codes: ['SAVEBIG2015', '279F507D817E3E7'],
                     cart_value: 190,
                     currency: 'USD',
-                    id: "b20deef40f9699e48671bbc3fef6ca44dc80e3c7",
+                    event_id: "b20deef40f9699e48671bbc3fef6ca44dc80e3c7",
                     line_items: [{
                         product_id: 103,
                         sku: 'CLC',
@@ -107,7 +107,7 @@ describe('BodlEmitterService', () => {
                         quantity: 1,
                         brand_name: 'OFS',
                         discount: 10,
-                        category_name: 'Cat 1',
+                        category_names: ['Cat 1'],
                         variant_id: 71,
                         currency: 'USD'
                     }, {
@@ -120,7 +120,7 @@ describe('BodlEmitterService', () => {
                         quantity: 1,
                         discount: 0,
                         brand_name: 'Digitalia',
-                        category_name: 'Ebooks, Audio Books',
+                        category_names: ['Ebooks', 'Audio Books'],
                         variant_id: 72,
                         currency: 'USD'
                     }, {
@@ -149,10 +149,10 @@ describe('BodlEmitterService', () => {
         });
 
 
-        it('tracks the id', () => {
+        it('tracks the event id', () => {
             expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                    event_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                 })
             );
         });
@@ -168,7 +168,7 @@ describe('BodlEmitterService', () => {
         it('tracks the transaction id', () => {
             expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    transaction_id: 295,
+                    order_id: 295,
                 })
             );
         });
@@ -184,7 +184,7 @@ describe('BodlEmitterService', () => {
         it('tracks the coupon amount, single field, comma separated', () => {
             expect(bodlEvents.emitOrderPurchasedEvent).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    coupon: 'SAVEBIG2015,279F507D817E3E7',
+                    coupon_codes: ['SAVEBIG2015', '279F507D817E3E7'],
                 })
             );
         });
@@ -226,7 +226,7 @@ describe('BodlEmitterService', () => {
                         quantity: 1,
                         brand_name: 'OFS',
                         discount: 10,
-                        category_name: 'Cat 1',
+                        category_names: ['Cat 1'],
                         variant_id: 71,
                         currency: 'USD'
                     }, {

--- a/packages/core/src/bodl/bodl-window.ts
+++ b/packages/core/src/bodl/bodl-window.ts
@@ -13,29 +13,29 @@ export interface BODLProduct {
     discount?: number;
     index?: number;
     brand_name?: string;
-    category_name?: string;
+    category_names?: string[];
     currency?: string;
 }
 
 
 export interface CheckoutBeginData {
-    id: string
+    event_id: string
     currency: string,
     channel_id: number,
     cart_value: number,
-    coupon: string,
+    coupon_codes: string[],
     line_items: BODLProduct[]
 }
 
 
 export interface OrderPurchasedData {
-    id: string
+    event_id: string
     currency: string,
     tax: number,
     channel_id: number,
-    transaction_id: number,
+    order_id: number,
     cart_value: number,
-    coupon: string,
+    coupon_codes: string[],
     shipping_cost: number,
     line_items: BODLProduct[]
 


### PR DESCRIPTION
## What? [DATA-10422](https://bigcommercecloud.atlassian.net/browse/DATA-10422)
**Event: Purchase**

- Rename event from ‘purchase’ to ‘order_purchased’.
- Rename ‘id’ field to ‘event_id’
- Rename ‘transaction_id’ to ‘order_id’.
- Rename ‘coupon’ to ‘coupon_codes’. Transform to array

**Event: Checkout**

- Rename ‘id’ field to ‘event_id’
- Rename ‘coupon’ to ‘coupon_codes’. Transform to array

## Why?
Product requirement

## Testing / Proof
Unit tests

@bigcommerce/checkout @bigcommerce/payments
