### PR TITLE
fix(payment): PAYPAL-000 fixed the issue with createOrder props in PayPalCommerceCustomerStrategy

### DIFF
--- a/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.spec.ts
@@ -373,10 +373,9 @@ describe('PaypalCommerceCustomerStrategy', () => {
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                cartMock.id,
-                'paypalcommerce',
-            );
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith('paypalcommerce', {
+                cartId: cartMock.id,
+            });
         });
     });
 

--- a/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/paypalcommerce/paypalcommerce-customer-strategy.ts
@@ -364,10 +364,9 @@ export default class PaypalCommerceCustomerStrategy implements CustomerStrategy 
     private async _createOrder(): Promise<string> {
         const cart = this._store.getState().cart.getCartOrThrow();
 
-        const { orderId } = await this._paypalCommerceRequestSender.createOrder(
-            cart.id,
-            'paypalcommerce',
-        );
+        const { orderId } = await this._paypalCommerceRequestSender.createOrder('paypalcommerce', {
+            cartId: cart.id,
+        });
 
         return orderId;
     }


### PR DESCRIPTION
## What?
Fixed the issue with createOrder props in PayPalCommerceCustomerStrategy

## Why?
It was an issue with PayPalCommerceCustomerStrategy create order request params. The implementation for createOrder method in PayPalCommerceRequestSender were changed in one of the prev merged PR.

## Testing / Proof
Unit tests
CI tests
