### PR TITLE
fix(payment): PAYPAL-1929 renamed several PayPal Commerce interfaces to fix the issue with doc files

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-options.ts
@@ -2,7 +2,7 @@ import { Address } from '../../../address';
 import { BuyNowCartRequestBody } from '../../../cart';
 import { StandardError } from '../../../common/error/errors';
 import { BraintreeError } from '../../../payment/strategies/braintree';
-import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
+import { PaypalStyleOptions } from '../../../payment/strategies/paypal';
 
 export interface BraintreePaypalButtonInitializeOptions {
     /**
@@ -20,7 +20,7 @@ export interface BraintreePaypalButtonInitializeOptions {
      * A set of styling options for the checkout button.
      */
     style?: Pick<
-        PaypalButtonStyleOptions,
+        PaypalStyleOptions,
         'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons' | 'height'
     >;
 

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-options.ts
@@ -2,7 +2,7 @@ import { Address } from '../../../address';
 import { BuyNowCartRequestBody } from '../../../cart';
 import { StandardError } from '../../../common/error/errors';
 import { BraintreeError } from '../../../payment/strategies/braintree';
-import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
+import { PaypalStyleOptions } from '../../../payment/strategies/paypal';
 
 export interface BraintreePaypalCreditButtonInitializeOptions {
     /**
@@ -15,7 +15,7 @@ export interface BraintreePaypalCreditButtonInitializeOptions {
      * A set of styling options for the checkout button.
      */
     style?: Pick<
-        PaypalButtonStyleOptions,
+        PaypalStyleOptions,
         'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons' | 'height'
     >;
 

--- a/packages/core/src/checkout-buttons/strategies/braintree/get-valid-button-style.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/get-valid-button-style.ts
@@ -1,10 +1,8 @@
 import { isNil, omitBy } from 'lodash';
 
-import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
+import { PaypalStyleOptions } from '../../../payment/strategies/paypal';
 
-export default function getValidButtonStyle(
-    style: PaypalButtonStyleOptions,
-): PaypalButtonStyleOptions {
+export default function getValidButtonStyle(style: PaypalStyleOptions): PaypalStyleOptions {
     const { color, fundingicons, height, layout, shape, size, tagline } = style;
 
     const validStyles = {

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.spec.ts
@@ -1,8 +1,8 @@
 import {
-    StyleButtonColor,
-    StyleButtonLabel,
-    StyleButtonLayout,
-    StyleButtonShape,
+    PaypalStyleButtonColor,
+    PaypalStyleButtonLabel,
+    PaypalStyleButtonLayout,
+    PaypalStyleButtonShape,
 } from '../../../payment/strategies/paypal-commerce';
 
 import getValidButtonStyle from './get-valid-button-style';
@@ -10,9 +10,9 @@ import getValidButtonStyle from './get-valid-button-style';
 describe('#getValidButtonStyle()', () => {
     it('returns valid button style', () => {
         const stylesMock = {
-            color: StyleButtonColor.silver,
+            color: PaypalStyleButtonColor.silver,
             height: 55,
-            shape: StyleButtonShape.rect,
+            shape: PaypalStyleButtonShape.rect,
         };
 
         const expects = {
@@ -24,9 +24,9 @@ describe('#getValidButtonStyle()', () => {
 
     it('returns button style without shape if shape is not valid', () => {
         const stylesMock = {
-            color: StyleButtonColor.silver,
+            color: PaypalStyleButtonColor.silver,
             height: 55,
-            shape: 'ellipse' as StyleButtonShape,
+            shape: 'ellipse' as PaypalStyleButtonShape,
         };
 
         const expects = {
@@ -39,7 +39,7 @@ describe('#getValidButtonStyle()', () => {
 
     it('returns button style without color if color is not valid', () => {
         const stylesMock = {
-            color: 'red' as StyleButtonColor,
+            color: 'red' as PaypalStyleButtonColor,
             height: 55,
         };
 
@@ -54,7 +54,7 @@ describe('#getValidButtonStyle()', () => {
     it('returns button style without label if label is not valid', () => {
         const stylesMock = {
             height: 55,
-            label: 'label' as StyleButtonLabel,
+            label: 'label' as PaypalStyleButtonLabel,
         };
 
         const expects = {
@@ -68,7 +68,7 @@ describe('#getValidButtonStyle()', () => {
     it('returns button style without layout if layout is not valid', () => {
         const stylesMock = {
             height: 55,
-            layout: 'layout' as StyleButtonLayout,
+            layout: 'layout' as PaypalStyleButtonLayout,
         };
 
         const expects = {
@@ -81,9 +81,9 @@ describe('#getValidButtonStyle()', () => {
 
     it('returns styles with updated height if height value is bigger than expected', () => {
         const stylesMock = {
-            color: StyleButtonColor.silver,
+            color: PaypalStyleButtonColor.silver,
             height: 110,
-            shape: StyleButtonShape.rect,
+            shape: PaypalStyleButtonShape.rect,
         };
 
         const expects = {
@@ -96,9 +96,9 @@ describe('#getValidButtonStyle()', () => {
 
     it('returns styles with updated height if height value is less than expected', () => {
         const stylesMock = {
-            color: StyleButtonColor.silver,
+            color: PaypalStyleButtonColor.silver,
             height: 10,
-            shape: StyleButtonShape.rect,
+            shape: PaypalStyleButtonShape.rect,
         };
 
         const expects = {
@@ -111,9 +111,9 @@ describe('#getValidButtonStyle()', () => {
 
     it('returns styles with default height if height value not provided', () => {
         const stylesMock = {
-            color: StyleButtonColor.silver,
+            color: PaypalStyleButtonColor.silver,
             height: undefined,
-            shape: StyleButtonShape.rect,
+            shape: PaypalStyleButtonShape.rect,
         };
 
         const expects = {
@@ -126,10 +126,10 @@ describe('#getValidButtonStyle()', () => {
 
     it('returns styles without tagline for vertical layout', () => {
         const stylesMock = {
-            color: StyleButtonColor.silver,
+            color: PaypalStyleButtonColor.silver,
             height: 55,
-            shape: StyleButtonShape.rect,
-            layout: StyleButtonLayout.vertical,
+            shape: PaypalStyleButtonShape.rect,
+            layout: PaypalStyleButtonLayout.vertical,
             tagline: true,
         };
 
@@ -143,10 +143,10 @@ describe('#getValidButtonStyle()', () => {
 
     it('returns styles with tagline if the layout is horizontal', () => {
         const stylesMock = {
-            color: StyleButtonColor.silver,
+            color: PaypalStyleButtonColor.silver,
             height: 55,
-            shape: StyleButtonShape.rect,
-            layout: StyleButtonLayout.horizontal,
+            shape: PaypalStyleButtonShape.rect,
+            layout: PaypalStyleButtonLayout.horizontal,
             tagline: true,
         };
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/get-valid-button-style.ts
@@ -1,16 +1,14 @@
 import { isNil, omitBy } from 'lodash';
 
 import {
-    PaypalButtonStyleOptions,
-    StyleButtonColor,
-    StyleButtonLabel,
-    StyleButtonLayout,
-    StyleButtonShape,
+    PaypalStyleButtonColor,
+    PaypalStyleButtonLabel,
+    PaypalStyleButtonLayout,
+    PaypalStyleButtonShape,
+    PaypalStyleOptions,
 } from '../../../payment/strategies/paypal-commerce';
 
-export default function getValidButtonStyle(
-    style: PaypalButtonStyleOptions,
-): PaypalButtonStyleOptions {
+export default function getValidButtonStyle(style: PaypalStyleOptions): PaypalStyleOptions {
     const { label, color, layout, shape, height, tagline } = style;
 
     const validStyles = {
@@ -25,28 +23,24 @@ export default function getValidButtonStyle(
     return omitBy(validStyles, isNil);
 }
 
-function getValidColor(color?: StyleButtonColor): StyleButtonColor | undefined {
-    return color && StyleButtonColor[color] ? color : undefined;
+function getValidColor(color?: PaypalStyleButtonColor): PaypalStyleButtonColor | undefined {
+    return color && PaypalStyleButtonColor[color] ? color : undefined;
 }
 
-function getValidLabel(label?: StyleButtonLabel): StyleButtonLabel | undefined {
-    return label && StyleButtonLabel[label] ? label : undefined;
+function getValidLabel(label?: PaypalStyleButtonLabel): PaypalStyleButtonLabel | undefined {
+    return label && PaypalStyleButtonLabel[label] ? label : undefined;
 }
 
-function getValidLayout(layout?: StyleButtonLayout): StyleButtonLayout | undefined {
-    return layout && StyleButtonLayout[layout] ? layout : undefined;
+function getValidLayout(layout?: PaypalStyleButtonLayout): PaypalStyleButtonLayout | undefined {
+    return layout && PaypalStyleButtonLayout[layout] ? layout : undefined;
 }
 
-function getValidShape(shape?: StyleButtonShape): StyleButtonShape | undefined {
-    return shape && StyleButtonShape[shape] ? shape : undefined;
+function getValidShape(shape?: PaypalStyleButtonShape): PaypalStyleButtonShape | undefined {
+    return shape && PaypalStyleButtonShape[shape] ? shape : undefined;
 }
 
 function getValidTagline(tagline?: boolean, layout?: string): boolean | undefined {
-    if (
-        tagline &&
-        typeof tagline === 'boolean' &&
-        layout === StyleButtonLayout[StyleButtonLayout.horizontal]
-    ) {
+    if (tagline && typeof tagline === 'boolean' && layout === PaypalStyleButtonLayout.horizontal) {
         return tagline;
     }
 

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-options.ts
@@ -1,5 +1,5 @@
 import { BuyNowCartRequestBody } from '../../../cart';
-import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+import { PaypalStyleOptions } from '../../../payment/strategies/paypal-commerce';
 
 export interface PaypalCommerceAlternativeMethodsButtonOptions {
     /**
@@ -15,7 +15,7 @@ export interface PaypalCommerceAlternativeMethodsButtonOptions {
     /**
      * A set of styling options for the checkout button.
      */
-    style?: PaypalButtonStyleOptions;
+    style?: PaypalStyleOptions;
 
     /**
      * The option that used to initialize a PayPal script with provided currency code.

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-alternative-methods-button-strategy.ts
@@ -12,10 +12,10 @@ import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
 import {
     ApproveCallbackPayload,
     ButtonsOptions,
-    PaypalButtonStyleOptions,
     PaypalCommerceRequestSender,
     PaypalCommerceScriptLoader,
     PaypalCommerceSDK,
+    PaypalStyleOptions,
 } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
@@ -202,7 +202,7 @@ export default class PaypalCommerceAlternativeMethodsButtonStrategy
         return this._paypalCommerceSdk;
     }
 
-    private _getButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+    private _getButtonStyle(style: PaypalStyleOptions): PaypalStyleOptions {
         const { height, label, layout, shape } = getValidButtonStyle(style);
 
         return { height, label, layout, shape };

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-options.ts
@@ -1,11 +1,11 @@
 import { BuyNowCartRequestBody } from '../../../cart';
-import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+import { PaypalStyleOptions } from '../../../payment/strategies/paypal-commerce';
 
 export interface PaypalCommerceButtonInitializeOptions {
     /**
      * A set of styling options for the checkout button.
      */
-    style?: PaypalButtonStyleOptions;
+    style?: PaypalStyleOptions;
 
     /**
      * Flag which helps to detect that the strategy initializes on Checkout page.

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -17,10 +17,10 @@ import {
     ApproveCallbackActions,
     ApproveCallbackPayload,
     ButtonsOptions,
-    PaypalButtonStyleOptions,
     PaypalCommerceRequestSender,
     PaypalCommerceScriptLoader,
     PaypalCommerceSDK,
+    PaypalStyleOptions,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../../../payment/strategies/paypal-commerce';
@@ -409,7 +409,7 @@ export default class PaypalCommerceButtonStrategy implements CheckoutButtonStrat
         return this._paypalCommerceSdk;
     }
 
-    private _getButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+    private _getButtonStyle(style: PaypalStyleOptions): PaypalStyleOptions {
         const { color, height, label, layout, shape } = getValidButtonStyle(style);
 
         return { color, height, label, layout, shape };

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-options.ts
@@ -1,5 +1,5 @@
 import { BuyNowCartRequestBody } from '../../../cart';
-import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+import { PaypalStyleOptions } from '../../../payment/strategies/paypal-commerce';
 
 export interface PaypalCommerceCreditButtonInitializeOptions {
     /**
@@ -15,7 +15,7 @@ export interface PaypalCommerceCreditButtonInitializeOptions {
     /**
      * A set of styling options for the checkout button.
      */
-    style?: PaypalButtonStyleOptions;
+    style?: PaypalStyleOptions;
 
     /**
      * The option that used to initialize a PayPal script with provided currency code.

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-credit-button-strategy.ts
@@ -17,10 +17,10 @@ import {
     ApproveCallbackActions,
     ApproveCallbackPayload,
     ButtonsOptions,
-    PaypalButtonStyleOptions,
     PaypalCommerceRequestSender,
     PaypalCommerceScriptLoader,
     PaypalCommerceSDK,
+    PaypalStyleOptions,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../../../payment/strategies/paypal-commerce';
@@ -441,7 +441,7 @@ export default class PaypalCommerceCreditButtonStrategy implements CheckoutButto
         return this._paypalCommerceSdk;
     }
 
-    private _getButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+    private _getButtonStyle(style: PaypalStyleOptions): PaypalStyleOptions {
         const { color, height, label, layout, shape } = getValidButtonStyle(style);
 
         return { color, height, label, layout, shape };

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-options.ts
@@ -1,11 +1,11 @@
 import { BuyNowCartRequestBody } from '../../../cart';
-import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal-commerce';
+import { PaypalStyleOptions } from '../../../payment/strategies/paypal-commerce';
 
 export interface PaypalCommerceVenmoButtonInitializeOptions {
     /**
      * A set of styling options for the checkout button.
      */
-    style?: PaypalButtonStyleOptions;
+    style?: PaypalStyleOptions;
 
     /**
      * Flag which helps to detect that the strategy initializes on Checkout page

--- a/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal-commerce/paypal-commerce-venmo-button-strategy.ts
@@ -12,10 +12,10 @@ import { PaymentMethodClientUnavailableError } from '../../../payment/errors';
 import {
     ApproveCallbackPayload,
     ButtonsOptions,
-    PaypalButtonStyleOptions,
     PaypalCommerceRequestSender,
     PaypalCommerceScriptLoader,
     PaypalCommerceSDK,
+    PaypalStyleOptions,
 } from '../../../payment/strategies/paypal-commerce';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonStrategy from '../checkout-button-strategy';
@@ -188,7 +188,7 @@ export default class PaypalCommerceVenmoButtonStrategy implements CheckoutButton
         return this._paypalCommerceSdk;
     }
 
-    private _getVenmoButtonStyle(style: PaypalButtonStyleOptions): PaypalButtonStyleOptions {
+    private _getVenmoButtonStyle(style: PaypalStyleOptions): PaypalStyleOptions {
         const { height, label, layout, shape } = getValidButtonStyle(style);
 
         return { height, label, layout, shape };

--- a/packages/core/src/checkout-buttons/strategies/paypal/paypal-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/paypal/paypal-button-options.ts
@@ -1,5 +1,5 @@
 import { StandardError } from '../../../common/error/errors';
-import { PaypalButtonStyleOptions } from '../../../payment/strategies/paypal';
+import { PaypalStyleOptions } from '../../../payment/strategies/paypal';
 
 export interface PaypalButtonInitializeOptions {
     /**
@@ -22,7 +22,7 @@ export interface PaypalButtonInitializeOptions {
      * A set of styling options for the checkout button.
      */
     style?: Pick<
-        PaypalButtonStyleOptions,
+        PaypalStyleOptions,
         'layout' | 'size' | 'color' | 'label' | 'shape' | 'tagline' | 'fundingicons'
     >;
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-payment-processor.ts
@@ -19,7 +19,6 @@ import {
     FieldsOptions,
     NON_INSTANT_PAYMENT_METHODS,
     ParamsForProvider,
-    PaypalButtonStyleOptions,
     PaypalCommerceButtons,
     PaypalCommerceFields,
     PaypalCommerceHostedFields,
@@ -34,10 +33,11 @@ import {
     PaypalCommerceSDK,
     PaypalCommerceSDKFunding,
     PaypalFieldsStyleOptions,
-    StyleButtonColor,
-    StyleButtonLabel,
-    StyleButtonLayout,
-    StyleButtonShape,
+    PaypalStyleButtonColor,
+    PaypalStyleButtonLabel,
+    PaypalStyleButtonLayout,
+    PaypalStyleButtonShape,
+    PaypalStyleOptions,
 } from './index';
 
 export interface OptionalParamsRenderButtons {
@@ -350,23 +350,23 @@ export default class PaypalCommercePaymentProcessor {
         );
     }
 
-    private _validateStyleParams = (style: PaypalButtonStyleOptions): PaypalButtonStyleOptions => {
-        const updatedStyle: PaypalButtonStyleOptions = { ...style };
+    private _validateStyleParams = (style: PaypalStyleOptions): PaypalStyleOptions => {
+        const updatedStyle: PaypalStyleOptions = { ...style };
         const { label, color, layout, shape, height, tagline } = style;
 
-        if (label && !StyleButtonLabel[label]) {
+        if (label && !PaypalStyleButtonLabel[label]) {
             delete updatedStyle.label;
         }
 
-        if (layout && !StyleButtonLayout[layout]) {
+        if (layout && !PaypalStyleButtonLayout[layout]) {
             delete updatedStyle.layout;
         }
 
-        if (color && !StyleButtonColor[color]) {
+        if (color && !PaypalStyleButtonColor[color]) {
             delete updatedStyle.color;
         }
 
-        if (shape && !StyleButtonShape[shape]) {
+        if (shape && !PaypalStyleButtonShape[shape]) {
             delete updatedStyle.shape;
         }
 
@@ -378,7 +378,7 @@ export default class PaypalCommercePaymentProcessor {
 
         if (
             typeof tagline !== 'boolean' ||
-            (tagline && updatedStyle.layout !== StyleButtonLayout[StyleButtonLayout.horizontal])
+            (tagline && updatedStyle.layout !== PaypalStyleButtonLayout.horizontal)
         ) {
             delete updatedStyle.tagline;
         }

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-sdk.ts
@@ -18,7 +18,7 @@ export interface OrderStatus {
     status: 'APPROVED' | 'CREATED' | string;
 }
 
-export enum StyleButtonLabel {
+export enum PaypalStyleButtonLabel {
     paypal = 'paypal',
     checkout = 'checkout',
     buynow = 'buynow',
@@ -26,12 +26,12 @@ export enum StyleButtonLabel {
     installment = 'installment',
 }
 
-export enum StyleButtonLayout {
+export enum PaypalStyleButtonLayout {
     vertical = 'vertical',
     horizontal = 'horizontal',
 }
 
-export enum StyleButtonColor {
+export enum PaypalStyleButtonColor {
     gold = 'gold',
     blue = 'blue',
     silver = 'silver',
@@ -39,17 +39,17 @@ export enum StyleButtonColor {
     white = 'white',
 }
 
-export enum StyleButtonShape {
+export enum PaypalStyleButtonShape {
     pill = 'pill',
     rect = 'rect',
 }
 
-export interface PaypalButtonStyleOptions {
-    layout?: StyleButtonLayout;
-    color?: StyleButtonColor;
-    shape?: StyleButtonShape;
+export interface PaypalStyleOptions {
+    layout?: PaypalStyleButtonLayout;
+    color?: PaypalStyleButtonColor;
+    shape?: PaypalStyleButtonShape;
     height?: number;
-    label?: StyleButtonLabel;
+    label?: PaypalStyleButtonLabel;
     tagline?: boolean;
     custom?: {
         label?: string;
@@ -130,7 +130,7 @@ export interface PayPalOrderDetails {
 
 // TODO: this type should be merged with PayPalCheckoutButtonOptions in the future
 export interface ButtonsOptions {
-    style?: PaypalButtonStyleOptions;
+    style?: PaypalStyleOptions;
     fundingSource?: string;
     createOrder?(): Promise<string | void>; // TODO: this method should return only Promise<void>
     onApprove?(data: ApproveCallbackPayload, actions?: ApproveCallbackActions): void;
@@ -144,7 +144,7 @@ export interface ButtonsOptions {
 
 export interface PaypalCheckoutButtonOptions {
     experience: string;
-    style?: PaypalButtonStyleOptions;
+    style?: PaypalStyleOptions;
     fundingSource: string;
     createOrder(): Promise<string>;
     onError(error: Error): void;

--- a/packages/core/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal/paypal-sdk.ts
@@ -34,7 +34,7 @@ export interface MessagingOptions {
 export interface PaypalButtonOptions {
     env?: string;
     commit?: boolean;
-    style?: PaypalButtonStyleOptions;
+    style?: PaypalStyleOptions;
     funding?: PaypalFundingType;
     fundingSource?: string;
     client?: PaypalClientToken;
@@ -86,7 +86,7 @@ export enum PaypalButtonStyleShapeOption {
     RECT = 'rect',
 }
 
-export interface PaypalButtonStyleOptions {
+export interface PaypalStyleOptions {
     layout?: PaypalButtonStyleLayoutOption;
     size?: PaypalButtonStyleSizeOption;
     color?: PaypalButtonStyleColorOption;


### PR DESCRIPTION
## What?
Renamed several PayPal Commerce interfaces to fix the issue with doc files

## Why?
Due to the issues with docs in dev env

## Testing / Proof
Doc generating command passed successfully:
<img width="1742" alt="Screenshot 2023-01-27 at 11 55 59" src="https://user-images.githubusercontent.com/25133454/215058225-17ba1f79-37a1-4510-b194-05b82d65b004.png">
