### PR TITLE
refactor(payment): PAYPAL-1971 removed initializesOnCheckout page property from PayPalCommerce initialize button options

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-initialize-options.ts
@@ -17,13 +17,6 @@ export default interface PayPalCommerceAlternativeMethodsButtonOptions {
     currencyCode?: string;
 
     /**
-     * // TODO: this flag should be removed, because the strategy does not used on checkout page
-     * // and it always equals to 'false'
-     * Flag which helps to detect that the strategy initializes on Checkout page
-     */
-    initializesOnCheckoutPage?: boolean;
-
-    /**
      * A set of styling options for the checkout button.
      */
     style?: PayPalButtonStyleOptions;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -60,7 +60,6 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
                 getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
             },
             currencyCode: 'USD',
-            initializesOnCheckoutPage: false,
             style: {
                 height: 45,
             },
@@ -74,7 +73,6 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
 
     const paypalCommerceAlternativeMethodsOptions: PayPalCommerceAlternativeMethodsButtonOptions = {
         apm: apmProviderId,
-        initializesOnCheckoutPage: false,
         style: {
             height: 45,
         },

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-initialize-options.ts
@@ -2,11 +2,6 @@ import { PayPalButtonStyleOptions, PayPalBuyNowInitializeOptions } from '../payp
 
 export default interface PayPalCommerceCreditButtonInitializeOptions {
     /**
-     * Flag which helps to detect that the strategy initializes on Checkout page
-     */
-    initializesOnCheckoutPage?: boolean;
-
-    /**
      * The ID of a container which the messaging should be inserted.
      */
     messagingContainerId?: string;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-initialize-options.ts
@@ -7,11 +7,6 @@ export default interface PayPalCommerceVenmoButtonInitializeOptions {
     style?: PayPalButtonStyleOptions;
 
     /**
-     * Flag which helps to detect that the strategy initializes on Checkout page
-     */
-    initializesOnCheckoutPage?: boolean;
-
-    /**
      * The option that used to initialize a PayPal script with provided currency code.
      */
     currencyCode?: string;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
@@ -57,7 +57,6 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
             getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
         },
         currencyCode: 'USD',
-        initializesOnCheckoutPage: false,
         style: {
             height: 45,
         },
@@ -70,7 +69,6 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
     };
 
     const paypalCommerceVenmoOptions: PayPalCommerceVenmoButtonInitializeOptions = {
-        initializesOnCheckoutPage: false,
         style: {
             height: 45,
         },

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-initialize-options.ts
@@ -18,13 +18,6 @@ export default interface PayPalCommerceButtonInitializeOptions {
     currencyCode?: string;
 
     /**
-     * // TODO: this flag should be removed, because the strategy does not used on checkout page
-     * // and it always equals to 'false'
-     * Flag which helps to detect that the strategy initializes on Checkout page.
-     */
-    initializesOnCheckoutPage?: boolean;
-
-    /**
      * A set of styling options for the checkout button.
      */
     style?: PayPalButtonStyleOptions;

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -62,7 +62,6 @@ describe('PayPalCommerceButtonStrategy', () => {
             getBuyNowCartRequestBody: jest.fn().mockReturnValue(buyNowCartRequestBody),
         },
         currencyCode: 'USD',
-        initializesOnCheckoutPage: false,
         style: {
             height: 45,
         },
@@ -76,7 +75,6 @@ describe('PayPalCommerceButtonStrategy', () => {
     };
 
     const paypalCommerceOptions: PayPalCommerceButtonInitializeOptions = {
-        initializesOnCheckoutPage: false,
         style: {
             height: 45,
         },


### PR DESCRIPTION
## What?
Removed `initializesOnCheckout` page property from PayPalCommerce initialize button options

## Why?
`InitializeOnCheckoutPage` property was added to detect where PayPalCommerce button strategy is in use. However, due to our progress, checkout buttons are used outside checkout page, though, `initializeOnCheckoutPage` will always have false value for button strategies. So we can remove this method because it has static value.

## Testing / Proof
Unit tests
