### PR TITLE
fix(payment): STRIPE-281 Fixed error when making purchases with only digital products

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -390,7 +390,11 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             appearance,
         });
 
-        const { postalCode } = state.shippingAddress.getShippingAddressOrThrow();
+        const {
+            billingAddress: { getBillingAddress },
+            shippingAddress: { getShippingAddress },
+        } = state;
+        const { postalCode } = getShippingAddress() || getBillingAddress() || {};
 
         const stripeElement: StripeElement =
             this._stripeElements.getElement(StripeElementType.PAYMENT) ||


### PR DESCRIPTION
## What? [STRIPE-281](https://bigcommercecloud.atlassian.net/browse/STRIPE-281) 

No exception is thrown when retrieving shipping address when there are only digital products in the order.

## Why?

Trying to purchase digital products results in an error "Unable to proceed because shipping address data is unavailable" on payment step

## Testing / Proof

https://user-images.githubusercontent.com/69487174/209418303-9723d6d4-81ea-4552-8e51-92855db6a2f7.mov



ping @bigcommerce/payments @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team 
