### PR TITLE
fix(payment): INT-6890 AmazonPayV2: Change `isReadyToPay` logic

### DIFF
--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -405,4 +405,96 @@ describe('AmazonPayV2PaymentProcessor', () => {
             });
         });
     });
+
+    describe('#isPh4Enabled', () => {
+        describe('should return TRUE if...', () => {
+            test('3483.PH4 is ON, 6885.PH4_US_OLY is OFF, and country is US', () => {
+                const features = {
+                    'PROJECT-3483.amazon_pay_ph4': true,
+                }
+
+                const isPh4Enabled = processor.isPh4Enabled(features, 'US');
+
+                expect(isPh4Enabled).toBe(true);
+            });
+
+            test('3483.PH4 is ON, 6885.PH4_US_OLY is OFF, and country is not US', () => {
+                const features = {
+                    'PROJECT-3483.amazon_pay_ph4': true,
+                }
+
+                const isPh4Enabled = processor.isPh4Enabled(features, 'FOO');
+
+                expect(isPh4Enabled).toBe(true);
+            });
+
+            test('3483.PH4 is ON, 6885.PH4_US_OLY is ON, and country is US', () => {
+                const features = {
+                    'PROJECT-3483.amazon_pay_ph4': true,
+                    'INT-6885.amazon_pay_ph4_us_only': true,
+                }
+
+                const isPh4Enabled = processor.isPh4Enabled(features, 'US');
+
+                expect(isPh4Enabled).toBe(true);
+            });
+        });
+
+        describe('should return FALSE if...', () => {
+            test('3483.PH4 is OFF, 6885.PH4_US_OLY is OFF, and country is US', () => {
+                const features = {
+                    'PROJECT-3483.amazon_pay_ph4': false,
+                    'INT-6885.amazon_pay_ph4_us_only': false,
+                }
+
+                const isPh4Enabled = processor.isPh4Enabled(features, 'US');
+
+                expect(isPh4Enabled).toBe(false);
+            });
+
+            test('3483.PH4 is OFF, 6885.PH4_US_OLY is OFF, and country is not US', () => {
+                const features = {
+                    'PROJECT-3483.amazon_pay_ph4': false,
+                    'INT-6885.amazon_pay_ph4_us_only': false,
+                }
+
+                const isPh4Enabled = processor.isPh4Enabled(features, 'FOO');
+
+                expect(isPh4Enabled).toBe(false);
+            });
+
+            test('3483.PH4 is OFF, 6885.PH4_US_OLY is ON, and country is US', () => {
+                const features = {
+                    'PROJECT-3483.amazon_pay_ph4': false,
+                    'INT-6885.amazon_pay_ph4_us_only': true,
+                }
+
+                const isPh4Enabled = processor.isPh4Enabled(features, 'US');
+
+                expect(isPh4Enabled).toBe(false);
+            });
+
+            test('3483.PH4 is OFF, 6885.PH4_US_OLY is ON, and country is not US', () => {
+                const features = {
+                    'PROJECT-3483.amazon_pay_ph4': false,
+                    'INT-6885.amazon_pay_ph4_us_only': true,
+                }
+
+                const isPh4Enabled = processor.isPh4Enabled(features, 'FOO');
+
+                expect(isPh4Enabled).toBe(false);
+            });
+
+            test('3483.PH4 is ON, 6885.PH4_US_OLY is ON, and country is not US', () => {
+                const features = {
+                    'PROJECT-3483.amazon_pay_ph4': true,
+                    'INT-6885.amazon_pay_ph4_us_only': true,
+                }
+
+                const isPh4Enabled = processor.isPh4Enabled(features, 'FOO');
+
+                expect(isPh4Enabled).toBe(false);
+            });
+        });
+    });
 });

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -211,7 +211,7 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
     describe('#renderAmazonPayButton', () => {
         const CONTAINER_ID = 'container_passed_by_the_client';
-        const renderAmazonPayButton = (containerId = CONTAINER_ID, decoupleCheckoutInitiation = false) => {
+        const renderAmazonPayButton = (containerId = CONTAINER_ID, decoupleCheckoutInitiation = false) =>
             processor.renderAmazonPayButton({
                 checkoutState: store.getState(),
                 containerId,
@@ -219,7 +219,6 @@ describe('AmazonPayV2PaymentProcessor', () => {
                 methodId: 'amazonpay',
                 placement: AmazonPayV2Placement.Checkout,
             });
-        };
         const expectedContainerId = expect.stringMatching(/^#amazonpay_button_parent_container_[0-9a-f]{4}$/);
 
         let store: CheckoutStore;
@@ -232,6 +231,17 @@ describe('AmazonPayV2PaymentProcessor', () => {
 
         beforeEach(() => {
             store = createCheckoutStore(getCheckoutStoreState());
+        });
+
+        it('should return the buttonParentContainer', async () => {
+            const parentContainer = document.createElement('div');
+            jest.spyOn(document, 'createElement')
+                .mockReturnValueOnce(parentContainer);
+
+            await processor.initialize(amazonPayV2Mock);
+            const amazonPayButton = renderAmazonPayButton();
+
+            expect(amazonPayButton).toBe(parentContainer);
         });
 
         it('should render an Amazon Pay button and validate if cart contains physical items', async () => {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -72,7 +72,7 @@ export default class AmazonPayV2PaymentProcessor {
         methodId,
         options,
         placement,
-    }: AmazonPayV2ButtonRenderingOptions): HTMLElement {
+    }: AmazonPayV2ButtonRenderingOptions): HTMLDivElement {
         const container = document.querySelector<HTMLElement>(`#${containerId}`);
 
         if (!container) {
@@ -87,7 +87,7 @@ export default class AmazonPayV2PaymentProcessor {
 
         this.createButton(parentContainerId, amazonPayV2ButtonOptions);
 
-        return container;
+        return this._getButtonParentContainer();
     }
 
     /**

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -2,6 +2,8 @@ import { PaymentMethod } from '../..';
 import { InternalCheckoutSelectors } from '../../../../../core/src/checkout';
 import { getShippableItemsCount } from '../../../../../core/src/shipping';
 import { guard } from '../../../../src/common/utility';
+import { StoreProfile } from '../../../../src/config';
+import { CheckoutSettings } from '../../../../src/config/config';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType, NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
 
 import { AmazonPayV2Button, AmazonPayV2ButtonColor, AmazonPayV2ButtonParameters, AmazonPayV2ButtonRenderingOptions, AmazonPayV2ChangeActionType, AmazonPayV2CheckoutSessionConfig, AmazonPayV2NewButtonParams, AmazonPayV2PayOptions, AmazonPayV2Placement, AmazonPayV2SDK } from './amazon-pay-v2';
@@ -88,6 +90,23 @@ export default class AmazonPayV2PaymentProcessor {
         return container;
     }
 
+    /**
+     * @internal
+     */
+    isPh4Enabled(
+        features: CheckoutSettings['features'],
+        storeCountryCode: StoreProfile['storeCountryCode']
+    ): boolean {
+        const isPh4Enabled = !!features['PROJECT-3483.amazon_pay_ph4'];
+        const isPh4UsOnly = !!features['INT-6885.amazon_pay_ph4_us_only'];
+
+        if (isPh4Enabled && isPh4UsOnly) {
+            return storeCountryCode === 'US';
+        }
+
+        return isPh4Enabled;
+    }
+
     private _createAmazonPayButtonParentContainer(): HTMLDivElement {
         const uid = Math.random().toString(16).substr(-4);
         const parentContainer = document.createElement('div');
@@ -121,7 +140,7 @@ export default class AmazonPayV2PaymentProcessor {
 
         const {
             checkoutSettings: { features },
-            storeProfile: { shopPath },
+            storeProfile: { shopPath, storeCountryCode },
         } = getStoreConfigOrThrow();
 
         const cart = getCart();
@@ -141,7 +160,7 @@ export default class AmazonPayV2PaymentProcessor {
             buttonColor: AmazonPayV2ButtonColor.Gold,
         };
 
-        if (features['PROJECT-3483.amazon_pay_ph4']) {
+        if (this.isPh4Enabled(features, storeCountryCode)) {
             const amount = getCheckout()?.outstandingBalance.toString();
             const currencyCode = cart?.currency.code;
             const buttonOptions: AmazonPayV2NewButtonParams = { ...buttonBaseConfig };

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
@@ -39,8 +39,10 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
 
         await this._amazonPayV2PaymentProcessor.initialize(paymentMethod);
 
-        if (this._isReadyToPay(features, paymentToken) && amazonpay?.editButtonId) {
-            this._bindEditButton(amazonpay.editButtonId, paymentToken, 'changePayment', this._isModalFlow(region));
+        if (this._isReadyToPay(paymentToken)) {
+            if (amazonpay?.editButtonId) {
+                this._bindEditButton(amazonpay.editButtonId, paymentToken, 'changePayment', this._isModalFlow(region));
+            }
         } else {
             const { id: containerId } = this._createContainer();
 
@@ -70,7 +72,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
         const { features } = this._store.getState().config.getStoreConfigOrThrow().checkoutSettings;
         const { region, paymentToken } = this._store.getState().paymentMethods.getPaymentMethodOrThrow(methodId).initializationData;
 
-        if (this._isReadyToPay(features, paymentToken) || this._isOneTimeTransaction(features)) {
+        if (this._isReadyToPay(paymentToken) || this._isOneTimeTransaction(features)) {
             const paymentPayload = {
                 methodId,
                 paymentData: { nonce: paymentToken || 'apb' },
@@ -175,11 +177,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
         return features['PROJECT-3483.amazon_pay_ph4'] && features['INT-6399.amazon_pay_apb'];
     }
 
-    private _isStandardIntegration(features: CheckoutSettings['features']): boolean {
-        return !this._isOneTimeTransaction(features);
-    }
-
-    private _isReadyToPay(features: CheckoutSettings['features'], paymentToken?: string): boolean {
-        return this._isStandardIntegration(features) && !!paymentToken;
+    private _isReadyToPay(paymentToken?: string): boolean {
+        return !!paymentToken;
     }
 }

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-strategy.ts
@@ -17,7 +17,7 @@ import { AmazonPayV2ChangeActionType, AmazonPayV2Placement } from './amazon-pay-
 import AmazonPayV2PaymentProcessor from './amazon-pay-v2-payment-processor';
 
 export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
-    private _buttonContainer?: HTMLElement;
+    private _amazonPayButton?: HTMLDivElement;
 
     constructor(
         private _store: CheckoutStore,
@@ -47,7 +47,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
         } else {
             const { id: containerId } = this._createContainer();
 
-            this._buttonContainer =
+            this._amazonPayButton =
                 this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
                     checkoutState: this._store.getState(),
                     containerId,
@@ -98,7 +98,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
             }
         }
 
-        this._getButtonContainer().click();
+        this._getAmazonPayButton().click();
 
         // Focus of parent window used to try and detect the user cancelling the Amazon log in modal
         // Should be refactored if/when Amazon add a modal close hook to their SDK
@@ -123,7 +123,7 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
     async deinitialize(): Promise<InternalCheckoutSelectors> {
         await this._amazonPayV2PaymentProcessor.deinitialize();
 
-        this._buttonContainer = undefined;
+        this._amazonPayButton = undefined;
 
         return this._store.getState();
     }
@@ -170,8 +170,8 @@ export default class AmazonPayV2PaymentStrategy implements PaymentStrategy {
         return document.body.appendChild(container);
     }
 
-    private _getButtonContainer() {
-        return guard(this._buttonContainer, () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
+    private _getAmazonPayButton() {
+        return guard(this._amazonPayButton, () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
     }
 
     private _isOneTimeTransaction(


### PR DESCRIPTION
## What? [INT-6890](https://bigcommercecloud.atlassian.net/browse/INT-6890) and [INT-6885](https://bigcommercecloud.atlassian.net/browse/INT-6885)
1. I changed the logic to bind the edit button in the payment strategy when the `APB` experiment is `ON`.
2. Put US merchant functionality behind its own experiment. 🇺🇸
3. Fixes a bug introduced in #1655 🐞 

## Why?
1. The logic is wrong. The buyer must be able to edit regardless of the `APB` experiment value. We should only validate the presence of the `paymentToken` and a `containerId`.
2. This will allow us to release the enhancement to US merchants only.
3. Simulated mouse click on the pay button doesn't work.

## Testing / Proof
https://user-images.githubusercontent.com/4843328/198750934-5e7e2dea-cc04-4299-b173-3c9aaf3f1d48.mp4

## Depends on:
👉 https://github.com/bigcommerce/bigcommerce/pull/49563

@bigcommerce/apex-integrations  @bigcommerce/checkout @bigcommerce/payments
