### PR TITLE
fix(payment): PAYPAL-1763 fixed an issue when we could not proceed checkout after trying to place order with an empty CVV for stored card

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -150,7 +150,7 @@ export default class BraintreeHostedForm {
 
             return { nonce };
         } catch (error) {
-            const errors = this._mapTokenizeError(error);
+            const errors = this._mapTokenizeError(error, true);
 
             if (errors) {
                 this._formOptions?.onValidate?.({
@@ -270,17 +270,32 @@ export default class BraintreeHostedForm {
 
     private _mapTokenizeError(
         error: BraintreeHostedFormError,
+        isStoredCard = false,
     ): BraintreeFormFieldValidateEventData['errors'] | undefined {
         if (error.code === 'HOSTED_FIELDS_FIELDS_EMPTY') {
-            return {
+            const cvvValidation = {
                 [this._mapFieldType('cvv')]: [this._createRequiredError(this._mapFieldType('cvv'))],
+            };
+
+            const expirationDateValidation = {
                 [this._mapFieldType('expirationDate')]: [
                     this._createRequiredError(this._mapFieldType('expirationDate')),
                 ],
+            };
+
+            const cardNumberValidation = {
                 [this._mapFieldType('number')]: [
                     this._createRequiredError(this._mapFieldType('number')),
                 ],
             };
+
+            return isStoredCard
+                ? cvvValidation
+                : {
+                      ...cvvValidation,
+                      ...expirationDateValidation,
+                      ...cardNumberValidation,
+                  };
         }
 
         return error.details?.invalidFieldKeys?.reduce(


### PR DESCRIPTION
## What?

Fixed an issue when we could not proceed checkout after trying to place order with an empty CVV for stored card

## Why?

According to task [PAYPAL-1763](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1763)

## Testing / Proof

https://user-images.githubusercontent.com/99336044/213465895-fb60736b-a316-4f01-a8d0-9b5e15006e09.mov


@bigcommerce/checkout @bigcommerce/payments


[PAYPAL-1763]: https://bigcommercecloud.atlassian.net/browse/PAYPAL-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ