### PR TITLE
refactor(payment): PAYPAL-1973 updated PayPalCommerceCustomerStrategy with PayPalCommerceIntegrationService

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -248,11 +248,7 @@ export default class PayPalCommerceIntegrationService {
      *
      */
     getValidButtonStyle(style?: PayPalButtonStyleOptions): PayPalButtonStyleOptions {
-        if (!style) {
-            return {};
-        }
-
-        const { color, height, label, layout, shape, tagline } = style;
+        const { color, height, label, layout, shape, tagline } = style || {};
 
         // TODO: remove layout and tagline properties when paypal commerce common will be added to all paypal commerce strategies
         const validStyles = {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-customer-strategy.ts
@@ -7,7 +7,11 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { PayPalCommerceRequestSender, PayPalCommerceScriptLoader } from '../index';
+import {
+    PayPalCommerceIntegrationService,
+    PayPalCommerceRequestSender,
+    PayPalCommerceScriptLoader,
+} from '../index';
 
 import PayPalCommerceCustomerStrategy from './paypal-commerce-customer-strategy';
 
@@ -16,11 +20,16 @@ const createPayPalCommerceCustomerStrategy: CustomerStrategyFactory<
 > = (paymentIntegrationService) => {
     const { getHost } = paymentIntegrationService.getState();
 
-    return new PayPalCommerceCustomerStrategy(
+    const paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
         createFormPoster(),
         paymentIntegrationService,
         new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
         new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+
+    return new PayPalCommerceCustomerStrategy(
+        paymentIntegrationService,
+        paypalCommerceIntegrationService,
     );
 };
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -205,7 +205,7 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         });
 
         try {
-            // Info: we use the same address to fill billing and consignment addresses to have valid quota on BE for order updating process
+            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
             // on this stage we don't have access to valid customer's address accept shipping data
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -1,8 +1,6 @@
-import { FormPoster } from '@bigcommerce/form-poster';
 import { noop } from 'lodash';
 
 import {
-    BillingAddressRequestBody,
     CustomerCredentials,
     CustomerInitializeOptions,
     CustomerStrategy,
@@ -11,35 +9,28 @@ import {
     MissingDataError,
     MissingDataErrorType,
     PaymentIntegrationService,
-    PaymentMethodClientUnavailableError,
     RequestOptions,
-    ShippingOption,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
-import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import {
     ApproveCallbackActions,
     ApproveCallbackPayload,
     PayPalCommerceButtonsOptions,
-    PayPalSDK,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
-import PaypalCommerceCustomerInitializeOptions, {
+import PayPalCommerceCustomerInitializeOptions, {
     WithPayPalCommerceCustomerInitializeOptions,
 } from './paypal-commerce-customer-initialize-options';
 
 export default class PayPalCommerceCustomerStrategy implements CustomerStrategy {
     private onError = noop;
-    private paypalSdk?: PayPalSDK;
 
     constructor(
-        private formPoster: FormPoster,
         private paymentIntegrationService: PaymentIntegrationService,
-        private paypalCommerceRequestSender: PayPalCommerceRequestSender,
-        private paypalCommerceScriptLoader: PayPalCommerceScriptLoader,
+        private paypalCommerceIntegrationService: PayPalCommerceIntegrationService,
     ) {}
 
     async initialize(
@@ -59,18 +50,16 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
             );
         }
 
+        if (!paypalcommerce.container) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommerce.container" argument is not provided.`,
+            );
+        }
+
         this.onError = paypalcommerce.onError || noop;
 
         await this.paymentIntegrationService.loadPaymentMethod(methodId);
-
-        const state = this.paymentIntegrationService.getState();
-        const currencyCode = state.getCartOrThrow().currency.code;
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
-
-        this.paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
-            paymentMethod,
-            currencyCode,
-        );
+        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
 
         this.renderButton(methodId, paypalcommerce);
     }
@@ -99,26 +88,20 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
 
     private renderButton(
         methodId: string,
-        paypalcommerce: PaypalCommerceCustomerInitializeOptions,
+        paypalcommerce: PayPalCommerceCustomerInitializeOptions,
     ): void {
-        const paypalSdk = this.getPayPalSdkOrThrow();
         const { container, onComplete } = paypalcommerce;
 
+        const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
         const paymentMethod = state.getPaymentMethodOrThrow(methodId);
         const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
 
-        if (!container) {
-            throw new InvalidArgumentError(
-                `Unable to initialize payment because "options.paypalcommerce.container" argument is not provided.`,
-            );
-        }
-
-        if (isHostedCheckoutEnabled && (!onComplete || typeof onComplete !== 'function')) {
-            throw new InvalidArgumentError(
-                `Unable to initialize payment because "options.paypalcommerce.onComplete" argument is not provided or it is not a function.`,
-            );
-        }
+        const defaultCallbacks = {
+            createOrder: () => this.paypalCommerceIntegrationService.createOrder('paypalcommerce'),
+            onApprove: ({ orderID }: ApproveCallbackPayload) =>
+                this.paypalCommerceIntegrationService.tokenizePayment(methodId, orderID),
+        };
 
         const hostedCheckoutCallbacks = {
             onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
@@ -129,22 +112,11 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
 
-        const regularCallbacks = {
-            onApprove: ({ orderID }: ApproveCallbackPayload) =>
-                this.tokenizePayment(methodId, orderID),
-        };
-
-        const paypalCallbacks = isHostedCheckoutEnabled
-            ? hostedCheckoutCallbacks
-            : regularCallbacks;
-
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.PAYPAL,
-            style: {
-                height: 40,
-            },
-            createOrder: () => this.createOrder(),
-            ...paypalCallbacks,
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle(),
+            ...defaultCallbacks,
+            ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),
         };
 
         const paypalButton = paypalSdk.Buttons(buttonRenderOptions);
@@ -152,21 +124,8 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         if (paypalButton.isEligible()) {
             paypalButton.render(`#${container}`);
         } else {
-            this.removeElement(container);
+            this.paypalCommerceIntegrationService.removeElement(container);
         }
-    }
-
-    private tokenizePayment(methodId: string, orderId?: string): void {
-        if (!orderId) {
-            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
-        }
-
-        return this.formPoster.postForm('/checkout.php', {
-            action: 'set_external_checkout',
-            order_id: orderId,
-            payment_type: 'paypal',
-            provider: methodId,
-        });
     }
 
     private async onHostedCheckoutApprove(
@@ -183,45 +142,27 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         const orderDetails = await actions.order.get();
 
         try {
+            const billingAddress =
+                this.paypalCommerceIntegrationService.getBillingAddressFromOrderDetails(
+                    orderDetails,
+                );
+
+            await this.paymentIntegrationService.updateBillingAddress(billingAddress);
+
             if (cart.lineItems.physicalItems.length > 0) {
-                const { payer, purchase_units } = orderDetails;
-                const shippingAddress = purchase_units[0]?.shipping?.address || {};
+                const shippingAddress =
+                    this.paypalCommerceIntegrationService.getShippingAddressFromOrderDetails(
+                        orderDetails,
+                    );
 
-                const address = this.getAddress({
-                    firstName: payer.name.given_name,
-                    lastName: payer.name.surname,
-                    email: payer.email_address,
-                    address1: shippingAddress.address_line_1,
-                    city: shippingAddress.admin_area_2,
-                    countryCode: shippingAddress.country_code,
-                    postalCode: shippingAddress.postal_code,
-                    stateOrProvinceCode: shippingAddress.admin_area_1,
-                });
-
-                await this.paymentIntegrationService.updateBillingAddress(address);
-                await this.paymentIntegrationService.updateShippingAddress(address);
-                await this.updateOrder();
-            } else {
-                const { payer } = orderDetails;
-
-                const address = this.getAddress({
-                    firstName: payer.name.given_name,
-                    lastName: payer.name.surname,
-                    email: payer.email_address,
-                    address1: payer.address.address_line_1,
-                    city: payer.address.admin_area_2,
-                    countryCode: payer.address.country_code,
-                    postalCode: payer.address.postal_code,
-                    stateOrProvinceCode: payer.address.admin_area_1,
-                });
-
-                await this.paymentIntegrationService.updateBillingAddress(address);
+                await this.paymentIntegrationService.updateShippingAddress(shippingAddress);
+                await this.paypalCommerceIntegrationService.updateOrder();
             }
 
             await this.paymentIntegrationService.submitOrder({}, { params: { methodId } });
-            await this.submitPayment(methodId, data.orderID);
+            await this.paypalCommerceIntegrationService.submitPayment(methodId, data.orderID);
 
-            if (onComplete) {
+            if (onComplete && typeof onComplete === 'function') {
                 onComplete();
             }
         } catch (error) {
@@ -232,7 +173,7 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
     private async onShippingAddressChange(
         data: ShippingAddressChangeCallbackPayload,
     ): Promise<void> {
-        const address = this.getAddress({
+        const address = this.paypalCommerceIntegrationService.getAddress({
             city: data.shippingAddress.city,
             countryCode: data.shippingAddress.country_code,
             postalCode: data.shippingAddress.postal_code,
@@ -245,10 +186,10 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);
 
-            const shippingOption = this.getShippingOptionOrThrow();
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
 
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.updateOrder();
+            await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {
             this.handleError(error);
         }
@@ -257,108 +198,15 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
     private async onShippingOptionsChange(
         data: ShippingOptionChangeCallbackPayload,
     ): Promise<void> {
-        const shippingOption = this.getShippingOptionOrThrow(data.selectedShippingOption.id);
+        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+            data.selectedShippingOption.id,
+        );
 
         try {
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.updateOrder();
+            await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {
             this.handleError(error);
-        }
-    }
-
-    private async submitPayment(methodId: string, orderId: string): Promise<void> {
-        const paymentData = {
-            formattedPayload: {
-                vault_payment_instrument: null,
-                set_as_default_stored_instrument: null,
-                device_info: null,
-                method_id: methodId,
-                paypal_account: {
-                    order_id: orderId,
-                },
-            },
-        };
-
-        await this.paymentIntegrationService.submitPayment({ methodId, paymentData });
-    }
-
-    private async updateOrder(): Promise<void> {
-        const state = this.paymentIntegrationService.getState();
-        const cart = state.getCartOrThrow();
-        const consignment = state.getConsignmentsOrThrow()[0];
-
-        await this.paypalCommerceRequestSender.updateOrder({
-            availableShippingOptions: consignment.availableShippingOptions,
-            cartId: cart.id,
-            selectedShippingOption: consignment.selectedShippingOption,
-        });
-    }
-
-    private getAddress(address?: Partial<BillingAddressRequestBody>): BillingAddressRequestBody {
-        return {
-            firstName: address?.firstName || '',
-            lastName: address?.lastName || '',
-            email: address?.email || '',
-            phone: '',
-            company: '',
-            address1: address?.address1 || '',
-            address2: '',
-            city: address?.city || '',
-            countryCode: address?.countryCode || '',
-            postalCode: address?.postalCode || '',
-            stateOrProvince: '',
-            stateOrProvinceCode: address?.stateOrProvinceCode || '',
-            customFields: [],
-        };
-    }
-
-    private getShippingOptionOrThrow(selectedShippingOptionId?: string): ShippingOption {
-        const consignment = this.paymentIntegrationService.getState().getConsignmentsOrThrow()[0];
-        const availableShippingOptions = consignment.availableShippingOptions || [];
-
-        const recommendedShippingOption = availableShippingOptions.find(
-            (option) => option.isRecommended,
-        );
-        const selectedShippingOption = selectedShippingOptionId
-            ? availableShippingOptions.find((option) => option.id === selectedShippingOptionId)
-            : availableShippingOptions.find(
-                  (option) => option.id === consignment.selectedShippingOption?.id,
-              );
-
-        const shippingOptionToSelect =
-            selectedShippingOption || recommendedShippingOption || availableShippingOptions[0];
-
-        if (!shippingOptionToSelect) {
-            throw new Error("Your order can't be shipped to this address");
-        }
-
-        return shippingOptionToSelect;
-    }
-
-    private async createOrder(): Promise<string> {
-        const cart = this.paymentIntegrationService.getState().getCartOrThrow();
-
-        const { orderId } = await this.paypalCommerceRequestSender.createOrder('paypalcommerce', {
-            cartId: cart.id,
-        });
-
-        return orderId;
-    }
-
-    private getPayPalSdkOrThrow(): PayPalSDK {
-        if (!this.paypalSdk) {
-            throw new PaymentMethodClientUnavailableError();
-        }
-
-        return this.paypalSdk;
-    }
-
-    private removeElement(elementId?: string): void {
-        const element = elementId && document.getElementById(elementId);
-
-        if (element) {
-            element.remove();
         }
     }
 


### PR DESCRIPTION
## What?
Updated PayPalCommerceCustomerStrategy with PayPalCommerceIntegrationService

## Why?
To reduce amount of code duplication. PayPalCommerceIntegrationService contains a lot of methods that can be used in different PayPalCommerce strategies.

## Testing / Proof
Unit tests
Manual tests
