### PR TITLE
feat(payment): PAYPAL-1882 sending PPC APM V2 gateway instead of PPC APM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1457,9 +1457,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.21.0.tgz",
-      "integrity": "sha512-CyQZ/3fJXadbhies/+WPu6iESWsCQS1FPfWD3RnDJG8ThPsJofqKsJUyrEPsMwUnK1PHqQRhW9y6NLfpTPHbZg==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.22.0.tgz",
+      "integrity": "sha512-M3xr9mo6DEKuiEU6WrXon+WSUVj8OoazmUoXk1KxO9uWAT3iyXixRw3zbhcTKwLu+MfTs3TJ4ksxfztLtVTGDQ==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
-    "@bigcommerce/bigpay-client": "^5.21.0",
+    "@bigcommerce/bigpay-client": "^5.22.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -20,6 +20,7 @@ export enum BaseCheckoutButtonMethodType {
     PAYPALCOMMERCE = 'paypalcommerce',
     PAYPALCOMMERCE_CREDIT = 'paypalcommercecredit',
     PAYPALCOMMERCE_APMS = 'paypalcommercealternativemethods',
+    PAYPALCOMMERCE_APMS_TEMPORARY = 'paypalcommercealternativemethodsv2',
     PAYPALCOMMERCE_INLINE = 'paypalcommerceinline',
     PAYPALCOMMERCE_VENMO = 'paypalcommercevenmo',
 }

--- a/packages/core/src/payment/payment-request-transformer.ts
+++ b/packages/core/src/payment/payment-request-transformer.ts
@@ -164,6 +164,7 @@ export default class PaymentRequestTransformer {
             return { ...paymentMethod, id: CheckoutButtonMethodType.BRAINTREE_PAYPAL };
         }
 
+        // TODO: this block of code should be removed in PAYPAL-1921
         if (
             paymentMethod.gateway === CheckoutButtonMethodType.PAYPALCOMMERCE_APMS &&
             storeConfig?.checkoutSettings.features['PAYPAL-1883.paypal-commerce-split-gateway']


### PR DESCRIPTION
## What?
Added temporary PayPalCommerceAlternativeMethods transformer to PayPalCommerceAlternativeMethodsV2

## Why?
PayPalCommerceAlternativeMethods gateway should be sent to BigPay without transforming to PayPalCommerce gateway. We have only one possible way how to make it as smooth as possible, transform temporary gateway to what we need. 

This code will be removed in the future.

## Testing / Proof
Unit tests
Manual tests

Here is a screenshot of payment method gateway sent to the BigPay:
<img width="737" alt="Screenshot 2023-01-19 at 13 57 19" src="https://user-images.githubusercontent.com/25133454/213486431-18e7de4a-ee99-4550-99ec-5cef37275abb.png">

## Sibling PR:
bigpay-client-js: https://github.com/bigcommerce/bigpay-client-js/pull/155
bigcommerce: https://github.com/bigcommerce/bigcommerce/pull/50776