### PR TITLE
feat(payment): PAYPAL-1808 passing vaulting data to order creation request for PayPal Commerce CC

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -411,8 +411,10 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                cartMock.id,
                 'paypalcommercealternativemethod',
+                {
+                    cartId: cartMock.id,
+                },
             );
         });
 
@@ -434,8 +436,10 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                cartMock.id,
                 'paypalcommercealternativemethodscheckout',
+                {
+                    cartId: cartMock.id,
+                },
             );
         });
 
@@ -456,8 +460,10 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                buyNowCartMock.id,
                 'paypalcommercealternativemethod',
+                {
+                    cartId: buyNowCartMock.id,
+                },
             );
         });
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
@@ -173,7 +173,9 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy
             ? 'paypalcommercealternativemethodscheckout'
             : 'paypalcommercealternativemethod';
 
-        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cartId, providerId);
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(providerId, {
+            cartId,
+        });
 
         return orderId;
     }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -512,10 +512,9 @@ describe('PaypalCommerceButtonStrategy', () => {
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                cartMock.id,
-                'paypalcommerce',
-            );
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith('paypalcommerce', {
+                cartId: cartMock.id,
+            });
         });
 
         it('creates an order with paypalcommercecheckout as provider id if its initializes on checkout page', async () => {
@@ -536,8 +535,10 @@ describe('PaypalCommerceButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                cartMock.id,
                 'paypalcommercecheckout',
+                {
+                    cartId: cartMock.id,
+                },
             );
         });
 
@@ -557,10 +558,9 @@ describe('PaypalCommerceButtonStrategy', () => {
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                buyNowCartMock.id,
-                'paypalcommerce',
-            );
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith('paypalcommerce', {
+                cartId: buyNowCartMock.id,
+            });
         });
 
         it('throws an error if orderId is not provided by PayPal on approve', async () => {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -380,7 +380,9 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
 
         const providerId = initializesOnCheckoutPage ? 'paypalcommercecheckout' : 'paypalcommerce';
 
-        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cartId, providerId);
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(providerId, {
+            cartId,
+        });
 
         return orderId;
     }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
@@ -553,8 +553,10 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
                 await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                    cartMock.id,
                     'paypalcommercecredit',
+                    {
+                        cartId: cartMock.id,
+                    },
                 );
             });
 
@@ -576,8 +578,10 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
                 await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                    cartMock.id,
                     'paypalcommercecreditcheckout',
+                    {
+                        cartId: cartMock.id,
+                    },
                 );
             });
 
@@ -598,8 +602,10 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
                 await new Promise((resolve) => process.nextTick(resolve));
 
                 expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                    buyNowCartMock.id,
                     'paypalcommercecredit',
+                    {
+                        cartId: buyNowCartMock.id,
+                    },
                 );
             });
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
@@ -412,7 +412,9 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
             ? 'paypalcommercecreditcheckout'
             : 'paypalcommercecredit';
 
-        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cartId, providerId);
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(providerId, {
+            cartId,
+        });
 
         return orderId;
     }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.spec.ts
@@ -377,8 +377,10 @@ describe('PaypalCommerceInlineCheckoutButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                cartMock.id,
                 initializationOptions.methodId,
+                {
+                    cartId: cartMock.id,
+                },
             );
         });
     });

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-inline-checkout-button-strategy.ts
@@ -127,7 +127,9 @@ export default class PaypalCommerceInlineCheckoutButtonStrategy implements Check
         const state = this._store.getState();
         const cart = state.cart.getCartOrThrow();
 
-        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cart.id, methodId);
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(methodId, {
+            cartId: cart.id,
+        });
 
         return orderId;
     }

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
@@ -373,8 +373,10 @@ describe('PaypalCommerceVenmoButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                cartMock.id,
                 'paypalcommercevenmo',
+                {
+                    cartId: cartMock.id,
+                },
             );
         });
 
@@ -396,8 +398,10 @@ describe('PaypalCommerceVenmoButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                cartMock.id,
                 'paypalcommercevenmocheckout',
+                {
+                    cartId: cartMock.id,
+                },
             );
         });
 
@@ -418,8 +422,10 @@ describe('PaypalCommerceVenmoButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                buyNowCartMock.id,
                 'paypalcommercevenmo',
+                {
+                    cartId: buyNowCartMock.id,
+                },
             );
         });
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.ts
@@ -159,7 +159,9 @@ export default class PaypalCommerceVenmoButtonStrategy implements CheckoutButton
             ? 'paypalcommercevenmocheckout'
             : 'paypalcommercevenmo';
 
-        const { orderId } = await this._paypalCommerceRequestSender.createOrder(cartId, providerId);
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder(providerId, {
+            cartId,
+        });
 
         return orderId;
     }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
@@ -147,6 +147,36 @@ describe('PaypalCommerceHostedForm', () => {
                 },
             },
             expectEvents,
+            undefined,
+        );
+    });
+
+    it('render hosted fields with form fields with extra instrument data callback', async () => {
+        const getInstrumentDataCallback = expect.any(Function);
+
+        await hostedForm.initialize(
+            formOptions,
+            cart,
+            paymentMethodMock.initializationData,
+            getInstrumentDataCallback,
+        );
+
+        expect(paypalCommercePaymentProcessor.renderHostedFields).toHaveBeenCalledWith(
+            cart.id,
+            {
+                fields: {
+                    cvv: { selector: '#cardCode', placeholder: 'Card code' },
+                    expirationDate: { selector: '#cardExpiry', placeholder: 'Card expiry' },
+                    number: { selector: '#cardNumber', placeholder: 'Card number' },
+                },
+                styles: {
+                    input: { color: '#000' },
+                    '.invalid': { color: '#f00', 'font-weight': 'bold' },
+                    ':focus': { color: '#00f' },
+                },
+            },
+            expectEvents,
+            getInstrumentDataCallback,
         );
     });
 
@@ -185,6 +215,7 @@ describe('PaypalCommerceHostedForm', () => {
                 },
             },
             expectEvents,
+            undefined,
         );
     });
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
@@ -1,7 +1,7 @@
 import { isNil, kebabCase, omitBy } from 'lodash';
 
 import { Cart } from '../../../cart';
-import { PaymentMethod } from '../../../payment';
+import { HostedInstrument, PaymentMethod, VaultedInstrument } from '../../../payment';
 import {
     PaymentInvalidFormError,
     PaymentInvalidFormErrorDetails,
@@ -45,6 +45,7 @@ export default class PaypalCommerceHostedForm {
         options: PaypalCommerceFormOptions,
         cart: Cart,
         paymentMethod: PaymentMethod<PaypalCommerceInitializationData>,
+        getInstrumentParams?: () => HostedInstrument | VaultedInstrument,
     ) {
         await this._paypalCommercePaymentProcessor.initialize(paymentMethod, cart.currency.code);
 
@@ -65,7 +66,12 @@ export default class PaypalCommerceHostedForm {
             inputSubmitRequest: this._handleInputSubmitRequest,
         };
 
-        await this._paypalCommercePaymentProcessor.renderHostedFields(cart.id, params, events);
+        await this._paypalCommercePaymentProcessor.renderHostedFields(
+            cart.id,
+            params,
+            events,
+            getInstrumentParams,
+        );
 
         if (this._isPaypalCommerceFormFieldsMap(options.fields)) {
             this._cardNameField = new PaypalCommerceRegularField(

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.spec.ts
@@ -141,5 +141,57 @@ describe('PaypalCommerceRequestSender', () => {
                 }),
             );
         });
+
+        it('creates an order providing extra data to save vaulting instrument for paypal commerce', async () => {
+            paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
+            await paypalCommerceRequestSender.createOrder('paypalcommerce', {
+                cartId: 'abc',
+                shouldSaveInstrument: true,
+                shouldSetAsDefaultInstrument: true,
+            });
+
+            const headers = {
+                'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
+            };
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                '/api/storefront/payment/paypalcommerce',
+                {
+                    headers,
+                    body: {
+                        cartId: 'abc',
+                        shouldSaveInstrument: true,
+                        shouldSetAsDefaultInstrument: true,
+                    },
+                },
+            );
+        });
+
+        it('creates an order providing extra data to use vaulting instrument for paypal commerce', async () => {
+            paypalCommerceRequestSender = new PaypalCommerceRequestSender(requestSender);
+            await paypalCommerceRequestSender.createOrder('paypalcommerce', {
+                cartId: 'abc',
+                instrumentId: 'instrumentId',
+            });
+
+            const headers = {
+                'X-API-INTERNAL': INTERNAL_USE_ONLY,
+                'Content-Type': ContentType.Json,
+                ...SDK_VERSION_HEADERS,
+            };
+
+            expect(requestSender.post).toHaveBeenCalledWith(
+                '/api/storefront/payment/paypalcommerce',
+                {
+                    headers,
+                    body: {
+                        cartId: 'abc',
+                        instrumentId: 'instrumentId',
+                    },
+                },
+            );
+        });
     });
 });

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-request-sender.ts
@@ -2,7 +2,12 @@ import { RequestSender } from '@bigcommerce/request-sender';
 
 import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../../../common/http-request';
 
-import { OrderData, OrderStatus, UpdateOrderPayload } from './paypal-commerce-sdk';
+import {
+    OrderData,
+    OrderStatus,
+    PayPalCreateOrderRequestBody,
+    UpdateOrderPayload,
+} from './paypal-commerce-sdk';
 
 export interface ParamsForProvider {
     isCredit?: boolean;
@@ -39,12 +44,15 @@ export default class PaypalCommerceRequestSender {
                 : 'paypalcommercealternativemethod';
         }
 
-        return this.createOrder(cartId, provider);
+        return this.createOrder(provider, { cartId });
     }
 
-    async createOrder(cartId: string, providerId: string): Promise<OrderData> {
+    async createOrder(
+        providerId: string,
+        requestBody: PayPalCreateOrderRequestBody,
+    ): Promise<OrderData> {
         const url = `/api/storefront/payment/${providerId}`;
-        const body = { cartId };
+        const body = requestBody;
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
             'Content-Type': ContentType.Json,

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -357,3 +357,10 @@ export interface UpdateOrderPayload {
     cartId: string;
     selectedShippingOption?: ShippingOption;
 }
+
+export interface PayPalCreateOrderRequestBody {
+    cartId: string;
+    instrumentId?: string;
+    shouldSaveInstrument?: boolean;
+    shouldSetAsDefaultInstrument?: boolean;
+}


### PR DESCRIPTION
## What?
Passing vaulting data to order creation request for PayPal Commerce

## Why?
To make hosted Credit Cards component work with vaultings.

## Testing / Proof
Unit tests
Manual tests
