### PR TITLE
fix(payment): INT-7103 SquareV2: Assume that `postalCode` is valid unless it changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 /packages/payment-integration @bigcommerce/checkout
 /packages/payment-integration-test-utils @bigcommerce/checkout
 /packages/paypal-commerce @bigcommerce/kyiv-payments-team
+/packages/squarev2-integration @bigcommerce/apex-leads

--- a/packages/squarev2-integration/src/mocks/squarev2-web-payments-sdk.mock.ts
+++ b/packages/squarev2-integration/src/mocks/squarev2-web-payments-sdk.mock.ts
@@ -1,8 +1,9 @@
 import {
     Card,
-    CardFieldNames,
+    CardFieldNamesValues,
     CardInputEvent,
     CardInputEventTypes,
+    CardInputEventTypesValues,
     Payments,
     SqEvent,
 } from '../types';
@@ -28,8 +29,8 @@ export function getSquareV2MockFunctions() {
             },
         );
     const simulateEvent = (
-        type: CardInputEventTypes,
-        field: CardFieldNames,
+        type: CardInputEventTypesValues,
+        field: CardFieldNamesValues,
         isCompletelyValid: boolean,
     ) => {
         const callback = listeners[type];

--- a/packages/squarev2-integration/src/squarev2-payment-processor.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-processor.spec.ts
@@ -10,7 +10,7 @@ import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment
 import { getSquareV2MockFunctions } from './mocks/squarev2-web-payments-sdk.mock';
 import SquareV2PaymentProcessor from './squarev2-payment-processor';
 import SquareV2ScriptLoader from './squarev2-script-loader';
-import { CardFieldNames, CardInputEventTypes, Square } from './types';
+import { Square } from './types';
 
 describe('SquareV2PaymentProcessor', () => {
     let squareV2ScriptLoader: SquareV2ScriptLoader;
@@ -106,11 +106,7 @@ describe('SquareV2PaymentProcessor', () => {
                 containerId: 'card-container',
                 onValidationChange,
             });
-            squareV2MockFunctions.simulateEvent(
-                'focusClassAdded' as CardInputEventTypes,
-                'cardNumber' as CardFieldNames,
-                true,
-            );
+            squareV2MockFunctions.simulateEvent('focusClassAdded', 'cardNumber', true);
 
             expect(onValidationChange).toHaveBeenCalledTimes(1);
             expect(onValidationChange).toHaveBeenCalledWith(false);
@@ -123,26 +119,10 @@ describe('SquareV2PaymentProcessor', () => {
                 containerId: 'card-container',
                 onValidationChange,
             });
-            squareV2MockFunctions.simulateEvent(
-                'focusClassAdded' as CardInputEventTypes,
-                'cardNumber' as CardFieldNames,
-                true,
-            );
-            squareV2MockFunctions.simulateEvent(
-                'focusClassRemoved' as CardInputEventTypes,
-                'expirationDate' as CardFieldNames,
-                true,
-            );
-            squareV2MockFunctions.simulateEvent(
-                'errorClassRemoved' as CardInputEventTypes,
-                'cvv' as CardFieldNames,
-                true,
-            );
-            squareV2MockFunctions.simulateEvent(
-                'postalCodeChanged' as CardInputEventTypes,
-                'postalCode' as CardFieldNames,
-                true,
-            );
+            squareV2MockFunctions.simulateEvent('focusClassAdded', 'cardNumber', true);
+            squareV2MockFunctions.simulateEvent('focusClassRemoved', 'expirationDate', true);
+            squareV2MockFunctions.simulateEvent('errorClassRemoved', 'cvv', true);
+            squareV2MockFunctions.simulateEvent('postalCodeChanged', 'postalCode', true);
 
             expect(onValidationChange).toHaveBeenCalledTimes(2);
             expect(onValidationChange).toHaveBeenNthCalledWith(1, false);
@@ -156,36 +136,32 @@ describe('SquareV2PaymentProcessor', () => {
                 containerId: 'card-container',
                 onValidationChange,
             });
-            squareV2MockFunctions.simulateEvent(
-                'focusClassAdded' as CardInputEventTypes,
-                'cardNumber' as CardFieldNames,
-                true,
-            );
-            squareV2MockFunctions.simulateEvent(
-                'focusClassRemoved' as CardInputEventTypes,
-                'expirationDate' as CardFieldNames,
-                true,
-            );
-            squareV2MockFunctions.simulateEvent(
-                'errorClassRemoved' as CardInputEventTypes,
-                'cvv' as CardFieldNames,
-                true,
-            );
-            squareV2MockFunctions.simulateEvent(
-                'postalCodeChanged' as CardInputEventTypes,
-                'postalCode' as CardFieldNames,
-                true,
-            );
-            squareV2MockFunctions.simulateEvent(
-                'cardBrandChanged' as CardInputEventTypes,
-                'cardNumber' as CardFieldNames,
-                false,
-            );
+            squareV2MockFunctions.simulateEvent('focusClassAdded', 'cardNumber', true);
+            squareV2MockFunctions.simulateEvent('focusClassRemoved', 'expirationDate', true);
+            squareV2MockFunctions.simulateEvent('errorClassRemoved', 'cvv', true);
+            squareV2MockFunctions.simulateEvent('postalCodeChanged', 'postalCode', true);
+            squareV2MockFunctions.simulateEvent('cardBrandChanged', 'cardNumber', false);
 
             expect(onValidationChange).toHaveBeenCalledTimes(3);
             expect(onValidationChange).toHaveBeenNthCalledWith(1, false);
             expect(onValidationChange).toHaveBeenNthCalledWith(2, true);
             expect(onValidationChange).toHaveBeenNthCalledWith(3, false);
+        });
+
+        it("should exempt postalCode from validation if it hasn't been rendered yet", async () => {
+            const onValidationChange = jest.fn();
+
+            await processor.initializeCard({
+                containerId: 'card-container',
+                onValidationChange,
+            });
+            squareV2MockFunctions.simulateEvent('focusClassAdded', 'cardNumber', true);
+            squareV2MockFunctions.simulateEvent('focusClassRemoved', 'expirationDate', true);
+            squareV2MockFunctions.simulateEvent('errorClassRemoved', 'cvv', true);
+
+            expect(onValidationChange).toHaveBeenCalledTimes(2);
+            expect(onValidationChange).toHaveBeenNthCalledWith(1, false);
+            expect(onValidationChange).toHaveBeenNthCalledWith(2, true);
         });
     });
 

--- a/packages/squarev2-integration/src/squarev2-payment-processor.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-processor.ts
@@ -129,12 +129,7 @@ export default class SquareV2PaymentProcessor {
         card: Card,
         observer: Required<SquareV2PaymentInitializeOptions>['onValidationChange'],
     ): Subscription {
-        const invalidFields = new Set<string>([
-            'cardNumber',
-            'expirationDate',
-            'cvv',
-            'postalCode',
-        ]);
+        const invalidFields = new Set<string>(['cardNumber', 'expirationDate', 'cvv']);
         const eventObservables = [
             'focusClassAdded',
             'focusClassRemoved',


### PR DESCRIPTION
## What? [INT-7103](https://bigcommercecloud.atlassian.net/browse/INT-7103)
Exempt the postal code input field from validation if it hasn't been rendered yet.

## Why?
There are regions that do not prompt for a postal code, so we need to allow buyers from those regions to continue as long as the other fields are valid. For those regions that prompt for a postal code, as soon as the input is displayed, events will be fired and the field will start to be validated.

## Testing / Proof
https://user-images.githubusercontent.com/4843328/211678871-ab7f4e6a-76ed-4225-9da2-adca82ecd733.mov

@bigcommerce/checkout @bigcommerce/payments

[INT-7103]: https://bigcommercecloud.atlassian.net/browse/INT-7103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ