### PR TITLE
feat(payment): STRIPE-289 Loading Submit button after card loads

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -83,6 +83,10 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
 
         this._isDeinitialize = false;
 
+        this._loadStripeElement(stripeupe, gatewayId, methodId).catch((error) =>
+            stripeupe.onError?.(error),
+        );
+
         this._unsubscribe = await this._store.subscribe(
             async (_state) => {
                 const payment = this._stripeElements?.getElement(StripeElementType.PAYMENT);
@@ -110,10 +114,6 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                         payment.mount(`#${stripeupe.containerId}`);
                         this._isMounted = true;
                     }
-                } else {
-                    this._loadStripeElement(stripeupe, gatewayId, methodId).catch((error) =>
-                        stripeupe.onError?.(error),
-                    );
                 }
             },
             (state) => {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
@@ -11,6 +11,7 @@ export function getStripeUPEJsMock(): StripeUPEClient {
             create: jest.fn(() => ({
                 mount: jest.fn(),
                 unmount: jest.fn(),
+                on: jest.fn((_, callback) => callback()),
             })),
             getElement: jest.fn().mockReturnValue(null),
             update: jest.fn(),


### PR DESCRIPTION
## What? [STRIPE-289](https://bigcommercecloud.atlassian.net/browse/STRIPE-289)
Render Submit Button after the payment form and input elements have fully loaded.

## Why?
Found a bug that didn't render the pay button if you changed step and go back to the payment

## Testing / Proof
Bug
https://user-images.githubusercontent.com/106765049/211430384-02361724-f2ae-4bfd-9ee5-319116493c10.mov

Bug Fixed
https://user-images.githubusercontent.com/106765049/211428828-69587e7f-a549-40e2-b518-30f1635447d5.mov

Coverage
<img width="748" alt="Screenshot 2023-01-31 at 11 39 50" src="https://user-images.githubusercontent.com/106765049/215840090-9e9979b7-50e8-475a-bb5d-b236cf345c82.png">


@bigcommerce/checkout @bigcommerce/payments

[STRIPE-289]: https://bigcommercecloud.atlassian.net/browse/STRIPE-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ