### PR TITLE
refactor(payment): PAYPAL-1978 updated PayPalCommerceAlternativeMethodsButtonStrategy with PayPalCommerceIntegrationService

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-button-strategy.ts
@@ -7,7 +7,11 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { PayPalCommerceRequestSender, PayPalCommerceScriptLoader } from '../index';
+import {
+    PayPalCommerceIntegrationService,
+    PayPalCommerceRequestSender,
+    PayPalCommerceScriptLoader,
+} from '../index';
 
 import PayPalCommerceAlternativeMethodsButtonStrategy from './paypal-commerce-alternative-methods-button-strategy';
 
@@ -16,11 +20,16 @@ const createPayPalCommerceAlternativeMethodsButtonStrategy: CheckoutButtonStrate
 > = (paymentIntegrationService) => {
     const { getHost } = paymentIntegrationService.getState();
 
-    return new PayPalCommerceAlternativeMethodsButtonStrategy(
+    const paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
         createFormPoster(),
         paymentIntegrationService,
         new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
         new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+
+    return new PayPalCommerceAlternativeMethodsButtonStrategy(
+        paymentIntegrationService,
+        paypalCommerceIntegrationService,
     );
 };
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-initialize-options.ts
@@ -1,6 +1,4 @@
-import { BuyNowCartRequestBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
-import { PayPalButtonStyleOptions } from '../paypal-commerce-types';
+import { PayPalButtonStyleOptions, PayPalBuyNowInitializeOptions } from '../paypal-commerce-types';
 
 export default interface PayPalCommerceAlternativeMethodsButtonOptions {
     /**
@@ -9,14 +7,9 @@ export default interface PayPalCommerceAlternativeMethodsButtonOptions {
     apm: string;
 
     /**
-     * A set of styling options for the checkout button.
+     * The options that required to initialize Buy Now functionality.
      */
-    style?: PayPalButtonStyleOptions;
-
-    /**
-     * Flag which helps to detect that the strategy initializes on Checkout page
-     */
-    initializesOnCheckoutPage?: boolean;
+    buyNowInitializeOptions?: PayPalBuyNowInitializeOptions;
 
     /**
      * The option that used to initialize a PayPal script with provided currency code.
@@ -24,11 +17,16 @@ export default interface PayPalCommerceAlternativeMethodsButtonOptions {
     currencyCode?: string;
 
     /**
-     * The options that required to initialize Buy Now functionality.
+     * // TODO: this flag should be removed, because the strategy does not used on checkout page
+     * // and it always equals to 'false'
+     * Flag which helps to detect that the strategy initializes on Checkout page
      */
-    buyNowInitializeOptions?: {
-        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
-    };
+    initializesOnCheckoutPage?: boolean;
+
+    /**
+     * A set of styling options for the checkout button.
+     */
+    style?: PayPalButtonStyleOptions;
 }
 
 export interface WithPayPalCommerceAlternativeMethodsButtonOptions {


### PR DESCRIPTION
## What?
Updated PayPalCommerceAlternativeMethodsButtonStrategy with PayPalCommerceIntegrationService

## Why?
To reduce amount of code duplication. PayPalCommerceIntegrationService contains a lot of methods that can be used in different PayPalCommerce strategies.

## Testing / Proof
Unit tests
