### PR TITLE
feat(payment): PAYPAL-1898 added CartActionCreator to use it in payment integration packages

### DIFF
--- a/packages/core/src/cart/cart-action-creator.spec.ts
+++ b/packages/core/src/cart/cart-action-creator.spec.ts
@@ -1,0 +1,99 @@
+import { createAction } from '@bigcommerce/data-store';
+import { createRequestSender, Response } from '@bigcommerce/request-sender';
+import { from, of } from 'rxjs';
+import { catchError, toArray } from 'rxjs/operators';
+
+import { CheckoutActionCreator, CheckoutActionType, CheckoutRequestSender } from '../checkout';
+import { getCheckoutWithBuyNowCart } from '../checkout/checkouts.mock';
+import { ErrorResponseBody } from '../common/error';
+import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
+import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
+
+import { getBuyNowCart, getBuyNowCartRequestBody } from './carts.mock';
+import { Cart, CartActionCreator, CartActionType, CartRequestSender } from './index';
+
+describe('CartActionCreator', () => {
+    let cartActionCreator: CartActionCreator;
+    let cartRequestSender: CartRequestSender;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let errorResponse: Response<ErrorResponseBody>;
+    let response: Response<Cart>;
+
+    beforeEach(() => {
+        const requestSender = createRequestSender();
+
+        response = getResponse(getBuyNowCart());
+        errorResponse = getErrorResponse();
+
+        cartRequestSender = new CartRequestSender(requestSender);
+
+        jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue(
+            Promise.resolve(response),
+        );
+
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender)),
+        );
+
+        jest.spyOn(checkoutActionCreator, 'loadCheckout').mockReturnValue(
+            from([
+                createAction(CheckoutActionType.LoadCheckoutRequested),
+                createAction(CheckoutActionType.LoadCheckoutSucceeded, getCheckoutWithBuyNowCart()),
+            ]),
+        );
+
+        cartActionCreator = new CartActionCreator(cartRequestSender, checkoutActionCreator);
+    });
+
+    describe('#createBuyNowCart', () => {
+        it('emits actions if able to create buy now cart', async () => {
+            const actions = await from(
+                cartActionCreator.createBuyNowCart(getBuyNowCartRequestBody()),
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([
+                { type: CartActionType.CreateBuyNowCartRequested },
+                { type: CheckoutActionType.LoadCheckoutRequested },
+                {
+                    type: CheckoutActionType.LoadCheckoutSucceeded,
+                    payload: getCheckoutWithBuyNowCart(),
+                },
+                { type: CartActionType.CreateBuyNowCartSucceeded, payload: response.body },
+            ]);
+        });
+
+        it('emits error actions if unable to create buy now cart', async () => {
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue(
+                Promise.reject(errorResponse),
+            );
+
+            const errorHandler = jest.fn((action) => of(action));
+            const actions = await from(
+                cartActionCreator.createBuyNowCart(getBuyNowCartRequestBody()),
+            )
+                .pipe(catchError(errorHandler), toArray())
+                .toPromise();
+
+            expect(errorHandler).toHaveBeenCalled();
+            expect(actions).toEqual([
+                { type: CartActionType.CreateBuyNowCartRequested },
+                {
+                    type: CartActionType.CreateBuyNowCartFailed,
+                    payload: errorResponse,
+                    error: true,
+                },
+            ]);
+        });
+
+        it('emits actions to load checkout by buy now cart id', async () => {
+            await from(cartActionCreator.createBuyNowCart(getBuyNowCartRequestBody())).toPromise();
+
+            expect(checkoutActionCreator.loadCheckout).toHaveBeenCalledWith(getBuyNowCart().id);
+        });
+    });
+});

--- a/packages/core/src/cart/cart-action-creator.ts
+++ b/packages/core/src/cart/cart-action-creator.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@bigcommerce/data-store';
+import { concat, from, Observable, of } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
+
+import { CheckoutActionCreator } from '../checkout';
+import { throwErrorAction } from '../common/error';
+import { RequestOptions } from '../common/http-request';
+
+import BuyNowCartRequestBody from './buy-now-cart-request-body';
+import { CartAction, CartActionType } from './cart-actions';
+import CartRequestSender from './cart-request-sender';
+
+export default class CartActionCreator {
+    constructor(
+        private _cartRequestSender: CartRequestSender,
+        private _checkoutActionCreator: CheckoutActionCreator,
+    ) {}
+
+    createBuyNowCart(
+        body: BuyNowCartRequestBody,
+        options?: RequestOptions,
+    ): Observable<CartAction> {
+        return concat(
+            of(createAction(CartActionType.CreateBuyNowCartRequested)),
+            from(this._cartRequestSender.createBuyNowCart(body, options)).pipe(
+                switchMap(({ body: buyNowCart }) =>
+                    concat(
+                        this._checkoutActionCreator.loadCheckout(buyNowCart.id),
+                        of(createAction(CartActionType.CreateBuyNowCartSucceeded, buyNowCart)),
+                    ),
+                ),
+            ),
+        ).pipe(
+            catchError((error) => throwErrorAction(CartActionType.CreateBuyNowCartFailed, error)),
+        );
+    }
+}

--- a/packages/core/src/cart/cart-actions.ts
+++ b/packages/core/src/cart/cart-actions.ts
@@ -1,0 +1,29 @@
+import { Action } from '@bigcommerce/data-store';
+
+import { LoadCheckoutAction } from '../checkout';
+
+export enum CartActionType {
+    CreateBuyNowCartRequested = 'CREATE_BUY_NOW_CART_REQUESTED',
+    CreateBuyNowCartSucceeded = 'CREATE_BUY_NOW_CART_SUCCEEDED',
+    CreateBuyNowCartFailed = 'CREATE_BUY_NOW_CART_FAILED',
+}
+
+export type CartAction = CreateBuyNowCartAction;
+
+export type CreateBuyNowCartAction =
+    | CreateBuyNowCartRequestedAction
+    | CreateBuyNowCartSucceededAction
+    | CreateBuyNowCartFailedAction
+    | LoadCheckoutAction;
+
+export interface CreateBuyNowCartRequestedAction extends Action {
+    type: CartActionType.CreateBuyNowCartRequested;
+}
+
+export interface CreateBuyNowCartSucceededAction extends Action {
+    type: CartActionType.CreateBuyNowCartSucceeded;
+}
+
+export interface CreateBuyNowCartFailedAction extends Action {
+    type: CartActionType.CreateBuyNowCartFailed;
+}

--- a/packages/core/src/cart/cart-request-sender.spec.ts
+++ b/packages/core/src/cart/cart-request-sender.spec.ts
@@ -5,6 +5,8 @@ import {
     Response,
 } from '@bigcommerce/request-sender';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
@@ -26,7 +28,7 @@ describe('CartRequestSender', () => {
 
     describe('#createBuyNowCart', () => {
         const buyNowCartRequestBody: BuyNowCartRequestBody = {
-            source: 'BUY_NOW',
+            source: CartSource.BuyNow,
             lineItems: [
                 {
                     productId: 1,

--- a/packages/core/src/cart/carts.mock.ts
+++ b/packages/core/src/cart/carts.mock.ts
@@ -1,4 +1,6 @@
-import { Cart, CartState } from '../cart';
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { BuyNowCartRequestBody, Cart, CartState } from '../cart';
 import { getCoupon, getShippingCoupon } from '../coupon/coupons.mock';
 import { getCurrency } from '../currency/currencies.mock';
 import { getDiscount } from '../discount/discounts.mock';
@@ -25,6 +27,25 @@ export function getCart(): Cart {
         },
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
+    };
+}
+
+export function getBuyNowCart(): Cart {
+    return {
+        ...getCart(),
+        source: CartSource.BuyNow,
+    };
+}
+
+export function getBuyNowCartRequestBody(): BuyNowCartRequestBody {
+    return {
+        lineItems: [
+            {
+                productId: 1,
+                quantity: 1,
+            },
+        ],
+        source: CartSource.BuyNow,
     };
 }
 

--- a/packages/core/src/cart/index.ts
+++ b/packages/core/src/cart/index.ts
@@ -11,6 +11,8 @@ export {
 } from './line-item';
 export { default as LineItemMap } from './line-item-map';
 
+export { CartAction, CartActionType } from './cart-actions';
+export { default as CartActionCreator } from './cart-action-creator';
 export { default as CartComparator } from './cart-comparator';
 export { default as CartRequestSender } from './cart-request-sender';
 export { default as cartReducer } from './cart-reducer';

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -3,7 +3,7 @@ import { RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
-import { CartRequestSender } from '../cart';
+import { CartActionCreator, CartRequestSender } from '../cart';
 import {
     CheckoutActionCreator,
     CheckoutRequestSender,
@@ -123,6 +123,7 @@ export default function createCheckoutButtonRegistry(
         checkoutRequestSender,
     );
     const cartRequestSender = new CartRequestSender(requestSender);
+    const cartActionCreator = new CartActionCreator(cartRequestSender, checkoutActionCreator);
 
     registry.register(
         CheckoutButtonMethodType.APPLEPAY,
@@ -344,7 +345,7 @@ export default function createCheckoutButtonRegistry(
             new PaypalCommerceButtonStrategy(
                 store,
                 checkoutActionCreator,
-                cartRequestSender,
+                cartActionCreator,
                 formPoster,
                 paypalScriptLoader,
                 paypalCommerceRequestSender,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -3,8 +3,9 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
-import { CartRequestSender } from '../../../cart';
-import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { BuyNowCartRequestBody, CartRequestSender } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import {
     CheckoutActionCreator,
@@ -87,11 +88,11 @@ describe('BraintreePaypalButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -3,10 +3,10 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { getCart } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
-import { CartRequestSender } from '../../../cart';
-import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
+import { BuyNowCartRequestBody, CartRequestSender } from '../../../cart';
 import {
     CheckoutActionCreator,
     CheckoutRequestSender,
@@ -86,11 +86,11 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
@@ -2,8 +2,9 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
-import { CartRequestSender } from '../../../cart';
-import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { BuyNowCartRequestBody, CartRequestSender } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
@@ -44,11 +45,11 @@ describe('BraintreeVenmoButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -1,3 +1,5 @@
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BuyNowCartRequestBody } from '../../../cart';
 import { PaymentMethod } from '../../../payment';
 import { getGooglePay } from '../../../payment/payment-methods.mock';
@@ -33,7 +35,7 @@ export enum Mode {
 }
 
 const buyNowCartRequestBody: BuyNowCartRequestBody = {
-    source: 'BUY_NOW',
+    source: CartSource.BuyNow,
     lineItems: [
         {
             productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -3,6 +3,8 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BuyNowCartRequestBody, Cart, CartRequestSender } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { BuyNowCartCreationError } from '../../../cart/errors';
@@ -67,11 +69,11 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
@@ -3,9 +3,10 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
-import { Cart, CartRequestSender } from '../../../cart';
-import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
+import { BuyNowCartRequestBody, Cart, CartRequestSender } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { BuyNowCartCreationError } from '../../../cart/errors';
 import {
@@ -94,11 +95,11 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
@@ -3,6 +3,8 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BuyNowCartRequestBody, Cart, CartRequestSender } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { BuyNowCartCreationError } from '../../../cart/errors';
@@ -66,11 +68,11 @@ describe('PaypalCommerceVenmoButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -1,5 +1,5 @@
 import { getBillingAddress, getBillingAddressState } from '../billing/billing-addresses.mock';
-import { getCart, getCartState } from '../cart/carts.mock';
+import { getBuyNowCart, getCart, getCartState } from '../cart/carts.mock';
 import { getCheckoutButtonState } from '../checkout-buttons/checkout-buttons.mock';
 import { getConfigState } from '../config/configs.mock';
 import { getCoupon, getCouponsState, getShippingCoupon } from '../coupon/coupons.mock';
@@ -64,6 +64,13 @@ export function getCheckout(): Checkout {
             },
         ],
         channelId: 1,
+    };
+}
+
+export function getCheckoutWithBuyNowCart(): Checkout {
+    return {
+        ...getCheckout(),
+        cart: getBuyNowCart(),
     };
 }
 

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -4,6 +4,7 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
+import { CartActionCreator, CartRequestSender } from '../cart';
 import {
     CheckoutActionCreator,
     CheckoutRequestSender,
@@ -92,6 +93,11 @@ export default function createPaymentIntegrationService(
         ),
     );
 
+    const cartActionCreator = new CartActionCreator(
+        new CartRequestSender(requestSender),
+        checkoutActionCreator,
+    );
+
     return new DefaultPaymentIntegrationService(
         store,
         storeProjectionFactory,
@@ -103,5 +109,6 @@ export default function createPaymentIntegrationService(
         paymentMethodActionCreator,
         paymentActionCreator,
         customerActionCreator,
+        cartActionCreator,
     );
 }

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -9,6 +9,8 @@ import {
 
 import { BillingAddressActionCreator } from '../billing';
 import { getBillingAddress } from '../billing/billing-addresses.mock';
+import { CartActionCreator } from '../cart';
+import { getBuyNowCartRequestBody } from '../cart/carts.mock';
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../checkout';
 import { DataStoreProjection } from '../common/data-store';
 import { CustomerActionCreator } from '../customer';
@@ -51,6 +53,7 @@ describe('DefaultPaymentIntegrationService', () => {
         'submitPayment' | 'initializeOffsitePayment'
     >;
     let customerActionCreator: Pick<CustomerActionCreator, 'signInCustomer' | 'signOutCustomer'>;
+    let cartActionCreator: Pick<CartActionCreator, 'createBuyNowCart'>;
 
     beforeEach(() => {
         hostedFormFactory = new HostedFormFactory(store as CheckoutStore);
@@ -111,6 +114,10 @@ describe('DefaultPaymentIntegrationService', () => {
             signOutCustomer: jest.fn(async () => () => createAction('SIGN_OUT_CUSTOMER')),
         };
 
+        cartActionCreator = {
+            createBuyNowCart: jest.fn(async () => () => createAction('CREATE_BUY_NOW_CART')),
+        };
+
         subject = new DefaultPaymentIntegrationService(
             store as CheckoutStore,
             storeProjectionFactory as PaymentIntegrationStoreProjectionFactory,
@@ -122,6 +129,7 @@ describe('DefaultPaymentIntegrationService', () => {
             paymentMethodActionCreator as PaymentMethodActionCreator,
             paymentActionCreator as PaymentActionCreator,
             customerActionCreator as CustomerActionCreator,
+            cartActionCreator as CartActionCreator,
         );
     });
 
@@ -284,6 +292,22 @@ describe('DefaultPaymentIntegrationService', () => {
 
             expect(customerActionCreator.signOutCustomer).toHaveBeenCalledWith({});
             expect(store.dispatch).toHaveBeenCalledWith(customerActionCreator.signOutCustomer({}));
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#createBuyNowCart', () => {
+        it('creates buy now cart', async () => {
+            const buyNowCartRequestBody = getBuyNowCartRequestBody();
+            const output = await subject.createBuyNowCart(buyNowCartRequestBody);
+
+            expect(cartActionCreator.createBuyNowCart).toHaveBeenCalledWith(
+                buyNowCartRequestBody,
+                undefined,
+            );
+            expect(store.dispatch).toHaveBeenCalledWith(
+                cartActionCreator.createBuyNowCart(buyNowCartRequestBody, undefined),
+            );
             expect(output).toEqual(paymentIntegrationSelectors);
         });
     });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -12,6 +12,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { BillingAddressActionCreator } from '../billing';
+import { BuyNowCartRequestBody, CartActionCreator } from '../cart';
 import { CheckoutActionCreator, CheckoutStore } from '../checkout';
 import { DataStoreProjection } from '../common/data-store';
 import { CustomerActionCreator, CustomerCredentials } from '../customer';
@@ -37,6 +38,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
         private _customerActionCreator: CustomerActionCreator,
+        private _cartActionCreator: CartActionCreator,
     ) {
         this._storeProjection = this._storeProjectionFactory.create(this._store);
     }
@@ -151,6 +153,15 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
 
     async signOutCustomer(options?: RequestOptions): Promise<PaymentIntegrationSelectors> {
         await this._store.dispatch(this._customerActionCreator.signOutCustomer(options));
+
+        return this._storeProjection.getState();
+    }
+
+    async createBuyNowCart(
+        body: BuyNowCartRequestBody,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(this._cartActionCreator.createBuyNowCart(body, options));
 
         return this._storeProjection.getState();
     }

--- a/packages/payment-integration-api/src/cart/buy-now-cart-request-body.ts
+++ b/packages/payment-integration-api/src/cart/buy-now-cart-request-body.ts
@@ -1,4 +1,4 @@
-import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { CartSource } from './cart-source';
 
 interface LineItem {
     productId: number;

--- a/packages/payment-integration-api/src/cart/cart-source.ts
+++ b/packages/payment-integration-api/src/cart/cart-source.ts
@@ -1,0 +1,3 @@
+export enum CartSource {
+    BuyNow = 'BUY_NOW',
+}

--- a/packages/payment-integration-api/src/cart/index.ts
+++ b/packages/payment-integration-api/src/cart/index.ts
@@ -1,4 +1,6 @@
+export { default as BuyNowCartRequestBody } from './buy-now-cart-request-body';
 export { default as Cart } from './cart';
+export { CartSource } from './cart-source';
 export { default as InternalLineItem } from './internal-line-item';
 export { PhysicalItem, DigitalItem, GiftCertificateItem } from './line-item';
 export { default as LineItemMap } from './line-item-map';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -6,7 +6,7 @@ export {
     CheckoutButtonStrategyResolveId,
     CheckoutButtonInitializeOptions,
 } from './checkout-buttons';
-export { Cart, DigitalItem, GiftCertificateItem, PhysicalItem } from './cart';
+export { Cart, CartSource, DigitalItem, GiftCertificateItem, PhysicalItem } from './cart';
 export { Checkout } from './checkout';
 export { BrowserInfo, getBrowserInfo } from './common/browser-info';
 export { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from './common/http-request';

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -1,4 +1,5 @@
 import { BillingAddressRequestBody } from './billing';
+import { BuyNowCartRequestBody } from './cart';
 import { CustomerCredentials } from './customer';
 import { HostedForm, HostedFormOptions } from './hosted-form';
 import { OrderRequestBody } from './order';
@@ -53,4 +54,9 @@ export default interface PaymentIntegrationService {
     ): Promise<PaymentIntegrationSelectors>;
 
     signOutCustomer(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
+
+    createBuyNowCart(
+        body: BuyNowCartRequestBody,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors>;
 }


### PR DESCRIPTION
## What?
Created CartActionCreator to have an ability to use buy now feature in payment integration packages like PayPal Commerce and Braintree.

## Why?
We don't have an ability to migrate PayPalCommerce strategies to their own package because payment-integration-api package doesn't have buy now cart creation method what core package has.

## Testing / Proof
Unit tests
Manual tests

https://user-images.githubusercontent.com/25133454/212728151-4879dac9-4de6-4ee0-bc3f-44dcd8e71f60.mov