### PR TITLE
feat(payment): PAYMENTS-8378 Update bigpay-client-js version to 5.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1457,9 +1457,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.20.3",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.20.3.tgz",
-      "integrity": "sha512-fv6pPPZ0iDF0bZEnTCmFy9PlBjEirXoNPG2SwrGecnmefKCBH1BWsGdNhA1lTuxQdkjWEzniPEWNQHTs89I2jw==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.21.0.tgz",
+      "integrity": "sha512-CyQZ/3fJXadbhies/+WPu6iESWsCQS1FPfWD3RnDJG8ThPsJofqKsJUyrEPsMwUnK1PHqQRhW9y6NLfpTPHbZg==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
-    "@bigcommerce/bigpay-client": "^5.20.3",
+    "@bigcommerce/bigpay-client": "^5.21.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Update bigpay-client-js version to 5.21.0

## Why?
Needed for [this PR](https://github.com/bigcommerce/checkout-sdk-js/pull/1745).

## Testing / Proof
Unit tests

@bigcommerce/checkout @bigcommerce/payments
