### PR TITLE
feat(payment): PAYPAL-1722 added skip checkout functionality to PDP

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -832,5 +832,37 @@ describe('PaypalCommerceButtonStrategy', () => {
 
             expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalled();
         });
-    })
+    });
+    
+    describe('#_handleClick', () => {
+        beforeEach(() => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue(new Promise(resolve => resolve({body:{...buyNowCartMock}})));
+            jest.spyOn(checkoutActionCreator, 'loadCheckout').mockReturnValue(true);
+        });
+
+        it('calls _cartRequestSender.createBuyNowCart on button click', async () => {
+            const options = {
+                ...initializationOptions,
+                ...buyNowInitializationOptions
+            }
+            await strategy.initialize(options);
+            eventEmitter.emit('onClick');
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(cartRequestSender.createBuyNowCart).toHaveBeenCalled();
+        });
+
+        it('calls loadCheckout with proper cartId on button click', async () => {
+            const options = {
+                ...initializationOptions,
+                ...buyNowInitializationOptions
+            }
+            const cartId = buyNowCartMock.id;
+            await strategy.initialize(options);
+            eventEmitter.emit('onClick');
+            await new Promise(resolve => process.nextTick(resolve));
+
+            expect(checkoutActionCreator.loadCheckout).toHaveBeenCalledWith(cartId);
+        });
+    });
 });

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -123,6 +123,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
             try {
                 const { body: cart } = await this._cartRequestSender.createBuyNowCart(cartRequestBody);
                 this._buyNowCartId = cart.id;
+                await this._store.dispatch(this._checkoutActionCreator.loadCheckout(cart.id));
             } catch (error) {
                 throw new BuyNowCartCreationError();
             }


### PR DESCRIPTION
## What?
Added ability for skip checkout to work on PDP (paypalcommerce).

## Why?
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1722
smart-payment-buttons PR: https://github.com/bigcommerce/smart-payment-buttons/pull/12
bcapp PR: https://github.com/bigcommerce/bigcommerce/pull/49657
## Testing / Proof
Tested on dev and int

@bigcommerce/checkout @bigcommerce/payments
