### PR TITLE
[SPIKE] feat(payment): hack braintree options

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -254,6 +254,24 @@ export default class BraintreeHostedForm {
         }
     }
 
+    private _mapErrors(fields: any): any {
+        const errors = {};
+
+        for (const [key, value] of Object.entries(fields)) {
+            const { isValid, isEmpty, isPotentialyValid } = value as any;
+
+            (errors as any)[key] = {
+                [key]: {
+                    isValid,
+                    isEmpty,
+                    isPotentialyValid,
+                },
+            };
+        }
+
+        return errors;
+    }
+
     private _mapValidationErrors(
         fields: BraintreeHostedFieldsState['fields'],
     ): BraintreeFormFieldValidateEventData['errors'] {
@@ -403,6 +421,7 @@ export default class BraintreeHostedForm {
     private _handleBlur: (event: BraintreeHostedFieldsState) => void = (event) => {
         this._formOptions?.onBlur?.({
             fieldType: this._mapFieldType(event.emittedBy),
+            errors: this._mapErrors(event.fields),
         });
     };
 

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
@@ -173,6 +173,7 @@ export type BraintreeFormFieldStyles = Partial<
 
 export interface BraintreeFormFieldKeyboardEventData {
     fieldType: string;
+    errors?: any;
 }
 
 export type BraintreeFormFieldBlurEventData = BraintreeFormFieldKeyboardEventData;


### PR DESCRIPTION
## What?
Expose braintree options

## Why?
In order to provide more information to SDK clients for error states

## Testing / Proof
N/A

@bigcommerce/checkout @bigcommerce/payments
