### PR TITLE
fix(payment): ADYEN-629 added adyen credit card es translation fix

### DIFF
--- a/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.ts
@@ -91,6 +91,15 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
             locale: this._paymentIntegrationService.getState().getLocale(),
             [clientSideAuthentication.key]: clientSideAuthentication.value,
             paymentMethodsResponse: paymentMethod.initializationData.paymentMethodsResponse,
+            translations: {
+                es: { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-AR': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-ES': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-MX': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-CL': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-CO': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-PE': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+            },
         });
 
         this._paymentComponent = await this._mountPaymentComponent(paymentMethod);

--- a/packages/adyen-integration/src/adyenv2/adyenv2.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2.ts
@@ -239,6 +239,26 @@ export interface AdyenConfiguration {
      */
     paymentMethodsResponse?: PaymentMethodsResponse;
 
+    /**
+     * If your shoppers use a language that isn't supported by the Components, you can create your own localization.
+     * To create a localization:
+     * Add a translations object to your payment page, specifying:
+     * The localization you want to create.
+     * An object containing the fields that are used in the Components, as well as the text you want displayed for each field.
+     *
+     * "en": {
+     *  "paymentMethods.moreMethodsButton": "More payment methods",
+     *  "payButton": "Pay",
+     *  "storeDetails": "Save for my next payment",
+     *   ...
+     * }
+     */
+    translations?: {
+        [index: string]: {
+            [index: string]: string;
+        };
+    };
+
     /*
      * Specify the function that you created, for example, handleOnChange. If you wish
      * to override this function, you can also define an onChange event on the Component

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -82,6 +82,15 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             clientKey,
             paymentMethodsResponse,
             showPayButton: false,
+            translations: {
+                es: { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-AR': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-ES': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-MX': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-CL': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-CO': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+                'es-PE': { 'creditCard.expiryDateField.title': 'Fecha de caducidad' },
+            },
         });
 
         this._paymentComponent = await this._mountPaymentComponent(paymentMethod);

--- a/packages/adyen-integration/src/adyenv3/adyenv3.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3.ts
@@ -239,6 +239,26 @@ export interface AdyenConfiguration {
 
     showPayButton?: boolean;
 
+    /**
+     * If your shoppers use a language that isn't supported by the Components, you can create your own localization.
+     * To create a localization:
+     * Add a translations object to your payment page, specifying:
+     * The localization you want to create.
+     * An object containing the fields that are used in the Components, as well as the text you want displayed for each field.
+     *
+     * "en": {
+     *  "paymentMethods.moreMethodsButton": "More payment methods",
+     *  "payButton": "Pay",
+     *  "storeDetails": "Save for my next payment",
+     *   ...
+     * }
+     */
+    translations?: {
+        [index: string]: {
+            [index: string]: string;
+        };
+    };
+
     /*
      * Specify the function that you created, for example, handleOnChange. If you wish
      * to override this function, you can also define an onChange event on the Component


### PR DESCRIPTION
## What?
Added adyen credit card es translation fix.
‘Fecha de caducidad’ instead of  ‘Fecha de expiración’

## Why?
Due to the https://bigcommercecloud.atlassian.net/browse/ADYEN-629

## Testing / Proof
<img width="544" alt="image" src="https://user-images.githubusercontent.com/79574476/207085733-a5c701e5-2709-42c6-95fa-296cfae5dddd.png">

@bigcommerce/checkout @bigcommerce/payments
