### PR TITLE
fix(checkout): ADYEN-502 hide wrong placeholder text for the vaulted validation fields

### DIFF
--- a/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.ts
@@ -343,6 +343,14 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
             if (adyenv2.cardVerificationContainerId) {
                 cardVerificationComponent = adyenClient.create(AdyenComponentType.SecuredFields, {
                     ...adyenv2.options,
+                    styles: {
+                        ...adyenv2.options?.styles,
+                        placeholder: {
+                            color: 'transparent',
+                            caretColor: '#000',
+                            ...adyenv2.options?.styles?.placeholder,
+                        },
+                    },
                     onChange: (componentState) => this._updateComponentState(componentState),
                     onError: (validateState) => adyenv2.validateCardFields(validateState),
                     onFieldValid: (validateState) => adyenv2.validateCardFields(validateState),

--- a/packages/adyen-integration/src/adyenv2/adyenv2.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2.ts
@@ -347,7 +347,7 @@ export interface AdyenHostWindow extends Window {
     AdyenCheckout?: new (configuration: AdyenConfiguration) => AdyenClient;
 }
 
-export interface AdyenIdealComponentOptions {
+export interface AdyenIdealComponentOptions extends AdyenBaseCardComponentOptions {
     /**
      * Optional. Set to **false** to remove the bank logos from the iDEAL form.
      */
@@ -564,6 +564,7 @@ export interface AccountState {
 
 export interface CssProperties {
     background?: string;
+    caretColor?: string;
     color?: string;
     display?: string;
     font?: string;

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -326,6 +326,14 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             if (adyenv3.cardVerificationContainerId) {
                 cardVerificationComponent = adyenClient.create(AdyenComponentType.SecuredFields, {
                     ...adyenv3.options,
+                    styles: {
+                        ...adyenv3.options?.styles,
+                        placeholder: {
+                            color: 'transparent',
+                            caretColor: '#000',
+                            ...adyenv3.options?.styles?.placeholder,
+                        },
+                    },
                     onChange: (componentState) => this._updateComponentState(componentState),
                     onError: (validateState) => adyenv3.validateCardFields(validateState),
                     onFieldValid: (validateState) => adyenv3.validateCardFields(validateState),

--- a/packages/adyen-integration/src/adyenv3/adyenv3.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3.ts
@@ -555,6 +555,7 @@ export interface AccountState {
 
 export interface CssProperties {
     background?: string;
+    caretColor?: string;
     color?: string;
     display?: string;
     font?: string;


### PR DESCRIPTION
## What?
We can’t force the Adyen widget to show the correct placeholder for selected vaulted card because the Adyen widget doesn’t know what card brand was chosen inside the vaulted card select. We decided just hide wrong placeholder to not distract user with wrong typing advice 

## Why?
Due to the https://bigcommercecloud.atlassian.net/browse/ADYEN-502

## Testing / Proof


https://user-images.githubusercontent.com/79574476/214330159-b4acfdab-bdce-4ef6-946c-10ead95a1c80.mov


