### PR TITLE
fix(shipping): STRIPE-202 Split name input into First and Last name

### DIFF
--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -11,6 +11,7 @@ import {
     StripeElements,
     StripeElementType,
     StripeEventType,
+    StripeFormMode,
     StripeScriptLoader,
     StripeUPEAppearanceOptions,
     StripeUPEClient,
@@ -118,7 +119,9 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
             const consignments = getConsignments();
             const id = consignments?.[0]?.id;
             const { email: billingEmail } = getBillingAddress() || {};
-            const options = billingEmail ? { defaultValues: { email: billingEmail } } : {};
+            const options = billingEmail
+                ? { defaultValues: { mode: StripeFormMode.SHIPPING, email: billingEmail } }
+                : {};
             const linkAuthenticationElement =
                 this._stripeElements.getElement(StripeElementType.AUTHENTICATION) ||
                 this._stripeElements.create(StripeElementType.AUTHENTICATION, options);

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -59,6 +59,7 @@ export interface StripeCustomerEvent extends StripeEvent {
 }
 
 export interface StripeShippingEvent extends StripeEvent {
+    mode?: string;
     isNewAddress?: boolean;
     phoneFieldRequired: boolean;
     value: {
@@ -70,8 +71,16 @@ export interface StripeShippingEvent extends StripeEvent {
             postal_code: string;
             state: string;
         };
-        name: string;
+        name?: string;
+        firstName?: string;
+        lastName?: string;
+        phone?: string;
+    };
+    fields?: {
         phone: string;
+    };
+    display?: {
+        name: string;
     };
 }
 
@@ -186,6 +195,7 @@ export interface StripeElementsCreateOptions {
     allowedCountries?: string[];
     defaultValues?: ShippingDefaultValues | CustomerDefaultValues;
     validation?: validationElement;
+    display?: { name: DisplayName };
 }
 
 interface validationElement {
@@ -197,7 +207,9 @@ interface validationRequiredElement {
 }
 
 interface ShippingDefaultValues {
-    name: string;
+    name?: string;
+    firstName?: string;
+    lastName?: string;
     phone: string;
     address: {
         line1: string;
@@ -209,8 +221,31 @@ interface ShippingDefaultValues {
     };
 }
 
+/*
+Decide which mode you are going to use the Address Element
+Shipping: is used with the Payment Element and Link Authentication Element, it will automatically pass shipping
+information when confirming Payment Intent or Setup Intent.
+Billing: is used with the Payment Element, it will automatically pass the billing information when confirming
+Payment Intent or Setup Intent.
+ */
+export enum StripeFormMode {
+    SHIPPING = 'shipping',
+    BILLING = 'billing',
+}
+
+export enum DisplayName {
+    SPLIT = 'split',
+    FULL = 'full',
+    ORGANIZATION = 'organization',
+}
+
 interface CustomerDefaultValues {
+    mode: StripeFormMode;
     email: string;
+    allowedCountries?: string[];
+    display?: {
+        name: DisplayName;
+    };
 }
 
 export interface StripeElements {

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../payment';
 import { getStripeUPE } from '../../../payment/payment-methods.mock';
 import {
+    DisplayName,
     StripeElement,
     StripeHostWindow,
     StripeScriptLoader,
@@ -70,8 +71,12 @@ describe('StripeUPEShippingStrategy', () => {
                     postal_code: '44910',
                     state: 'TX',
                 },
-                name: 'Alan',
+                firstName: 'Alan',
+                lastName: 'Muñoz',
                 phone: '+523333333333',
+            },
+            display: {
+                name: DisplayName.SPLIT,
             },
         };
     };
@@ -274,6 +279,21 @@ describe('StripeUPEShippingStrategy', () => {
             const promise = strategy.initialize(shippingInitialization);
 
             expect(promise).rejects.toBeInstanceOf(MissingDataError);
+        });
+
+        it('loads a single instance of StripeUPEClient without first and last name fields', async () => {
+            jest.spyOn(store.getState().shippingAddress, 'getShippingAddress').mockReturnValue({
+                ...getShippingAddress(),
+                firstName: '',
+                lastName: '',
+            });
+
+            await expect(strategy.initialize(shippingInitialization)).resolves.toBe(
+                store.getState(),
+            );
+
+            expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
+            expect(stripeUPEJsMock.elements).toHaveBeenCalledTimes(1);
         });
 
         it('triggers onChange event callback and mounts component', async () => {

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -7,10 +7,12 @@ import {
 } from '../../../common/error/errors';
 import { PaymentMethodActionCreator } from '../../../payment';
 import {
+    DisplayName,
     StripeElements,
     StripeElementsCreateOptions,
     StripeElementType,
     StripeEventType,
+    StripeFormMode,
     StripeScriptLoader,
     StripeUPEAppearanceOptions,
     StripeUPEClient,
@@ -142,7 +144,7 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
         const shipping = getShippingAddress();
         const shippingPhoneField = shippingFields.find((field) => field.name === 'phone');
         let option: StripeElementsCreateOptions = {
-            mode: 'shipping',
+            mode: StripeFormMode.SHIPPING,
             allowedCountries: [availableCountries],
             fields: {
                 phone: 'always',
@@ -152,6 +154,9 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
                     required:
                         shippingPhoneField && shippingPhoneField.required ? 'always' : 'never',
                 },
+            },
+            display: {
+                name: DisplayName.SPLIT,
             },
         };
 
@@ -175,7 +180,8 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
             option = {
                 ...option,
                 defaultValues: {
-                    name: lastName ? `${firstName} ${lastName}` : firstName,
+                    firstName,
+                    lastName,
                     phone,
                     address: {
                         line1: address1,


### PR DESCRIPTION
## What? [STRIPE-202](https://bigcommercecloud.atlassian.net/browse/STRIPE-202)
Split name input into First and Last name

## Why?
To have a better input field design

## Based documentation
[stripe_doc](https://stripe.com/docs/js/elements_object/create_address_element)

## Refactor
Noticed that there was a missing space in the stripe-upe-payment-strategy.ts so I added it to be more readable

## Testing / Proof
<img width="557" alt="Screen Shot 2022-11-08 at 16 02 34" src="https://user-images.githubusercontent.com/106765049/200685408-3923f183-8561-42a8-bd7a-49f864e01dc2.png">

<img width="831" alt="Screenshot 2023-02-08 at 16 21 06" src="https://user-images.githubusercontent.com/106765049/217664428-21ee5e07-914f-4dd6-9e5c-1b2f7cf7e3c1.png">

## Dependency of
[1200](https://github.com/bigcommerce/checkout-js/pull/1200)

@bigcommerce/checkout @bigcommerce/payments
