### PR TITLE
refactor(checkout): CHECKOUT-7291 Remove ApplePay button style

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -31,17 +31,6 @@ enum DefaultLabels {
     Shipping = 'Shipping',
 }
 
-const style = {
-    width: '160px',
-    backgroundColor: '#000',
-    backgroundPosition: '50% 50%',
-    backgroundSize: '100% 60%',
-    padding: '1.5rem',
-    backgroundImage: '-webkit-named-image(apple-pay-logo-white)',
-    borderRadius: '4px',
-    backgroundRepeat: 'no-repeat',
-};
-
 function isShippingOptions(options: ShippingOption[] | undefined): options is ShippingOption[] {
     return options instanceof Array;
 }
@@ -127,7 +116,6 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
 
         button.setAttribute('type', 'button');
         button.setAttribute('aria-label', 'Apple Pay');
-        Object.assign(button.style, style);
         container.appendChild(button);
 
         return button;

--- a/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/apple-pay/apple-pay-customer-strategy.ts
@@ -46,17 +46,6 @@ enum DefaultLabels {
     Shipping = 'Shipping',
 }
 
-const style = {
-    width: '160px',
-    backgroundColor: '#000',
-    backgroundPosition: '50% 50%',
-    backgroundSize: '100% 60%',
-    padding: '1.5rem',
-    backgroundImage: '-webkit-named-image(apple-pay-logo-white)',
-    borderRadius: '4px',
-    backgroundRepeat: 'no-repeat',
-};
-
 function isShippingOptions(options: ShippingOption[] | undefined): options is ShippingOption[] {
     return options instanceof Array;
 }
@@ -151,7 +140,6 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
 
         button.setAttribute('type', 'button');
         button.setAttribute('aria-label', 'Apple Pay');
-        Object.assign(button.style, style);
         container.appendChild(button);
 
         return button;


### PR DESCRIPTION
## What?
Move Apple Pay buttons styles to `checkout-js`'s SCSS file.

Following this PR, a `checkout-js` PR will be created.

## Why?
Those inline styles make it impossible for `checkout-js` to manage the appearance of an Apple Pay wallet button.

## Testing / Proof
After moving styles to `checkout-js`.

<img width="1417" alt="Screenshot 2023-02-13 at 3 54 02 pm" src="https://user-images.githubusercontent.com/88361607/218374376-8f40dfd8-c2d2-45a9-8135-a9b37a3e8d1c.png">


@bigcommerce/checkout @bigcommerce/payments
