### PR TITLE
fix(checkout): CHECKOUT-6406 Fix payload for offline payment method

### DIFF
--- a/packages/offline-integration/src/create-offline-payment-strategy.spec.ts
+++ b/packages/offline-integration/src/create-offline-payment-strategy.spec.ts
@@ -1,8 +1,9 @@
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
-import createOfflinePaymentStrategy from './create-offline-payment-strategy';
 import OfflinePaymentStrategy from './offline-payment-strategy';
+
+import { createOfflinePaymentStrategy } from './';
 
 describe('createOfflinePaymentStrategy', () => {
     let paymentIntegrationService: PaymentIntegrationService;

--- a/packages/offline-integration/src/offline-payment-strategy.spec.ts
+++ b/packages/offline-integration/src/offline-payment-strategy.spec.ts
@@ -20,7 +20,7 @@ describe('OfflinePaymentStrategy', () => {
     });
 
     describe('#execute()', () => {
-        it('calls submit order with the right data', async () => {
+        it('calls submit order with payment data', async () => {
             await strategy.execute(getOrderRequestBody(), undefined);
 
             expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
@@ -29,6 +29,18 @@ describe('OfflinePaymentStrategy', () => {
                     payment: {
                         methodId: 'authorizenet',
                     },
+                },
+                undefined,
+            );
+        });
+
+        it('calls submit order without payment data if no payment data provided', async () => {
+            await strategy.execute({ ...getOrderRequestBody(), payment: undefined }, undefined);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                {
+                    ...getOrderRequestBody(),
+                    payment: undefined,
                 },
                 undefined,
             );

--- a/packages/offline-integration/src/offline-payment-strategy.spec.ts
+++ b/packages/offline-integration/src/offline-payment-strategy.spec.ts
@@ -1,5 +1,3 @@
-import { omit } from 'lodash';
-
 import {
     OrderFinalizationNotRequiredError,
     PaymentIntegrationService,
@@ -26,7 +24,12 @@ describe('OfflinePaymentStrategy', () => {
             await strategy.execute(getOrderRequestBody(), undefined);
 
             expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
-                omit(getOrderRequestBody(), 'payment'),
+                {
+                    ...getOrderRequestBody(),
+                    payment: {
+                        methodId: 'authorizenet',
+                    },
+                },
                 undefined,
             );
         });
@@ -37,7 +40,12 @@ describe('OfflinePaymentStrategy', () => {
             await strategy.execute(getOrderRequestBody(), options);
 
             expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
-                omit(getOrderRequestBody(), 'payment'),
+                {
+                    ...getOrderRequestBody(),
+                    payment: {
+                        methodId: 'authorizenet',
+                    },
+                },
                 options,
             );
         });

--- a/packages/offline-integration/src/offline-payment-strategy.ts
+++ b/packages/offline-integration/src/offline-payment-strategy.ts
@@ -1,5 +1,3 @@
-import { omit } from 'lodash';
-
 import {
     OrderFinalizationNotRequiredError,
     OrderRequestBody,
@@ -12,7 +10,13 @@ export default class OfflinePaymentStrategy implements PaymentStrategy {
     constructor(private _paymentIntegrationService: PaymentIntegrationService) {}
 
     async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
-        await this._paymentIntegrationService.submitOrder(omit(payload, 'payment'), options);
+        await this._paymentIntegrationService.submitOrder(
+            {
+                ...payload,
+                payment: payload.payment ? { methodId: payload.payment.methodId } : undefined,
+            },
+            options,
+        );
 
         return Promise.resolve();
     }


### PR DESCRIPTION
## What?
Add payment method data to the offline payment method order creation payload.

## Why?
Otherwise, instead of "Awaiting payment," the newly placed order would be "pending".

## Testing / Proof
- CI checks.
- Manual testing:

https://user-images.githubusercontent.com/88361607/208001487-e750095e-e4fc-4764-bdfb-125bdfe85f7c.mov

![image](https://user-images.githubusercontent.com/88361607/208001598-d2a601e0-2abc-4e3c-8729-7da97042140c.png)





@bigcommerce/checkout @bigcommerce/payments
