### PR TITLE
feat(payment): PAYPAL-1838 Create paypalcommercevenmo customer button strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -36,6 +36,9 @@ export { WithPayPalCommerceInlineButtonInitializeOptions } from './paypal-commer
 export { default as createPayPalCommerceVenmoButtonStrategy } from './paypal-commerce-venmo/create-paypal-commerce-venmo-button-strategy';
 export { WithPayPalCommerceVenmoButtonInitializeOptions } from './paypal-commerce-venmo/paypal-commerce-venmo-button-initialize-options';
 
+export { default as createPayPalCommerceVenmoCustomerStrategy } from './paypal-commerce-venmo/create-paypal-commerce-venmo-customer-strategy';
+export { WithPayPalCommerceVenmoCustomerInitializeOptions } from './paypal-commerce-venmo/paypal-commerce-venmo-customer-initialize-options';
+
 /**
  *
  * PayPalCommerce Alternative methods strategies

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-cuastomer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-cuastomer-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createPaypalCommerceVenmoCustomerStrategy from './create-paypal-commerce-venmo-customer-strategy';
+import PayPalCommerceVenmoCustomerStrategy from './paypal-commerce-venmo-customer-strategy';
+
+describe('createPayPalCommerceVenmoCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates paypal commerce venmo customer strategy', () => {
+        const strategy = createPaypalCommerceVenmoCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(PayPalCommerceVenmoCustomerStrategy);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-customer-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { PayPalCommerceRequestSender, PayPalCommerceScriptLoader } from '../index';
+
+import PayPalCommerceVenmoCustomerStrategy from './paypal-commerce-venmo-customer-strategy';
+
+const createPayPalCommerceVenmoCustomerStrategy: CustomerStrategyFactory<
+    PayPalCommerceVenmoCustomerStrategy
+> = (paymentIntegrationService) => {
+    const { getHost } = paymentIntegrationService.getState();
+
+    return new PayPalCommerceVenmoCustomerStrategy(
+        createFormPoster(),
+        paymentIntegrationService,
+        new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
+        new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+};
+
+export default toResolvableModule(createPayPalCommerceVenmoCustomerStrategy, [
+    { id: 'paypalcommercevenmo' },
+]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-initialize-options.ts
@@ -1,0 +1,18 @@
+export default interface PayPalCommerceVenmoCustomerInitializeOptions {
+    /**
+     * The ID of a container which the checkout button should be inserted into.
+     */
+    container: string;
+
+    /**
+     * A callback that gets called if unable to initialize the widget or select
+     * one of the address options provided by the widget.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error?: Error): void;
+}
+
+export interface WithPayPalCommerceVenmoCustomerInitializeOptions {
+    paypalcommercevenmo?: PayPalCommerceVenmoCustomerInitializeOptions;
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
@@ -1,0 +1,378 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+
+import {
+    Cart,
+    CheckoutButtonInitializeOptions,
+    InvalidArgumentError,
+    MissingDataError,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentMethodClientUnavailableError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getCart,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { getPayPalCommercePaymentMethod } from '../mocks/paypal-commerce-payment-method.mock';
+import { getPayPalSDKMock } from '../mocks/paypal-sdk.mock';
+import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import {
+    PayPalCommerceButtonsOptions,
+    PayPalCommerceHostWindow,
+    PayPalSDK,
+} from '../paypal-commerce-types';
+
+import PayPalCommerceVenmoCustomerInitializeOptions from './paypal-commerce-venmo-customer-initialize-options';
+import PayPalCommerceVenmoCustomerStrategy from './paypal-commerce-venmo-customer-strategy';
+
+describe('PayPalCommerceVenmoCustomerStrategy', () => {
+    let cart: Cart;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let requestSender: RequestSender;
+    let strategy: PayPalCommerceVenmoCustomerStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paymentMethod: PaymentMethod;
+    let paypalButtonElement: HTMLDivElement;
+    let paypalCommerceRequestSender: PayPalCommerceRequestSender;
+    let paypalCommerceScriptLoader: PayPalCommerceScriptLoader;
+    let paypalSdk: PayPalSDK;
+
+    const defaultMethodId = 'paypalcommercevenmo';
+    const defaultButtonContainerId = 'paypal-commerce-venmo-customer-mock-id';
+    const paypalOrderId = 'ORDER_ID';
+
+    const paypalCommerceVenmoOptions: PayPalCommerceVenmoCustomerInitializeOptions = {
+        container: defaultButtonContainerId,
+        onError: jest.fn(),
+    };
+
+    const initializationOptions: CheckoutButtonInitializeOptions = {
+        methodId: defaultMethodId,
+        containerId: defaultButtonContainerId,
+        paypalcommercevenmo: paypalCommerceVenmoOptions,
+    };
+
+    beforeEach(() => {
+        cart = getCart();
+
+        eventEmitter = new EventEmitter();
+
+        paymentMethod = { ...getPayPalCommercePaymentMethod(), id: 'paypalcommercevenmo' };
+        paypalSdk = getPayPalSDKMock();
+
+        formPoster = createFormPoster();
+        requestSender = createRequestSender();
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+        paypalCommerceRequestSender = new PayPalCommerceRequestSender(requestSender);
+        paypalCommerceScriptLoader = new PayPalCommerceScriptLoader(getScriptLoader());
+
+        strategy = new PayPalCommerceVenmoCustomerStrategy(
+            formPoster,
+            paymentIntegrationService,
+            paypalCommerceRequestSender,
+            paypalCommerceScriptLoader,
+        );
+
+        paypalButtonElement = document.createElement('div');
+        paypalButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalButtonElement);
+
+        const state = paymentIntegrationService.getState();
+
+        jest.spyOn(state, 'getPaymentMethodOrThrow').mockReturnValue(paymentMethod);
+        jest.spyOn(paymentIntegrationService, 'loadDefaultCheckout').mockImplementation(jest.fn());
+        jest.spyOn(formPoster, 'postForm').mockImplementation(jest.fn());
+        jest.spyOn(paypalCommerceScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdk);
+
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+            (options: PayPalCommerceButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(jest.fn());
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove(
+                            { orderID: paypalOrderId },
+                            {
+                                order: {
+                                    get: jest.fn(),
+                                },
+                            },
+                        );
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                };
+            },
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PayPalCommerceHostWindow).paypal;
+
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalButtonElement);
+        }
+    });
+
+    it('creates an instance of the PayPal Commerce Venmo checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(PayPalCommerceVenmoCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = {} as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommercevenmo is not provided', async () => {
+            const options = {
+                methodId: defaultMethodId,
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if containerId is not provided', async () => {
+            const options = {
+                ...initializationOptions,
+                paypalcommercevenmo: {},
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('loads paypalcommerce venmo payment method', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                defaultMethodId,
+            );
+        });
+
+        it('loads paypal commerce sdk script', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethod,
+                cart.currency.code,
+            );
+        });
+
+        it('initializes PayPal Venmo button to render', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.VENMO,
+                style: {
+                    height: 40,
+                },
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('renders PayPal Venmo button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => true),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+        });
+
+        it('does not render PayPal Venmo button if it is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
+        it('removes Venmo PayPal button container if the button has not rendered', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(document.getElementById(defaultButtonContainerId)).toBeNull();
+        });
+
+        it('creates an order with paypalcommercevenmocheckout as provider id if its initializes on checkout page', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+            const updatedIntializationOptions = {
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    ...paypalCommerceVenmoOptions,
+                },
+            };
+
+            await strategy.initialize(updatedIntializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
+                'paypalcommercevenmo',
+                {
+                    cartId: cart.id,
+                },
+            );
+        });
+
+        it('throws an error if orderId is not provided by PayPal on approve', async () => {
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                (options: PayPalCommerceButtonsOptions) => {
+                    eventEmitter.on('createOrder', () => {
+                        if (options.createOrder) {
+                            options.createOrder().catch(jest.fn());
+                        }
+                    });
+
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove(
+                                { orderID: '' },
+                                {
+                                    order: {
+                                        get: jest.fn(),
+                                    },
+                                },
+                            );
+                        }
+                    });
+
+                    return {
+                        isEligible: jest.fn(() => true),
+                        render: jest.fn(),
+                    };
+                },
+            );
+
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onApprove');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws an error if no paypalSdk exists', async () => {
+            jest.spyOn(paypalCommerceScriptLoader, 'getPayPalSDK').mockReturnValue(undefined);
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
+            }
+        });
+
+        it('tokenizes payment on paypal approve', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(formPoster.postForm).toHaveBeenCalledWith(
+                '/checkout.php',
+                expect.objectContaining({
+                    action: 'set_external_checkout',
+                    order_id: paypalOrderId,
+                    payment_type: 'paypal',
+                    provider: paymentMethod.id,
+                }),
+            );
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            const result = await strategy.deinitialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('#signIn()', () => {
+        it('calls default sign in method', async () => {
+            const credentials = {
+                email: 'test@test.com',
+                password: '123',
+            };
+
+            await strategy.signIn(credentials);
+
+            expect(paymentIntegrationService.signInCustomer).toHaveBeenCalledWith(
+                credentials,
+                undefined,
+            );
+        });
+    });
+
+    describe('#signOut()', () => {
+        it('calls default sign out method', async () => {
+            await strategy.signOut();
+
+            expect(paymentIntegrationService.signOutCustomer).toHaveBeenCalled();
+        });
+    });
+
+    describe('#executePaymentMethodCheckout()', () => {
+        it('calls default continue with checkout callback', async () => {
+            const continueWithCheckoutCallback = jest.fn();
+
+            await strategy.executePaymentMethodCheckout({ continueWithCheckoutCallback });
+
+            expect(continueWithCheckoutCallback).toHaveBeenCalled();
+        });
+
+        it('makes nothing if continue with checkout callback is not provided', async () => {
+            const result = await strategy.executePaymentMethodCheckout();
+
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
@@ -1,0 +1,148 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import {
+    CheckoutButtonInitializeOptions,
+    CustomerCredentials,
+    CustomerStrategy,
+    ExecutePaymentMethodCheckoutOptions,
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    PaymentIntegrationService,
+    PaymentMethodClientUnavailableError,
+    RequestOptions,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import {
+    ApproveCallbackPayload,
+    PayPalCommerceButtonsOptions,
+    PayPalSDK,
+} from '../paypal-commerce-types';
+
+import { WithPayPalCommerceVenmoCustomerInitializeOptions } from './paypal-commerce-venmo-customer-initialize-options';
+
+export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStrategy {
+    private paypalSdk?: PayPalSDK;
+
+    constructor(
+        private formPoster: FormPoster,
+        private paymentIntegrationService: PaymentIntegrationService,
+        private paypalCommerceRequestSender: PayPalCommerceRequestSender,
+        private paypalCommerceScriptLoader: PayPalCommerceScriptLoader,
+    ) {}
+
+    async initialize(
+        options: CheckoutButtonInitializeOptions & WithPayPalCommerceVenmoCustomerInitializeOptions,
+    ): Promise<void> {
+        const { paypalcommercevenmo, methodId } = options;
+        const { container } = paypalcommercevenmo || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!container) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "paypalcommercevenmo.containerId" argument is not provided.`,
+            );
+        }
+
+        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+
+        const state = this.paymentIntegrationService.getState();
+        const cart = state.getCartOrThrow();
+        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+
+        this.paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
+            paymentMethod,
+            cart.currency.code,
+        );
+
+        this.renderButton(container, methodId);
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    async signIn(credentials: CustomerCredentials, options?: RequestOptions): Promise<void> {
+        await this.paymentIntegrationService.signInCustomer(credentials, options);
+    }
+
+    async signOut(options?: RequestOptions): Promise<void> {
+        await this.paymentIntegrationService.signOutCustomer(options);
+    }
+
+    executePaymentMethodCheckout(options?: ExecutePaymentMethodCheckoutOptions): Promise<void> {
+        options?.continueWithCheckoutCallback?.();
+
+        return Promise.resolve();
+    }
+
+    private renderButton(containerId: string, methodId: string): void {
+        const paypalSdk = this.getPayPalSdkOrThrow();
+        const fundingSource = paypalSdk.FUNDING.VENMO;
+
+        const buttonRenderOptions: PayPalCommerceButtonsOptions = {
+            fundingSource,
+            style: {
+                height: 40,
+            },
+            createOrder: () => this.createOrder(),
+            onApprove: ({ orderID }: ApproveCallbackPayload) =>
+                this.tokenizePayment(methodId, orderID),
+        };
+
+        const paypalButtonRender = paypalSdk.Buttons(buttonRenderOptions);
+
+        if (paypalButtonRender.isEligible()) {
+            paypalButtonRender.render(`#${containerId}`);
+        } else {
+            this.removeElement(containerId);
+        }
+    }
+
+    private async createOrder(): Promise<string> {
+        const cartId = this.paymentIntegrationService.getState().getCartOrThrow().id;
+
+        const { orderId } = await this.paypalCommerceRequestSender.createOrder(
+            'paypalcommercevenmo',
+            { cartId },
+        );
+
+        return orderId;
+    }
+
+    private tokenizePayment(methodId: string, orderId?: string): void {
+        if (!orderId) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        return this.formPoster.postForm('/checkout.php', {
+            payment_type: 'paypal',
+            action: 'set_external_checkout',
+            provider: methodId,
+            order_id: orderId,
+        });
+    }
+
+    private getPayPalSdkOrThrow(): PayPalSDK {
+        if (!this.paypalSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this.paypalSdk;
+    }
+
+    private removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+}


### PR DESCRIPTION
## What?
Add PayPal Commerce Venmo customer strategy which will be used as button on customer step

## Why?
PayPal Commerce Venmo button was added to make ability for shoppers to use venmo payment method on first step and simplify checkout process.
PR for checkout-js: [https://github.com/bigcommerce/checkout-js/pull/1189](https://github.com/bigcommerce/checkout-js/pull/1189)

## Testing / Proof

https://user-images.githubusercontent.com/9430298/217316025-da535674-8ab6-4330-a387-244731bf6e11.mov

<img width="359" alt="Screenshot 2023-02-07 at 19 00 49" src="https://user-images.githubusercontent.com/9430298/217316079-484381d7-ac8f-4b5a-9ae1-425c6d166d78.png">


@bigcommerce/checkout @bigcommerce/payments
