### PR TITLE
feat(checkout): CHECKOUT-7231 Add checkoutUXSettings to interface

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -92,6 +92,7 @@ export interface StoreCurrency {
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
+    checkoutUXSettings: { [settingName: string]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -94,7 +94,7 @@ export type UXSettingNames = 'walletButtonsOnTop';
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
-    checkoutUXSettings: { [key in UXSettingNames]: boolean };
+    CheckoutUserExperienceSettings: { [key in UXSettingNames]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -89,10 +89,12 @@ export interface StoreCurrency {
     thousandsSeparator: string;
 }
 
+export type UXSettingNames = 'walletButtonsOnTop';
+
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
-    checkoutUXSettings: { [settingName: string]: boolean };
+    checkoutUXSettings: { [key in UXSettingNames]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -89,12 +89,12 @@ export interface StoreCurrency {
     thousandsSeparator: string;
 }
 
-export type UXSettingNames = 'walletButtonsOnTop';
+export type UserExperienceSettingNames = 'walletButtonsOnTop';
 
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
-    CheckoutUserExperienceSettings: { [key in UXSettingNames]: boolean };
+    CheckoutUserExperienceSettings: { [key in UserExperienceSettingNames]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -21,6 +21,7 @@ export function getConfig(): Config {
             checkoutSettings: {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
+                checkoutUXSettings: {},
                 enableOrderComments: true,
                 enableTermsAndConditions: false,
                 guestCheckoutEnabled: true,

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -21,7 +21,7 @@ export function getConfig(): Config {
             checkoutSettings: {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
-                checkoutUXSettings: {
+                CheckoutUserExperienceSettings: {
                     walletButtonsOnTop: false,
                 },
                 enableOrderComments: true,

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -21,7 +21,9 @@ export function getConfig(): Config {
             checkoutSettings: {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
-                checkoutUXSettings: {},
+                checkoutUXSettings: {
+                    walletButtonsOnTop: false,
+                },
                 enableOrderComments: true,
                 enableTermsAndConditions: false,
                 guestCheckoutEnabled: true,

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -93,7 +93,7 @@ export type UXSettingNames = 'walletButtonsOnTop';
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
-    checkoutUXSettings: { [key in UXSettingNames]: boolean };
+    CheckoutUserExperienceSettings: { [key in UXSettingNames]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -91,6 +91,7 @@ export interface StoreCurrency {
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
+    checkoutUXSettings: { [settingName: string]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -88,10 +88,12 @@ export interface StoreCurrency {
     thousandsSeparator: string;
 }
 
+export type UXSettingNames = 'walletButtonsOnTop';
+
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
-    checkoutUXSettings: { [settingName: string]: boolean };
+    checkoutUXSettings: { [key in UXSettingNames]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -88,12 +88,12 @@ export interface StoreCurrency {
     thousandsSeparator: string;
 }
 
-export type UXSettingNames = 'walletButtonsOnTop';
+export type UserExperienceSettingNames = 'walletButtonsOnTop';
 
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
-    CheckoutUserExperienceSettings: { [key in UXSettingNames]: boolean };
+    CheckoutUserExperienceSettings: { [key in UserExperienceSettingNames]: boolean };
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
@@ -18,6 +18,7 @@ export default function getConfig(): Config {
             checkoutSettings: {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
+                checkoutUXSettings: {},
                 enableOrderComments: true,
                 enableTermsAndConditions: false,
                 guestCheckoutEnabled: true,

--- a/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
@@ -18,7 +18,9 @@ export default function getConfig(): Config {
             checkoutSettings: {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
-                checkoutUXSettings: {},
+                checkoutUXSettings: {
+                    walletButtonsOnTop: false,
+                },
                 enableOrderComments: true,
                 enableTermsAndConditions: false,
                 guestCheckoutEnabled: true,

--- a/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
@@ -18,7 +18,7 @@ export default function getConfig(): Config {
             checkoutSettings: {
                 features: {},
                 checkoutBillingSameAsShippingEnabled: true,
-                checkoutUXSettings: {
+                CheckoutUserExperienceSettings: {
                     walletButtonsOnTop: false,
                 },
                 enableOrderComments: true,


### PR DESCRIPTION
## What?
Add `checkoutUXSettings` to the `CheckoutSettings` interface.

## Why?
We will introduce a few UX options to merchants in the following weeks.

## Related PR
- https://github.com/bigcommerce/bigcommerce/pull/51091

## Testing / Proof
CI checks.
