### PR TITLE
refactor(payment): PAYPAL-1979 updated PayPalCommerceCreditButtonStrategy with PayPalCommerceIntegrationService

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-button-strategy.ts
@@ -7,7 +7,11 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { PayPalCommerceRequestSender, PayPalCommerceScriptLoader } from '../index';
+import {
+    PayPalCommerceIntegrationService,
+    PayPalCommerceRequestSender,
+    PayPalCommerceScriptLoader,
+} from '../index';
 
 import PayPalCommerceCreditButtonStrategy from './paypal-commerce-credit-button-strategy';
 
@@ -16,11 +20,16 @@ const createPayPalCommerceCreditButtonStrategy: CheckoutButtonStrategyFactory<
 > = (paymentIntegrationService) => {
     const { getHost } = paymentIntegrationService.getState();
 
-    return new PayPalCommerceCreditButtonStrategy(
+    const paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
         createFormPoster(),
         paymentIntegrationService,
         new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
         new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+
+    return new PayPalCommerceCreditButtonStrategy(
+        paymentIntegrationService,
+        paypalCommerceIntegrationService,
     );
 };
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-initialize-options.ts
@@ -1,6 +1,4 @@
-import { BuyNowCartRequestBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
-import { PayPalButtonStyleOptions } from '../paypal-commerce-types';
+import { PayPalButtonStyleOptions, PayPalBuyNowInitializeOptions } from '../paypal-commerce-types';
 
 export default interface PayPalCommerceCreditButtonInitializeOptions {
     /**
@@ -26,9 +24,7 @@ export default interface PayPalCommerceCreditButtonInitializeOptions {
     /**
      * The options that are required to initialize Buy Now functionality.
      */
-    buyNowInitializeOptions?: {
-        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
-    };
+    buyNowInitializeOptions?: PayPalBuyNowInitializeOptions;
 
     /**
      * A callback that gets called when payment complete on paypal side.

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -4,11 +4,9 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 import { EventEmitter } from 'events';
 
 import {
-    BuyNowCartCreationError,
     Cart,
     CheckoutButtonInitializeOptions,
     InvalidArgumentError,
-    MissingDataError,
     PaymentIntegrationService,
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -21,21 +19,24 @@ import {
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
+import getBillingAddressFromOrderDetails from '../mocks/get-billing-address-from-order-details.mock';
+import getPayPalCommerceOrderDetails from '../mocks/get-paypal-commerce-order-details.mock';
+import getShippingAddressFromOrderDetails from '../mocks/get-shipping-address-from-order-details.mock';
 import { getPayPalCommercePaymentMethod } from '../mocks/paypal-commerce-payment-method.mock';
 import { getPayPalSDKMock } from '../mocks/paypal-sdk.mock';
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
 import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
 import {
     PayPalCommerceButtonsOptions,
     PayPalCommerceHostWindow,
-    PayPalOrderDetails,
     PayPalSDK,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditButtonInitializeOptions from './paypal-commerce-credit-button-initialize-options';
 import PayPalCommerceCreditButtonStrategy from './paypal-commerce-credit-button-strategy';
 
-describe('PayPalCommerceButtonStrategy', () => {
+describe('PayPalCommerceCreditButtonStrategy', () => {
     let buyNowCart: Cart;
     let cart: Cart;
     let eventEmitter: EventEmitter;
@@ -46,6 +47,7 @@ describe('PayPalCommerceButtonStrategy', () => {
     let paymentMethod: PaymentMethod;
     let paypalButtonElement: HTMLDivElement;
     let paypalMessageElement: HTMLDivElement;
+    let paypalCommerceIntegrationService: PayPalCommerceIntegrationService;
     let paypalCommerceRequestSender: PayPalCommerceRequestSender;
     let paypalCommerceScriptLoader: PayPalCommerceScriptLoader;
     let paypalSdk: PayPalSDK;
@@ -62,7 +64,6 @@ describe('PayPalCommerceButtonStrategy', () => {
             getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
         },
         currencyCode: 'USD',
-        initializesOnCheckoutPage: false,
         messagingContainerId: defaultMessageContainerId,
         style: {
             height: 45,
@@ -77,7 +78,6 @@ describe('PayPalCommerceButtonStrategy', () => {
     };
 
     const paypalCommerceCreditOptions: PayPalCommerceCreditButtonInitializeOptions = {
-        initializesOnCheckoutPage: false,
         messagingContainerId: defaultMessageContainerId,
         style: {
             height: 45,
@@ -115,7 +115,7 @@ describe('PayPalCommerceButtonStrategy', () => {
 
         eventEmitter = new EventEmitter();
 
-        paymentMethod = { ...getPayPalCommercePaymentMethod(), id: defaultMethodId };
+        paymentMethod = getPayPalCommercePaymentMethod();
         paypalSdk = getPayPalSDKMock();
 
         formPoster = createFormPoster();
@@ -124,11 +124,16 @@ describe('PayPalCommerceButtonStrategy', () => {
         paypalCommerceRequestSender = new PayPalCommerceRequestSender(requestSender);
         paypalCommerceScriptLoader = new PayPalCommerceScriptLoader(getScriptLoader());
 
-        strategy = new PayPalCommerceCreditButtonStrategy(
+        paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
             formPoster,
             paymentIntegrationService,
             paypalCommerceRequestSender,
             paypalCommerceScriptLoader,
+        );
+
+        strategy = new PayPalCommerceCreditButtonStrategy(
+            paymentIntegrationService,
+            paypalCommerceIntegrationService,
         );
 
         paypalButtonElement = document.createElement('div');
@@ -142,25 +147,44 @@ describe('PayPalCommerceButtonStrategy', () => {
         jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
             paymentMethod,
         );
-
         jest.spyOn(paymentIntegrationService, 'loadDefaultCheckout').mockImplementation(jest.fn());
-        jest.spyOn(paymentIntegrationService, 'selectShippingOption').mockImplementation(jest.fn());
-        jest.spyOn(paymentIntegrationService, 'submitOrder').mockImplementation(jest.fn());
-        jest.spyOn(paymentIntegrationService, 'submitPayment').mockImplementation(jest.fn());
         jest.spyOn(paymentIntegrationService, 'updateBillingAddress').mockImplementation(jest.fn());
         jest.spyOn(paymentIntegrationService, 'updateShippingAddress').mockImplementation(
             jest.fn(),
         );
+        jest.spyOn(paymentIntegrationService, 'selectShippingOption').mockImplementation(jest.fn());
 
-        jest.spyOn(formPoster, 'postForm').mockImplementation(jest.fn());
-        jest.spyOn(paypalCommerceScriptLoader, 'getPayPalSDK').mockReturnValue(paypalSdk);
-        jest.spyOn(paypalCommerceRequestSender, 'updateOrder').mockReturnValue(true);
+        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
+            paypalSdk,
+        );
+        jest.spyOn(paypalCommerceIntegrationService, 'createBuyNowCartOrThrow').mockReturnValue(
+            buyNowCart,
+        );
+        jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockImplementation(jest.fn());
+        jest.spyOn(paypalCommerceIntegrationService, 'updateOrder').mockImplementation(jest.fn());
+        jest.spyOn(paypalCommerceIntegrationService, 'tokenizePayment').mockImplementation(
+            jest.fn(),
+        );
+        jest.spyOn(paypalCommerceIntegrationService, 'submitPayment').mockImplementation(jest.fn());
+        jest.spyOn(paypalCommerceIntegrationService, 'removeElement').mockImplementation(jest.fn());
+        jest.spyOn(
+            paypalCommerceIntegrationService,
+            'getBillingAddressFromOrderDetails',
+        ).mockReturnValue(getBillingAddressFromOrderDetails());
+        jest.spyOn(
+            paypalCommerceIntegrationService,
+            'getShippingAddressFromOrderDetails',
+        ).mockReturnValue(getShippingAddressFromOrderDetails());
+        jest.spyOn(paypalCommerceIntegrationService, 'getShippingOptionOrThrow').mockReturnValue(
+            getShippingOption(),
+        );
 
         jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
             (options: PayPalCommerceButtonsOptions) => {
                 eventEmitter.on('createOrder', () => {
                     if (options.createOrder) {
-                        options.createOrder().catch(jest.fn());
+                        options.createOrder();
                     }
                 });
 
@@ -171,7 +195,7 @@ describe('PayPalCommerceButtonStrategy', () => {
                         try {
                             if (options.onClick) {
                                 await options.onClick(
-                                    { fundingSource: 'paylater' },
+                                    { fundingSource: 'paypal' },
                                     {
                                         reject: jest.fn(),
                                         resolve: jest.fn(),
@@ -233,10 +257,6 @@ describe('PayPalCommerceButtonStrategy', () => {
                 };
             },
         );
-
-        jest.spyOn(paypalSdk, 'Messages').mockImplementation(() => ({
-            render: jest.fn(),
-        }));
     });
 
     afterEach(() => {
@@ -247,13 +267,9 @@ describe('PayPalCommerceButtonStrategy', () => {
         if (document.getElementById(defaultButtonContainerId)) {
             document.body.removeChild(paypalButtonElement);
         }
-
-        if (document.getElementById(defaultMessageContainerId)) {
-            document.body.removeChild(paypalMessageElement);
-        }
     });
 
-    it('creates an instance of the PayPal Commerce Credit (PayLater) checkout button strategy', () => {
+    it('creates an instance of the PayPal Commerce Credit checkout button strategy', () => {
         expect(strategy).toBeInstanceOf(PayPalCommerceCreditButtonStrategy);
     });
 
@@ -295,6 +311,41 @@ describe('PayPalCommerceButtonStrategy', () => {
             }
         });
 
+        it('throws an error if paypalcommercecredit.currencyCode is not provided (for buyNowFlow only)', async () => {
+            const { currencyCode, ...rest } = buyNowPayPalCommerceCreditOptions;
+
+            const newInitializationOptions = {
+                ...buyNowInitializationOptions,
+                paypalcommercecredit: rest,
+            };
+
+            try {
+                await strategy.initialize(newInitializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if provided buyNow callback is not a function is not provided (for buyNowFlow only)', async () => {
+            const { buyNowInitializeOptions, ...rest } = buyNowPayPalCommerceCreditOptions;
+
+            const newInitializationOptions = {
+                ...buyNowInitializationOptions,
+                paypalcommercecredit: {
+                    ...rest,
+                    buyNowInitializeOptions: {
+                        getBuyNowCartRequestBody: 'string',
+                    },
+                },
+            } as CheckoutButtonInitializeOptions;
+
+            try {
+                await strategy.initialize(newInitializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
         it('loads default checkout', async () => {
             await strategy.initialize(initializationOptions);
 
@@ -307,427 +358,74 @@ describe('PayPalCommerceButtonStrategy', () => {
             expect(paymentIntegrationService.loadDefaultCheckout).not.toHaveBeenCalled();
         });
 
-        it('loads paypal commerce sdk script', async () => {
+        it('loads paypal sdk script', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
-                paymentMethod,
+            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
+                defaultMethodId,
                 cart.currency.code,
-                paypalCommerceCreditOptions.initializesOnCheckoutPage,
+                false,
             );
         });
 
-        it('loads paypal commerce sdk script with provided currency code (Buy Now flow)', async () => {
+        it('loads paypal sdk script with provided currency code (Buy Now flow)', async () => {
             await strategy.initialize(buyNowInitializationOptions);
 
-            expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
-                paymentMethod,
+            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
+                defaultMethodId,
                 buyNowPayPalCommerceCreditOptions.currencyCode,
-                buyNowPayPalCommerceCreditOptions.initializesOnCheckoutPage,
+                false,
             );
-        });
-
-        describe('PayPal Commerce Credit buttons logic', () => {
-            it('initializes PayPal Paylater button to render', async () => {
-                await strategy.initialize(initializationOptions);
-
-                expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                    fundingSource: paypalSdk.FUNDING.PAYLATER,
-                    style: paypalCommerceCreditOptions.style,
-                    createOrder: expect.any(Function),
-                    onApprove: expect.any(Function),
-                    onClick: expect.any(Function),
-                });
-            });
-
-            it('does not throw an error if onComplete method is not provided for default flow', async () => {
-                jest.spyOn(
-                    paymentIntegrationService.getState(),
-                    'getPaymentMethodOrThrow',
-                ).mockReturnValue({
-                    ...paymentMethod,
-                    initializationData: {
-                        ...paymentMethod.initializationData,
-                        isHostedCheckoutEnabled: false,
-                    },
-                });
-
-                const { onComplete, ...rest } = paypalCommerceCreditOptions;
-
-                const options = {
-                    ...initializationOptions,
-                    paypalcommercecredit: rest,
-                };
-
-                await strategy.initialize(options);
-
-                expect(paypalSdk.Buttons).toHaveBeenCalled();
-            });
-
-            it('throws an error if onComplete method is not provided for shippingOptions flow', async () => {
-                jest.spyOn(
-                    paymentIntegrationService.getState(),
-                    'getPaymentMethodOrThrow',
-                ).mockReturnValue({
-                    ...paymentMethod,
-                    initializationData: {
-                        ...paymentMethod.initializationData,
-                        isHostedCheckoutEnabled: true,
-                    },
-                });
-
-                const { onComplete, ...rest } = paypalCommerceCreditOptions;
-
-                const options = {
-                    ...initializationOptions,
-                    paypalcommercecredit: rest,
-                };
-
-                try {
-                    await strategy.initialize(options);
-                } catch (error) {
-                    expect(error).toBeInstanceOf(InvalidArgumentError);
-                }
-            });
-
-            it('initializes PayPal Credit button to render if PayPal PayLater is not eligible', async () => {
-                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-                    (options: PayPalCommerceButtonsOptions) => {
-                        return {
-                            render: jest.fn(),
-                            isEligible: jest.fn(() => {
-                                return options.fundingSource === paypalSdk.FUNDING.CREDIT;
-                            }),
-                        };
-                    },
-                );
-
-                await strategy.initialize(initializationOptions);
-
-                expect(paypalSdk.Buttons).toHaveBeenCalledWith({
-                    fundingSource: paypalSdk.FUNDING.CREDIT,
-                    style: paypalCommerceCreditOptions.style,
-                    createOrder: expect.any(Function),
-                    onApprove: expect.any(Function),
-                    onClick: expect.any(Function),
-                });
-            });
-
-            it('renders PayPal button', async () => {
-                const paypalCommerceSdkRenderMock = jest.fn();
-
-                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
-                    isEligible: jest.fn(() => true),
-                    render: paypalCommerceSdkRenderMock,
-                }));
-
-                await strategy.initialize(initializationOptions);
-
-                expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
-            });
-
-            it('does not render PayPal button if it is not eligible', async () => {
-                const paypalCommerceSdkRenderMock = jest.fn();
-
-                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
-                    isEligible: jest.fn(() => false),
-                    render: paypalCommerceSdkRenderMock,
-                }));
-
-                await strategy.initialize(initializationOptions);
-
-                expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
-            });
-
-            it('removes PayPal button container if the button has not rendered', async () => {
-                const paypalCommerceSdkRenderMock = jest.fn();
-
-                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
-                    isEligible: jest.fn(() => false),
-                    render: paypalCommerceSdkRenderMock,
-                }));
-
-                await strategy.initialize(initializationOptions);
-
-                expect(document.getElementById(defaultButtonContainerId)).toBeNull();
-            });
-
-            it('throws an error if buy now cart request body data is not provided on button click (Buy Now flow)', async () => {
-                const buyNowInitializationOptionsMock = {
-                    ...buyNowInitializationOptions,
-                    paypalcommercecredit: {
-                        ...buyNowPayPalCommerceCreditOptions,
-                        buyNowInitializeOptions: {
-                            getBuyNowCartRequestBody: jest.fn().mockReturnValue(undefined),
-                        },
-                    },
-                };
-
-                await strategy.initialize(buyNowInitializationOptionsMock);
-                eventEmitter.emit('onClick', undefined, (error: Error) => {
-                    expect(error).toBeInstanceOf(MissingDataError);
-                });
-            });
-
-            it('creates buy now cart (Buy Now Flow)', async () => {
-                jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(
-                    buyNowCart,
-                );
-
-                await strategy.initialize(buyNowInitializationOptions);
-
-                eventEmitter.emit('onClick', () => {
-                    expect(paymentIntegrationService.createBuyNowCart).toHaveBeenCalledWith(
-                        buyNowCartRequestBody,
-                    );
-                });
-            });
-
-            it('throws an error if failed to create buy now cart (Buy Now Flow)', async () => {
-                jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockImplementation(() =>
-                    Promise.reject(),
-                );
-
-                await strategy.initialize(buyNowInitializationOptions);
-                eventEmitter.emit('onClick', undefined, (error: Error) => {
-                    expect(error).toBeInstanceOf(BuyNowCartCreationError);
-                });
-            });
-
-            it('creates an order with paypalcommercecredit as provider id if its initializes outside checkout page', async () => {
-                jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
-
-                await strategy.initialize(initializationOptions);
-
-                eventEmitter.emit('createOrder');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                    'paypalcommercecredit',
-                    {
-                        cartId: cart.id,
-                    },
-                );
-            });
-
-            it('creates an order with paypalcommercecreditcheckout as provider id if its initializes on checkout page', async () => {
-                jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
-
-                const updatedIntializationOptions = {
-                    ...initializationOptions,
-                    paypalcommercecredit: {
-                        ...paypalCommerceCreditOptions,
-                        initializesOnCheckoutPage: true,
-                    },
-                };
-
-                await strategy.initialize(updatedIntializationOptions);
-
-                eventEmitter.emit('createOrder');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                    'paypalcommercecreditcheckout',
-                    {
-                        cartId: cart.id,
-                    },
-                );
-            });
-
-            it('creates order with Buy Now cart id (Buy Now flow)', async () => {
-                jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(
-                    buyNowCart,
-                );
-                jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('');
-
-                await strategy.initialize(buyNowInitializationOptions);
-
-                eventEmitter.emit('onClick');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                eventEmitter.emit('createOrder');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(
-                    'paypalcommercecredit',
-                    {
-                        cartId: buyNowCart.id,
-                    },
-                );
-            });
-
-            it('throws an error if orderId is not provided by PayPal on approve', async () => {
-                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-                    (options: PayPalCommerceButtonsOptions) => {
-                        eventEmitter.on('createOrder', () => {
-                            if (options.createOrder) {
-                                options.createOrder().catch(jest.fn());
-                            }
-                        });
-
-                        eventEmitter.on('onApprove', () => {
-                            if (options.onApprove) {
-                                options.onApprove(
-                                    { orderID: undefined },
-                                    {
-                                        order: {
-                                            get: jest.fn(),
-                                        },
-                                    },
-                                );
-                            }
-                        });
-
-                        return {
-                            isEligible: jest.fn(() => true),
-                            render: jest.fn(),
-                        };
-                    },
-                );
-
-                try {
-                    await strategy.initialize(initializationOptions);
-                    eventEmitter.emit('onApprove');
-                } catch (error) {
-                    expect(error).toBeInstanceOf(MissingDataError);
-                }
-            });
-
-            it('tokenizes payment on paypal approve', async () => {
-                await strategy.initialize(initializationOptions);
-
-                eventEmitter.emit('onApprove');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(formPoster.postForm).toHaveBeenCalledWith(
-                    '/checkout.php',
-                    expect.objectContaining({
-                        action: 'set_external_checkout',
-                        order_id: paypalOrderId,
-                        payment_type: 'paypal',
-                        provider: paymentMethod.id,
-                    }),
-                );
-            });
-
-            it('provides buy now cart_id on payment tokenization on paypal approve', async () => {
-                jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue(
-                    buyNowCart,
-                );
-                jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue('111');
-
-                await strategy.initialize(buyNowInitializationOptions);
-
-                eventEmitter.emit('onClick');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                eventEmitter.emit('createOrder');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                eventEmitter.emit('onApprove');
-
-                await new Promise((resolve) => process.nextTick(resolve));
-
-                expect(formPoster.postForm).toHaveBeenCalledWith('/checkout.php', {
-                    action: 'set_external_checkout',
-                    cart_id: buyNowCart.id,
-                    order_id: paypalOrderId,
-                    payment_type: 'paypal',
-                    provider: defaultMethodId,
-                });
-            });
-        });
-
-        describe('PayPal Commerce Credit messages logic', () => {
-            it('initializes PayPal Messages component', async () => {
-                await strategy.initialize(initializationOptions);
-
-                expect(paypalSdk.Messages).toHaveBeenCalledWith({
-                    amount: cart.cartAmount,
-                    placement: 'cart',
-                    style: {
-                        layout: 'text',
-                    },
-                });
-            });
-
-            it('renders PayPal message', async () => {
-                const paypalCommerceSdkRenderMock = jest.fn();
-
-                jest.spyOn(paypalSdk, 'Messages').mockImplementation(() => ({
-                    render: paypalCommerceSdkRenderMock,
-                }));
-
-                await strategy.initialize(initializationOptions);
-
-                expect(paypalCommerceSdkRenderMock).toHaveBeenCalledWith(
-                    `#${defaultMessageContainerId}`,
-                );
-            });
         });
     });
 
-    describe('#onApprove button callback', () => {
-        const paypalOrderDetails: PayPalOrderDetails = {
-            purchase_units: [
-                {
-                    shipping: {
-                        address: {
-                            address_line_1: '2 E 61st St',
-                            admin_area_2: 'New York',
-                            admin_area_1: 'NY',
-                            postal_code: '10065',
-                            country_code: 'US',
-                        },
-                    },
-                },
-            ],
-            payer: {
-                name: {
-                    given_name: 'John',
-                    surname: 'Doe',
-                },
-                email_address: 'john@doe.com',
-                address: {
-                    address_line_1: '1 Main St',
-                    admin_area_2: 'San Jose',
-                    admin_area_1: 'CA',
-                    postal_code: '95131',
-                    country_code: 'US',
-                },
-            },
-        };
+    describe('#renderButton', () => {
+        it('initializes PayPal button to render (default flow)', async () => {
+            await strategy.initialize(initializationOptions);
 
-        beforeEach(() => {
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYLATER,
+                style: paypalCommerceCreditOptions.style,
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('initializes PayPal Credit button to render if PayPal PayLater is not eligible', async () => {
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
                 (options: PayPalCommerceButtonsOptions) => {
-                    eventEmitter.on('onApprove', () => {
-                        if (options.onApprove) {
-                            options.onApprove(
-                                { orderID: paypalOrderId },
-                                {
-                                    order: {
-                                        get: jest.fn(() => paypalOrderDetails),
-                                    },
-                                },
-                            );
-                        }
-                    });
-
                     return {
                         render: jest.fn(),
-                        isEligible: jest.fn(() => true),
+                        isEligible: jest.fn(() => {
+                            return options.fundingSource === paypalSdk.FUNDING.CREDIT;
+                        }),
                     };
                 },
             );
 
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.CREDIT,
+                style: paypalCommerceCreditOptions.style,
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('initializes PayPal button to render (buy now flow)', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYLATER,
+                style: paypalCommerceCreditOptions.style,
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+                onClick: expect.any(Function),
+            });
+        });
+
+        it('initializes PayPal button to render (with shipping options feature enabled)', async () => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
                 initializationData: {
@@ -740,122 +438,247 @@ describe('PayPalCommerceButtonStrategy', () => {
                 paymentIntegrationService.getState(),
                 'getPaymentMethodOrThrow',
             ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.PAYLATER,
+                style: paypalCommerceCreditOptions.style,
+                createOrder: expect.any(Function),
+                onShippingAddressChange: expect.any(Function),
+                onShippingOptionsChange: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
         });
 
-        it('takes order details data from paypal', async () => {
-            const getOrderActionMock = jest.fn(() => paypalOrderDetails);
+        it('renders PayPal button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
 
-            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
-                (options: PayPalCommerceButtonsOptions) => {
-                    eventEmitter.on('onApprove', () => {
-                        if (options.onApprove) {
-                            options.onApprove(
-                                { orderID: paypalOrderId },
-                                {
-                                    order: {
-                                        get: getOrderActionMock,
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => true),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+        });
+
+        it('does not render PayPal button if it is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
+        it('removes PayPal button container if the button is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceIntegrationService.removeElement).toHaveBeenCalledWith(
+                defaultButtonContainerId,
+            );
+        });
+    });
+
+    describe('#createOrder', () => {
+        it('creates paypal order', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.createOrder).toHaveBeenCalledWith(
+                'paypalcommercecredit',
+            );
+        });
+    });
+
+    describe('#handleClick', () => {
+        beforeEach(() => {
+            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(buyNowCart);
+            jest.spyOn(paymentIntegrationService, 'loadCheckout').mockReturnValue(true);
+        });
+
+        it('creates buy now cart on button click', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.createBuyNowCartOrThrow).toHaveBeenCalled();
+        });
+
+        it('loads checkout related to buy now cart on button click', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledWith(buyNowCart.id);
+        });
+    });
+
+    describe('#onApprove button callback', () => {
+        describe('default flow', () => {
+            it('tokenizes payment on paypal approve', async () => {
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paypalCommerceIntegrationService.tokenizePayment).toHaveBeenCalledWith(
+                    defaultMethodId,
+                    paypalOrderId,
+                );
+            });
+        });
+
+        describe('shipping options feature flow', () => {
+            const paypalOrderDetails = getPayPalCommerceOrderDetails();
+
+            beforeEach(() => {
+                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                    (options: PayPalCommerceButtonsOptions) => {
+                        eventEmitter.on('onApprove', () => {
+                            if (options.onApprove) {
+                                options.onApprove(
+                                    { orderID: paypalOrderId },
+                                    {
+                                        order: {
+                                            get: jest.fn(() => paypalOrderDetails),
+                                        },
                                     },
-                                },
-                            );
-                        }
-                    });
+                                );
+                            }
+                        });
 
-                    return {
-                        render: jest.fn(),
-                        isEligible: jest.fn(() => true),
-                    };
-                },
-            );
-
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onApprove');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(getOrderActionMock).toHaveBeenCalled();
-            expect(getOrderActionMock).toHaveReturnedWith(paypalOrderDetails);
-        });
-
-        it('updates only billing address with valid customers data from order details if there is no shipping needed', async () => {
-            const defaultCart = getCart();
-            const cartWithoutShipping = {
-                ...defaultCart,
-                lineItems: {
-                    ...defaultCart.lineItems,
-                    physicalItems: [],
-                },
-            };
-
-            jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue(
-                cartWithoutShipping,
-            );
-
-            const address = {
-                firstName: paypalOrderDetails.payer.name.given_name,
-                lastName: paypalOrderDetails.payer.name.surname,
-                email: paypalOrderDetails.payer.email_address,
-                phone: '',
-                company: '',
-                address1: paypalOrderDetails.payer.address.address_line_1,
-                address2: '',
-                city: paypalOrderDetails.payer.address.admin_area_2,
-                countryCode: paypalOrderDetails.payer.address.country_code,
-                postalCode: paypalOrderDetails.payer.address.postal_code,
-                stateOrProvince: '',
-                stateOrProvinceCode: paypalOrderDetails.payer.address.admin_area_1,
-                customFields: [],
-            };
-
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onApprove');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(address);
-        });
-
-        it('submits BC order with provided methodId', async () => {
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onApprove');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
-                {},
-                {
-                    params: {
-                        methodId: initializationOptions.methodId,
+                        return {
+                            render: jest.fn(),
+                            isEligible: jest.fn(() => true),
+                        };
                     },
-                },
-            );
-        });
+                );
 
-        it('submits BC payment to update BC order data', async () => {
-            const methodId = initializationOptions.methodId;
-            const paymentData = {
-                formattedPayload: {
-                    vault_payment_instrument: null,
-                    set_as_default_stored_instrument: null,
-                    device_info: null,
-                    method_id: methodId,
-                    paypal_account: {
-                        order_id: paypalOrderId,
+                const paymentMethodWithShippingOptionsFeature = {
+                    ...paymentMethod,
+                    initializationData: {
+                        ...paymentMethod.initializationData,
+                        isHostedCheckoutEnabled: true,
                     },
-                },
-            };
+                };
 
-            await strategy.initialize(initializationOptions);
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
+            });
 
-            eventEmitter.emit('onApprove');
+            it('takes order details data from paypal', async () => {
+                const getOrderActionMock = jest.fn(() => paypalOrderDetails);
 
-            await new Promise((resolve) => process.nextTick(resolve));
+                jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+                    (options: PayPalCommerceButtonsOptions) => {
+                        eventEmitter.on('onApprove', () => {
+                            if (options.onApprove) {
+                                options.onApprove(
+                                    { orderID: paypalOrderId },
+                                    {
+                                        order: {
+                                            get: getOrderActionMock,
+                                        },
+                                    },
+                                );
+                            }
+                        });
 
-            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
-                methodId,
-                paymentData,
+                        return {
+                            render: jest.fn(),
+                            isEligible: jest.fn(() => true),
+                        };
+                    },
+                );
+
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(getOrderActionMock).toHaveBeenCalled();
+                expect(getOrderActionMock).toHaveReturnedWith(paypalOrderDetails);
+            });
+
+            it('updates billing address with valid customers data', async () => {
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(
+                    paypalCommerceIntegrationService.getBillingAddressFromOrderDetails,
+                ).toHaveBeenCalledWith(getPayPalCommerceOrderDetails());
+                expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(
+                    getBillingAddressFromOrderDetails(),
+                );
+            });
+
+            it('updates shipping address with valid customers data if physical items are available in the cart', async () => {
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(
+                    paypalCommerceIntegrationService.getShippingAddressFromOrderDetails,
+                ).toHaveBeenCalledWith(getPayPalCommerceOrderDetails());
+                expect(paymentIntegrationService.updateShippingAddress).toHaveBeenCalledWith(
+                    getShippingAddressFromOrderDetails(),
+                );
+            });
+
+            it('submits BC order with provided methodId', async () => {
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paymentIntegrationService.submitOrder).toHaveBeenCalledWith(
+                    {},
+                    {
+                        params: {
+                            methodId: initializationOptions.methodId,
+                        },
+                    },
+                );
+            });
+
+            it('submits BC payment to update BC order data', async () => {
+                await strategy.initialize(initializationOptions);
+
+                eventEmitter.emit('onApprove');
+
+                await new Promise((resolve) => process.nextTick(resolve));
+
+                expect(paypalCommerceIntegrationService.submitPayment).toHaveBeenCalledWith(
+                    defaultMethodId,
+                    paypalOrderId,
+                );
             });
         });
     });
@@ -877,7 +700,7 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
 
         it('updates billing and shipping address with data returned from PayPal', async () => {
-            const providedAddress = {
+            const address = {
                 firstName: '',
                 lastName: '',
                 email: '',
@@ -893,90 +716,32 @@ describe('PayPalCommerceButtonStrategy', () => {
                 customFields: [],
             };
 
+            jest.spyOn(paypalCommerceIntegrationService, 'getAddress').mockReturnValue(address);
+
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('onShippingAddressChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(
-                providedAddress,
-            );
-            expect(paymentIntegrationService.updateShippingAddress).toHaveBeenCalledWith(
-                providedAddress,
-            );
+            expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith(address);
+            expect(paymentIntegrationService.updateShippingAddress).toHaveBeenCalledWith(address);
         });
 
-        it('selects recommended shipping option if it was not selected earlier', async () => {
-            const recommendedShippingOption = {
-                ...getShippingOption(),
-                isRecommended: true,
-            };
-
-            const consignment = {
-                ...getConsignment(),
-                availableShippingOptions: [recommendedShippingOption],
-                selectedShippingOption: null,
-            };
-
-            const updatedConsignment = {
-                ...consignment,
-                selectedShippingOption: recommendedShippingOption,
-            };
-
-            jest.spyOn(paymentIntegrationService.getState(), 'getConsignmentsOrThrow')
-                .mockReturnValueOnce([consignment])
-                .mockReturnValue([updatedConsignment]);
-
+        it('selects shipping option after address update', async () => {
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('onShippingAddressChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
+            expect(paypalCommerceIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
             expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
-                recommendedShippingOption.id,
+                getShippingOption().id,
             );
         });
 
-        it('selects first available shipping option if there is no recommended option', async () => {
-            const firstShippingOption = {
-                ...getShippingOption(),
-                id: 1,
-            };
-
-            const secondShippingOption = {
-                ...getShippingOption(),
-                id: 2,
-            };
-
-            const consignment = {
-                ...getConsignment(),
-                availableShippingOptions: [firstShippingOption, secondShippingOption],
-                selectedShippingOption: null,
-            };
-
-            const updatedConsignment = {
-                ...consignment,
-                selectedShippingOption: firstShippingOption,
-            };
-
-            jest.spyOn(paymentIntegrationService.getState(), 'getConsignmentsOrThrow')
-                .mockReturnValueOnce([consignment])
-                .mockReturnValue([updatedConsignment]);
-
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onShippingAddressChange');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
-                firstShippingOption.id,
-            );
-        });
-
-        it('updates PayPal order', async () => {
+        it('updates PayPal order after shipping option selection', async () => {
             const consignment = getConsignment();
 
             // INFO: lets imagine that it is a state that we get after consignmentActionCreator.selectShippingOption call
@@ -991,11 +756,7 @@ describe('PayPalCommerceButtonStrategy', () => {
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalledWith({
-                availableShippingOptions: consignment.availableShippingOptions,
-                cartId: cart.id,
-                selectedShippingOption: consignment.selectedShippingOption,
-            });
+            expect(paypalCommerceIntegrationService.updateOrder).toHaveBeenCalled();
         });
     });
 
@@ -1016,112 +777,56 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
 
         it('selects shipping option', async () => {
-            const recommendedShippingOption = getShippingOption();
-            const shippingOptionThatShouldBeSelected = {
-                ...getShippingOption(),
-                id: paypalSelectedShippingOptionPayloadMock.id,
-                isRecommended: false,
-            };
-
-            const consignment = {
-                ...getConsignment(),
-                availableShippingOptions: [
-                    recommendedShippingOption,
-                    shippingOptionThatShouldBeSelected,
-                ],
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getConsignmentsOrThrow',
-            ).mockReturnValue([consignment]);
-
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('onShippingOptionsChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
+            expect(paypalCommerceIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
             expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
-                shippingOptionThatShouldBeSelected.id,
-            );
-        });
-
-        it('selects recommended shipping option if there is no match with payload from paypal', async () => {
-            const recommendedShippingOption = getShippingOption();
-            const anotherShippingOption = {
-                ...getShippingOption(),
-                id: 'asdag123',
-                isRecommended: false,
-            };
-
-            const consignment = {
-                ...getConsignment(),
-                availableShippingOptions: [recommendedShippingOption, anotherShippingOption],
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getConsignmentsOrThrow',
-            ).mockReturnValue([consignment]);
-
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onShippingOptionsChange');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paymentIntegrationService.selectShippingOption).not.toHaveBeenCalledWith(
-                paypalSelectedShippingOptionPayloadMock.id,
-            );
-            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
-                recommendedShippingOption.id,
+                getShippingOption().id,
             );
         });
 
         it('updates PayPal order', async () => {
-            const consignment = getConsignment();
-
-            // INFO: lets imagine that it is a state that we get after consignmentActionCreator.selectShippingOption call
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getConsignmentsOrThrow',
-            ).mockReturnValue([consignment]);
-
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('onShippingOptionsChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
-            expect(paypalCommerceRequestSender.updateOrder).toHaveBeenCalledWith({
-                availableShippingOptions: consignment.availableShippingOptions,
-                cartId: cart.id,
-                selectedShippingOption: consignment.selectedShippingOption,
-            });
+            expect(paypalCommerceIntegrationService.updateOrder).toHaveBeenCalled();
         });
     });
 
-    describe('#handleClick', () => {
+    describe('PayPal Commerce Credit messages logic', () => {
+        const paypalCommerceSdkRenderMock = jest.fn();
+
         beforeEach(() => {
-            jest.spyOn(paymentIntegrationService, 'createBuyNowCart').mockReturnValue(buyNowCart);
-            jest.spyOn(paymentIntegrationService, 'loadCheckout').mockReturnValue(true);
+            jest.spyOn(paypalSdk, 'Messages').mockImplementation(() => ({
+                render: paypalCommerceSdkRenderMock,
+            }));
         });
 
-        it('creates buy now cart on button click', async () => {
-            await strategy.initialize(buyNowInitializationOptions);
-            eventEmitter.emit('onClick');
-            await new Promise((resolve) => process.nextTick(resolve));
+        it('initializes PayPal Messages component', async () => {
+            await strategy.initialize(initializationOptions);
 
-            expect(paymentIntegrationService.createBuyNowCart).toHaveBeenCalled();
+            expect(paypalSdk.Messages).toHaveBeenCalledWith({
+                amount: cart.cartAmount,
+                placement: 'cart',
+                style: {
+                    layout: 'text',
+                },
+            });
         });
 
-        it('loads checkout related to buy now cart on button click', async () => {
-            await strategy.initialize(buyNowInitializationOptions);
-            eventEmitter.emit('onClick');
-            await new Promise((resolve) => process.nextTick(resolve));
+        it('renders PayPal message', async () => {
+            await strategy.initialize(initializationOptions);
 
-            expect(paymentIntegrationService.loadCheckout).toHaveBeenCalledWith(buyNowCart.id);
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalledWith(
+                `#${defaultMessageContainerId}`,
+            );
         });
     });
 });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -46,13 +46,13 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
 
         if (!paypalcommercecredit) {
             throw new InvalidArgumentError(
-                `Unable to initialize payment because "paypalcommercecredit.containerId" argument is not provided.`,
+                `Unable to initialize payment because "paypalcommercecredit" argument is not provided.`,
             );
         }
 
         if (!paypalcommercecredit.container) {
             throw new InvalidArgumentError(
-                `Unable to initialize payment because "paypalcommercecredit.containerId" argument is not provided.`,
+                `Unable to initialize payment because "paypalcommercecredit.container" argument is not provided.`,
             );
         }
 


### PR DESCRIPTION
## What?
Updated PayPalCommerceCreditButtonStrategy with PayPalCommerceIntegrationService

## Why?
To reduce amount of code duplication. PayPalCommerceIntegrationService contains a lot of methods that can be used in different PayPalCommerce strategies.

## Testing / Proof
Unit tests
