### PR TITLE
fix(checkout): ADYEN-588 update payment data request on wallet button click googlepay

### DIFF
--- a/packages/core/src/customer/strategies/googlepay/googlepay-adyenv2-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-adyenv2-customer-strategy.spec.ts
@@ -237,6 +237,9 @@ describe('GooglePayCustomerStrategy', () => {
         beforeEach(() => {
             customerInitializeOptions = getAdyenV2CustomerInitializeOptions();
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
@@ -243,6 +243,9 @@ describe('GooglePayCustomerStrategy', () => {
         beforeEach(() => {
             customerInitializeOptions = getAuthNetCustomerInitializeOptions();
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/customer/strategies/googlepay/googlepay-bnz-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-bnz-customer-strategy.spec.ts
@@ -241,6 +241,9 @@ describe('GooglePayCustomerStrategy', () => {
                 },
             };
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
@@ -246,6 +246,9 @@ describe('GooglePayCustomerStrategy', () => {
         beforeEach(() => {
             customerInitializeOptions = getBraintreeCustomerInitializeOptions();
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/customer/strategies/googlepay/googlepay-checkoutcom-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-checkoutcom-customer-strategy.spec.ts
@@ -250,6 +250,9 @@ describe('GooglePayCustomerStrategy', () => {
                 },
             };
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -171,6 +171,13 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         const cart = this._store.getState().cart.getCartOrThrow();
         const hasPhysicalItems = getShippableItemsCount(cart) > 0;
 
+        const payloadToUpdate = {
+            currencyCode: cart.currency.code,
+            totalPrice: String(cart.cartAmount),
+        };
+
+        this._googlePayPaymentProcessor.updatePaymentDataRequest(payloadToUpdate);
+
         try {
             const paymentData = await this._googlePayPaymentProcessor.displayWallet();
 

--- a/packages/core/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
@@ -250,6 +250,9 @@ describe('GooglePayCustomerStrategy', () => {
                 },
             };
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/customer/strategies/googlepay/googlepay-orbital-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-orbital-customer-strategy.spec.ts
@@ -248,6 +248,9 @@ describe('GooglePayCustomerStrategy', () => {
                 },
             };
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
@@ -245,6 +245,9 @@ describe('GooglePayCustomerStrategy', () => {
                 },
             };
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/customer/strategies/googlepay/googlepay-stripe-upe-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-stripe-upe-customer-strategy.spec.ts
@@ -248,6 +248,9 @@ describe('GooglePayCustomerStrategy', () => {
                 },
             };
 
+            jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+                Promise.resolve(),
+            );
             jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
             jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -186,6 +186,9 @@ describe('GooglePayPaymentStrategy', () => {
         jest.spyOn(googlePayCheckoutcomPaymentProcessor, 'processAdditionalAction').mockReturnValue(
             Promise.resolve(),
         );
+        jest.spyOn(googlePayPaymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
+            Promise.resolve(),
+        );
         jest.spyOn(googlePayPaymentProcessor, 'initialize').mockReturnValue(Promise.resolve());
         jest.spyOn(googlePayPaymentProcessor, 'deinitialize').mockReturnValue(Promise.resolve());
         jest.spyOn(googlePayPaymentProcessor, 'displayWallet').mockReturnValue(

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -387,6 +387,15 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         return (event?: Event) => {
             event?.preventDefault();
 
+            const cart = this._store.getState().cart.getCartOrThrow();
+
+            const payloadToUpdate = {
+                currencyCode: cart.currency.code,
+                totalPrice: String(cart.cartAmount),
+            };
+
+            this._googlePayPaymentProcessor.updatePaymentDataRequest(payloadToUpdate);
+
             if (!methodId || !this._googlePayOptions) {
                 throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
             }


### PR DESCRIPTION
## What?
Update payment data request on googlepay wallet button click 

## Why?
We've found that Google Pay does not include coupon discount at the 'Customer' step of checkout.
That is why we need to update payment data request on googlepay wallet button click

## Testing / Proof
**Before fix:**

https://user-images.githubusercontent.com/79574476/218151786-bacaa63a-82f6-4c4e-b267-d525a6a6be28.mov

**After fix:**

https://user-images.githubusercontent.com/79574476/218151769-9ca95fb7-be10-4c10-96a9-781739f1e677.mov

@bigcommerce/checkout @bigcommerce/payments
