### PR TITLE
feat(payment): INT-5953-T Force to use Payment Strategy V1 when Mollie and Apple pay

### DIFF
--- a/packages/core/src/payment/payment-strategy-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.spec.ts
@@ -152,6 +152,27 @@ describe("PaymentStrategyActionCreator", () => {
             expect(registry.getByMethod).toHaveBeenCalledWith(method);
         });
 
+        it("finds payment strategy by method when methodId is apple pay and gatewayId is mollie", async () => {
+            const method = {
+                ...getPaymentMethod(),
+                id: 'applepay',
+                gateway: 'mollie'
+            }
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(method);
+            jest.spyOn(store.getState().paymentStrategies, 'isInitialized').mockReturnValue(false);
+
+
+            await from(
+                actionCreator.initialize({
+                    methodId: method.id,
+                    gatewayId: method.gateway,
+                })(store)
+            ).toPromise();
+
+            expect(registry.getByMethod).toHaveBeenCalledWith(method);
+        });
+
         it("initializes payment strategy", async () => {
             const method = getPaymentMethod();
 
@@ -288,6 +309,27 @@ describe("PaymentStrategyActionCreator", () => {
             expect(registry.getByMethod).toHaveBeenCalledWith(method);
         });
 
+        it("finds payment strategy by method when methodId is apple pay and gatewayId is mollie", async () => {
+            const method = {
+                ...getPaymentMethod(),
+                id: 'applepay',
+                gateway: 'mollie'
+            }
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(method);
+            jest.spyOn(store.getState().paymentStrategies, 'isInitialized').mockReturnValue(true);
+
+
+            await from(
+                actionCreator.deinitialize({
+                    methodId: method.id,
+                    gatewayId: method.gateway,
+                })(store)
+            ).toPromise();
+
+            expect(registry.getByMethod).toHaveBeenCalledWith(method);
+        });
+
         it("deinitializes payment strategy", async () => {
             await from(
                 actionCreator.deinitialize({
@@ -391,6 +433,24 @@ describe("PaymentStrategyActionCreator", () => {
 
         it("finds payment strategy by method", async () => {
             const method = getPaymentMethod();
+
+            await from(
+                actionCreator.execute(getOrderRequestBody())(store)
+            ).toPromise();
+
+            expect(registry.getByMethod).toHaveBeenCalledWith(method);
+        });
+
+        it("finds payment strategy by method when methodId is apple pay and gatewayId is mollie", async () => {
+            const method = {
+                ...getPaymentMethod(),
+                id: 'applepay',
+                gateway: 'mollie'
+            }
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(method);
+            jest.spyOn(store.getState().paymentStrategies, 'isInitialized').mockReturnValue(false);
+
 
             await from(
                 actionCreator.execute(getOrderRequestBody())(store)
@@ -569,6 +629,24 @@ describe("PaymentStrategyActionCreator", () => {
             const method = getPaymentMethod();
 
             await from(actionCreator.finalize()(store)).toPromise();
+
+            expect(registry.getByMethod).toHaveBeenCalledWith(method);
+        });
+
+        it("finds payment strategy by method when methodId is apple pay and gatewayId is mollie", async () => {
+            const method = {
+                ...getPaymentMethod(),
+                id: 'applepay',
+                gateway: 'mollie'
+            }
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(method);
+            jest.spyOn(store.getState().paymentStrategies, 'isInitialized').mockReturnValue(false);
+
+
+            await from(
+                actionCreator.finalize()(store)
+            ).toPromise();
 
             expect(registry.getByMethod).toHaveBeenCalledWith(method);
         });

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -90,9 +90,13 @@ export default class PaymentStrategyActionCreator {
                         }
 
                         try {
-                            strategy = this._strategyRegistryV2.get({
-                                id: method.id, gateway: method.gateway, type: method.type,
-                            });
+                            if (method.id == PaymentStrategyType.APPLEPAY && method.gateway == PaymentStrategyType.MOLLIE) {
+                                strategy = this._strategyRegistry.getByMethod(method);
+                            } else {
+                                strategy = this._strategyRegistryV2.get({
+                                    id: method.id, gateway: method.gateway, type: method.type,
+                                });
+                            }
                         } catch {
                             strategy =
                                 this._strategyRegistry.getByMethod(method);
@@ -153,9 +157,13 @@ export default class PaymentStrategyActionCreator {
                     let strategy: PaymentStrategy | PaymentStrategyV2;
 
                     try {
-                        strategy = this._strategyRegistryV2.get({
-                            id: method.id, gateway: method.gateway, type: method.type,
-                        });
+                        if (method.id == PaymentStrategyType.APPLEPAY && method.gateway == PaymentStrategyType.MOLLIE) {
+                            strategy = this._strategyRegistry.getByMethod(method);
+                        } else {
+                            strategy = this._strategyRegistryV2.get({
+                                id: method.id, gateway: method.gateway, type: method.type,
+                            });
+                        }
                     } catch {
                         strategy = this._strategyRegistry.getByMethod(method);
                     }
@@ -215,9 +223,13 @@ export default class PaymentStrategyActionCreator {
                 let strategy: PaymentStrategy | PaymentStrategyV2;
 
                 try {
-                    strategy = this._strategyRegistryV2.get({
-                        id: method.id, gateway: method.gateway, type: method.type,
-                    });
+                    if (method.id == PaymentStrategyType.APPLEPAY && method.gateway == PaymentStrategyType.MOLLIE) {
+                        strategy = this._strategyRegistry.getByMethod(method);
+                    } else {
+                        strategy = this._strategyRegistryV2.get({
+                            id: method.id, gateway: method.gateway, type: method.type,
+                        });
+                    }
                 } catch {
                     strategy = this._strategyRegistry.getByMethod(method);
                 }
@@ -284,9 +296,13 @@ export default class PaymentStrategyActionCreator {
                 let strategy: PaymentStrategy | PaymentStrategyV2;
 
                 try {
-                    strategy = this._strategyRegistryV2.get({
-                        id: method.id, gateway: method.gateway, type: method.type,
-                    });
+                    if (method.id == PaymentStrategyType.APPLEPAY && method.gateway == PaymentStrategyType.MOLLIE) {
+                        strategy = this._strategyRegistry.getByMethod(method);
+                    } else {
+                        strategy = this._strategyRegistryV2.get({
+                            id: method.id, gateway: method.gateway, type: method.type,
+                        });
+                    }
                 } catch {
                     strategy = this._strategyRegistry.getByMethod(method);
                 }


### PR DESCRIPTION
## What?
Add a validation to force to use PaymentStrategy V1 when the methodId is apple pay and gateway is mollie.
This to use the MolliePaymentStrategy.

## Why?
As a momentarily solution to support Apple Pay on Mollie, and meanwhile an enhancement to support Mollie as PaymentStrategy V2.

## Testing / Proof
<img width="1087" alt="image" src="https://user-images.githubusercontent.com/35146660/199547923-60e7e1f5-d69e-4014-99be-3dc84f9fbde4.png">


@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
