### PR TITLE
refactor(payment): PAYPAL-1921 removed unnecessary PayPalCommerceAlternativeMethods v2 transformation in payment request transformer file

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -17,6 +17,4 @@ export enum BaseCheckoutButtonMethodType {
     GOOGLEPAY_STRIPEUPE = 'googlepaystripeupe',
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',
-    PAYPALCOMMERCE_APMS = 'paypalcommercealternativemethods', // TODO: this block of code should be removed in PAYPAL-1921
-    PAYPALCOMMERCE_APMS_TEMPORARY = 'paypalcommercealternativemethodsv2', // TODO: this block of code should be removed in PAYPAL-1921
 }

--- a/packages/core/src/payment/payment-request-transformer.ts
+++ b/packages/core/src/payment/payment-request-transformer.ts
@@ -5,7 +5,6 @@ import { mapToInternalCart } from '../cart';
 import { InternalCheckoutSelectors } from '../checkout';
 import { CheckoutButtonMethodType } from '../checkout-buttons/strategies';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
-import { StoreConfig } from '../config';
 import { mapToInternalCustomer } from '../customer';
 import { HostedFormOrderData } from '../hosted-form';
 import {
@@ -72,8 +71,7 @@ export default class PaymentRequestTransformer {
             order: order && mapToInternalOrder(order, orderMeta),
             orderMeta,
             payment: payment.paymentData,
-            paymentMethod:
-                paymentMethod && this._transformPaymentMethod(paymentMethod, storeConfig),
+            paymentMethod: paymentMethod && this._transformPaymentMethod(paymentMethod),
             quoteMeta: {
                 request: {
                     ...paymentMeta,
@@ -148,10 +146,7 @@ export default class PaymentRequestTransformer {
         };
     }
 
-    private _transformPaymentMethod(
-        paymentMethod: PaymentMethod,
-        storeConfig?: StoreConfig,
-    ): PaymentMethod {
+    private _transformPaymentMethod(paymentMethod: PaymentMethod): PaymentMethod {
         if (paymentMethod.method === 'multi-option' && !paymentMethod.gateway) {
             return { ...paymentMethod, gateway: paymentMethod.id };
         }
@@ -162,17 +157,6 @@ export default class PaymentRequestTransformer {
 
         if (paymentMethod.id === CheckoutButtonMethodType.BRAINTREE_VENMO) {
             return { ...paymentMethod, id: CheckoutButtonMethodType.BRAINTREE_PAYPAL };
-        }
-
-        // TODO: this block of code should be removed in PAYPAL-1921
-        if (
-            paymentMethod.gateway === CheckoutButtonMethodType.PAYPALCOMMERCE_APMS &&
-            storeConfig?.checkoutSettings.features['PAYPAL-1883.paypal-commerce-split-gateway']
-        ) {
-            return {
-                ...paymentMethod,
-                gateway: CheckoutButtonMethodType.PAYPALCOMMERCE_APMS_TEMPORARY,
-            };
         }
 
         return paymentMethod;


### PR DESCRIPTION
## What?
Removed unnecessary PayPalCommerceAlternativeMethods v2 transformation in payment request transformer file

## Why?
The transformer used to speed up a process of refactoring paypal commerce code in other project. We don't need this code anymore.

## Testing / Proof
Unit tests
