### PR TITLE
fix(payment): STRIPE-167 Adding Postal Code to stripe card element if not obtained in billing

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -410,7 +410,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                 postalCode,
             } = address;
 
-            return { city, country, postalCode };
+            return { city, country, postal_code: postalCode };
         }
 
         throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -82,7 +82,7 @@ export interface AddressOptions {
     city?: string;
     country?: string;
     state?: string;
-    postalCode?: string;
+    postal_code?: string;
     line1?: string;
     line2?: string;
 }

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -77,6 +77,7 @@ export type StripeEventType = StripeShippingEvent | StripeCustomerEvent;
 
 /**
  * Object definition for part of the data sent to confirm the PaymentIntent.
+ * https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-shipping
  */
 export interface AddressOptions {
     city?: string;
@@ -89,6 +90,7 @@ export interface AddressOptions {
 
 /**
  * Object definition for part of the data sent to confirm the PaymentIntent.
+ * https://stripe.com/docs/js/elements_object/create_payment_element
  */
 export interface AddressProperties {
     city?: AutoOrNever;


### PR DESCRIPTION
## What? [STRIPE-167](https://bigcommercecloud.atlassian.net/browse/STRIPE-167)

update postal code field name

## Why?
To match stripe parameters

## Testing / Proof
![image](https://user-images.githubusercontent.com/42154828/202313344-b82948b5-bbe4-43a3-ac30-6b31913decea.png)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
