### PR TITLE
fix(payment): CHECKOUT-000 Fix default setup for offsite payment strategy

### DIFF
--- a/packages/core/src/payment/payment-strategy-registry.ts
+++ b/packages/core/src/payment/payment-strategy-registry.ts
@@ -92,10 +92,6 @@ export default class PaymentStrategyRegistry extends Registry<
             return PaymentStrategyType.OFFLINE;
         }
 
-        if (paymentMethod.type === paymentMethodTypes.HOSTED) {
-            return PaymentStrategyType.OFFSITE;
-        }
-
         throw new InvalidArgumentError(`'${methodId}' is not registered.`);
     }
 

--- a/packages/offsite-integration/src/create-offsite-payment-strategy.ts
+++ b/packages/offsite-integration/src/create-offsite-payment-strategy.ts
@@ -9,4 +9,4 @@ const createOffsitePaymentStrategy: PaymentStrategyFactory<OffsitePaymentStrateg
     paymentIntegrationService,
 ) => new OffsitePaymentStrategy(paymentIntegrationService);
 
-export default toResolvableModule(createOffsitePaymentStrategy, [{ id: 'offsite' }]);
+export default toResolvableModule(createOffsitePaymentStrategy, [{ type: 'PAYMENT_TYPE_HOSTED' }]);


### PR DESCRIPTION
## What?
Fix v1 payment registry automatically registering offsite/hosted strategies.

## Why?
Since offsite payment registry has been moved to a separate package we need to remove the fallback in V1 registry. Also set the type for strategy to setup correctly, since as of now the fallback loads credit-card strategy.

## Testing / Proof
- circle

@bigcommerce/checkout @bigcommerce/payments
