### PR TITLE
feat(payment): PAYPAL-000 added an ability to loadCheckout by provided id in payments-integration-api

### DIFF
--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -46,7 +46,7 @@ describe('DefaultPaymentIntegrationService', () => {
     let storeProjectionFactory: Pick<PaymentIntegrationStoreProjectionFactory, 'create'>;
     let checkoutActionCreator: Pick<
         CheckoutActionCreator,
-        'loadCurrentCheckout' | 'loadDefaultCheckout'
+        'loadCheckout' | 'loadCurrentCheckout' | 'loadDefaultCheckout'
     >;
     let orderActionCreator: Pick<OrderActionCreator, 'submitOrder' | 'finalizeOrder'>;
     let billingAddressActionCreator: Pick<BillingAddressActionCreator, 'updateAddress'>;
@@ -89,6 +89,7 @@ describe('DefaultPaymentIntegrationService', () => {
         };
 
         checkoutActionCreator = {
+            loadCheckout: jest.fn(async () => () => createAction('LOAD_CHECKOUT')),
             loadCurrentCheckout: jest.fn(async () => () => createAction('LOAD_CHECKOUT')),
             loadDefaultCheckout: jest.fn(async () => () => createAction('LOAD_CHECKOUT')),
         };
@@ -145,6 +146,17 @@ describe('DefaultPaymentIntegrationService', () => {
             expect(checkoutActionCreator.loadCurrentCheckout).toHaveBeenCalled();
             expect(store.dispatch).toHaveBeenCalledWith(
                 checkoutActionCreator.loadCurrentCheckout(),
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+
+        it('loads checkout by provided id', async () => {
+            const checkoutId = '1';
+            const output = await subject.loadCheckout(checkoutId);
+
+            expect(checkoutActionCreator.loadCheckout).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(
+                checkoutActionCreator.loadCheckout(checkoutId),
             );
             expect(output).toEqual(paymentIntegrationSelectors);
         });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -70,8 +70,12 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         return this._storeProjection.getState();
     }
 
-    async loadCheckout(): Promise<PaymentIntegrationSelectors> {
-        await this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout());
+    async loadCheckout(id?: string): Promise<PaymentIntegrationSelectors> {
+        if (id) {
+            await this._store.dispatch(this._checkoutActionCreator.loadCheckout(id));
+        } else {
+            await this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout());
+        }
 
         return this._storeProjection.getState();
     }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -22,7 +22,7 @@ export default interface PaymentIntegrationService {
         initializeOffsitePaymentConfig: InitializeOffsitePaymentConfig,
     ): Promise<PaymentIntegrationSelectors>;
 
-    loadCheckout(): Promise<PaymentIntegrationSelectors>;
+    loadCheckout(id?: string): Promise<PaymentIntegrationSelectors>;
 
     loadDefaultCheckout(): Promise<PaymentIntegrationSelectors>;
 


### PR DESCRIPTION
## What?
Added an ability to loadCheckout by provided id in payments-integration-api

## Why?
It is not possible to migrate PayPal Commerce to its own package due to the implementation issues. 

## Testing / Proof
Unit tests
