### PR TITLE
feat(payment): PAYPAL-1634 added ability for applepay spb to work with buyNowCart on PDP

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-initialize-options.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-initialize-options.ts
@@ -1,3 +1,5 @@
+import { BuyNowCartRequestBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 /**
  * A set of options that are required to initialize ApplePay in cart.
  *
@@ -5,6 +7,18 @@
  * DOM. When a customer clicks on it, it will trigger Apple sheet.
  */
 export default interface ApplePayButtonInitializeOptions {
+    /**
+     * This option indicates if product requires shipping
+     */
+    requiresShipping?: boolean;
+
+    /**
+     * The options that are required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    };
+
     /**
      * The class name of the ApplePay button style.
      */

--- a/packages/apple-pay-integration/src/mocks/apple-pay-button.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-button.mock.ts
@@ -1,5 +1,7 @@
 import { CheckoutButtonInitializeOptions } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import { getBuyNowCartRequestBody } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
 import { WithApplePayButtonInitializeOptions } from '../apple-pay-button-initialize-options';
 import ApplePayButtonMethodType from '../apple-pay-button-method-type';
 
@@ -10,6 +12,21 @@ export function getApplePayButtonInitializationOptions(): CheckoutButtonInitiali
         methodId: ApplePayButtonMethodType.APPLEPAY,
         applepay: {
             onPaymentAuthorize: jest.fn(),
+        },
+    };
+}
+
+export function getApplePayButtonInitializationOptionsWithBuyNow(): CheckoutButtonInitializeOptions &
+    WithApplePayButtonInitializeOptions {
+    return {
+        containerId: 'applePayCheckoutButton',
+        methodId: ApplePayButtonMethodType.APPLEPAY,
+        applepay: {
+            onPaymentAuthorize: jest.fn(),
+            buyNowInitializeOptions: {
+                getBuyNowCartRequestBody: jest.fn().mockReturnValue(getBuyNowCartRequestBody()),
+            },
+            requiresShipping: false,
         },
     };
 }

--- a/packages/apple-pay-integration/src/mocks/apple-pay-payment.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-payment.mock.ts
@@ -6,10 +6,12 @@ export class MockApplePaySession {
 
     begin = jest.fn();
     oncancel = jest.fn();
+    onpaymentmethodselected = jest.fn();
 
     completeShippingContactSelection = jest.fn();
 
     completeShippingMethodSelection = jest.fn();
+    completePaymentMethodSelection = jest.fn();
 
     abort = jest.fn();
 


### PR DESCRIPTION
## What?
Added ability for applepay to work with buyNowCart functionality on product detail page

## Why?
The aim is to make applepay button work with buy now cart that will be created on click. Because in moment of click there is a possibility that the store doesn't have checkout object yet.

## Testing / Proof

https://user-images.githubusercontent.com/56301104/215708251-0f98f0ff-b45b-4fa1-a712-6f0cd1b099e3.mov


https://user-images.githubusercontent.com/56301104/215708271-75200192-aae2-4e82-ade0-62ac7786b19d.mov



@bigcommerce/checkout @bigcommerce/payments @animesh1987 
