### PR TITLE
chore(common): CHECKOUT-6271 Make changes to circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,8 @@ workflows:
             branches:
               only: master
           requires:
-            - test
+            - test-core
+            - test-packages
             - lint
             - build
             - ci/validate-commits

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,16 +26,19 @@ jobs:
     steps:
       - ci/pre-setup
       - node/npm-install
+      - run: mkdir ~/junit
       - run:
           name: "Run unit tests for core package"
           command: |
             TEST=$(circleci tests glob "packages/core/**/*.spec.js" | circleci tests split --split-by=timings)
             npm test $TEST
+      - run:
+          command: cp junit.xml ~/junit/
+          when: always
       - store_test_results:
-          path: test_results
+          path: ~/junit
       - store_artifacts:
-          path: test_results
-          destination: test_results
+          path: ~/junit
 
   test:
     <<: *node_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,15 @@ jobs:
       - run:
           name: "Run unit tests"
           command: npm run test:others -- --coverage
+
+  test:
+    <<: *node_executor
+    steps:
+      - ci/pre-setup
+      - node/npm-install
+      - run:
+          name: "Run unit tests"
+          command: npm run test:series -- --coverage
     
   lint:
     <<: *node_executor
@@ -100,7 +109,8 @@ workflows:
 
   default:
     jobs:
-      - test
+      - test-core
+      - test-packages
       - lint
       - build
       - ci/validate-commits
@@ -111,7 +121,8 @@ workflows:
             branches:
               ignore: /pull\/[0-9]+/
           requires:
-            - test
+            - test-core
+            - test-packages
             - lint
             - build
             - ci/validate-commits

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     <<: *node_executor
     steps:
       - ci/pre-setup
-      - node/npm install
+      - node/npm-install
       - run:
           name: "Run lint"
           command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: |
             TEST=$(circleci tests glob "packages/core/**/*.spec.ts" | circleci tests split --split-by=timings)
             npx nx run core:generate
-            npm test $TEST -- --coverage --runInBand
+            npm test $TEST -- --runInBand
       - run:
           command: cp junit.xml ~/junit/
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           name: "Run unit tests for core package"
           command: |
             TEST=$(circleci tests glob "packages/core/**/*.spec.ts" | circleci tests split --split-by=timings)
+            npx nx run core:generate
             npm test $TEST -- --coverage --runInBand
       - run:
           command: cp junit.xml ~/junit/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,23 @@ orbs:
   node: bigcommerce/internal-node@volatile
 
 jobs:
-  test:
+  test-core:
     <<: *node_executor
-    parallelism: 5
     steps:
       - ci/pre-setup
       - node/npm-install
       - run:
           name: "Run unit tests"
-          command: npm run test:series -- --coverage
+          command: npm run test:core -- --coverage
+
+  test-packages:
+    <<: *node_executor
+    steps:
+      - ci/pre-setup
+      - node/npm-install
+      - run:
+          name: "Run unit tests"
+          command: npm run test:others -- --coverage
     
   lint:
     <<: *node_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,23 +11,31 @@ orbs:
   node: bigcommerce/internal-node@volatile
 
 jobs:
-  test-core:
-    <<: *node_executor
-    steps:
-      - ci/pre-setup
-      - node/npm-install
-      - run:
-          name: "Run unit tests"
-          command: npm run test:core
-
   test-packages:
     <<: *node_executor
     steps:
       - ci/pre-setup
       - node/npm-install
       - run:
-          name: "Run unit tests"
-          command: npm run test:others -- --coverage
+          name: "Run unit tests for packages"
+          command: npm run test:others
+
+  test-core:
+    <<: *node_executor
+    parallelism: 3
+    steps:
+      - ci/pre-setup
+      - node/npm-install
+      - run:
+          name: "Run unit tests for core package"
+          command: |
+            TEST=$(circleci tests glob "packages/core/**/*.spec.js" | circleci tests split --split-by=timings)
+            npm test $TEST
+      - store_test_results:
+          path: test_results
+      - store_artifacts:
+          path: test_results
+          destination: test_results
 
   test:
     <<: *node_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ orbs:
 jobs:
   test:
     <<: *node_executor
-    resource_class: medium+
+    parallelism: 5
     steps:
       - ci/pre-setup
       - node/npm-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
 
   test-core:
     <<: *node_executor
-    parallelism: 3
+    parallelism: 2
+    resource_class: small
     steps:
       - ci/pre-setup
       - node/npm-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,6 @@ jobs:
       - run:
           name: "Run unit tests"
           command: npm run test:series -- --coverage
-      - store_artifacts:
-          path: coverage
-          destination: coverage
     
   lint:
     <<: *node_executor
@@ -94,6 +91,7 @@ workflows:
   default:
     jobs:
       - test
+      - lint
       - build
       - ci/validate-commits
 
@@ -104,6 +102,7 @@ workflows:
               ignore: /pull\/[0-9]+/
           requires:
             - test
+            - lint
             - build
             - ci/validate-commits
       - ci/build-js-artifact:
@@ -126,6 +125,7 @@ workflows:
               only: master
           requires:
             - test
+            - lint
             - build
             - ci/validate-commits
       - npm_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,15 +22,21 @@ jobs:
       - store_artifacts:
           path: coverage
           destination: coverage
+    
+  lint:
+    <<: *node_executor
+    steps:
+      - ci/pre-setup
+      - node/npm install
+      - run:
+          name: "Run lint"
+          command: npm run lint
 
   build:
     <<: *node_executor
     steps:
       - ci/pre-setup
       - node/npm-install
-      - run:
-          name: "Run linter"
-          command: npm run lint
       - run:
           name: "Build distribution files"
           command: npm run build && npm run docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
   test-core:
     <<: *node_executor
-    parallelism: 5
+    parallelism: 3
     steps:
       - ci/pre-setup
       - node/npm-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - node/npm-install
       - run:
           name: "Run unit tests"
-          command: npm run test:core -- --coverage
+          command: npm run test:core
 
   test-packages:
     <<: *node_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: "Run unit tests for core package"
           command: |
-            TEST=$(circleci tests glob "packages/core/**/*.spec.js" | circleci tests split --split-by=timings)
+            TEST=$(circleci tests glob "packages/core/**/*.spec.ts" | circleci tests split --split-by=timings)
             npm test $TEST
       - run:
           command: cp junit.xml ~/junit/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,11 +158,7 @@ workflows:
             branches:
               only: master
           requires:
-            - test-core
-            - test-packages
-            - lint
-            - build
-            - ci/validate-commits
+            - ci/notify-success
       - npm_release:
           requires:
             - approve_npm_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ orbs:
 jobs:
   test:
     <<: *node_executor
+    resource_class: medium+
     steps:
       - ci/pre-setup
       - node/npm-install
@@ -22,6 +23,7 @@ jobs:
     
   lint:
     <<: *node_executor
+    resource_class: medium+
     steps:
       - ci/pre-setup
       - node/npm-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
   test-core:
     <<: *node_executor
-    parallelism: 3
+    parallelism: 5
     steps:
       - ci/pre-setup
       - node/npm-install
@@ -31,7 +31,7 @@ jobs:
           name: "Run unit tests for core package"
           command: |
             TEST=$(circleci tests glob "packages/core/**/*.spec.ts" | circleci tests split --split-by=timings)
-            npm test $TEST -- --coverage
+            npm test $TEST -- --coverage --runInBand
       - run:
           command: cp junit.xml ~/junit/
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: "Run unit tests for core package"
           command: |
             TEST=$(circleci tests glob "packages/core/**/*.spec.ts" | circleci tests split --split-by=timings)
-            npm test $TEST
+            npm test $TEST -- --coverage
       - run:
           command: cp junit.xml ~/junit/
           when: always

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /packages/**/generated
 .idea
 .vscode
+junit.xml

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,15 +1,7 @@
-const { getJestProjects } = require('@nrwl/jest');
 const nxPreset = require('@nrwl/jest/preset');
-
-const projects = getJestProjects().map((project) => {
-    return project.replace('<rootDir>', '<rootDir>/../../');
-});
-
-console.log('Jest projects are', projects);
 
 module.exports = {
     ...nxPreset,
-    projects,
     coverageThreshold: {
         global: {
             branches: 80,

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,8 +1,15 @@
-
+const { getJestProjects } = require('@nrwl/jest');
 const nxPreset = require('@nrwl/jest/preset');
-     
+
+const projects = getJestProjects().map((project) => {
+    return project.replace('<rootDir>', '<rootDir>/../../');
+});
+
+console.log('Jest projects are', projects);
+
 module.exports = {
     ...nxPreset,
+    projects,
     coverageThreshold: {
         global: {
             branches: 80,
@@ -12,17 +19,8 @@ module.exports = {
         },
     },
     transform: {
-        '^.+\\.[tj]s$': 'ts-jest'
+        '^.+\\.[tj]s$': 'ts-jest',
     },
-    moduleFileExtensions: [
-        'ts',
-        'tsx',
-        'js',
-        'jsx',
-        'json',
-    ],
-    collectCoverageFrom: [
-        'src/**/*.{js,ts}',
-        '!src/**/*.mock.ts'
-    ],
-}
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+    collectCoverageFrom: ['src/**/*.{js,ts}', '!src/**/*.mock.ts'],
+};

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -10,6 +10,7 @@ module.exports = {
             statements: 80,
         },
     },
+    reporters: ['default', 'jest-junit'],
     transform: {
         '^.+\\.[tj]s$': 'ts-jest',
     },

--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,9 @@
           "build-watch",
           "lint",
           "test"
-        ]
+        ],
+        ,
+        "parallel": 10
       }
     }
   }

--- a/nx.json
+++ b/nx.json
@@ -17,7 +17,6 @@
           "lint",
           "test"
         ],
-        ,
         "parallel": 10
       }
     }

--- a/nx.json
+++ b/nx.json
@@ -17,7 +17,7 @@
           "lint",
           "test"
         ],
-        "parallel": 10
+        "parallel": 5
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21082,6 +21082,47 @@
         "throat": "^4.0.0"
       }
     },
+    "jest-junit": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-15.0.0.tgz",
+      "integrity": "sha512-Z5sVX0Ag3HZdMUnD5DFlG+1gciIFSy7yIVPhOdGUi8YJaI9iLvvBb530gtQL2CHmv0JJeiwRZenr0VrSR7frvg==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
     "jest-leak-detector": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
@@ -27119,6 +27160,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,21 +40,15 @@
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",
-    "test": "npx nx run core:test -- --coverage",
+    "test": "npx nx run core:test",
     "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
     "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
     "test:core": "npx nx run core:test -- --coverage --runInBand",
     "test:others": "npx nx run-many --all --target=test --exclude core --parallel=5 -- --runInBand",
     "test:watch": "npx nx run-many --all --target=test --parallel -- --watch"
   },
-  "jest": {
-    "reporters": [
-      "default",
-      "jest-junit"
-    ]
-  },
   "jest-junit": {
-    "outputDirectory": "test_results/junit"
+    "addFileAttribute": "true"
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,15 @@
     "test:others": "npx nx run-many --all --target=test --exclude core --parallel=5 -- --runInBand",
     "test:watch": "npx nx run-many --all --target=test --parallel -- --watch"
   },
+  "jest": {
+    "reporters": [
+      "default",
+      "jest-junit"
+    ]
+  },
+  "jest-junit": {
+    "outputDirectory": "test_results/junit"
+  },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
     "@bigcommerce/bigpay-client": "^5.22.0",
@@ -106,6 +115,7 @@
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^24.9.0",
+    "jest-junit": "^15.0.0",
     "nx": "^13.10.3",
     "prettier": "^2.6.2",
     "request": "^2.83.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",
-    "test": "jest",
+    "test": "jest --config packages/core/jest.config.js",
     "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
     "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
     "test:core": "npx nx run core:test -- --coverage --runInBand",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",
     "test": "npx nx run-many --all --target=test --parallel",
     "test:coverage": "npx nx run-many --all --target=test --parallel -- --coverage",
-    "test:series": "npx nx run-many --all --target=test --parallel -- --runInBand",
+    "test:series": "npx nx run-many --all --target=test --parallel=10 -- --runInBand",
     "test:watch": "npx nx run-many --all --target=test --parallel -- --watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",
-    "test": "npx nx run core:test",
+    "test": "jest",
     "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
     "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
     "test:core": "npx nx run core:test -- --coverage --runInBand",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "test": "npx nx run-many --all --target=test --parallel",
     "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
     "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
+    "test:core": "npx nx core:test -- --runInBand",
+    "test:others": "npx nx run-many --all --target=test --exclude core --parallel=5 -- --runInBand",
     "test:watch": "npx nx run-many --all --target=test --parallel -- --watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bundle-dts": "npx nx run core:build-dts",
     "docs": "npx nx run core:docs",
     "generate": "npx nx run core:generate",
-    "lint": "npx nx run-many --target=lint --parallel=10 --all",
+    "lint": "npx nx run-many --target=lint --parallel=10 --all --lint",
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bundle-dts": "npx nx run core:build-dts",
     "docs": "npx nx run core:docs",
     "generate": "npx nx run core:generate",
-    "lint": "npx nx run-many --target=lint --all",
+    "lint": "npx nx run-many --target=lint --parallel=10 --all",
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test": "npx nx run-many --all --target=test --parallel",
     "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
     "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
-    "test:core": "npx nx run core:test --coverage",
+    "test:core": "npx nx run core:test -- --coverage --runInBand",
     "test:others": "npx nx run-many --all --target=test --exclude core --parallel=5 -- --runInBand",
     "test:watch": "npx nx run-many --all --target=test --parallel -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",
-    "test": "npx nx run-many --all --target=test --parallel",
+    "test": "npx nx run core:test -- --coverage --runInBand",
     "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
     "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
     "test:core": "npx nx run core:test -- --coverage --runInBand",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test": "npx nx run-many --all --target=test --parallel",
     "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
     "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
-    "test:core": "npx nx core:test -- --runInBand",
+    "test:core": "npx nx run core:test --coverage",
     "test:others": "npx nx run-many --all --target=test --exclude core --parallel=5 -- --runInBand",
     "test:watch": "npx nx run-many --all --target=test --parallel -- --watch"
   },

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",
     "test": "npx nx run-many --all --target=test --parallel",
-    "test:coverage": "npx nx run-many --all --target=test --parallel -- --coverage",
-    "test:series": "npx nx run-many --all --target=test --parallel=10 -- --runInBand",
+    "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
+    "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
     "test:watch": "npx nx run-many --all --target=test --parallel -- --watch"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bundle-dts": "npx nx run core:build-dts",
     "docs": "npx nx run core:docs",
     "generate": "npx nx run core:generate",
-    "lint": "npx nx run-many --target=lint --parallel=10 --all --verbose",
+    "lint": "npx nx run-many --target=lint --parallel=1 --all --verbose",
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bundle-dts": "npx nx run core:build-dts",
     "docs": "npx nx run core:docs",
     "generate": "npx nx run core:generate",
-    "lint": "npx nx run-many --target=lint --parallel=1 --all --verbose",
+    "lint": "npx nx run-many --target=lint --parallel=5 --all --verbose",
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bundle-dts": "npx nx run core:build-dts",
     "docs": "npx nx run core:docs",
     "generate": "npx nx run core:generate",
-    "lint": "npx nx run-many --target=lint --parallel=10 --all --lint",
+    "lint": "npx nx run-many --target=lint --parallel=10 --all --verbose",
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release": "echo 'Please do not release locally, use CircleCi'",
     "release:version": "git add dist docs && standard-version -a",
     "release:alpha": "export PRERELEASE=alpha; npm run lint && npm test && npm run build && npm run release:version",
-    "test": "npx nx run core:test -- --coverage --runInBand",
+    "test": "npx nx run core:test -- --coverage",
     "test:coverage": "npx nx run-many --all --target=test --parallel=5 -- --coverage",
     "test:series": "npx nx run-many --all --target=test --parallel=5 -- --runInBand",
     "test:core": "npx nx run core:test -- --coverage --runInBand",

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -8,5 +8,5 @@ module.exports = {
         },
     },
     setupFilesAfterEnv: ['../../jest-setup.js'],
-    coverageDirectory: '../../coverage/packages/core'
+    coverageDirectory: '../../coverage/packages/core',
 };

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -103,7 +103,8 @@
             "outputs": ["coverage/packages/core"],
             "options": {
                 "jestConfig": "packages/core/jest.config.js",
-                "passWithNoTests": true
+                "passWithNoTests": true,
+                "runInBand": true
             },
             "dependsOn": [
                 {

--- a/packages/core/src/spam-protection/google-recaptcha-script-loader.spec.ts
+++ b/packages/core/src/spam-protection/google-recaptcha-script-loader.spec.ts
@@ -60,7 +60,6 @@ describe('GoogleRecaptchaScriptLoader', () => {
             const loadPromise = googleRecaptchaScriptLoader.load();
 
             mockWindow.grecaptcha = getGoogleRecaptchaMock();
-            // tslint:disable-next-line:no-non-null-assertion
             mockWindow.initRecaptcha!();
 
             expect(loadPromise).resolves.toEqual(mockWindow.grecaptcha);


### PR DESCRIPTION
## What?
- Move lint to a separate process
- Remove test artifact uploads
- Split test runs into two jobs one for core package and one for the rest of the packages
- Split test runs of core package into two parallel streams

## Why?
At the moment circlet CI runs take around 10 mins approximately, we can optimise this and have a quicker turn around in our CI steps.

## Testing / Proof
- Circle

Updated CI times for PRs

<img width="1232" alt="Screen Shot 2023-01-30 at 10 03 14 pm" src="https://user-images.githubusercontent.com/7134802/215459935-938c1de6-424a-4ab5-8923-ba32a0450b12.png">


@bigcommerce/checkout @icatalina 
