### PR TITLE
feat(payment): PAYPAL-1913 Create braintreevenmo payment strategy

### DIFF
--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -60,6 +60,7 @@ import {
     BraintreePaypalPaymentStrategy,
     BraintreeScriptLoader,
     BraintreeSDKCreator,
+    BraintreeVenmoPaymentStrategy,
     BraintreeVisaCheckoutPaymentStrategy,
     createBraintreePaymentProcessor,
     createBraintreeVisaCheckoutPaymentProcessor,
@@ -377,7 +378,7 @@ export default function createPaymentStrategyRegistry(
     registry.register(
         PaymentStrategyType.BRAINTREE_VENMO,
         () =>
-            new BraintreePaypalPaymentStrategy(
+            new BraintreeVenmoPaymentStrategy(
                 store,
                 orderActionCreator,
                 paymentActionCreator,

--- a/packages/core/src/payment/payment-methods.mock.ts
+++ b/packages/core/src/payment/payment-methods.mock.ts
@@ -20,6 +20,23 @@ export function getBraintree(): PaymentMethod {
     };
 }
 
+export function getBraintreeVenmo(): PaymentMethod {
+    return {
+        id: 'braintreevenmo',
+        logoUrl: '',
+        method: 'paypal',
+        supportedCards: [],
+        config: {
+            testMode: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        clientToken: 'foo',
+        initializationData: {
+            isBrainteeVenmoEnabled: false,
+        },
+    };
+}
+
 export function getBraintreePaypal(): PaymentMethod {
     return {
         id: 'braintreepaypal',

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -21,6 +21,7 @@ import {
     BraintreeShippingAddressOverride,
     BraintreeThreeDSecure,
     BraintreeTokenizePayload,
+    BraintreeVenmoCheckout,
     BraintreeVerifyPayload,
 } from './braintree';
 import BraintreeHostedForm from './braintree-hosted-form';
@@ -178,6 +179,12 @@ export default class BraintreePaymentProcessor {
         const threeDSecure = await this._braintreeSDKCreator.get3DS();
 
         return this._present3DSChallenge(threeDSecure, amount, nonce);
+    }
+
+    async getVenmoCheckout(): Promise<BraintreeVenmoCheckout> {
+        return new Promise((resolve, reject) => {
+            this._braintreeSDKCreator.getVenmoCheckout(resolve, reject);
+        });
     }
 
     private _getErrorsRequiredFields(

--- a/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.spec.ts
@@ -1,0 +1,303 @@
+import { Action, createAction } from '@bigcommerce/data-store';
+import { omit } from 'lodash';
+import { Observable, of } from 'rxjs';
+
+import { CheckoutStore, createCheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MissingDataError } from '../../../common/error/errors';
+import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import { getOrderRequestBody } from '../../../order/internal-orders.mock';
+import {
+    PaymentArgumentInvalidError,
+    PaymentMethodCancelledError,
+    PaymentMethodFailedError,
+} from '../../errors';
+import PaymentActionCreator from '../../payment-action-creator';
+import { PaymentActionType } from '../../payment-actions';
+import PaymentMethod from '../../payment-method';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentMethodActionType } from '../../payment-method-actions';
+import { getBraintreeVenmo } from '../../payment-methods.mock';
+import { PaymentInitializeOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+import { BraintreeTokenizePayload, BraintreeVenmoCheckout } from './braintree';
+import BraintreePaymentProcessor from './braintree-payment-processor';
+import BraintreeVenmoPaymentStrategy from './braintree-venmo-payment-strategy';
+
+describe('BraintreeVenmoPaymentStrategy', () => {
+    let orderActionCreator: OrderActionCreator;
+    let paymentActionCreator: PaymentActionCreator;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let braintreePaymentProcessorMock: BraintreePaymentProcessor;
+    let braintreeVenmoPaymentStrategy: PaymentStrategy;
+    let paymentMethodMock: PaymentMethod;
+    let loadPaymentMethodAction: Observable<Action>;
+    let store: CheckoutStore;
+    let submitOrderAction: Observable<Action>;
+    let submitPaymentAction: Observable<Action>;
+    let tokenizeMock: BraintreeVenmoCheckout['tokenize'];
+    let options: PaymentInitializeOptions;
+
+    beforeEach(() => {
+        const braintreeTokenizePayload: Partial<BraintreeTokenizePayload> = {
+            nonce: 'nonce-key',
+            details: {
+                email: 'braintreeTokenize@email.com',
+            },
+        };
+
+        tokenizeMock = jest.fn((callback) => callback(undefined, braintreeTokenizePayload));
+        braintreePaymentProcessorMock = {} as BraintreePaymentProcessor;
+        braintreePaymentProcessorMock.initialize = jest.fn();
+        braintreePaymentProcessorMock.getVenmoCheckout = jest.fn(
+            (): Promise<Partial<BraintreeVenmoCheckout>> =>
+                Promise.resolve({
+                    tokenize: tokenizeMock,
+                    isBrowserSupported: () => true,
+                }),
+        );
+        braintreePaymentProcessorMock.getSessionId = jest.fn(() => 'my_session_id');
+        braintreePaymentProcessorMock.deinitialize = jest.fn();
+
+        paymentMethodMock = { ...getBraintreeVenmo(), clientToken: 'myToken' };
+        options = { methodId: paymentMethodMock.id };
+        submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
+        submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
+        loadPaymentMethodAction = of(
+            createAction(
+                PaymentMethodActionType.LoadPaymentMethodSucceeded,
+                paymentMethodMock,
+                options,
+            ),
+        );
+
+        store = createCheckoutStore(getCheckoutStoreState());
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethodMock,
+        );
+
+        orderActionCreator = {} as OrderActionCreator;
+        orderActionCreator.submitOrder = jest.fn(() => submitOrderAction);
+
+        paymentActionCreator = {} as PaymentActionCreator;
+        paymentActionCreator.submitPayment = jest.fn(() => submitPaymentAction);
+
+        paymentMethodActionCreator = {} as PaymentMethodActionCreator;
+        paymentMethodActionCreator.loadPaymentMethod = jest.fn(() => loadPaymentMethodAction);
+
+        braintreeVenmoPaymentStrategy = new BraintreeVenmoPaymentStrategy(
+            store,
+            orderActionCreator,
+            paymentActionCreator,
+            paymentMethodActionCreator,
+            braintreePaymentProcessorMock,
+        );
+    });
+
+    it('creates an instance of the braintree venmo payment strategy', () => {
+        expect(braintreeVenmoPaymentStrategy).toBeInstanceOf(BraintreeVenmoPaymentStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('initializes the braintree venmo payment processor with the client token', async () => {
+            const options = { methodId: paymentMethodMock.id };
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith('myToken');
+            expect(braintreePaymentProcessorMock.getVenmoCheckout).toHaveBeenCalled();
+        });
+
+        it('throws error if clientToken does not exist', async () => {
+            paymentMethodMock.clientToken = undefined;
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+                paymentMethodMock,
+            );
+
+            try {
+                await braintreeVenmoPaymentStrategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throw error if getVenmoCheckout fails', async () => {
+            jest.spyOn(braintreePaymentProcessorMock, 'getVenmoCheckout').mockReturnValue(
+                Promise.reject({
+                    name: 'notBraintreeError',
+                    message: 'my_message',
+                }),
+            );
+
+            try {
+                await braintreeVenmoPaymentStrategy.initialize(options);
+            } catch (error) {
+                expect(error.message).toBe('my_message');
+            }
+        });
+    });
+
+    describe('#execute()', () => {
+        let orderRequestBody: OrderRequestBody;
+
+        beforeEach(() => {
+            orderRequestBody = getOrderRequestBody();
+        });
+
+        it('calls submit order with the order request information', async () => {
+            await braintreeVenmoPaymentStrategy.initialize(options);
+            await braintreeVenmoPaymentStrategy.execute(orderRequestBody, options);
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(
+                omit(orderRequestBody, 'payment'),
+                expect.any(Object),
+            );
+            expect(store.dispatch).toHaveBeenCalledWith(submitOrderAction);
+        });
+
+        it('refresh the state if paymentMethod has nonce value', async () => {
+            paymentMethodMock.nonce = 'some-nonce';
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+                paymentMethodMock,
+            );
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+            await braintreeVenmoPaymentStrategy.execute(orderRequestBody, options);
+
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledTimes(1);
+            expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledTimes(1);
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledTimes(1);
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledTimes(1);
+        });
+
+        it('pass the options to submitOrder', async () => {
+            await braintreeVenmoPaymentStrategy.initialize(options);
+            await braintreeVenmoPaymentStrategy.execute(orderRequestBody, options);
+
+            expect(orderActionCreator.submitOrder).toHaveBeenCalledWith(
+                expect.any(Object),
+                options,
+            );
+        });
+
+        it('does not call braintreeVenmoCheckout.tokenize if a nonce is present', async () => {
+            paymentMethodMock.nonce = 'some-nonce';
+
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+                paymentMethodMock,
+            );
+
+            const expected = expect.objectContaining({
+                paymentData: {
+                    formattedPayload: {
+                        vault_payment_instrument: null,
+                        set_as_default_stored_instrument: null,
+                        device_info: null,
+                        paypal_account: {
+                            token: 'some-nonce',
+                            email: null,
+                        },
+                    },
+                },
+            });
+
+            await braintreeVenmoPaymentStrategy.initialize({ methodId: paymentMethodMock.id });
+            await braintreeVenmoPaymentStrategy.execute(orderRequestBody, options);
+
+            expect(tokenizeMock).not.toHaveBeenCalled();
+            expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);
+            expect(store.dispatch).toHaveBeenCalledWith(submitPaymentAction);
+        });
+
+        it('throw error after user closed modal window', async () => {
+            const tokenizeMockError = jest.fn((callback) =>
+                callback(
+                    {
+                        name: 'BraintreeError',
+                        message: 'my_message',
+                        code: 'PAYPAL_POPUP_CLOSED',
+                    },
+                    undefined,
+                ),
+            );
+
+            braintreePaymentProcessorMock.getVenmoCheckout = jest.fn(
+                (): Promise<Partial<BraintreeVenmoCheckout>> =>
+                    Promise.resolve({
+                        tokenize: tokenizeMockError,
+                        isBrowserSupported: () => true,
+                    }),
+            );
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            await expect(
+                braintreeVenmoPaymentStrategy.execute(orderRequestBody, options),
+            ).rejects.toEqual(expect.any(PaymentMethodCancelledError));
+            expect(orderActionCreator.submitOrder).not.toHaveBeenCalled();
+        });
+
+        it('throw error after tokenize error', async () => {
+            const tokenizeMockError = jest.fn((callback) =>
+                callback(
+                    {
+                        name: 'BraintreeError',
+                        message: 'my_message',
+                    },
+                    undefined,
+                ),
+            );
+
+            braintreePaymentProcessorMock.getVenmoCheckout = jest.fn(
+                (): Promise<Partial<BraintreeVenmoCheckout>> =>
+                    Promise.resolve({
+                        tokenize: tokenizeMockError,
+                        isBrowserSupported: () => true,
+                    }),
+            );
+
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            await expect(
+                braintreeVenmoPaymentStrategy.execute(orderRequestBody, options),
+            ).rejects.toEqual(expect.any(PaymentMethodFailedError));
+            expect(orderActionCreator.submitOrder).not.toHaveBeenCalled();
+        });
+
+        it('throw error when no payment options exist', async () => {
+            await braintreeVenmoPaymentStrategy.initialize(options);
+
+            try {
+                braintreeVenmoPaymentStrategy.execute({}, options);
+            } catch (error) {
+                expect(error).toEqual(expect.any(PaymentArgumentInvalidError));
+            }
+
+            expect(orderActionCreator.submitOrder).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('calls deinitialize in the braintree payment processor', async () => {
+            braintreePaymentProcessorMock.deinitialize = jest.fn(() => Promise.resolve());
+
+            await braintreeVenmoPaymentStrategy.deinitialize();
+
+            expect(braintreePaymentProcessorMock.deinitialize).toHaveBeenCalled();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            try {
+                await braintreeVenmoPaymentStrategy.finalize();
+            } catch (error) {
+                expect(error).toBeInstanceOf(OrderFinalizationNotRequiredError);
+            }
+        });
+    });
+});

--- a/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.ts
@@ -1,0 +1,156 @@
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
+import { OrderFinalizationNotRequiredError } from '../../../order/errors';
+import {
+    PaymentArgumentInvalidError,
+    PaymentMethodCancelledError,
+    PaymentMethodFailedError,
+} from '../../errors';
+import Payment, { FormattedPayload, PaypalInstrument } from '../../payment';
+import PaymentActionCreator from '../../payment-action-creator';
+import PaymentMethodActionCreator from '../../payment-method-action-creator';
+import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
+import PaymentStrategy from '../payment-strategy';
+
+import { BraintreeError, BraintreeTokenizePayload, BraintreeVenmoCheckout } from './braintree';
+import BraintreePaymentProcessor from './braintree-payment-processor';
+import isBraintreeError from './is-braintree-error';
+
+export default class BraintreeVenmoPaymentStrategy implements PaymentStrategy {
+    private _braintreeVenmoCheckout?: BraintreeVenmoCheckout;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _orderActionCreator: OrderActionCreator,
+        private _paymentActionCreator: PaymentActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _braintreePaymentProcessor: BraintreePaymentProcessor,
+    ) {}
+
+    async initialize(options: PaymentInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options;
+
+        const state = await this._store.dispatch(
+            this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+        );
+
+        const { clientToken } = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        await this._initializeBraintreeVenmo(clientToken);
+
+        return this._store.getState();
+    }
+
+    async execute(
+        orderRequest: OrderRequestBody,
+        options?: PaymentRequestOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        const { payment, ...order } = orderRequest;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        try {
+            const paymentData = await this._preparePaymentData(payment);
+
+            await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
+
+            return await this._store.dispatch(
+                this._paymentActionCreator.submitPayment(paymentData),
+            );
+        } catch (error) {
+            this._handleError(error);
+        }
+    }
+
+    finalize(): Promise<InternalCheckoutSelectors> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    async deinitialize(): Promise<InternalCheckoutSelectors> {
+        await this._braintreePaymentProcessor.deinitialize();
+
+        return this._store.getState();
+    }
+
+    private _handleError(error: BraintreeError | Error): never {
+        if (!isBraintreeError(error)) {
+            throw error;
+        }
+
+        if (error.code === 'PAYPAL_POPUP_CLOSED') {
+            throw new PaymentMethodCancelledError(error.message);
+        }
+
+        throw new PaymentMethodFailedError(error.message);
+    }
+
+    private async _initializeBraintreeVenmo(clientToken?: string): Promise<void> {
+        if (!clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        try {
+            this._braintreePaymentProcessor.initialize(clientToken);
+            this._braintreeVenmoCheckout = await this._braintreePaymentProcessor.getVenmoCheckout();
+        } catch (error) {
+            this._handleError(error);
+        }
+    }
+
+    private async _preparePaymentData(payment: OrderPaymentRequestBody): Promise<Payment> {
+        const { nonce } = this._store
+            .getState()
+            .paymentMethods.getPaymentMethodOrThrow(payment.methodId);
+
+        if (nonce) {
+            return { ...payment, paymentData: this._formattedPayload(nonce) };
+        }
+
+        const tokenizeResult = await this._braintreeVenmoTokenize();
+        const sessionId = await this._braintreePaymentProcessor.getSessionId();
+
+        return {
+            ...payment,
+            paymentData: this._formattedPayload(
+                tokenizeResult.nonce,
+                tokenizeResult.details.email,
+                sessionId,
+            ),
+        };
+    }
+
+    private _formattedPayload(
+        token: string,
+        email?: string,
+        sessionId?: string,
+    ): FormattedPayload<PaypalInstrument> {
+        return {
+            formattedPayload: {
+                vault_payment_instrument: null,
+                set_as_default_stored_instrument: null,
+                device_info: sessionId || null,
+                paypal_account: {
+                    token,
+                    email: email || null,
+                },
+            },
+        };
+    }
+
+    private _braintreeVenmoTokenize(): Promise<BraintreeTokenizePayload> {
+        return new Promise((resolve, reject) => {
+            this._braintreeVenmoCheckout?.tokenize(
+                (error: BraintreeError, payload: BraintreeTokenizePayload) => {
+                    if (error) {
+                        return reject(error);
+                    }
+
+                    resolve(payload);
+                },
+            );
+        });
+    }
+}

--- a/packages/core/src/payment/strategies/braintree/index.ts
+++ b/packages/core/src/payment/strategies/braintree/index.ts
@@ -5,6 +5,7 @@ export { BraintreePaymentInitializeOptions } from './braintree-payment-options';
 export { default as BraintreeCreditCardPaymentStrategy } from './braintree-credit-card-payment-strategy';
 export { default as BraintreePaymentProcessor } from './braintree-payment-processor';
 export { default as BraintreePaypalPaymentStrategy } from './braintree-paypal-payment-strategy';
+export { default as BraintreeVenmoPaymentStrategy } from './braintree-venmo-payment-strategy';
 export { default as BraintreeVisaCheckoutPaymentProcessor } from './braintree-visacheckout-payment-processor';
 export { default as BraintreeScriptLoader } from './braintree-script-loader';
 export { default as BraintreeSDKCreator } from './braintree-sdk-creator';


### PR DESCRIPTION
## What?
Add Braintree venmo strategy for payment step
PR BCapp: [https://github.com/bigcommerce/bigcommerce/pull/50862](https://github.com/bigcommerce/bigcommerce/pull/50862)

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/PAYPAL-1913](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1913)

## Testing / Proof
<img width="1217" alt="Screenshot 2023-01-26 at 11 00 44" src="https://user-images.githubusercontent.com/9430298/214805130-6ab3d072-e545-4d99-8729-1b11bbb9b7b6.png">
<img width="1212" alt="Screenshot 2023-01-26 at 11 00 55" src="https://user-images.githubusercontent.com/9430298/214805153-2f3d3334-9ac3-482b-8d06-d0997039b4c2.png">
Checkout-sdk-js test:
<img width="437" alt="Screenshot 2023-01-26 at 11 28 43" src="https://user-images.githubusercontent.com/9430298/214805209-318a9fb7-ddce-483f-b00c-fe8eb51230e5.png">
BCapp test:
<img width="1561" alt="Screenshot 2023-01-26 at 11 31 29" src="https://user-images.githubusercontent.com/9430298/214805264-11e97f46-ec65-4326-87fe-41ded186c1dd.png">


@bigcommerce/checkout @bigcommerce/payments
