### PR TITLE
chore(common): CHECKOUT-000 Remove small resource and restore old approve pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
   test-core:
     <<: *node_executor
     parallelism: 2
-    resource_class: small
     steps:
       - ci/pre-setup
       - node/npm-install
@@ -158,7 +157,11 @@ workflows:
             branches:
               only: master
           requires:
-            - ci/notify-success
+            - test-core
+            - test-packages
+            - lint
+            - build
+            - ci/validate-commits
       - npm_release:
           requires:
             - approve_npm_release


### PR DESCRIPTION
## What?
- Remove small as a resource for test core jobs
- Restore old approve pipeline

## Why?
- Need to remove small as resource since fresh node install fails most of the time, causing flakiness to the pipeline.
- Restoring old approve pipeline, since now we need to wait for CDN build to complete which is not required for NPM release.

## Testing / Proof
- circle

@bigcommerce/checkout
