### PR TITLE
feat(payment): PAYPAL-1723 added ability to skip checkout page  on PDP (paypalcommercecredit)

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
@@ -949,5 +949,37 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
                 expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalled();
             });
         });
+
+        describe('#_handleClick', () => {
+            beforeEach(() => {
+                jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue(new Promise(resolve => resolve({body:{...buyNowCartMock}})));
+                jest.spyOn(checkoutActionCreator, 'loadCheckout').mockReturnValue(true);
+            });
+
+            it('calls _cartRequestSender.createBuyNowCart on button click', async () => {
+                const options = {
+                    ...initializationOptions,
+                    ...buyNowInitializationOptions
+                }
+                await strategy.initialize(options);
+                eventEmitter.emit('onClick');
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(cartRequestSender.createBuyNowCart).toHaveBeenCalled();
+            });
+
+            it('calls loadCheckout with proper cartId on button click', async () => {
+                const options = {
+                    ...initializationOptions,
+                    ...buyNowInitializationOptions
+                }
+                const cartId = buyNowCartMock.id;
+                await strategy.initialize(options);
+                eventEmitter.emit('onClick');
+                await new Promise(resolve => process.nextTick(resolve));
+
+                expect(checkoutActionCreator.loadCheckout).toHaveBeenCalledWith(cartId);
+            });
+        });
     });
 });

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
@@ -320,6 +320,7 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
                 const { body: cart } = await this._cartRequestSender.createBuyNowCart(cartRequestBody);
 
                 this._buyNowCartId = cart.id;
+                await this._store.dispatch(this._checkoutActionCreator.loadCheckout(cart.id));
             } catch (error) {
                 throw new BuyNowCartCreationError();
             }


### PR DESCRIPTION
## What?
Added ability for skip checkout to work on PDP (paypalcommercecredit).

## Why?
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1723

## Testing / Proof
Tested on int and dev

@bigcommerce/checkout @bigcommerce/payments
