### PR TITLE
refactor(payment): PAYPAL-1891 added PayPalCommerceVenmoButtonStrategy to paypal commerce integration package

### DIFF
--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -27,3 +27,11 @@ export { WithPayPalCommerceCreditButtonInitializeOptions } from './paypal-commer
  */
 export { default as createPayPalCommerceInlineButtonStrategy } from './paypal-commerce-inline/create-paypal-commerce-inline-button-strategy';
 export { WithPayPalCommerceInlineButtonInitializeOptions } from './paypal-commerce-inline/paypal-commerce-inline-button-initialize-options';
+
+/**
+ *
+ * PayPalCommerce Venmo strategies
+ *
+ */
+export { default as createPayPalCommerceVenmoButtonStrategy } from './paypal-commerce-venmo/create-paypal-commerce-venmo-button-strategy';
+export { WithPayPalCommerceVenmoButtonInitializeOptions } from './paypal-commerce-venmo/paypal-commerce-venmo-button-initialize-options';

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-button-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createPayPalCommerceVenmoButtonStrategy from './create-paypal-commerce-venmo-button-strategy';
+import PayPalCommerceButtonStrategy from './paypal-commerce-venmo-button-strategy';
+
+describe('createPayPalCommerceVenmoButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates paypal commerce venmo button strategy', () => {
+        const strategy = createPayPalCommerceVenmoButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(PayPalCommerceButtonStrategy);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { PayPalCommerceRequestSender, PayPalCommerceScriptLoader } from '../index';
+
+import PayPalCommerceVenmoButtonStrategy from './paypal-commerce-venmo-button-strategy';
+
+const createPayPalCommerceVenmoButtonStrategy: CheckoutButtonStrategyFactory<
+    PayPalCommerceVenmoButtonStrategy
+> = (paymentIntegrationService) => {
+    const { getHost } = paymentIntegrationService.getState();
+
+    return new PayPalCommerceVenmoButtonStrategy(
+        createFormPoster(),
+        paymentIntegrationService,
+        new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
+        new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+};
+
+export default toResolvableModule(createPayPalCommerceVenmoButtonStrategy, [
+    { id: 'paypalcommercevenmo' },
+]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-initialize-options.ts
@@ -1,0 +1,31 @@
+import { BuyNowCartRequestBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { PayPalButtonStyleOptions } from '../paypal-commerce-types';
+
+export default interface PayPalCommerceVenmoButtonInitializeOptions {
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: PayPalButtonStyleOptions;
+
+    /**
+     * Flag which helps to detect that the strategy initializes on Checkout page
+     */
+    initializesOnCheckoutPage?: boolean;
+
+    /**
+     * The option that used to initialize a PayPal script with provided currency code.
+     */
+    currencyCode?: string;
+
+    /**
+     * The options that required to initialize Buy Now functionality.
+     */
+    buyNowInitializeOptions?: {
+        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
+    };
+}
+
+export interface WithPayPalCommerceVenmoButtonInitializeOptions {
+    paypalcommercevenmo?: PayPalCommerceVenmoButtonInitializeOptions;
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
@@ -1,0 +1,508 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+
+import {
+    BuyNowCartCreationError,
+    Cart,
+    CheckoutButtonInitializeOptions,
+    InvalidArgumentError,
+    MissingDataError,
+    PaymentIntegrationService,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getBuyNowCart,
+    getBuyNowCartRequestBody,
+    getCart,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { getPayPalCommercePaymentMethod } from '../mocks/paypal-commerce-payment-method.mock';
+import { getPayPalSDKMock } from '../mocks/paypal-sdk.mock';
+import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import {
+    PayPalCommerceButtonsOptions,
+    PayPalCommerceHostWindow,
+    PayPalSDK,
+} from '../paypal-commerce-types';
+
+import PayPalCommerceVenmoButtonInitializeOptions from './paypal-commerce-venmo-button-initialize-options';
+import PayPalCommerceVenmoButtonStrategy from './paypal-commerce-venmo-button-strategy';
+
+describe('PayPalCommerceVenmoButtonStrategy', () => {
+    let buyNowCart: Cart;
+    let cart: Cart;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let requestSender: RequestSender;
+    let strategy: PayPalCommerceVenmoButtonStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paymentMethod: PaymentMethod;
+    let paypalButtonElement: HTMLDivElement;
+    let paypalCommerceRequestSender: PayPalCommerceRequestSender;
+    let paypalCommerceScriptLoader: PayPalCommerceScriptLoader;
+    let paypalSdk: PayPalSDK;
+
+    const defaultMethodId = 'paypalcommercevenmo';
+    const defaultButtonContainerId = 'paypal-commerce-venmo-button-mock-id';
+    const paypalOrderId = 'ORDER_ID';
+
+    const buyNowCartRequestBody = getBuyNowCartRequestBody();
+
+    const buyNowPayPalCommerceVenmoOptions: PayPalCommerceVenmoButtonInitializeOptions = {
+        buyNowInitializeOptions: {
+            getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
+        },
+        currencyCode: 'USD',
+        initializesOnCheckoutPage: false,
+        style: {
+            height: 45,
+        },
+    };
+
+    const buyNowInitializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: defaultMethodId,
+        containerId: defaultButtonContainerId,
+        paypalcommercevenmo: buyNowPayPalCommerceVenmoOptions,
+    };
+
+    const paypalCommerceVenmoOptions: PayPalCommerceVenmoButtonInitializeOptions = {
+        initializesOnCheckoutPage: false,
+        style: {
+            height: 45,
+        },
+    };
+
+    const initializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: defaultMethodId,
+        containerId: defaultButtonContainerId,
+        paypalcommercevenmo: paypalCommerceVenmoOptions,
+    };
+
+    beforeEach(() => {
+        buyNowCart = getBuyNowCart();
+        cart = getCart();
+
+        eventEmitter = new EventEmitter();
+
+        paymentMethod = { ...getPayPalCommercePaymentMethod(), id: 'paypalcommercevenmo' };
+        paypalSdk = getPayPalSDKMock();
+
+        formPoster = createFormPoster();
+        requestSender = createRequestSender();
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+        paypalCommerceRequestSender = new PayPalCommerceRequestSender(requestSender);
+        paypalCommerceScriptLoader = new PayPalCommerceScriptLoader(getScriptLoader());
+
+        strategy = new PayPalCommerceVenmoButtonStrategy(
+            formPoster,
+            paymentIntegrationService,
+            paypalCommerceRequestSender,
+            paypalCommerceScriptLoader,
+        );
+
+        paypalButtonElement = document.createElement('div');
+        paypalButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalButtonElement);
+
+        const state = paymentIntegrationService.getState();
+
+        jest.spyOn(state, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethod);
+        jest.spyOn(paymentIntegrationService, 'loadDefaultCheckout').mockImplementation(jest.fn());
+        jest.spyOn(formPoster, 'postForm').mockImplementation(jest.fn());
+        jest.spyOn(paypalCommerceScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdk);
+
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+            (options: PayPalCommerceButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(jest.fn());
+                    }
+                });
+
+                eventEmitter.on(
+                    'onClick',
+                    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+                    async (jestSuccessExpectationsCallback, jestFailureExpectationsCallback) => {
+                        try {
+                            if (options.onClick) {
+                                await options.onClick(
+                                    { fundingSource: 'venmo' },
+                                    {
+                                        reject: jest.fn(),
+                                        resolve: jest.fn(),
+                                    },
+                                );
+
+                                if (
+                                    jestSuccessExpectationsCallback &&
+                                    typeof jestSuccessExpectationsCallback === 'function'
+                                ) {
+                                    jestSuccessExpectationsCallback();
+                                }
+                            }
+                        } catch (error) {
+                            if (
+                                jestFailureExpectationsCallback &&
+                                typeof jestFailureExpectationsCallback === 'function'
+                            ) {
+                                jestFailureExpectationsCallback(error);
+                            }
+                        }
+                    },
+                );
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove(
+                            { orderID: paypalOrderId },
+                            {
+                                order: {
+                                    get: jest.fn(),
+                                },
+                            },
+                        );
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                };
+            },
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PayPalCommerceHostWindow).paypal;
+
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalButtonElement);
+        }
+    });
+
+    it('creates an instance of the PayPal Commerce Venmo checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(PayPalCommerceVenmoButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = {
+                methodId: defaultMethodId,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommercevenmo is not provided', async () => {
+            const options = {
+                containerId: defaultButtonContainerId,
+                methodId: defaultMethodId,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('loads default checkout', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.loadDefaultCheckout).toHaveBeenCalled();
+        });
+
+        it('does not load default checkout for Buy Now flow', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(paymentIntegrationService.loadDefaultCheckout).not.toHaveBeenCalled();
+        });
+
+        it('loads paypal commerce sdk script', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethod,
+                cart.currency.code,
+                paypalCommerceVenmoOptions.initializesOnCheckoutPage,
+            );
+        });
+
+        it('loads paypal commerce sdk script with provided currency code (Buy Now flow)', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethod,
+                buyNowPayPalCommerceVenmoOptions.currencyCode,
+                buyNowPayPalCommerceVenmoOptions.initializesOnCheckoutPage,
+            );
+        });
+
+        it('initializes PayPal Venmo button to render', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.VENMO,
+                style: paypalCommerceVenmoOptions.style,
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+                onClick: expect.any(Function),
+            });
+        });
+
+        it('renders PayPal Venmo button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => true),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+        });
+
+        it('does not render PayPal Venmo button if it is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
+        it('removes Venmo PayPal button container if the button has not rendered', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(document.getElementById(defaultButtonContainerId)).toBeNull();
+        });
+
+        it('throws an error if buy now cart request body data is not provided on button click (Buy Now flow)', async () => {
+            const buyNowInitializationOptionsMock = {
+                ...buyNowInitializationOptions,
+                paypalcommercevenmo: {
+                    ...buyNowPayPalCommerceVenmoOptions,
+                    buyNowInitializeOptions: {
+                        getBuyNowCartRequestBody: jest.fn().mockReturnValue(undefined),
+                    },
+                },
+            };
+
+            await strategy.initialize(buyNowInitializationOptionsMock);
+            eventEmitter.emit('onClick', undefined, (error: Error) => {
+                expect(error).toBeInstanceOf(MissingDataError);
+            });
+        });
+
+        it('creates buy now cart (Buy Now Flow)', async () => {
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(buyNowCart);
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('onClick', () => {
+                expect(paymentIntegrationService.createBuyNowCart).toHaveBeenCalledWith(
+                    buyNowCartRequestBody,
+                );
+            });
+        });
+
+        it('throws an error if failed to create buy now cart (Buy Now Flow)', async () => {
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockImplementation(() =>
+                Promise.reject(),
+            );
+
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit('onClick', undefined, (error: Error) => {
+                expect(error).toBeInstanceOf(BuyNowCartCreationError);
+            });
+        });
+
+        it('creates an order with paypalcommercevenmo as provider id if its initializes outside checkout page', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
+                'paypalcommercevenmo',
+                {
+                    cartId: cart.id,
+                },
+            );
+        });
+
+        it('creates an order with paypalcommercevenmocheckout as provider id if its initializes on checkout page', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            const updatedIntializationOptions = {
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    ...paypalCommerceVenmoOptions,
+                    initializesOnCheckoutPage: true,
+                },
+            };
+
+            await strategy.initialize(updatedIntializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
+                'paypalcommercevenmocheckout',
+                {
+                    cartId: cart.id,
+                },
+            );
+        });
+
+        it('creates order with Buy Now cart id (Buy Now flow)', async () => {
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(buyNowCart);
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
+                'paypalcommercevenmo',
+                {
+                    cartId: buyNowCart.id,
+                },
+            );
+        });
+
+        it('throws an error if orderId is not provided by PayPal on approve', async () => {
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                (options: PayPalCommerceButtonsOptions) => {
+                    eventEmitter.on('createOrder', () => {
+                        if (options.createOrder) {
+                            options.createOrder().catch(jest.fn());
+                        }
+                    });
+
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove({ orderID: '' });
+                        }
+                    });
+
+                    return {
+                        isEligible: jest.fn(() => true),
+                        render: jest.fn(),
+                    };
+                },
+            );
+
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onApprove');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('tokenizes payment on paypal approve', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith(
+                '/checkout.php',
+                expect.objectContaining({
+                    action: 'set_external_checkout',
+                    order_id: paypalOrderId,
+                    payment_type: 'paypal',
+                    provider: paymentMethod.id,
+                }),
+            );
+        });
+
+        it('provides buy now cart_id on payment tokenization on paypal approve', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue(
+                buyNowCart,
+            );
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('111');
+
+            await strategy.initialize(buyNowInitializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', {
+                action: 'set_external_checkout',
+                cart_id: buyNowCart.id,
+                order_id: paypalOrderId,
+                payment_type: 'paypal',
+                provider: defaultMethodId,
+            });
+        });
+    });
+
+    describe('#handleClick', () => {
+        it('creates buy now cart on button click', async () => {
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(buyNowCart);
+            jest.spyOn(paymentIntegrationService, 'loadCheckout').mockReturnValue(true);
+
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.createBuyNowCart).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
@@ -1,0 +1,206 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import {
+    BuyNowCartCreationError,
+    CheckoutButtonInitializeOptions,
+    CheckoutButtonStrategy,
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    PaymentIntegrationService,
+    PaymentMethodClientUnavailableError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import {
+    ApproveCallbackPayload,
+    PayPalButtonStyleOptions,
+    PayPalCommerceButtonsOptions,
+    PayPalSDK,
+} from '../paypal-commerce-types';
+import { getValidButtonStyle } from '../utils';
+
+import PayPalCommerceVenmoButtonInitializeOptions, {
+    WithPayPalCommerceVenmoButtonInitializeOptions,
+} from './paypal-commerce-venmo-button-initialize-options';
+
+export default class PayPalCommerceVenmoButtonStrategy implements CheckoutButtonStrategy {
+    private buyNowCartId?: string;
+    private paypalSdk?: PayPalSDK;
+
+    constructor(
+        private formPoster: FormPoster,
+        private paymentIntegrationService: PaymentIntegrationService,
+        private paypalCommerceRequestSender: PayPalCommerceRequestSender,
+        private paypalCommerceScriptLoader: PayPalCommerceScriptLoader,
+    ) {}
+
+    async initialize(
+        options: CheckoutButtonInitializeOptions & WithPayPalCommerceVenmoButtonInitializeOptions,
+    ): Promise<void> {
+        const { paypalcommercevenmo, containerId, methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!containerId) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.containerId" argument is not provided.`,
+            );
+        }
+
+        if (!paypalcommercevenmo) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommercevenmo" argument is not provided.`,
+            );
+        }
+
+        const { buyNowInitializeOptions, currencyCode, initializesOnCheckoutPage } =
+            paypalcommercevenmo;
+
+        if (buyNowInitializeOptions) {
+            const state = this.paymentIntegrationService.getState();
+            const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+
+            if (!currencyCode) {
+                throw new InvalidArgumentError(
+                    `Unable to initialize payment because "options.paypalcommercevenmo.currencyCode" argument is not provided.`,
+                );
+            }
+
+            this.paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
+                paymentMethod,
+                currencyCode,
+                initializesOnCheckoutPage,
+            );
+        } else {
+            await this.paymentIntegrationService.loadDefaultCheckout();
+
+            const state = this.paymentIntegrationService.getState();
+            const cart = state.getCartOrThrow();
+            const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+
+            this.paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
+                paymentMethod,
+                cart.currency.code,
+                initializesOnCheckoutPage,
+            );
+        }
+
+        this.renderButton(containerId, methodId, paypalcommercevenmo);
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private renderButton(
+        containerId: string,
+        methodId: string,
+        paypalcommercevenmo: PayPalCommerceVenmoButtonInitializeOptions,
+    ): void {
+        const { buyNowInitializeOptions, initializesOnCheckoutPage, style } = paypalcommercevenmo;
+
+        const paypalSdk = this.getPayPalSdkOrThrow();
+        const fundingSource = paypalSdk.FUNDING.VENMO;
+
+        const validButtonStyle = style ? this.getVenmoButtonStyle(style) : {};
+
+        const buttonRenderOptions: PayPalCommerceButtonsOptions = {
+            fundingSource,
+            style: validButtonStyle,
+            onClick: () => this.handleClick(buyNowInitializeOptions),
+            createOrder: () => this.createOrder(initializesOnCheckoutPage),
+            onApprove: ({ orderID }: ApproveCallbackPayload) =>
+                this.tokenizePayment(methodId, orderID),
+        };
+
+        const paypalButtonRender = paypalSdk.Buttons(buttonRenderOptions);
+
+        if (paypalButtonRender.isEligible()) {
+            paypalButtonRender.render(`#${containerId}`);
+        } else {
+            this.removeElement(containerId);
+        }
+    }
+
+    private async handleClick(
+        buyNowInitializeOptions: PayPalCommerceVenmoButtonInitializeOptions['buyNowInitializeOptions'],
+    ): Promise<void> {
+        if (
+            buyNowInitializeOptions &&
+            typeof buyNowInitializeOptions.getBuyNowCartRequestBody === 'function'
+        ) {
+            const cartRequestBody = buyNowInitializeOptions.getBuyNowCartRequestBody();
+
+            if (!cartRequestBody) {
+                throw new MissingDataError(MissingDataErrorType.MissingCart);
+            }
+
+            try {
+                const buyNowCart = await this.paymentIntegrationService.createBuyNowCart(
+                    cartRequestBody,
+                );
+
+                this.buyNowCartId = buyNowCart.id;
+            } catch (error) {
+                throw new BuyNowCartCreationError();
+            }
+        }
+    }
+
+    private async createOrder(initializesOnCheckoutPage?: boolean): Promise<string> {
+        const cartId =
+            this.buyNowCartId || this.paymentIntegrationService.getState().getCartOrThrow().id;
+
+        const providerId = initializesOnCheckoutPage
+            ? 'paypalcommercevenmocheckout'
+            : 'paypalcommercevenmo';
+
+        const { orderId } = await this.paypalCommerceRequestSender.createOrder(providerId, {
+            cartId,
+        });
+
+        return orderId;
+    }
+
+    private tokenizePayment(methodId: string, orderId?: string): void {
+        if (!orderId) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        return this.formPoster.postForm('/checkout.php', {
+            payment_type: 'paypal',
+            action: 'set_external_checkout',
+            provider: methodId,
+            order_id: orderId,
+            ...(this.buyNowCartId && { cart_id: this.buyNowCartId }),
+        });
+    }
+
+    private getPayPalSdkOrThrow(): PayPalSDK {
+        if (!this.paypalSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this.paypalSdk;
+    }
+
+    private getVenmoButtonStyle(style: PayPalButtonStyleOptions): PayPalButtonStyleOptions {
+        const { height, label, layout, shape } = getValidButtonStyle(style);
+
+        return { height, label, layout, shape };
+    }
+
+    private removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+}


### PR DESCRIPTION
## What?
Added PayPalCommerceVenmoButtonStrategy to paypal commerce integration package

## Why?
As part of migration paypal commerce code from core to paypal commerce integration package

## Testing / Proof
Unit tests
Manual tests
