### PR TITLE
feat(payment): PAYPAL-1898 added CartRequestSender to payment integration api package

### DIFF
--- a/packages/core/src/cart/buy-now-cart-request-body.ts
+++ b/packages/core/src/cart/buy-now-cart-request-body.ts
@@ -3,6 +3,7 @@ import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
 interface LineItem {
     productId: number;
     quantity: number;
+    variantId?: number;
     optionSelections?: {
         optionId: number;
         optionValue: number | string;

--- a/packages/core/src/cart/cart-request-sender.spec.ts
+++ b/packages/core/src/cart/cart-request-sender.spec.ts
@@ -5,6 +5,8 @@ import {
     Response,
 } from '@bigcommerce/request-sender';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { ContentType, SDK_VERSION_HEADERS } from '../common/http-request';
 import { getResponse } from '../common/http-request/responses.mock';
 
@@ -26,7 +28,7 @@ describe('CartRequestSender', () => {
 
     describe('#createBuyNowCart', () => {
         const buyNowCartRequestBody: BuyNowCartRequestBody = {
-            source: 'BUY_NOW',
+            source: CartSource.BuyNow,
             lineItems: [
                 {
                     productId: 1,
@@ -40,7 +42,7 @@ describe('CartRequestSender', () => {
         };
 
         beforeEach(() => {
-            cart = { ...getCart(), source: 'BUY_NOW' };
+            cart = { ...getCart(), source: CartSource.BuyNow };
             response = getResponse(cart);
 
             jest.spyOn(requestSender, 'post').mockResolvedValue(response);

--- a/packages/core/src/cart/cart-request-sender.ts
+++ b/packages/core/src/cart/cart-request-sender.ts
@@ -1,9 +1,8 @@
 import { RequestSender, Response } from '@bigcommerce/request-sender';
 
-import { ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
+import { BuyNowCartRequestBody, Cart } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import BuyNowCartRequestBody from './buy-now-cart-request-body';
-import Cart from './cart';
+import { ContentType, RequestOptions, SDK_VERSION_HEADERS } from '../common/http-request';
 
 export default class CartRequestSender {
     constructor(private _requestSender: RequestSender) {}

--- a/packages/core/src/cart/cart.ts
+++ b/packages/core/src/cart/cart.ts
@@ -1,3 +1,5 @@
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { Coupon } from '../coupon';
 import { Currency } from '../currency';
 import { Discount } from '../discount';
@@ -18,5 +20,5 @@ export default interface Cart {
     lineItems: LineItemMap;
     createdTime: string;
     updatedTime: string;
-    source?: 'BUY_NOW';
+    source?: CartSource;
 }

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -3,6 +3,8 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { CartRequestSender } from '../../../cart';
 import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
 import { getCart } from '../../../cart/carts.mock';
@@ -87,11 +89,11 @@ describe('BraintreePaypalButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -3,6 +3,7 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import { getCart } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import { CartRequestSender } from '../../../cart';
@@ -86,11 +87,11 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
@@ -2,6 +2,8 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { CartRequestSender } from '../../../cart';
 import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
 import { getCart } from '../../../cart/carts.mock';
@@ -44,11 +46,11 @@ describe('BraintreeVenmoButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -2,7 +2,10 @@ import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { InvalidArgumentError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    CartSource,
+    InvalidArgumentError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { Cart, CartRequestSender } from '../../../cart';
 import { getCart, getCartState } from '../../../cart/carts.mock';
@@ -49,7 +52,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     beforeEach(() => {

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -1,3 +1,5 @@
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BuyNowCartRequestBody } from '../../../cart';
 import { PaymentMethod } from '../../../payment';
 import { getGooglePay } from '../../../payment/payment-methods.mock';
@@ -33,7 +35,7 @@ export enum Mode {
 }
 
 const buyNowCartRequestBody: BuyNowCartRequestBody = {
-    source: 'BUY_NOW',
+    source: CartSource.BuyNow,
     lineItems: [
         {
             productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -3,6 +3,8 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BuyNowCartRequestBody, Cart, CartRequestSender } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { BuyNowCartCreationError } from '../../../cart/errors';
@@ -67,11 +69,11 @@ describe('PaypalCommerceAlternativeMethodsButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -3,6 +3,8 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
 import { Cart, CartRequestSender } from '../../../cart';
 import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
@@ -90,11 +92,11 @@ describe('PaypalCommerceButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.spec.ts
@@ -3,6 +3,8 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
 import { Cart, CartRequestSender } from '../../../cart';
 import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
@@ -94,11 +96,11 @@ describe('PaypalCommerceCreditButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.spec.ts
@@ -3,6 +3,8 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
+import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { BuyNowCartRequestBody, Cart, CartRequestSender } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { BuyNowCartCreationError } from '../../../cart/errors';
@@ -66,11 +68,11 @@ describe('PaypalCommerceVenmoButtonStrategy', () => {
     const buyNowCartMock = {
         ...getCart(),
         id: 999,
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
     };
 
     const buyNowCartRequestBody: BuyNowCartRequestBody = {
-        source: 'BUY_NOW',
+        source: CartSource.BuyNow,
         lineItems: [
             {
                 productId: 1,

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -4,6 +4,7 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
+import { CartRequestSender } from '../cart';
 import {
     CheckoutActionCreator,
     CheckoutRequestSender,
@@ -92,6 +93,8 @@ export default function createPaymentIntegrationService(
         ),
     );
 
+    const cartRequestSender = new CartRequestSender(requestSender);
+
     return new DefaultPaymentIntegrationService(
         store,
         storeProjectionFactory,
@@ -103,5 +106,6 @@ export default function createPaymentIntegrationService(
         paymentMethodActionCreator,
         paymentActionCreator,
         customerActionCreator,
+        cartRequestSender,
     );
 }

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -311,7 +311,10 @@ describe('DefaultPaymentIntegrationService', () => {
 
             const output = await subject.createBuyNowCart(buyNowCartRequestBody);
 
-            expect(cartRequestSender.createBuyNowCart).toHaveBeenCalledWith(buyNowCartRequestBody);
+            expect(cartRequestSender.createBuyNowCart).toHaveBeenCalledWith(
+                buyNowCartRequestBody,
+                undefined,
+            );
             expect(output).toEqual(buyNowCart);
         });
     });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -159,9 +159,13 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         return this._storeProjection.getState();
     }
 
-    async createBuyNowCart(buyNowCartRequestBody: BuyNowCartRequestBody): Promise<Cart> {
+    async createBuyNowCart(
+        buyNowCartRequestBody: BuyNowCartRequestBody,
+        options?: RequestOptions,
+    ): Promise<Cart> {
         const { body: buyNowCart } = await this._cartRequestSender.createBuyNowCart(
             buyNowCartRequestBody,
+            options,
         );
 
         return buyNowCart;

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -1,5 +1,7 @@
 import {
     BillingAddressRequestBody,
+    BuyNowCartRequestBody,
+    Cart,
     HostedForm,
     HostedFormOptions,
     InitializeOffsitePaymentConfig,
@@ -12,6 +14,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { BillingAddressActionCreator } from '../billing';
+import { CartRequestSender } from '../cart';
 import { CheckoutActionCreator, CheckoutStore } from '../checkout';
 import { DataStoreProjection } from '../common/data-store';
 import { CustomerActionCreator, CustomerCredentials } from '../customer';
@@ -37,6 +40,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _paymentMethodActionCreator: PaymentMethodActionCreator,
         private _paymentActionCreator: PaymentActionCreator,
         private _customerActionCreator: CustomerActionCreator,
+        private _cartRequestSender: CartRequestSender,
     ) {
         this._storeProjection = this._storeProjectionFactory.create(this._store);
     }
@@ -153,5 +157,13 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         await this._store.dispatch(this._customerActionCreator.signOutCustomer(options));
 
         return this._storeProjection.getState();
+    }
+
+    async createBuyNowCart(buyNowCartRequestBody: BuyNowCartRequestBody): Promise<Cart> {
+        const { body: buyNowCart } = await this._cartRequestSender.createBuyNowCart(
+            buyNowCartRequestBody,
+        );
+
+        return buyNowCart;
     }
 }

--- a/packages/payment-integration-api/src/cart/buy-now-cart-request-body.ts
+++ b/packages/payment-integration-api/src/cart/buy-now-cart-request-body.ts
@@ -1,4 +1,4 @@
-import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { CartSource } from './cart-source';
 
 interface LineItem {
     productId: number;

--- a/packages/payment-integration-api/src/cart/buy-now-cart-request-body.ts
+++ b/packages/payment-integration-api/src/cart/buy-now-cart-request-body.ts
@@ -3,6 +3,7 @@ import { CartSource } from './cart-source';
 interface LineItem {
     productId: number;
     quantity: number;
+    variantId?: number;
     optionSelections?: {
         optionId: number;
         optionValue: number | string;

--- a/packages/payment-integration-api/src/cart/cart-source.ts
+++ b/packages/payment-integration-api/src/cart/cart-source.ts
@@ -1,0 +1,3 @@
+export enum CartSource {
+    BuyNow = 'BUY_NOW',
+}

--- a/packages/payment-integration-api/src/cart/cart.ts
+++ b/packages/payment-integration-api/src/cart/cart.ts
@@ -2,6 +2,7 @@ import { Coupon } from '../coupon';
 import { Currency } from '../currency';
 import { Discount } from '../discount';
 
+import { CartSource } from './cart-source';
 import LineItemMap from './line-item-map';
 
 export default interface Cart {
@@ -18,4 +19,5 @@ export default interface Cart {
     lineItems: LineItemMap;
     createdTime: string;
     updatedTime: string;
+    source?: CartSource;
 }

--- a/packages/payment-integration-api/src/cart/index.ts
+++ b/packages/payment-integration-api/src/cart/index.ts
@@ -1,4 +1,6 @@
+export { default as BuyNowCartRequestBody } from './buy-now-cart-request-body';
 export { default as Cart } from './cart';
+export { CartSource } from './cart-source';
 export { default as InternalLineItem } from './internal-line-item';
 export { PhysicalItem, DigitalItem, GiftCertificateItem } from './line-item';
 export { default as LineItemMap } from './line-item-map';

--- a/packages/payment-integration-api/src/errors/buy-now-cart-creation-error.ts
+++ b/packages/payment-integration-api/src/errors/buy-now-cart-creation-error.ts
@@ -1,0 +1,17 @@
+import StandardError from './standard-error';
+
+/**
+ * This error should be thrown when a shopper tries to sign in as a guest but
+ * they are already signed in as a registered customer.
+ */
+export default class BuyNowCartCreationError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message ||
+                'An unexpected error has occurred during buy now cart creation process. Please try again later.',
+        );
+
+        this.name = 'BuyNowCartCreationError';
+        this.type = 'buy_now_cart_creation_error';
+    }
+}

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -6,7 +6,14 @@ export {
     CheckoutButtonStrategyResolveId,
     CheckoutButtonInitializeOptions,
 } from './checkout-buttons';
-export { Cart, DigitalItem, GiftCertificateItem, PhysicalItem } from './cart';
+export {
+    BuyNowCartRequestBody,
+    Cart,
+    CartSource,
+    DigitalItem,
+    GiftCertificateItem,
+    PhysicalItem,
+} from './cart';
 export { Checkout } from './checkout';
 export { BrowserInfo, getBrowserInfo } from './common/browser-info';
 export { ContentType, INTERNAL_USE_ONLY, SDK_VERSION_HEADERS } from './common/http-request';

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -1,4 +1,5 @@
 import { BillingAddressRequestBody } from './billing';
+import { BuyNowCartRequestBody, Cart } from './cart';
 import { CustomerCredentials } from './customer';
 import { HostedForm, HostedFormOptions } from './hosted-form';
 import { OrderRequestBody } from './order';
@@ -53,4 +54,6 @@ export default interface PaymentIntegrationService {
     ): Promise<PaymentIntegrationSelectors>;
 
     signOutCustomer(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
+
+    createBuyNowCart(body: BuyNowCartRequestBody, options?: RequestOptions): Promise<Cart>;
 }

--- a/packages/payment-integrations-test-utils/src/index.ts
+++ b/packages/payment-integrations-test-utils/src/index.ts
@@ -1,7 +1,10 @@
 export {
     PaymentIntegrationServiceMock,
+    getBuyNowCart,
+    getBuyNowCartRequestBody,
     getCart,
     getCheckout,
+    getCheckoutWithBuyNowCart,
     getConfig,
     getConsignment,
     getOrder,

--- a/packages/payment-integrations-test-utils/src/test-utils/buy-now-cart-request-body.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/buy-now-cart-request-body.mock.ts
@@ -1,0 +1,16 @@
+import {
+    BuyNowCartRequestBody,
+    CartSource,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default function getBuyNowCartRequestBody(): BuyNowCartRequestBody {
+    return {
+        lineItems: [
+            {
+                productId: 1,
+                quantity: 1,
+            },
+        ],
+        source: CartSource.BuyNow,
+    };
+}

--- a/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
@@ -1,4 +1,4 @@
-import { Cart } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { Cart, CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { getCoupon } from './coupons.mock';
 import { getCurrency } from './currency.mock';
@@ -25,5 +25,12 @@ export default function getCart(): Cart {
         },
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',
+    };
+}
+
+export function getBuyNowCart(): Cart {
+    return {
+        ...getCart(),
+        source: CartSource.BuyNow,
     };
 }

--- a/packages/payment-integrations-test-utils/src/test-utils/checkouts.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/checkouts.mock.ts
@@ -1,7 +1,7 @@
 import { Checkout } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { getBillingAddress } from './address.mock';
-import getCart from './carts.mock';
+import getCart, { getBuyNowCart } from './carts.mock';
 import getConsignment from './consignment.mock';
 import { getCustomer } from './customer.mock';
 
@@ -46,5 +46,12 @@ export default function getCheckout(): Checkout {
                 ],
             },
         ],
+    };
+}
+
+export function getCheckoutWithBuyNowCart() {
+    return {
+        ...getCheckout(),
+        cart: getBuyNowCart(),
     };
 }

--- a/packages/payment-integrations-test-utils/src/test-utils/index.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/index.ts
@@ -1,6 +1,7 @@
 export { default as PaymentIntegrationServiceMock } from './payment-integration-service.mock';
-export { default as getCart } from './carts.mock';
-export { default as getCheckout } from './checkouts.mock';
+export { default as getBuyNowCartRequestBody } from './buy-now-cart-request-body.mock';
+export { default as getCart, getBuyNowCart } from './carts.mock';
+export { default as getCheckout, getCheckoutWithBuyNowCart } from './checkouts.mock';
 export { default as getConfig } from './config.mock';
 export { default as getConsignment } from './consignment.mock';
 export { default as getOrderRequestBody } from './internal-orders.mock';

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -22,6 +22,7 @@ const state = {
     getBillingAddressOrThrow: jest.fn(() => getBillingAddress()),
 };
 
+const createBuyNowCart = jest.fn();
 const createHostedForm = jest.fn();
 const getState = jest.fn(() => state);
 const initializeOffsitePayment = jest.fn();
@@ -39,6 +40,7 @@ const selectShippingOption = jest.fn();
 
 const PaymentIntegrationServiceMock = jest.fn().mockImplementation(() => {
     return {
+        createBuyNowCart,
         createHostedForm,
         subscribe,
         getState,


### PR DESCRIPTION
## What?
Added CartRequestSender to payment integration api package

## Why?
We don't have an ability to migrate PayPalCommerce strategies to their own package because payment-integration-api package doesn't have buy now cart creation method what core package has.

## Testing / Proof
Unit tests
