### PR TITLE
feat(payment): PAYPAL-1934 move PaymentMethodFailedError to integration package

### DIFF
--- a/packages/core/src/customer/strategies/bolt/bolt-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/bolt/bolt-customer-strategy.spec.ts
@@ -3,6 +3,8 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { of } from 'rxjs';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import {
     CheckoutActionCreator,
     CheckoutRequestSender,
@@ -19,7 +21,6 @@ import {
     PaymentMethodActionCreator,
     PaymentMethodRequestSender,
 } from '../../../payment';
-import { PaymentMethodFailedError } from '../../../payment/errors';
 import { getBolt } from '../../../payment/payment-methods.mock';
 import { BoltCheckout, BoltScriptLoader } from '../../../payment/strategies/bolt';
 import { getQuote } from '../../../quote/internal-quotes.mock';

--- a/packages/core/src/customer/strategies/bolt/bolt-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/bolt/bolt-customer-strategy.ts
@@ -1,5 +1,7 @@
 import { noop } from 'rxjs';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
     InvalidArgumentError,
@@ -9,7 +11,7 @@ import {
     NotInitializedErrorType,
 } from '../../../common/error/errors';
 import { PaymentMethodActionCreator } from '../../../payment';
-import { PaymentMethodFailedError, PaymentMethodInvalidError } from '../../../payment/errors';
+import { PaymentMethodInvalidError } from '../../../payment/errors';
 import { BoltCheckout, BoltScriptLoader } from '../../../payment/strategies/bolt';
 import CustomerActionCreator from '../../customer-action-creator';
 import CustomerCredentials from '../../customer-credentials';

--- a/packages/core/src/payment/errors/index.ts
+++ b/packages/core/src/payment/errors/index.ts
@@ -1,6 +1,5 @@
 export { default as PaymentArgumentInvalidError } from './payment-argument-invalid-error';
 export { default as PaymentMethodCancelledError } from './payment-method-cancelled-error';
-export { default as PaymentMethodFailedError } from './payment-method-failed-error';
 export { default as PaymentMethodClientUnavailableError } from './payment-method-client-unavailable-error';
 export { default as PaymentMethodDeclinedError } from './payment-method-declined-error';
 export { default as PaymentMethodInvalidError } from './payment-method-invalid-error';

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -5,6 +5,8 @@ import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import localStorageFallback from 'local-storage-fallback';
 import { Observable, of } from 'rxjs';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import AnalyticsExtraItemsManager from '../../../analytics/analytics-extra-items-manager';
 import {
     Checkout,
@@ -43,7 +45,6 @@ import {
 import {
     PaymentArgumentInvalidError,
     PaymentMethodCancelledError,
-    PaymentMethodFailedError,
     PaymentMethodInvalidError,
 } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -1,3 +1,5 @@
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import AnalyticsExtraItemsManager from '../../../analytics/analytics-extra-items-manager';
 import { isAnalyticsTrackerWindow } from '../../../analytics/is-analytics-step-tracker-window';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
@@ -14,7 +16,6 @@ import { StoreCreditActionCreator } from '../../../store-credit';
 import {
     PaymentArgumentInvalidError,
     PaymentMethodCancelledError,
-    PaymentMethodFailedError,
     PaymentMethodInvalidError,
 } from '../../errors';
 import { withAccountCreation } from '../../index';

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -1,11 +1,13 @@
 import { some } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { Address } from '../../../address';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import { MissingDataError, MissingDataErrorType, RequestError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentArgumentInvalidError, PaymentMethodFailedError } from '../../errors';
+import { PaymentArgumentInvalidError } from '../../errors';
 import { isHostedInstrumentLike, PaymentMethod } from '../../index';
 import isVaultedInstrument from '../../is-vaulted-instrument';
 import {

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -2,13 +2,11 @@ import { Action, createAction } from '@bigcommerce/data-store';
 import { omit } from 'lodash';
 import { Observable, of } from 'rxjs';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
-import {
-    InvalidArgumentError,
-    MissingDataError,
-    StandardError,
-} from '../../../common/error/errors';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
 import { OrderActionCreator, OrderActionType, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { getOrderRequestBody } from '../../../order/internal-orders.mock';
@@ -268,7 +266,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
             await expect(
                 braintreePaypalPaymentStrategy.execute(orderRequestBody, options),
-            ).rejects.toEqual(expect.any(StandardError));
+            ).rejects.toEqual(expect.any(PaymentMethodFailedError));
         });
 
         it('if paypal fails we do not submit an order', async () => {
@@ -279,7 +277,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
             try {
                 await braintreePaypalPaymentStrategy.execute(orderRequestBody, options);
             } catch (error) {
-                expect(error).toBeInstanceOf(StandardError);
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
                 expect(orderActionCreator.submitOrder).not.toHaveBeenCalled();
             }
         });

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -1,3 +1,5 @@
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
     InvalidArgumentError,
@@ -8,11 +10,7 @@ import {
 } from '../../../common/error/errors';
 import { OrderActionCreator, OrderPaymentRequestBody, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import {
-    PaymentArgumentInvalidError,
-    PaymentMethodCancelledError,
-    PaymentMethodFailedError,
-} from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
 import { isHostedInstrumentLike } from '../../index';
 import isVaultedInstrument, { isHostedVaultedInstrument } from '../../is-vaulted-instrument';
 import Payment, { FormattedPayload, PaypalInstrument } from '../../payment';

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
@@ -1,5 +1,7 @@
 import { noop } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
     InvalidArgumentError,
@@ -8,7 +10,6 @@ import {
 } from '../../../common/error/errors';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import { PaymentMethodFailedError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';

--- a/packages/core/src/payment/strategies/cardinal/cardinal-client.spec.ts
+++ b/packages/core/src/payment/strategies/cardinal/cardinal-client.spec.ts
@@ -1,6 +1,8 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { MissingDataError, NotInitializedError, StandardError } from '../../../common/error/errors';
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { MissingDataError, NotInitializedError } from '../../../common/error/errors';
 
 import {
     getCardinalBinProcessResponse,
@@ -242,7 +244,7 @@ describe('CardinalClient', () => {
                     getCardinalOrderData(),
                 );
             } catch (error) {
-                expect(error).toBeInstanceOf(StandardError);
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
             }
         });
 
@@ -268,7 +270,7 @@ describe('CardinalClient', () => {
                     getCardinalOrderData(),
                 );
             } catch (error) {
-                expect(error).toBeInstanceOf(StandardError);
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
             }
         });
 
@@ -286,7 +288,7 @@ describe('CardinalClient', () => {
                     getCardinalOrderData(),
                 );
             } catch (error) {
-                expect(error).toBeInstanceOf(StandardError);
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
             }
         });
 
@@ -304,7 +306,7 @@ describe('CardinalClient', () => {
                     getCardinalOrderData(),
                 );
             } catch (error) {
-                expect(error).toBeInstanceOf(StandardError);
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
                 expect(error.message).toBe(
                     'User failed authentication or an error was encountered while processing the transaction.',
                 );
@@ -375,7 +377,7 @@ describe('CardinalClient', () => {
                     getCardinalOrderData(),
                 );
             } catch (error) {
-                expect(error).toBeInstanceOf(StandardError);
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
                 expect(error.message).toBe(
                     'An error was encountered while processing the transaction.',
                 );

--- a/packages/core/src/payment/strategies/cardinal/cardinal-client.ts
+++ b/packages/core/src/payment/strategies/cardinal/cardinal-client.ts
@@ -1,5 +1,7 @@
 import { includes } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { Address } from '../../../address';
 import { BillingAddress } from '../../../billing';
 import {
@@ -8,7 +10,6 @@ import {
     NotInitializedError,
     NotInitializedErrorType,
 } from '../../../common/error/errors';
-import { PaymentMethodFailedError } from '../../errors';
 import { CreditCardInstrument, ThreeDSecureToken, VaultedInstrument } from '../../payment';
 import { ThreeDsResult } from '../../payment-response-body';
 

--- a/packages/core/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.spec.ts
@@ -5,6 +5,8 @@ import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import { merge } from 'lodash';
 import { Observable, of } from 'rxjs';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import {
     CheckoutRequestSender,
     CheckoutStore,
@@ -27,11 +29,7 @@ import { getOrderRequestBody } from '../../../order/internal-orders.mock';
 import { getOrder } from '../../../order/orders.mock';
 import { PaymentMethodActionCreator } from '../../../payment';
 import { createSpamProtection, PaymentHumanVerificationHandler } from '../../../spam-protection';
-import {
-    PaymentArgumentInvalidError,
-    PaymentMethodDeclinedError,
-    PaymentMethodFailedError,
-} from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodDeclinedError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';

--- a/packages/core/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/cba-mpgs/cba-mpgs-payment-strategy.ts
@@ -1,5 +1,7 @@
 import { noop, some } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {
     MissingDataError,
@@ -11,11 +13,7 @@ import {
 import { HostedFormFactory } from '../../../hosted-form';
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
-import {
-    PaymentArgumentInvalidError,
-    PaymentMethodDeclinedError,
-    PaymentMethodFailedError,
-} from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodDeclinedError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';

--- a/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.spec.ts
@@ -1,8 +1,9 @@
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
 import { merge } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { InvalidArgumentError } from '../../../common/error/errors';
-import { PaymentMethodFailedError } from '../../errors';
 
 import GooglePayCheckoutcomInitializer from './googlepay-checkoutcom-initializer';
 import {

--- a/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
@@ -1,10 +1,11 @@
 import { RequestSender } from '@bigcommerce/request-sender';
 import { round } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { Checkout } from '../../../checkout';
 import { InvalidArgumentError } from '../../../common/error/errors';
 import { ContentType } from '../../../common/http-request';
-import { PaymentMethodFailedError } from '../../errors';
 import PaymentMethod from '../../payment-method';
 import { CheckoutcomGooglePayToken, CheckoutcomToken } from '../checkoutcom';
 

--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-upe-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-upe-initializer.ts
@@ -1,8 +1,9 @@
 import { round } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { Checkout } from '../../../checkout';
 import { InvalidArgumentError } from '../../../common/error/errors';
-import { PaymentMethodFailedError } from '../../errors';
 import PaymentMethod from '../../payment-method';
 
 import {

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.spec.ts
@@ -3,13 +3,15 @@ import { createRequestSender, RequestSender } from '@bigcommerce/request-sender'
 import { getScriptLoader } from '@bigcommerce/script-loader';
 import { Observable, of } from 'rxjs';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { Cart } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { OrderActionCreator, OrderActionType } from '../../../order';
 import { PaymentMethod } from '../../../payment';
-import { PaymentInvalidFormError, PaymentMethodFailedError } from '../../errors';
+import { PaymentInvalidFormError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType } from '../../payment-actions';
 import { getPaypalCommerce } from '../../payment-methods.mock';

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-hosted-form.ts
@@ -1,12 +1,10 @@
 import { isNil, kebabCase, omitBy } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { Cart } from '../../../cart';
 import { HostedInstrument, PaymentMethod, VaultedInstrument } from '../../../payment';
-import {
-    PaymentInvalidFormError,
-    PaymentInvalidFormErrorDetails,
-    PaymentMethodFailedError,
-} from '../../errors';
+import { PaymentInvalidFormError, PaymentInvalidFormErrorDetails } from '../../errors';
 
 import {
     PaypalCommerceFormFieldsMap,

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -4,6 +4,8 @@ import { createRequestSender } from '@bigcommerce/request-sender';
 import { createScriptLoader } from '@bigcommerce/script-loader';
 import { Observable, of } from 'rxjs';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import {
     BillingAddressActionCreator,
     BillingAddressActionType,
@@ -49,11 +51,7 @@ import {
     StoreCreditRequestSender,
 } from '../../../store-credit';
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../../../subscription';
-import {
-    PaymentArgumentInvalidError,
-    PaymentMethodCancelledError,
-    PaymentMethodFailedError,
-} from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
 import PaymentActionCreator from '../../payment-action-creator';
 import { PaymentActionType, SubmitPaymentAction } from '../../payment-actions';
 import PaymentMethod from '../../payment-method';

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -1,5 +1,7 @@
 import { includes, some } from 'lodash';
 
+import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { isHostedInstrumentLike } from '../..';
 import { Address } from '../../../address';
 import { BillingAddressActionCreator } from '../../../billing';
@@ -15,11 +17,7 @@ import {
 import { OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { StoreCreditActionCreator } from '../../../store-credit';
-import {
-    PaymentArgumentInvalidError,
-    PaymentMethodCancelledError,
-    PaymentMethodFailedError,
-} from '../../errors';
+import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
 import isVaultedInstrument from '../../is-vaulted-instrument';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';

--- a/packages/payment-integration-api/src/errors/index.ts
+++ b/packages/payment-integration-api/src/errors/index.ts
@@ -10,5 +10,6 @@ export { default as OrderFinalizationNotRequiredError } from './order-finalizati
 export { default as PaymentArgumentInvalidError } from './payment-argument-invalid-error';
 export { default as PaymentMethodCancelledError } from './payment-method-cancelled-error';
 export { default as PaymentMethodClientUnavailableError } from './payment-method-client-unavailable-error';
+export { default as PaymentMethodFailedError } from './payment-method-failed-error';
 export { default as RequestError } from './request-error';
 export { default as isRequestError } from './is-request-error';

--- a/packages/payment-integration-api/src/errors/payment-method-failed-error.ts
+++ b/packages/payment-integration-api/src/errors/payment-method-failed-error.ts
@@ -1,4 +1,4 @@
-import { StandardError } from '../../common/error/errors';
+import StandardError from './standard-error';
 
 /**
  * This error should be thrown when a payment method experiences some kind of

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -45,6 +45,7 @@ export {
     PaymentInvalidFormErrorDetails,
     PaymentMethodCancelledError,
     PaymentMethodClientUnavailableError,
+    PaymentMethodFailedError,
     RequestError,
     isRequestError,
 } from './errors';


### PR DESCRIPTION
## What?
Make an ability to use PaymentMethodFailedError from core package in integration checkout-sdk packages

## Why?
because of task: [https://bigcommercecloud.atlassian.net/browse/PAYPAL-1934](https://bigcommercecloud.atlassian.net/browse/PAYPAL-1934)

## Testing / Proof
<img width="453" alt="Screenshot 2023-01-27 at 17 05 18" src="https://user-images.githubusercontent.com/9430298/215119426-3d8ccbbe-e96b-48a8-828c-914696263818.png">


@bigcommerce/checkout @bigcommerce/payments
