### PR TITLE
style(checkout): STRIPE-192 Add labels as floating

### DIFF
--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer-strategy.ts
@@ -79,6 +79,7 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
 
             if (styles) {
                 appearance = {
+                    labels: 'floating',
                     variables: {
                         colorPrimary: styles.fieldInnerShadow,
                         colorBackground: styles.fieldBackground,
@@ -90,8 +91,20 @@ export default class StripeUPECustomerStrategy implements CustomerStrategy {
                     rules: {
                         '.Input': {
                             borderColor: styles.fieldBorder,
-                            color: styles.fieldText,
-                            boxShadow: styles.fieldInnerShadow,
+                            color: '#333',
+                            boxShadow: 'inset 0 1px 1px #ebebeb',
+                            fontSize: '14px',
+                            padding: '5px 10px 7px 10px',
+                            backgroundColor: '#fcfcfc',
+                            fontWeight: '500',
+                        },
+                        '.Label--floating': {
+                            fontSize: '11px',
+                            marginTop: '1px',
+                        },
+                        '.Label--resting': {
+                            fontSize: '0.99rem !important',
+                            marginTop: '1px',
                         },
                     },
                 };

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -225,11 +225,24 @@ describe('StripeUPEPaymentStrategy', () => {
                 locale: 'en',
                 clientSecret: 'myToken',
                 appearance: {
+                    labels: 'floating',
                     rules: {
                         '.Input': {
                             borderColor: testColor,
-                            boxShadow: testColor,
-                            color: testColor,
+                            boxShadow: 'inset 0 1px 1px #ebebeb',
+                            color: '#333',
+                            fontSize: '14px',
+                            padding: '5px 10px 7px 10px',
+                            backgroundColor: '#fcfcfc',
+                            fontWeight: '500',
+                        },
+                        '.Label--floating': {
+                            fontSize: '11px',
+                            marginTop: '1px',
+                        },
+                        '.Label--resting': {
+                            fontSize: '0.99rem !important',
+                            marginTop: '1px',
                         },
                     },
                     variables: {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -365,6 +365,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             const styles = style;
 
             appearance = {
+                labels: 'floating',
                 variables: {
                     colorPrimary: styles.fieldInnerShadow,
                     colorBackground: styles.fieldBackground,
@@ -377,8 +378,20 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                 rules: {
                     '.Input': {
                         borderColor: styles.fieldBorder,
-                        color: styles.fieldText,
-                        boxShadow: styles.fieldInnerShadow,
+                        color: '#333',
+                        boxShadow: 'inset 0 1px 1px #ebebeb',
+                        fontSize: '14px',
+                        padding: '5px 10px 7px 10px',
+                        backgroundColor: '#fcfcfc',
+                        fontWeight: '500',
+                    },
+                    '.Label--floating': {
+                        fontSize: '11px',
+                        marginTop: '1px',
+                    },
+                    '.Label--resting': {
+                        fontSize: '0.99rem !important',
+                        marginTop: '1px',
                     },
                 },
             };

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -231,6 +231,8 @@ export interface StripeElements {
  * All available options are here https://stripe.com/docs/stripe-js/appearance-api#supported-css-properties
  */
 export interface StripeUPEAppearanceOptions {
+    labels?: string;
+
     variables?: {
         colorPrimary?: string;
         colorBackground?: string;
@@ -250,6 +252,20 @@ export interface StripeUPEAppearanceOptions {
             borderColor?: string;
             color?: string;
             boxShadow?: string;
+            fontSize?: string;
+            padding?: string;
+            backgroundColor?: string;
+            fontWeight?: string;
+        };
+
+        '.Label--floating'?: {
+            fontSize?: string;
+            marginTop?: string;
+        };
+
+        '.Label--resting'?: {
+            fontSize?: string;
+            marginTop?: string;
         };
     };
 }

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -99,6 +99,7 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
 
         if (styles) {
             appearance = {
+                labels: 'floating',
                 variables: {
                     colorPrimary: styles.fieldInnerShadow,
                     colorBackground: styles.fieldBackground,
@@ -112,8 +113,20 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
                 rules: {
                     '.Input': {
                         borderColor: styles.fieldBorder,
-                        color: styles.fieldText,
-                        boxShadow: styles.fieldInnerShadow,
+                        color: '#333',
+                        boxShadow: 'inset 0 1px 1px #ebebeb',
+                        fontSize: '14px',
+                        padding: '5px 10px 7px 10px',
+                        backgroundColor: '#fcfcfc',
+                        fontWeight: '500',
+                    },
+                    '.Label--floating': {
+                        fontSize: '11px',
+                        marginTop: '1px',
+                    },
+                    '.Label--resting': {
+                        fontSize: '0.99rem !important',
+                        marginTop: '1px',
                     },
                 },
             };


### PR DESCRIPTION
## What? [STRIPE-192](https://bigcommercecloud.atlassian.net/jira/software/c/projects/STRIPE/boards/622?modal=detail&selectedIssue=STRIPE-192)

Add labels as floating

## Why?
in order to change the style of the label in checkout customer, billing and payment inputs to be inside.

## Ticket Related [checkout-js](https://github.com/bigcommerce/checkout-js/pull/1112)

## Testing / Proof

https://user-images.githubusercontent.com/67211919/208209385-97c2ae58-df3d-4c23-a7bc-4c61c7f5633c.mov



@bigcommerce/checkout @bigcommerce/payments
