### PR TITLE
feat(payment): PAYPAL-1837 Create paypalcommercecredit customer button strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -20,6 +20,9 @@ export { WithPayPalCommerceCustomerInitializeOptions } from './paypal-commerce/p
 export { default as createPayPalCommerceCreditButtonStrategy } from './paypal-commerce-credit/create-paypal-commerce-credit-button-strategy';
 export { WithPayPalCommerceCreditButtonInitializeOptions } from './paypal-commerce-credit/paypal-commerce-credit-button-initialize-options';
 
+export { default as createPayPalCommerceCreditCustomerStrategy } from './paypal-commerce-credit/create-paypal-commerce-credit-customer-strategy';
+export { WithPayPalCommerceCreditCustomerInitializeOptions } from './paypal-commerce-credit/paypal-commerce-credit-customer-initialize-options';
+
 /**
  *
  * PayPalCommerce Inline (Accelerated) Checkout strategies

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-customer-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createPaypalCommerceCreditCustomerStrategy from './create-paypal-commerce-credit-customer-strategy';
+import PayPalCommerceCreditCustomerStrategy from './paypal-commerce-credit-customer-strategy';
+
+describe('createPayPalCommerceCreditCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates paypal commerce button strategy', () => {
+        const strategy = createPaypalCommerceCreditCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(PayPalCommerceCreditCustomerStrategy);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-customer-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { PayPalCommerceRequestSender, PayPalCommerceScriptLoader } from '../index';
+
+import PayPalCommerceCreditCustomerStrategy from './paypal-commerce-credit-customer-strategy';
+
+const createPayPalCommerceCreditCustomerStrategy: CustomerStrategyFactory<
+    PayPalCommerceCreditCustomerStrategy
+> = (paymentIntegrationService) => {
+    const { getHost } = paymentIntegrationService.getState();
+
+    return new PayPalCommerceCreditCustomerStrategy(
+        createFormPoster(),
+        paymentIntegrationService,
+        new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
+        new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+};
+
+export default toResolvableModule(createPayPalCommerceCreditCustomerStrategy, [
+    { id: 'paypalcommercecredit' },
+]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-initialize-options.ts
@@ -1,0 +1,23 @@
+export default interface PayPalCommerceCreditCustomerInitializeOptions {
+    /**
+     * The ID of a container which the checkout button should be inserted into.
+     */
+    container: string;
+
+    /**
+     * A callback that gets called if unable to initialize the widget or select
+     * one of the address options provided by the widget.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error?: Error): void;
+
+    /**
+     * A callback that gets called when payment complete on paypal side.
+     */
+    onComplete?(): void;
+}
+
+export interface WithPayPalCommerceCreditCustomerInitializeOptions {
+    paypalcommercecredit?: PayPalCommerceCreditCustomerInitializeOptions;
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -1,0 +1,953 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { EventEmitter } from 'events';
+
+import {
+    Cart,
+    CustomerInitializeOptions,
+    InvalidArgumentError,
+    MissingDataError,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentMethodClientUnavailableError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getCart,
+    getConsignment,
+    getShippingOption,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { getPayPalCommercePaymentMethod } from '../mocks/paypal-commerce-payment-method.mock';
+import { getPayPalSDKMock } from '../mocks/paypal-sdk.mock';
+import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import {
+    PayPalCommerceButtonsOptions,
+    PayPalCommerceHostWindow,
+    PayPalOrderDetails,
+    PayPalSDK,
+    StyleButtonColor,
+} from '../paypal-commerce-types';
+
+import PayPalCommerceCreditCustomerInitializeOptions from './paypal-commerce-credit-customer-initialize-options';
+import PayPalCommerceCreditCustomerStrategy from './paypal-commerce-credit-customer-strategy';
+
+describe('PayPalCommerceCreditCustomerStrategy', () => {
+    let cart: Cart;
+    let eventEmitter: EventEmitter;
+    let formPoster: FormPoster;
+    let requestSender: RequestSender;
+    let strategy: PayPalCommerceCreditCustomerStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paymentMethod: PaymentMethod;
+    let paypalButtonElement: HTMLDivElement;
+    let paypalCommerceRequestSender: PayPalCommerceRequestSender;
+    let paypalCommerceScriptLoader: PayPalCommerceScriptLoader;
+    let paypalSdk: PayPalSDK;
+
+    const defaultMethodId = 'paypalcommercecredit';
+    const defaultButtonContainerId = 'paypal-commerce-credit-button-mock-id';
+    const paypalOrderId = 'ORDER_ID';
+
+    const paypalCommerceCreditOptions: PayPalCommerceCreditCustomerInitializeOptions = {
+        container: defaultButtonContainerId,
+        onComplete: jest.fn(),
+    };
+
+    const initializationOptions: CustomerInitializeOptions = {
+        methodId: defaultMethodId,
+        paypalcommercecredit: paypalCommerceCreditOptions,
+    };
+
+    const paypalShippingAddressPayloadMock = {
+        city: 'New York',
+        country_code: 'US',
+        postal_code: '07564',
+        state: 'New York',
+    };
+
+    const paypalSelectedShippingOptionPayloadMock = {
+        amount: {
+            currency_code: 'USD',
+            value: '100',
+        },
+        id: '1',
+        label: 'Free shipping',
+        selected: true,
+        type: 'type_shipping',
+    };
+
+    beforeEach(() => {
+        cart = getCart();
+
+        eventEmitter = new EventEmitter();
+
+        paymentMethod = { ...getPayPalCommercePaymentMethod(), id: defaultMethodId };
+        paypalSdk = getPayPalSDKMock();
+
+        formPoster = createFormPoster();
+        requestSender = createRequestSender();
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+        paypalCommerceRequestSender = new PayPalCommerceRequestSender(requestSender);
+        paypalCommerceScriptLoader = new PayPalCommerceScriptLoader(getScriptLoader());
+
+        strategy = new PayPalCommerceCreditCustomerStrategy(
+            formPoster,
+            paymentIntegrationService,
+            paypalCommerceRequestSender,
+            paypalCommerceScriptLoader,
+        );
+
+        paypalButtonElement = document.createElement('div');
+        paypalButtonElement.id = defaultButtonContainerId;
+        document.body.appendChild(paypalButtonElement);
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethod,
+        );
+
+        jest.spyOn(paymentIntegrationService, 'selectShippingOption').mockImplementation(jest.fn());
+        jest.spyOn(paymentIntegrationService, 'submitOrder').mockImplementation(jest.fn());
+        jest.spyOn(paymentIntegrationService, 'submitPayment').mockImplementation(jest.fn());
+        jest.spyOn(paymentIntegrationService, 'updateBillingAddress').mockImplementation(jest.fn());
+        jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockImplementation(
+            jest.fn(),
+        );
+
+        jest.spyOn(formPoster, 'postForm').mockImplementation(jest.fn());
+        jest.spyOn(paypalCommerceScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalCommerceRequestSender, 'updateOrder').mockReturnValue(true);
+
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+            (options: PayPalCommerceButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder().catch(jest.fn());
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove(
+                            { orderID: paypalOrderId },
+                            {
+                                order: {
+                                    get: jest.fn(),
+                                },
+                            },
+                        );
+                    }
+                });
+
+                eventEmitter.on('onShippingAddressChange', () => {
+                    if (options.onShippingAddressChange) {
+                        options.onShippingAddressChange({
+                            orderId: paypalOrderId,
+                            shippingAddress: paypalShippingAddressPayloadMock,
+                        });
+                    }
+                });
+
+                eventEmitter.on('onShippingOptionsChange', () => {
+                    if (options.onShippingOptionsChange) {
+                        options.onShippingOptionsChange({
+                            orderId: paypalOrderId,
+                            selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
+                        });
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                };
+            },
+        );
+
+        jest.spyOn(paypalSdk, 'Messages').mockImplementation(() => ({
+            render: jest.fn(),
+        }));
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PayPalCommerceHostWindow).paypal;
+
+        if (document.getElementById(defaultButtonContainerId)) {
+            document.body.removeChild(paypalButtonElement);
+        }
+    });
+
+    it('creates an instance of the PayPal Commerce Credit (PayLater) checkout button strategy', () => {
+        expect(strategy).toBeInstanceOf(PayPalCommerceCreditCustomerStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            try {
+                await strategy.initialize({
+                    ...initializationOptions,
+                    methodId: undefined,
+                });
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if container is not provided', async () => {
+            try {
+                await strategy.initialize({
+                    ...initializationOptions,
+                    paypalcommercecredit: undefined,
+                });
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('loads payment method', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                defaultMethodId,
+            );
+        });
+
+        it('loads paypal commerce sdk script', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
+                paymentMethod,
+                cart.currency.code,
+            );
+        });
+
+        it('throw error if loads paypal commerce sdk script failed', async () => {
+            jest.spyOn(paypalCommerceScriptLoader, 'getPayPalSDK').mockReturnValue(undefined);
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
+            }
+        });
+
+        describe('PayPal Commerce Credit buttons logic', () => {
+            it('initializes PayPal Paylater button to render', async () => {
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                    fundingSource: paypalSdk.FUNDING.PAYLATER,
+                    style: {
+                        height: 40,
+                        color: StyleButtonColor.gold,
+                    },
+                    createOrder: expect.any(Function),
+                    onApprove: expect.any(Function),
+                });
+            });
+
+            it('does not throw an error if onComplete method is not provided for default flow', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...paymentMethod,
+                    initializationData: {
+                        ...paymentMethod.initializationData,
+                        isHostedCheckoutEnabled: false,
+                    },
+                });
+
+                const { onComplete, ...rest } = paypalCommerceCreditOptions;
+
+                const options = {
+                    ...initializationOptions,
+                    paypalcommercecredit: rest,
+                };
+
+                await strategy.initialize(options);
+
+                expect(paypalSdk.Buttons).toHaveBeenCalled();
+            });
+
+            it('throws an error if onComplete method is not provided for shippingOptions flow', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...paymentMethod,
+                    initializationData: {
+                        ...paymentMethod.initializationData,
+                        isHostedCheckoutEnabled: true,
+                    },
+                });
+
+                const { onComplete, ...rest } = paypalCommerceCreditOptions;
+
+                const options = {
+                    ...initializationOptions,
+                    paypalcommercecredit: rest,
+                };
+
+                try {
+                    await strategy.initialize(options);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(InvalidArgumentError);
+                }
+            });
+
+            it('initializes PayPal Credit button to render if PayPal PayLater is not eligible', async () => {
+                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                    (options: PayPalCommerceButtonsOptions) => {
+                        return {
+                            render: jest.fn(),
+                            isEligible: jest.fn(() => {
+                                return options.fundingSource === paypalSdk.FUNDING.CREDIT;
+                            }),
+                        };
+                    },
+                );
+
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                    fundingSource: paypalSdk.FUNDING.CREDIT,
+                    style: {
+                        height: 40,
+                        color: StyleButtonColor.gold,
+                    },
+                    createOrder: expect.any(Function),
+                    onApprove: expect.any(Function),
+                });
+            });
+
+            it('renders PayPal button', async () => {
+                const paypalCommerceSdkRenderMock = jest.fn();
+
+                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                    isEligible: jest.fn(() => true),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+            });
+
+            it('does not render PayPal button if it is not eligible', async () => {
+                const paypalCommerceSdkRenderMock = jest.fn();
+
+                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                    isEligible: jest.fn(() => false),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+                await strategy.initialize(initializationOptions);
+
+                expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+            });
+
+            it('removes PayPal button container if the button has not rendered', async () => {
+                const paypalCommerceSdkRenderMock = jest.fn();
+
+                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                    isEligible: jest.fn(() => false),
+                    render: paypalCommerceSdkRenderMock,
+                }));
+
+                await strategy.initialize(initializationOptions);
+
+                expect(document.getElementById(defaultButtonContainerId)).toBeNull();
+            });
+
+            it('creates an order with paypalcommercecredit as provider id if its initializes outside checkout page', async () => {
+                jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
+
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('createOrder');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
+                    'paypalcommercecredit',
+                    {
+                        cartId: cart.id,
+                    },
+                );
+            });
+
+            it('throws an error if orderId is not provided by PayPal on approve', async () => {
+                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                    (options: PayPalCommerceButtonsOptions) => {
+                        eventEmitter.on('createOrder', () => {
+                            if (options.createOrder) {
+                                options.createOrder().catch(jest.fn());
+                            }
+                        });
+
+                        eventEmitter.on('onApprove', () => {
+                            if (options.onApprove) {
+                                options.onApprove(
+                                    { orderID: undefined },
+                                    {
+                                        order: {
+                                            get: jest.fn(),
+                                        },
+                                    },
+                                );
+                            }
+                        });
+
+                        return {
+                            isEligible: jest.fn(() => true),
+                            render: jest.fn(),
+                        };
+                    },
+                );
+
+                try {
+                    await strategy.initialize(initializationOptions);
+                    eventEmitter.emit('onApprove');
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('tokenizes payment on paypal approve', async () => {
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(formPoster.postForm).toHaveBeenCalledWith(
+                    '/checkout.php',
+                    expect.objectContaining({
+                        action: 'set_external_checkout',
+                        order_id: paypalOrderId,
+                        payment_type: 'paypal',
+                        provider: paymentMethod.id,
+                    }),
+                );
+            });
+        });
+    });
+
+    describe('#onApprove button callback', () => {
+        const paypalOrderDetails: PayPalOrderDetails = {
+            purchase_units: [
+                {
+                    shipping: {
+                        address: {
+                            address_line_1: '2 E 61st St',
+                            admin_area_2: 'New York',
+                            admin_area_1: 'NY',
+                            postal_code: '10065',
+                            country_code: 'US',
+                        },
+                    },
+                },
+            ],
+            payer: {
+                name: {
+                    given_name: 'John',
+                    surname: 'Doe',
+                },
+                email_address: 'john@doe.com',
+                address: {
+                    address_line_1: '1 Main St',
+                    admin_area_2: 'San Jose',
+                    admin_area_1: 'CA',
+                    postal_code: '95131',
+                    country_code: 'US',
+                },
+            },
+        };
+
+        beforeEach(() => {
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                (options: PayPalCommerceButtonsOptions) => {
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove(
+                                { orderID: paypalOrderId },
+                                {
+                                    order: {
+                                        get: jest.fn(() => paypalOrderDetails),
+                                    },
+                                },
+                            );
+                        }
+                    });
+
+                    return {
+                        render: jest.fn(),
+                        isEligible: jest.fn(() => true),
+                    };
+                },
+            );
+
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+        });
+
+        it('takes order details data from paypal', async () => {
+            const getOrderActionMock = jest.fn(() => paypalOrderDetails);
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                (options: PayPalCommerceButtonsOptions) => {
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove(
+                                { orderID: paypalOrderId },
+                                {
+                                    order: {
+                                        get: getOrderActionMock,
+                                    },
+                                },
+                            );
+                        }
+                    });
+
+                    return {
+                        render: jest.fn(),
+                        isEligible: jest.fn(() => true),
+                    };
+                },
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(getOrderActionMock).toHaveBeenCalled();
+            expect(getOrderActionMock).toHaveReturnedWith(paypalOrderDetails);
+        });
+
+        it('updates only billing address with valid customers data from order details if there is no shipping needed', async () => {
+            const defaultCart = getCart();
+            const cartWithoutShipping = {
+                ...defaultCart,
+                lineItems: {
+                    ...defaultCart.lineItems,
+                    physicalItems: [],
+                },
+            };
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue(
+                cartWithoutShipping,
+            );
+
+            const address = {
+                firstName: paypalOrderDetails.payer.name.given_name,
+                lastName: paypalOrderDetails.payer.name.surname,
+                email: paypalOrderDetails.payer.email_address,
+                phone: '',
+                company: '',
+                address1: paypalOrderDetails.payer.address.address_line_1,
+                address2: '',
+                city: paypalOrderDetails.payer.address.admin_area_2,
+                countryCode: paypalOrderDetails.payer.address.country_code,
+                postalCode: paypalOrderDetails.payer.address.postal_code,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalOrderDetails.payer.address.admin_area_1,
+                customFields: [],
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(address);
+        });
+
+        it('submits BC order with provided methodId', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                {},
+                {
+                    params: {
+                        methodId: initializationOptions.methodId,
+                    },
+                },
+            );
+        });
+
+        it('submits BC payment to update BC order data', async () => {
+            const methodId = initializationOptions.methodId;
+            const paymentData = {
+                formattedPayload: {
+                    vault_payment_instrument: null,
+                    set_as_default_stored_instrument: null,
+                    device_info: null,
+                    method_id: methodId,
+                    paypal_account: {
+                        order_id: paypalOrderId,
+                    },
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId,
+                paymentData,
+            });
+        });
+
+        it('throws an error if orderId is not provided by PayPal on approve (hosted checkout)', async () => {
+            const getOrderActionMock = jest.fn(() => paypalOrderDetails);
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                (options: PayPalCommerceButtonsOptions) => {
+                    eventEmitter.on('onApprove', () => {
+                        if (options.onApprove) {
+                            options.onApprove(
+                                { orderID: undefined },
+                                {
+                                    order: {
+                                        get: getOrderActionMock,
+                                    },
+                                },
+                            );
+                        }
+                    });
+
+                    return {
+                        render: jest.fn(),
+                        isEligible: jest.fn(() => true),
+                    };
+                },
+            );
+
+            try {
+                await strategy.initialize(initializationOptions);
+                eventEmitter.emit('onApprove');
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(getOrderActionMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('#onShippingAddressChange button callback', () => {
+        beforeEach(() => {
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+        });
+
+        it('updates billing and shipping address with data returned from PayPal', async () => {
+            const providedAddress = {
+                firstName: '',
+                lastName: '',
+                email: '',
+                phone: '',
+                company: '',
+                address1: '',
+                address2: '',
+                city: paypalShippingAddressPayloadMock.city,
+                countryCode: paypalShippingAddressPayloadMock.country_code,
+                postalCode: paypalShippingAddressPayloadMock.postal_code,
+                stateOrProvince: '',
+                stateOrProvinceCode: paypalShippingAddressPayloadMock.state,
+                customFields: [],
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(
+                providedAddress,
+            );
+            expect(paymentIntegrationService.updateShippingAddress).toHaveBeenCalledWith(
+                providedAddress,
+            );
+        });
+
+        it('selects recommended shipping option if it was not selected earlier', async () => {
+            const recommendedShippingOption = {
+                ...getShippingOption(),
+                isRecommended: true,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [recommendedShippingOption],
+                selectedShippingOption: null,
+            };
+
+            const updatedConsignment = {
+                ...consignment,
+                selectedShippingOption: recommendedShippingOption,
+            };
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getConsignmentsOrThrow')
+                .mockReturnValueOnce([consignment])
+                .mockReturnValue([updatedConsignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                recommendedShippingOption.id,
+            );
+        });
+
+        it('selects first available shipping option if there is no recommended option', async () => {
+            const firstShippingOption = {
+                ...getShippingOption(),
+                id: 1,
+            };
+
+            const secondShippingOption = {
+                ...getShippingOption(),
+                id: 2,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [firstShippingOption, secondShippingOption],
+                selectedShippingOption: null,
+            };
+
+            const updatedConsignment = {
+                ...consignment,
+                selectedShippingOption: firstShippingOption,
+            };
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getConsignmentsOrThrow')
+                .mockReturnValueOnce([consignment])
+                .mockReturnValue([updatedConsignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                firstShippingOption.id,
+            );
+        });
+
+        it('updates PayPal order', async () => {
+            const consignment = getConsignment();
+
+            // INFO: lets imagine that it is a state that we get after consignmentActionCreator.selectShippingOption call
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getConsignmentsOrThrow',
+            ).mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingAddressChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalledWith({
+                availableShippingOptions: consignment.availableShippingOptions,
+                cartId: cart.id,
+                selectedShippingOption: consignment.selectedShippingOption,
+            });
+        });
+    });
+
+    describe('#onShippingOptionsChange button callback', () => {
+        beforeEach(() => {
+            const paymentMethodWithShippingOptionsFeature = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    isHostedCheckoutEnabled: true,
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+        });
+
+        it('selects shipping option', async () => {
+            const recommendedShippingOption = getShippingOption();
+            const shippingOptionThatShouldBeSelected = {
+                ...getShippingOption(),
+                id: paypalSelectedShippingOptionPayloadMock.id,
+                isRecommended: false,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [
+                    recommendedShippingOption,
+                    shippingOptionThatShouldBeSelected,
+                ],
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getConsignmentsOrThrow',
+            ).mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                shippingOptionThatShouldBeSelected.id,
+            );
+        });
+
+        it('selects recommended shipping option if there is no match with payload from paypal', async () => {
+            const recommendedShippingOption = getShippingOption();
+            const anotherShippingOption = {
+                ...getShippingOption(),
+                id: 'asdag123',
+                isRecommended: false,
+            };
+
+            const consignment = {
+                ...getConsignment(),
+                availableShippingOptions: [recommendedShippingOption, anotherShippingOption],
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getConsignmentsOrThrow',
+            ).mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.selectShippingOption).not.toHaveBeenCalledWith(
+                paypalSelectedShippingOptionPayloadMock.id,
+            );
+            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
+                recommendedShippingOption.id,
+            );
+        });
+
+        it('updates PayPal order', async () => {
+            const consignment = getConsignment();
+
+            // INFO: lets imagine that it is a state that we get after consignmentActionCreator.selectShippingOption call
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getConsignmentsOrThrow',
+            ).mockReturnValue([consignment]);
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onShippingOptionsChange');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalledWith({
+                availableShippingOptions: consignment.availableShippingOptions,
+                cartId: cart.id,
+                selectedShippingOption: consignment.selectedShippingOption,
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            const result = await strategy.deinitialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('#signIn()', () => {
+        it('calls default sign in method', async () => {
+            const credentials = {
+                email: 'test@test.com',
+                password: '123',
+            };
+
+            await strategy.signIn(credentials);
+
+            expect(paymentIntegrationService.signInCustomer).toHaveBeenCalledWith(
+                credentials,
+                undefined,
+            );
+        });
+    });
+
+    describe('#signOut()', () => {
+        it('calls default sign out method', async () => {
+            await strategy.signOut();
+
+            expect(paymentIntegrationService.signOutCustomer).toHaveBeenCalled();
+        });
+    });
+
+    describe('#executePaymentMethodCheckout()', () => {
+        it('calls default continue with checkout callback', async () => {
+            const continueWithCheckoutCallback = jest.fn();
+
+            await strategy.executePaymentMethodCheckout({ continueWithCheckoutCallback });
+
+            expect(continueWithCheckoutCallback).toHaveBeenCalled();
+        });
+
+        it('makes nothing if continue with checkout callback is not provided', async () => {
+            const result = await strategy.executePaymentMethodCheckout();
+
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -1,0 +1,338 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import {
+    BillingAddressRequestBody,
+    CustomerCredentials,
+    CustomerInitializeOptions,
+    CustomerStrategy,
+    ExecutePaymentMethodCheckoutOptions,
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    PaymentIntegrationService,
+    PaymentMethodClientUnavailableError,
+    RequestOptions,
+    ShippingOption,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import {
+    ApproveCallbackActions,
+    ApproveCallbackPayload,
+    PayPalCommerceButtonsOptions,
+    PayPalSDK,
+    ShippingAddressChangeCallbackPayload,
+    ShippingOptionChangeCallbackPayload,
+    StyleButtonColor,
+} from '../paypal-commerce-types';
+
+import { WithPayPalCommerceCreditCustomerInitializeOptions } from './paypal-commerce-credit-customer-initialize-options';
+
+export default class PayPalCommerceCreditCustomerStrategy implements CustomerStrategy {
+    constructor(
+        private formPoster: FormPoster,
+        private paymentIntegrationService: PaymentIntegrationService,
+        private paypalCommerceRequestSender: PayPalCommerceRequestSender,
+        private paypalCommerceScriptLoader: PayPalCommerceScriptLoader,
+    ) {}
+
+    async initialize(
+        options: CustomerInitializeOptions & WithPayPalCommerceCreditCustomerInitializeOptions,
+    ): Promise<void> {
+        const { paypalcommercecredit, methodId } = options;
+        const { container, onComplete } = paypalcommercecredit || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!container) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "paypalcommercecredit.containerId" argument is not provided.`,
+            );
+        }
+
+        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+
+        const state = this.paymentIntegrationService.getState();
+        const cart = state.getCartOrThrow();
+        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        const paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
+            paymentMethod,
+            cart.currency.code,
+        );
+
+        if (!paypalSdk) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        this.renderButton(container, methodId, paypalSdk, onComplete);
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    async signIn(credentials: CustomerCredentials, options?: RequestOptions): Promise<void> {
+        await this.paymentIntegrationService.signInCustomer(credentials, options);
+    }
+
+    async signOut(options?: RequestOptions): Promise<void> {
+        await this.paymentIntegrationService.signOutCustomer(options);
+    }
+
+    executePaymentMethodCheckout(options?: ExecutePaymentMethodCheckoutOptions): Promise<void> {
+        options?.continueWithCheckoutCallback?.();
+
+        return Promise.resolve();
+    }
+
+    private renderButton(
+        containerId: string,
+        methodId: string,
+        paypalSdk: PayPalSDK,
+        onComplete?: () => void,
+    ): void {
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
+
+        if (isHostedCheckoutEnabled && (!onComplete || typeof onComplete !== 'function')) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommercecredit.onComplete" argument is not provided or it is not a function.`,
+            );
+        }
+
+        const defaultCallbacks = {
+            createOrder: () => this.createOrder(),
+            onApprove: ({ orderID }: ApproveCallbackPayload) =>
+                this.tokenizePayment(methodId, orderID),
+        };
+        const hostedCheckoutCallbacks = {
+            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
+                this.onShippingAddressChange(data),
+            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
+                this.onShippingOptionsChange(data),
+            onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
+                this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
+        };
+        const fundingSources = [paypalSdk.FUNDING.PAYLATER, paypalSdk.FUNDING.CREDIT];
+        let hasRenderedSmartButton = false;
+
+        fundingSources.forEach((fundingSource) => {
+            if (!hasRenderedSmartButton) {
+                const buttonRenderOptions: PayPalCommerceButtonsOptions = {
+                    fundingSource,
+                    style: {
+                        height: 40,
+                        color: StyleButtonColor.gold,
+                    },
+                    ...defaultCallbacks,
+                    ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),
+                };
+
+                const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
+
+                if (paypalButton.isEligible()) {
+                    paypalButton.render(`#${containerId}`);
+                    hasRenderedSmartButton = true;
+                }
+            }
+        });
+
+        if (!hasRenderedSmartButton) {
+            this.removeElement(containerId);
+        }
+    }
+
+    private async onHostedCheckoutApprove(
+        data: ApproveCallbackPayload,
+        actions: ApproveCallbackActions,
+        methodId: string,
+        onComplete?: () => void,
+    ): Promise<boolean> {
+        if (!data.orderID) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        const state = this.paymentIntegrationService.getState();
+        const cart = state.getCartOrThrow();
+        const orderDetails = await actions.order.get();
+
+        if (cart.lineItems.physicalItems.length > 0) {
+            const { payer, purchase_units } = orderDetails;
+            const shippingAddress = purchase_units[0]?.shipping?.address || {};
+
+            const address = this.getAddress({
+                firstName: payer.name.given_name,
+                lastName: payer.name.surname,
+                email: payer.email_address,
+                address1: shippingAddress.address_line_1,
+                city: shippingAddress.admin_area_2,
+                countryCode: shippingAddress.country_code,
+                postalCode: shippingAddress.postal_code,
+                stateOrProvinceCode: shippingAddress.admin_area_1,
+            });
+
+            await this.paymentIntegrationService.updateBillingAddress(address);
+            await this.paymentIntegrationService.updateShippingAddress(address);
+            await this.updateOrder();
+        } else {
+            const { payer } = orderDetails;
+
+            const address = this.getAddress({
+                firstName: payer.name.given_name,
+                lastName: payer.name.surname,
+                email: payer.email_address,
+                address1: payer.address.address_line_1,
+                city: payer.address.admin_area_2,
+                countryCode: payer.address.country_code,
+                postalCode: payer.address.postal_code,
+                stateOrProvinceCode: payer.address.admin_area_1,
+            });
+
+            await this.paymentIntegrationService.updateBillingAddress(address);
+        }
+
+        await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
+        await this.submitPayment(methodId, data.orderID);
+
+        if (onComplete) {
+            onComplete();
+        }
+
+        return true;
+    }
+
+    private async onShippingOptionsChange(
+        data: ShippingOptionChangeCallbackPayload,
+    ): Promise<void> {
+        const shippingOption = this.getShippingOptionOrThrow(data.selectedShippingOption.id);
+
+        await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+        await this.updateOrder();
+    }
+
+    private async submitPayment(methodId: string, orderId: string): Promise<void> {
+        const paymentData = {
+            formattedPayload: {
+                vault_payment_instrument: null,
+                set_as_default_stored_instrument: null,
+                device_info: null,
+                method_id: methodId,
+                paypal_account: {
+                    order_id: orderId,
+                },
+            },
+        };
+
+        await this.paymentIntegrationService.submitPayment({ methodId, paymentData });
+    }
+
+    private async onShippingAddressChange(
+        data: ShippingAddressChangeCallbackPayload,
+    ): Promise<void> {
+        const address = this.getAddress({
+            city: data.shippingAddress.city,
+            countryCode: data.shippingAddress.country_code,
+            postalCode: data.shippingAddress.postal_code,
+            stateOrProvinceCode: data.shippingAddress.state,
+        });
+
+        // Info: we use the same address to fill billing and consignment addresses to have valid quota on BE for order updating process
+        // on this stage we don't have access to valid customer's address accept shipping data
+        await this.paymentIntegrationService.updateBillingAddress(address);
+        await this.paymentIntegrationService.updateShippingAddress(address);
+
+        const shippingOption = this.getShippingOptionOrThrow();
+
+        await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
+        await this.updateOrder();
+    }
+
+    private async updateOrder(): Promise<void> {
+        const state = this.paymentIntegrationService.getState();
+        const cart = state.getCartOrThrow();
+        const consignment = state.getConsignmentsOrThrow()[0];
+
+        await this.paypalCommerceRequestSender.updateOrder({
+            availableShippingOptions: consignment.availableShippingOptions,
+            cartId: cart.id,
+            selectedShippingOption: consignment.selectedShippingOption,
+        });
+    }
+
+    private getShippingOptionOrThrow(selectedShippingOptionId?: string): ShippingOption {
+        const state = this.paymentIntegrationService.getState();
+        const consignment = state.getConsignmentsOrThrow()[0];
+        const availableShippingOptions = consignment.availableShippingOptions || [];
+        const recommendedShippingOption = availableShippingOptions.find(
+            (option) => option.isRecommended,
+        );
+        const selectedShippingOption = selectedShippingOptionId
+            ? availableShippingOptions.find((option) => option.id === selectedShippingOptionId)
+            : availableShippingOptions.find(
+                  (option) => option.id === consignment.selectedShippingOption?.id,
+              );
+        const shippingOptionToSelect =
+            selectedShippingOption || recommendedShippingOption || availableShippingOptions[0];
+
+        if (!shippingOptionToSelect) {
+            throw new Error("Your order can't be shipped to this address");
+        }
+
+        return shippingOptionToSelect;
+    }
+
+    private getAddress(address?: Partial<BillingAddressRequestBody>): BillingAddressRequestBody {
+        return {
+            firstName: address?.firstName || '',
+            lastName: address?.lastName || '',
+            email: address?.email || '',
+            phone: '',
+            company: '',
+            address1: address?.address1 || '',
+            address2: '',
+            city: address?.city || '',
+            countryCode: address?.countryCode || '',
+            postalCode: address?.postalCode || '',
+            stateOrProvince: '',
+            stateOrProvinceCode: address?.stateOrProvinceCode || '',
+            customFields: [],
+        };
+    }
+
+    private async createOrder(): Promise<string> {
+        const cartId = this.paymentIntegrationService.getState().getCartOrThrow().id;
+        const { orderId } = await this.paypalCommerceRequestSender.createOrder(
+            'paypalcommercecredit',
+            { cartId },
+        );
+
+        return orderId;
+    }
+
+    private tokenizePayment(methodId: string, orderId?: string): void {
+        if (!orderId) {
+            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
+        }
+
+        return this.formPoster.postForm('/checkout.php', {
+            payment_type: 'paypal',
+            action: 'set_external_checkout',
+            provider: methodId,
+            order_id: orderId,
+        });
+    }
+
+    private removeElement(elementId?: string): void {
+        const element = elementId && document.getElementById(elementId);
+
+        if (element) {
+            element.remove();
+        }
+    }
+}


### PR DESCRIPTION
## What?
Add PayPal Commerce Credit (PayLater) customer strategy which will be used as button on customer step

## Why?
PayPal Commerce Credit (PayLater) button was added to make ability for shoppers to use PayLater payment method on first step and simplify checkout process.
PR for checkout-js: [https://github.com/bigcommerce/checkout-js/pull/1190](https://github.com/bigcommerce/checkout-js/pull/1190)
PR for BCapp: [https://github.com/bigcommerce/bigcommerce/pull/51145](https://github.com/bigcommerce/bigcommerce/pull/51145)

## Testing / Proof
<img width="1161" alt="Screenshot 2023-02-08 at 21 02 41" src="https://user-images.githubusercontent.com/9430298/217628955-c10e4e2a-c11f-4e5b-817c-0c581a32df0c.png">
<img width="350" alt="Screenshot 2023-02-08 at 21 10 12" src="https://user-images.githubusercontent.com/9430298/217628994-3cd0e1c7-47d3-4623-b789-3f53edce08db.png">


@bigcommerce/checkout @bigcommerce/payments
