### PR TITLE
feat(payment): BOLT-465 move AnalyticsExtraItemsManager to payment-integration-api package

### DIFF
--- a/packages/analytics/.eslintrc.json
+++ b/packages/analytics/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {
+                "@typescript-eslint/no-unsafe-return": "off"
+            }
+        },
+        {
+            "files": ["*.spec.ts", "*.spec.tsx"],
+            "rules": {
+                "@typescript-eslint/consistent-type-assertions": "off"
+            }
+        }
+    ]
+}

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,0 +1,11 @@
+# analytics
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test analytics` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint analytics` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/analytics/jest.config.js
+++ b/packages/analytics/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    displayName: 'analytics',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
+        },
+    },
+    setupFilesAfterEnv: ['../../jest-setup.js'],
+    coverageDirectory: '../../coverage/packages/analytics',
+};

--- a/packages/analytics/project.json
+++ b/packages/analytics/project.json
@@ -1,0 +1,23 @@
+{
+    "root": "packages/analytics",
+    "sourceRoot": "packages/analytics/src",
+    "projectType": "library",
+    "targets": {
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/analytics/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/analytics"],
+            "options": {
+                "jestConfig": "packages/analytics/jest.config.js",
+                "passWithNoTests": true
+            }
+        }
+    },
+    "tags": ["scope:shared"]
+}

--- a/packages/analytics/src/analytics-extra-items-manager.spec.ts
+++ b/packages/analytics/src/analytics-extra-items-manager.spec.ts
@@ -1,0 +1,153 @@
+import localStorageFallback from 'local-storage-fallback';
+
+import { DigitalItem, PhysicalItem } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import AnalyticsExtraItemsManager from './analytics-extra-items-manager';
+import { ExtraItemsData } from './extra-items-data';
+
+describe('AnalyticsExtraItemsManager', () => {
+    it('save extra items data', () => {
+        const resultExtraItemsData: ExtraItemsData = {
+            1: {
+                brand: 'brand1',
+                category: 'category1, category2',
+            },
+            2: {
+                brand: '',
+                category: '',
+            },
+        };
+        const setItemMock = jest.fn((id: string, result: { [key: string]: unknown }) => ({
+            id,
+            result,
+        }));
+        const localStorageFallbackMock = {
+            ...localStorageFallback,
+            setItem: setItemMock,
+        };
+
+        const analyticsExtraItemsManager = new AnalyticsExtraItemsManager(localStorageFallbackMock);
+
+        const resultData = analyticsExtraItemsManager.saveExtraItemsData('dataId', {
+            physicalItems: [
+                {
+                    productId: 1,
+                    brand: 'brand1',
+                    categoryNames: ['category1', 'category2'],
+                },
+            ] as PhysicalItem[],
+            digitalItems: [
+                {
+                    productId: 2,
+                },
+            ] as DigitalItem[],
+            giftCertificates: [],
+        });
+
+        expect(resultData).toEqual(resultExtraItemsData);
+        expect(setItemMock).toHaveBeenCalledWith(
+            'ORDER_ITEMS_dataId',
+            JSON.stringify(resultExtraItemsData),
+        );
+    });
+
+    it('catch error after try save extra items data', () => {
+        const localStorageFallbackMock = {
+            ...localStorageFallback,
+            setItem: jest.fn(() => {
+                throw new Error();
+            }),
+        };
+
+        const analyticsExtraItemsManager = new AnalyticsExtraItemsManager(localStorageFallbackMock);
+
+        const resultData = analyticsExtraItemsManager.saveExtraItemsData('dataId', {
+            physicalItems: [
+                {
+                    productId: 1,
+                    brand: 'brand1',
+                    categoryNames: ['category1', 'category2'],
+                },
+            ] as PhysicalItem[],
+            digitalItems: [
+                {
+                    productId: 2,
+                },
+            ] as DigitalItem[],
+            giftCertificates: [],
+        });
+
+        expect(resultData).toEqual({});
+    });
+
+    it('read extra items data', () => {
+        const getItemMock = jest.fn((id: string) => `{"result": "${id}"}`);
+        const localStorageFallbackMock = {
+            ...localStorageFallback,
+            getItem: getItemMock,
+        };
+
+        const analyticsExtraItemsManager = new AnalyticsExtraItemsManager(localStorageFallbackMock);
+
+        const readResult = analyticsExtraItemsManager.readExtraItemsData('dataId');
+
+        expect(getItemMock).toHaveBeenCalledWith('ORDER_ITEMS_dataId');
+        expect(readResult).toEqual({ result: 'ORDER_ITEMS_dataId' });
+    });
+
+    it('read empty extra items data', () => {
+        const localStorageFallbackMock = {
+            ...localStorageFallback,
+            getItem: jest.fn(() => undefined),
+        };
+
+        const analyticsExtraItemsManager = new AnalyticsExtraItemsManager(localStorageFallbackMock);
+
+        const readResult = analyticsExtraItemsManager.readExtraItemsData('dataId');
+
+        expect(readResult).toBeNull();
+    });
+
+    it('catch error while read extra items data', () => {
+        const localStorageFallbackMock = {
+            ...localStorageFallback,
+            getItem: jest.fn(() => {
+                throw new Error();
+            }),
+        };
+
+        const analyticsExtraItemsManager = new AnalyticsExtraItemsManager(localStorageFallbackMock);
+
+        const readResult = analyticsExtraItemsManager.readExtraItemsData('dataId');
+
+        expect(readResult).toBeNull();
+    });
+
+    it('clear extra items data', () => {
+        const removeItemMock = jest.fn((id: string) => id);
+        const localStorageFallbackMock = {
+            ...localStorageFallback,
+            removeItem: removeItemMock,
+        };
+
+        const analyticsExtraItemsManager = new AnalyticsExtraItemsManager(localStorageFallbackMock);
+
+        analyticsExtraItemsManager.clearExtraItemData('dataId');
+
+        expect(removeItemMock).toHaveBeenCalledWith('ORDER_ITEMS_dataId');
+    });
+
+    it('clear extra items data by empty id', () => {
+        const removeItemMock = jest.fn((id: string) => id);
+        const localStorageFallbackMock = {
+            ...localStorageFallback,
+            removeItem: removeItemMock,
+        };
+
+        const analyticsExtraItemsManager = new AnalyticsExtraItemsManager(localStorageFallbackMock);
+
+        analyticsExtraItemsManager.clearExtraItemData('');
+
+        expect(removeItemMock).toHaveBeenCalledWith('');
+    });
+});

--- a/packages/analytics/src/analytics-extra-items-manager.ts
+++ b/packages/analytics/src/analytics-extra-items-manager.ts
@@ -1,6 +1,8 @@
-import { LineItemMap } from '../cart';
+import { LineItemMap } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { ExtraItemsData } from './analytics-step-tracker';
+import { ExtraItemsData } from './extra-items-data';
+
+type StorageFallback = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
 
 const ORDER_ITEMS_STORAGE_KEY = 'ORDER_ITEMS';
 

--- a/packages/analytics/src/extra-items-data.ts
+++ b/packages/analytics/src/extra-items-data.ts
@@ -1,0 +1,6 @@
+export interface ExtraItemsData {
+    [productId: string]: {
+        brand: string;
+        category: string;
+    };
+}

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,0 +1,2 @@
+export { ExtraItemsData } from './extra-items-data';
+export { default as AnalyticsExtraItemsManager } from './analytics-extra-items-manager';

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "references": [
+        {
+          "path": "./tsconfig.spec.json"
+        }
+      ]
+}

--- a/packages/analytics/tsconfig.spec.json
+++ b/packages/analytics/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.spec.tsx"
+    ]
+}

--- a/packages/core/src/analytics/analytics-step-tracker.spec.ts
+++ b/packages/core/src/analytics/analytics-step-tracker.spec.ts
@@ -1,3 +1,5 @@
+import { AnalyticsExtraItemsManager } from '@bigcommerce/checkout-sdk/analytics';
+
 import { getGiftCertificateItem } from '../cart/line-items.mock';
 import { CheckoutService, createCheckoutService } from '../checkout';
 import { getCheckoutWithCoupons } from '../checkout/checkouts.mock';
@@ -10,7 +12,6 @@ import { getOrder } from '../order/orders.mock';
 import { getPaymentMethod } from '../payment/payment-methods.mock';
 import { getShippingOption } from '../shipping/shipping-options.mock';
 
-import AnalyticsExtraItemsManager from './analytics-extra-items-manager';
 import AnalyticsStepTracker, { AnalyticStepId, AnalyticStepType } from './analytics-step-tracker';
 import {
     isGoogleAnalyticsAvailable,

--- a/packages/core/src/analytics/analytics-step-tracker.ts
+++ b/packages/core/src/analytics/analytics-step-tracker.ts
@@ -1,5 +1,7 @@
 import { keys } from 'lodash';
 
+import { AnalyticsExtraItemsManager, ExtraItemsData } from '@bigcommerce/checkout-sdk/analytics';
+
 import { LineItemMap } from '../cart';
 import { Checkout, CheckoutService } from '../checkout';
 import { InvalidArgumentError } from '../common/error/errors';
@@ -8,7 +10,6 @@ import { Coupon } from '../coupon';
 import { Order } from '../order';
 import { ShippingOption } from '../shipping';
 
-import AnalyticsExtraItemsManager from './analytics-extra-items-manager';
 import {
     isGoogleAnalyticsAvailable,
     isPayloadSizeLimitReached,
@@ -443,11 +444,4 @@ export interface AnalyticsProduct {
     category?: string;
     variant?: string;
     brand?: string;
-}
-
-export interface ExtraItemsData {
-    [productId: string]: {
-        brand: string;
-        category: string;
-    };
 }

--- a/packages/core/src/analytics/analytics-tracker-ga.spec.ts
+++ b/packages/core/src/analytics/analytics-tracker-ga.spec.ts
@@ -1,9 +1,11 @@
+import { ExtraItemsData } from '@bigcommerce/checkout-sdk/analytics';
+
 import { LineItemMap } from '../cart';
 import { getGiftCertificateItem } from '../cart/line-items.mock';
 import { getPhysicalItem } from '../order/line-items.mock';
 import { getOrder } from '../order/orders.mock';
 
-import { AnalyticsProduct, ExtraItemsData } from './analytics-step-tracker';
+import { AnalyticsProduct } from './analytics-step-tracker';
 import { isPayloadSizeLimitReached } from './analytics-tracker-ga';
 
 describe('analytics step tracker helpers', () => {

--- a/packages/core/src/analytics/create-step-tracker.ts
+++ b/packages/core/src/analytics/create-step-tracker.ts
@@ -1,9 +1,10 @@
 import localStorageFallback from 'local-storage-fallback';
 
+import { AnalyticsExtraItemsManager } from '@bigcommerce/checkout-sdk/analytics';
+
 import { CheckoutService } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 
-import AnalyticsExtraItemsManager from './analytics-extra-items-manager';
 import AnalyticsStepTracker, { StepTrackerConfig } from './analytics-step-tracker';
 import { isAnalyticsTrackerWindow } from './is-analytics-step-tracker-window';
 import NoopStepTracker from './noop-step-tracker';

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -7,9 +7,9 @@ import {
 } from '@bigcommerce/script-loader';
 import localStorageFallback from 'local-storage-fallback';
 
+import { AnalyticsExtraItemsManager } from '@bigcommerce/checkout-sdk/analytics';
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
-import AnalyticsExtraItemsManager from '../analytics/analytics-extra-items-manager';
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import {
     CheckoutActionCreator,

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.spec.ts
@@ -5,12 +5,12 @@ import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 import localStorageFallback from 'local-storage-fallback';
 import { Observable, of } from 'rxjs';
 
+import { AnalyticsExtraItemsManager } from '@bigcommerce/checkout-sdk/analytics';
 import {
     PaymentMethodFailedError,
     PaymentMethodInvalidError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import AnalyticsExtraItemsManager from '../../../analytics/analytics-extra-items-manager';
 import {
     Checkout,
     CheckoutRequestSender,

--- a/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/bolt/bolt-payment-strategy.ts
@@ -1,9 +1,9 @@
+import { AnalyticsExtraItemsManager } from '@bigcommerce/checkout-sdk/analytics';
 import {
     PaymentMethodFailedError,
     PaymentMethodInvalidError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import AnalyticsExtraItemsManager from '../../../analytics/analytics-extra-items-manager';
 import { isAnalyticsTrackerWindow } from '../../../analytics/is-analytics-step-tracker-window';
 import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import {

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -12,6 +12,7 @@ export {
     CartSource,
     DigitalItem,
     GiftCertificateItem,
+    LineItemMap,
     PhysicalItem,
 } from './cart';
 export { Checkout } from './checkout';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,6 +20,7 @@
             "@bigcommerce/checkout-sdk/adyen-integration": [
                 "packages/adyen-integration/src/index.ts"
             ],
+            "@bigcommerce/checkout-sdk/analytics": ["packages/analytics/src/index.ts"],
             "@bigcommerce/checkout-sdk/apple-pay-integration": [
                 "packages/apple-pay-integration/src/index.ts"
             ],

--- a/workspace.json
+++ b/workspace.json
@@ -2,6 +2,7 @@
     "version": 2,
     "projects": {
         "adyen-integration": "packages/adyen-integration",
+        "analytics": "packages/analytics",
         "apple-pay-integration": "packages/apple-pay-integration",
         "core": "packages/core",
         "credit-card-integration": "packages/credit-card-integration",


### PR DESCRIPTION
## What?
Move `AnalyticsExtraItemsManager` interface to paymant-integration-api package

## Why?
to get ability to use `AnalyticsExtraItemsManager` interfaces in other payment integration packages

## Testing / Proof
Unit tests:
<img width="357" alt="Screenshot 2023-02-17 at 18 48 13" src="https://user-images.githubusercontent.com/9430298/219715393-e258a424-5aa5-4b0f-bbd5-2569ea55505e.png">


@bigcommerce/checkout @bigcommerce/payments
