### PR TITLE
fix(payment): PAYPAL-1923 fixed the issue with wrong paypal sdk configuration

### DIFF
--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -97,7 +97,7 @@ export default class PaypalCommerceScriptLoader {
         const enableCreditFunding = isPayPalCreditAvailable ? ['credit', 'paylater'] : [];
         const disableCreditFunding = !isPayPalCreditAvailable ? ['credit', 'paylater'] : [];
 
-        const shouldEnableAPMs = !shouldShowInlineCheckout && !isHostedCheckoutEnabled; // should disable APMs if Inline Checkout or Shipping Options feature enabled
+        const shouldEnableAPMs = initializesOnCheckoutPage || !commit;
         const enableVenmoFunding = shouldEnableAPMs && isVenmoEnabled ? ['venmo'] : [];
         const disableVenmoFunding = !shouldEnableAPMs || !isVenmoEnabled ? ['venmo'] : [];
         const enableAPMsFunding = shouldEnableAPMs ? enabledAlternativePaymentMethods : [];

--- a/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.spec.ts
@@ -325,7 +325,7 @@ describe('PayPalCommerceScriptLoader', () => {
             },
         };
 
-        await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD');
+        await paypalLoader.getPayPalSDK(paymentMethodProp, 'USD', false);
 
         const paypalSdkLoaderOptions = {
             'client-id': paymentMethod.initializationData.clientId,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.ts
@@ -101,7 +101,7 @@ export default class PayPalCommerceScriptLoader {
         const enableCreditFunding = isPayPalCreditAvailable ? ['credit', 'paylater'] : [];
         const disableCreditFunding = !isPayPalCreditAvailable ? ['credit', 'paylater'] : [];
 
-        const shouldEnableAPMs = !shouldShowInlineCheckout && !isHostedCheckoutEnabled; // should disable APMs if Inline (Accelerated) Checkout or Shipping Options feature is enabled
+        const shouldEnableAPMs = initializesOnCheckoutPage || !commit;
         const enableVenmoFunding = shouldEnableAPMs && isVenmoEnabled ? ['venmo'] : [];
         const disableVenmoFunding = !shouldEnableAPMs || !isVenmoEnabled ? ['venmo'] : [];
         const enableAPMsFunding = shouldEnableAPMs ? enabledAlternativePaymentMethods : [];


### PR DESCRIPTION
## What?
Fixed the issue with wrong PayPal Sdk configuration to make APMs work in payment step in Checkout Page. 

## Why?
PayPal APMs does not work on Checkout page due to the mistake in preparing PayPal Sdk configuration. PayPal alternative payment methods don't work in payment step on Checkout page in cases when PayPal Hosted Checkout feature is enabled. 

## Testing / Proof
Unit tests
Manual tests

Here is a screenrecord of the result:

https://user-images.githubusercontent.com/25133454/214807269-bdd97714-09af-4176-95c1-818bf4c8c4ef.mov