### PR TITLE
feat(payment): STRIPE-194 Clean address when logout

### DIFF
--- a/packages/core/src/customer/create-customer-strategy-registry.ts
+++ b/packages/core/src/customer/create-customer-strategy-registry.ts
@@ -304,7 +304,11 @@ export default function createCustomerStrategyRegistry(
             store,
             new StripeScriptLoader(scriptLoader),
             customerActionCreator,
-            paymentMethodActionCreator
+            paymentMethodActionCreator,
+            new ConsignmentActionCreator(
+                new ConsignmentRequestSender(requestSender),
+                new CheckoutRequestSender(requestSender)
+            )
         )
     );
 

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.spec.ts
@@ -1,6 +1,7 @@
 import { createAction } from '@bigcommerce/data-store';
 import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
+import { ConsignmentActionCreator } from 'packages/core/src/shipping';
 import { of, Observable } from 'rxjs';
 
 import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
@@ -30,6 +31,7 @@ describe('StripeUpeCustomerStrategy', () => {
     const mutationObserverFactory = new MutationObserverFactory();
     const googleRecaptcha = new GoogleRecaptcha(googleRecaptchaScriptLoader, mutationObserverFactory);
     const requestSender = createRequestSender();
+    let consignmentActionCreator: ConsignmentActionCreator;
 
     let customerActionCreator: CustomerActionCreator;
     let paymentMethodActionCreator: PaymentMethodActionCreator;
@@ -86,7 +88,8 @@ describe('StripeUpeCustomerStrategy', () => {
             store,
             stripeScriptLoader,
             customerActionCreator,
-            paymentMethodActionCreator
+            paymentMethodActionCreator,
+            consignmentActionCreator
         );
     });
 

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -136,25 +136,5 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
 
         return Promise.resolve(this._store.getState());
     }
-
-    _resetAddress(address: AddressRequestBody) {
-
-        const { firstName, lastName, company, address1, address2, city, stateOrProvince, stateOrProvinceCode, countryCode, postalCode, phone  } = address;
-
-        return {
-            ...address,
-            firstName: firstName !== 'Fake' ? firstName : '',
-            lastName: lastName !== 'Fake' ? lastName : '',
-            company: company !== 'Fake' ? company : '',
-            address1: address1 !== 'Fake' ? address1 : '',
-            address2: address2 !== 'Fake' ? address2 : '',
-            city: city !== 'Fake' ? city : '',
-            stateOrProvince: stateOrProvince !== 'Fake' ? stateOrProvince : '',
-            stateOrProvinceCode: stateOrProvinceCode !== 'Fake' ? stateOrProvinceCode : '',
-            countryCode: countryCode !== 'Fake' ? countryCode : '',
-            postalCode: postalCode !== 'Fake' ? postalCode : '',
-            phone: phone !== 'Fake' ? phone : '',
-        }
-    }
 }
 

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -92,11 +92,9 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
                 }
                 if (isStripeLinkAuthenticated && !event.authenticated) {
                     const state = this._store.getState();
-                    const shippingAddres = state.shippingAddress.getShippingAddressOrThrow();
-                    const resetAddress = this._resetAddress(shippingAddres);
-
+                    const consignmentShipping = state.consignments.getConsignmentsOrThrow();
                     return this._store.dispatch(
-                        this._consignmentActionCreator.updateAddress(resetAddress, options)
+                        this._consignmentActionCreator.deleteConsignment(consignmentShipping[0].id)
                     );
 
                 }

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -1,5 +1,4 @@
 import { createAction } from '@bigcommerce/data-store';
-import { AddressRequestBody } from 'packages/core/src/address';
 import ConsignmentActionCreator from 'packages/core/src/shipping/consignment-action-creator';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';

--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -8,16 +8,18 @@ import { CustomerActionType } from '../../customer-actions';
 import CustomerCredentials from '../../customer-credentials';
 import { CustomerInitializeOptions, CustomerRequestOptions, ExecutePaymentMethodCheckoutOptions } from '../../customer-request-options';
 import CustomerStrategy from '../customer-strategy';
+import { ShippingStrategy } from 'packages/core/src/shipping/strategies';
 
 export default class StripeUPECustomerStrategy implements CustomerStrategy {
     private _stripeElements?: StripeElements;
+    private _shippingAddres?: ShippingStrategy
 
     constructor(
         private _store: CheckoutStore,
         private _stripeUPEScriptLoader: StripeScriptLoader,
         private _customerActionCreator: CustomerActionCreator,
         private _paymentMethodActionCreator: PaymentMethodActionCreator
-    ) {}
+    ) { }
 
     async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
         let stripeUPEClient: StripeUPEClient;
@@ -41,7 +43,7 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
         const {
             clientToken, initializationData: { stripePublishableKey, stripeConnectedAccount } = {}
         } = getPaymentMethodOrThrow(methodId, gatewayId);
-        const { email } = getCustomerOrThrow();
+        const { email, isStripeLinkAuthenticated } = getCustomerOrThrow();
 
         if (!email) {
             if (!stripePublishableKey || !clientToken) {
@@ -81,10 +83,29 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
             });
 
             const linkAuthenticationElement = this._stripeElements.getElement(StripeElementType.AUTHENTICATION) || this._stripeElements.create(StripeElementType.AUTHENTICATION);
+            const shippingAddress = this._shippingAddres;
 
             linkAuthenticationElement.on('change', (event: StripeEventType) => {
                 if (!('authenticated' in event)) {
                     throw new MissingDataError(MissingDataErrorType.MissingCustomer);
+                }
+                if (isStripeLinkAuthenticated && !event.authenticated) {
+                    const address = {
+                        firstName: '',
+                        lastName: '',
+                        company: '',
+                        address1: '',
+                        address2: '',
+                        city: '',
+                        stateOrProvince: '',
+                        stateOrProvinceCode: '',
+                        countryCode: '',
+                        postalCode: '',
+                        phone: '',
+                    }
+                    shippingAddress?.updateAddress(address);
+                    shippingAddress?.initialize();
+
                 }
                 this._store.dispatch(createAction(CustomerActionType.StripeLinkAuthenticated, event.authenticated));
                 event.complete ? onEmailChange(event.authenticated, event.value.email) : onEmailChange(false, '');


### PR DESCRIPTION
## What? [STRIPE-194](https://bigcommercecloud.atlassian.net/browse/STRIPE-194?atlOrigin=eyJpIjoiYTUzOWZkZjFmMGU3NDk3OGFjNTQzOWJlNmYyOGRiMGYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Why?
When we log out we need to clean address inputs

## Testing / Proof

<img width="679" alt="Screen Shot 2022-11-07 at 4 34 18 PM" src="https://user-images.githubusercontent.com/25911489/200429858-8d916831-728d-471b-b8a7-2b467e26bdb3.png">

<img width="667" alt="Screen Shot 2022-11-07 at 4 34 27 PM" src="https://user-images.githubusercontent.com/25911489/200429894-5f4885da-9d97-494c-942a-37ae3072b967.png">


@bigcommerce/checkout @bigcommerce/payments
