### PR TITLE
refactor(payment): PAYPAL-1982 updated PayPalCommerceVenmoCustomerStrategy with PayPalCommerceIntegrationService

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-customer-strategy.ts
@@ -7,7 +7,11 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { PayPalCommerceRequestSender, PayPalCommerceScriptLoader } from '../index';
+import {
+    PayPalCommerceIntegrationService,
+    PayPalCommerceRequestSender,
+    PayPalCommerceScriptLoader,
+} from '../index';
 
 import PayPalCommerceVenmoCustomerStrategy from './paypal-commerce-venmo-customer-strategy';
 
@@ -16,11 +20,16 @@ const createPayPalCommerceVenmoCustomerStrategy: CustomerStrategyFactory<
 > = (paymentIntegrationService) => {
     const { getHost } = paymentIntegrationService.getState();
 
-    return new PayPalCommerceVenmoCustomerStrategy(
+    const paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
         createFormPoster(),
         paymentIntegrationService,
         new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
         new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+
+    return new PayPalCommerceVenmoCustomerStrategy(
+        paymentIntegrationService,
+        paypalCommerceIntegrationService,
     );
 };
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
@@ -1,41 +1,28 @@
-import { FormPoster } from '@bigcommerce/form-poster';
-
 import {
-    CheckoutButtonInitializeOptions,
     CustomerCredentials,
+    CustomerInitializeOptions,
     CustomerStrategy,
     ExecutePaymentMethodCheckoutOptions,
     InvalidArgumentError,
-    MissingDataError,
-    MissingDataErrorType,
     PaymentIntegrationService,
-    PaymentMethodClientUnavailableError,
     RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
-import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
-import {
-    ApproveCallbackPayload,
-    PayPalCommerceButtonsOptions,
-    PayPalSDK,
-} from '../paypal-commerce-types';
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
+import { ApproveCallbackPayload, PayPalCommerceButtonsOptions } from '../paypal-commerce-types';
 
 import { WithPayPalCommerceVenmoCustomerInitializeOptions } from './paypal-commerce-venmo-customer-initialize-options';
 
 export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStrategy {
     constructor(
-        private formPoster: FormPoster,
         private paymentIntegrationService: PaymentIntegrationService,
-        private paypalCommerceRequestSender: PayPalCommerceRequestSender,
-        private paypalCommerceScriptLoader: PayPalCommerceScriptLoader,
+        private paypalCommerceIntegrationService: PayPalCommerceIntegrationService,
     ) {}
 
     async initialize(
-        options: CheckoutButtonInitializeOptions & WithPayPalCommerceVenmoCustomerInitializeOptions,
+        options: CustomerInitializeOptions & WithPayPalCommerceVenmoCustomerInitializeOptions,
     ): Promise<void> {
         const { paypalcommercevenmo, methodId } = options;
-        const { container } = paypalcommercevenmo || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -43,27 +30,22 @@ export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStra
             );
         }
 
-        if (!container) {
+        if (!paypalcommercevenmo) {
             throw new InvalidArgumentError(
-                `Unable to initialize payment because "paypalcommercevenmo.containerId" argument is not provided.`,
+                `Unable to initialize payment because "paypalcommercevenmo" argument is not provided.`,
+            );
+        }
+
+        if (!paypalcommercevenmo.container) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "paypalcommercevenmo.container" argument is not provided.`,
             );
         }
 
         await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
 
-        const state = this.paymentIntegrationService.getState();
-        const cart = state.getCartOrThrow();
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
-        const paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
-            paymentMethod,
-            cart.currency.code,
-        );
-
-        if (!paypalSdk) {
-            throw new PaymentMethodClientUnavailableError();
-        }
-
-        this.renderButton(container, methodId, paypalSdk);
+        this.renderButton(methodId, paypalcommercevenmo.container);
     }
 
     deinitialize(): Promise<void> {
@@ -84,15 +66,16 @@ export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStra
         return Promise.resolve();
     }
 
-    private renderButton(containerId: string, methodId: string, paypalSdk: PayPalSDK): void {
+    private renderButton(methodId: string, containerId: string): void {
+        const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
+
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.VENMO,
-            style: {
-                height: 40,
-            },
-            createOrder: () => this.createOrder(),
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle(),
+            createOrder: () =>
+                this.paypalCommerceIntegrationService.createOrder('paypalcommercevenmo'),
             onApprove: ({ orderID }: ApproveCallbackPayload) =>
-                this.tokenizePayment(methodId, orderID),
+                this.paypalCommerceIntegrationService.tokenizePayment(methodId, orderID),
         };
 
         const paypalButtonRender = paypalSdk.Buttons(buttonRenderOptions);
@@ -100,39 +83,7 @@ export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStra
         if (paypalButtonRender.isEligible()) {
             paypalButtonRender.render(`#${containerId}`);
         } else {
-            this.removeElement(containerId);
-        }
-    }
-
-    private async createOrder(): Promise<string> {
-        const cartId = this.paymentIntegrationService.getState().getCartOrThrow().id;
-
-        const { orderId } = await this.paypalCommerceRequestSender.createOrder(
-            'paypalcommercevenmo',
-            { cartId },
-        );
-
-        return orderId;
-    }
-
-    private tokenizePayment(methodId: string, orderId?: string): void {
-        if (!orderId) {
-            throw new MissingDataError(MissingDataErrorType.MissingOrderId);
-        }
-
-        return this.formPoster.postForm('/checkout.php', {
-            payment_type: 'paypal',
-            action: 'set_external_checkout',
-            provider: methodId,
-            order_id: orderId,
-        });
-    }
-
-    private removeElement(elementId?: string): void {
-        const element = elementId && document.getElementById(elementId);
-
-        if (element) {
-            element.remove();
+            this.paypalCommerceIntegrationService.removeElement(containerId);
         }
     }
 }


### PR DESCRIPTION
## What?
Updated PayPalCommerceVenmoCustomerStrategy with PayPalCommerceIntegrationService

## Why?
To reduce amount of code duplication. PayPalCommerceIntegrationService contains a lot of methods that can be used in different PayPalCommerce strategies.

## Testing / Proof
Unit tests
