### PR TITLE
feat(payment): PAYPAL-1840 Create braintreepaypalcredit customer button strategy

### DIFF
--- a/packages/core/src/customer/create-customer-strategy-registry.ts
+++ b/packages/core/src/customer/create-customer-strategy-registry.ts
@@ -65,6 +65,7 @@ import { AmazonPayV2CustomerStrategy } from './strategies/amazon-pay-v2';
 import { ApplePayCustomerStrategy } from './strategies/apple-pay';
 import { BoltCustomerStrategy } from './strategies/bolt';
 import {
+    BraintreePaypalCreditCustomerStrategy,
     BraintreePaypalCustomerStrategy,
     BraintreeVisaCheckoutCustomerStrategy,
 } from './strategies/braintree';
@@ -182,6 +183,20 @@ export default function createCustomerStrategyRegistry(
         'braintreepaypal',
         () =>
             new BraintreePaypalCustomerStrategy(
+                store,
+                checkoutActionCreator,
+                customerActionCreator,
+                paymentMethodActionCreator,
+                braintreeSDKCreator,
+                formPoster,
+                window,
+            ),
+    );
+
+    registry.register(
+        'braintreepaypalcredit',
+        () =>
+            new BraintreePaypalCreditCustomerStrategy(
                 store,
                 checkoutActionCreator,
                 customerActionCreator,

--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -3,6 +3,7 @@ import { RequestOptions } from '../common/http-request';
 import { AmazonPayV2CustomerInitializeOptions } from './strategies/amazon-pay-v2';
 import { BoltCustomerInitializeOptions } from './strategies/bolt';
 import {
+    BraintreePaypalCreditCustomerInitializeOptions,
     BraintreePaypalCustomerInitializeOptions,
     BraintreeVisaCheckoutCustomerInitializeOptions,
 } from './strategies/braintree';
@@ -48,6 +49,12 @@ export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
      * when using Braintree PayPal provided.
      */
     braintreepaypal?: BraintreePaypalCustomerInitializeOptions;
+
+    /**
+     * The options that are required to facilitate Braintree Credit. They can be
+     * omitted unless you need to support Braintree Credit.
+     */
+    braintreepaypalcredit?: BraintreePaypalCreditCustomerInitializeOptions;
 
     /**
      * The options that are required to initialize the customer step of checkout

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-options.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-options.ts
@@ -1,0 +1,16 @@
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+
+export default interface BraintreePaypalCreditCustomerInitializeOptions {
+    /**
+     * The ID of a container which the checkout button should be inserted into.
+     */
+    container: string;
+
+    /**
+     * A callback that gets called on any error instead of submit payment or authorization errors.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: BraintreeError | StandardError): void;
+}

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
@@ -1,0 +1,507 @@
+import { Action, createAction } from '@bigcommerce/data-store';
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+import { Observable, of } from 'rxjs';
+
+import {
+    CheckoutActionCreator,
+    CheckoutRequestSender,
+    CheckoutStore,
+    createCheckoutStore,
+} from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
+import { MutationObserverFactory } from '../../../common/dom';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfig } from '../../../config/configs.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import {
+    PaymentMethod,
+    PaymentMethodActionCreator,
+    PaymentMethodActionType,
+    PaymentStrategyType,
+} from '../../../payment';
+import { getBraintree } from '../../../payment/payment-methods.mock';
+import {
+    BraintreeDataCollector,
+    BraintreePaypalCheckout,
+    BraintreePaypalCheckoutCreator,
+    BraintreeScriptLoader,
+    BraintreeSDKCreator,
+} from '../../../payment/strategies/braintree';
+import {
+    getDataCollectorMock,
+    getPayPalCheckoutCreatorMock,
+    getPaypalCheckoutMock,
+} from '../../../payment/strategies/braintree/braintree.mock';
+import {
+    PaypalButtonOptions,
+    PaypalButtonStyleColorOption,
+    PaypalHostWindow,
+    PaypalSDK,
+} from '../../../payment/strategies/paypal';
+import { getPaypalMock } from '../../../payment/strategies/paypal/paypal.mock';
+import {
+    GoogleRecaptcha,
+    GoogleRecaptchaScriptLoader,
+    GoogleRecaptchaWindow,
+    SpamProtectionActionCreator,
+    SpamProtectionRequestSender,
+} from '../../../spam-protection';
+import CustomerActionCreator from '../../customer-action-creator';
+import { CustomerInitializeOptions } from '../../customer-request-options';
+import CustomerRequestSender from '../../customer-request-sender';
+
+import BraintreePaypalCreditCustomerInitializeOptions from './braintree-paypal-credit-customer-options';
+import BraintreePaypalCreditCustomerStrategy from './braintree-paypal-credit-customer-strategy';
+
+describe('BraintreePaypalCreditCustomerStrategy', () => {
+    let braintreeSDKCreator: BraintreeSDKCreator;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let braintreePaypalCheckoutCreatorMock: BraintreePaypalCheckoutCreator;
+    let braintreePaypalCheckoutMock: BraintreePaypalCheckout;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let dataCollector: BraintreeDataCollector;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let paymentMethodMock: PaymentMethod;
+    let paypalButtonElement: HTMLDivElement;
+    let paypalSdkMock: PaypalSDK;
+    let store: CheckoutStore;
+    let strategy: BraintreePaypalCreditCustomerStrategy;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let customerActionCreator: CustomerActionCreator;
+    let loadPaymentMethodAction: Observable<Action>;
+    let googleRecaptcha: GoogleRecaptcha;
+    let googleRecaptchaMockWindow: GoogleRecaptchaWindow;
+    let googleRecaptchaScriptLoader: GoogleRecaptchaScriptLoader;
+
+    const defaultButtonContainerId = 'braintree-paypal-button-mock-id';
+
+    const braintreePaypalCreditOptions: BraintreePaypalCreditCustomerInitializeOptions = {
+        container: defaultButtonContainerId,
+        onError: jest.fn(),
+    };
+
+    const initializationOptions: CustomerInitializeOptions = {
+        methodId: PaymentStrategyType.BRAINTREE_PAYPAL_CREDIT,
+        braintreepaypalcredit: braintreePaypalCreditOptions,
+    };
+
+    beforeEach(() => {
+        braintreePaypalCheckoutMock = getPaypalCheckoutMock();
+        braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(
+            braintreePaypalCheckoutMock,
+            false,
+        );
+        dataCollector = getDataCollectorMock();
+        paypalSdkMock = getPaypalMock();
+        eventEmitter = new EventEmitter();
+
+        store = createCheckoutStore(getCheckoutStoreState());
+        checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(createRequestSender()),
+            new ConfigActionCreator(new ConfigRequestSender(createRequestSender())),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(createRequestSender())),
+        );
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader());
+        braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+        formPoster = createFormPoster();
+
+        paymentMethodMock = {
+            ...getBraintree(),
+            clientToken: 'myToken',
+        };
+
+        googleRecaptchaMockWindow = { grecaptcha: {} } as GoogleRecaptchaWindow;
+        googleRecaptchaScriptLoader = new GoogleRecaptchaScriptLoader(
+            createScriptLoader(),
+            googleRecaptchaMockWindow,
+        );
+        googleRecaptcha = new GoogleRecaptcha(
+            googleRecaptchaScriptLoader,
+            new MutationObserverFactory(),
+        );
+        loadPaymentMethodAction = of(
+            createAction(PaymentMethodActionType.LoadPaymentMethodSucceeded, paymentMethodMock, {
+                methodId: paymentMethodMock.id,
+            }),
+        );
+
+        customerActionCreator = new CustomerActionCreator(
+            new CustomerRequestSender(createRequestSender()),
+            checkoutActionCreator,
+            new SpamProtectionActionCreator(
+                googleRecaptcha,
+                new SpamProtectionRequestSender(createRequestSender()),
+            ),
+        );
+        paymentMethodActionCreator = {} as PaymentMethodActionCreator;
+        paymentMethodActionCreator.loadPaymentMethod = jest.fn(() => loadPaymentMethodAction);
+
+        (window as PaypalHostWindow).paypal = paypalSdkMock;
+
+        strategy = new BraintreePaypalCreditCustomerStrategy(
+            store,
+            checkoutActionCreator,
+            customerActionCreator,
+            paymentMethodActionCreator,
+            braintreeSDKCreator,
+            formPoster,
+            window,
+        );
+
+        paypalButtonElement = document.createElement('div');
+        paypalButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalButtonElement);
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethodMock,
+        );
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
+            getConfig().storeConfig,
+        );
+        jest.spyOn(braintreeSDKCreator, 'getClient').mockReturnValue(paymentMethodMock.clientToken);
+        jest.spyOn(braintreeSDKCreator, 'getDataCollector').mockReturnValue(dataCollector);
+        jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(
+            braintreePaypalCheckoutCreatorMock,
+        );
+        jest.spyOn(formPoster, 'postForm').mockImplementation(() => {});
+        jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout').mockImplementation(() => {});
+
+        jest.spyOn(paypalSdkMock, 'Buttons').mockImplementation((options: PaypalButtonOptions) => {
+            eventEmitter.on('createOrder', () => {
+                if (options.createOrder) {
+                    options.createOrder().catch(() => {});
+                }
+            });
+
+            eventEmitter.on('approve', () => {
+                if (options.onApprove) {
+                    options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {});
+                }
+            });
+
+            return {
+                isEligible: jest.fn(() => true),
+                render: jest.fn(),
+            };
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PaypalHostWindow).paypal;
+
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalButtonElement);
+        }
+    });
+
+    it('creates an instance of the braintree paypal credit checkout customer strategy', () => {
+        expect(strategy).toBeInstanceOf(BraintreePaypalCreditCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = {
+                methodId: PaymentStrategyType.BRAINTREE_PAYPAL_CREDIT,
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if braintreepaypalcredit is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+                methodId: PaymentStrategyType.BRAINTREE_PAYPAL_CREDIT,
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if client token is missing', async () => {
+            paymentMethodMock.clientToken = undefined;
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('initializes braintree sdk creator', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
+                paymentMethodMock.clientToken,
+            );
+        });
+
+        it('initializes braintree paypal checkout', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
+                paymentMethodMock.clientToken,
+            );
+            expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
+        });
+
+        it('calls braintree paypal checkout create method', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreePaypalCheckoutCreatorMock.create).toHaveBeenCalled();
+        });
+
+        it('calls onError callback option if the error was caught on paypal checkout creation', async () => {
+            braintreePaypalCheckoutCreatorMock = getPayPalCheckoutCreatorMock(undefined, true);
+
+            jest.spyOn(braintreeScriptLoader, 'loadPaypalCheckout').mockReturnValue(
+                braintreePaypalCheckoutCreatorMock,
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            expect(initializationOptions.braintreepaypalcredit?.onError).toHaveBeenCalled();
+        });
+
+        it('renders braintree paylater button', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.PAYLATER,
+                onApprove: expect.any(Function),
+                style: {
+                    height: 40,
+                    color: PaypalButtonStyleColorOption.GOLD,
+                },
+            });
+
+            expect(paypalSdkMock.Buttons).not.toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.CREDIT,
+                onApprove: expect.any(Function),
+                style: {
+                    label: 'credit',
+                    shape: 'rect',
+                    height: 45,
+                },
+            });
+        });
+
+        it('renders braintree credit button if paylater is not eligible', async () => {
+            jest.spyOn(paypalSdkMock, 'Buttons').mockImplementationOnce(() => {
+                return {
+                    isEligible: jest.fn(() => false),
+                };
+            });
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.PAYLATER,
+                onApprove: expect.any(Function),
+                style: {
+                    height: 40,
+                    color: PaypalButtonStyleColorOption.GOLD,
+                },
+            });
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.CREDIT,
+                onApprove: expect.any(Function),
+                style: {
+                    height: 40,
+                    label: 'credit',
+                    color: PaypalButtonStyleColorOption.GOLD,
+                },
+            });
+        });
+
+        it('renders braintree checkout button in production environment if payment method is in test mode', async () => {
+            paymentMethodMock.config.testMode = false;
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith(
+                expect.objectContaining({ env: 'production' }),
+            );
+        });
+
+        it('loads checkout details when customer is ready to pay', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(checkoutActionCreator.loadDefaultCheckout).toHaveBeenCalledTimes(1);
+        });
+
+        it('sets up PayPal payment flow with current checkout details when customer is ready to pay', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.createPayment).toHaveBeenCalledWith({
+                amount: 190,
+                currency: 'USD',
+                enableShippingAddress: true,
+                flow: 'checkout',
+                offerCredit: true,
+                shippingAddressEditable: false,
+                shippingAddressOverride: {
+                    city: 'Some City',
+                    countryCode: 'US',
+                    line1: '12345 Testing Way',
+                    line2: '',
+                    phone: '555-555-5555',
+                    postalCode: '95555',
+                    recipientName: 'Test Tester',
+                    state: 'CA',
+                },
+            });
+        });
+
+        it('triggers error callback if unable to set up payment flow', async () => {
+            const expectedError = new Error('Unable to set up payment flow');
+
+            jest.spyOn(braintreePaypalCheckoutMock, 'createPayment').mockImplementation(() =>
+                Promise.reject(expectedError),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalCreditOptions.onError).toHaveBeenCalledWith(expectedError);
+        });
+
+        it('tokenizes PayPal payment details when authorization event is triggered', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalCheckoutMock.tokenizePayment).toHaveBeenCalledWith({
+                payerId: 'PAYER_ID',
+            });
+        });
+
+        it('posts payment details to server to set checkout data when PayPal payment details are tokenized', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith(
+                '/checkout.php',
+                expect.objectContaining({
+                    payment_type: 'paypal',
+                    provider: 'braintreepaypalcredit',
+                    action: 'set_external_checkout',
+                    device_data: dataCollector.deviceData,
+                    nonce: 'NONCE',
+                    billing_address: JSON.stringify({
+                        email: 'foo@bar.com',
+                        first_name: 'Foo',
+                        last_name: 'Bar',
+                        address_line_1: '56789 Testing Way',
+                        address_line_2: 'Level 2',
+                        city: 'Some Other City',
+                        state: 'Arizona',
+                        country_code: 'US',
+                        postal_code: '96666',
+                    }),
+                    shipping_address: JSON.stringify({
+                        email: 'foo@bar.com',
+                        first_name: 'Hello',
+                        last_name: 'World',
+                        address_line_1: '12345 Testing Way',
+                        address_line_2: 'Level 1',
+                        city: 'Some City',
+                        state: 'California',
+                        country_code: 'US',
+                        postal_code: '95555',
+                    }),
+                }),
+            );
+        });
+
+        it('triggers error callback if unable to tokenize payment', async () => {
+            const expectedError = new Error('Unable to tokenize');
+
+            jest.spyOn(braintreePaypalCheckoutMock, 'tokenizePayment').mockReturnValue(
+                Promise.reject(expectedError),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('approve');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalCreditOptions.onError).toHaveBeenCalledWith(expectedError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('teardowns braintree sdk creator on strategy deinitialize', async () => {
+            braintreeSDKCreator.teardown = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+            await strategy.deinitialize();
+
+            expect(braintreeSDKCreator.teardown).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -1,0 +1,263 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import mapToLegacyBillingAddress from '../../../checkout-buttons/strategies/braintree/map-to-legacy-billing-address';
+import mapToLegacyShippingAddress from '../../../checkout-buttons/strategies/braintree/map-to-legacy-shipping-address';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+} from '../../../common/error/errors';
+import { PaymentMethodActionCreator } from '../../../payment';
+import {
+    BraintreeError,
+    BraintreePaypalCheckout,
+    BraintreeSDKCreator,
+    BraintreeTokenizePayload,
+    mapToBraintreeShippingAddressOverride,
+} from '../../../payment/strategies/braintree';
+import {
+    PaypalAuthorizeData,
+    PaypalButtonStyleColorOption,
+    PaypalButtonStyleLabelOption,
+    PaypalHostWindow,
+} from '../../../payment/strategies/paypal';
+import CustomerActionCreator from '../../customer-action-creator';
+import CustomerCredentials from '../../customer-credentials';
+import {
+    CustomerInitializeOptions,
+    CustomerRequestOptions,
+    ExecutePaymentMethodCheckoutOptions,
+} from '../../customer-request-options';
+import CustomerStrategy from '../customer-strategy';
+
+import BraintreePaypalCreditCustomerInitializeOptions from './braintree-paypal-credit-customer-options';
+
+export default class BraintreePaypalCreditCustomerStrategy implements CustomerStrategy {
+    constructor(
+        private _store: CheckoutStore,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _customerActionCreator: CustomerActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _braintreeSDKCreator: BraintreeSDKCreator,
+        private _formPoster: FormPoster,
+        private _window: PaypalHostWindow,
+    ) {}
+
+    async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
+        const { braintreepaypalcredit, methodId } = options;
+        const { container } = braintreepaypalcredit || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!braintreepaypalcredit) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.braintreepaypalcredit" argument is not provided.`,
+            );
+        }
+
+        if (!container) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "braintreepaypalcredit.container" argument is not provided.`,
+            );
+        }
+
+        const state = await this._store.dispatch(
+            this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+        );
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+
+        if (!paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        const currencyCode = state.cart.getCartOrThrow().currency.code;
+        const paypalCheckoutOptions = { currency: currencyCode };
+        const paypalCheckoutCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) =>
+            this._renderPayPalButton(
+                braintreePaypalCheckout,
+                braintreepaypalcredit,
+                methodId,
+                Boolean(paymentMethod.config.testMode),
+            );
+        const paypalCheckoutErrorCallback = (error: BraintreeError) =>
+            this._handleError(error, braintreepaypalcredit);
+
+        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        await this._braintreeSDKCreator.getPaypalCheckout(
+            paypalCheckoutOptions,
+            paypalCheckoutCallback,
+            paypalCheckoutErrorCallback,
+        );
+
+        return this._store.getState();
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        this._braintreeSDKCreator.teardown();
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    signIn(
+        credentials: CustomerCredentials,
+        options?: CustomerRequestOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._customerActionCreator.signInCustomer(credentials, options),
+        );
+    }
+
+    signOut(options?: CustomerRequestOptions): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(this._customerActionCreator.signOutCustomer(options));
+    }
+
+    executePaymentMethodCheckout(
+        options?: ExecutePaymentMethodCheckoutOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        options?.continueWithCheckoutCallback?.();
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _renderPayPalButton(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypalcredit: BraintreePaypalCreditCustomerInitializeOptions,
+        methodId: string,
+        testMode: boolean,
+    ): void {
+        const { container } = braintreepaypalcredit;
+        const { paypal } = this._window;
+
+        let hasRenderedSmartButton = false;
+
+        if (paypal) {
+            const fundingSources = [paypal.FUNDING.PAYLATER, paypal.FUNDING.CREDIT];
+            const commonButtonStyle = {
+                height: 40,
+                color: PaypalButtonStyleColorOption.GOLD,
+            };
+
+            fundingSources.forEach((fundingSource) => {
+                const buttonStyle =
+                    fundingSource === paypal.FUNDING.CREDIT
+                        ? { label: PaypalButtonStyleLabelOption.CREDIT, ...commonButtonStyle }
+                        : commonButtonStyle;
+
+                if (!hasRenderedSmartButton) {
+                    const paypalButtonRender = paypal.Buttons({
+                        env: testMode ? 'sandbox' : 'production',
+                        commit: false,
+                        fundingSource,
+                        style: buttonStyle,
+                        createOrder: () =>
+                            this._setupPayment(braintreePaypalCheckout, braintreepaypalcredit),
+                        onApprove: (authorizeData: PaypalAuthorizeData) =>
+                            this._tokenizePayment(
+                                authorizeData,
+                                braintreePaypalCheckout,
+                                braintreepaypalcredit,
+                                methodId,
+                            ),
+                    });
+
+                    if (paypalButtonRender.isEligible()) {
+                        paypalButtonRender.render(`#${container}`);
+                        hasRenderedSmartButton = true;
+                    }
+                }
+            });
+        }
+
+        if (!paypal || !hasRenderedSmartButton) {
+            this._removeElement(container);
+        }
+    }
+
+    private async _setupPayment(
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypalcredit: BraintreePaypalCreditCustomerInitializeOptions,
+    ): Promise<string | undefined> {
+        try {
+            const state = await this._store.dispatch(
+                this._checkoutActionCreator.loadDefaultCheckout(),
+            );
+
+            const customer = state.customer.getCustomer();
+            const amount = state.checkout.getCheckoutOrThrow().outstandingBalance;
+            const currencyCode = state.cart.getCartOrThrow().currency.code;
+            const address = customer?.addresses[0];
+            const shippingAddressOverride = address
+                ? mapToBraintreeShippingAddressOverride(address)
+                : undefined;
+
+            return await braintreePaypalCheckout.createPayment({
+                flow: 'checkout',
+                enableShippingAddress: true,
+                shippingAddressEditable: false,
+                shippingAddressOverride,
+                amount,
+                currency: currencyCode,
+                offerCredit: true,
+            });
+        } catch (error) {
+            this._handleError(error, braintreepaypalcredit);
+        }
+    }
+
+    private async _tokenizePayment(
+        authorizeData: PaypalAuthorizeData,
+        braintreePaypalCheckout: BraintreePaypalCheckout,
+        braintreepaypalcredit: BraintreePaypalCreditCustomerInitializeOptions,
+        methodId: string,
+    ): Promise<BraintreeTokenizePayload | undefined> {
+        try {
+            const { deviceData } = await this._braintreeSDKCreator.getDataCollector({
+                paypal: true,
+            });
+            const tokenizePayload = await braintreePaypalCheckout.tokenizePayment(authorizeData);
+            const { details, nonce } = tokenizePayload;
+
+            this._formPoster.postForm('/checkout.php', {
+                payment_type: 'paypal',
+                provider: methodId,
+                action: 'set_external_checkout',
+                nonce,
+                device_data: deviceData,
+                billing_address: JSON.stringify(mapToLegacyBillingAddress(details)),
+                shipping_address: JSON.stringify(mapToLegacyShippingAddress(details)),
+            });
+
+            return tokenizePayload;
+        } catch (error) {
+            this._handleError(error, braintreepaypalcredit);
+        }
+    }
+
+    private _handleError(
+        error: BraintreeError,
+        braintreepaypalcredit: BraintreePaypalCreditCustomerInitializeOptions,
+    ): void {
+        const { container, onError } = braintreepaypalcredit;
+
+        this._removeElement(container);
+
+        if (onError) {
+            onError(error);
+        } else {
+            throw error;
+        }
+    }
+
+    private _removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+}

--- a/packages/core/src/customer/strategies/braintree/index.ts
+++ b/packages/core/src/customer/strategies/braintree/index.ts
@@ -2,3 +2,5 @@ export { default as BraintreeVisaCheckoutCustomerStrategy } from './braintree-vi
 export { default as BraintreeVisaCheckoutCustomerInitializeOptions } from './braintree-visacheckout-customer-initialize-options';
 export { default as BraintreePaypalCustomerStrategy } from './braintree-paypal-customer-strategy';
 export { default as BraintreePaypalCustomerInitializeOptions } from './braintree-paypal-customer-options';
+export { default as BraintreePaypalCreditCustomerStrategy } from './braintree-paypal-credit-customer-strategy';
+export { default as BraintreePaypalCreditCustomerInitializeOptions } from './braintree-paypal-credit-customer-options';


### PR DESCRIPTION
## What?
Create Braintree PayPal Credit customer button strategy
Related PRs:
checkout-js: [https://github.com/bigcommerce/checkout-js/pull/1171](https://github.com/bigcommerce/checkout-js/pull/1171)
BCapp: [https://github.com/bigcommerce/bigcommerce/pull/50845](https://github.com/bigcommerce/bigcommerce/pull/50845)

## Why?
Because of task: [https://bigcommercecloud.atlassian.net/browse/PAYPAL-1840](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1840)

## Testing / Proof
<img width="1210" alt="Screenshot 2023-01-23 at 12 49 55" src="https://user-images.githubusercontent.com/9430298/214035776-b8fd7f13-2103-46b0-b780-a8c6edbc9507.png">
Checkout-sdk-js unit test:
<img width="610" alt="Screenshot 2023-01-23 at 13 55 28" src="https://user-images.githubusercontent.com/9430298/214035861-93eabfdf-9d9f-45c9-9187-a808f30491e4.png">
BCapp unit tests:
<img width="1572" alt="Screenshot 2023-01-23 at 13 46 08" src="https://user-images.githubusercontent.com/9430298/214035913-268fd9ef-b6f6-4343-b784-e2cd5489253e.png">


@bigcommerce/checkout @bigcommerce/payments
