### PR TITLE
feat(payment): STRIPE-194 Clear Prefilled Shipping Address Information If Shopper Logs Out Of Link

### DIFF
--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../payment/strategies/stripe-upe';
 import {
     getShippingStripeUPEJsMock,
+    getShippingStripeUPEJsMockWithAnElementCreated,
     getStripeUPEShippingInitializeOptionsMock,
 } from '../../../shipping/strategies/stripe-upe/stripe-upe-shipping.mock';
 import ConsignmentActionCreator from '../../consignment-action-creator';
@@ -105,6 +106,22 @@ describe('StripeUPEShippingStrategy', () => {
 
             expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
             expect(stripeUPEJsMock.elements).toHaveBeenCalledTimes(1);
+        });
+
+        it('destroys and create an instance of StripeUPEClient and StripeElements', async () => {
+            stripeUPEJsMock = getShippingStripeUPEJsMockWithAnElementCreated();
+            jest.spyOn(stripeScriptLoader, 'getStripeClient').mockResolvedValue(stripeUPEJsMock);
+
+            await expect(strategy.initialize(shippingInitialization)).resolves.toBe(
+                store.getState(),
+            );
+
+            expect(stripeScriptLoader.getStripeClient).toHaveBeenCalledTimes(1);
+            expect(stripeUPEJsMock.elements).toHaveBeenCalledTimes(1);
+            expect(
+                (stripeUPEJsMock.elements as jest.Mock).mock.results[0].value.getElement.mock
+                    .results[0].value.destroy,
+            ).toHaveBeenCalledTimes(1);
         });
 
         it('loads a single instance of StripeUPEClient and StripeElements when shipping data is provided', async () => {

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping-strategy.ts
@@ -153,9 +153,13 @@ export default class StripeUPEShippingStrategy implements ShippingStrategy {
             },
         };
 
-        const shippingAddressElement =
-            this._stripeElements.getElement(StripeElementType.SHIPPING) ||
-            this._stripeElements.create(StripeElementType.SHIPPING, option);
+        let shippingAddressElement = this._stripeElements.getElement(StripeElementType.SHIPPING);
+
+        if (shippingAddressElement) {
+            shippingAddressElement.destroy();
+        }
+
+        shippingAddressElement = this._stripeElements.create(StripeElementType.SHIPPING, option);
 
         shippingAddressElement.on('change', (event: StripeEventType) => {
             if (!('isNewAddress' in event)) {

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
@@ -8,8 +8,32 @@ export function getShippingStripeUPEJsMock(): StripeUPEClient {
                 mount: jest.fn(),
                 unmount: jest.fn(),
                 on: jest.fn(),
+                destroy: jest.fn(),
             })),
             getElement: jest.fn().mockReturnValue(null),
+            update: jest.fn(),
+            fetchUpdates: jest.fn(),
+        })),
+        confirmPayment: jest.fn(),
+        confirmCardPayment: jest.fn(),
+    };
+}
+
+export function getShippingStripeUPEJsMockWithAnElementCreated(): StripeUPEClient {
+    return {
+        elements: jest.fn(() => ({
+            create: jest.fn(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn(),
+                destroy: jest.fn(),
+            })),
+            getElement: jest.fn(() => ({
+                mount: jest.fn(),
+                unmount: jest.fn(),
+                on: jest.fn(),
+                destroy: jest.fn(),
+            })),
             update: jest.fn(),
             fetchUpdates: jest.fn(),
         })),


### PR DESCRIPTION
## What? [STRIPE-194](https://bigcommercecloud.atlassian.net/browse/STRIPE-194)
Destroy the StripeShippingElement and create another when the element exists

## Why?
StripeShippingElement is created in blank the first time since there is no previous shipping info and when the StripeLink user logs out and returns to the step, the last StripeShippingElement is called (because we have one element already created), and the Stripe get method doesn't accept parameters by default, that's why the fields will render in the blank(because last StripeShippingElement was created with no parameters filled by default), To fix this we are deleting the previous element created and creating it again with new default values, with this approach we can prevent it from leaving blank

## Testing / Proof
 https://drive.google.com/file/d/1YZSS76WX_nUta-Qqk8D15q4gg-GsEz6c/view?usp=sharing
 
@bigcommerce/checkout @bigcommerce/payments


[STRIPE-194]: https://bigcommercecloud.atlassian.net/browse/STRIPE-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ