### PR TITLE
feat(payment): PAYMENTS-8378 Send multiple addresses to trusted_shipping_address endpoint in case of multi-shipping

### DIFF
--- a/packages/core/src/payment-integration/create-payment-integration-selectors.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-selectors.ts
@@ -25,7 +25,7 @@ export default function createPaymentIntegrationSelectors({
     },
     paymentMethods: { getPaymentMethod, getPaymentMethodOrThrow },
     paymentStrategies: { isInitialized: isPaymentMethodInitialized },
-    shippingAddress: { getShippingAddress, getShippingAddressOrThrow },
+    shippingAddress: { getShippingAddress, getShippingAddresses, getShippingAddressOrThrow },
 }: InternalCheckoutSelectors): PaymentIntegrationSelectors {
     return {
         getHost: clone(getHost),
@@ -58,6 +58,7 @@ export default function createPaymentIntegrationSelectors({
         getPaymentMethodOrThrow: clone(getPaymentMethodOrThrow),
         getShippingAddress: clone(getShippingAddress),
         getShippingAddressOrThrow: clone(getShippingAddressOrThrow),
+        getShippingAddresses: clone(getShippingAddresses),
         isPaymentDataRequired,
         isPaymentMethodInitialized,
     };

--- a/packages/core/src/payment-integration/create-payment-integration-selectors.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-selectors.ts
@@ -25,7 +25,12 @@ export default function createPaymentIntegrationSelectors({
     },
     paymentMethods: { getPaymentMethod, getPaymentMethodOrThrow },
     paymentStrategies: { isInitialized: isPaymentMethodInitialized },
-    shippingAddress: { getShippingAddress, getShippingAddresses, getShippingAddressOrThrow },
+    shippingAddress: {
+        getShippingAddress,
+        getShippingAddressOrThrow,
+        getShippingAddresses,
+        getShippingAddressesOrThrow,
+    },
 }: InternalCheckoutSelectors): PaymentIntegrationSelectors {
     return {
         getHost: clone(getHost),
@@ -59,6 +64,7 @@ export default function createPaymentIntegrationSelectors({
         getShippingAddress: clone(getShippingAddress),
         getShippingAddressOrThrow: clone(getShippingAddressOrThrow),
         getShippingAddresses: clone(getShippingAddresses),
+        getShippingAddressesOrThrow: clone(getShippingAddressesOrThrow),
         isPaymentDataRequired,
         isPaymentMethodInitialized,
     };

--- a/packages/core/src/payment/instrument/instrument-action-creator.spec.ts
+++ b/packages/core/src/payment/instrument/instrument-action-creator.spec.ts
@@ -39,6 +39,7 @@ describe('InstrumentActionCreator', () => {
     let instrumentId: string;
     let currencyCode: string;
     let shippingAddress: Address;
+    let shippingAddresses: Address[];
     let vaultAccessExpiry: number;
     let vaultAccessToken: string;
 
@@ -69,6 +70,8 @@ describe('InstrumentActionCreator', () => {
         // tslint:disable-next-line:no-non-null-assertion
         customerId = state.cart.data!.customerId;
         shippingAddress = getShippingAddress();
+        // shippingAddresses equivalent to the consignments mock
+        shippingAddresses = [shippingAddress, shippingAddress];
         instrumentId = '123';
         currencyCode = 'USD';
 
@@ -85,7 +88,7 @@ describe('InstrumentActionCreator', () => {
             expect(instrumentRequestSender.getVaultAccessToken).toHaveBeenCalled();
             expect(instrumentRequestSender.loadInstruments).toHaveBeenCalledWith(
                 { storeId, customerId, currencyCode, authToken: vaultAccessToken },
-                shippingAddress,
+                shippingAddresses,
             );
         });
 
@@ -105,7 +108,7 @@ describe('InstrumentActionCreator', () => {
             expect(instrumentRequestSender.getVaultAccessToken).toHaveBeenCalled();
             expect(instrumentRequestSender.loadInstruments).toHaveBeenCalledWith(
                 { storeId, customerId, currencyCode, authToken: vaultAccessToken },
-                shippingAddress,
+                shippingAddresses,
             );
         });
 
@@ -126,7 +129,7 @@ describe('InstrumentActionCreator', () => {
             expect(instrumentRequestSender.getVaultAccessToken).not.toHaveBeenCalled();
             expect(instrumentRequestSender.loadInstruments).toHaveBeenCalledWith(
                 { storeId, customerId, currencyCode, authToken: vaultAccessToken },
-                shippingAddress,
+                shippingAddresses,
             );
         });
 

--- a/packages/core/src/payment/instrument/instrument-action-creator.ts
+++ b/packages/core/src/payment/instrument/instrument-action-creator.ts
@@ -136,10 +136,11 @@ export default class InstrumentActionCreator {
             : this._instrumentRequestSender.getVaultAccessToken().then(({ body }) => body);
     }
 
-    private _getShippingAddress(store: ReadableCheckoutStore): Address | undefined {
+    private _getShippingAddress(store: ReadableCheckoutStore): Address | Address[] | undefined {
         const state = store.getState();
+        const addresses = state.shippingAddress.getShippingAddresses();
 
-        return state.shippingAddress.getShippingAddress();
+        return addresses.length > 1 ? addresses : state.shippingAddress.getShippingAddress();
     }
 
     private _getSessionContext(store: ReadableCheckoutStore): SessionContext {

--- a/packages/core/src/payment/instrument/instrument-request-sender.ts
+++ b/packages/core/src/payment/instrument/instrument-request-sender.ts
@@ -36,7 +36,7 @@ export default class InstrumentRequestSender {
 
     loadInstruments(
         requestContext: InstrumentRequestContext,
-        shippingAddress?: Address,
+        shippingAddress?: Address | Address[],
     ): Promise<Response<InstrumentsResponseBody>> {
         return shippingAddress
             ? this._loadInstrumentsWithAddress(requestContext, shippingAddress)
@@ -85,11 +85,13 @@ export default class InstrumentRequestSender {
 
     private _loadInstrumentsWithAddress(
         requestContext: InstrumentRequestContext,
-        shippingAddress: Address,
+        shippingAddress: Address | Address[],
     ): Promise<Response<InstrumentsResponseBody>> {
         const payload = {
             ...requestContext,
-            shippingAddress: mapToInternalAddress(shippingAddress),
+            shippingAddress: Array.isArray(shippingAddress)
+                ? shippingAddress.map((address) => mapToInternalAddress(address))
+                : mapToInternalAddress(shippingAddress),
         };
 
         return new Promise((resolve, reject) => {

--- a/packages/core/src/shipping/shipping-address-selector.ts
+++ b/packages/core/src/shipping/shipping-address-selector.ts
@@ -9,8 +9,9 @@ import ConsignmentState, { DEFAULT_STATE } from './consignment-state';
 
 export default interface ShippingAddressSelector {
     getShippingAddress(): Address | undefined;
-    getShippingAddresses(): Address[];
     getShippingAddressOrThrow(): Address;
+    getShippingAddresses(): Address[];
+    getShippingAddressesOrThrow(): Address[];
 }
 
 export type ShippingAddressSelectorFactory = (state: ConsignmentState) => ShippingAddressSelector;
@@ -50,11 +51,22 @@ export function createShippingAddressSelectorFactory(): ShippingAddressSelectorF
         },
     );
 
+    const getShippingAddressesOrThrow = createSelector(
+        getShippingAddresses,
+        (getShippingAddresses) => () => {
+            return guard(
+                getShippingAddresses(),
+                () => new MissingDataError(MissingDataErrorType.MissingShippingAddress),
+            );
+        },
+    );
+
     return memoizeOne((state: ConsignmentState = DEFAULT_STATE): ShippingAddressSelector => {
         return {
             getShippingAddress: getShippingAddress(state),
-            getShippingAddresses: getShippingAddresses(state),
             getShippingAddressOrThrow: getShippingAddressOrThrow(state),
+            getShippingAddresses: getShippingAddresses(state),
+            getShippingAddressesOrThrow: getShippingAddressesOrThrow(state),
         };
     });
 }

--- a/packages/core/src/shipping/shipping-address-selector.ts
+++ b/packages/core/src/shipping/shipping-address-selector.ts
@@ -9,6 +9,7 @@ import ConsignmentState, { DEFAULT_STATE } from './consignment-state';
 
 export default interface ShippingAddressSelector {
     getShippingAddress(): Address | undefined;
+    getShippingAddresses(): Address[];
     getShippingAddressOrThrow(): Address;
 }
 
@@ -36,9 +37,23 @@ export function createShippingAddressSelectorFactory(): ShippingAddressSelectorF
         },
     );
 
+    const getShippingAddresses = createSelector(
+        (state: ConsignmentState) => state.data,
+        (consignments) => () => {
+            const shippingConsignments = consignments?.filter(
+                (consignment) => !consignment.selectedPickupOption,
+            );
+
+            return shippingConsignments
+                ? shippingConsignments.map((consignment) => consignment.shippingAddress)
+                : [];
+        },
+    );
+
     return memoizeOne((state: ConsignmentState = DEFAULT_STATE): ShippingAddressSelector => {
         return {
             getShippingAddress: getShippingAddress(state),
+            getShippingAddresses: getShippingAddresses(state),
             getShippingAddressOrThrow: getShippingAddressOrThrow(state),
         };
     });

--- a/packages/payment-integration-api/src/payment-integration-selectors.ts
+++ b/packages/payment-integration-api/src/payment-integration-selectors.ts
@@ -52,8 +52,9 @@ export default interface PaymentIntegrationSelectors {
     getPaymentMethodOrThrow(methodId: string, gatewayId?: string): PaymentMethod;
 
     getShippingAddress(): ShippingAddress | undefined;
-    getShippingAddresses(): ShippingAddress[];
     getShippingAddressOrThrow(): ShippingAddress;
+    getShippingAddresses(): ShippingAddress[];
+    getShippingAddressesOrThrow(): ShippingAddress[];
 
     isPaymentDataRequired(useStoreCredit?: boolean): boolean;
     isPaymentMethodInitialized(methodId: string): boolean;

--- a/packages/payment-integration-api/src/payment-integration-selectors.ts
+++ b/packages/payment-integration-api/src/payment-integration-selectors.ts
@@ -52,6 +52,7 @@ export default interface PaymentIntegrationSelectors {
     getPaymentMethodOrThrow(methodId: string, gatewayId?: string): PaymentMethod;
 
     getShippingAddress(): ShippingAddress | undefined;
+    getShippingAddresses(): ShippingAddress[];
     getShippingAddressOrThrow(): ShippingAddress;
 
     isPaymentDataRequired(useStoreCredit?: boolean): boolean;


### PR DESCRIPTION
## What?
In case of multi-shipping, we want to send an array of addresses to the `trusted_shipping_address` endpoint instead of a single address.

## Why?
This is required to allow vaulting cards with multi-shipping.

## Testing / Proof
Screenshots
**Before**
<img width="1066" alt="Screen Shot 2022-12-22 at 10 36 42 am" src="https://user-images.githubusercontent.com/36555311/209023690-f2bd5814-8fd4-4180-91b6-fb5ad2b9a797.png">

**After (with multiple addresses)**
<img width="1068" alt="Screen Shot 2022-12-22 at 4 33 43 pm" src="https://user-images.githubusercontent.com/36555311/209064607-eedd620a-606f-4b9d-b808-126b64dd7895.png">

**After (with single address)**
<img width="1065" alt="Screen Shot 2022-12-22 at 4 44 11 pm" src="https://user-images.githubusercontent.com/36555311/209065693-75f38f6b-b1b6-49ad-b959-543f845e4be2.png">

@bigcommerce/checkout @bigcommerce/payments
