### PR TITLE
feat(payment): BOLT-463 add applyStoreCredit to PaymentIntegrationService

### DIFF
--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -31,6 +31,7 @@ import {
     SpamProtectionActionCreator,
     SpamProtectionRequestSender,
 } from '../spam-protection';
+import { StoreCreditActionCreator, StoreCreditRequestSender } from '../store-credit';
 import { SubscriptionsActionCreator, SubscriptionsRequestSender } from '../subscription';
 
 import createPaymentIntegrationSelectors from './create-payment-integration-selectors';
@@ -93,6 +94,10 @@ export default function createPaymentIntegrationService(
         ),
     );
 
+    const storeCreditActionCreator = new StoreCreditActionCreator(
+        new StoreCreditRequestSender(requestSender),
+    );
+
     const cartRequestSender = new CartRequestSender(requestSender);
 
     return new DefaultPaymentIntegrationService(
@@ -107,5 +112,6 @@ export default function createPaymentIntegrationService(
         paymentActionCreator,
         customerActionCreator,
         cartRequestSender,
+        storeCreditActionCreator,
     );
 }

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -27,6 +27,7 @@ import PaymentMethodActionCreator from '../payment/payment-method-action-creator
 import { getPayment } from '../payment/payments.mock';
 import { ConsignmentActionCreator } from '../shipping';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
+import { StoreCreditActionCreator } from '../store-credit';
 
 import DefaultPaymentIntegrationService from './default-payment-integration-service';
 import PaymentIntegrationStoreProjectionFactory from './payment-integration-store-projection-factory';
@@ -60,6 +61,7 @@ describe('DefaultPaymentIntegrationService', () => {
     >;
     let customerActionCreator: Pick<CustomerActionCreator, 'signInCustomer' | 'signOutCustomer'>;
     let cartRequestSender: CartRequestSender;
+    let storeCreditActionCreator: Pick<StoreCreditActionCreator, 'applyStoreCredit'>;
 
     beforeEach(() => {
         requestSender = createRequestSender();
@@ -123,6 +125,12 @@ describe('DefaultPaymentIntegrationService', () => {
             signOutCustomer: jest.fn(async () => () => createAction('SIGN_OUT_CUSTOMER')),
         };
 
+        storeCreditActionCreator = {
+            applyStoreCredit: jest.fn(
+                async () => () => createAction('APPLY_STORE_CREDIT_REQUESTED'),
+            ),
+        };
+
         subject = new DefaultPaymentIntegrationService(
             store as CheckoutStore,
             storeProjectionFactory as PaymentIntegrationStoreProjectionFactory,
@@ -135,6 +143,7 @@ describe('DefaultPaymentIntegrationService', () => {
             paymentActionCreator as PaymentActionCreator,
             customerActionCreator as CustomerActionCreator,
             cartRequestSender,
+            storeCreditActionCreator as StoreCreditActionCreator,
         );
     });
 
@@ -347,6 +356,24 @@ describe('DefaultPaymentIntegrationService', () => {
                 undefined,
             );
             expect(output).toEqual(buyNowCart);
+        });
+    });
+
+    describe('#applyStoreCredit', () => {
+        it('applies store credits', async () => {
+            const output = await subject.applyStoreCredit(true, {
+                params: {},
+            });
+
+            expect(storeCreditActionCreator.applyStoreCredit).toHaveBeenCalledWith(true, {
+                params: {},
+            });
+            expect(store.dispatch).toHaveBeenCalledWith(
+                storeCreditActionCreator.applyStoreCredit(true, {
+                    params: {},
+                }),
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
         });
     });
 });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -23,6 +23,7 @@ import { OrderActionCreator } from '../order';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
 import { ConsignmentActionCreator } from '../shipping';
+import { StoreCreditActionCreator } from '../store-credit';
 
 import PaymentIntegrationStoreProjectionFactory from './payment-integration-store-projection-factory';
 
@@ -41,6 +42,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _paymentActionCreator: PaymentActionCreator,
         private _customerActionCreator: CustomerActionCreator,
         private _cartRequestSender: CartRequestSender,
+        private _storeCreditActionCreator: StoreCreditActionCreator,
     ) {
         this._storeProjection = this._storeProjectionFactory.create(this._store);
     }
@@ -178,5 +180,16 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         );
 
         return buyNowCart;
+    }
+
+    async applyStoreCredit(
+        useStoreCredit: boolean,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._storeCreditActionCreator.applyStoreCredit(useStoreCredit, options),
+        );
+
+        return this._storeProjection.getState();
     }
 }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -58,5 +58,10 @@ export default interface PaymentIntegrationService {
 
     signOutCustomer(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
 
+    applyStoreCredit(
+        useStoreCredit: boolean,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors>;
+
     createBuyNowCart(body: BuyNowCartRequestBody, options?: RequestOptions): Promise<Cart>;
 }


### PR DESCRIPTION
## What?
Add applyStoreCredit to PaymentIntegrationService

## Why?
To get ability to use `storeCreditActionCreator.applyStoreCredit` from `PaymentIntegrationService`

## Testing / Proof
Unit test result:
<img width="351" alt="Screenshot 2023-02-17 at 13 49 56" src="https://user-images.githubusercontent.com/9430298/219649705-757c6c1b-a1a5-4c0c-8f69-6d797c260730.png">


@bigcommerce/checkout @bigcommerce/payments
