### PR TITLE
feat(payment): INT-6727 add Klarna support for greece

### DIFF
--- a/packages/core/src/payment/strategies/klarnav2/klarna-supported-countries.ts
+++ b/packages/core/src/payment/strategies/klarnav2/klarna-supported-countries.ts
@@ -9,6 +9,7 @@ export const supportedCountries = [
     'FI',
     'FR',
     'GB',
+    'GR',
     'IE',
     'IT',
     'NL',


### PR DESCRIPTION
## What?
Added the Greece country code to support the capability to show klarna widget in greek

## Why?
As a Merchant I want to present the Klarna payment step in greek

## Testing / Proof
Greece purchase flow with all the different locales cases [video](https://drive.google.com/file/d/1lHSw15qiclOAojvimd2Lawu1y_JEZ7wq/view?usp=sharing)

![image](https://user-images.githubusercontent.com/68653578/201994210-6839cbf9-ea52-4b9e-b17c-c401a11bdcec.png)

## Depends on
https://github.com/bigcommerce/bigpay/pull/6339

Greece purchase flow with all the different locales cases [video](https://drive.google.com/file/d/1lHSw15qiclOAojvimd2Lawu1y_JEZ7wq/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
