### PR TITLE
fix(payment): PAYPAL-1758 added condition to submit payment in onComplete method for auth&capture transaction only for PayPalInlineCheckoutButton

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
@@ -196,7 +196,13 @@ export default class PaypalCommerceInlineCheckoutButtonStrategy implements Check
         methodId: string,
         callback?: () => void
     ): Promise<void> {
-        await this._submitPayment(methodId, data.orderID);
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const { intent } = paymentMethod.initializationData;
+
+        if (intent === 'capture') {
+            await this._submitPayment(methodId, data.orderID);
+        }
 
         if (callback) {
             callback();

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
@@ -5,7 +5,7 @@ import { OrderActionCreator } from '../../../order';
 import { PaymentActionCreator } from '../../../payment';
 import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
 import { ConsignmentActionCreator, ShippingOption } from '../../../shipping';
-import { ApproveCallbackActions, ApproveCallbackPayload, CompleteCallbackDataPayload, PaypalCheckoutButtonOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, ShippingAddressChangeCallbackPayload, ShippingOptionChangeCallbackPayload } from '../../../payment/strategies/paypal-commerce';
+import { ApproveCallbackActions, ApproveCallbackPayload, CompleteCallbackDataPayload, PaypalCheckoutButtonOptions, PayPalCommerceIntent, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, ShippingAddressChangeCallbackPayload, ShippingOptionChangeCallbackPayload } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
 import CheckoutButtonStrategy from '../checkout-button-strategy';
@@ -200,7 +200,7 @@ export default class PaypalCommerceInlineCheckoutButtonStrategy implements Check
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         const { intent } = paymentMethod.initializationData;
 
-        if (intent === 'capture') {
+        if (intent === PayPalCommerceIntent.capture) {
             await this._submitPayment(methodId, data.orderID);
         }
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -313,12 +313,17 @@ export interface PaypalCommerceHostWindow extends Window {
 export type FundingType = string[];
 export type EnableFundingType =  FundingType | string;
 
+export enum PayPalCommerceIntent {
+    authorize = 'authorize',
+    capture = 'capture',
+}
+
 export interface PaypalCommerceInitializationData {
     clientId: string;
     merchantId?: string;
     buyerCountry?: string;
     isDeveloperModeApplicable?: boolean;
-    intent?: 'capture' | 'authorize';
+    intent?: PayPalCommerceIntent;
     isHostedCheckoutEnabled?: boolean;
     isInlineCheckoutEnabled?: boolean;
     isPayPalCreditAvailable?: boolean;
@@ -341,7 +346,7 @@ export interface PaypalCommerceScriptParams  {
     'data-partner-attribution-id'?: string;
     currency?: string;
     commit?: boolean;
-    intent?: 'capture' | 'authorize';
+    intent?: PayPalCommerceIntent;
     components?: ComponentsScriptType;
 }
 


### PR DESCRIPTION
## What?
Added condition to submit payment in `onComplete` method for auth&capture transactions for PayPalInlineCheckoutButtonStrategy

## Why?
We should not make secondary submit payment request for 'Authentication only' transaction types because it causes an error on BigPay side. Order data will be updated after 'Capture Funds' for transaction in CP by using Webhooks. 

## Sibling PRs:
bcapp: https://github.com/bigcommerce/bigcommerce/pull/49407

## Testing / Proof
Unit tests
Manual tests
QA tests
