### PR TITLE
feat(payment): STRIPE-200 add stripe phone field

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-script-loader.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-script-loader.ts
@@ -30,6 +30,7 @@ export default class StripeUPEScriptLoader {
                     'alipay_pm_beta_1',
                     'link_default_integration_beta_1',
                     'shipping_address_element_beta_1',
+                    'address_element_beta_1',
                 ],
                 apiVersion: '2020-03-02;alipay_beta=v1;link_beta=v1',
             });

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -180,14 +180,25 @@ export interface WalletOptions {
  * All available options are here https://stripe.com/docs/js/elements_object/create_payment_element
  */
 export interface StripeElementsCreateOptions {
+    mode?: string;
     fields?: FieldsOptions;
     wallets?: WalletOptions;
     allowedCountries?: string[];
     defaultValues?: ShippingDefaultValues | CustomerDefaultValues;
+    validation?: validationElement;
+}
+
+interface validationElement {
+    phone?: validationRequiredElement;
+}
+
+interface validationRequiredElement {
+    required?: string;
 }
 
 interface ShippingDefaultValues {
     name: string;
+    phone: string;
     address: {
         line1: string;
         line2: string;

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -60,7 +60,7 @@ export interface StripeCustomerEvent extends StripeEvent {
 
 export interface StripeShippingEvent extends StripeEvent {
     isNewAddress?: boolean;
-    phoneFieldRequired: boolean
+    phoneFieldRequired: boolean;
     value: {
         address: {
             city: string;

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -60,6 +60,7 @@ export interface StripeCustomerEvent extends StripeEvent {
 
 export interface StripeShippingEvent extends StripeEvent {
     isNewAddress?: boolean;
+    phoneFieldRequired: boolean
     value: {
         address: {
             city: string;
@@ -70,6 +71,7 @@ export interface StripeShippingEvent extends StripeEvent {
             state: string;
         };
         name: string;
+        phone: string;
     };
 }
 
@@ -166,6 +168,7 @@ export interface StripeConfirmPaymentData {
 
 export interface FieldsOptions {
     billingDetails?: AutoOrNever | BillingDetailsProperties;
+    phone?: string;
 }
 
 export interface WalletOptions {
@@ -356,5 +359,5 @@ export enum StripeStringConstants {
 export enum StripeElementType {
     PAYMENT = 'payment',
     AUTHENTICATION = 'linkAuthentication',
-    SHIPPING = 'shippingAddress',
+    SHIPPING = 'address',
 }

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -98,7 +98,8 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
         const styles = getStyles && getStyles();
 
         const {
-            form: { getShippingAddressFields }, shippingAddress: { getShippingAddress }
+            form: { getShippingAddressFields },
+            shippingAddress: { getShippingAddress },
         } = this._store.getState();
 
         const shippingFields = getShippingAddressFields([], '');
@@ -142,7 +143,7 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
             shipping?.stateOrProvinceCode && shipping?.countryCode
                 ? getStripeState(shipping?.countryCode, shipping?.stateOrProvinceCode)
                 : shipping?.stateOrProvinceCode;
-        const shippingPhoneField = shippingFields.find(field => field.name === 'phone');
+        const shippingPhoneField = shippingFields.find((field) => field.name === 'phone');
         const option = {
             mode: 'shipping',
             allowedCountries: [availableCountries],
@@ -153,21 +154,22 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
                 phone: shipping?.phone || '',
                 address: {
                     line1: shipping?.address1 || '',
-                    line2: shipping?.address2  || '',
-                    city: shipping?.city  || '',
-                    state: stripeState  || '',
-                    postal_code: shipping?.postalCode  || '',
-                    country: shipping?.countryCode  || ''
-                }
+                    line2: shipping?.address2 || '',
+                    city: shipping?.city || '',
+                    state: stripeState || '',
+                    postal_code: shipping?.postalCode || '',
+                    country: shipping?.countryCode || '',
+                },
             },
             fields: {
-                phone: 'always'
+                phone: 'always',
             },
             validation: {
                 phone: {
-                    required: shippingPhoneField && shippingPhoneField.required ? 'always' : 'never'
-                }
-            }
+                    required:
+                        shippingPhoneField && shippingPhoneField.required ? 'always' : 'never',
+                },
+            },
         };
 
         let shippingAddressElement = this._stripeElements.getElement(StripeElementType.SHIPPING);
@@ -189,7 +191,12 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
                 }
 
                 this.sendData = setTimeout(() => {
-                    onChangeShipping({ ...event, phoneFieldRequired: shippingPhoneField ? shippingPhoneField.required : false });
+                    onChangeShipping({
+                        ...event,
+                        phoneFieldRequired: shippingPhoneField
+                            ? shippingPhoneField.required
+                            : false,
+                    });
                 }, 1000);
             }
         });

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -168,7 +168,7 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
                 postalCode,
             } = shipping;
             const stripeState =
-                shipping && stateOrProvinceCode && countryCode
+                stateOrProvinceCode && countryCode
                     ? getStripeState(countryCode, stateOrProvinceCode)
                     : stateOrProvinceCode;
 

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -207,7 +207,11 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
     }
 
     deinitialize(): Promise<InternalCheckoutSelectors> {
-        this._stripeElements?.getElement(StripeElementType.SHIPPING)?.unmount();
+        /* The new shipping component by StripeLink has a small bug, when the component is unmounted,
+        Stripe does not save the shipping, to solve this, we will leave it mounted,
+        and once it is fixed will be unmounted again */
+
+        // this._stripeElements?.getElement(StripeElementType.SHIPPING)?.unmount();
 
         return Promise.resolve(this._store.getState());
     }

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
@@ -1,4 +1,4 @@
-import { StripeUPEClient } from '../../../payment/strategies/stripe-upe';
+import { StripeElement, StripeUPEClient } from '../../../payment/strategies/stripe-upe';
 import { ShippingInitializeOptions } from '../../shipping-request-options';
 
 export function getShippingStripeUPEJsMock(): StripeUPEClient {
@@ -11,6 +11,19 @@ export function getShippingStripeUPEJsMock(): StripeUPEClient {
                 destroy: jest.fn(),
             })),
             getElement: jest.fn().mockReturnValue(null),
+            update: jest.fn(),
+            fetchUpdates: jest.fn(),
+        })),
+        confirmPayment: jest.fn(),
+        confirmCardPayment: jest.fn(),
+    };
+}
+
+export function getShippingStripeUPEJsOnMock(returnElement?: StripeElement): StripeUPEClient {
+    return {
+        elements: jest.fn(() => ({
+            create: jest.fn(() => returnElement),
+            getElement: jest.fn(() => returnElement),
             update: jest.fn(),
             fetchUpdates: jest.fn(),
         })),
@@ -52,6 +65,23 @@ export function getStripeUPEShippingInitializeOptionsMock(): ShippingInitializeO
             onChangeShipping: jest.fn(),
             availableCountries: 'US,MX',
             getStyles: jest.fn(),
+            getStripeState: jest.fn(),
+        },
+    };
+}
+
+export function getStripeUPEInitializeOptionsMockWithStyles(
+    style: { [key: string]: string } = { fieldText: '#ccc' },
+): ShippingInitializeOptions {
+    return {
+        methodId: 'stripeupe',
+        stripeupe: {
+            container: 'stripeupeLink',
+            methodId: 'card',
+            gatewayId: 'stripeupe',
+            onChangeShipping: jest.fn(),
+            availableCountries: 'US,MX',
+            getStyles: () => style,
             getStripeState: jest.fn(),
         },
     };


### PR DESCRIPTION
## What? [STRIPE-200](https://bigcommercecloud.atlassian.net/browse/STRIPE-200)

- Add a Stripe phone field
- Temporarily delete the unmount as the Stripe team has a bug with their new component
- Add pending unit testing

## Why?
It's required by Stripe to support new fields

## Testing / Proof
<img width="801" alt="image" src="https://user-images.githubusercontent.com/42154828/200919646-21e94c29-96c3-45f5-b79b-e40a39a8c334.png">


## Coverage 
**BEFORE:**
<img width="258" alt="image" src="https://user-images.githubusercontent.com/42154828/216702724-6ad91e3d-c223-4282-ba0e-5c37244e7d9c.png">

**AFTER:**
<img width="231" alt="image" src="https://user-images.githubusercontent.com/42154828/216702555-a27f2ad4-d428-47c4-b454-ae0687ca118f.png">

## Depends on 
https://github.com/bigcommerce/checkout-js/pull/1100

@bigcommerce/checkout @bigcommerce/payments
