### PR TITLE
refactor(checkout): CHECKOUT-6394 Refactor credit card payment method

### DIFF
--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -20,6 +20,7 @@ import {
     CustomerStrategyActionCreator,
 } from '../customer';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
+import * as defaultPaymentStrategyFactories from '../generated/payment-strategies';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
 import { OrderActionCreator, OrderRequestSender } from '../order';
 import {
@@ -126,7 +127,11 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         formFieldsActionCreator,
     );
     const paymentIntegrationService = createPaymentIntegrationService(store);
-    const registryV2 = createPaymentStrategyRegistryV2(paymentIntegrationService);
+    const registryV2 = createPaymentStrategyRegistryV2(
+        paymentIntegrationService,
+        defaultPaymentStrategyFactories,
+        { useFallback: true },
+    );
     const customerRegistryV2 = createCustomerStrategyRegistryV2(paymentIntegrationService);
 
     return new CheckoutService(

--- a/packages/core/src/common/registry/resolve-id-registry.spec.ts
+++ b/packages/core/src/common/registry/resolve-id-registry.spec.ts
@@ -6,9 +6,9 @@ describe('ResolveIdRegistry', () => {
     }
 
     interface TestResolveId {
+        [key: string]: unknown;
         id?: string;
         type?: string;
-        [key: string]: unknown;
     }
 
     class FooStrategy implements TestStrategy {
@@ -29,6 +29,12 @@ describe('ResolveIdRegistry', () => {
         }
     }
 
+    class DefaultStrategy implements TestStrategy {
+        execute() {
+            return true;
+        }
+    }
+
     let subject: ResolveIdRegistry<TestStrategy, TestResolveId>;
 
     beforeEach(() => {
@@ -36,6 +42,7 @@ describe('ResolveIdRegistry', () => {
         subject.register({ id: 'foo' }, () => new FooStrategy());
         subject.register({ type: 'bar' }, () => new BarStrategy());
         subject.register({ id: 'foo', type: 'bar' }, () => new FoobarStrategy());
+        subject.register({ default: true }, () => new DefaultStrategy());
     });
 
     it('returns strategy if able to resolve to one by id', () => {
@@ -50,7 +57,23 @@ describe('ResolveIdRegistry', () => {
         expect(subject.get({ id: 'foo', type: 'bar' })).toBeInstanceOf(FoobarStrategy);
     });
 
-    it('throws error if unable to resolve to one', () => {
+    it('throws error if unable to resolve to one when useFallback is false', () => {
         expect(() => subject.get({ type: 'hello' })).toThrow();
+    });
+
+    it('returns default strategy if unable to resolve to one when useFallback is true', () => {
+        subject = new ResolveIdRegistry(true);
+        subject.register({ default: true }, () => new DefaultStrategy());
+
+        expect(subject.get({ type: 'bigbigpaypay' })).toBeInstanceOf(DefaultStrategy);
+    });
+
+    it('returns new strategy instance if multiple methods fallback to default strategy', () => {
+        subject = new ResolveIdRegistry(true);
+        subject.register({ default: true }, () => new DefaultStrategy());
+
+        expect(subject.get({ type: 'bigbigpay' })).toBeInstanceOf(DefaultStrategy);
+        expect(subject.get({ type: 'bigpaypay' })).toBeInstanceOf(DefaultStrategy);
+        expect(subject.get({ type: 'bigbigpay' })).not.toBe(subject.get({ type: 'bigpaypay' }));
     });
 });

--- a/packages/core/src/payment/create-payment-strategy-registry-v2.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry-v2.ts
@@ -7,7 +7,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { ResolveIdRegistry } from '../common/registry';
-import * as defaultCustomerStrategyFactories from '../generated/payment-strategies';
+import * as defaultPaymentStrategyFactories from '../generated/payment-strategies';
 
 export interface PaymentStrategyFactories {
     [key: string]: PaymentStrategyFactory<PaymentStrategy>;
@@ -15,9 +15,11 @@ export interface PaymentStrategyFactories {
 
 export default function createPaymentStrategyRegistry(
     paymentIntegrationService: PaymentIntegrationService,
-    paymentStrategyFactories: PaymentStrategyFactories = defaultCustomerStrategyFactories,
+    paymentStrategyFactories: PaymentStrategyFactories = defaultPaymentStrategyFactories,
+    options: { useFallback: boolean } = { useFallback: false },
 ): ResolveIdRegistry<PaymentStrategy, PaymentStrategyResolveId> {
-    const registry = new ResolveIdRegistry<PaymentStrategy, PaymentStrategyResolveId>();
+    const { useFallback } = options;
+    const registry = new ResolveIdRegistry<PaymentStrategy, PaymentStrategyResolveId>(useFallback);
 
     for (const [, createPaymentStrategy] of Object.entries(paymentStrategyFactories)) {
         if (

--- a/packages/core/src/payment/create-payment-strategy-registry.spec.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.spec.ts
@@ -28,7 +28,6 @@ import {
 } from './strategies/checkoutcom-custom';
 import { ClearpayPaymentStrategy } from './strategies/clearpay';
 import { ConvergePaymentStrategy } from './strategies/converge';
-import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource';
 import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
@@ -188,12 +187,6 @@ describe('CreatePaymentStrategyRegistry', () => {
         const paymentStrategy = registry.get(PaymentStrategyType.CONVERGE);
 
         expect(paymentStrategy).toBeInstanceOf(ConvergePaymentStrategy);
-    });
-
-    it('can instantiate creditcard', () => {
-        const paymentStrategy = registry.get(PaymentStrategyType.CREDIT_CARD);
-
-        expect(paymentStrategy).toBeInstanceOf(CreditCardPaymentStrategy);
     });
 
     it('can instantiate cybersource', () => {

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -82,7 +82,6 @@ import {
 } from './strategies/checkoutcom-custom';
 import { ClearpayPaymentStrategy, ClearpayScriptLoader } from './strategies/clearpay';
 import { ConvergePaymentStrategy } from './strategies/converge';
-import { CreditCardPaymentStrategy } from './strategies/credit-card';
 import { CreditCardRedirectPaymentStrategy } from './strategies/credit-card-redirect';
 import { CyberSourcePaymentStrategy } from './strategies/cybersource/index';
 import { CyberSourceV2PaymentStrategy } from './strategies/cybersourcev2';
@@ -468,17 +467,6 @@ export default function createPaymentStrategyRegistry(
                 paymentActionCreator,
                 hostedFormFactory,
                 formPoster,
-            ),
-    );
-
-    registry.register(
-        PaymentStrategyType.CREDIT_CARD,
-        () =>
-            new CreditCardPaymentStrategy(
-                store,
-                orderActionCreator,
-                paymentActionCreator,
-                hostedFormFactory,
             ),
     );
 

--- a/packages/core/src/payment/payment-request-options.ts
+++ b/packages/core/src/payment/payment-request-options.ts
@@ -1,3 +1,5 @@
+import { CreditCardPaymentInitializeOptions } from '@bigcommerce/checkout-sdk/credit-card-integration';
+
 import { RequestOptions } from '../common/http-request';
 
 import { AmazonPayPaymentInitializeOptions } from './strategies/amazon-pay';
@@ -9,7 +11,6 @@ import {
     BraintreeVisaCheckoutPaymentInitializeOptions,
 } from './strategies/braintree';
 import { ChasePayInitializeOptions } from './strategies/chasepay';
-import { CreditCardPaymentInitializeOptions } from './strategies/credit-card';
 import { DigitalRiverPaymentInitializeOptions } from './strategies/digitalriver';
 import { GooglePayPaymentInitializeOptions } from './strategies/googlepay';
 import { KlarnaPaymentInitializeOptions } from './strategies/klarna';

--- a/packages/core/src/payment/payment-strategy-action-creator.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.ts
@@ -71,20 +71,13 @@ export default class PaymentStrategyActionCreator {
                         }
 
                         try {
-                            if (
-                                method.id == PaymentStrategyType.APPLEPAY &&
-                                method.gateway == PaymentStrategyType.MOLLIE
-                            ) {
-                                strategy = this._strategyRegistry.getByMethod(method);
-                            } else {
-                                strategy = this._strategyRegistryV2.get({
-                                    id: method.id,
-                                    gateway: method.gateway,
-                                    type: method.type,
-                                });
-                            }
-                        } catch {
                             strategy = this._strategyRegistry.getByMethod(method);
+                        } catch {
+                            strategy = this._strategyRegistryV2.get({
+                                id: method.id,
+                                gateway: method.gateway,
+                                type: method.type,
+                            });
                         }
                     } else {
                         strategy = this._strategyRegistryV2.get({
@@ -132,20 +125,13 @@ export default class PaymentStrategyActionCreator {
                     let strategy: PaymentStrategy | PaymentStrategyV2;
 
                     try {
-                        if (
-                            method.id == PaymentStrategyType.APPLEPAY &&
-                            method.gateway == PaymentStrategyType.MOLLIE
-                        ) {
-                            strategy = this._strategyRegistry.getByMethod(method);
-                        } else {
-                            strategy = this._strategyRegistryV2.get({
-                                id: method.id,
-                                gateway: method.gateway,
-                                type: method.type,
-                            });
-                        }
-                    } catch {
                         strategy = this._strategyRegistry.getByMethod(method);
+                    } catch {
+                        strategy = this._strategyRegistryV2.get({
+                            id: method.id,
+                            gateway: method.gateway,
+                            type: method.type,
+                        });
                     }
 
                     await strategy.finalize({
@@ -191,20 +177,13 @@ export default class PaymentStrategyActionCreator {
                 let strategy: PaymentStrategy | PaymentStrategyV2;
 
                 try {
-                    if (
-                        method.id == PaymentStrategyType.APPLEPAY &&
-                        method.gateway == PaymentStrategyType.MOLLIE
-                    ) {
-                        strategy = this._strategyRegistry.getByMethod(method);
-                    } else {
-                        strategy = this._strategyRegistryV2.get({
-                            id: method.id,
-                            gateway: method.gateway,
-                            type: method.type,
-                        });
-                    }
-                } catch {
                     strategy = this._strategyRegistry.getByMethod(method);
+                } catch {
+                    strategy = this._strategyRegistryV2.get({
+                        id: method.id,
+                        gateway: method.gateway,
+                        type: method.type,
+                    });
                 }
 
                 const promise: Promise<InternalCheckoutSelectors | void> = strategy.initialize({
@@ -255,20 +234,13 @@ export default class PaymentStrategyActionCreator {
                 let strategy: PaymentStrategy | PaymentStrategyV2;
 
                 try {
-                    if (
-                        method.id == PaymentStrategyType.APPLEPAY &&
-                        method.gateway == PaymentStrategyType.MOLLIE
-                    ) {
-                        strategy = this._strategyRegistry.getByMethod(method);
-                    } else {
-                        strategy = this._strategyRegistryV2.get({
-                            id: method.id,
-                            gateway: method.gateway,
-                            type: method.type,
-                        });
-                    }
-                } catch {
                     strategy = this._strategyRegistry.getByMethod(method);
+                } catch {
+                    strategy = this._strategyRegistryV2.get({
+                        id: method.id,
+                        gateway: method.gateway,
+                        type: method.type,
+                    });
                 }
 
                 const promise: Promise<InternalCheckoutSelectors | void> = strategy.deinitialize({

--- a/packages/core/src/payment/payment-strategy-registry.spec.ts
+++ b/packages/core/src/payment/payment-strategy-registry.spec.ts
@@ -1,4 +1,5 @@
 import { CheckoutStore, createCheckoutStore, InternalCheckoutSelectors } from '../checkout';
+import { InvalidArgumentError } from '../common/error/errors';
 import { getConfigState } from '../config/configs.mock';
 import { getFormFieldsState } from '../form/form.mock';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
@@ -8,7 +9,6 @@ import {
     getAmazonPay,
     getBankDeposit,
     getBraintree,
-    getBraintreePaypal,
     getCybersource,
     getPPSDK,
 } from './payment-methods.mock';
@@ -91,18 +91,8 @@ describe('PaymentStrategyRegistry', () => {
             expect(registry.getByMethod(getAmazonPay())).toBeInstanceOf(AmazonPayPaymentStrategy);
         });
 
-        it('returns credit card strategy if none is registered with method name', () => {
-            expect(registry.getByMethod(getBraintree())).toBeInstanceOf(CreditCardPaymentStrategy);
-        });
-
-        it('returns new strategy instance if multiple methods belong to same type', () => {
-            expect(registry.getByMethod(getBraintree())).toBeInstanceOf(CreditCardPaymentStrategy);
-            expect(registry.getByMethod(getBraintreePaypal())).toBeInstanceOf(
-                CreditCardPaymentStrategy,
-            );
-            expect(registry.getByMethod(getBraintree())).not.toBe(
-                registry.getByMethod(getBraintreePaypal()),
-            );
+        it('throws error if none is registered with method name (expected V1 behavior)', () => {
+            expect(() => registry.getByMethod(getBraintree())).toThrow(InvalidArgumentError);
         });
 
         it('returns offsite strategy if none is registered with method name and method is hosted', () => {

--- a/packages/core/src/payment/payment-strategy-registry.ts
+++ b/packages/core/src/payment/payment-strategy-registry.ts
@@ -2,7 +2,11 @@ import { ReadableDataStore } from '@bigcommerce/data-store';
 import { some } from 'lodash';
 
 import { InternalCheckoutSelectors } from '../checkout';
-import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+} from '../common/error/errors';
 import { Registry, RegistryOptions } from '../common/registry';
 
 import PaymentMethod from './payment-method';
@@ -91,7 +95,7 @@ export default class PaymentStrategyRegistry extends Registry<
             return PaymentStrategyType.OFFSITE;
         }
 
-        return PaymentStrategyType.CREDIT_CARD;
+        throw new InvalidArgumentError(`'${methodId}' is not registered.`);
     }
 
     private _hasFactoryForMethod(methodId: string): methodId is PaymentStrategyType {

--- a/packages/core/src/payment/strategies/credit-card/index.ts
+++ b/packages/core/src/payment/strategies/credit-card/index.ts
@@ -1,2 +1,1 @@
 export { default as CreditCardPaymentStrategy } from './credit-card-payment-strategy';
-export { default as CreditCardPaymentInitializeOptions } from './credit-card-payment-initialize-options';

--- a/packages/credit-card-integration/.eslintrc.json
+++ b/packages/credit-card-integration/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {
+                "@typescript-eslint/naming-convention": "off"
+            }
+        },
+        {
+            "files": ["*.spec.ts"],
+            "rules": {
+                "jest/no-conditional-expect": "off",
+                "@typescript-eslint/consistent-type-assertions": "off"
+            }
+        }
+    ]
+}

--- a/packages/credit-card-integration/README.md
+++ b/packages/credit-card-integration/README.md
@@ -1,0 +1,11 @@
+# credit-card-integration
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test credit-card-integration` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint credit-card-integration` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/credit-card-integration/jest.config.js
+++ b/packages/credit-card-integration/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    displayName: "credit-card-integration",
+    preset: "../../jest.preset.js",
+    globals: {
+        "ts-jest": {
+            tsconfig: "<rootDir>/tsconfig.spec.json",
+            diagnostics: false,
+        },
+    },
+    setupFilesAfterEnv: ["../../jest-setup.js"],
+    coverageDirectory: "../../coverage/packages/credit-card-integration",
+};

--- a/packages/credit-card-integration/project.json
+++ b/packages/credit-card-integration/project.json
@@ -1,0 +1,22 @@
+{
+    "root": "packages/credit-card-integration",
+    "sourceRoot": "packages/credit-card-integration/src",
+    "projectType": "library",
+    "targets": {
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/credit-card-integration/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/credit-card-integration"],
+            "options": {
+                "jestConfig": "packages/credit-card-integration/jest.config.js"
+            }
+        }
+    },
+    "tags": ["scope:shared"]
+}

--- a/packages/credit-card-integration/src/create-credit-card-payment-strategy.spec.ts
+++ b/packages/credit-card-integration/src/create-credit-card-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createCreditCardPaymentStrategy from './create-credit-card-payment-strategy';
+import CreditCardPaymentStrategy from './credit-card-payment-strategy';
+
+describe('createExternalPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates external payment strategy', () => {
+        const strategy = createCreditCardPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(CreditCardPaymentStrategy);
+    });
+});

--- a/packages/credit-card-integration/src/create-credit-card-payment-strategy.ts
+++ b/packages/credit-card-integration/src/create-credit-card-payment-strategy.ts
@@ -1,0 +1,14 @@
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import CreditCardPaymentStrategy from './credit-card-payment-strategy';
+
+const createCreditCardPaymentStrategy: PaymentStrategyFactory<CreditCardPaymentStrategy> = (
+    paymentIntegrationService,
+) => {
+    return new CreditCardPaymentStrategy(paymentIntegrationService);
+};
+
+export default toResolvableModule(createCreditCardPaymentStrategy, [{ default: true }]);

--- a/packages/credit-card-integration/src/credit-card-payment-initialize-options.ts
+++ b/packages/credit-card-integration/src/credit-card-payment-initialize-options.ts
@@ -1,4 +1,4 @@
-import { HostedFormOptions } from '../../../hosted-form';
+import { HostedFormOptions } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 /**
  * A set of options to initialize credit card payment methods, unless those
@@ -77,6 +77,10 @@ import { HostedFormOptions } from '../../../hosted-form';
  * });
  * ```
  */
-export default interface CreditCardPaymentInitializeOptions {
+export interface CreditCardPaymentInitializeOptions {
     form: HostedFormOptions;
+}
+
+export interface WithCreditCardPaymentInitializeOptions {
+    creditCard?: CreditCardPaymentInitializeOptions;
 }

--- a/packages/credit-card-integration/src/credit-card-payment-strategy.spec.ts
+++ b/packages/credit-card-integration/src/credit-card-payment-strategy.spec.ts
@@ -1,0 +1,182 @@
+import { omit } from 'lodash';
+
+import {
+    HostedFieldType,
+    HostedForm,
+    OrderFinalizationNotRequiredError,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getOrderRequestBody,
+    getPaymentMethod,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { CreditCardPaymentStrategy, WithCreditCardPaymentInitializeOptions } from '.';
+
+describe('CreditCardPaymentStrategy', () => {
+    let form: Pick<HostedForm, 'attach' | 'submit' | 'validate'>;
+    let options: PaymentInitializeOptions & WithCreditCardPaymentInitializeOptions;
+    let strategy: CreditCardPaymentStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService =
+            new PaymentIntegrationServiceMock() as PaymentIntegrationService;
+        strategy = new CreditCardPaymentStrategy(paymentIntegrationService);
+        form = {
+            attach: jest.fn(() => Promise.resolve()),
+            submit: jest.fn(() => Promise.resolve()),
+            validate: jest.fn(() => Promise.resolve()),
+        };
+        options = {
+            creditCard: {
+                form: {
+                    fields: {
+                        [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+                        [HostedFieldType.CardName]: { containerId: 'card-name' },
+                        [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+                    },
+                },
+            },
+            methodId: 'authorizenet',
+        };
+
+        jest.spyOn(paymentIntegrationService, 'createHostedForm').mockReturnValue(form);
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            {
+                ...getPaymentMethod(),
+                config: {
+                    isHostedFormEnabled: true,
+                },
+            },
+        );
+    });
+
+    describe('#initialize()', () => {
+        it('does not create hosted form if form is disabled', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...getPaymentMethod(),
+                config: {
+                    isHostedFormEnabled: false,
+                },
+            });
+
+            await strategy.initialize(options);
+
+            expect(paymentIntegrationService.createHostedForm).not.toHaveBeenCalled();
+        });
+
+        it('does not create hosted form if no fields', async () => {
+            options = {
+                creditCard: {
+                    form: {
+                        fields: {},
+                    },
+                },
+                methodId: 'authorizenet',
+            };
+            await strategy.initialize(options);
+
+            expect(paymentIntegrationService.createHostedForm).not.toHaveBeenCalled();
+        });
+
+        it('creates hosted form if form is enabled', async () => {
+            const result = await strategy.initialize(options);
+
+            expect(paymentIntegrationService.createHostedForm).toHaveBeenCalledWith(
+                'https://bigpay.integration.zone',
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                options.creditCard!.form,
+            );
+            expect(form.attach).toHaveBeenCalled();
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('#execute()', () => {
+        it('throws error when payment data is empty', async () => {
+            await expect(strategy.execute({})).rejects.toThrow(PaymentArgumentInvalidError);
+        });
+
+        describe('with hosted form', () => {
+            it('validates user input before submitting data', async () => {
+                await strategy.initialize(options);
+                await strategy.execute(getOrderRequestBody());
+
+                expect(form.validate).toHaveBeenCalled();
+            });
+
+            it('does not submit payment data with hosted form if validation fails', async () => {
+                jest.spyOn(form, 'validate').mockRejectedValue(new Error());
+
+                try {
+                    await strategy.initialize(options);
+                    await strategy.execute(getOrderRequestBody());
+                } catch (error) {
+                    expect(form.submit).not.toHaveBeenCalled();
+                }
+            });
+
+            it('submits payment data with hosted form', async () => {
+                const payload = getOrderRequestBody();
+
+                await strategy.initialize(options);
+                await strategy.execute(payload, options);
+
+                expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                    omit(payload, 'payment'),
+                    options,
+                );
+                expect(form.submit).toHaveBeenCalledWith(payload.payment);
+            });
+        });
+
+        describe('without hosted form', () => {
+            it('does not submit with hosted form', async () => {
+                const payload = getOrderRequestBody();
+                const { payment, ...order } = payload;
+                const paymentData = payment && payment.paymentData;
+
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...getPaymentMethod(),
+                    config: {
+                        isHostedFormEnabled: false,
+                    },
+                });
+
+                await strategy.initialize(options);
+                await strategy.execute(payload);
+
+                expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(order, options);
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                    ...payment,
+                    paymentData,
+                });
+                expect(form.submit).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            const result = await strategy.deinitialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+});

--- a/packages/credit-card-integration/src/credit-card-payment-strategy.ts
+++ b/packages/credit-card-integration/src/credit-card-payment-strategy.ts
@@ -1,0 +1,131 @@
+import { isNil, values } from 'lodash';
+
+import {
+    HostedForm,
+    InvalidArgumentError,
+    NotInitializedError,
+    NotInitializedErrorType,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentRequestOptions,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { WithCreditCardPaymentInitializeOptions } from './credit-card-payment-initialize-options';
+
+export default class CreditCardPaymentStrategy implements PaymentStrategy {
+    protected _hostedForm?: HostedForm;
+    protected _shouldRenderHostedForm?: boolean;
+
+    constructor(private _paymentIntegrationService: PaymentIntegrationService) {}
+
+    execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        return this._isHostedPaymentFormEnabled(
+            payload.payment?.methodId,
+            payload.payment?.gatewayId,
+        ) && this._shouldRenderHostedForm
+            ? this._executeWithHostedForm(payload, options)
+            : this._executeWithoutHostedForm(payload, options);
+    }
+
+    initialize(
+        options?: PaymentInitializeOptions & WithCreditCardPaymentInitializeOptions,
+    ): Promise<void> {
+        if (
+            !this._isHostedPaymentFormEnabled(options?.methodId, options?.gatewayId) ||
+            !this._isHostedFieldAvailable(options)
+        ) {
+            this._shouldRenderHostedForm = false;
+
+            return Promise.resolve();
+        }
+
+        const formOptions = options && options.creditCard && options.creditCard.form;
+        const state = this._paymentIntegrationService.getState();
+        const { paymentSettings: { bigpayBaseUrl: host = '' } = {} } =
+            state.getStoreConfigOrThrow();
+
+        if (!formOptions) {
+            throw new InvalidArgumentError();
+        }
+
+        const form = this._paymentIntegrationService.createHostedForm(host, formOptions);
+
+        return form.attach().then(() => {
+            this._shouldRenderHostedForm = true;
+            this._hostedForm = form;
+
+            return Promise.resolve();
+        });
+    }
+
+    deinitialize(): Promise<void> {
+        if (this._hostedForm) {
+            this._hostedForm.detach();
+        }
+
+        return Promise.resolve();
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    protected async _executeWithoutHostedForm(
+        payload: OrderRequestBody,
+        options?: PaymentRequestOptions,
+    ): Promise<void> {
+        const { payment, ...order } = payload;
+        const paymentData = payment && payment.paymentData;
+
+        if (!payment || !paymentData) {
+            throw new PaymentArgumentInvalidError(['payment.paymentData']);
+        }
+
+        await this._paymentIntegrationService.submitOrder(order, options);
+
+        await this._paymentIntegrationService.submitPayment({ ...payment, paymentData });
+    }
+
+    protected async _executeWithHostedForm(
+        payload: OrderRequestBody,
+        options?: PaymentRequestOptions,
+    ): Promise<void> {
+        const { payment, ...order } = payload;
+        const form = this._hostedForm;
+
+        if (!form) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        if (!payment || !payment.methodId) {
+            throw new PaymentArgumentInvalidError(['payment.methodId']);
+        }
+
+        await this._paymentIntegrationService.submitOrder(order, options);
+
+        await form.validate().then(() => form.submit(payment));
+    }
+
+    protected _isHostedPaymentFormEnabled(methodId?: string, gatewayId?: string): boolean {
+        if (!methodId) {
+            return false;
+        }
+
+        const state = this._paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethodOrThrow(methodId, gatewayId);
+
+        return paymentMethod.config.isHostedFormEnabled === true;
+    }
+
+    private _isHostedFieldAvailable(
+        options?: PaymentInitializeOptions & WithCreditCardPaymentInitializeOptions,
+    ): boolean {
+        return !values(options && options.creditCard && options.creditCard.form.fields).every(
+            isNil,
+        );
+    }
+}

--- a/packages/credit-card-integration/src/index.ts
+++ b/packages/credit-card-integration/src/index.ts
@@ -1,0 +1,6 @@
+export { default as createCreditCardPaymentStrategy } from './create-credit-card-payment-strategy';
+export {
+    CreditCardPaymentInitializeOptions,
+    WithCreditCardPaymentInitializeOptions,
+} from './credit-card-payment-initialize-options';
+export { default as CreditCardPaymentStrategy } from './credit-card-payment-strategy';

--- a/packages/credit-card-integration/tsconfig.json
+++ b/packages/credit-card-integration/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.base.json"
+}

--- a/packages/credit-card-integration/tsconfig.lib.json
+++ b/packages/credit-card-integration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts"]
+}

--- a/packages/credit-card-integration/tsconfig.spec.json
+++ b/packages/credit-card-integration/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/packages/payment-integrations-test-utils/src/index.ts
+++ b/packages/payment-integrations-test-utils/src/index.ts
@@ -7,6 +7,7 @@ export {
     getOrderRequestBody,
     getShippingOption,
     getPayment,
+    getPaymentMethod,
     getResponse,
     getCreditCardInstrument,
     getVaultedInstrument,

--- a/packages/payment-integrations-test-utils/src/test-utils/index.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/index.ts
@@ -8,6 +8,7 @@ export { getResponse } from './responses.mock';
 export { default as getShippingOption } from './shipping-option.mock';
 export {
     getPayment,
+    getPaymentMethod,
     getCreditCardInstrument,
     getVaultedInstrument,
     getErrorPaymentResponseBody,

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -16,6 +16,7 @@ const state = {
     getBillingAddressOrThrow: jest.fn(() => getBillingAddress()),
 };
 
+const createHostedForm = jest.fn();
 const getState = jest.fn(() => state);
 const loadCheckout = jest.fn();
 const loadDefaultCheckout = jest.fn();
@@ -30,6 +31,7 @@ const selectShippingOption = jest.fn();
 
 const PaymentIntegrationServiceMock = jest.fn().mockImplementation(() => {
     return {
+        createHostedForm,
         subscribe,
         getState,
         loadCheckout,

--- a/packages/payment-integrations-test-utils/src/test-utils/payments.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payments.mock.ts
@@ -1,6 +1,7 @@
 import {
     CreditCardInstrument,
     Payment,
+    PaymentMethod,
     PaymentResponseBody,
     VaultedInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -9,6 +10,20 @@ export function getPayment(): Payment {
     return {
         methodId: 'authorizenet',
         paymentData: getCreditCardInstrument(),
+    };
+}
+
+export function getPaymentMethod(): PaymentMethod {
+    return {
+        id: 'authorizenet',
+        logoUrl: '',
+        method: 'credit-card',
+        supportedCards: [],
+        config: {
+            displayName: 'Authorizenet',
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
     };
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,6 +30,9 @@
             "@bigcommerce/checkout-sdk/no-payment-integration": [
                 "packages/no-payment-integration/src/index.ts"
             ],
+            "@bigcommerce/checkout-sdk/credit-card-integration": [
+                "packages/credit-card-integration/src/index.ts"
+            ],
             "@bigcommerce/checkout-sdk/payment-integration-api": [
                 "packages/payment-integration-api/src/index.ts"
             ],

--- a/workspace.json
+++ b/workspace.json
@@ -4,6 +4,7 @@
         "adyen-integration": "packages/adyen-integration",
         "apple-pay-integration": "packages/apple-pay-integration",
         "core": "packages/core",
+        "credit-card-integration": "packages/credit-card-integration",
         "external-integration": "packages/external-integration",
         "no-payment-integration": "packages/no-payment-integration",
         "payment-integration-api": "packages/payment-integration-api",


### PR DESCRIPTION
## What?
Refactor the existing `credit-card` payment strategy to use the new checkout payment integration JS API.

## Why?
Restructuring `checkout-sdk` into a monorepo.

## Testing / Proof
- CI checks.
- ~Manual testing: `checkout-js` e2e credit card payment method test with changes from this PR.~
