### PR TITLE
fix(payment): PAYPAL-1997 make CyberSourceV2 Google Pay compatible with Buy Now cart

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.spec.ts
@@ -28,6 +28,23 @@ describe('GooglePayCybersourceV2Initializer', () => {
 
             expect(initialize).toEqual(getCybersourceV2PaymentDataRequest());
         });
+
+        it('initializes the google pay configuration for cybersourcev2 with Buy Now Flow', async () => {
+            const paymentDataRequest = {
+                ...getCybersourceV2PaymentDataRequest(),
+                transactionInfo: {
+                    ...getCybersourceV2PaymentDataRequest().transactionInfo,
+                    currencyCode: '',
+                    totalPrice: '',
+                },
+            };
+
+            await googlePayInitializer
+                .initialize(undefined, getCybersourceV2PaymentMethodMock(), false)
+                .then((response) => {
+                    expect(response).toEqual(paymentDataRequest);
+                });
+        });
     });
 
     describe('#teardown', () => {

--- a/packages/core/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.ts
@@ -13,7 +13,7 @@ import {
 
 export default class GooglePayCybersourceV2Initializer implements GooglePayInitializer {
     initialize(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
@@ -46,16 +46,14 @@ export default class GooglePayCybersourceV2Initializer implements GooglePayIniti
     }
 
     private _getGooglePayPaymentDataRequest(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): GooglePayPaymentDataRequestV2 {
-        const {
-            outstandingBalance,
-            cart: {
-                currency: { code: currencyCode },
-            },
-        } = checkout;
+        const currencyCode = checkout?.cart.currency.code || '';
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, 2).toFixed(2)
+            : '';
 
         const {
             initializationData: {
@@ -101,7 +99,7 @@ export default class GooglePayCybersourceV2Initializer implements GooglePayIniti
             transactionInfo: {
                 currencyCode,
                 totalPriceStatus: 'FINAL',
-                totalPrice: round(outstandingBalance, 2).toFixed(2),
+                totalPrice,
             },
             emailRequired: true,
             shippingAddressRequired: !hasShippingAddress,


### PR DESCRIPTION
## What?
Fixed GooglePayCybersourceV2Initializer to make it work with buyNowCart

## Why?
To Make CyberSourceV2 Google Pay compatible with Buy Now cart

## Testing / Proof
Unit tests
