### PR TITLE
feat(payment): INT-6957 Sezzle - Use window.location.replace to redirect

### DIFF
--- a/packages/external-integration/project.json
+++ b/packages/external-integration/project.json
@@ -18,5 +18,5 @@
             }
         }
     },
-    "tags": ["scope:integration"]
+    "tags": ["scope:shared"]
 }

--- a/packages/external-integration/src/create-external-payment-strategy.ts
+++ b/packages/external-integration/src/create-external-payment-strategy.ts
@@ -11,7 +11,4 @@ const createExternalPaymentStrategy: PaymentStrategyFactory<ExternalPaymentStrat
     paymentIntegrationService,
 ) => new ExternalPaymentStrategy(createFormPoster(), paymentIntegrationService);
 
-export default toResolvableModule(createExternalPaymentStrategy, [
-    { id: 'laybuy' },
-    { id: 'sezzle' },
-]);
+export default toResolvableModule(createExternalPaymentStrategy, [{ id: 'laybuy' }]);

--- a/packages/external-integration/src/index.ts
+++ b/packages/external-integration/src/index.ts
@@ -1,1 +1,2 @@
 export { default as createExternalPaymentStrategy } from './create-external-payment-strategy';
+export { default as ExternalPaymentStrategy } from './external-payment-strategy';

--- a/packages/sezzle-integration/.eslintrc.json
+++ b/packages/sezzle-integration/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/naming-convention": "off",
+                "@typescript-eslint/no-unsafe-return": "off",
+                "@typescript-eslint/no-floating-promises": "off"
+            }
+        }
+    ]
+}

--- a/packages/sezzle-integration/README.md
+++ b/packages/sezzle-integration/README.md
@@ -1,0 +1,11 @@
+# sezzle-integration
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test sezzle-integration` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint sezzle-integration` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/sezzle-integration/jest.config.js
+++ b/packages/sezzle-integration/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    displayName: "sezzle-integration",
+    preset: "../../jest.preset.js",
+    globals: {
+        "ts-jest": {
+            tsconfig: "<rootDir>/tsconfig.spec.json",
+            diagnostics: false,
+        },
+    },
+    setupFilesAfterEnv: ["../../jest-setup.js"],
+    coverageDirectory: "../../coverage/packages/sezzle-integration",
+};

--- a/packages/sezzle-integration/project.json
+++ b/packages/sezzle-integration/project.json
@@ -1,0 +1,22 @@
+{
+    "root": "packages/sezzle-integration",
+    "sourceRoot": "packages/sezzle-integration/src",
+    "projectType": "library",
+    "targets": {
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/sezzle-integration/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/sezzle-integration"],
+            "options": {
+                "jestConfig": "packages/sezzle-integration/jest.config.js"
+            }
+        }
+    },
+    "tags": ["scope:integration"]
+}

--- a/packages/sezzle-integration/src/create-sezzle-payment-strategy.spec.ts
+++ b/packages/sezzle-integration/src/create-sezzle-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createSezzlePaymentStrategy from './create-sezzle-payment-strategy';
+import SezzlePaymentStrategy from './sezzle-payment-strategy';
+
+describe('createSezzlePaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates sezzle payment strategy', () => {
+        const strategy = createSezzlePaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(SezzlePaymentStrategy);
+    });
+});

--- a/packages/sezzle-integration/src/create-sezzle-payment-strategy.ts
+++ b/packages/sezzle-integration/src/create-sezzle-payment-strategy.ts
@@ -1,0 +1,14 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import SezzlePaymentStrategy from './sezzle-payment-strategy';
+
+const createSezzlePaymentStrategy: PaymentStrategyFactory<SezzlePaymentStrategy> = (
+    paymentIntegrationService,
+) => new SezzlePaymentStrategy(createFormPoster(), paymentIntegrationService);
+
+export default toResolvableModule(createSezzlePaymentStrategy, [{ id: 'sezzle' }]);

--- a/packages/sezzle-integration/src/index.spec.ts
+++ b/packages/sezzle-integration/src/index.spec.ts
@@ -1,0 +1,7 @@
+import { createSezzlePaymentStrategy } from './index';
+
+describe('createExternalPaymentStrategy', () => {
+    it('instantiates external payment strategy', () => {
+        expect(typeof createSezzlePaymentStrategy).toBe('function');
+    });
+});

--- a/packages/sezzle-integration/src/index.ts
+++ b/packages/sezzle-integration/src/index.ts
@@ -1,0 +1,1 @@
+export { default as createSezzlePaymentStrategy } from './create-sezzle-payment-strategy';

--- a/packages/sezzle-integration/src/sezzle-payment-strategy.spec.ts
+++ b/packages/sezzle-integration/src/sezzle-payment-strategy.spec.ts
@@ -1,0 +1,62 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { noop } from 'lodash';
+
+import {
+    PaymentIntegrationService,
+    RequestError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getErrorPaymentResponseBody,
+    getOrderRequestBody,
+    getResponse,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import SezzlePaymentStrategy from './sezzle-payment-strategy';
+
+describe('SezzlePaymentStrategy', () => {
+    let formPoster: FormPoster;
+    let strategy: SezzlePaymentStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        formPoster = createFormPoster();
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        strategy = new SezzlePaymentStrategy(formPoster, paymentIntegrationService);
+    });
+
+    describe('#execute()', () => {
+        it('redirect to Sezzle if additional action is required with GET mothod', async () => {
+            jest.spyOn(window.location, 'replace').mockImplementation((_url, callback = noop) =>
+                callback(),
+            );
+
+            const error = new RequestError(
+                getResponse({
+                    ...getErrorPaymentResponseBody(),
+                    provider_data: '',
+                    additional_action_required: {
+                        data: {
+                            redirect_url: 'https://sandbox.checkout.sezzle.com',
+                        },
+                        type: 'offsite_redirect',
+                    },
+                    status: 'additional_action_required',
+                }),
+            );
+
+            jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
+                Promise.reject(error),
+            );
+
+            strategy.execute(getOrderRequestBody());
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(window.location.replace).toHaveBeenCalledWith(
+                'https://sandbox.checkout.sezzle.com',
+            );
+        });
+    });
+});

--- a/packages/sezzle-integration/src/sezzle-payment-strategy.ts
+++ b/packages/sezzle-integration/src/sezzle-payment-strategy.ts
@@ -1,0 +1,7 @@
+import { ExternalPaymentStrategy } from '@bigcommerce/checkout-sdk/external-integration';
+
+export default class SezzlePaymentStrategy extends ExternalPaymentStrategy {
+    protected redirectUrl(url: string): void {
+        window.location.replace(url);
+    }
+}

--- a/packages/sezzle-integration/tsconfig.json
+++ b/packages/sezzle-integration/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.base.json"
+}

--- a/packages/sezzle-integration/tsconfig.lib.json
+++ b/packages/sezzle-integration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts"]
+}

--- a/packages/sezzle-integration/tsconfig.spec.json
+++ b/packages/sezzle-integration/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -48,7 +48,10 @@
             "@bigcommerce/checkout-sdk/squarev2-integration": [
                 "packages/squarev2-integration/src/index.ts"
             ],
-            "@bigcommerce/checkout-sdk/workspace-tools": ["packages/workspace-tools/src/index.ts"]
+            "@bigcommerce/checkout-sdk/workspace-tools": ["packages/workspace-tools/src/index.ts"],
+            "@bigcommerce/checkout-sdk/sezzle-integration": [
+                "packages/sezzle-integration/src/index.ts"
+            ]
         }
     }
 }

--- a/workspace.json
+++ b/workspace.json
@@ -12,6 +12,7 @@
         "payment-integration-api": "packages/payment-integration-api",
         "payment-integrations-test-utils": "packages/payment-integrations-test-utils",
         "squarev2-integration": "packages/squarev2-integration",
+        "sezzle-integration": "packages/sezzle-integration",
         "workspace-tools": "packages/workspace-tools"
     }
 }


### PR DESCRIPTION
## What? [INT-6957](https://bigcommercecloud.atlassian.net/browse/INT-6957)
Create a sezzle strategy to redirect to Sezzle using window.location.replace

## Why?
Sezzle deprecated POST method, now we require to redirect using GET method

## Testing / Proof
[Video](https://drive.google.com/file/d/1XCA_47V988tWV878Jcd4QEJt8AEij0c2/view?usp=sharing)

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 
