### PR TITLE
feat(payment): PAYPAL-1755 validating height option

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/braintree/get-valid-button-style.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/get-valid-button-style.ts
@@ -18,11 +18,11 @@ export default function getValidButtonStyle(style: PaypalButtonStyleOptions): Pa
     return omitBy(validStyles, isNil);
 }
 
-function getValidHeight(height?: number): number {
+function getValidHeight(height?: number | string): number {
     const minHeight = 25;
     const maxHeight = 55;
 
-    if (typeof height !== 'number' || height > maxHeight) {
+    if (!height || typeof Number(height) !== 'number' || height > maxHeight) {
         return maxHeight;
     }
 
@@ -30,5 +30,5 @@ function getValidHeight(height?: number): number {
         return minHeight;
     }
 
-    return height;
+    return Number(height);
 }


### PR DESCRIPTION
## What?

Just in case where we get `String` type for the height param witch can be converted to `Number` the `getValidHeight` function returns incorrect results

For example when we get data by `JSON.parse`:
[main_script.html#28](https://github.com/bigcommerce/bigcommerce/blob/master/app/templates/smart_payment_buttons/main_script.html#L28
)

## Why?

According to task [PAYPAL-1755](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1755)

## Testing / Proof
Tests are not required

@bigcommerce/checkout @bigcommerce/payments
