### PR TITLE
refactor(checkout): CHECKOUT-7107 Refactor `hosted-form`

### DIFF
--- a/packages/core/src/hosted-form/hosted-form.ts
+++ b/packages/core/src/hosted-form/hosted-form.ts
@@ -1,5 +1,9 @@
 import { noop, without } from 'lodash';
 
+import {
+    HostedForm as HostedFormInterface
+} from "@bigcommerce/checkout-sdk/payment-integration-api";
+
 import { IframeEventListener } from '../common/iframe';
 import { OrderPaymentRequestBody } from '../order';
 import { PaymentAdditionalAction } from '../payment';
@@ -13,7 +17,7 @@ import { HostedInputEnterEvent, HostedInputEventMap, HostedInputEventType, Hoste
 
 type HostedFormEventCallbacks = Pick<HostedFormOptions, 'onBlur' | 'onCardTypeChange' | 'onFocus' | 'onEnter' | 'onValidate'>;
 
-export default class HostedForm {
+export default class HostedForm implements HostedFormInterface {
     private _bin?: string;
     private _cardType?: string;
 

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -14,6 +14,7 @@ import {
 } from "../checkout";
 import { ConfigActionCreator, ConfigRequestSender } from "../config";
 import { FormFieldsActionCreator, FormFieldsRequestSender } from "../form";
+import { HostedFormFactory } from "../hosted-form";
 import { OrderActionCreator, OrderRequestSender } from "../order";
 import {
     createPaymentClient,
@@ -58,6 +59,8 @@ export default function createPaymentIntegrationService(
         new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender))
     );
 
+    const hostedFormFactory = new HostedFormFactory(store);
+
     const orderActionCreator = new OrderActionCreator(
         new OrderRequestSender(requestSender),
         new CheckoutValidator(new CheckoutRequestSender(requestSender))
@@ -92,6 +95,7 @@ export default function createPaymentIntegrationService(
         store,
         storeProjectionFactory,
         checkoutActionCreator,
+        hostedFormFactory,
         orderActionCreator,
         billingAddressActionCreator,
         consignmentActionCreator,

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -13,7 +13,7 @@ import {
     CheckoutActionCreator,
 } from "../checkout";
 import { DataStoreProjection } from "../common/data-store";
-import HostedForm from "../hosted-form/hosted-form";
+import { HostedForm, HostedFormFactory } from "../hosted-form";
 import { OrderActionCreator } from "../order";
 import { getOrder } from "../order/orders.mock";
 import PaymentActionCreator from "../payment/payment-action-creator";
@@ -27,6 +27,7 @@ import PaymentIntegrationStoreProjectionFactory from "./payment-integration-stor
 
 describe("DefaultPaymentIntegrationService", () => {
     let subject: PaymentIntegrationService;
+    let hostedFormFactory: HostedFormFactory;
     let paymentIntegrationSelectors: PaymentIntegrationSelectors;
     let internalCheckoutSelectors: InternalCheckoutSelectors;
     let store: Pick<CheckoutStore, "dispatch" | "getState">;
@@ -61,6 +62,7 @@ describe("DefaultPaymentIntegrationService", () => {
     let paymentActionCreator: Pick<PaymentActionCreator, "submitPayment">;
 
     beforeEach(() => {
+        hostedFormFactory = new HostedFormFactory(store as CheckoutStore);
         paymentIntegrationSelectors = {} as PaymentIntegrationSelectors;
 
         internalCheckoutSelectors = {
@@ -132,6 +134,7 @@ describe("DefaultPaymentIntegrationService", () => {
             store as CheckoutStore,
             storeProjectionFactory as PaymentIntegrationStoreProjectionFactory,
             checkoutActionCreator as CheckoutActionCreator,
+            hostedFormFactory as HostedFormFactory,
             orderActionCreator as OrderActionCreator,
             billingAddressActionCreator as BillingAddressActionCreator,
             consignmentActionCreator as ConsignmentActionCreator,

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -1,4 +1,5 @@
 import {
+    HostedFieldType,
     PaymentIntegrationSelectors,
     PaymentIntegrationService,
 } from "@bigcommerce/checkout-sdk/payment-integration-api";
@@ -12,6 +13,7 @@ import {
     CheckoutActionCreator,
 } from "../checkout";
 import { DataStoreProjection } from "../common/data-store";
+import HostedForm from "../hosted-form/hosted-form";
 import { OrderActionCreator } from "../order";
 import { getOrder } from "../order/orders.mock";
 import PaymentActionCreator from "../payment/payment-action-creator";
@@ -149,6 +151,21 @@ describe("DefaultPaymentIntegrationService", () => {
                 checkoutActionCreator.loadCurrentCheckout()
             );
             expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe("#hostedForm", () => {
+        it("creates hosted form", async () => {
+            const output = await subject.createHostedForm('http://www.example.com',{
+                fields: {
+                    [HostedFieldType.CardCode]: { containerId: 'card-code' },
+                    [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                    [HostedFieldType.CardName]: { containerId: 'card-name' },
+                    [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                },
+            });
+
+            expect(output).toBeInstanceOf(HostedForm);
         });
     });
 

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -17,6 +17,7 @@ import { OrderActionCreator } from "../order";
 import PaymentActionCreator from "../payment/payment-action-creator";
 import PaymentMethodActionCreator from "../payment/payment-method-action-creator";
 import { ConsignmentActionCreator } from "../shipping";
+
 import PaymentIntegrationStoreProjectionFactory from "./payment-integration-store-projection-factory";
 
 export default class DefaultPaymentIntegrationService

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -1,4 +1,6 @@
 import {
+    HostedForm,
+    HostedFormOptions,
     PaymentIntegrationService,
     PaymentIntegrationSelectors,
     BillingAddressRequestBody,
@@ -10,11 +12,11 @@ import {
 import { BillingAddressActionCreator } from "../billing";
 import { CheckoutStore, CheckoutActionCreator } from "../checkout";
 import { DataStoreProjection } from "../common/data-store";
+import { HostedFormFactory } from "../hosted-form";
 import { OrderActionCreator } from "../order";
 import PaymentActionCreator from "../payment/payment-action-creator";
 import PaymentMethodActionCreator from "../payment/payment-method-action-creator";
 import { ConsignmentActionCreator } from "../shipping";
-
 import PaymentIntegrationStoreProjectionFactory from "./payment-integration-store-projection-factory";
 
 export default class DefaultPaymentIntegrationService
@@ -35,6 +37,12 @@ export default class DefaultPaymentIntegrationService
         this._storeProjection = this._storeProjectionFactory.create(
             this._store
         );
+    }
+
+    createHostedForm(host: string, options: HostedFormOptions): HostedForm {
+        const hostedFormFactory = new HostedFormFactory(this._store);
+
+        return hostedFormFactory.create(host,options);
     }
 
     /* eslint-disable  @typescript-eslint/no-explicit-any */

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -29,6 +29,7 @@ export default class DefaultPaymentIntegrationService
         private _store: CheckoutStore,
         private _storeProjectionFactory: PaymentIntegrationStoreProjectionFactory,
         private _checkoutActionCreator: CheckoutActionCreator,
+        private _hostedFormFactory: HostedFormFactory,
         private _orderActionCreator: OrderActionCreator,
         private _billingAddressActionCreator: BillingAddressActionCreator,
         private _consignmentActionCreator: ConsignmentActionCreator,
@@ -41,9 +42,7 @@ export default class DefaultPaymentIntegrationService
     }
 
     createHostedForm(host: string, options: HostedFormOptions): HostedForm {
-        const hostedFormFactory = new HostedFormFactory(this._store);
-
-        return hostedFormFactory.create(host,options);
+        return this._hostedFormFactory.create(host,options);
     }
 
     /* eslint-disable  @typescript-eslint/no-explicit-any */

--- a/packages/payment-integration-api/src/hosted-form/hosted-field-type.ts
+++ b/packages/payment-integration-api/src/hosted-form/hosted-field-type.ts
@@ -1,0 +1,12 @@
+//copied from packages/core/src/hosted-form/hosted-field-type.ts
+
+enum HostedFieldType {
+    CardCode = 'cardCode',
+    CardCodeVerification = 'cardCodeVerification',
+    CardExpiry = 'cardExpiry',
+    CardName = 'cardName',
+    CardNumber = 'cardNumber',
+    CardNumberVerification = 'cardNumberVerification',
+}
+
+export default HostedFieldType;

--- a/packages/payment-integration-api/src/hosted-form/hosted-form-options.ts
+++ b/packages/payment-integration-api/src/hosted-form/hosted-form-options.ts
@@ -1,0 +1,52 @@
+//copied from packages/core/src/hosted-form/hosted-form-options.ts
+
+import HostedFieldType from './hosted-field-type';
+import { HostedInputBlurEvent, HostedInputCardTypeChangeEvent, HostedInputEnterEvent, HostedInputFocusEvent, HostedInputStyles, HostedInputValidateEvent } from './iframe-content';
+
+export default interface HostedFormOptions {
+    fields: HostedFieldOptionsMap;
+    styles?: HostedFieldStylesMap;
+    onBlur?(data: HostedFieldBlurEventData): void;
+    onCardTypeChange?(data: HostedFieldCardTypeChangeEventData): void;
+    onEnter?(data: HostedFieldEnterEventData): void;
+    onFocus?(data: HostedFieldFocusEventData): void;
+    onValidate?(data: HostedFieldValidateEventData): void;
+}
+
+type HostedFieldBlurEventData = HostedInputBlurEvent['payload'];
+type HostedFieldCardTypeChangeEventData = HostedInputCardTypeChangeEvent['payload'];
+type HostedFieldEnterEventData = HostedInputEnterEvent['payload'];
+type HostedFieldFocusEventData = HostedInputFocusEvent['payload'];
+type HostedFieldValidateEventData = HostedInputValidateEvent['payload'];
+
+type HostedFieldOptionsMap = HostedCardFieldOptionsMap | HostedStoredCardFieldOptionsMap;
+
+interface HostedCardFieldOptionsMap {
+    [HostedFieldType.CardCode]?: HostedCardFieldOptions;
+    [HostedFieldType.CardExpiry]: HostedCardFieldOptions;
+    [HostedFieldType.CardName]: HostedCardFieldOptions;
+    [HostedFieldType.CardNumber]: HostedCardFieldOptions;
+}
+
+interface HostedStoredCardFieldOptionsMap {
+    [HostedFieldType.CardCodeVerification]?: HostedStoredCardFieldOptions;
+    [HostedFieldType.CardNumberVerification]?: HostedStoredCardFieldOptions;
+}
+
+interface HostedCardFieldOptions {
+    accessibilityLabel?: string;
+    containerId: string;
+    placeholder?: string;
+}
+
+interface HostedStoredCardFieldOptions extends HostedCardFieldOptions {
+    instrumentId: string;
+}
+
+interface HostedFieldStylesMap {
+    default?: HostedFieldStyles;
+    error?: HostedFieldStyles;
+    focus?: HostedFieldStyles;
+}
+
+type HostedFieldStyles = HostedInputStyles;

--- a/packages/payment-integration-api/src/hosted-form/hosted-form.ts
+++ b/packages/payment-integration-api/src/hosted-form/hosted-form.ts
@@ -1,0 +1,13 @@
+import { OrderPaymentRequestBody } from "../order";
+import { PaymentAdditionalAction } from "../payment";
+
+import { HostedInputSubmitSuccessEvent } from "./hosted-input-events";
+
+export interface HostedForm {
+    attach(): Promise<void>;
+    detach(): void;
+    getBin(): string | undefined;
+    getCardType(): string | undefined;
+    submit(payload: OrderPaymentRequestBody, additionalActionData?: PaymentAdditionalAction): Promise<HostedInputSubmitSuccessEvent>
+    validate(): Promise<void>
+}

--- a/packages/payment-integration-api/src/hosted-form/hosted-input-events.ts
+++ b/packages/payment-integration-api/src/hosted-form/hosted-input-events.ts
@@ -1,0 +1,22 @@
+import { Response } from "@bigcommerce/request-sender";
+
+export enum HostedInputEventType {
+    AttachSucceeded = 'HOSTED_INPUT:ATTACH_SUCCEEDED',
+    AttachFailed = 'HOSTED_INPUT:ATTACH_FAILED',
+    BinChanged = 'HOSTED_INPUT:BIN_CHANGED',
+    Blurred = 'HOSTED_INPUT:BLURRED',
+    Changed = 'HOSTED_INPUT:CHANGED',
+    CardTypeChanged = 'HOSTED_INPUT:CARD_TYPE_CHANGED',
+    Entered = 'HOSTED_INPUT:ENTERED',
+    Focused = 'HOSTED_INPUT:FOCUSED',
+    SubmitSucceeded = 'HOSTED_INPUT:SUBMIT_SUCCEEDED',
+    SubmitFailed = 'HOSTED_INPUT:SUBMIT_FAILED',
+    Validated = 'HOSTED_INPUT:VALIDATED',
+}
+
+export interface HostedInputSubmitSuccessEvent {
+    type: HostedInputEventType.SubmitSucceeded;
+    payload: {
+        response: Response<unknown>;
+    };
+}

--- a/packages/payment-integration-api/src/hosted-form/iframe-content.ts
+++ b/packages/payment-integration-api/src/hosted-form/iframe-content.ts
@@ -1,0 +1,65 @@
+//copied from packages/core/src/hosted-form/iframe-content
+
+import HostedFieldType from "./hosted-field-type";
+import { HostedInputEventType } from "./hosted-input-events";
+
+interface HostedInputValidateErrorData {
+    fieldType: string;
+    message: string;
+    type: string;
+}
+
+interface HostedInputValidateErrorDataMap {
+    [HostedFieldType.CardCode]?: HostedInputValidateErrorData[];
+    [HostedFieldType.CardCodeVerification]?: HostedInputValidateErrorData[];
+    [HostedFieldType.CardExpiry]?: HostedInputValidateErrorData[];
+    [HostedFieldType.CardName]?: HostedInputValidateErrorData[];
+    [HostedFieldType.CardNumber]?: HostedInputValidateErrorData[];
+    [HostedFieldType.CardNumberVerification]?: HostedInputValidateErrorData[];
+}
+
+interface HostedInputValidateResults {
+    errors: HostedInputValidateErrorDataMap;
+    isValid: boolean;
+}
+
+export interface HostedInputBlurEvent {
+    type: HostedInputEventType.Blurred;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputCardTypeChangeEvent {
+    type: HostedInputEventType.CardTypeChanged;
+    payload: {
+        cardType?: string;
+    };
+}
+
+export interface HostedInputEnterEvent {
+    type: HostedInputEventType.Entered;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export interface HostedInputFocusEvent {
+    type: HostedInputEventType.Focused;
+    payload: {
+        fieldType: HostedFieldType;
+    };
+}
+
+export type HostedInputStyles = Partial<Pick<
+    CSSStyleDeclaration,
+    'color' |
+    'fontFamily' |
+    'fontSize' |
+    'fontWeight'
+    >>;
+
+export interface HostedInputValidateEvent {
+    type: HostedInputEventType.Validated;
+    payload: HostedInputValidateResults;
+}

--- a/packages/payment-integration-api/src/hosted-form/index.ts
+++ b/packages/payment-integration-api/src/hosted-form/index.ts
@@ -1,0 +1,4 @@
+export { default as HostedFormOptions } from "./hosted-form-options";
+export { default as HostedFieldType } from "./hosted-field-type";
+export { HostedForm } from "./hosted-form";
+export { HostedInputEventType } from "./hosted-input-events";

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -39,6 +39,7 @@ export {
     RequestError,
     isRequestError,
 } from "./errors";
+export { HostedForm, HostedFormOptions, HostedFieldType } from "./hosted-form";
 export { Order, OrderPaymentRequestBody, OrderRequestBody } from "./order";
 export {
     CardInstrument,

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -1,4 +1,6 @@
 import { BillingAddressRequestBody } from "./billing";
+import { HostedForm } from "./hosted-form";
+import HostedFormOptions from "./hosted-form/hosted-form-options";
 import { OrderRequestBody } from "./order";
 import { Payment } from "./payment";
 import PaymentIntegrationSelectors from "./payment-integration-selectors";
@@ -6,6 +8,11 @@ import { RequestOptions } from "./util-types";
 import { ShippingAddressRequestBody } from "./shipping";
 
 export default interface PaymentIntegrationService {
+    createHostedForm(
+        host: string,
+        options: HostedFormOptions
+    ): HostedForm;
+
     subscribe(
         subscriber: (state: PaymentIntegrationSelectors) => void,
         ...filters: Array<(state: PaymentIntegrationSelectors) => unknown>

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -1,6 +1,5 @@
 import { BillingAddressRequestBody } from "./billing";
-import { HostedForm } from "./hosted-form";
-import HostedFormOptions from "./hosted-form/hosted-form-options";
+import { HostedForm, HostedFormOptions } from "./hosted-form";
 import { OrderRequestBody } from "./order";
 import { Payment } from "./payment";
 import PaymentIntegrationSelectors from "./payment-integration-selectors";

--- a/packages/payment-integration-api/src/payment/index.ts
+++ b/packages/payment-integration-api/src/payment/index.ts
@@ -28,6 +28,7 @@ export { default as isVaultedInstrument,
 } from "./is-vaulted-instrument";
 
 export { PaymentActionType, SubmitPaymentAction } from './payment-actions';
+export { default as PaymentAdditionalAction  } from "./payment-additional-action";
 export { PaymentInitializeOptions } from "./payment-initialize-options";
 export { PaymentRequestOptions } from "./payment-request-options";
 export { default as PaymentMethod } from "./payment-method";


### PR DESCRIPTION
## What?
Add `HostedForm` to the payment integration JS API.

## Why?
Unblock refactoring subsequent payment methods, such as `credit-card-payment-method`, which depends on `HostedForm`, `HostedFormOptions`, `HostedFieldType`, and `HostedFormFactory`.

## Testing / Proof
- Added one unit test.
- CI checks.