### PR TITLE
feat(payment): STRIPE-178 Render Submit button after Stripe elements are loaded

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-initialize-options.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-initialize-options.ts
@@ -33,4 +33,6 @@ export default interface StripeUPEPaymentInitializeOptions {
         [key: string]: string;
     };
     onError?(error?: Error): void;
+
+    render(): void;
 }

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -40,6 +40,7 @@ import {
     StripeUPEClient,
 } from './stripe-upe';
 import StripeUPEScriptLoader from './stripe-upe-script-loader';
+import { StripeUPEPaymentInitializeOptions } from './';
 
 const APM_REDIRECT = [
     StripePaymentMethodType.SOFORT,
@@ -112,12 +113,9 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                         this._isMounted = true;
                     }
                 } else {
-                    this._loadStripeElement(
-                        stripeupe.containerId,
-                        stripeupe.style,
-                        gatewayId,
-                        methodId,
-                    ).catch((error) => stripeupe.onError?.(error));
+                    this._loadStripeElement(stripeupe, gatewayId, methodId).catch((error) =>
+                        stripeupe.onError?.(error),
+                    );
                 }
             },
             (state) => {
@@ -335,11 +333,11 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
     }
 
     private async _loadStripeElement(
-        containerId: string,
-        style: { [key: string]: string } | undefined,
+        stripeupe: StripeUPEPaymentInitializeOptions,
         gatewayId: string,
         methodId: string,
     ) {
+        const { containerId, style, render } = stripeupe;
         const state = await this._store.dispatch(
             this._paymentMethodActionCreator.loadPaymentMethod(gatewayId, {
                 params: { method: methodId },
@@ -423,6 +421,10 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                 );
             }
         }
+
+        stripeElement.on('ready', () => {
+            render();
+        });
     }
 
     private async _processAdditionalAction(

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
@@ -49,6 +49,7 @@ export function getStripeUPEInitializeOptionsMock(
         stripeupe: {
             containerId: `stripe-${stripePaymentMethodType}-component-field`,
             style,
+            render: jest.fn(),
         },
     };
 }

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -41,7 +41,7 @@ export interface StripeElement {
      * in addition to some Element-specific keys.
      * https://stripe.com/docs/js/element/events/on_change?type=paymentElement
      */
-    on(event: 'change', handler: (event: StripeEventType) => void): void;
+    on(event: 'change' | 'ready', handler: (event: StripeEventType) => void): void;
 }
 
 export interface StripeEvent {


### PR DESCRIPTION
## What? [STRIPE-178](https://bigcommercecloud.atlassian.net/browse/STRIPE-178)
Render Submit Button after the payment form and input elements have fully loaded.

## Why?
So that shoppers know that they have additional information to fill in prior to trying to submit payment.

## Testing / Proof
On loading
<img width="681" alt="Screen Shot 2022-10-26 at 17 08 40" src="https://user-images.githubusercontent.com/106765049/198148008-c70a3101-23fb-4a14-81d3-1e0d4733df72.png">

Loaded
<img width="732" alt="Screen Shot 2022-10-26 at 17 08 48" src="https://user-images.githubusercontent.com/106765049/198147949-0822a8e8-2375-4cb8-a017-f422248f6761.png">

## Dependency of
[#1080](https://github.com/bigcommerce/checkout-js/pull/1080)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
