### PR TITLE
feat(checkout): CHECKOUT-7231 Add getUserExperienceSettings selector

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-adyenv3-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-adyenv3-button-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
 import { InvalidArgumentError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { Cart, CartRequestSender } from '../../../cart';

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-authorizenet-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-authorizenet-button-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
 import { InvalidArgumentError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { Cart, CartRequestSender } from '../../../cart';

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-checkoutcom-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-checkoutcom-button-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
 import { InvalidArgumentError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { Cart, CartRequestSender } from '../../../cart';

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-cybersourcev2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-cybersourcev2-button-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
 import { InvalidArgumentError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { Cart, CartRequestSender } from '../../../cart';

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-orbital-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-orbital-button-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
 import { InvalidArgumentError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { Cart, CartRequestSender } from '../../../cart';

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-stripe-button-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
 import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
 import { InvalidArgumentError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { Cart, CartRequestSender } from '../../../cart';

--- a/packages/core/src/checkout/checkout-store-selector.spec.ts
+++ b/packages/core/src/checkout/checkout-store-selector.spec.ts
@@ -89,6 +89,13 @@ describe('CheckoutStoreSelector', () => {
         expect(selector.getCustomer()).toEqual(internalSelectors.customer.getCustomer());
     });
 
+    it('returns user experience settings', () => {
+        expect(selector.getUserExperienceSettings()).toEqual(
+            internalSelectors.config.getStoreConfigOrThrow().checkoutSettings
+                .checkoutUserExperienceSettings,
+        );
+    });
+
     describe('#getBillingAddress()', () => {
         it('returns billing address', () => {
             expect(selector.getBillingAddress()).toEqual(

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -541,7 +541,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
                 }
 
                 return config.checkoutSettings.checkoutUserExperienceSettings;
-        }),
+            }),
     );
 
     return memoizeOne((state: InternalCheckoutSelectors): CheckoutStoreSelector => {

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -6,7 +6,7 @@ import { BillingAddress } from '../billing';
 import { Cart } from '../cart';
 import { createSelector } from '../common/selector';
 import { cloneResult as clone } from '../common/utility';
-import { FlashMessage, FlashMessageType, StoreConfig } from '../config';
+import { FlashMessage, FlashMessageType, StoreConfig, UserExperienceSettings } from '../config';
 import { Coupon, GiftCertificate } from '../coupon';
 import { Customer } from '../customer';
 import { FormField } from '../form';
@@ -268,6 +268,13 @@ export default interface CheckoutStoreSelector {
         consignmentId: string,
         searchArea: SearchArea,
     ): PickupOptionResult[] | undefined;
+
+    /**
+     * Gets user experience settings.
+     *
+     * @returns The object of user experience settings if it is loaded, otherwise undefined.
+     */
+    getUserExperienceSettings(): UserExperienceSettings | undefined;
 }
 
 export type CheckoutStoreSelectorFactory = (
@@ -523,6 +530,20 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getPickupOptions) => clone(getPickupOptions),
     );
 
+    const getUserExperienceSettings = createSelector(
+        ({ config }: InternalCheckoutSelectors) => config.getStoreConfig,
+        (getStoreConfig) =>
+            clone(() => {
+                const config = getStoreConfig();
+
+                if (!config) {
+                    return;
+                }
+
+                return config.checkoutSettings.checkoutUserExperienceSettings;
+        }),
+    );
+
     return memoizeOne((state: InternalCheckoutSelectors): CheckoutStoreSelector => {
         return {
             getCheckout: getCheckout(state),
@@ -551,6 +572,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             getBillingAddressFields: getBillingAddressFields(state),
             getShippingAddressFields: getShippingAddressFields(state),
             getPickupOptions: getPickupOptions(state),
+            getUserExperienceSettings: getUserExperienceSettings(state),
         };
     });
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -91,10 +91,12 @@ export interface StoreCurrency {
 
 export type UserExperienceSettingNames = 'walletButtonsOnTop';
 
+export type UserExperienceSettings = { [key in UserExperienceSettingNames]: boolean };
+
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
-    checkoutUserExperienceSettings: { [key in UserExperienceSettingNames]: boolean };
+    checkoutUserExperienceSettings: UserExperienceSettings;
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -7,6 +7,7 @@ export {
     ShopperCurrency,
     FlashMessage,
     FlashMessageType,
+    UserExperienceSettings,
 } from './config';
 export { default as ConfigActionCreator } from './config-action-creator';
 export {

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -7,7 +7,6 @@ import {
     PaymentIntegrationSelectors,
     PaymentIntegrationService,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
 import {
     getBuyNowCart,
     getBuyNowCartRequestBody,

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -38,6 +38,7 @@ import {
     StripeUPEClient,
 } from './stripe-upe';
 import StripeUPEScriptLoader from './stripe-upe-script-loader';
+
 import { StripeUPEPaymentInitializeOptions } from './';
 
 const APM_REDIRECT = [

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -90,10 +90,12 @@ export interface StoreCurrency {
 
 export type UserExperienceSettingNames = 'walletButtonsOnTop';
 
+export type UserExperienceSettings = { [key in UserExperienceSettingNames]: boolean };
+
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };
     checkoutBillingSameAsShippingEnabled: boolean;
-    checkoutUserExperienceSettings: { [key in UserExperienceSettingNames]: boolean };
+    checkoutUserExperienceSettings: UserExperienceSettings;
     enableOrderComments: boolean;
     enableTermsAndConditions: boolean;
     googleMapsApiKey: string;


### PR DESCRIPTION
## What?
Add `getUserExperienceSettings` to `CheckoutStoreSelector`.

## Why?
Developers can easily read user experience settings in the feature.

Sample usage: `data.getUserExperienceSettings()?.walletButtonsOnTop` will return the flag of using wallet buttons at the top of the checkout page.

## Testing / Proof
Added one unit test.

@bigcommerce/checkout @bigcommerce/payments
