### PR TITLE
feat(payment): PAYPAL-1836 added PayPalCommerceCustomer strategy

### DIFF
--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -7,6 +7,7 @@ import { BraintreeVisaCheckoutCustomerInitializeOptions } from './strategies/bra
 import { ChasePayCustomerInitializeOptions } from './strategies/chasepay';
 import { GooglePayCustomerInitializeOptions } from './strategies/googlepay';
 import { MasterpassCustomerInitializeOptions } from './strategies/masterpass';
+import { PaypalCommerceCustomerInitializeOptions } from './strategies/paypalcommerce';
 import { StripeUPECustomerInitializeOptions } from './strategies/stripe-upe';
 
 export { CustomerInitializeOptions } from '../generated/customer-initialize-options';
@@ -130,6 +131,12 @@ export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
      * They can be omitted unless you need to support GooglePay.
      */
     googlepaystripeupe?: GooglePayCustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the PayPalCommerce payment method.
+     * They can be omitted unless you need to support PayPalCommerce.
+     */
+    paypalcommerce?: PaypalCommerceCustomerInitializeOptions;
 
     /**
      * The options that are required to initialize the Customer Stripe Upe payment method.

--- a/packages/core/src/customer/strategies/paypalcommerce/index.ts
+++ b/packages/core/src/customer/strategies/paypalcommerce/index.ts
@@ -1,0 +1,2 @@
+export { default as PaypalCommerceCustomerInitializeOptions } from './paypalcommerce-customer-initialize-options';
+export { default as PaypalCommerceCustomerStrategy } from './paypalcommerce-customer-strategy';

--- a/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-initialize-options.ts
+++ b/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-initialize-options.ts
@@ -1,0 +1,23 @@
+/**
+ * A set of options that are required to initialize the customer step of
+ * checkout to support PayPalCommerce.
+ */
+export default interface PaypalCommerceCustomerInitializeOptions {
+    /**
+     * The ID of a container which the checkout button should be inserted into.
+     */
+    container: string;
+
+    /**
+     * A callback that gets called if unable to initialize the widget or select
+     * one of the address options provided by the widget.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error?: Error): void;
+
+    /**
+     * A callback that gets called when payment complete on paypal side.
+     */
+    onComplete?(): void;
+}

--- a/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.spec.ts
@@ -1,0 +1,719 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
+import { getCart } from '../../../cart/carts.mock';
+
+import { Cart } from '../../../cart';
+import {
+    CheckoutActionCreator,
+    CheckoutRequestSender,
+    CheckoutStore,
+    CheckoutValidator,
+    createCheckoutStore,
+} from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { OrderActionCreator, OrderRequestSender } from '../../../order';
+import {
+    PaymentActionCreator,
+    PaymentMethod,
+    PaymentMethodActionCreator,
+    PaymentMethodRequestSender,
+    PaymentRequestSender,
+    PaymentRequestTransformer,
+} from '../../../payment';
+import { getPaypalCommerce } from '../../../payment/payment-methods.mock';
+import {
+    ButtonsOptions,
+    PaypalCheckoutButtonOptions,
+    PaypalCommerceRequestSender,
+    PaypalCommerceScriptLoader,
+    PaypalCommerceSDK,
+    PayPalOrderDetails,
+} from '../../../payment/strategies/paypal-commerce';
+import { getPaypalCommerceMock } from '../../../payment/strategies/paypal-commerce/paypal-commerce.mock';
+import { ConsignmentActionCreator, ConsignmentRequestSender } from '../../../shipping';
+import {
+    createSpamProtection,
+    GoogleRecaptcha,
+    GoogleRecaptchaScriptLoader,
+    GoogleRecaptchaWindow,
+    PaymentHumanVerificationHandler,
+    SpamProtectionActionCreator,
+    SpamProtectionRequestSender,
+} from '../../../spam-protection';
+import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
+import PaypalCommerceCustomerInitializeOptions from './paypalcommerce-customer-initialize-options';
+import PaypalCommerceCustomerStrategy from './paypalcommerce-customer-strategy';
+
+describe('PaypalCommerceCustomerStrategy', () => {
+    let billingAddressActionCreator: BillingAddressActionCreator;
+    let cartMock: Cart;
+    let checkoutRequestSender: CheckoutRequestSender;
+    let consignmentActionCreator: ConsignmentActionCreator;
+    let customerActionCreator: CustomerActionCreator;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentMethodMock: PaymentMethod;
+    let paypalCommerceRequestSender: PaypalCommerceRequestSender;
+    let paypalScriptLoader: PaypalCommerceScriptLoader;
+    let paypalSdkMock: PaypalCommerceSDK;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: PaypalCommerceCustomerStrategy;
+    let subscriptionsActionCreator: SubscriptionsActionCreator;
+
+    const defaultContainerId = 'paypal-commerce-container-mock-id';
+    const approveDataOrderId = 'ORDER_ID';
+
+    const paypalCommerceOptions: PaypalCommerceCustomerInitializeOptions = {
+        container: defaultContainerId,
+        onComplete: () => {},
+    };
+
+    const methodId = 'paypalcommerce';
+    const initializationOptions: CustomerInitializeOptions = {
+        methodId,
+        paypalcommerce: paypalCommerceOptions,
+    };
+
+    beforeEach(() => {
+        cartMock = getCart();
+        eventEmitter = new EventEmitter();
+        paymentMethodMock = getPaypalCommerce();
+        paypalSdkMock = getPaypalCommerceMock();
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        requestSender = createRequestSender();
+        formPoster = createFormPoster();
+
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(
+            createScriptLoader(),
+            googleRecaptchaMockWindow,
+        );
+        googleRecaptcha = new GoogleRecaptcha(
+            googleRecaptchaScriptLoader,
+            new MutationObserverFactory(),
+        );
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            new CheckoutActionCreator(
+                new CheckoutRequestSender(createRequestSender()),
+                new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+                new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender())),
+            ),
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender()),
+            ),
+        );
+        paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
+        paypalScriptLoader = new PaypalCommerceScriptLoader(getScriptLoader());
+        checkoutRequestSender = new CheckoutRequestSender(requestSender);
+        consignmentActionCreator = new ConsignmentActionCreator(
+            new ConsignmentRequestSender(requestSender),
+            checkoutRequestSender,
+        );
+        subscriptionsActionCreator = new SubscriptionsActionCreator(
+            new SubscriptionsRequestSender(requestSender),
+        );
+        billingAddressActionCreator = new BillingAddressActionCreator(
+            new BillingAddressRequestSender(requestSender),
+            subscriptionsActionCreator,
+        );
+        orderActionCreator = new OrderActionCreator(
+            new OrderRequestSender(requestSender),
+            new CheckoutValidator(checkoutRequestSender),
+        );
+        paymentActionCreator = new PaymentActionCreator(
+            new PaymentRequestSender(requestSender),
+            orderActionCreator,
+            new PaymentRequestTransformer(),
+            new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader())),
+        );
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(createRequestSender()),
+        );
+
+        strategy = new PaypalCommerceCustomerStrategy(
+            store,
+            customerActionCreator,
+            formPoster,
+            paypalScriptLoader,
+            paypalCommerceRequestSender,
+            consignmentActionCreator,
+            billingAddressActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            orderActionCreator,
+        );
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethodMock,
+        );
+        jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockResolvedValue(
+            store.getState(),
+        );
+        jest.spyOn(paypalScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdkMock);
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+        jest.spyOn(billingAddressActionCreator, 'updateAddress').mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'loadShippingOptions').mockReturnValue(true);
+        jest.spyOn(consignmentActionCreator, 'selectShippingOption').mockReturnValue(true);
+        jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(true);
+        jest.spyOn(paymentActionCreator, 'submitPayment').mockReturnValue(true);
+        jest.spyOn(paypalCommerceRequestSender, 'updateOrder').mockReturnValue(true);
+
+        jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation((options: ButtonsOptions) => {
+            eventEmitter.on('createOrder', () => {
+                if (options.createOrder) {
+                    options.createOrder().catch(() => {});
+                }
+            });
+
+            eventEmitter.on('onApprove', () => {
+                if (options.onApprove) {
+                    options.onApprove({ orderID: approveDataOrderId });
+                }
+            });
+
+            eventEmitter.on('onShippingAddressChange', () => {
+                if (options.onShippingAddressChange) {
+                    options.onShippingAddressChange({
+                        orderId: approveDataOrderId,
+                        shippingAddress: {
+                            city: 'New York',
+                            country_code: 'US',
+                            postal_code: '07564',
+                            state: 'New York',
+                        },
+                    });
+                }
+            });
+
+            eventEmitter.on('onShippingOptionsChange', () => {
+                if (options.onShippingOptionsChange) {
+                    options.onShippingOptionsChange({
+                        orderId: approveDataOrderId,
+                        selectedShippingOption: {
+                            amount: {
+                                currency_code: 'USD',
+                                value: '100',
+                            },
+                            id: '1',
+                            label: 'Free shipping',
+                            selected: true,
+                            type: 'type_shipping',
+                        },
+                    });
+                }
+            });
+
+            return {
+                isEligible: jest.fn(() => true),
+                render: jest.fn(),
+            };
+        });
+    });
+
+    it('creates an interface of the PayPal Commerce customer strategy', () => {
+        expect(strategy).toBeInstanceOf(PaypalCommerceCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws an error if methodId is not provided', async () => {
+            const options = {} as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommerce is not provided', async () => {
+            const options = { methodId } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommerce.container is not provided', async () => {
+            const options = {
+                methodId,
+                paypalcommerce: {},
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('loads paypalcommerce payment method', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(methodId);
+        });
+
+        it('loads paypal sdk with provided params', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethodMock,
+                cartMock.currency.code,
+            );
+        });
+
+        it('throws an error if onComplete method is not provided for hosted checkout feature', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            });
+
+            try {
+                await strategy.initialize({
+                    methodId,
+                    paypalcommerce: {
+                        container: defaultContainerId,
+                    },
+                });
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('initializes paypal commerce sdk buttons for default flow', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdkMock.FUNDING.PAYPAL,
+                style: { height: 40 },
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('initializes paypal commerce sdk buttons for hosted checkout feature', async () => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdkMock.FUNDING.PAYPAL,
+                style: { height: 40 },
+                createOrder: expect.any(Function),
+                onShippingAddressChange: expect.any(Function),
+                onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('renders PayPal button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => true),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+        });
+
+        it('does not render PayPal button if it is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
+        it('creates an order with paypalcommerce as provider id if its initializes on checkout page', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
+                cartMock.id,
+                'paypalcommerce',
+            );
+        });
+    });
+
+    describe('#_onApprove button callback for default flow', () => {
+        it('throws an error if orderId is not provided by PayPal', async () => {
+            jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation((options: ButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(() => {});
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove({ orderID: '' });
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                };
+            });
+
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onApprove');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('tokenizes payment', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith(
+                '/checkout.php',
+                expect.objectContaining({
+                    action: 'set_external_checkout',
+                    order_id: approveDataOrderId,
+                    payment_type: 'paypal',
+                    provider: paymentMethodMock.id,
+                }),
+            );
+        });
+    });
+
+    describe('#_onApprove button callback (hosted checkout flow)', () => {
+        const paypalOrderDetails: PayPalOrderDetails = {
+            purchase_units: [
+                {
+                    shipping: {
+                        address: {
+                            address_line_1: '2 E 61st St',
+                            admin_area_2: 'New York',
+                            admin_area_1: 'NY',
+                            postal_code: '10065',
+                            country_code: 'US',
+                        },
+                    },
+                },
+            ],
+            payer: {
+                name: {
+                    given_name: 'John',
+                    surname: 'Doe',
+                },
+                email_address: 'john@doe.com',
+                address: {
+                    address_line_1: '1 Main St',
+                    admin_area_2: 'San Jose',
+                    admin_area_1: 'CA',
+                    postal_code: '95131',
+                    country_code: 'US',
+                },
+            },
+        };
+
+        beforeEach(() => {
+            jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation(
+                (options: PaypalCheckoutButtonOptions) => {
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove(
+                                { orderID: approveDataOrderId },
+                                {
+                                    order: {
+                                        get: jest.fn(() => paypalOrderDetails),
+                                    },
+                                },
+                            );
+                        }
+                    });
+
+                    return {
+                        render: jest.fn(),
+                        isEligible: jest.fn(() => true),
+                    };
+                },
+            );
+
+            const paymentMethod = {
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+                paymentMethod,
+            );
+        });
+
+        it('takes order details data from paypal', async () => {
+            const getOrderActionMock = jest.fn(() => paypalOrderDetails);
+
+            jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation(
+                (options: PaypalCheckoutButtonOptions) => {
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove(
+                                { orderID: approveDataOrderId },
+                                {
+                                    order: {
+                                        get: getOrderActionMock,
+                                    },
+                                },
+                            );
+                        }
+                    });
+
+                    return {
+                        render: jest.fn(),
+                        isEligible: jest.fn(() => true),
+                    };
+                },
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(getOrderActionMock).toHaveBeenCalled();
+            expect(getOrderActionMock).toHaveReturnedWith(paypalOrderDetails);
+        });
+
+        it('updates only billing address with valid customers data from order details if there is no shipping needed', async () => {
+            const defaultCart = getCart();
+            const cartWithoutShipping = {
+                ...defaultCart,
+                lineItems: {
+                    ...defaultCart.lineItems,
+                    physicalItems: [],
+                },
+            };
+
+            jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(
+                cartWithoutShipping,
+            );
+
+            const address = {
+                firstName: paypalOrderDetails.payer.name.given_name,
+                lastName: paypalOrderDetails.payer.name.surname,
+                email: paypalOrderDetails.payer.email_address,
+                phone: '',
+                company: '',
+                address1: paypalOrderDetails.payer.address.address_line_1,
+                address2: '',
+                city: paypalOrderDetails.payer.address.admin_area_2,
+                countryCode: paypalOrderDetails.payer.address.country_code,
+                postalCode: paypalOrderDetails.payer.address.postal_code,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalOrderDetails.payer.address.admin_area_1,
+                customFields: [],
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalledWith(address);
+        });
+
+        it('submits BC order with provided methodId', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(
+                {},
+                {
+                    params: {
+                        methodId: initializationOptions.methodId,
+                    },
+                },
+            );
+        });
+
+        it('submits BC payment to update BC order data', async () => {
+            const methodId = initializationOptions.methodId;
+            const paymentData = {
+                formattedPayload: {
+                    vault_payment_instrument: null,
+                    set_as_default_stored_instrument: null,
+                    device_info: null,
+                    method_id: methodId,
+                    paypal_account: {
+                        order_id: approveDataOrderId,
+                    },
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({
+                methodId,
+                paymentData,
+            });
+        });
+    });
+
+    describe('#_onShippingAddressChange button callback (hosted checkout flow)', () => {
+        beforeEach(() => {
+            const paymentMethod = {
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(
+                Promise.resolve(),
+            );
+            jest.spyOn(consignmentActionCreator, 'selectShippingOption').mockReturnValue(
+                Promise.resolve(),
+            );
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+                paymentMethod,
+            );
+        });
+
+        it('calls billingAddressActionCreator.updateAddress', async () => {
+            await strategy.initialize(initializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onShippingAddressChange');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(billingAddressActionCreator.updateAddress).toHaveBeenCalled();
+        });
+
+        it('calls consignmentActionCreator.updateAddress', async () => {
+            await strategy.initialize(initializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onShippingAddressChange');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(consignmentActionCreator.updateAddress).toHaveBeenCalled();
+        });
+
+        it('calls consignmentActionCreator.selectShippingOption', async () => {
+            await strategy.initialize(initializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onShippingAddressChange');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(consignmentActionCreator.selectShippingOption).toHaveBeenCalled();
+        });
+
+        it('calls updateOrder', async () => {
+            await strategy.initialize(initializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onShippingAddressChange');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalled();
+        });
+    });
+
+    describe('#_onShippingOptionsChange button callback (hosted checkout flow)', () => {
+        beforeEach(() => {
+            const paymentMethod = {
+                ...paymentMethodMock,
+                initializationData: {
+                    ...paymentMethodMock.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(consignmentActionCreator, 'updateAddress').mockReturnValue(
+                Promise.resolve(),
+            );
+            jest.spyOn(consignmentActionCreator, 'selectShippingOption').mockReturnValue(
+                Promise.resolve(),
+            );
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+                paymentMethod,
+            );
+        });
+
+        it('calls consignmentActionCreator.selectShippingOption', async () => {
+            await strategy.initialize(initializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onShippingOptionsChange');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(consignmentActionCreator.selectShippingOption).toHaveBeenCalled();
+        });
+
+        it('calls updateOrder', async () => {
+            await strategy.initialize(initializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onShippingOptionsChange');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.ts
@@ -1,0 +1,411 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+import { noop } from 'lodash';
+
+import { BillingAddressActionCreator, BillingAddressRequestBody } from '../../../billing';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    RequestError,
+} from '../../../common/error/errors';
+import { OrderActionCreator } from '../../../order';
+import { PaymentActionCreator, PaymentMethodActionCreator } from '../../../payment';
+import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
+import {
+    ApproveCallbackActions,
+    ApproveCallbackPayload,
+    ButtonsOptions,
+    PaypalCommerceRequestSender,
+    PaypalCommerceScriptLoader,
+    PaypalCommerceSDK,
+    PayPalOrderDetails,
+    ShippingAddressChangeCallbackPayload,
+    ShippingOptionChangeCallbackPayload,
+} from '../../../payment/strategies/paypal-commerce';
+import { ConsignmentActionCreator, ShippingOption } from '../../../shipping';
+import CustomerActionCreator from '../../customer-action-creator';
+import CustomerCredentials from '../../customer-credentials';
+import {
+    CustomerInitializeOptions,
+    CustomerRequestOptions,
+    ExecutePaymentMethodCheckoutOptions,
+} from '../../customer-request-options';
+import CustomerStrategy from '../customer-strategy';
+import PaypalCommerceCustomerInitializeOptions from './paypalcommerce-customer-initialize-options';
+
+export default class PaypalCommerceCustomerStrategy implements CustomerStrategy {
+    private _paypalCommerceSdk?: PaypalCommerceSDK;
+    private _onError = noop;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _customerActionCreator: CustomerActionCreator,
+        private _formPoster: FormPoster,
+        private _paypalScriptLoader: PaypalCommerceScriptLoader,
+        private _paypalCommerceRequestSender: PaypalCommerceRequestSender,
+        private _consignmentActionCreator: ConsignmentActionCreator,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _orderActionCreator: OrderActionCreator,
+    ) {}
+
+    async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { paypalcommerce, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!paypalcommerce) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommerce" argument is not provided.`,
+            );
+        }
+
+        const { container, onError } = paypalcommerce;
+
+        this._onError = onError || noop;
+
+        if (!container) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommerce.container" argument is not provided.`,
+            );
+        }
+
+        const state = await this._store.dispatch(
+            this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+        );
+        const currencyCode = state.cart.getCartOrThrow().currency.code;
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        this._paypalCommerceSdk = await this._paypalScriptLoader.getPayPalSDK(
+            paymentMethod,
+            currencyCode,
+        );
+
+        this._renderButton(methodId, paypalcommerce);
+
+        return this._store.getState();
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    signIn(
+        credentials: CustomerCredentials,
+        options?: CustomerRequestOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.signInCustomer(credentials, options),
+        );
+    }
+
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(this._customerActionCreator.signOutCustomer(options));
+    }
+
+    executePaymentMethodCheckout(
+        options?: ExecutePaymentMethodCheckoutOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        options?.continueWithCheckoutCallback?.();
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _renderButton(
+        methodId: string,
+        paypalcommerce: PaypalCommerceCustomerInitializeOptions,
+    ): void {
+        const { container, onComplete } = paypalcommerce;
+        const paypalCommerceSdk = this._getPayPalCommerceSdkOrThrow();
+
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
+
+        if (isHostedCheckoutEnabled && (!onComplete || typeof onComplete !== 'function')) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommerce.onComplete" argument is not provided or it is not a function.`,
+            );
+        }
+
+        const hostedCheckoutCallbacks = {
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this._onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this._onShippingOptionsChange(data),
+            onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
+                this._onHostedCheckoutApprove(data, actions, methodId, onComplete),
+        };
+
+        const regularCallbacks = {
+            onApprove: ({ orderID }: ApproveCallbackPayload) =>
+                this._tokenizePayment(methodId, orderID),
+        };
+
+        const paypalCallbacks = isHostedCheckoutEnabled
+            ? hostedCheckoutCallbacks
+            : regularCallbacks;
+
+        const buttonRenderOptions: ButtonsOptions = {
+            fundingSource: paypalCommerceSdk.FUNDING.PAYPAL,
+            style: {
+                height: 40,
+            },
+            createOrder: () => this._createOrder(),
+            ...paypalCallbacks,
+        };
+
+        const paypalButton = paypalCommerceSdk.Buttons(buttonRenderOptions);
+
+        if (paypalButton.isEligible()) {
+            paypalButton.render(`#${container}`);
+        } else {
+            this._removeElement(container);
+        }
+    }
+
+    private async _onHostedCheckoutApprove(
+        data: ApproveCallbackPayload,
+        actions: ApproveCallbackActions,
+        methodId: string,
+        onComplete?: () => void,
+    ): Promise<void> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const orderDetails = await this._getOrderDetailsOrThrow(actions);
+
+        try {
+            if (cart.lineItems.physicalItems.length > 0) {
+                const { payer, purchase_units } = orderDetails;
+                const shippingAddress = purchase_units[0]?.shipping?.address || {};
+
+                const address = this._getAddress({
+                    firstName: payer.name.given_name,
+                    lastName: payer.name.surname,
+                    email: payer.email_address,
+                    address1: shippingAddress.address_line_1,
+                    city: shippingAddress.admin_area_2,
+                    countryCode: shippingAddress.country_code,
+                    postalCode: shippingAddress.postal_code,
+                    stateOrProvinceCode: shippingAddress.admin_area_1,
+                });
+
+                await this._store.dispatch(
+                    this._billingAddressActionCreator.updateAddress(address),
+                );
+                await this._store.dispatch(this._consignmentActionCreator.updateAddress(address));
+                await this._updateOrder();
+            } else {
+                const { payer } = orderDetails;
+
+                const address = this._getAddress({
+                    firstName: payer.name.given_name,
+                    lastName: payer.name.surname,
+                    email: payer.email_address,
+                    address1: payer.address.address_line_1,
+                    city: payer.address.admin_area_2,
+                    countryCode: payer.address.country_code,
+                    postalCode: payer.address.postal_code,
+                    stateOrProvinceCode: payer.address.admin_area_1,
+                });
+
+                await this._store.dispatch(
+                    this._billingAddressActionCreator.updateAddress(address),
+                );
+            }
+
+            await this._store.dispatch(
+                this._orderActionCreator.submitOrder({}, { params: { methodId } }),
+            );
+            await this._submitPayment(methodId, data.orderID);
+
+            if (onComplete) {
+                onComplete();
+            }
+        } catch (error) {
+            this._handleError(error);
+        }
+    }
+
+    private async _getOrderDetailsOrThrow(
+        actions: ApproveCallbackActions,
+    ): Promise<PayPalOrderDetails> {
+        try {
+            return actions.order.get();
+        } catch (_) {
+            throw new RequestError();
+        }
+    }
+
+    private async _onShippingAddressChange(
+        data: ShippingAddressChangeCallbackPayload,
+    ): Promise<void> {
+        const address = this._getAddress({
+            city: data.shippingAddress.city,
+            countryCode: data.shippingAddress.country_code,
+            postalCode: data.shippingAddress.postal_code,
+            stateOrProvinceCode: data.shippingAddress.state,
+        });
+
+        try {
+            // Info: we use the same address to fill billing and consignment addresses to have valid quota on BE for order updating process
+            // on this stage we don't have access to valid customer's address accept shipping data
+            await this._store.dispatch(this._billingAddressActionCreator.updateAddress(address));
+            await this._store.dispatch(this._consignmentActionCreator.updateAddress(address));
+
+            const shippingOption = this._getShippingOptionOrThrow();
+
+            await this._store.dispatch(
+                this._consignmentActionCreator.selectShippingOption(shippingOption.id),
+            );
+            await this._updateOrder();
+        } catch (error) {
+            this._handleError(error);
+        }
+    }
+
+    private async _onShippingOptionsChange(
+        data: ShippingOptionChangeCallbackPayload,
+    ): Promise<void> {
+        const shippingOption = this._getShippingOptionOrThrow(data.selectedShippingOption.id);
+
+        try {
+            await this._store.dispatch(
+                this._consignmentActionCreator.selectShippingOption(shippingOption.id),
+            );
+            await this._updateOrder();
+        } catch (error) {
+            this._handleError(error);
+        }
+    }
+
+    private async _submitPayment(methodId: string, orderId: string): Promise<void> {
+        const paymentData = {
+            formattedPayload: {
+                vault_payment_instrument: null,
+                set_as_default_stored_instrument: null,
+                device_info: null,
+                method_id: methodId,
+                paypal_account: {
+                    order_id: orderId,
+                },
+            },
+        };
+
+        await this._store.dispatch(
+            this._paymentActionCreator.submitPayment({ methodId, paymentData }),
+        );
+    }
+
+    private async _updateOrder(): Promise<void> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const consignment = state.consignments.getConsignmentsOrThrow()[0];
+
+        try {
+            await this._paypalCommerceRequestSender.updateOrder({
+                availableShippingOptions: consignment.availableShippingOptions,
+                cartId: cart.id,
+                selectedShippingOption: consignment.selectedShippingOption,
+            });
+        } catch (_error) {
+            throw new RequestError();
+        }
+    }
+
+    private _getAddress(address?: Partial<BillingAddressRequestBody>): BillingAddressRequestBody {
+        return {
+            firstName: address?.firstName || '',
+            lastName: address?.lastName || '',
+            email: address?.email || '',
+            phone: '',
+            company: '',
+            address1: address?.address1 || '',
+            address2: '',
+            city: address?.city || '',
+            countryCode: address?.countryCode || '',
+            postalCode: address?.postalCode || '',
+            stateOrProvince: '',
+            stateOrProvinceCode: address?.stateOrProvinceCode || '',
+            customFields: [],
+        };
+    }
+
+    private _getShippingOptionOrThrow(selectedShippingOptionId?: string): ShippingOption {
+        const state = this._store.getState();
+        const consignment = state.consignments.getConsignmentsOrThrow()[0];
+
+        const availableShippingOptions = consignment.availableShippingOptions || [];
+
+        const recommendedShippingOption = availableShippingOptions.find(
+            (option) => option.isRecommended,
+        );
+        const selectedShippingOption = selectedShippingOptionId
+            ? availableShippingOptions.find((option) => option.id === selectedShippingOptionId)
+            : availableShippingOptions.find(
+                  (option) => option.id === consignment.selectedShippingOption?.id,
+              );
+
+        const shippingOptionToSelect = selectedShippingOption || recommendedShippingOption;
+
+        if (!shippingOptionToSelect) {
+            throw new Error("Your order can't be shipped to this address");
+        }
+
+        return shippingOptionToSelect;
+    }
+
+    private async _createOrder(): Promise<string> {
+        const cart = this._store.getState().cart.getCartOrThrow();
+
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(
+            cart.id,
+            'paypalcommerce',
+        );
+
+        return orderId;
+    }
+
+    private _tokenizePayment(methodId: string, orderId?: string): void {
+        if (!orderId) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        return this._formPoster.postForm('/checkout.php', {
+            payment_type: 'paypal',
+            action: 'set_external_checkout',
+            provider: methodId,
+            order_id: orderId,
+        });
+    }
+
+    private _getPayPalCommerceSdkOrThrow(): PaypalCommerceSDK {
+        if (!this._paypalCommerceSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this._paypalCommerceSdk;
+    }
+
+    private _removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+
+    private _handleError(error: Error) {
+        if (this._onError && typeof this._onError === 'function') {
+            this._onError(error);
+        } else {
+            throw error;
+        }
+    }
+}

--- a/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.ts
@@ -255,7 +255,7 @@ export default class PaypalCommerceCustomerStrategy implements CustomerStrategy 
 
         try {
             // Info: we use the same address to fill billing and consignment addresses to have valid quota on BE for order updating process
-            // on this stage we don't have access to valid customer's address accept shipping data
+            // on this stage we don't have access to valid customer's address except shipping data
             await this._store.dispatch(this._billingAddressActionCreator.updateAddress(address));
             await this._store.dispatch(this._consignmentActionCreator.updateAddress(address));
 


### PR DESCRIPTION
## What?
Added PayPalCommerceCustomer strategy

## Why?
To add PayPal Commerce button to the customer step

## Testing / Proof
Here is a screenshot of the PayPal button in customer step and a video of the result:
<img width="1228" alt="Screenshot 2022-12-13 at 14 08 06" src="https://user-images.githubusercontent.com/25133454/207336021-fc49bf8c-f067-47a7-b35b-f8d99a7b1970.png">

https://user-images.githubusercontent.com/25133454/207329128-0a3e051d-a49a-4d0c-adc6-e850b0c23051.mov

## Sibling PRs
bigcommerce: https://github.com/bigcommerce/bigcommerce/pull/50236
checkout-js: https://github.com/bigcommerce/checkout-js/pull/1123