### PR TITLE
fix(payment): PAYPAL-1930 added intent param to Braintree SDK config and to the paypal order creation config

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -14,6 +14,7 @@ import {
     BraintreeModule,
     BraintreePaypal,
     BraintreePaypalCheckout,
+    BraintreePaypalSdkCreatorConfig,
     BraintreeThreeDSecure,
     BraintreeVenmoCheckout,
     BraintreeVisaCheckout,
@@ -71,7 +72,7 @@ export default class BraintreeSDKCreator {
     }
 
     async getPaypalCheckout(
-        config: { currency: string },
+        config: Partial<BraintreePaypalSdkCreatorConfig>,
         onSuccess: (instance: BraintreePaypalCheckout) => void,
         onError: (error: BraintreeError) => void,
     ): Promise<BraintreePaypalCheckout> {
@@ -91,6 +92,7 @@ export default class BraintreeSDKCreator {
             const paypalSdkLoadConfig = {
                 currency: config.currency,
                 components: PAYPAL_COMPONENTS.toString(),
+                intent: config.intent,
             };
 
             if (!this._window.paypal) {

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -436,6 +436,7 @@ export interface BraintreePaypalCheckout {
 export interface BraintreePaypalSdkCreatorConfig {
     components?: string;
     currency?: string;
+    intent?: string;
 }
 
 /**


### PR DESCRIPTION
## What?
Added intent param to Braintree SDK and to the paypal order creation config

## Why?
Sometimes Braintree SDK intent may differ from intent param that was set in CP.
We should have an ability to pass the same intent as we have in Braintree CP settings to Braintree SDK. 

## Testing / Proof
Unit tests
Manual tests

https://user-images.githubusercontent.com/25133454/217488291-3f5c8b66-a4fb-4cd9-b305-e9783e647233.mov



