### PR TITLE
feat(payment): PAYPAL-1737 added currencyCode param to loadPaymentMethod request

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -59,6 +59,11 @@ export interface BaseCheckoutButtonInitializeOptions extends CheckoutButtonOptio
     containerId: string;
 
     /**
+     * The option that is required to load payment method configuration for provided currency code in Buy Now flow.
+     */
+    currencyCode?: string;
+
+    /**
      * The options that are required to initialize the GooglePay payment method.
      * They can be omitted unless you need to support adyenv2 GooglePay.
      */

--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.spec.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.spec.ts
@@ -73,6 +73,28 @@ describe('CheckoutButtonStrategyActionCreator', () => {
             .toHaveBeenCalledWith(CheckoutButtonMethodType.BRAINTREE_PAYPAL, { useCache: true });
     });
 
+    it('loads required payment method for provided currency', async () => {
+        const optionsMock = {
+            methodId: CheckoutButtonMethodType.BRAINTREE_PAYPAL,
+            containerId: 'checkout-button',
+            currencyCode: 'USD',
+        };
+
+        await from(strategyActionCreator.initialize(optionsMock)(store))
+            .pipe(toArray())
+            .toPromise();
+
+        const expectedPaymentMethodOptions = {
+            useCache: true,
+            params: {
+                currencyCode: 'USD',
+            },
+        };
+
+        expect(paymentMethodActionCreator.loadPaymentMethod)
+            .toHaveBeenCalledWith(CheckoutButtonMethodType.BRAINTREE_PAYPAL, expectedPaymentMethodOptions);
+    });
+
     it('finds strategy and initializes it', async () => {
         jest.spyOn(registry, 'get');
         jest.spyOn(strategy, 'initialize');

--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -47,6 +47,16 @@ export default class CheckoutButtonStrategyActionCreator {
                 return empty();
             }
 
+            const paymentMethodRequestParams = options.currencyCode
+                ? { params: { currencyCode: options.currencyCode } }
+                : {};
+
+            const paymentMethodRequestOptions = {
+                ...paymentMethodRequestParams,
+                timeout: options.timeout,
+                useCache: true,
+            };
+
             return concat(
                 of(
                     createAction(
@@ -57,15 +67,7 @@ export default class CheckoutButtonStrategyActionCreator {
                 ),
                 this._paymentMethodActionCreator.loadPaymentMethod(
                     options.methodId,
-                    {
-                        ...options.currencyCode && {
-                            params: {
-                                currencyCode: options.currencyCode,
-                            }
-                        },
-                        timeout: options.timeout,
-                        useCache: true,
-                    },
+                    paymentMethodRequestOptions,
                 )(store),
                 defer(() =>
                     this._getStrategy(options.methodId)

--- a/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-strategy-action-creator.ts
@@ -57,7 +57,15 @@ export default class CheckoutButtonStrategyActionCreator {
                 ),
                 this._paymentMethodActionCreator.loadPaymentMethod(
                     options.methodId,
-                    { timeout: options.timeout, useCache: true }
+                    {
+                        ...options.currencyCode && {
+                            params: {
+                                currencyCode: options.currencyCode,
+                            }
+                        },
+                        timeout: options.timeout,
+                        useCache: true,
+                    },
                 )(store),
                 defer(() =>
                     this._getStrategy(options.methodId)


### PR DESCRIPTION
## What?
Added currencyCode param to loadPaymentMethod request to make an ability to load payment method for specific currencyCode 

## Why?
The main point that we can't get valid payment method configuration for wallet payment button on Product Details Page, because we don't created buy now cart and quota to get currency from there.

## Sibling PRs
bcapp: https://github.com/bigcommerce/bigcommerce/pull/49198

## Testing / Proof
Unit tests
Manual tests

**Before:**
USD:
<img width="1662" alt="Screenshot 2022-10-03 at 11 00 06" src="https://user-images.githubusercontent.com/54856617/196699598-224d0994-dd34-4d89-968b-219eb44d2789.png">

GBP:
<img width="1642" alt="Screenshot 2022-10-03 at 11 00 48" src="https://user-images.githubusercontent.com/54856617/196699702-5038c54c-8238-437f-878d-ab07e08d9fdc.png">

**After:**
USD:
<img width="696" alt="Screenshot 2022-10-28 at 12 40 51" src="https://user-images.githubusercontent.com/25133454/198575375-8be06b53-2925-4dd6-bf46-9ddabb190b92.png">

GBP:
<img width="695" alt="Screenshot 2022-10-28 at 12 41 26" src="https://user-images.githubusercontent.com/25133454/198575527-8e998bae-cabd-49e2-ae11-e849e931c8d9.png">

Default currency:
<img width="694" alt="Screenshot 2022-10-28 at 12 43 36" src="https://user-images.githubusercontent.com/25133454/198575543-82fd4eb1-65eb-485b-bd47-bab51ebb9d27.png">
