### PR TITLE
feat(payment): BOLT-408 Add BODL event for customer suggestion init

### DIFF
--- a/packages/core/src/bodl/bodl-emitter-service.ts
+++ b/packages/core/src/bodl/bodl-emitter-service.ts
@@ -120,6 +120,10 @@ export default class BodlEmitterService implements BodlService {
         this.bodlEvents.emit('bodl_checkout_email_entry_began');
     }
 
+    customerSuggestionInit(payload?: BodlEventsPayload) {
+        this.bodlEvents.emit('bodl_checkout_customer_suggestion_initialization', payload);
+    }
+
     customerSuggestionExecute() {
         this.bodlEvents.emit('bodl_checkout_customer_suggestion_execute');
     }

--- a/packages/core/src/bodl/bodl-events-service.spec.ts
+++ b/packages/core/src/bodl/bodl-events-service.spec.ts
@@ -374,6 +374,15 @@ describe('BodlEmitterService', () => {
                 expectedData: [string, BodlEventsPayload?];
             }> = [
                 {
+                    eventMethod: (payload: BodlEventsPayload) =>
+                        bodlEmitterService.customerSuggestionInit(payload),
+                    methodArguments: { test: 'data' },
+                    expectedData: [
+                        'bodl_checkout_customer_suggestion_initialization',
+                        { test: 'data' },
+                    ],
+                },
+                {
                     eventMethod: () => bodlEmitterService.customerSuggestionExecute(),
                     expectedData: ['bodl_checkout_customer_suggestion_execute'],
                 },

--- a/packages/core/src/bodl/bodl-service.ts
+++ b/packages/core/src/bodl/bodl-service.ts
@@ -5,6 +5,7 @@ export default interface BodlService {
     orderPurchased(): void;
     stepCompleted(step?: string): void;
     customerEmailEntry(email?: string): void;
+    customerSuggestionInit(payload?: BodlEventsPayload): void;
     customerSuggestionExecute(): void;
     customerPaymentMethodExecuted(payload?: BodlEventsPayload): void;
     showShippingMethods(): void;

--- a/packages/core/src/bodl/noop-bodl-service.ts
+++ b/packages/core/src/bodl/noop-bodl-service.ts
@@ -9,6 +9,8 @@ export default class NoopBodlService implements BodlService {
 
     customerEmailEntry(): void {}
 
+    customerSuggestionInit(): void {}
+
     customerSuggestionExecute(): void {}
 
     customerPaymentMethodExecuted(): void {}


### PR DESCRIPTION
## What?
Add new Bodl analytics event to Bolt customer suggestion initialization

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-408](https://bigcommercecloud.atlassian.net/browse/BOLT-408)

## Testing / Proof
<img width="440" alt="Screenshot 2022-11-29 at 10 45 32" src="https://user-images.githubusercontent.com/9430298/204497641-f0aa53bb-caec-4948-bbd1-f5763542f953.png">


@bigcommerce/checkout @bigcommerce/payments
