### PR TITLE
CHECKOUT-7148: Update CircleCI config to use new context when building artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ workflows:
             - build
             - ci/validate-commits
       - ci/build-js-artifact:
-          context: "Artifact Bucket Access"
+          context: "GCR + Artifact Bucket Access"
           dist_directory: dist-cdn
           prepare_dist_directory:
             - attach_workspace:


### PR DESCRIPTION
## What?
Update CircleCI config to use new context when building artifact.

## Why?
This is the [new context](https://bigcommerce.slack.com/archives/C04HQKQ6ES0/p1673220267636719?thread_ts=1673217936.859679&cid=C04HQKQ6ES0) we should use.

## Testing / Proof
CircleCI

@bigcommerce/checkout @bigcommerce/payments
