### PR TITLE
fix(payment): PAYPAL-1926 added extra shipping option selection if there is no recommended options available

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -939,6 +939,43 @@ describe('PayPalCommerceButtonStrategy', () => {
             );
         });
 
+        it('selects first available shipping option if there is no recommended option', async () => {
+            const firstShippingOption = {
+                ...getShippingOption(),
+                id: 1,
+            };
+
+            const secondShippingOption = {
+                ...getShippingOption(),
+                id: 2,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [firstShippingOption, secondShippingOption],
+                selectedShippingOption: null,
+            };
+
+            const updatedConsignment = {
+                ...consignment,
+                selectedShippingOption: firstShippingOption,
+            };
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getConsignmentsOrThrow')
+                .mockReturnValueOnce([consignment])
+                .mockReturnValue([updatedConsignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                firstShippingOption.id,
+            );
+        });
+
         it('updates PayPal order', async () => {
             const consignment = getConsignment();
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -305,7 +305,8 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
                   (option) => option.id === consignment.selectedShippingOption?.id,
               );
 
-        const shippingOptionToSelect = selectedShippingOption || recommendedShippingOption;
+        const shippingOptionToSelect =
+            selectedShippingOption || recommendedShippingOption || availableShippingOptions[0];
 
         if (!shippingOptionToSelect) {
             throw new Error("Your order can't be shipped to this address");

--- a/packages/paypal-commerce-integration/src/paypal-commerce-inline/paypal-commerce-inline-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-inline/paypal-commerce-inline-button-strategy.spec.ts
@@ -373,6 +373,43 @@ describe('PayPalCommerceInlineButtonStrategy', () => {
             );
         });
 
+        it('selects first available shipping option if there is no recommended option', async () => {
+            const firstShippingOption = {
+                ...getShippingOption(),
+                id: 1,
+            };
+
+            const secondShippingOption = {
+                ...getShippingOption(),
+                id: 2,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [firstShippingOption, secondShippingOption],
+                selectedShippingOption: null,
+            };
+
+            const updatedConsignment = {
+                ...consignment,
+                selectedShippingOption: firstShippingOption,
+            };
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getConsignmentsOrThrow')
+                .mockReturnValueOnce([consignment])
+                .mockReturnValue([updatedConsignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                firstShippingOption.id,
+            );
+        });
+
         it('updates PayPal order', async () => {
             const consignment = getConsignment();
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-inline/paypal-commerce-inline-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-inline/paypal-commerce-inline-button-strategy.ts
@@ -293,7 +293,8 @@ export default class PayPalCommerceInlineButtonStrategy implements CheckoutButto
                   (option) => option.id === consignment.selectedShippingOption?.id,
               );
 
-        const shippingOptionToSelect = selectedShippingOption || recommendedShippingOption;
+        const shippingOptionToSelect =
+            selectedShippingOption || recommendedShippingOption || availableShippingOptions[0];
 
         if (!shippingOptionToSelect) {
             throw new Error("Your order can't be shipped to this address");

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -858,6 +858,43 @@ describe('PayPalCommerceButtonStrategy', () => {
             );
         });
 
+        it('selects first available shipping option if there is no recommended option', async () => {
+            const firstShippingOption = {
+                ...getShippingOption(),
+                id: 1,
+            };
+
+            const secondShippingOption = {
+                ...getShippingOption(),
+                id: 2,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [firstShippingOption, secondShippingOption],
+                selectedShippingOption: null,
+            };
+
+            const updatedConsignment = {
+                ...consignment,
+                selectedShippingOption: firstShippingOption,
+            };
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getConsignmentsOrThrow')
+                .mockReturnValueOnce([consignment])
+                .mockReturnValue([updatedConsignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                firstShippingOption.id,
+            );
+        });
+
         it('updates PayPal order', async () => {
             const consignment = getConsignment();
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -338,13 +338,15 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         const recommendedShippingOption = availableShippingOptions.find(
             (option) => option.isRecommended,
         );
+
         const selectedShippingOption = selectedShippingOptionId
             ? availableShippingOptions.find((option) => option.id === selectedShippingOptionId)
             : availableShippingOptions.find(
                   (option) => option.id === consignment.selectedShippingOption?.id,
               );
 
-        const shippingOptionToSelect = selectedShippingOption || recommendedShippingOption;
+        const shippingOptionToSelect =
+            selectedShippingOption || recommendedShippingOption || availableShippingOptions[0];
 
         if (!shippingOptionToSelect) {
             throw new Error("Your order can't be shipped to this address");

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -326,7 +326,8 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
                   (option) => option.id === consignment.selectedShippingOption?.id,
               );
 
-        const shippingOptionToSelect = selectedShippingOption || recommendedShippingOption;
+        const shippingOptionToSelect =
+            selectedShippingOption || recommendedShippingOption || availableShippingOptions[0];
 
         if (!shippingOptionToSelect) {
             throw new Error("Your order can't be shipped to this address");


### PR DESCRIPTION
## What?
Added extra shipping option selection if there is no recommended options available for several PayPal Commerce strategies.

## Why?
There are several merchants that faced with problems with Shipping Options PayPal Commerce feature. The main reason that consignment available shipping options array does not have any recommended shipping option in the array. This behaviour creates some problems with PayPal Commerce Shipping Option feature initialisation. In this case we should select the first shipping option available in consignment.

## Testing / Proof
Unit tests
Manual tests
