### PR TITLE
feat(payment): PAYPAL-000 added an ability to use BuyNowCartCreationError from payment-integration-api

### DIFF
--- a/packages/payment-integration-api/src/errors/index.ts
+++ b/packages/payment-integration-api/src/errors/index.ts
@@ -1,3 +1,4 @@
+export { default as BuyNowCartCreationError } from './buy-now-cart-creation-error';
 export { default as InvalidArgumentError } from './invalid-argument-error';
 export { default as MissingDataError, MissingDataErrorType } from './missing-data-error';
 export { default as NotImplementedError } from './not-implemented-error';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from './customer';
 export { Discount } from './discount';
 export {
+    BuyNowCartCreationError,
     InvalidArgumentError,
     MissingDataError,
     MissingDataErrorType,


### PR DESCRIPTION
## What?
Added an ability to use BuyNowCartCreationError from payment-integration-api

## Why?
To use it in other packages

## Testing / Proof
Unit tests
