### PR TITLE
fix(payment): PAYPAL-1635 Buy Now feature for amazon pay

### DIFF
--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -50,7 +50,7 @@ import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subsc
 
 import { CheckoutButtonMethodType, CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
-import AmazonPayV2ConfigRequestSender from './strategies/amazon-pay-v2/amazon-pay-v2-config-request-sender';
+import AmazonPayV2RequestSender from './strategies/amazon-pay-v2/amazon-pay-v2-request-sender';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
 import {
     BraintreePaypalButtonStrategy,
@@ -124,7 +124,7 @@ export default function createCheckoutButtonRegistry(
         checkoutRequestSender,
     );
     const cartRequestSender = new CartRequestSender(requestSender);
-    const amazonPayV2ConfigRequestSender = new AmazonPayV2ConfigRequestSender(requestSender);
+    const amazonPayV2RequestSender = new AmazonPayV2RequestSender(requestSender);
 
     registry.register(
         CheckoutButtonMethodType.APPLEPAY,
@@ -151,7 +151,7 @@ export default function createCheckoutButtonRegistry(
                 checkoutActionCreator,
                 createAmazonPayV2PaymentProcessor(),
                 cartRequestSender,
-                amazonPayV2ConfigRequestSender,
+                amazonPayV2RequestSender,
             ),
     );
 

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -50,6 +50,7 @@ import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subsc
 
 import { CheckoutButtonMethodType, CheckoutButtonStrategy } from './strategies';
 import { AmazonPayV2ButtonStrategy } from './strategies/amazon-pay-v2';
+import AmazonPayV2ConfigRequestSender from './strategies/amazon-pay-v2/amazon-pay-v2-config-request-sender';
 import { ApplePayButtonStrategy } from './strategies/apple-pay';
 import {
     BraintreePaypalButtonStrategy,
@@ -123,6 +124,7 @@ export default function createCheckoutButtonRegistry(
         checkoutRequestSender,
     );
     const cartRequestSender = new CartRequestSender(requestSender);
+    const amazonPayV2ConfigRequestSender = new AmazonPayV2ConfigRequestSender(requestSender);
 
     registry.register(
         CheckoutButtonMethodType.APPLEPAY,
@@ -148,6 +150,8 @@ export default function createCheckoutButtonRegistry(
                 store,
                 checkoutActionCreator,
                 createAmazonPayV2PaymentProcessor(),
+                cartRequestSender,
+                amazonPayV2ConfigRequestSender,
             ),
     );
 

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
@@ -3,11 +3,11 @@ import { AmazonPayV2ButtonParameters } from '../../../payment/strategies/amazon-
 
 export function isWithBuyNowFeatures(
     options?: AmazonPayV2ButtonInitializeOptions,
-): options is WithBuyNowFeatures {
-    return !!(options as WithBuyNowFeatures)?.buyNowInitializeOptions;
+): options is WithBuyNowFeature {
+    return !!(options as WithBuyNowFeature)?.buyNowInitializeOptions;
 }
 
-export interface WithBuyNowFeatures {
+export interface WithBuyNowFeature {
     /**
      * The options that are required to initialize Buy Now functionality.
      */
@@ -19,4 +19,4 @@ export interface WithBuyNowFeatures {
 /**
  * The required config to render the AmazonPayV2 button.
  */
-export type AmazonPayV2ButtonInitializeOptions = AmazonPayV2ButtonParameters | WithBuyNowFeatures;
+export type AmazonPayV2ButtonInitializeOptions = AmazonPayV2ButtonParameters | WithBuyNowFeature;

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
@@ -1,10 +1,12 @@
 import { BuyNowCartRequestBody } from '../../../cart';
 import { AmazonPayV2ButtonParameters } from '../../../payment/strategies/amazon-pay-v2';
 
-export function isWithBuyNowFeatures(
-    options?: AmazonPayV2ButtonInitializeOptions,
-): options is WithBuyNowFeature {
-    return !!(options as WithBuyNowFeature)?.buyNowInitializeOptions;
+export function isWithBuyNowFeatures(options: unknown): options is WithBuyNowFeature {
+    if (!(options instanceof Object)) {
+        return false;
+    }
+
+    return 'buyNowInitializeOptions' in options;
 }
 
 export interface WithBuyNowFeature {

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
@@ -1,6 +1,22 @@
+import { BuyNowCartRequestBody } from '../../../cart';
 import { AmazonPayV2ButtonParameters } from '../../../payment/strategies/amazon-pay-v2';
 
+export function isWithBuyNowFeatures(
+    options?: AmazonPayV2ButtonInitializeOptions,
+): options is WithBuyNowFeatures {
+    return !!(options as WithBuyNowFeatures)?.buyNowInitializeOptions;
+}
+
+export interface WithBuyNowFeatures {
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    };
+}
+
 /**
- * The required config to render the AmazonPayV2 buttton.
+ * The required config to render the AmazonPayV2 button.
  */
-export type AmazonPayV2ButtonInitializeOptions = AmazonPayV2ButtonParameters;
+export type AmazonPayV2ButtonInitializeOptions = AmazonPayV2ButtonParameters | WithBuyNowFeatures;

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -8,7 +8,7 @@ import {
     CheckoutStore,
     createCheckoutStore,
 } from '../../../checkout';
-import { AmazonPayV2ConfigRequestSender } from '../../../checkout-buttons/strategies/amazon-pay-v2';
+import { AmazonPayV2RequestSender } from '../../../checkout-buttons/strategies/amazon-pay-v2';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
@@ -33,7 +33,7 @@ describe('AmazonPayV2ButtonStrategy', () => {
     let store: CheckoutStore;
     let strategy: AmazonPayV2ButtonStrategy;
     let cartRequestSender: CartRequestSender;
-    let amazonPayV2ConfigRequestSender: AmazonPayV2ConfigRequestSender;
+    let amazonPayV2RequestSender: AmazonPayV2RequestSender;
 
     const cart = getCart();
 
@@ -52,7 +52,7 @@ describe('AmazonPayV2ButtonStrategy', () => {
 
         cartRequestSender = new CartRequestSender(requestSender);
 
-        amazonPayV2ConfigRequestSender = new AmazonPayV2ConfigRequestSender(requestSender);
+        amazonPayV2RequestSender = new AmazonPayV2RequestSender(requestSender);
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
@@ -70,7 +70,7 @@ describe('AmazonPayV2ButtonStrategy', () => {
 
         jest.spyOn(paymentProcessor, 'renderAmazonPayButton').mockResolvedValue('foo');
 
-        jest.spyOn(amazonPayV2ConfigRequestSender, 'createCheckoutConfig').mockResolvedValue({
+        jest.spyOn(amazonPayV2RequestSender, 'createCheckoutConfig').mockResolvedValue({
             body: getCheckoutRequestConfig(),
         });
 
@@ -89,7 +89,7 @@ describe('AmazonPayV2ButtonStrategy', () => {
             checkoutActionCreator,
             paymentProcessor,
             cartRequestSender,
-            amazonPayV2ConfigRequestSender,
+            amazonPayV2RequestSender,
         );
     });
 
@@ -165,7 +165,7 @@ describe('AmazonPayV2ButtonStrategy', () => {
                     checkoutActionCreator,
                     paymentProcessor,
                     cartRequestSender,
-                    amazonPayV2ConfigRequestSender,
+                    amazonPayV2RequestSender,
                 );
 
                 const initialize = strategy.initialize(checkoutButtonOptions);

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -8,10 +8,7 @@ import {
     CheckoutStore,
     createCheckoutStore,
 } from '../../../checkout';
-import {
-    AmazonPayV2ConfigRequestSender,
-    getCheckoutRequestConfig,
-} from '../../../checkout-buttons/strategies/amazon-pay-v2';
+import { AmazonPayV2ConfigRequestSender } from '../../../checkout-buttons/strategies/amazon-pay-v2';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
@@ -26,6 +23,7 @@ import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 
 import AmazonPayV2ButtonStrategy from './amazon-pay-v2-button-strategy';
 import { getAmazonPayV2CheckoutButtonOptions, Mode } from './amazon-pay-v2-button.mock';
+import { getCheckoutRequestConfig } from './amazon-pay-v2-config-request-sender-mock';
 
 describe('AmazonPayV2ButtonStrategy', () => {
     let checkoutButtonOptions: CheckoutButtonInitializeOptions;

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -1,11 +1,17 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 
+import { CartRequestSender } from '../../../cart';
+import { getCart } from '../../../cart/carts.mock';
 import {
     CheckoutActionCreator,
     CheckoutRequestSender,
     CheckoutStore,
     createCheckoutStore,
 } from '../../../checkout';
+import {
+    AmazonPayV2ConfigRequestSender,
+    getCheckoutRequestConfig,
+} from '../../../checkout-buttons/strategies/amazon-pay-v2';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
@@ -28,6 +34,16 @@ describe('AmazonPayV2ButtonStrategy', () => {
     let requestSender: RequestSender;
     let store: CheckoutStore;
     let strategy: AmazonPayV2ButtonStrategy;
+    let cartRequestSender: CartRequestSender;
+    let amazonPayV2ConfigRequestSender: AmazonPayV2ConfigRequestSender;
+
+    const cart = getCart();
+
+    const buyNowCartMock = {
+        ...cart,
+        id: 999,
+        source: 'BUY_NOW',
+    };
 
     beforeEach(() => {
         checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions();
@@ -35,6 +51,10 @@ describe('AmazonPayV2ButtonStrategy', () => {
         store = createCheckoutStore(getCheckoutStoreState());
 
         requestSender = createRequestSender();
+
+        cartRequestSender = new CartRequestSender(requestSender);
+
+        amazonPayV2ConfigRequestSender = new AmazonPayV2ConfigRequestSender(requestSender);
 
         checkoutActionCreator = new CheckoutActionCreator(
             new CheckoutRequestSender(requestSender),
@@ -52,9 +72,27 @@ describe('AmazonPayV2ButtonStrategy', () => {
 
         jest.spyOn(paymentProcessor, 'renderAmazonPayButton').mockResolvedValue('foo');
 
+        jest.spyOn(amazonPayV2ConfigRequestSender, 'createCheckoutConfig').mockResolvedValue({
+            body: getCheckoutRequestConfig(),
+        });
+
+        jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({
+            body: buyNowCartMock,
+        });
+
+        jest.spyOn(paymentProcessor, 'prepareCheckoutWithCreationRequestConfig').mockReturnValue(
+            undefined,
+        );
+
         jest.spyOn(paymentProcessor, 'deinitialize').mockResolvedValue(undefined);
 
-        strategy = new AmazonPayV2ButtonStrategy(store, checkoutActionCreator, paymentProcessor);
+        strategy = new AmazonPayV2ButtonStrategy(
+            store,
+            checkoutActionCreator,
+            paymentProcessor,
+            cartRequestSender,
+            amazonPayV2ConfigRequestSender,
+        );
     });
 
     describe('#initialize', () => {
@@ -62,6 +100,15 @@ describe('AmazonPayV2ButtonStrategy', () => {
             await strategy.initialize(checkoutButtonOptions);
 
             expect(paymentProcessor.initialize).toHaveBeenCalledWith(getAmazonPayV2());
+        });
+
+        it('should initialize with Buy Now Flow', async () => {
+            checkoutButtonOptions = getAmazonPayV2CheckoutButtonOptions(Mode.BuyNowFlow);
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(getAmazonPayV2());
+            expect(checkoutActionCreator.loadDefaultCheckout).not.toHaveBeenCalled();
+            expect(paymentProcessor.prepareCheckoutWithCreationRequestConfig).toHaveBeenCalled();
         });
 
         it('loads the checkout if AmazonPayV2ButtonInitializeOptions is not provided', async () => {
@@ -114,10 +161,13 @@ describe('AmazonPayV2ButtonStrategy', () => {
                 const state = { ...getCheckoutStoreState(), paymentMethods };
 
                 store = createCheckoutStore(state);
+
                 strategy = new AmazonPayV2ButtonStrategy(
                     store,
                     checkoutActionCreator,
                     paymentProcessor,
+                    cartRequestSender,
+                    amazonPayV2ConfigRequestSender,
                 );
 
                 const initialize = strategy.initialize(checkoutButtonOptions);

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -18,7 +18,7 @@ import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
 import { isWithBuyNowFeatures } from './amazon-pay-v2-button-options';
-import AmazonPayV2ConfigRequestSender from './amazon-pay-v2-config-request-sender';
+import AmazonPayV2RequestSender from './amazon-pay-v2-request-sender';
 import AmazonPayV2ConfigCreationError from './errors/amazon-pay-v2-config-creation-error';
 
 export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy {
@@ -29,7 +29,7 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
         private _checkoutActionCreator: CheckoutActionCreator,
         private _amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor,
         private _cartRequestSender: CartRequestSender,
-        private _amazonPayV2ConfigRequestSender: AmazonPayV2ConfigRequestSender,
+        private _amazonPayV2ConfigRequestSender: AmazonPayV2RequestSender,
     ) {}
 
     async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -17,6 +17,7 @@ import { getShippableItemsCount } from '../../../shipping';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
+import { isWithBuyNowFeatures } from './amazon-pay-v2-button-options';
 import AmazonPayV2ConfigRequestSender from './amazon-pay-v2-config-request-sender';
 import AmazonPayV2ConfigCreationError from './errors/amazon-pay-v2-config-creation-error';
 
@@ -50,11 +51,14 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
             await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         }
 
-        const initializeAmazonButtonOptions = amazonpay?.buyNowInitializeOptions
+        const initializeAmazonButtonOptions = isWithBuyNowFeatures(amazonpay)
             ? undefined
             : amazonpay;
 
-        if (typeof amazonpay?.buyNowInitializeOptions?.getBuyNowCartRequestBody === 'function') {
+        if (
+            isWithBuyNowFeatures(amazonpay) &&
+            typeof amazonpay?.buyNowInitializeOptions?.getBuyNowCartRequestBody === 'function'
+        ) {
             this._buyNowCartRequestBody =
                 amazonpay.buyNowInitializeOptions.getBuyNowCartRequestBody();
 

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -1,17 +1,34 @@
+import { CartRequestSender } from '../../../cart';
+import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
+import { BuyNowCartCreationError } from '../../../cart/errors';
 import { CheckoutActionCreator, CheckoutStore } from '../../../checkout';
-import { InvalidArgumentError } from '../../../common/error/errors';
 import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+} from '../../../common/error/errors';
+import {
+    AmazonPayV2CheckoutSessionConfig,
     AmazonPayV2PaymentProcessor,
+    AmazonPayV2PayOptions,
     AmazonPayV2Placement,
 } from '../../../payment/strategies/amazon-pay-v2';
+import { getShippableItemsCount } from '../../../shipping';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
 
+import AmazonPayV2ConfigRequestSender from './amazon-pay-v2-config-request-sender';
+import AmazonPayV2ConfigCreationError from './errors/amazon-pay-v2-config-creation-error';
+
 export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy {
+    private _buyNowCartRequestBody?: BuyNowCartRequestBody | void;
+
     constructor(
         private _store: CheckoutStore,
         private _checkoutActionCreator: CheckoutActionCreator,
         private _amazonPayV2PaymentProcessor: AmazonPayV2PaymentProcessor,
+        private _cartRequestSender: CartRequestSender,
+        private _amazonPayV2ConfigRequestSender: AmazonPayV2ConfigRequestSender,
     ) {}
 
     async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
@@ -33,16 +50,89 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
             await this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout());
         }
 
+        const initializeAmazonButtonOptions = amazonpay?.buyNowInitializeOptions
+            ? undefined
+            : amazonpay;
+
+        if (typeof amazonpay?.buyNowInitializeOptions?.getBuyNowCartRequestBody === 'function') {
+            this._buyNowCartRequestBody =
+                amazonpay.buyNowInitializeOptions.getBuyNowCartRequestBody();
+
+            if (this._buyNowCartRequestBody) {
+                this._amazonPayV2PaymentProcessor.setCartRequestBody(this._buyNowCartRequestBody);
+            }
+        }
+
         this._amazonPayV2PaymentProcessor.renderAmazonPayButton({
             checkoutState: this._store.getState(),
             containerId,
             methodId,
-            options: amazonpay,
+            options: initializeAmazonButtonOptions,
             placement: AmazonPayV2Placement.Cart,
         });
+
+        if (this._buyNowCartRequestBody) {
+            this._amazonPayV2PaymentProcessor.prepareCheckoutWithCreationRequestConfig(
+                this._getCheckoutCreationRequestConfig.bind(this),
+            );
+        }
     }
 
     deinitialize(): Promise<void> {
         return this._amazonPayV2PaymentProcessor.deinitialize();
+    }
+
+    private async _createBuyNowCart() {
+        if (!this._buyNowCartRequestBody) {
+            throw new MissingDataError(MissingDataErrorType.MissingCart);
+        }
+
+        try {
+            const { body: buyNowCart } = await this._cartRequestSender.createBuyNowCart(
+                this._buyNowCartRequestBody,
+            );
+
+            return buyNowCart;
+        } catch (error) {
+            throw new BuyNowCartCreationError();
+        }
+    }
+
+    private async _createCheckoutConfig(
+        id: string,
+    ): Promise<Required<AmazonPayV2CheckoutSessionConfig>> {
+        try {
+            const {
+                body: { payload, public_key, ...rest },
+            } = await this._amazonPayV2ConfigRequestSender.createCheckoutConfig(id);
+
+            return {
+                payloadJSON: payload,
+                publicKeyId: public_key,
+                ...rest,
+            };
+        } catch (error) {
+            throw new AmazonPayV2ConfigCreationError();
+        }
+    }
+
+    private async _getCheckoutCreationRequestConfig() {
+        const buyNowCart = await this._createBuyNowCart();
+
+        const estimatedOrderAmount = {
+            amount: String(buyNowCart.baseAmount),
+            currencyCode: buyNowCart.currency.code,
+        };
+
+        const createCheckoutSessionConfig = await this._createCheckoutConfig(buyNowCart.id);
+
+        return {
+            createCheckoutSessionConfig,
+            estimatedOrderAmount,
+            productType:
+                getShippableItemsCount(buyNowCart) === 0
+                    ? AmazonPayV2PayOptions.PayOnly
+                    : AmazonPayV2PayOptions.PayAndShip,
+        };
     }
 }

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button.mock.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button.mock.ts
@@ -1,14 +1,30 @@
+import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
 import { getAmazonPayV2ButtonParamsMock } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonMethodType from '../checkout-button-method-type';
 
 export enum Mode {
     Full,
+    BuyNowFlow,
     UndefinedContainer,
     InvalidContainer,
     UndefinedMethodId,
     UndefinedAmazonPay,
 }
+
+const buyNowCartRequestBody: BuyNowCartRequestBody = {
+    source: 'BUY_NOW',
+    lineItems: [
+        {
+            productId: 1,
+            quantity: 2,
+            optionSelections: {
+                optionId: 11,
+                optionValue: 11,
+            },
+        },
+    ],
+};
 
 export function getAmazonPayV2CheckoutButtonOptions(
     mode: Mode = Mode.Full,
@@ -18,6 +34,12 @@ export function getAmazonPayV2CheckoutButtonOptions(
     const undefinedContainerId = { containerId: '' };
     const invalidContainerId = { containerId: 'invalid_container' };
     const amazonPayV2Options = { containerId, amazonpay: getAmazonPayV2ButtonParamsMock() };
+
+    const amazonPayV2BuyNowOptions = {
+        buyNowInitializeOptions: {
+            getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
+        },
+    };
 
     switch (mode) {
         case Mode.UndefinedContainer:
@@ -34,6 +56,9 @@ export function getAmazonPayV2CheckoutButtonOptions(
 
         case Mode.UndefinedAmazonPay:
             return { ...getAmazonPayV2CheckoutButtonOptions(Mode.Full), amazonpay: undefined };
+
+        case Mode.BuyNowFlow:
+            return { ...methodId, containerId, amazonpay: { ...amazonPayV2BuyNowOptions } };
 
         default:
             return { ...methodId, containerId };

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-config-request-sender-mock.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-config-request-sender-mock.ts
@@ -1,4 +1,4 @@
-import { CheckoutConfig } from './amazon-pay-v2-config-request-sender';
+import { CheckoutConfig } from './amazon-pay-v2-request-sender';
 
 export function getCheckoutRequestConfig(): CheckoutConfig {
     return {

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-config-request-sender-mock.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-config-request-sender-mock.ts
@@ -1,0 +1,9 @@
+import { CheckoutConfig } from './amazon-pay-v2-config-request-sender';
+
+export function getCheckoutRequestConfig(): CheckoutConfig {
+    return {
+        payload: 'payload',
+        signature: 'signature',
+        public_key: 'public_key',
+    };
+}

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-config-request-sender.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-config-request-sender.ts
@@ -1,0 +1,24 @@
+import { RequestSender, Response } from '@bigcommerce/request-sender';
+
+import { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from '../../../common/http-request';
+
+export interface CheckoutConfig {
+    payload: string;
+    signature: string;
+    public_key: string;
+}
+
+export default class AmazonPayV2ConfigRequestSender {
+    constructor(private _requestSender: RequestSender) {}
+
+    createCheckoutConfig(cartId: string | number): Promise<Response<CheckoutConfig>> {
+        const body = { cartId };
+        const headers = {
+            'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            'Content-Type': ContentType.Json,
+            ...SDK_VERSION_HEADERS,
+        };
+
+        return this._requestSender.post('/api/storefront/payment/amazonpay', { headers, body });
+    }
+}

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-request-sender.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-request-sender.ts
@@ -8,7 +8,7 @@ export interface CheckoutConfig {
     public_key: string;
 }
 
-export default class AmazonPayV2ConfigRequestSender {
+export default class AmazonPayV2RequestSender {
     constructor(private _requestSender: RequestSender) {}
 
     createCheckoutConfig(cartId: string | number): Promise<Response<CheckoutConfig>> {

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/errors/amazon-pay-v2-config-creation-error.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/errors/amazon-pay-v2-config-creation-error.ts
@@ -1,0 +1,13 @@
+import { StandardError } from '../../../../common/error/errors';
+
+export default class AmazonPayV2ConfigCreationError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'An unexpected error has occurred during config creation process. Please try again later.',
+        );
+
+        this.name = 'AmazonPayV2ConfigCreationError';
+        this.type = 'amazon_pay_v2_config_creation_error';
+    }
+}

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/index.ts
@@ -1,6 +1,6 @@
 export { default as AmazonPayV2ButtonStrategy } from './amazon-pay-v2-button-strategy';
 export { AmazonPayV2ButtonInitializeOptions } from './amazon-pay-v2-button-options';
 export {
-    default as AmazonPayV2ConfigRequestSender,
+    default as AmazonPayV2RequestSender,
     CheckoutConfig,
-} from './amazon-pay-v2-config-request-sender';
+} from './amazon-pay-v2-request-sender';

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/index.ts
@@ -4,4 +4,3 @@ export {
     default as AmazonPayV2ConfigRequestSender,
     CheckoutConfig,
 } from './amazon-pay-v2-config-request-sender';
-export { getCheckoutRequestConfig } from './amazon-pay-v2-config-request-sender-mock';

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/index.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/index.ts
@@ -1,2 +1,7 @@
 export { default as AmazonPayV2ButtonStrategy } from './amazon-pay-v2-button-strategy';
 export { AmazonPayV2ButtonInitializeOptions } from './amazon-pay-v2-button-options';
+export {
+    default as AmazonPayV2ConfigRequestSender,
+    CheckoutConfig,
+} from './amazon-pay-v2-config-request-sender';
+export { getCheckoutRequestConfig } from './amazon-pay-v2-config-request-sender-mock';

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -75,7 +75,7 @@ export default class AmazonPayV2PaymentProcessor {
         const requestConfig = this._prepareRequestConfig(createCheckoutSessionConfig);
 
         this._getAmazonPayV2Button().onClick(() => {
-            return this._getAmazonPayV2Button().initCheckout(requestConfig);
+            this._getAmazonPayV2Button().initCheckout(requestConfig);
         });
     }
 
@@ -94,7 +94,7 @@ export default class AmazonPayV2PaymentProcessor {
                 config.productType,
             );
 
-            return this._getAmazonPayV2Button().initCheckout(requestConfig);
+            this._getAmazonPayV2Button().initCheckout(requestConfig);
         });
     }
 

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -4,6 +4,7 @@ import { getShippableItemsCount } from '../../../../../core/src/shipping';
 import { guard } from '../../../../src/common/utility';
 import { StoreProfile } from '../../../../src/config';
 import { CheckoutSettings } from '../../../../src/config/config';
+import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
 import {
     InvalidArgumentError,
     MissingDataError,
@@ -15,6 +16,7 @@ import {
 import {
     AmazonPayV2Button,
     AmazonPayV2ButtonColor,
+    AmazonPayV2ButtonConfig,
     AmazonPayV2ButtonParameters,
     AmazonPayV2ButtonRenderingOptions,
     AmazonPayV2ChangeActionType,
@@ -22,7 +24,9 @@ import {
     AmazonPayV2NewButtonParams,
     AmazonPayV2PayOptions,
     AmazonPayV2Placement,
+    AmazonPayV2Price,
     AmazonPayV2SDK,
+    RequestConfig,
 } from './amazon-pay-v2';
 import AmazonPayV2ScriptLoader from './amazon-pay-v2-script-loader';
 
@@ -30,6 +34,7 @@ export default class AmazonPayV2PaymentProcessor {
     private _amazonPayV2SDK?: AmazonPayV2SDK;
     private _buttonParentContainer?: HTMLDivElement;
     private _amazonPayV2Button?: AmazonPayV2Button;
+    private _buyNowCartRequestBody?: BuyNowCartRequestBody;
 
     constructor(private _amazonPayV2ScriptLoader: AmazonPayV2ScriptLoader) {}
 
@@ -66,18 +71,31 @@ export default class AmazonPayV2PaymentProcessor {
         );
     }
 
-    prepareCheckout(createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>): void {
-        const { publicKeyId, ...signedPayload } = createCheckoutSessionConfig;
+    prepareCheckout(createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>) {
+        const requestConfig = this._prepareRequestConfig(createCheckoutSessionConfig);
 
-        const requestConfig = {
-            createCheckoutSessionConfig: this._isEnvironmentSpecific(publicKeyId)
-                ? signedPayload
-                : createCheckoutSessionConfig,
-        };
+        this._getAmazonPayV2Button().onClick(() => {
+            return this._getAmazonPayV2Button().initCheckout(requestConfig);
+        });
+    }
 
-        this._getAmazonPayV2Button().onClick(() =>
-            this._getAmazonPayV2Button().initCheckout(requestConfig),
-        );
+    prepareCheckoutWithCreationRequestConfig(
+        createCheckoutConfig: () => Promise<{
+            createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>;
+            estimatedOrderAmount: AmazonPayV2Price;
+            productType: AmazonPayV2PayOptions;
+        }>,
+    ) {
+        this._getAmazonPayV2Button().onClick(async () => {
+            const config = await createCheckoutConfig();
+            const requestConfig = this._prepareRequestConfig(
+                config.createCheckoutSessionConfig,
+                config.estimatedOrderAmount,
+                config.productType,
+            );
+
+            return this._getAmazonPayV2Button().initCheckout(requestConfig);
+        });
     }
 
     async signout(): Promise<void> {
@@ -120,6 +138,10 @@ export default class AmazonPayV2PaymentProcessor {
         return this._getButtonParentContainer();
     }
 
+    setCartRequestBody(buyNowCartRequestBody: BuyNowCartRequestBody) {
+        this._buyNowCartRequestBody = buyNowCartRequestBody;
+    }
+
     /**
      * @internal
      */
@@ -135,6 +157,22 @@ export default class AmazonPayV2PaymentProcessor {
         }
 
         return isPh4Enabled;
+    }
+
+    private _prepareRequestConfig(
+        createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>,
+        estimatedOrderAmount?: AmazonPayV2Price,
+        productType?: AmazonPayV2PayOptions,
+    ): RequestConfig {
+        const { publicKeyId, ...signedPayload } = createCheckoutSessionConfig;
+
+        return {
+            createCheckoutSessionConfig: this._isEnvironmentSpecific(publicKeyId)
+                ? signedPayload
+                : createCheckoutSessionConfig,
+            ...(estimatedOrderAmount && { estimatedOrderAmount }),
+            ...(productType && { productType }),
+        };
     }
 
     private _createAmazonPayButtonParentContainer(): HTMLDivElement {
@@ -169,28 +207,34 @@ export default class AmazonPayV2PaymentProcessor {
             },
         } = getPaymentMethodOrThrow(methodId);
 
-        const {
-            checkoutSettings: { features },
-            storeProfile: { shopPath, storeCountryCode },
-        } = getStoreConfigOrThrow();
-
-        const cart = getCart();
-
         if (!merchantId || !ledgerCurrency) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const buttonBaseConfig = {
+        const buttonBaseConfig: AmazonPayV2ButtonConfig = {
             merchantId,
             ledgerCurrency,
             checkoutLanguage,
-            productType:
-                cart && getShippableItemsCount(cart) === 0
-                    ? AmazonPayV2PayOptions.PayOnly
-                    : AmazonPayV2PayOptions.PayAndShip,
             placement,
             buttonColor: AmazonPayV2ButtonColor.Gold,
+            sandbox: !!testMode,
         };
+
+        if (this._buyNowCartRequestBody) {
+            return buttonBaseConfig;
+        }
+
+        const cart = getCart();
+
+        buttonBaseConfig.productType =
+            cart && getShippableItemsCount(cart) === 0
+                ? AmazonPayV2PayOptions.PayOnly
+                : AmazonPayV2PayOptions.PayAndShip;
+
+        const {
+            checkoutSettings: { features },
+            storeProfile: { shopPath, storeCountryCode },
+        } = getStoreConfigOrThrow();
 
         if (this.isPh4Enabled(features, storeCountryCode)) {
             const amount = getCheckout()?.outstandingBalance.toString();

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -217,11 +217,13 @@ export default class AmazonPayV2PaymentProcessor {
             checkoutLanguage,
             placement,
             buttonColor: AmazonPayV2ButtonColor.Gold,
-            sandbox: !!testMode,
         };
 
         if (this._buyNowCartRequestBody) {
-            return buttonBaseConfig;
+            return {
+                ...buttonBaseConfig,
+                sandbox: !!testMode,
+            };
         }
 
         const cart = getCart();

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -3,6 +3,7 @@ import { getAmazonPayV2 } from '../../payment-methods.mock';
 
 import {
     AmazonPayV2ButtonColor,
+    AmazonPayV2ButtonConfig,
     AmazonPayV2ButtonParameters,
     AmazonPayV2CheckoutLanguage,
     AmazonPayV2LedgerCurrency,
@@ -57,6 +58,18 @@ export function getAmazonPayV2Ph4ButtonParamsMock(): AmazonPayV2ButtonParameters
             payloadJSON: 'payload',
             signature: 'xxxx',
         },
+        sandbox: true,
+    };
+}
+
+export function getAmazonPayBaseButtonParamsMock(): AmazonPayV2ButtonConfig {
+    return {
+        merchantId: 'checkout_amazonpay',
+        ledgerCurrency: AmazonPayV2LedgerCurrency.USD,
+        checkoutLanguage: AmazonPayV2CheckoutLanguage.en_US,
+        placement: AmazonPayV2Placement.Checkout,
+        buttonColor: AmazonPayV2ButtonColor.Gold,
+        sandbox: true,
     };
 }
 

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -58,7 +58,6 @@ export function getAmazonPayV2Ph4ButtonParamsMock(): AmazonPayV2ButtonParameters
             payloadJSON: 'payload',
             signature: 'xxxx',
         },
-        sandbox: true,
     };
 }
 

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -1,5 +1,4 @@
 import { InternalCheckoutSelectors } from '../../../../../core/src/checkout';
-import { BuyNowCartRequestBody } from '../../../cart';
 
 export type EnvironmentType = 'PRODUCTION' | 'TEST';
 
@@ -62,17 +61,17 @@ export interface AmazonPayV2ButtonConfig {
     /**
      * Amazon Pay merchant account identifier.
      */
-    merchantId?: string;
+    merchantId: string;
 
     /**
      * Placement of the Amazon Pay button on your website.
      */
-    placement?: AmazonPayV2Placement;
+    placement: AmazonPayV2Placement;
 
     /**
      * Ledger currency provided during registration for the given merchant identifier.
      */
-    ledgerCurrency?: AmazonPayV2LedgerCurrency;
+    ledgerCurrency: AmazonPayV2LedgerCurrency;
 
     /**
      * Product type selected for checkout. Default is 'PayAndShip'.
@@ -94,13 +93,6 @@ export interface AmazonPayV2ButtonConfig {
      * if your `publicKeyId` has an environment prefix. Default is false.
      */
     sandbox?: boolean;
-
-    /**
-     * The options that are required to initialize Buy Now functionality.
-     */
-    buyNowInitializeOptions?: {
-        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
-    };
 }
 
 export interface AmazonPayV2ButtonParams extends AmazonPayV2ButtonConfig {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -1,4 +1,5 @@
 import { InternalCheckoutSelectors } from '../../../../../core/src/checkout';
+import { BuyNowCartRequestBody } from '../../../cart';
 
 export type EnvironmentType = 'PRODUCTION' | 'TEST';
 
@@ -10,6 +11,12 @@ export interface AmazonPayV2SDK {
     Pay: AmazonPayV2Client;
 }
 
+export interface RequestConfig {
+    createCheckoutSessionConfig: AmazonPayV2CheckoutSessionConfig;
+    estimatedOrderAmount?: AmazonPayV2Price;
+    productType?: AmazonPayV2PayOptions;
+}
+
 export interface AmazonPayV2Button {
     /**
      * Allows you to define custom actions.
@@ -19,9 +26,7 @@ export interface AmazonPayV2Button {
     /**
      * Initiates the Amazon Pay checkout.
      */
-    initCheckout(requestConfig: {
-        createCheckoutSessionConfig: AmazonPayV2CheckoutSessionConfig;
-    }): void;
+    initCheckout(requestConfig: RequestConfig): void;
 }
 
 export type AmazonPayV2ButtonParameters = AmazonPayV2ButtonParams | AmazonPayV2NewButtonParams;
@@ -53,21 +58,21 @@ export interface AmazonPayV2HostWindow extends Window {
     amazon?: AmazonPayV2SDK;
 }
 
-interface AmazonPayV2ButtonConfig {
+export interface AmazonPayV2ButtonConfig {
     /**
      * Amazon Pay merchant account identifier.
      */
-    merchantId: string;
+    merchantId?: string;
 
     /**
      * Placement of the Amazon Pay button on your website.
      */
-    placement: AmazonPayV2Placement;
+    placement?: AmazonPayV2Placement;
 
     /**
      * Ledger currency provided during registration for the given merchant identifier.
      */
-    ledgerCurrency: AmazonPayV2LedgerCurrency;
+    ledgerCurrency?: AmazonPayV2LedgerCurrency;
 
     /**
      * Product type selected for checkout. Default is 'PayAndShip'.
@@ -89,6 +94,13 @@ interface AmazonPayV2ButtonConfig {
      * if your `publicKeyId` has an environment prefix. Default is false.
      */
     sandbox?: boolean;
+
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    };
 }
 
 export interface AmazonPayV2ButtonParams extends AmazonPayV2ButtonConfig {


### PR DESCRIPTION
## What?

Added Buy Now functionality for amazon pay on the Product Details Page

## Why?

According to task [PAYPAL-1635](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1635)

## Testing / Proof

Testing with dependent PR

https://user-images.githubusercontent.com/99336044/210571152-d0df58f2-190a-4c6f-9967-66ab3fef6cf4.mov

Testing the rest of the Amazon flow to make sure that everything works correctly with our changes

- Amazon button flow

https://user-images.githubusercontent.com/99336044/211554560-ed067fbc-6033-4015-a0cf-ce40351b85db.mov

https://user-images.githubusercontent.com/99336044/211554616-9b0ade8b-7c25-46a1-a77e-906874036877.mov

- Amazon payment flow

https://user-images.githubusercontent.com/99336044/211575527-22ee341d-efc9-462b-a9ed-a6f326661e15.mov

https://user-images.githubusercontent.com/99336044/211575649-a39733af-45a0-4e6e-b47f-7406c9925eeb.mov

## Depends on 

https://github.com/bigcommerce/bigcommerce/pull/50031

@bigcommerce/checkout @bigcommerce/payments


[PAYPAL-1635]: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAYPAL-1635]: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ