### PR TITLE
feat(payment): PAYPAL-1839 Create braintreepaypal customer button strategy

### DIFF
--- a/packages/core/src/customer/create-customer-strategy-registry.ts
+++ b/packages/core/src/customer/create-customer-strategy-registry.ts
@@ -66,7 +66,10 @@ import { AmazonPayCustomerStrategy } from './strategies/amazon';
 import { AmazonPayV2CustomerStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayCustomerStrategy } from './strategies/apple-pay';
 import { BoltCustomerStrategy } from './strategies/bolt';
-import { BraintreeVisaCheckoutCustomerStrategy } from './strategies/braintree';
+import {
+    BraintreePaypalCustomerStrategy,
+    BraintreeVisaCheckoutCustomerStrategy,
+} from './strategies/braintree';
 import { ChasePayCustomerStrategy } from './strategies/chasepay';
 import { DefaultCustomerStrategy } from './strategies/default';
 import { GooglePayCustomerStrategy } from './strategies/googlepay';
@@ -125,6 +128,7 @@ export default function createCustomerStrategyRegistry(
         new PaymentHumanVerificationHandler(createSpamProtection(createScriptLoader())),
     );
 
+    const braintreeSDKCreator = new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader));
     const paymentIntegrationService = createPaymentIntegrationService(store);
     const customerRegistryV2 = createCustomerStrategyRegistryV2(paymentIntegrationService);
 
@@ -185,6 +189,20 @@ export default function createCustomerStrategyRegistry(
                 createBraintreeVisaCheckoutPaymentProcessor(scriptLoader, requestSender),
                 new VisaCheckoutScriptLoader(scriptLoader),
                 formPoster,
+            ),
+    );
+
+    registry.register(
+        'braintreepaypal',
+        () =>
+            new BraintreePaypalCustomerStrategy(
+                store,
+                checkoutActionCreator,
+                customerActionCreator,
+                paymentMethodActionCreator,
+                braintreeSDKCreator,
+                formPoster,
+                window,
             ),
     );
 
@@ -263,9 +281,7 @@ export default function createCustomerStrategyRegistry(
                 remoteCheckoutActionCreator,
                 createGooglePayPaymentProcessor(
                     store,
-                    new GooglePayBraintreeInitializer(
-                        new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
-                    ),
+                    new GooglePayBraintreeInitializer(braintreeSDKCreator),
                 ),
                 formPoster,
             ),

--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -3,7 +3,10 @@ import { RequestOptions } from '../common/http-request';
 import { AmazonPayCustomerInitializeOptions } from './strategies/amazon';
 import { AmazonPayV2CustomerInitializeOptions } from './strategies/amazon-pay-v2';
 import { BoltCustomerInitializeOptions } from './strategies/bolt';
-import { BraintreeVisaCheckoutCustomerInitializeOptions } from './strategies/braintree';
+import {
+    BraintreePaypalCustomerInitializeOptions,
+    BraintreeVisaCheckoutCustomerInitializeOptions,
+} from './strategies/braintree';
 import { ChasePayCustomerInitializeOptions } from './strategies/chasepay';
 import { GooglePayCustomerInitializeOptions } from './strategies/googlepay';
 import { MasterpassCustomerInitializeOptions } from './strategies/masterpass';
@@ -46,6 +49,12 @@ export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
      * when using AmazonPayV2.
      */
     amazonpay?: AmazonPayV2CustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the customer step of checkout
+     * when using Braintree PayPal provided.
+     */
+    braintreepaypal?: BraintreePaypalCustomerInitializeOptions;
 
     /**
      * The options that are required to initialize the customer step of checkout

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-options.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-options.ts
@@ -1,0 +1,16 @@
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+
+export default interface BraintreePaypalCustomerInitializeOptions {
+    /**
+     * The ID of a container which the checkout button should be inserted into.
+     */
+    container: string;
+
+    /**
+     * A callback that gets called on any error instead of submit payment or authorization errors.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: BraintreeError | StandardError): void;
+}

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.spec.ts
@@ -1,0 +1,477 @@
+import { Action, createAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+import { Observable, of } from 'rxjs';
+
+import {
+    CheckoutActionCreator,
+    CheckoutRequestSender,
+    CheckoutStore,
+    createCheckoutStore,
+} from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import {
+    PaymentMethod,
+    PaymentMethodActionCreator,
+    PaymentMethodActionType,
+    PaymentStrategyType,
+} from '../../../payment';
+import { getBraintree } from '../../../payment/payment-methods.mock';
+import {
+    BraintreeDataCollector,
+    BraintreePaypalCheckout,
+    BraintreePaypalCheckoutCreator,
+    BraintreeScriptLoader,
+    BraintreeSDKCreator,
+} from '../../../payment/strategies/braintree';
+import {
+    getDataCollectorMock,
+    getPayPalCheckoutCreatorMock,
+    getPaypalCheckoutMock,
+} from '../../../payment/strategies/braintree/braintree.mock';
+import {
+    PaypalButtonOptions,
+    PaypalHostWindow,
+    PaypalSDK,
+} from '../../../payment/strategies/paypal';
+import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
+import {
+    GoogleRecaptcha,
+    GoogleRecaptchaScriptLoader,
+    GoogleRecaptchaWindow,
+    SpamProtectionActionCreator,
+    SpamProtectionRequestSender,
+} from '../../../spam-protection';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
+
+import BraintreePaypalCustomerInitializeOptions from './braintree-paypal-customer-options';
+import BraintreePaypalCustomerStrategy from './braintree-paypal-customer-strategy';
+
+describe('BraintreePaypalCustomerStrategy', () => {
+    let braintreeSDKCreator: BraintreeSDKCreator;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let braintreePaypalCheckoutCreatorMock: BraintreePaypalCheckoutCreator;
+    let braintreePaypalCheckoutMock: BraintreePaypalCheckout;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let dataCollector: BraintreeDataCollector;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let paymentMethodMock: PaymentMethod;
+    let paypalButtonElement: HTMLDivElement;
+    let paypalSdkMock: PaypalSDK;
+    let store: CheckoutStore;
+    let strategy: BraintreePaypalCustomerStrategy;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let customerActionCreator: CustomerActionCreator;
+    let loadPaymentMethodAction: Observable<Action>;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
+
+    const defaultButtonContainerId = 'braintree-paypal-button-mock-id';
+
+    const braintreePaypalOptions: BraintreePaypalCustomerInitializeOptions = {
+        container: defaultButtonContainerId,
+        onError: jest.fn(),
+    };
+
+    const initializationOptions: CustomerInitializeOptions = {
+        methodId: PaymentStrategyType.BRAINTREE_PAYPAL,
+        container: defaultButtonContainerId,
+        braintreepaypal: braintreePaypalOptions,
+    };
+
+    beforeEach(() => {
+        braintreePaypalCheckoutMock = getPaypalCheckoutMock();
+        braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(
+            braintreePaypalCheckoutMock,
+            false,
+        );
+        dataCollector = getDataCollectorMock();
+        paypalSdkMock = getPaypalMock();
+        eventEmitter = new EventEmitter();
+        paymentMethodMock = {
+            ...getBraintree(),
+            clientToken: 'myToken',
+        };
+
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(
+            createScriptLoader(),
+            googleRecaptchaMockWindow,
+        );
+        googleRecaptcha = new GoogleRecaptcha(
+            googleRecaptchaScriptLoader,
+            new MutationObserverFactory(),
+        );
+
+        loadPaymentMethodAction = of(
+            createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, {
+                methodId: paymentMethodMock.id,
+            }),
+        );
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(createRequestSender()),
+            new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender())),
+        );
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader());
+        braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        formPoster = createFormPoster();
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            checkoutActionCreator,
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender()),
+            ),
+        );
+        paymentMethodActionCreator = {} as PaymentMethodActionCreator;
+        paymentMethodActionCreator.loadPaymentMethod = jest.fn(() => loadPaymentMethodAction);
+
+        (window as PaypalHostWindow).paypal = paypalSdkMock;
+
+        strategy = new BraintreePaypalCustomerStrategy(
+            store,
+            checkoutActionCreator,
+            customerActionCreator,
+            paymentMethodActionCreator,
+            braintreeSDKCreator,
+            formPoster,
+            window,
+        );
+
+        paypalButtonElement = document.createElement('div');
+        paypalButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalButtonElement);
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethodMock,
+        );
+        jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(paymentMethodMock.clientToken);
+        jest.spyOn(braintreeSDKCreator, 'getDataCollector').mockReturnValue(dataCollector);
+        jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(
+            braintreePaypalCheckoutCreatorMock,
+        );
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout').mockImplementation(() => {});
+
+        jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation((options: PaypalButtonOptions) => {
+            eventEmitter.on('createOrder', () => {
+                if (options.createOrder) {
+                    options.createOrder().catch(() => {});
+                }
+            });
+
+            eventEmitter.on('approve', () => {
+                if (options.onApprove) {
+                    options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {});
+                }
+            });
+
+            return {
+                isEligible: jest.fn(() => true),
+                render: jest.fn(),
+            };
+        });
+
+        jest.spyOn(paypalSdkMock, 'Messages').mockImplementation(() => ({
+            render: jest.fn(),
+        }));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PaypalHostWindow).paypal;
+
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalButtonElement);
+        }
+    });
+
+    it('creates an instance of the braintree paypal checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(BraintreePaypalCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = {
+                container: defaultButtonContainerId,
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = {
+                methodId: PaymentStrategyType.BRAINTREE_PAYPAL,
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if braintreepaypal is not provided', async () => {
+            const options = {
+                container: defaultButtonContainerId,
+                methodId: PaymentStrategyType.BRAINTREE_PAYPAL,
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if client token is missing', async () => {
+            paymentMethodMock.clientToken = undefined;
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('initializes braintree sdk creator', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
+                paymentMethodMock.clientToken,
+            );
+        });
+
+        it('initializes braintree paypal checkout', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
+                paymentMethodMock.clientToken,
+            );
+            expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
+        });
+
+        it('calls braintree paypal checkout create method', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreePaypalCheckoutCreatorMock.create).toHaveBeenCalled();
+        });
+
+        it('calls onError callback option if the error was caught on paypal checkout creation', async () => {
+            braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(undefined, true);
+
+            jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(
+                braintreePaypalCheckoutCreatorMock,
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            expect(initializationOptions.braintreepaypal?.onError).toHaveBeenCalled();
+        });
+
+        it('renders PayPal checkout button', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                env: 'sandbox',
+                commit: false,
+                fundingSource: paypalSdkMock.FUNDING.PAYPAL,
+                style: {
+                    height: 40,
+                },
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('renders PayPal checkout button in production environment if payment method is in test mode', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith(
+                expect.objectContaining({ env: 'production' }),
+            );
+        });
+
+        it('loads checkout details when customer is ready to pay', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalledTimes(1);
+        });
+
+        it('sets up PayPal payment flow with no address when null is passed', async () => {
+            jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(undefined);
+
+            await strategy.initialize({
+                ...initializationOptions,
+                braintreepaypal: {
+                    ...initializationOptions.braintreepaypal,
+                    shippingAddress: null,
+                } as BraintreePaypalCustomerInitializeOptions,
+            });
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    shippingAddressOverride: undefined,
+                }),
+            );
+        });
+
+        it('sets up PayPal payment flow with current checkout details when customer is ready to pay', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith({
+                amount: 190,
+                currency: 'USD',
+                enableShippingAddress: true,
+                flow: 'checkout',
+                offerCredit: false,
+                shippingAddressEditable: false,
+                shippingAddressOverride: {
+                    city: 'Some City',
+                    countryCode: 'US',
+                    line1: '12345 Testing Way',
+                    line2: '',
+                    phone: '555-555-5555',
+                    postalCode: '95555',
+                    recipientName: 'Test Tester',
+                    state: 'CA',
+                },
+            });
+        });
+
+        it('triggers error callback if unable to set up payment flow', async () => {
+            const expectedError = new Error('Unable to set up payment flow');
+
+            jest.spyOn(braintreePaypalCheckoutMock, 'createPayment').mockImplementation(() =>
+                Promise.reject(expectedError),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalOptions.onError).toHaveBeenCalledWith(expectedError);
+        });
+
+        it('tokenizes PayPal payment details when authorization event is triggered', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.tokenizePayment).toHaveBeenCalledWith({
+                payerId: 'PAYER_ID',
+            });
+        });
+
+        it('posts payment details to server to set checkout data when PayPal payment details are tokenized', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith(
+                '/checkout.php',
+                expect.objectContaining({
+                    payment_type: 'paypal',
+                    provider: 'braintreepaypal',
+                    action: 'set_external_checkout',
+                    device_data: dataCollector.deviceData,
+                    nonce: 'NONCE',
+                    billing_address: JSON.stringify({
+                        email: 'foo@bar.com',
+                        first_name: 'Foo',
+                        last_name: 'Bar',
+                        address_line_1: '56789 Testing Way',
+                        address_line_2: 'Level 2',
+                        city: 'Some Other City',
+                        state: 'Arizona',
+                        country_code: 'US',
+                        postal_code: '96666',
+                    }),
+                    shipping_address: JSON.stringify({
+                        email: 'foo@bar.com',
+                        first_name: 'Hello',
+                        last_name: 'World',
+                        address_line_1: '12345 Testing Way',
+                        address_line_2: 'Level 1',
+                        city: 'Some City',
+                        state: 'California',
+                        country_code: 'US',
+                        postal_code: '95555',
+                    }),
+                }),
+            );
+        });
+
+        it('triggers error callback if unable to tokenize payment', async () => {
+            const expectedError = new Error('Unable to tokenize');
+
+            jest.spyOn(braintreePaypalCheckoutMock, 'tokenizePayment').mockReturnValue(
+                Promise.reject(expectedError),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalOptions.onError).toHaveBeenCalledWith(expectedError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('teardowns braintree sdk creator on strategy deinitialize', async () => {
+            braintreeSDKCreator.teardown = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+            await strategy.deinitialize();
+
+            expect(braintreeSDKCreator.teardown).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.ts
@@ -1,0 +1,246 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import mapToLegacyBillingAddress from '../../../checkout-buttons/strategies/braintree/map-to-legacy-billing-address';
+import mapToLegacyShippingAddress from '../../../checkout-buttons/strategies/braintree/map-to-legacy-shipping-address';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    StandardError,
+} from '../../../common/error/errors';
+import { PaymentMethodActionCreator } from '../../../payment';
+import {
+    BraintreeError,
+    BraintreePaypalCheckout,
+    BraintreeSDKCreator,
+    BraintreeTokenizePayload,
+    mapToBraintreeShippingAddressOverride,
+} from '../../../payment/strategies/braintree';
+import { PaypalAuthorizeData, PaypalHostWindow } from '../../../payment/strategies/paypal';
+import CustomerActionCreator from '../../customer-action-creator';
+import CustomerCredentials from '../../customer-credentials';
+import {
+    CustomerInitializeOptions,
+    CustomerRequestOptions,
+    ExecutePaymentMethodCheckoutOptions,
+} from '../../customer-request-options';
+import CustomerStrategy from '../customer-strategy';
+
+import BraintreePaypalCustomerInitializeOptions from './braintree-paypal-customer-options';
+
+export default class BraintreePaypalCustomerStrategy implements CustomerStrategy {
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _customerActionCreator: CustomerActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _braintreeSDKCreator: BraintreeSDKCreator,
+        private _formPoster: FormPoster,
+        private _window: PaypalHostWindow,
+    ) {}
+
+    async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { braintreepaypal, methodId } = options;
+        const { container, onError } = braintreepaypal || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!container) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.container" argument is not provided.`,
+            );
+        }
+
+        if (!braintreepaypal) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.braintreepaypal" argument is not provided.`,
+            );
+        }
+
+        const state = await this._store.dispatch(
+            this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+        );
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        if (!paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const currencyCode = state.cart.getCartOrThrow().currency.code;
+        const paypalCheckoutOptions = { currency: currencyCode };
+        const paypalCheckoutSuccessCallback = (
+            braintreePaypalCheckout: BraintreePaypalCheckout,
+        ) => {
+            this._renderPayPalButton(
+                braintreePaypalCheckout,
+                braintreepaypal,
+                container,
+                methodId,
+                Boolean(paymentMethod.config.testMode),
+            );
+        };
+        const paypalCheckoutErrorCallback = (error: BraintreeError) =>
+            this._handleError(error, container, onError);
+
+        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        await this._braintreeSDKCreator.getPaypalCheckout(
+            paypalCheckoutOptions,
+            paypalCheckoutSuccessCallback,
+            paypalCheckoutErrorCallback,
+        );
+
+        return this._store.getState();
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        this._braintreeSDKCreator.teardown();
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    signIn(
+        credentials: CustomerCredentials,
+        options?: CustomerRequestOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.signInCustomer(credentials, options),
+        );
+    }
+
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(this._customerActionCreator.signOutCustomer(options));
+    }
+
+    executePaymentMethodCheckout(
+        options?: ExecutePaymentMethodCheckoutOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        options?.continueWithCheckoutCallback?.();
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _renderPayPalButton(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypal: BraintreePaypalCustomerInitializeOptions,
+        containerId: string,
+        methodId: string,
+        testMode: boolean,
+    ): void {
+        const { paypal } = this._window;
+        const fundingSource = paypal?.FUNDING.PAYPAL;
+
+        if (paypal && fundingSource) {
+            const paypalButtonRender = paypal.Buttons({
+                env: testMode ? 'sandbox' : 'production',
+                commit: false,
+                fundingSource,
+                style: {
+                    height: 40,
+                },
+                createOrder: () => this._setupPayment(braintreePaypalCheckout, braintreepaypal),
+                onApprove: (authorizeData: PaypalAuthorizeData) =>
+                    this._tokenizePayment(
+                        authorizeData,
+                        braintreePaypalCheckout,
+                        methodId,
+                        braintreepaypal,
+                    ),
+            });
+
+            if (paypalButtonRender.isEligible()) {
+                paypalButtonRender.render(`#${containerId}`);
+            }
+        } else {
+            this._removeElement(containerId);
+        }
+    }
+
+    private async _setupPayment(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypal: BraintreePaypalCustomerInitializeOptions,
+    ): Promise<string | void> {
+        try {
+            const state = await this._store.dispatch(
+                this._checkoutActionCreator.loadDefaultCheckout(),
+            );
+
+            const amount = state.checkout.getCheckoutOrThrow().outstandingBalance;
+            const currency = state.cart.getCartOrThrow().currency.code;
+            const customer = state.customer.getCustomer();
+            const address = customer?.addresses[0];
+            const shippingAddressOverride = address
+                ? mapToBraintreeShippingAddressOverride(address)
+                : undefined;
+
+            return await braintreePaypalCheckout.createPayment({
+                flow: 'checkout',
+                enableShippingAddress: true,
+                shippingAddressEditable: false,
+                shippingAddressOverride,
+                amount,
+                currency,
+                offerCredit: false,
+            });
+        } catch (error) {
+            const { container, onError } = braintreepaypal;
+            this._handleError(error, container, onError);
+        }
+    }
+
+    private async _tokenizePayment(
+        authorizeData: PaypalAuthorizeData,
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        methodId: string,
+        braintreepaypal: BraintreePaypalCustomerInitializeOptions,
+    ): Promise<BraintreeTokenizePayload | void> {
+        try {
+            const { deviceData } = await this._braintreeSDKCreator.getDataCollector({
+                paypal: true,
+            });
+            const tokenizePayload = await braintreePaypalCheckout.tokenizePayment(authorizeData);
+            const { details, nonce } = tokenizePayload;
+
+            this._formPoster.postForm('/checkout.php', {
+                payment_type: 'paypal',
+                provider: methodId,
+                action: 'set_external_checkout',
+                nonce,
+                device_data: deviceData,
+                billing_address: JSON.stringify(mapToLegacyBillingAddress(details)),
+                shipping_address: JSON.stringify(mapToLegacyShippingAddress(details)),
+            });
+
+            return tokenizePayload;
+        } catch (error) {
+            const { container, onError } = braintreepaypal;
+            this._handleError(error, container, onError);
+        }
+    }
+
+    private _handleError(
+        error: BraintreeError | StandardError,
+        buttonContainerId: string,
+        onErrorCallback?: (error: BraintreeError | StandardError) => void,
+    ): void {
+        this._removeElement(buttonContainerId);
+
+        if (onErrorCallback) {
+            onErrorCallback(error);
+        } else {
+            throw error;
+        }
+    }
+
+    private _removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+}

--- a/packages/core/src/customer/strategies/braintree/index.ts
+++ b/packages/core/src/customer/strategies/braintree/index.ts
@@ -1,2 +1,4 @@
 export { default as BraintreeVisaCheckoutCustomerStrategy } from './braintree-visacheckout-customer-strategy';
 export { default as BraintreeVisaCheckoutCustomerInitializeOptions } from './braintree-visacheckout-customer-initialize-options';
+export { default as BraintreePaypalCustomerStrategy } from './braintree-paypal-customer-strategy';
+export { default as BraintreePaypalCustomerInitializeOptions } from './braintree-paypal-customer-options';


### PR DESCRIPTION
## What?
Create braintree-paypal customer button strategy
Checkout-js PR: [https://github.com/bigcommerce/checkout-js/pull/1140](https://github.com/bigcommerce/checkout-js/pull/1140)

## Why?
Because of task:  [https://bigcommercecloud.atlassian.net/browse/PAYPAL-1839](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1839)

## Testing / Proof
<img width="1248" alt="Screenshot 2023-01-03 at 16 54 44" src="https://user-images.githubusercontent.com/9430298/210381919-872609bb-37b9-4d1a-b4ae-a7547c123acb.png">

Manual testing a unit test
<img width="508" alt="Screenshot 2022-12-29 at 17 20 03" src="https://user-images.githubusercontent.com/9430298/209980701-62f643de-b91d-4f2d-90c0-bf2ff2fa0b39.png">


@bigcommerce/checkout @bigcommerce/payments
