### PR TITLE
fix(payment): INT-6928 [Mollie] No Ability To Use A Different Card To Pay

### DIFF
--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -510,6 +510,10 @@ describe('MolliePaymentStrategy', () => {
             jest.spyOn(formFactory, 'create').mockReturnValue(form);
         });
 
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
         it('creates hosted form', async () => {
             await strategy.initialize(initializeOptions);
 
@@ -557,6 +561,26 @@ describe('MolliePaymentStrategy', () => {
             await strategy.deinitialize();
 
             expect(form.detach).toHaveBeenCalled();
+        });
+
+        it('should unmount the elements of the card when adding a new one', async () => {
+            const options = getInitializeOptions();
+
+            await strategy.initialize(initializeOptions);
+            await strategy.deinitialize();
+
+            expect(form.detach).toHaveBeenCalled();
+
+            await strategy.initialize(options);
+
+            jest.runAllTimers();
+            expect(mollieClient.createComponent).toBeCalledTimes(4);
+            expect(mollieElement.mount).toBeCalledTimes(4);
+            jest.spyOn(document, 'getElementById');
+
+            await strategy.deinitialize(initializeOptions);
+
+            expect(mollieElement.unmount).toBeCalledTimes(4);
         });
     });
 

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -187,7 +187,12 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
                 element.remove();
             }
         } else if (options && options.methodId && this.isCreditCard(options.methodId)) {
-            if (this._cardHolderElement && this._cardNumberElement && this._verificationCodeElement && this._expiryDateElement) {
+            if (
+                this._cardHolderElement &&
+                this._cardNumberElement &&
+                this._verificationCodeElement &&
+                this._expiryDateElement
+            ) {
                 this._cardHolderElement.unmount();
                 this._cardHolderElement = undefined;
 

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.ts
@@ -180,15 +180,29 @@ export default class MolliePaymentStrategy implements PaymentStrategy {
             this._hostedForm.detach();
         }
 
-        this._mollieClient = undefined;
-
-        if (options && options.methodId && options.gatewayId) {
+        if (options && options.methodId && options.gatewayId && !this._hostedForm) {
             const element = document.getElementById(`${options.gatewayId}-${options.methodId}`);
 
             if (element) {
                 element.remove();
             }
+        } else if (options && options.methodId && this.isCreditCard(options.methodId)) {
+            if (this._cardHolderElement && this._cardNumberElement && this._verificationCodeElement && this._expiryDateElement) {
+                this._cardHolderElement.unmount();
+                this._cardHolderElement = undefined;
+
+                this._cardNumberElement.unmount();
+                this._cardNumberElement = undefined;
+
+                this._verificationCodeElement.unmount();
+                this._verificationCodeElement = undefined;
+
+                this._expiryDateElement.unmount();
+                this._expiryDateElement = undefined;
+            }
         }
+
+        this._mollieClient = undefined;
 
         return Promise.resolve(this._store.getState());
     }


### PR DESCRIPTION
## What? [INT-6928](https://bigcommercecloud.atlassian.net/browse/INT-6928)
Logged in shoppers who saved their card previously are not able to select the option of using a different card and entering their new credit card details.

## Why?
When the shopper selects “use a different card” they should see the credit card fields 

## Testing / Proof

### After

https://user-images.githubusercontent.com/104527753/203615753-1b3be81e-4fe2-4cfb-8de1-edf9049227a7.mov

### Before

https://user-images.githubusercontent.com/104527753/203615803-0205ef7e-3f38-41a6-bf89-76d34ff4de47.mov

## Depends on 

- https://github.com/bigcommerce/checkout-js/pull/1110

@bigcommerce/checkout @bigcommerce/apex-integrations 
