### PR TITLE
fix(billing): CHECKOUT-7214 Merge billing address as compared to replace

### DIFF
--- a/packages/core/src/billing/billing-address-reducer.spec.ts
+++ b/packages/core/src/billing/billing-address-reducer.spec.ts
@@ -4,8 +4,6 @@ import { CheckoutActionType } from '../checkout';
 import { getCheckout } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
-import { OrderActionType } from '../order';
-import { getOrder } from '../order/orders.mock';
 import { SubscriptionsActionType } from '../subscription';
 
 import { BillingAddressActionType } from './billing-address-actions';
@@ -27,17 +25,6 @@ describe('billingAddressReducer', () => {
             data: action.payload && action.payload.billingAddress,
             errors: { loadError: undefined },
             statuses: { isLoading: false },
-        });
-    });
-
-    it('returns billing address when order loads', () => {
-        const action = createAction(OrderActionType.LoadOrderSucceeded, getOrder());
-        const output = billingAddressReducer(initialState, action);
-
-        expect(output).toEqual({
-            data: action.payload && action.payload.billingAddress,
-            errors: {},
-            statuses: {},
         });
     });
 

--- a/packages/core/src/billing/billing-address-reducer.ts
+++ b/packages/core/src/billing/billing-address-reducer.ts
@@ -2,8 +2,8 @@ import { Action, combineReducers, composeReducers } from '@bigcommerce/data-stor
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
-import { objectMerge, objectSet, replace } from '../common/utility';
-import { OrderAction, OrderActionType } from '../order';
+import { objectSet, replace } from '../common/utility';
+import { OrderAction } from '../order';
 import { SubscriptionsActionType, UpdateSubscriptionsAction } from '../subscription';
 
 import BillingAddress from './billing-address';
@@ -36,8 +36,6 @@ function dataReducer(
         case BillingAddressActionType.ContinueAsGuestSucceeded:
         case CheckoutActionType.LoadCheckoutSucceeded:
             return replace(data, action.payload && action.payload.billingAddress);
-        case OrderActionType.LoadOrderSucceeded:
-            return objectMerge(data, action.payload && action.payload.billingAddress);
 
         default:
             return data;

--- a/packages/core/src/billing/billing-address-reducer.ts
+++ b/packages/core/src/billing/billing-address-reducer.ts
@@ -2,7 +2,7 @@ import { Action, combineReducers, composeReducers } from '@bigcommerce/data-stor
 
 import { CheckoutAction, CheckoutActionType } from '../checkout';
 import { clearErrorReducer } from '../common/error';
-import { objectSet, replace } from '../common/utility';
+import { objectMerge, objectSet, replace } from '../common/utility';
 import { OrderAction, OrderActionType } from '../order';
 import { SubscriptionsActionType, UpdateSubscriptionsAction } from '../subscription';
 
@@ -35,8 +35,9 @@ function dataReducer(
         case BillingAddressActionType.UpdateBillingAddressSucceeded:
         case BillingAddressActionType.ContinueAsGuestSucceeded:
         case CheckoutActionType.LoadCheckoutSucceeded:
-        case OrderActionType.LoadOrderSucceeded:
             return replace(data, action.payload && action.payload.billingAddress);
+        case OrderActionType.LoadOrderSucceeded:
+            return objectMerge(data, action.payload && action.payload.billingAddress);
 
         default:
             return data;

--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -7,6 +7,7 @@ import { CustomerState, CustomerStrategyState } from '../customer';
 import { FormFieldsState } from '../form';
 import { CountryState } from '../geography';
 import { OrderState } from '../order';
+import { OrderBillingAddressState } from '../order-billing-address';
 import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
 import { InstrumentState } from '../payment/instrument';
 import { RemoteCheckoutState } from '../remote-checkout';
@@ -37,6 +38,7 @@ export default interface CheckoutStoreState {
     giftCertificates: GiftCertificateState;
     instruments: InstrumentState;
     order: OrderState;
+    orderBillingAddress: OrderBillingAddressState;
     payment: PaymentState;
     paymentMethods: PaymentMethodState;
     paymentStrategies: PaymentStrategyState;

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -8,6 +8,7 @@ import { getCustomer, getCustomerState } from '../customer/customers.mock';
 import { getCustomerStrategyState } from '../customer/internal-customers.mock';
 import { getFormFieldsState } from '../form/form.mock';
 import { getCountriesState } from '../geography/countries.mock';
+import { getOrderBillingAddressState } from '../order-billing-address';
 import { getOrderState } from '../order/orders.mock';
 import { ACKNOWLEDGE, HOSTED } from '../payment';
 import { getInstrumentsState } from '../payment/instrument/instrument.mock';
@@ -123,7 +124,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         giftCertificates: getGiftCertificatesState(),
         instruments: getInstrumentsState(),
         order: { errors: {}, statuses: {} },
-        orderBillingAddress: {},
+        orderBillingAddress: getOrderBillingAddressState(),
         payment: getPaymentState(),
         paymentMethods: getPaymentMethodsState(),
         paymentStrategies: { data: {}, errors: {}, statuses: {} },

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -123,6 +123,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         giftCertificates: getGiftCertificatesState(),
         instruments: getInstrumentsState(),
         order: { errors: {}, statuses: {} },
+        orderBillingAddress: {},
         payment: getPaymentState(),
         paymentMethods: getPaymentMethodsState(),
         paymentStrategies: { data: {}, errors: {}, statuses: {} },

--- a/packages/core/src/checkout/create-checkout-store-reducer.ts
+++ b/packages/core/src/checkout/create-checkout-store-reducer.ts
@@ -9,6 +9,7 @@ import { customerReducer, customerStrategyReducer } from '../customer';
 import { formFieldsReducer } from '../form';
 import { countryReducer } from '../geography';
 import { orderReducer } from '../order';
+import { orderBillingAddressReducer } from '../order-billing-address';
 import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
 import { instrumentReducer } from '../payment/instrument';
 import { remoteCheckoutReducer } from '../remote-checkout';
@@ -40,6 +41,7 @@ export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState
         formFields: formFieldsReducer,
         giftCertificates: giftCertificateReducer,
         instruments: instrumentReducer,
+        orderBillingAddress: orderBillingAddressReducer,
         order: orderReducer,
         payment: paymentReducer,
         paymentMethods: paymentMethodReducer,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -118,7 +118,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             giftCertificates,
             instruments,
             order,
-            createOrderBillingAddressSelector,
+            orderBillingAddress,
             payment,
             paymentMethods,
             paymentStrategies,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -8,6 +8,7 @@ import { createCustomerSelectorFactory, createCustomerStrategySelectorFactory } 
 import { createFormSelectorFactory } from '../form';
 import { createCountrySelectorFactory } from '../geography';
 import { createOrderSelectorFactory } from '../order';
+import { createOrderBillingAddressSelectorFactory } from '../order-billing-address';
 import {
     createPaymentMethodSelectorFactory,
     createPaymentSelectorFactory,
@@ -58,6 +59,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createConsignmentSelector = createConsignmentSelectorFactory();
     const createCheckoutSelector = createCheckoutSelectorFactory();
     const createOrderSelector = createOrderSelectorFactory();
+    const createOrderBillingAddressSelector = createOrderBillingAddressSelectorFactory();
     const createPaymentSelector = createPaymentSelectorFactory();
     const createStoreCreditSelector = createStoreCreditSelectorFactory();
     const createSubscriptionsSelector = createSubscriptionsSelectorFactory();
@@ -74,6 +76,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const form = createFormSelector(state.formFields);
         const giftCertificates = createGiftCertificateSelector(state.giftCertificates);
         const instruments = createInstrumentSelector(state.instruments);
+        const orderBillingAddress = createOrderBillingAddressSelector(state.orderBillingAddress);
         const paymentMethods = createPaymentMethodSelector(state.paymentMethods);
         const paymentStrategies = createPaymentStrategySelector(state.paymentStrategies);
         const pickupOptions = createPickupOptionSelector(state.pickupOptions);
@@ -96,7 +99,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             customer,
             giftCertificates,
         );
-        const order = createOrderSelector(state.order, billingAddress, coupons);
+        const order = createOrderSelector(state.order, orderBillingAddress, coupons);
         const payment = createPaymentSelector(checkout, order);
         const config = createConfigSelector(state.config, state.formFields);
 
@@ -115,6 +118,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             giftCertificates,
             instruments,
             order,
+            createOrderBillingAddressSelector,
             payment,
             paymentMethods,
             paymentStrategies,

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -7,6 +7,7 @@ import { CustomerSelector, CustomerStrategySelector } from '../customer';
 import { FormSelector } from '../form';
 import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
+import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
@@ -38,6 +39,7 @@ export default interface InternalCheckoutSelectors {
     giftCertificates: GiftCertificateSelector;
     instruments: InstrumentSelector;
     order: OrderSelector;
+    orderBillingAddress: OrderBillingAddressSelector;
     payment: PaymentSelector;
     paymentMethods: PaymentMethodSelector;
     paymentStrategies: PaymentStrategySelector;

--- a/packages/core/src/customer/map-to-internal-customer.ts
+++ b/packages/core/src/customer/map-to-internal-customer.ts
@@ -1,5 +1,5 @@
 import { mapToInternalAddress } from '../address';
-import { BillingAddress } from '../billing';
+import { OrderBillingAddress } from '../order-billing-address/order-billing-address-state';
 
 import InternalCustomer from './internal-customer';
 
@@ -12,7 +12,7 @@ import { Customer } from '.';
  */
 export default function mapToInternalCustomer(
     customer: Customer,
-    billingAddress: BillingAddress,
+    billingAddress: OrderBillingAddress,
 ): InternalCustomer {
     const firstName = customer.firstName || billingAddress.firstName || '';
     const lastName = customer.lastName || billingAddress.lastName || '';

--- a/packages/core/src/order-billing-address/index.ts
+++ b/packages/core/src/order-billing-address/index.ts
@@ -1,0 +1,2 @@
+export { default as OrderBillingAddressState } from './order-billing-address-state';
+export { default as orderBillingAddressReducer } from './order-billing-address-reducer';

--- a/packages/core/src/order-billing-address/index.ts
+++ b/packages/core/src/order-billing-address/index.ts
@@ -1,2 +1,8 @@
 export { default as OrderBillingAddressState } from './order-billing-address-state';
 export { default as orderBillingAddressReducer } from './order-billing-address-reducer';
+export {
+    default as OrderBillingAddressSelectorFactory,
+    createOrderBillingAddressSelectorFactory,
+} from './order-billing-address-selector';
+
+export { getOrderBillingAddressState } from './order-billing-address.mock';

--- a/packages/core/src/order-billing-address/order-billing-address-reducer.spec.ts
+++ b/packages/core/src/order-billing-address/order-billing-address-reducer.spec.ts
@@ -1,0 +1,25 @@
+import { createAction } from '@bigcommerce/data-store';
+
+import { OrderActionType } from '../order';
+import { getOrder } from '../order/orders.mock';
+
+import orderBillingAddressReducer from './order-billing-address-reducer';
+
+import { OrderBillingAddressState } from '.';
+
+describe('orderBillingAddressReducer', () => {
+    let initialState: OrderBillingAddressState;
+
+    beforeEach(() => {
+        initialState = {};
+    });
+
+    it('returns billing address when order loads', () => {
+        const action = createAction(OrderActionType.LoadOrderSucceeded, getOrder());
+        const output = orderBillingAddressReducer(initialState, action);
+
+        expect(output).toEqual({
+            data: action.payload && action.payload.billingAddress,
+        });
+    });
+});

--- a/packages/core/src/order-billing-address/order-billing-address-reducer.ts
+++ b/packages/core/src/order-billing-address/order-billing-address-reducer.ts
@@ -1,11 +1,16 @@
 import { Action, combineReducers } from '@bigcommerce/data-store';
+
 import { replace } from '../common/utility';
 import { OrderAction, OrderActionType } from '../order';
-import OrderBillingAddressState, { DEFAULT_STATE, OrderBillingAddress } from "./order-billing-address-state";
+
+import OrderBillingAddressState, {
+    DEFAULT_STATE,
+    OrderBillingAddress,
+} from './order-billing-address-state';
 
 export default function orderBillingAddressReducer(
     state: OrderBillingAddressState = DEFAULT_STATE,
-    action: Action
+    action: Action,
 ): OrderBillingAddressState {
     const reducer = combineReducers<OrderBillingAddressState>({
         data: dataReducer,
@@ -20,7 +25,6 @@ function dataReducer(
 ): OrderBillingAddress | undefined {
     switch (action.type) {
         case OrderActionType.LoadOrderSucceeded:
-            console.log(action.type, 'lolol');
             return replace(data, action.payload && action.payload.billingAddress);
 
         default:

--- a/packages/core/src/order-billing-address/order-billing-address-reducer.ts
+++ b/packages/core/src/order-billing-address/order-billing-address-reducer.ts
@@ -1,0 +1,29 @@
+import { Action, combineReducers } from '@bigcommerce/data-store';
+import { replace } from '../common/utility';
+import { OrderAction, OrderActionType } from '../order';
+import OrderBillingAddressState, { DEFAULT_STATE, OrderBillingAddress } from "./order-billing-address-state";
+
+export default function orderBillingAddressReducer(
+    state: OrderBillingAddressState = DEFAULT_STATE,
+    action: Action
+): OrderBillingAddressState {
+    const reducer = combineReducers<OrderBillingAddressState>({
+        data: dataReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: OrderBillingAddress | undefined,
+    action: OrderAction,
+): OrderBillingAddress | undefined {
+    switch (action.type) {
+        case OrderActionType.LoadOrderSucceeded:
+            console.log(action.type, 'lolol');
+            return replace(data, action.payload && action.payload.billingAddress);
+
+        default:
+            return data;
+    }
+}

--- a/packages/core/src/order-billing-address/order-billing-address-selector.spec.ts
+++ b/packages/core/src/order-billing-address/order-billing-address-selector.spec.ts
@@ -1,0 +1,28 @@
+import { CheckoutStoreState } from '../checkout';
+import { getCheckoutStoreState } from '../checkout/checkouts.mock';
+
+import OrderBillingAddressSelector, {
+    createOrderBillingAddressSelectorFactory,
+    OrderBillingAddressSelectorFactory,
+} from './order-billing-address-selector';
+
+describe('OrderBillingAddressSelector', () => {
+    let orderBillingAddressSelector: OrderBillingAddressSelector;
+    let createOrderCreateBillingAddressSelector: OrderBillingAddressSelectorFactory;
+    let state: CheckoutStoreState;
+
+    beforeEach(() => {
+        createOrderCreateBillingAddressSelector = createOrderBillingAddressSelectorFactory();
+        state = getCheckoutStoreState();
+    });
+
+    it('returns the current billing address from order if present', () => {
+        orderBillingAddressSelector = createOrderCreateBillingAddressSelector(
+            state.orderBillingAddress,
+        );
+
+        expect(orderBillingAddressSelector.getOrderBillingAddress()).toEqual(
+            state.orderBillingAddress.data,
+        );
+    });
+});

--- a/packages/core/src/order-billing-address/order-billing-address-selector.ts
+++ b/packages/core/src/order-billing-address/order-billing-address-selector.ts
@@ -1,0 +1,31 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { createSelector } from '../common/selector';
+
+import OrderBillingAddressState, {
+    DEFAULT_STATE,
+    OrderBillingAddress,
+} from './order-billing-address-state';
+
+export default interface OrderBillingAddressSelector {
+    getOrderBillingAddress(): OrderBillingAddress | undefined;
+}
+
+export type OrderBillingAddressSelectorFactory = (
+    state: OrderBillingAddressState,
+) => OrderBillingAddressSelector;
+
+export function createOrderBillingAddressSelectorFactory(): OrderBillingAddressSelectorFactory {
+    const getOrderBillingAddress = createSelector(
+        (state: OrderBillingAddressState) => state.data,
+        (data) => () => data,
+    );
+
+    return memoizeOne(
+        (state: OrderBillingAddressState = DEFAULT_STATE): OrderBillingAddressSelector => {
+            return {
+                getOrderBillingAddress: getOrderBillingAddress(state),
+            };
+        },
+    );
+}

--- a/packages/core/src/order-billing-address/order-billing-address-state.ts
+++ b/packages/core/src/order-billing-address/order-billing-address-state.ts
@@ -1,4 +1,4 @@
-import { BillingAddress } from "../billing";
+import { BillingAddress } from '../billing';
 
 export type OrderBillingAddress = Omit<BillingAddress, 'id'>;
 

--- a/packages/core/src/order-billing-address/order-billing-address-state.ts
+++ b/packages/core/src/order-billing-address/order-billing-address-state.ts
@@ -1,0 +1,9 @@
+import { BillingAddress } from "../billing";
+
+export type OrderBillingAddress = Omit<BillingAddress, 'id'>;
+
+export default interface OrderBillingAddressState {
+    data?: OrderBillingAddress;
+}
+
+export const DEFAULT_STATE: OrderBillingAddressState = {};

--- a/packages/core/src/order-billing-address/order-billing-address-state.ts
+++ b/packages/core/src/order-billing-address/order-billing-address-state.ts
@@ -1,6 +1,8 @@
-import { BillingAddress } from '../billing';
+import { Address } from '../address';
 
-export type OrderBillingAddress = Omit<BillingAddress, 'id'>;
+export interface OrderBillingAddress extends Address {
+    email?: string;
+}
 
 export default interface OrderBillingAddressState {
     data?: OrderBillingAddress;

--- a/packages/core/src/order-billing-address/order-billing-address.mock.ts
+++ b/packages/core/src/order-billing-address/order-billing-address.mock.ts
@@ -1,0 +1,27 @@
+import OrderBillingAddressState, { OrderBillingAddress } from './order-billing-address-state';
+
+export function getOrderBillingAddress(): OrderBillingAddress {
+    return {
+        firstName: 'Test',
+        lastName: 'Tester',
+        email: 'test@bigcommerce.com',
+        company: 'Bigcommerce',
+        address1: '12345 Testing Way',
+        address2: '',
+        city: 'Some City',
+        stateOrProvince: 'California',
+        stateOrProvinceCode: 'CA',
+        country: 'United States',
+        countryCode: 'US',
+        postalCode: '95555',
+        shouldSaveAddress: true,
+        phone: '555-555-5555',
+        customFields: [],
+    };
+}
+
+export function getOrderBillingAddressState(): OrderBillingAddressState {
+    return {
+        data: getOrderBillingAddress(),
+    };
+}

--- a/packages/core/src/order/order-selector.spec.ts
+++ b/packages/core/src/order/order-selector.spec.ts
@@ -30,13 +30,13 @@ describe('OrderSelector', () => {
         it('returns the current order', () => {
             orderSelector = createOrderSelector(
                 state.order,
-                selectors.billingAddress,
+                selectors.orderBillingAddress,
                 selectors.coupons,
             );
 
             expect(orderSelector.getOrder()).toEqual({
                 ...getOrder(),
-                billingAddress: selectors.billingAddress.getBillingAddress(),
+                billingAddress: selectors.orderBillingAddress.getOrderBillingAddress(),
                 coupons: selectors.coupons.getCoupons(),
             });
         });
@@ -46,7 +46,7 @@ describe('OrderSelector', () => {
         it('returns order meta', () => {
             orderSelector = createOrderSelector(
                 state.order,
-                selectors.billingAddress,
+                selectors.orderBillingAddress,
                 selectors.coupons,
             );
 
@@ -63,7 +63,7 @@ describe('OrderSelector', () => {
                     ...state.order,
                     errors: { loadError },
                 },
-                selectors.billingAddress,
+                selectors.orderBillingAddress,
                 selectors.coupons,
             );
 
@@ -73,7 +73,7 @@ describe('OrderSelector', () => {
         it('does not returns error if able to load', () => {
             orderSelector = createOrderSelector(
                 state.order,
-                selectors.billingAddress,
+                selectors.orderBillingAddress,
                 selectors.coupons,
             );
 
@@ -96,7 +96,7 @@ describe('OrderSelector', () => {
 
                 orderSelector = createOrderSelector(
                     orderState,
-                    selectors.billingAddress,
+                    selectors.orderBillingAddress,
                     selectors.coupons,
                 );
 
@@ -108,7 +108,7 @@ describe('OrderSelector', () => {
             it('returns undefined', () => {
                 orderSelector = createOrderSelector(
                     state.order,
-                    selectors.billingAddress,
+                    selectors.orderBillingAddress,
                     selectors.coupons,
                 );
 
@@ -124,7 +124,7 @@ describe('OrderSelector', () => {
                     ...state.order,
                     statuses: { isLoading: true },
                 },
-                selectors.billingAddress,
+                selectors.orderBillingAddress,
                 selectors.coupons,
             );
 
@@ -134,7 +134,7 @@ describe('OrderSelector', () => {
         it('returns false if not loading order', () => {
             orderSelector = createOrderSelector(
                 state.order,
-                selectors.billingAddress,
+                selectors.orderBillingAddress,
                 selectors.coupons,
             );
 

--- a/packages/core/src/order/order-selector.ts
+++ b/packages/core/src/order/order-selector.ts
@@ -1,10 +1,10 @@
 import { memoizeOne } from '@bigcommerce/memoize';
 
-import { BillingAddressSelector } from '../billing';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { createSelector } from '../common/selector';
 import { guard } from '../common/utility';
 import { CouponSelector } from '../coupon';
+import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
 
 import Order from './order';
 import OrderState, { DEFAULT_STATE, OrderMetaState } from './order-state';
@@ -20,12 +20,12 @@ export default interface OrderSelector {
 
 export type OrderSelectorFactory = (
     state: OrderState,
-    billingAddress: BillingAddressSelector,
+    billingAddress: OrderBillingAddressSelector,
     coupons: CouponSelector,
 ) => OrderSelector;
 
 interface OrderSelectorDependencies {
-    billingAddress: BillingAddressSelector;
+    billingAddress: OrderBillingAddressSelector;
     coupons: CouponSelector;
 }
 
@@ -33,7 +33,7 @@ export function createOrderSelectorFactory(): OrderSelectorFactory {
     const getOrder = createSelector(
         (state: OrderState) => state.data,
         (_: OrderState, { billingAddress }: OrderSelectorDependencies) =>
-            billingAddress.getBillingAddress(),
+            billingAddress.getOrderBillingAddress(),
         (_: OrderState, { coupons }: OrderSelectorDependencies) => coupons.getCoupons(),
         (data, billingAddress, coupons = []) =>
             () => {
@@ -81,7 +81,7 @@ export function createOrderSelectorFactory(): OrderSelectorFactory {
     return memoizeOne(
         (
             state: OrderState = DEFAULT_STATE,
-            billingAddress: BillingAddressSelector,
+            billingAddress: OrderBillingAddressSelector,
             coupons: CouponSelector,
         ): OrderSelector => {
             return {

--- a/packages/core/src/order/order.ts
+++ b/packages/core/src/order/order.ts
@@ -1,14 +1,14 @@
-import { BillingAddress } from '../billing';
 import { LineItemMap } from '../cart';
 import { Coupon } from '../coupon';
 import { Currency } from '../currency';
+import { OrderBillingAddress } from '../order-billing-address/order-billing-address-state';
 import { Tax } from '../tax';
 
 import { OrderMetaState } from './order-state';
 
 export default interface Order {
     baseAmount: number;
-    billingAddress: BillingAddress;
+    billingAddress: OrderBillingAddress;
     cartId: string;
     coupons: Coupon[];
     consignments: OrderConsignment;

--- a/packages/core/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/affirm/affirm-payment-strategy.spec.ts
@@ -23,6 +23,7 @@ import {
     OrderRequestBody,
     OrderRequestSender,
 } from '../../../order';
+import { getOrderBillingAddressState } from '../../../order-billing-address';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getOrderState } from '../../../order/orders.mock';
@@ -79,6 +80,7 @@ describe('AffirmPaymentStrategy', () => {
             billingAddress: getBillingAddressState(),
             formFields: getFormFieldsState(),
             order: getOrderState(),
+            orderBillingAddress: getOrderBillingAddressState(),
         });
         checkoutRequestSender = new CheckoutRequestSender(requestSender);
         orderActionCreator = new OrderActionCreator(

--- a/packages/payment-integration-api/src/order/order-billing-address.ts
+++ b/packages/payment-integration-api/src/order/order-billing-address.ts
@@ -1,0 +1,5 @@
+import { Address } from '../address';
+
+export interface OrderBillingAddress extends Address {
+    email?: string;
+}

--- a/packages/payment-integration-api/src/order/order.ts
+++ b/packages/payment-integration-api/src/order/order.ts
@@ -1,14 +1,14 @@
-import { BillingAddress } from '../billing';
 import { LineItemMap } from '../cart';
 import { Coupon } from '../coupon';
 import { Currency } from '../currency';
 import { Tax } from '../tax';
 
+import { OrderBillingAddress } from './order-billing-address';
 import { OrderMetaState } from './order-state';
 
 export default interface Order {
     baseAmount: number;
-    billingAddress: BillingAddress;
+    billingAddress: OrderBillingAddress;
     cartId: string;
     channelId: number;
     coupons: Coupon[];


### PR DESCRIPTION
## What?
Merge billing address returned from load order endpoint with existing address in state.

## Why?
Since load order call returns a billing address without an id, it causes side effects since we replace the existing object. In order to maintain reference to the existing id we need to merge the two objects.

## Testing / Proof
- Circle

@bigcommerce/checkout 
