### PR TITLE
CHECKOUT-7148: Throw `CartConsistencyError` when server detects inconsistent projection data

### DIFF
--- a/packages/core/src/cart/errors/cart-consistency-error.ts
+++ b/packages/core/src/cart/errors/cart-consistency-error.ts
@@ -1,0 +1,17 @@
+import { StandardError } from '../../common/error/errors';
+
+/**
+ * This error is thrown when the server detects inconsistency in cart data since it is last requested,
+ * for example, product prices or eligible discounts have changed.
+ */
+export default class CartConsistencyError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'Your checkout could not be processed because some details have changed. Please review your order and try again.',
+        );
+
+        this.name = 'CartConsistencyError';
+        this.type = 'cart_consistency';
+    }
+}

--- a/packages/core/src/cart/errors/index.ts
+++ b/packages/core/src/cart/errors/index.ts
@@ -1,2 +1,3 @@
 export { default as BuyNowCartCreationError } from './buy-now-cart-creation-error';
 export { default as CartChangedError } from './cart-changed-error';
+export { default as CartConsistencyError } from './cart-consistency-error';

--- a/packages/core/src/checkout/checkout-store-error-selector.ts
+++ b/packages/core/src/checkout/checkout-store-error-selector.ts
@@ -1,6 +1,6 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 
-import { CartChangedError } from '../cart/errors';
+import { CartChangedError, CartConsistencyError } from '../cart/errors';
 import { RequestError } from '../common/error/errors';
 import { createSelector, createShallowEqualSelector } from '../common/selector';
 import { Omit } from '../common/types';
@@ -37,7 +37,7 @@ export default interface CheckoutStoreErrorSelector {
      *
      * @returns The error object if unable to submit, otherwise undefined.
      */
-    getSubmitOrderError(): Error | CartChangedError | undefined;
+    getSubmitOrderError(): Error | CartChangedError | CartConsistencyError | undefined;
 
     /**
      * Returns an error if unable to finalize the current order.

--- a/packages/core/src/order/order-request-sender.ts
+++ b/packages/core/src/order/order-request-sender.ts
@@ -1,6 +1,7 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 import { isNil, omitBy } from 'lodash';
 
+import { CartConsistencyError } from '../cart/errors';
 import {
     ContentType,
     joinIncludes,
@@ -70,6 +71,10 @@ export default class OrderRequestSender {
             .catch((error) => {
                 if (error.body.type === 'tax_provider_unavailable') {
                     throw new OrderTaxProviderUnavailableError();
+                }
+
+                if (error.body.type === 'cart_has_changed') {
+                    throw new CartConsistencyError();
                 }
 
                 throw error;


### PR DESCRIPTION
## What?
Throw `CartInconsistencyError` when server detects inconsistent projection data.

## Why?
To notify browser clients about the error so they can handle it accordingly when it is thrown.

## Testing / Proof
Unit + Manual

https://user-images.githubusercontent.com/667603/209246970-95ba9508-7912-4243-ad3e-189c8fb787d6.mov

@bigcommerce/checkout @bigcommerce/payments
