### PR TITLE
feat(payment): PAYPAL-1959 provided buyer-country to the paypal sdk config for dev mode

### DIFF
--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.spec.ts
@@ -327,6 +327,36 @@ describe('PaypalCommerceScriptLoader', () => {
         expect(paypalLoadScript).toHaveBeenCalledWith(paypalSdkLoaderOptions);
     });
 
+    it('successfully loads paypal sdk with dev configuration', async () => {
+        const paymentMethodMock = {
+            ...paymentMethod,
+            id: 'paypalcommerce',
+            initializationData: {
+                ...paymentMethod.initializationData,
+                buyerCountry: 'UA',
+                isDeveloperModeApplicable: true,
+            },
+        };
+
+        await paypalLoader.getPayPalSDK(paymentMethodMock, 'USD', false);
+
+        const paypalSdkLoaderOptions = {
+            'buyer-country': 'UA',
+            'client-id': paymentMethod.initializationData.clientId,
+            'merchant-id': paymentMethod.initializationData.merchantId,
+            'data-client-token': paymentMethod.clientToken,
+            'data-partner-attribution-id': paymentMethod.initializationData.attributionId,
+            'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
+            'enable-funding': undefined,
+            commit: false,
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            currency: 'USD',
+            intent: 'capture',
+        };
+
+        expect(paypalLoadScript).toHaveBeenCalledWith(paypalSdkLoaderOptions);
+    });
+
     // TODO: add extra test with commit flag in Inline Checkout and Shipping Options features prs
     // it('successfully loads PayPalSDK script with commit flag as false if ...', async () => {});
 

--- a/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
+++ b/packages/core/src/payment/strategies/paypal-commerce/paypal-commerce-script-loader.ts
@@ -76,11 +76,13 @@ export default class PaypalCommerceScriptLoader {
             intent,
             clientId,
             merchantId,
+            buyerCountry,
             attributionId,
             isVenmoEnabled,
             isHostedCheckoutEnabled,
             isInlineCheckoutEnabled,
             isPayPalCreditAvailable,
+            isDeveloperModeApplicable,
             availableAlternativePaymentMethods = [],
             enabledAlternativePaymentMethods = [],
         } = initializationData;
@@ -131,6 +133,7 @@ export default class PaypalCommerceScriptLoader {
             components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: currencyCode,
             intent,
+            ...(isDeveloperModeApplicable && { 'buyer-country': buyerCountry }),
         };
     }
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.spec.ts
@@ -453,6 +453,36 @@ describe('PayPalCommerceScriptLoader', () => {
         expect(paypalLoadScript).toHaveBeenCalledWith(paypalSdkLoaderOptions);
     });
 
+    it('successfully loads paypal sdk with dev configuration', async () => {
+        const paymentMethodMock = {
+            ...paymentMethod,
+            id: 'paypalcommerce',
+            initializationData: {
+                ...paymentMethod.initializationData,
+                buyerCountry: 'UA',
+                isDeveloperModeApplicable: true,
+            },
+        };
+
+        await paypalLoader.getPayPalSDK(paymentMethodMock, 'USD', false);
+
+        const paypalSdkLoaderOptions = {
+            'buyer-country': 'UA',
+            'client-id': paymentMethod.initializationData.clientId,
+            'merchant-id': paymentMethod.initializationData.merchantId,
+            'data-client-token': paymentMethod.clientToken,
+            'data-partner-attribution-id': paymentMethod.initializationData.attributionId,
+            'disable-funding': ['card', 'credit', 'paylater', 'venmo'],
+            'enable-funding': undefined,
+            commit: false,
+            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
+            currency: 'USD',
+            intent: 'capture',
+        };
+
+        expect(paypalLoadScript).toHaveBeenCalledWith(paypalSdkLoaderOptions);
+    });
+
     it('throw error if unable to load Paypal script', async () => {
         const expectedError = new PaymentMethodClientUnavailableError();
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.ts
@@ -80,11 +80,13 @@ export default class PayPalCommerceScriptLoader {
             intent,
             clientId,
             merchantId,
+            buyerCountry,
             attributionId,
             isVenmoEnabled,
             isHostedCheckoutEnabled,
             isInlineCheckoutEnabled,
             isPayPalCreditAvailable,
+            isDeveloperModeApplicable,
             availableAlternativePaymentMethods = [],
             enabledAlternativePaymentMethods = [],
         } = initializationData;
@@ -135,6 +137,7 @@ export default class PayPalCommerceScriptLoader {
             components: ['buttons', 'hosted-fields', 'messages', 'payment-fields'],
             currency: currencyCode,
             intent,
+            ...(isDeveloperModeApplicable && { 'buyer-country': buyerCountry }),
         };
     }
 }


### PR DESCRIPTION
## What?
Provided buyer-country to the paypal sdk config for dev mode

## Why?
We as a developers or QA engineers should have an ability to test tricky features without VPN. This feature should help us save some time on development and testing our country based features.

## Testing / Proof
Unit tests
Manual tests

Here how a script url looks like without dev mode:
<img width="572" alt="Screenshot 2023-02-06 at 19 11 13" src="https://user-images.githubusercontent.com/25133454/217039480-129dcc3c-ad51-4785-9bd2-535e47c46e55.png">

Dev mode + US store:
<img width="571" alt="Screenshot 2023-02-06 at 19 12 08" src="https://user-images.githubusercontent.com/25133454/217039568-c2c2d9b2-95f6-4d0b-bd47-7327e89aec21.png">

Dev mode + UA store:
<img width="562" alt="Screenshot 2023-02-06 at 19 10 28" src="https://user-images.githubusercontent.com/25133454/217039647-2d53d0e2-35d4-4f37-9bab-1d3cd0e3b77f.png">

