### PR TITLE
fix(payment): PAYMENTS-8239 puts recommended shipping option first in the applepay payment modal

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -267,14 +267,27 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
               ]
             : [];
 
-        unselectedOptions?.forEach((option) =>
-            shippingOptions.push({
-                label: option.description,
-                amount: `${option.cost.toFixed(decimalPlaces)}`,
-                detail: option.additionalDescription,
-                identifier: option.id,
-            }),
-        );
+        unselectedOptions
+            ?.filter((option) => option.isRecommended)
+            ?.forEach((option) =>
+                shippingOptions.push({
+                    label: option.description,
+                    amount: `${option.cost.toFixed(decimalPlaces)}`,
+                    detail: option.additionalDescription,
+                    identifier: option.id,
+                }),
+            );
+
+        unselectedOptions
+            ?.filter((option) => !option.isRecommended)
+            ?.forEach((option) =>
+                shippingOptions.push({
+                    label: option.description,
+                    amount: `${option.cost.toFixed(decimalPlaces)}`,
+                    detail: option.additionalDescription,
+                    identifier: option.id,
+                }),
+            );
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');

--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -267,9 +267,11 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
               ]
             : [];
 
-        unselectedOptions
-            ?.filter((option) => option.isRecommended)
-            ?.forEach((option) =>
+        if (unselectedOptions) {
+            [
+                ...unselectedOptions.filter((option) => option.isRecommended),
+                ...unselectedOptions.filter((option) => !option.isRecommended),
+            ].forEach((option) =>
                 shippingOptions.push({
                     label: option.description,
                     amount: `${option.cost.toFixed(decimalPlaces)}`,
@@ -277,17 +279,7 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
                     identifier: option.id,
                 }),
             );
-
-        unselectedOptions
-            ?.filter((option) => !option.isRecommended)
-            ?.forEach((option) =>
-                shippingOptions.push({
-                    label: option.description,
-                    amount: `${option.cost.toFixed(decimalPlaces)}`,
-                    detail: option.additionalDescription,
-                    identifier: option.id,
-                }),
-            );
+        }
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
@@ -324,6 +324,77 @@ describe('ApplePayCustomerStrategy', () => {
             }
         });
 
+        it('gets shipping options sorted correctly with recommended option first', async () => {
+            jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockResolvedValue(true);
+
+            const CheckoutButtonInitializeOptions = getApplePayCustomerInitializationOptions();
+            const newCheckout = {
+                ...getCheckout(),
+                consignments: [
+                    {
+                        ...getConsignment(),
+                        availableShippingOptions: [
+                            {
+                                ...getShippingOption(),
+                                description: 'Free Shipping',
+                                additionalDescription: 'Free shipping to your order',
+                                isRecommended: false,
+                                id: '0:1111111',
+                            },
+                            {
+                                ...getShippingOption(),
+                                id: '0:22222222',
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const freeShippingOption = newCheckout.consignments[0].availableShippingOptions[0];
+            const flatFeeShippingOption = newCheckout.consignments[0].availableShippingOptions[1];
+
+            const expectedShippingMethods = [
+                {
+                    label: flatFeeShippingOption.description,
+                    amount: flatFeeShippingOption.cost.toFixed(2),
+                    detail: flatFeeShippingOption.additionalDescription,
+                    identifier: flatFeeShippingOption.id,
+                },
+                {
+                    label: freeShippingOption.description,
+                    amount: freeShippingOption.cost.toFixed(2),
+                    detail: freeShippingOption.additionalDescription,
+                    identifier: freeShippingOption.id,
+                },
+            ];
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getCheckoutOrThrow').mockReturnValue(
+                newCheckout,
+            );
+
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const button = container.firstChild as HTMLElement;
+
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingContact: getContactAddress(),
+                    } as ApplePayJS.ApplePayShippingContactSelectedEvent;
+
+                    await applePaySession.onshippingcontactselected(event);
+
+                    const actualShippingMethods =
+                        applePaySession.completeShippingContactSelection.mock.calls[0][0]
+                            .newShippingMethods;
+
+                    expect(actualShippingMethods).toEqual(expectedShippingMethods);
+                }
+            }
+        });
+
         it('throws error if call to update address fails', async () => {
             jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockRejectedValue(false);
 

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -297,14 +297,27 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
               ]
             : [];
 
-        unselectedOptions?.forEach((option) =>
-            shippingOptions.push({
-                label: option.description,
-                amount: `${option.cost.toFixed(decimalPlaces)}`,
-                detail: option.additionalDescription,
-                identifier: option.id,
-            }),
-        );
+        unselectedOptions
+            ?.filter((option) => option.isRecommended)
+            ?.forEach((option) =>
+                shippingOptions.push({
+                    label: option.description,
+                    amount: `${option.cost.toFixed(decimalPlaces)}`,
+                    detail: option.additionalDescription,
+                    identifier: option.id,
+                }),
+            );
+
+        unselectedOptions
+            ?.filter((option) => !option.isRecommended)
+            ?.forEach((option) =>
+                shippingOptions.push({
+                    label: option.description,
+                    amount: `${option.cost.toFixed(decimalPlaces)}`,
+                    detail: option.additionalDescription,
+                    identifier: option.id,
+                }),
+            );
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -297,9 +297,11 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
               ]
             : [];
 
-        unselectedOptions
-            ?.filter((option) => option.isRecommended)
-            ?.forEach((option) =>
+        if (unselectedOptions) {
+            [
+                ...unselectedOptions.filter((option) => option.isRecommended),
+                ...unselectedOptions.filter((option) => !option.isRecommended),
+            ].forEach((option) =>
                 shippingOptions.push({
                     label: option.description,
                     amount: `${option.cost.toFixed(decimalPlaces)}`,
@@ -307,17 +309,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
                     identifier: option.id,
                 }),
             );
-
-        unselectedOptions
-            ?.filter((option) => !option.isRecommended)
-            ?.forEach((option) =>
-                shippingOptions.push({
-                    label: option.description,
-                    amount: `${option.cost.toFixed(decimalPlaces)}`,
-                    detail: option.additionalDescription,
-                    identifier: option.id,
-                }),
-            );
+        }
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');

--- a/packages/core/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.spec.ts
@@ -431,6 +431,78 @@ describe('ApplePayButtonStrategy', () => {
             }
         });
 
+        it('gets shipping options sorted correctly with recommended option first', async () => {
+            const CheckoutButtonInitializeOptions = getApplePayButtonInitializationOptions();
+            const newCheckout = {
+                ...getCheckout(),
+                consignments: [
+                    {
+                        ...getConsignment(),
+                        availableShippingOptions: [
+                            {
+                                ...getShippingOption(),
+                                description: 'Free Shipping',
+                                additionalDescription: 'Free shipping to your order',
+                                isRecommended: false,
+                                id: '0:11111111',
+                            },
+                            {
+                                ...getShippingOption(),
+                                id: '0:22222222',
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const freeShippingOption = newCheckout.consignments[0].availableShippingOptions[0];
+            const flatFeeShippingOption = newCheckout.consignments[0].availableShippingOptions[1];
+
+            const expectedShippingMethods = [
+                {
+                    label: flatFeeShippingOption.description,
+                    amount: flatFeeShippingOption.cost.toFixed(2),
+                    detail: flatFeeShippingOption.additionalDescription,
+                    identifier: flatFeeShippingOption.id,
+                },
+                {
+                    label: freeShippingOption.description,
+                    amount: freeShippingOption.cost.toFixed(2),
+                    detail: freeShippingOption.additionalDescription,
+                    identifier: freeShippingOption.id,
+                },
+            ];
+
+            jest.spyOn(checkoutActionCreator, 'loadDefaultCheckout').mockReturnValue(() =>
+                from([
+                    createAction(CheckoutActionType.LoadCheckoutRequested),
+                    createAction(CheckoutActionType.LoadCheckoutSucceeded, newCheckout),
+                ]),
+            );
+
+            await strategy.initialize(CheckoutButtonInitializeOptions);
+
+            if (CheckoutButtonInitializeOptions.applepay) {
+                const button = container.firstChild as HTMLElement;
+
+                if (button) {
+                    button.click();
+
+                    const event = {
+                        shippingContact: getContactAddress(),
+                    } as ApplePayJS.ApplePayShippingContactSelectedEvent;
+
+                    await applePaySession.onshippingcontactselected(event);
+
+                    const actualShippingMethods =
+                        applePaySession.completeShippingContactSelection.mock.calls[0][0]
+                            .newShippingMethods;
+
+                    expect(actualShippingMethods).toEqual(expectedShippingMethods);
+                }
+            }
+        });
+
         it('gets call to update shipping option in consignment fails', async () => {
             jest.spyOn(consignmentActionCreator, 'selectShippingOption').mockRejectedValue(false);
 

--- a/packages/core/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
@@ -282,14 +282,27 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
               ]
             : [];
 
-        unselectedOptions?.forEach((option) =>
-            shippingOptions.push({
-                label: option.description,
-                amount: `${option.cost.toFixed(decimalPlaces)}`,
-                detail: option.additionalDescription,
-                identifier: option.id,
-            }),
-        );
+        unselectedOptions
+            ?.filter((option) => option.isRecommended)
+            ?.forEach((option) =>
+                shippingOptions.push({
+                    label: option.description,
+                    amount: `${option.cost.toFixed(decimalPlaces)}`,
+                    detail: option.additionalDescription,
+                    identifier: option.id,
+                }),
+            );
+
+        unselectedOptions
+            ?.filter((option) => !option.isRecommended)
+            ?.forEach((option) =>
+                shippingOptions.push({
+                    label: option.description,
+                    amount: `${option.cost.toFixed(decimalPlaces)}`,
+                    detail: option.additionalDescription,
+                    identifier: option.id,
+                }),
+            );
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');

--- a/packages/core/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/apple-pay/apple-pay-button-strategy.ts
@@ -282,9 +282,11 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
               ]
             : [];
 
-        unselectedOptions
-            ?.filter((option) => option.isRecommended)
-            ?.forEach((option) =>
+        if (unselectedOptions) {
+            [
+                ...unselectedOptions.filter((option) => option.isRecommended),
+                ...unselectedOptions.filter((option) => !option.isRecommended),
+            ].forEach((option) =>
                 shippingOptions.push({
                     label: option.description,
                     amount: `${option.cost.toFixed(decimalPlaces)}`,
@@ -292,17 +294,7 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
                     identifier: option.id,
                 }),
             );
-
-        unselectedOptions
-            ?.filter((option) => !option.isRecommended)
-            ?.forEach((option) =>
-                shippingOptions.push({
-                    label: option.description,
-                    amount: `${option.cost.toFixed(decimalPlaces)}`,
-                    detail: option.additionalDescription,
-                    identifier: option.id,
-                }),
-            );
+        }
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');

--- a/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -323,14 +323,27 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
               ]
             : [];
 
-        unselectedOptions?.forEach((option) =>
-            shippingOptions.push({
-                label: option.description,
-                amount: `${option.cost.toFixed(decimalPlaces)}`,
-                detail: option.additionalDescription,
-                identifier: option.id,
-            }),
-        );
+        unselectedOptions
+            ?.filter((option) => option.isRecommended)
+            ?.forEach((option) =>
+                shippingOptions.push({
+                    label: option.description,
+                    amount: `${option.cost.toFixed(decimalPlaces)}`,
+                    detail: option.additionalDescription,
+                    identifier: option.id,
+                }),
+            );
+
+        unselectedOptions
+            ?.filter((option) => !option.isRecommended)
+            ?.forEach((option) =>
+                shippingOptions.push({
+                    label: option.description,
+                    amount: `${option.cost.toFixed(decimalPlaces)}`,
+                    detail: option.additionalDescription,
+                    identifier: option.id,
+                }),
+            );
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');

--- a/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -323,9 +323,11 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
               ]
             : [];
 
-        unselectedOptions
-            ?.filter((option) => option.isRecommended)
-            ?.forEach((option) =>
+        if (unselectedOptions) {
+            [
+                ...unselectedOptions.filter((option) => option.isRecommended),
+                ...unselectedOptions.filter((option) => !option.isRecommended),
+            ].forEach((option) =>
                 shippingOptions.push({
                     label: option.description,
                     amount: `${option.cost.toFixed(decimalPlaces)}`,
@@ -333,17 +335,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
                     identifier: option.id,
                 }),
             );
-
-        unselectedOptions
-            ?.filter((option) => !option.isRecommended)
-            ?.forEach((option) =>
-                shippingOptions.push({
-                    label: option.description,
-                    amount: `${option.cost.toFixed(decimalPlaces)}`,
-                    detail: option.additionalDescription,
-                    identifier: option.id,
-                }),
-            );
+        }
 
         if (!isShippingOptions(availableOptions)) {
             throw new Error('Shipping options not available.');


### PR DESCRIPTION
## What?
Puts recommended shipping option before non-recommended ones in the applepay shipping method dropdown.

## Why?
Before this change, when Merchant has selected the `Least expensive, excluding pickup in store` option in the checkout settings in the Control Panel. While shopper is paying via ApplePay, `Pickup in store` is the default selected option in the ApplePay payment modal.

The expectation is for `Pickup in store` to not be the default selected option. 

The issues occurs because triggering the selection of the recommended option here: https://github.com/bigcommerce/checkout-sdk-js/pull/1793/files#diff-1e21ac0b56385d124ac395b7ea974cf5c4b5bfe4975ad290180a53c6e6cfb4abR317
Doesn't select the appropriate select option in applepay modal. It continues to show the shipping option list received from the API as is, making it seem like `Pickup in store` is selected.  

In this PR we have put the shipping option that is `isRecommended` before the other options, making the UI consistent with the selection.

## Testing / Proof
Additional tests. 

https://user-images.githubusercontent.com/107909200/214488794-93c95d47-6021-4046-9ce2-a1f5605d8e0c.mov 

@bigcommerce/checkout @bigcommerce/payments
