### PR TITLE
refactor(payment): PAYPAL-1757 removed 'Fake' data implementation from paypal commerce credit button strategy

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
@@ -175,12 +175,6 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
                     }
                 });
 
-                eventEmitter.on('onCancel', () => {
-                    if (options.onCancel) {
-                        options.onCancel();
-                    }
-                });
-
                 eventEmitter.on('onClick', async (jestSuccessExpectationsCallback, jestFailureExpectationsCallback) => {
                     try {
                         if (options.onClick) {
@@ -863,77 +857,6 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
                 await new Promise(resolve => process.nextTick(resolve));
 
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({ methodId, paymentData });
-            });
-        });
-        describe('#_onCancel button callback', () => {
-            it('calls billingAddressActionCreator when isHostedCheckoutEnabled true', async () => {
-                const paymentMethod = {
-                    ...paymentMethodMock,
-                    initializationData: {
-                        ...paymentMethodMock.initializationData,
-                        isHostedCheckoutEnabled: true,
-                    }
-
-                }
-                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethod);
-                await strategy.initialize(initializationOptions);
-                eventEmitter.emit('onClick');
-                await new Promise(resolve => process.nextTick(resolve));
-                eventEmitter.emit('onCancel');
-                await new Promise(resolve => process.nextTick(resolve));
-
-                expect(billingAddressActionCreator.updateAddress).toHaveBeenCalled();
-            });
-
-            it('calls consignmentActionCreator when isHostedCheckoutEnabled true', async () => {
-                const paymentMethod = {
-                    ...paymentMethodMock,
-                    initializationData: {
-                        ...paymentMethodMock.initializationData,
-                        isHostedCheckoutEnabled: true,
-                    }
-
-                }
-                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethod);
-                jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(Promise.resolve());
-                await strategy.initialize(initializationOptions);
-                eventEmitter.emit('onClick');
-                await new Promise(resolve => process.nextTick(resolve));
-                eventEmitter.emit('onCancel');
-                await new Promise(resolve => process.nextTick(resolve));
-
-                expect(consignmentActionCreator.updateAddress).toHaveBeenCalled();
-            });
-
-            it('calls paypalCommerceRequestSender updateOrder when isHostedCheckoutEnabled true', async () => {
-                const paymentMethod = {
-                    ...paymentMethodMock,
-                    initializationData: {
-                        ...paymentMethodMock.initializationData,
-                        isHostedCheckoutEnabled: true,
-                    }
-
-                }
-                jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethod);
-                jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(Promise.resolve());
-                await strategy.initialize(initializationOptions);
-                eventEmitter.emit('onClick');
-                await new Promise(resolve => process.nextTick(resolve));
-                eventEmitter.emit('onCancel');
-                await new Promise(resolve => process.nextTick(resolve));
-
-                expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalled();
-            });
-
-            it('does not updateOrder when isHostedCheckoutEnabled false', async () => {
-                jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(Promise.resolve());
-                await strategy.initialize(initializationOptions);
-                eventEmitter.emit('onClick');
-                await new Promise(resolve => process.nextTick(resolve));
-                eventEmitter.emit('onCancel');
-                await new Promise(resolve => process.nextTick(resolve));
-
-                expect(paypalCommerceRequestSender.updateOrder).not.toHaveBeenCalled();
             });
         });
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
@@ -8,7 +8,7 @@ import { InvalidArgumentError, MissingDataError, MissingDataErrorType, RequestEr
 import { OrderActionCreator } from '../../../order';
 import { PaymentActionCreator } from '../../../payment';
 import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
-import { ApproveCallbackActions, ApproveCallbackPayload, ButtonsOptions, PaypalButtonStyleOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, PayPalOrderAddress, PayPalOrderDetails, ShippingAddressChangeCallbackPayload, ShippingOptionChangeCallbackPayload } from "../../../payment/strategies/paypal-commerce";
+import { ApproveCallbackActions, ApproveCallbackPayload, ButtonsOptions, PaypalButtonStyleOptions, PaypalCommerceRequestSender, PaypalCommerceScriptLoader, PaypalCommerceSDK, ShippingAddressChangeCallbackPayload, ShippingOptionChangeCallbackPayload } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 import { ConsignmentActionCreator, ShippingOption } from '../../../shipping';
@@ -89,7 +89,6 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
             onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) => this._onShippingAddressChange(data),
             onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) => this._onShippingOptionsChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) => this._onHostedCheckoutApprove(data, actions, methodId, onComplete),
-            onCancel: () => this._onCancel(),
         };
 
         const regularCallbacks = {
@@ -126,27 +125,6 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
         }
     }
 
-    private async _onCancel() {
-        const state = this._store.getState();
-        const billingAddress = state.billingAddress.getBillingAddressOrThrow();
-        const resetAddress = this._resetAddress(billingAddress);
-        await this._store.dispatch(this._billingAddressActionCreator.updateAddress(resetAddress));
-        await this._store.dispatch(this._consignmentActionCreator.updateAddress(resetAddress));
-        await this._updateOrder();
-    }
-
-    private _resetAddress(address: BillingAddressRequestBody) {
-        const { firstName, lastName, address1, email } = address;
-
-        return {
-            ...address,
-            firstName: firstName !== 'Fake' ? firstName : '',
-            lastName: lastName !== 'Fake' ? lastName : '',
-            address1: address1 !== 'Fake street' ? address1 : '',
-            email: email !== 'fake@fake.fake' ? email : '',
-        }
-    }
-
     private async _onHostedCheckoutApprove(
         data: ApproveCallbackPayload,
         actions: ApproveCallbackActions,
@@ -155,24 +133,39 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
     ): Promise<boolean> {
         const state = this._store.getState();
         const cart = state.cart.getCartOrThrow();
-        const orderDetails = await this.getActionsOrThrow(actions);
+        const orderDetails = await this._getOrderDetailsOrThrow(actions);
 
         if (cart.lineItems.physicalItems.length > 0) {
-            const address = this._getValidAddress(
-                orderDetails.payer.name,
-                orderDetails.payer.email_address,
-                orderDetails.purchase_units[0].shipping.address
-            );
+            const { payer, purchase_units } = orderDetails;
+            const shippingAddress = purchase_units?.[0]?.shipping?.address || {};
+
+            const address = this._getAddress({
+                firstName: payer.name.given_name,
+                lastName: payer.name.surname,
+                email: payer.email_address,
+                address1: shippingAddress.address_line_1,
+                city: shippingAddress.admin_area_2,
+                countryCode: shippingAddress.country_code,
+                postalCode: shippingAddress.postal_code,
+                stateOrProvinceCode: shippingAddress.admin_area_1,
+            });
 
             await this._store.dispatch(this._billingAddressActionCreator.updateAddress(address));
             await this._store.dispatch(this._consignmentActionCreator.updateAddress(address));
             await this._updateOrder();
         } else {
-            const address = this._getValidAddress(
-                orderDetails.payer.name,
-                orderDetails.payer.email_address,
-                orderDetails.payer.address
-            );
+            const { payer } = orderDetails;
+
+            const address = this._getAddress({
+                firstName: payer.name.given_name,
+                lastName: payer.name.surname,
+                email: payer.email_address,
+                address1: payer.address.address_line_1,
+                city: payer.address.admin_area_2,
+                countryCode: payer.address.country_code,
+                postalCode: payer.address.postal_code,
+                stateOrProvinceCode: payer.address.admin_area_1,
+            });
 
             await this._store.dispatch(this._billingAddressActionCreator.updateAddress(address));
         }
@@ -187,13 +180,12 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
         return true;
     }
 
-    private async getActionsOrThrow(actions: ApproveCallbackActions) {
-
-        if (!actions) {
-           throw new RequestError();
+    private async _getOrderDetailsOrThrow(actions: ApproveCallbackActions) {
+        try {
+            return await actions.order.get();
+        } catch (error) {
+            throw new RequestError();
         }
-
-        return actions.order.get();
     }
 
     private async _onShippingOptionsChange(data: ShippingOptionChangeCallbackPayload): Promise<void> {
@@ -220,7 +212,7 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
     }
 
     private async _onShippingAddressChange(data: ShippingAddressChangeCallbackPayload): Promise<void> {
-        const address = this._transformAddress({
+        const address = this._getAddress({
             city: data.shippingAddress.city,
             countryCode: data.shippingAddress.country_code,
             postalCode: data.shippingAddress.postal_code,
@@ -274,14 +266,14 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
         return shippingOptionToSelect;
     }
 
-    private _transformAddress(address?: Partial<BillingAddressRequestBody>): BillingAddressRequestBody {
+    private _getAddress(address?: Partial<BillingAddressRequestBody>): BillingAddressRequestBody {
         return {
-            firstName: address?.firstName || 'Fake',
-            lastName: address?.lastName || 'Fake',
-            email: address?.email || 'fake@fake.fake',
+            firstName: address?.firstName || '',
+            lastName: address?.lastName || '',
+            email: address?.email || '',
             phone: '',
             company: '',
-            address1: address?.address1 || 'Fake street',
+            address1: address?.address1 || '',
             address2: '',
             city: address?.city || '',
             countryCode: address?.countryCode || '',
@@ -290,23 +282,6 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
             stateOrProvinceCode: address?.stateOrProvinceCode || '',
             customFields: [],
         };
-    }
-
-    private _getValidAddress(
-        payerName: PayPalOrderDetails['payer']['name'],
-        email: string,
-        address: PayPalOrderAddress,
-    ) {
-        return this._transformAddress({
-            firstName: payerName.given_name,
-            lastName: payerName.surname,
-            email,
-            address1: address.address_line_1,
-            city: address.admin_area_2,
-            countryCode: address.country_code,
-            postalCode: address.postal_code,
-            stateOrProvinceCode: address.admin_area_1,
-        });
     }
 
     private _renderMessages(messagingContainerId?: string): void {


### PR DESCRIPTION
## What?
Removed 'Fake' data implementation from PayPalCommerceCreditButtonStrategy

## Why?
We used 'Fake' data to fill all required empty fields in onShippingAddressChange and onShippingOptionChange callbacks to create an order trough bigpay. But we don't need to mock the data for onShippingAddressChange and onShippingOptionChange to pass bigpay validation anymore, due to the bigpay mapper update

## Testing / Proof
Unit tests
Manual tests

https://user-images.githubusercontent.com/25133454/199946944-5fe03621-4057-40da-9fe9-32b031c45adc.mov





