### PR TITLE
fix(payment): STRIPE-287 Fixed error when using vaulted card L2/L3 field appear as null on dashboard

### DIFF
--- a/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -1564,6 +1564,21 @@ describe('StripeV3PaymentStrategy', () => {
             expect(form.submit).toHaveBeenCalledWith(payload.payment);
         });
 
+        it('submits payment data with hosted form and client_token', async () => {
+            const payload = getOrderRequestBodyVaultedCC();
+            const expectedPayload = {
+                shouldSaveInstrument: true,
+                shouldSetAsDefaultInstrument: true,
+                instrumentId: '{"token":"1234","client_token":"myToken"}',
+            };
+
+            await strategy.initialize(initializeOptions);
+            await strategy.execute(payload);
+
+            expect(form.submit).toHaveBeenCalledWith(payload.payment);
+            expect(payload.payment?.paymentData).toEqual(expectedPayload);
+        });
+
         it('validates user input before submitting data', async () => {
             await strategy.initialize(initializeOptions);
             await strategy.execute(getOrderRequestBodyVaultedCC());

--- a/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -350,6 +350,16 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         ) {
             const form = this._hostedForm;
 
+            if (payment.paymentData && isVaultedInstrument(payment.paymentData)) {
+                payment.paymentData = {
+                    ...payment.paymentData,
+                    instrumentId: JSON.stringify({
+                        token: payment.paymentData?.instrumentId || '',
+                        client_token: clientToken,
+                    }),
+                };
+            }
+
             await form.validate();
             await form.submit(payment);
 


### PR DESCRIPTION
## What? [STRIPE-287](https://bigcommercecloud.atlassian.net/browse/STRIPE-287) 

The `client_token` is sent in the hosted form flow to reuse the payment intent created during initialization and not create a new one.

## Why?

For Stripe V3, while having `PROJECT-5205.stripe.L3Data` set as on, if we generate orders using vaulted cards then validate the payment on Stripe dashboard, L2/L3 section appear as null. 

## Testing / Proof


https://user-images.githubusercontent.com/69487174/214392681-a9c4cb52-3b62-4d21-9472-197b12e123f5.mov


## Dependency of

https://github.com/bigcommerce/bigpay/pull/6576

ping @bigcommerce/payments @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team 

[STRIPE-287]: https://bigcommercecloud.atlassian.net/browse/STRIPE-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ