### PR TITLE
refactor(payment): PAYPAL-1773 removed unnecessary business logic from PayPalCommerceInlineCheckoutButton strategy

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-options.ts
@@ -2,32 +2,10 @@ import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-com
 
 export interface PaypalCommerceInlineCheckoutButtonInitializeOptions {
     /**
-     * Accelerated Checkout Buttons container - is a generic container for all AC buttons
-     * Used as a container where the button will be rendered with its own container
-     * Example: 'data-cart-accelerated-checkout-buttons'
-     * Info: we are using data attributes as an identifier because the buttons can be rendered in several places on the page
-     */
-    acceleratedCheckoutContainerDataId: string;
-
-    /**
-     * A container identifier what used to add special class for container where the button will be generated in
-     * Example: 'data-paypal-commerce-inline-button'
-     * Info: we are using data attributes as an identifier because the buttons can be rendered in several places on the page
-     */
-    buttonContainerDataId: string;
-
-    /**
      * A class name used to add special class for container where the button will be generated in
      * Default: 'PaypalCommerceInlineButton'
      */
     buttonContainerClassName?: string;
-
-    /**
-     * Used by Accelerated Checkout strategy to hide native action button before rendering PayPal inline checkout button
-     * Example: 'data-checkout-now-button'
-     * Info: we are using data attributes as an identifier because the buttons can be rendered in several places on the page
-     */
-    nativeCheckoutButtonDataId: string;
 
     /**
      * A set of styling options for the checkout button.
@@ -38,4 +16,9 @@ export interface PaypalCommerceInlineCheckoutButtonInitializeOptions {
      * A callback that gets called when payment complete on paypal side.
      */
     onComplete(): void;
+
+    /**
+     * A callback that gets called on any error
+     */
+    onError?(): void;
 }


### PR DESCRIPTION
## What?
Removed unnecessary business logic from PayPalCommerceInlineCheckoutButton strategy

## Why?
The business logic was moved to the place where PayPalCommerceInlineCheckoutButton strategy should be initialised. This change should make current strategy more abstract and easier to maintain.

## Sibling pull-request
https://github.com/bigcommerce/bigcommerce/pull/49605

## Testing / Proof
Unit tests
Manual tests

Cornerstone theme:
<img width="1399" alt="Screenshot 2022-11-03 at 15 46 48" src="https://user-images.githubusercontent.com/25133454/199758825-0610507f-559b-4d78-8da2-b6c0281cd6dc.png">

Merchant's theme:
<img width="1526" alt="Screenshot 2022-11-03 at 14 13 46" src="https://user-images.githubusercontent.com/25133454/199758980-fa0b8ff8-0971-4bda-961f-3f0bc1498def.png">

