### PR TITLE
fix(payment): BOLT-268 Bolt payment fields with store credits

### DIFF
--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -657,11 +657,22 @@ describe('BoltPaymentStrategy', () => {
     });
 
     describe('#deinitialize()', () => {
-        it('deinitializes strategy', async () => {
+        it('deinitializes Bolt client script strategy', async () => {
             await strategy.initialize(boltClientScriptInitializationOptions);
             await strategy.deinitialize();
 
             expect(await strategy.deinitialize()).toEqual(store.getState());
+            expect(boltEmbeddedField.unmount).not.toHaveBeenCalled();
+        });
+
+        it('deinitializes Bolt embedded one click strategy', async () => {
+            paymentMethodMock.initializationData.embeddedOneClickEnabled = true;
+            await strategy.initialize(boltEmbeddedScriptInitializationOptions);
+
+            const deinitializeResult = await strategy.deinitialize();
+
+            expect(boltEmbeddedField.unmount).toHaveBeenCalled();
+            expect(deinitializeResult).toEqual(store.getState());
         });
     });
 

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -117,6 +117,8 @@ export default class BoltPaymentStrategy implements PaymentStrategy {
     }
 
     deinitialize(): Promise<InternalCheckoutSelectors> {
+        this._embeddedField?.unmount();
+
         this._boltClient = undefined;
         this._boltEmbedded = undefined;
 

--- a/packages/core/src/payment/strategies/bolt/bolt.mock.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt.mock.ts
@@ -28,6 +28,7 @@ export function getBoltEmbeddedScriptMock(): BoltEmbedded {
         create: jest.fn((_formName: string) => {
             return {
                 mount: jest.fn(),
+                unmount: jest.fn(),
                 tokenize: jest.fn(),
             };
         }),

--- a/packages/core/src/payment/strategies/bolt/bolt.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt.ts
@@ -27,6 +27,7 @@ export interface BoltEmbedded {
 
 export interface BoltEmbededField {
     mount(element: string): void;
+    unmount(): void;
     tokenize(): Promise<BoltEmbeddedTokenize | Error>;
 }
 


### PR DESCRIPTION
## What?
Fix issue with empty Bolt payment fields after disabling store credits
Checkout-js changes: [https://github.com/bigcommerce/checkout-js/pull/1117](https://github.com/bigcommerce/checkout-js/pull/1117)

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/BOLT-268](https://bigcommercecloud.atlassian.net/browse/BOLT-268)

## Testing / Proof
Before:

https://user-images.githubusercontent.com/9430298/205292685-ae7ce077-bce6-4cea-8c16-078c62152da4.mov

After:


https://user-images.githubusercontent.com/9430298/205292732-77c8321a-263a-4ebe-b5bf-331e51191705.mov

Test:
<img width="480" alt="Screenshot 2022-12-02 at 12 45 08" src="https://user-images.githubusercontent.com/9430298/205292773-ba36aa39-614f-4f1b-b07b-07ee6d2775f5.png">



@bigcommerce/checkout @bigcommerce/payments
