### PR TITLE
fix(checkout): CHECKOUT-0000 Add skip-nx-cache build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "prepare": "check-node-version --node '>=14.18' --npm '>=6'",
     "build": "npm run bundle && npm run bundle-dts",
+    "build:link": "rm -rf dist && npx nx run core:build --skip-nx-cache && npm run bundle-dts",
     "prebuild-cdn": "rm -rf dist-cdn",
     "build-cdn": "npx nx run core:build-cdn",
     "prebundle": "rm -rf dist",


### PR DESCRIPTION
## What?
Add a `build:link` command to skip nx cache.

## Why?
When a developer runs the `build` command for the second time locally, nx only builds modified files due to its cache mechanism. This will result in `checkout-sdk` not functioning properly when it is linked to `checkout-js`. 

## Testing / Proof
- Manual testing: Custom console log can be seen on a VM store after running `npm run build:link`.

  <img width="500" alt="Screenshot 2023-01-31 at 5 06 15 pm" src="https://user-images.githubusercontent.com/88361607/215679771-6a564baa-6010-4f09-8f69-2eccfd230cef.png">


@bigcommerce/checkout @bigcommerce/payments
