### PR TITLE
feat(payment): INT-7044 BlueSnapDirect: Pass options to `loadPaymentMethod`

### DIFF
--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -193,9 +193,29 @@ describe('DefaultPaymentIntegrationService', () => {
         it('loads payment method', async () => {
             const output = await subject.loadPaymentMethod('braintree');
 
-            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith('braintree');
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(
+                'braintree',
+                undefined,
+            );
             expect(store.dispatch).toHaveBeenCalledWith(
-                paymentMethodActionCreator.loadPaymentMethod('braintree'),
+                paymentMethodActionCreator.loadPaymentMethod('braintree', undefined),
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+
+        it('loads payment method with params', async () => {
+            const output = await subject.loadPaymentMethod('bluesnapdirect', {
+                params: { method: 'cc' },
+            });
+
+            expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalledWith(
+                'bluesnapdirect',
+                { params: { method: 'cc' } },
+            );
+            expect(store.dispatch).toHaveBeenCalledWith(
+                paymentMethodActionCreator.loadPaymentMethod('bluesnapdirect', {
+                    params: { method: 'cc' },
+                }),
             );
             expect(output).toEqual(paymentIntegrationSelectors);
         });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -86,8 +86,13 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         return this._storeProjection.getState();
     }
 
-    async loadPaymentMethod(methodId: string): Promise<PaymentIntegrationSelectors> {
-        await this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId));
+    async loadPaymentMethod(
+        methodId: string,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._paymentMethodActionCreator.loadPaymentMethod(methodId, options),
+        );
 
         return this._storeProjection.getState();
     }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -26,7 +26,10 @@ export default interface PaymentIntegrationService {
 
     loadDefaultCheckout(): Promise<PaymentIntegrationSelectors>;
 
-    loadPaymentMethod(methodId: string): Promise<PaymentIntegrationSelectors>;
+    loadPaymentMethod(
+        methodId: string,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors>;
 
     submitOrder(
         payload?: OrderRequestBody,


### PR DESCRIPTION
## What? [INT-7044](https://bigcommercecloud.atlassian.net/browse/INT-7044)
Pass options to `loadPaymentMethod`

## Why?
We need to send the `method` param to be able to load a specific payment method from a gateway. e.g:
`/api/storefront/payments/bluesnapdirect?method=cc`
`/api/storefront/payments/bluesnapdirect?method=sepa`
`/api/storefront/payments/bluesnapdirect?method=ideal`

## Testing / Proof
Unit

## Dependency of
👉 #1811

@bigcommerce/checkout @bigcommerce/payments

[INT-7044]: https://bigcommercecloud.atlassian.net/browse/INT-7044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ