### PR TITLE
feat(checkout): CHECKOUT-0000 Enforce RegistryV2 for SquareV2

### DIFF
--- a/packages/core/src/payment/payment-strategy-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-strategy-action-creator.spec.ts
@@ -6,11 +6,11 @@ import { merge } from 'lodash';
 import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
-import { createNoPaymentStrategy } from '@bigcommerce/checkout-sdk/no-payment-integration';
 import {
     createCreditCardPaymentStrategy,
     CreditCardPaymentStrategy as CreditCardPaymentStrategyV2,
 } from '@bigcommerce/checkout-sdk/credit-card-integration';
+import { createNoPaymentStrategy } from '@bigcommerce/checkout-sdk/no-payment-integration';
 import {
     OrderFinalizationNotRequiredError as OrderFinalizationNotRequiredErrorV2,
     PaymentStrategyResolveId,

--- a/packages/core/src/payment/payment-strategy-registry.spec.ts
+++ b/packages/core/src/payment/payment-strategy-registry.spec.ts
@@ -113,9 +113,7 @@ describe('PaymentStrategyRegistry', () => {
 
             registry = new PaymentStrategyRegistry(store);
 
-            expect(() => registry.getByMethod({ ...getSquare(), id: 'squarev2' })).toThrow(
-                Error,
-            );
+            expect(() => registry.getByMethod({ ...getSquare(), id: 'squarev2' })).toThrow(Error);
             expect(() => registry.getByMethod({ ...getSquare(), id: 'squarev2' })).not.toThrow(
                 InvalidArgumentError,
             );

--- a/packages/core/src/payment/payment-strategy-registry.spec.ts
+++ b/packages/core/src/payment/payment-strategy-registry.spec.ts
@@ -1,6 +1,6 @@
 import { CheckoutStore, createCheckoutStore, InternalCheckoutSelectors } from '../checkout';
 import { InvalidArgumentError } from '../common/error/errors';
-import { getConfigState } from '../config/configs.mock';
+import { getConfig, getConfigState } from '../config/configs.mock';
 import { getFormFieldsState } from '../form/form.mock';
 import { OrderFinalizationNotRequiredError } from '../order/errors';
 
@@ -10,6 +10,7 @@ import {
     getBraintree,
     getCybersource,
     getPPSDK,
+    getSquare,
 } from './payment-methods.mock';
 import PaymentStrategyRegistry from './payment-strategy-registry';
 import PaymentStrategyType from './payment-strategy-type';
@@ -97,6 +98,27 @@ describe('PaymentStrategyRegistry', () => {
 
         it('returns legacy strategy if none is registered with method name and client-side payment is not supported by method', () => {
             expect(registry.getByMethod(getCybersource())).toBeInstanceOf(LegacyPaymentStrategy);
+        });
+
+        it('throws error if resolving squarev2 when the experiment is on', () => {
+            jest.spyOn(store.getState().config, 'getStoreConfig').mockReturnValue({
+                ...getConfig().storeConfig,
+                checkoutSettings: {
+                    ...getConfig().storeConfig.checkoutSettings,
+                    features: {
+                        'PROJECT-4113.squarev2_web_payments_sdk': true,
+                    },
+                },
+            });
+
+            registry = new PaymentStrategyRegistry(store);
+
+            expect(() => registry.getByMethod({ ...getSquare(), id: 'squarev2' })).toThrow(
+                Error,
+            );
+            expect(() => registry.getByMethod({ ...getSquare(), id: 'squarev2' })).not.toThrow(
+                InvalidArgumentError,
+            );
         });
     });
 });

--- a/packages/core/src/payment/payment-strategy-registry.ts
+++ b/packages/core/src/payment/payment-strategy-registry.ts
@@ -7,7 +7,6 @@ import {
     MissingDataError,
     MissingDataErrorType,
 } from '../common/error/errors';
-import StandardError from '../common/error/errors/standard-error';
 import { Registry, RegistryOptions } from '../common/registry';
 
 import PaymentMethod from './payment-method';

--- a/packages/core/src/payment/payment-strategy-registry.ts
+++ b/packages/core/src/payment/payment-strategy-registry.ts
@@ -14,6 +14,7 @@ import * as paymentMethodTypes from './payment-method-types';
 import PaymentStrategyType from './payment-strategy-type';
 import { isPPSDKPaymentMethod } from './ppsdk-payment-method';
 import { PaymentStrategy } from './strategies';
+import StandardError from "../common/error/errors/standard-error";
 
 const checkoutcomStrategies: {
     [key: string]: PaymentStrategyType;
@@ -51,6 +52,16 @@ export default class PaymentStrategyRegistry extends Registry<
     }
 
     private _getToken(paymentMethod: PaymentMethod): PaymentStrategyType {
+        const features = this._store.getState().config.getStoreConfig()?.checkoutSettings.features;
+
+        if (
+            paymentMethod.id === 'squarev2' &&
+            features &&
+            features['PROJECT-4113.squarev2_web_payments_sdk']
+        ) {
+            throw new Error('SquareV2 requires using registryV2');
+        }
+
         if (isPPSDKPaymentMethod(paymentMethod)) {
             return PaymentStrategyType.PPSDK;
         }

--- a/packages/core/src/payment/payment-strategy-registry.ts
+++ b/packages/core/src/payment/payment-strategy-registry.ts
@@ -7,6 +7,7 @@ import {
     MissingDataError,
     MissingDataErrorType,
 } from '../common/error/errors';
+import StandardError from '../common/error/errors/standard-error';
 import { Registry, RegistryOptions } from '../common/registry';
 
 import PaymentMethod from './payment-method';
@@ -14,7 +15,6 @@ import * as paymentMethodTypes from './payment-method-types';
 import PaymentStrategyType from './payment-strategy-type';
 import { isPPSDKPaymentMethod } from './ppsdk-payment-method';
 import { PaymentStrategy } from './strategies';
-import StandardError from "../common/error/errors/standard-error";
 
 const checkoutcomStrategies: {
     [key: string]: PaymentStrategyType;

--- a/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/mollie/mollie-payment-strategy.spec.ts
@@ -574,13 +574,15 @@ describe('MolliePaymentStrategy', () => {
             await strategy.initialize(options);
 
             jest.runAllTimers();
-            expect(mollieClient.createComponent).toBeCalledTimes(4);
-            expect(mollieElement.mount).toBeCalledTimes(4);
+
+            expect(mollieClient.createComponent).toHaveBeenCalledTimes(4);
+            expect(mollieElement.mount).toHaveBeenCalledTimes(4);
+
             jest.spyOn(document, 'getElementById');
 
             await strategy.deinitialize(initializeOptions);
 
-            expect(mollieElement.unmount).toBeCalledTimes(4);
+            expect(mollieElement.unmount).toHaveBeenCalledTimes(4);
         });
     });
 


### PR DESCRIPTION
## What?
Skip `RegistryV1` and enforce `RegistryV2` for `SquareV2` payment method.

## Why?
`SquareV2` shares the same method id with `SqaureV1`. As a result, `checkout-sdk` always resolves to the old Square payment method.

This PR enfoces the use of the new `Square` monorepo pacakge.

## Testing / Proof
- CI checks.

@bigcommerce/checkout @bigcommerce/payments
