### PR TITLE
feat(payment): PAYMENTS-8493 add untrusted shipping address card veri…

### DIFF
--- a/packages/core/src/payment/instrument/instrument-response-body.ts
+++ b/packages/core/src/payment/instrument/instrument-response-body.ts
@@ -1,4 +1,4 @@
-import PaymentInstrument from './instrument';
+import PaymentInstrument, { UntrustedShippingCardVerificationType } from './instrument';
 
 export interface InstrumentError {
     code: number;
@@ -35,6 +35,7 @@ export interface CardInternalInstrument extends BaseInternalInstrument {
     iin: string;
     last_4: string;
     method_type: 'card';
+    untrusted_shipping_address_card_verification_mode: UntrustedShippingCardVerificationType;
 }
 
 export interface PayPalInternalInstrument extends BaseInternalAccountInstrument {

--- a/packages/core/src/payment/instrument/instrument.mock.ts
+++ b/packages/core/src/payment/instrument/instrument.mock.ts
@@ -1,6 +1,7 @@
 import PaymentInstrument, {
     CardInstrument,
     InstrumentRequestContext,
+    UntrustedShippingCardVerificationType,
     VaultAccessToken,
 } from './instrument';
 import {
@@ -35,6 +36,7 @@ export function getInstruments(): PaymentInstrument[] {
             trustedShippingAddress: true,
             defaultInstrument: true,
             method: 'credit_card',
+            untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
             type: 'card',
         },
         {
@@ -48,6 +50,7 @@ export function getInstruments(): PaymentInstrument[] {
             trustedShippingAddress: false,
             defaultInstrument: false,
             method: 'credit_card',
+            untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
             type: 'card',
         },
         {
@@ -83,6 +86,7 @@ export function getInstruments(): PaymentInstrument[] {
             defaultInstrument: true,
             method: 'scheme',
             type: 'card',
+            untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
         },
     ];
 }
@@ -99,6 +103,7 @@ export function getCardInstrument(): CardInstrument {
         trustedShippingAddress: true,
         defaultInstrument: true,
         method: 'card',
+        untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
         type: 'card',
     };
 }
@@ -162,6 +167,8 @@ export function getInternalInstrumentsResponseBody(): InternalInstrumentsRespons
                 default_instrument: true,
                 method: 'credit_card',
                 method_type: 'card',
+                untrusted_shipping_address_card_verification_mode:
+                    UntrustedShippingCardVerificationType.PAN,
             },
             {
                 bigpay_token: '111',
@@ -175,6 +182,8 @@ export function getInternalInstrumentsResponseBody(): InternalInstrumentsRespons
                 default_instrument: false,
                 method_type: 'card',
                 method: 'credit_card',
+                untrusted_shipping_address_card_verification_mode:
+                    UntrustedShippingCardVerificationType.PAN,
             },
             {
                 bigpay_token: '31415',
@@ -209,6 +218,8 @@ export function getInternalInstrumentsResponseBody(): InternalInstrumentsRespons
                 default_instrument: true,
                 method: 'scheme',
                 method_type: 'card',
+                untrusted_shipping_address_card_verification_mode:
+                    UntrustedShippingCardVerificationType.PAN,
             },
         ],
     };

--- a/packages/core/src/payment/instrument/instrument.ts
+++ b/packages/core/src/payment/instrument/instrument.ts
@@ -11,6 +11,11 @@ interface BaseInstrument {
     type: string;
 }
 
+export enum UntrustedShippingCardVerificationType {
+    CVV = 'cvv',
+    PAN = 'pan',
+}
+
 export interface CardInstrument extends BaseInstrument {
     brand: string;
     expiryMonth: string;
@@ -18,6 +23,7 @@ export interface CardInstrument extends BaseInstrument {
     iin: string;
     last4: string;
     type: 'card';
+    untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType;
 }
 
 interface BaseAccountInstrument extends BaseInstrument {

--- a/packages/core/src/payment/instrument/map-to-card-instrument.spec.ts
+++ b/packages/core/src/payment/instrument/map-to-card-instrument.spec.ts
@@ -1,3 +1,4 @@
+import { UntrustedShippingCardVerificationType } from './instrument';
 import { mapToCardInstrument } from './map-to-card-instrument';
 
 describe('mapToCardInstrument', () => {
@@ -13,6 +14,8 @@ describe('mapToCardInstrument', () => {
             expiry_year: '2020',
             expiry_month: '12',
             default_instrument: false,
+            untrusted_shipping_address_card_verification_mode:
+                UntrustedShippingCardVerificationType.PAN,
             brand: 'VISA',
         });
 
@@ -27,6 +30,7 @@ describe('mapToCardInstrument', () => {
             expiryYear: '2020',
             expiryMonth: '12',
             defaultInstrument: false,
+            untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.PAN,
             type: 'card',
         });
     });

--- a/packages/core/src/payment/instrument/map-to-card-instrument.ts
+++ b/packages/core/src/payment/instrument/map-to-card-instrument.ts
@@ -12,6 +12,8 @@ export function mapToCardInstrument(instrument: CardInternalInstrument): CardIns
         expiryYear: instrument.expiry_year,
         brand: instrument.brand,
         trustedShippingAddress: instrument.trusted_shipping_address,
+        untrustedShippingCardVerificationMode:
+            instrument.untrusted_shipping_address_card_verification_mode,
         method: instrument.method,
         type: 'card',
     };


### PR DESCRIPTION
## What?
We are mapping `untrusted_shipping_address_card_verification_mode` to cardIntruemt mode.

This PR is a dependency of https://github.com/bigcommerce/checkout-js/pull/1195

## Why?
At BigPay, we have updated the trusted shipping endpoint to return instruments that include `untrusted_shipping_address_card_verification_mode`. We are going to use this attribute to determine which field should be shown on the payment form when untrusted shipping is detected.

For example, if a mode value `cvv` returns, the payment form should only show cvv input box, which means the shopper can only use cvv to finish the payment. If a mode value `number` returns, the number filed will be required.

For the logic how we gonna use this mode value, please refer to PR 
https://github.com/bigcommerce/checkout-js/pull/1195

## Testing / Proof
Local testing
untrusted shipping + cvv only
<img width="1346" alt="image" src="https://user-images.githubusercontent.com/79880337/218619961-bff3983e-7d22-48ec-868d-d52c46f37a68.png">
untrusted shipping + pan
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/79880337/218620070-9de31ec8-5fdc-4189-9dc9-b36f49f65e20.png">

Unit tests

## Depends on
none

## Dependency of
https://github.com/bigcommerce/checkout-js/pull/1195

@bigcommerce/checkout @bigcommerce/payments
