### PR TITLE
fix(payment): PAYPAL-1991 fixed GooglePay for adyenV2 and adyenV3 (Buy Now flow)

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.spec.ts
@@ -5,6 +5,7 @@ import {
     getAdyenV2PaymentMethodMock,
     getAdyenV2TokenizedPayload,
     getCheckoutMock,
+    getPaymentMethodMock,
 } from './googlepay.mock';
 
 describe('GooglePayAdyenV2Initializer', () => {
@@ -27,6 +28,24 @@ describe('GooglePayAdyenV2Initializer', () => {
             );
 
             expect(initialize).toEqual(getAdyenV2PaymentDataRequest());
+        });
+
+        it('initializes the google pay configuration for adyenv2 with Buy Now Flow', async () => {
+            const paymentData = await googlePayInitializer.initialize(
+                undefined,
+                getPaymentMethodMock(),
+                false,
+            );
+
+            expect(paymentData).toEqual(
+                expect.objectContaining({
+                    transactionInfo: {
+                        currencyCode: '',
+                        totalPriceStatus: 'FINAL',
+                        totalPrice: '',
+                    },
+                }),
+            );
         });
     });
 

--- a/packages/core/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
@@ -13,7 +13,7 @@ import {
 
 export default class GooglePayAdyenV2Initializer implements GooglePayInitializer {
     initialize(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
@@ -46,16 +46,14 @@ export default class GooglePayAdyenV2Initializer implements GooglePayInitializer
     }
 
     private _getGooglePayPaymentDataRequest(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): GooglePayPaymentDataRequestV2 {
-        const {
-            outstandingBalance,
-            cart: {
-                currency: { code: currencyCode },
-            },
-        } = checkout;
+        const currencyCode = checkout?.cart.currency.code || '';
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, 2).toFixed(2)
+            : '';
 
         const {
             initializationData: {
@@ -103,7 +101,7 @@ export default class GooglePayAdyenV2Initializer implements GooglePayInitializer
                 countryCode,
                 currencyCode,
                 totalPriceStatus: 'FINAL',
-                totalPrice: round(outstandingBalance, 2).toFixed(2),
+                totalPrice,
             },
             emailRequired: true,
             shippingAddressRequired: !hasShippingAddress,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-adyenv3-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-adyenv3-initializer.spec.ts
@@ -5,6 +5,7 @@ import {
     getAdyenV2PaymentMethodMock,
     getAdyenV2TokenizedPayload,
     getCheckoutMock,
+    getPaymentMethodMock,
 } from './googlepay.mock';
 
 describe('GooglePayAdyenV3Initializer', () => {
@@ -27,6 +28,24 @@ describe('GooglePayAdyenV3Initializer', () => {
             );
 
             expect(initialize).toEqual(getAdyenV2PaymentDataRequest());
+        });
+
+        it('initializes the google pay configuration for adyenv3 with Buy Now Flow', async () => {
+            const paymentData = await googlePayInitializer.initialize(
+                undefined,
+                getPaymentMethodMock(),
+                false,
+            );
+
+            expect(paymentData).toEqual(
+                expect.objectContaining({
+                    transactionInfo: {
+                        currencyCode: '',
+                        totalPriceStatus: 'FINAL',
+                        totalPrice: '',
+                    },
+                }),
+            );
         });
     });
 

--- a/packages/core/src/payment/strategies/googlepay/googlepay-adyenv3-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-adyenv3-initializer.ts
@@ -13,7 +13,7 @@ import {
 
 export default class GooglePayAdyenV3Initializer implements GooglePayInitializer {
     initialize(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
@@ -46,16 +46,14 @@ export default class GooglePayAdyenV3Initializer implements GooglePayInitializer
     }
 
     private _getGooglePayPaymentDataRequest(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): GooglePayPaymentDataRequestV2 {
-        const {
-            outstandingBalance,
-            cart: {
-                currency: { code: currencyCode },
-            },
-        } = checkout;
+        const currencyCode = checkout?.cart.currency.code || '';
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, 2).toFixed(2)
+            : '';
 
         const {
             initializationData: {
@@ -103,7 +101,7 @@ export default class GooglePayAdyenV3Initializer implements GooglePayInitializer
                 countryCode,
                 currencyCode,
                 totalPriceStatus: 'FINAL',
-                totalPrice: round(outstandingBalance, 2).toFixed(2),
+                totalPrice,
             },
             emailRequired: true,
             shippingAddressRequired: !hasShippingAddress,


### PR DESCRIPTION
## What?

Fixed GP initialization issue for adyenV2 and adyenV3 when we go through Buy Now Flow

<img width="681" alt="Screenshot 2023-02-21 at 14 09 40" src="https://user-images.githubusercontent.com/99336044/220360675-b987cfcd-8505-471f-8752-0a82dd640d85.png">


## Why?

When we go through Buy Now Flow to place an order from PDP we don't have `outstandingBalance` and `currencyCode` we get from `checkout` object. We don't have cart and we work with one item that has its own quate which creates by click on button. Information about collecting these variables is available here [googlepay-button-strategy.ts#L209](https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts#L209)

## Testing / Proof
Unit tests
Manual tests