### PR TITLE
fix(payment): PAYPAL-1930 add intent to braintree config

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -13,6 +13,7 @@ import PaymentMethod from '../../../payment/payment-method';
 import {
     BraintreeError,
     BraintreePaypalCheckout,
+    BraintreePaypalInitializationData,
     BraintreeSDKCreator,
     BraintreeTokenizePayload,
     mapToBraintreeShippingAddressOverride,
@@ -66,7 +67,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         }
 
         let state: InternalCheckoutSelectors;
-        let paymentMethod: PaymentMethod;
+        let paymentMethod: PaymentMethod<BraintreePaypalInitializationData>;
         let currencyCode: string;
 
         if (braintreepaypal.buyNowInitializeOptions) {
@@ -90,7 +91,11 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const paypalCheckoutOptions = { currency: currencyCode };
+        const paypalCheckoutOptions = {
+            currency: currencyCode,
+            intent: paymentMethod.initializationData?.intent,
+        };
+
         const paypalCheckoutSuccessCallback = (
             braintreePaypalCheckout: BraintreePaypalCheckout,
         ) => {

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -11,6 +11,7 @@ import {
     BraintreeError,
     BraintreeHostedFields,
     BraintreeHostedFieldsCreatorConfig,
+    BraintreeIntent,
     BraintreeModule,
     BraintreePaypal,
     BraintreePaypalCheckout,
@@ -71,7 +72,7 @@ export default class BraintreeSDKCreator {
     }
 
     async getPaypalCheckout(
-        config: { currency: string },
+        config: { currency: string; indent?: BraintreeIntent },
         onSuccess: (instance: BraintreePaypalCheckout) => void,
         onError: (error: BraintreeError) => void,
     ): Promise<BraintreePaypalCheckout> {
@@ -91,6 +92,7 @@ export default class BraintreeSDKCreator {
             const paypalSdkLoadConfig = {
                 currency: config.currency,
                 components: PAYPAL_COMPONENTS.toString(),
+                intent: config.indent,
             };
 
             if (!this._window.paypal) {

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -150,6 +150,15 @@ export interface BraintreeError extends Error {
     details?: unknown;
 }
 
+export enum BraintreeIntent {
+    AUTHORIZE = 'authorize',
+    CAPTURE = 'capture',
+}
+
+export interface BraintreePaypalInitializationData {
+    intent: BraintreeIntent;
+}
+
 /**
  *
  * Braintree Client


### PR DESCRIPTION
## What?
Add intent to braintree config

## Why?
To make it possible to switch intent in Braintree SDK configuration due to the changes in CP Braintree Settings form

## Testing / Proof
Unit tests
Manual tests

## Depends on
https://github.com/bigcommerce/bigcommerce/pull/50910