### PR TITLE
refactor(payment): PAYPAL-1983 removed layout and tagline styles property from PayPalCommerceButtons config

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -1,4 +1,5 @@
 import { noop } from 'lodash';
+
 import {
     CustomerCredentials,
     CustomerInitializeOptions,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
@@ -33,7 +33,6 @@ import {
     PayPalSDK,
     StyleButtonColor,
     StyleButtonLabel,
-    StyleButtonLayout,
     StyleButtonShape,
 } from './paypal-commerce-types';
 
@@ -468,20 +467,6 @@ describe('PayPalCommerceIntegrationService', () => {
             expect(subject.getValidButtonStyle(stylesMock)).toEqual(expects);
         });
 
-        it('returns button style without layout if layout is not valid', () => {
-            const stylesMock = {
-                height: 55,
-                layout: 'layout' as StyleButtonLayout,
-            };
-
-            const expects = {
-                ...stylesMock,
-                layout: undefined,
-            };
-
-            expect(subject.getValidButtonStyle(stylesMock)).toEqual(expects);
-        });
-
         it('returns styles with updated height if height value is bigger than expected', () => {
             const stylesMock = {
                 color: StyleButtonColor.silver,
@@ -522,39 +507,6 @@ describe('PayPalCommerceIntegrationService', () => {
             const expects = {
                 ...stylesMock,
                 height: 40,
-            };
-
-            expect(subject.getValidButtonStyle(stylesMock)).toEqual(expects);
-        });
-
-        it('returns styles without tagline for vertical layout', () => {
-            const stylesMock = {
-                color: StyleButtonColor.silver,
-                height: 55,
-                shape: StyleButtonShape.rect,
-                layout: StyleButtonLayout.vertical,
-                tagline: true,
-            };
-
-            const expects = {
-                ...stylesMock,
-                tagline: undefined,
-            };
-
-            expect(subject.getValidButtonStyle(stylesMock)).toEqual(expects);
-        });
-
-        it('returns styles with tagline if the layout is horizontal', () => {
-            const stylesMock = {
-                color: StyleButtonColor.silver,
-                height: 55,
-                shape: StyleButtonShape.rect,
-                layout: StyleButtonLayout.horizontal,
-                tagline: true,
-            };
-
-            const expects = {
-                ...stylesMock,
             };
 
             expect(subject.getValidButtonStyle(stylesMock)).toEqual(expects);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -23,7 +23,6 @@ import {
     PayPalSDK,
     StyleButtonColor,
     StyleButtonLabel,
-    StyleButtonLayout,
     StyleButtonShape,
 } from './paypal-commerce-types';
 
@@ -248,19 +247,13 @@ export default class PayPalCommerceIntegrationService {
      *
      */
     getValidButtonStyle(style?: PayPalButtonStyleOptions): PayPalButtonStyleOptions {
-        const { color, height, label, layout, shape, tagline } = style || {};
+        const { color, height, label, shape } = style || {};
 
-        // TODO: remove layout and tagline properties when paypal commerce common will be added to all paypal commerce strategies
         const validStyles = {
             color: color && StyleButtonColor[color] ? color : undefined,
             height: this.getValidHeight(height),
             label: label && StyleButtonLabel[label] ? label : undefined,
-            layout: layout && StyleButtonLayout[layout] ? layout : undefined,
             shape: shape && StyleButtonShape[shape] ? shape : undefined,
-            tagline:
-                tagline && typeof tagline === 'boolean' && layout === StyleButtonLayout.horizontal
-                    ? tagline
-                    : undefined,
         };
 
         return omitBy(validStyles, isNil);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -278,12 +278,6 @@ export enum StyleButtonLabel {
     installment = 'installment',
 }
 
-// TODO: should be removed in the future
-export enum StyleButtonLayout {
-    vertical = 'vertical',
-    horizontal = 'horizontal',
-}
-
 export enum StyleButtonColor {
     gold = 'gold',
     blue = 'blue',
@@ -298,12 +292,10 @@ export enum StyleButtonShape {
 }
 
 export interface PayPalButtonStyleOptions {
-    layout?: StyleButtonLayout;
     color?: StyleButtonColor;
     shape?: StyleButtonShape;
     height?: number;
     label?: StyleButtonLabel;
-    tagline?: boolean;
     custom?: {
         label?: string;
         css?: {

--- a/packages/paypal-commerce-integration/src/utils/get-valid-button-style.spec.ts
+++ b/packages/paypal-commerce-integration/src/utils/get-valid-button-style.spec.ts
@@ -1,9 +1,4 @@
-import {
-    StyleButtonColor,
-    StyleButtonLabel,
-    StyleButtonLayout,
-    StyleButtonShape,
-} from '../paypal-commerce-types';
+import { StyleButtonColor, StyleButtonLabel, StyleButtonShape } from '../paypal-commerce-types';
 
 import getValidButtonStyle from './get-valid-button-style';
 
@@ -65,20 +60,6 @@ describe('#getValidButtonStyle()', () => {
         expect(getValidButtonStyle(stylesMock)).toEqual(expects);
     });
 
-    it('returns button style without layout if layout is not valid', () => {
-        const stylesMock = {
-            height: 55,
-            layout: 'layout' as StyleButtonLayout,
-        };
-
-        const expects = {
-            ...stylesMock,
-            layout: undefined,
-        };
-
-        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
-    });
-
     it('returns styles with updated height if height value is bigger than expected', () => {
         const stylesMock = {
             color: StyleButtonColor.silver,
@@ -119,39 +100,6 @@ describe('#getValidButtonStyle()', () => {
         const expects = {
             ...stylesMock,
             height: 40,
-        };
-
-        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
-    });
-
-    it('returns styles without tagline for vertical layout', () => {
-        const stylesMock = {
-            color: StyleButtonColor.silver,
-            height: 55,
-            shape: StyleButtonShape.rect,
-            layout: StyleButtonLayout.vertical,
-            tagline: true,
-        };
-
-        const expects = {
-            ...stylesMock,
-            tagline: undefined,
-        };
-
-        expect(getValidButtonStyle(stylesMock)).toEqual(expects);
-    });
-
-    it('returns styles with tagline if the layout is horizontal', () => {
-        const stylesMock = {
-            color: StyleButtonColor.silver,
-            height: 55,
-            shape: StyleButtonShape.rect,
-            layout: StyleButtonLayout.horizontal,
-            tagline: true,
-        };
-
-        const expects = {
-            ...stylesMock,
         };
 
         expect(getValidButtonStyle(stylesMock)).toEqual(expects);

--- a/packages/paypal-commerce-integration/src/utils/get-valid-button-style.ts
+++ b/packages/paypal-commerce-integration/src/utils/get-valid-button-style.ts
@@ -4,7 +4,6 @@ import {
     PayPalButtonStyleOptions,
     StyleButtonColor,
     StyleButtonLabel,
-    StyleButtonLayout,
     StyleButtonShape,
 } from '../paypal-commerce-types';
 
@@ -12,15 +11,13 @@ import {
 export default function getValidButtonStyle(
     style: PayPalButtonStyleOptions,
 ): PayPalButtonStyleOptions {
-    const { label, color, layout, shape, height, tagline } = style;
+    const { label, color, shape, height } = style;
 
     const validStyles = {
         color: getValidColor(color),
         height: getValidHeight(height),
         label: getValidLabel(label),
-        layout: getValidLayout(layout),
         shape: getValidShape(shape),
-        tagline: getValidTagline(tagline, layout),
     };
 
     return omitBy(validStyles, isNil);
@@ -34,20 +31,8 @@ function getValidLabel(label?: StyleButtonLabel): StyleButtonLabel | undefined {
     return label && StyleButtonLabel[label] ? label : undefined;
 }
 
-function getValidLayout(layout?: StyleButtonLayout): StyleButtonLayout | undefined {
-    return layout && StyleButtonLayout[layout] ? layout : undefined;
-}
-
 function getValidShape(shape?: StyleButtonShape): StyleButtonShape | undefined {
     return shape && StyleButtonShape[shape] ? shape : undefined;
-}
-
-function getValidTagline(tagline?: boolean, layout?: string): boolean | undefined {
-    if (tagline && typeof tagline === 'boolean' && layout === StyleButtonLayout.horizontal) {
-        return tagline;
-    }
-
-    return undefined;
 }
 
 function getValidHeight(height?: number): number {


### PR DESCRIPTION
## What?
Removed layout and tagline styles property from PayPalCommerceButtons config

## Why?
The layout and tagline properties does not do anything for PayPalCommerce buttons after buttons were separated into their own strategies, so the removed styles properties are not in use anymore. 

## Testing / Proof
Unit tests
