### PR TITLE
fix(payment): PAYPAL-1995 fixed GooglePay for Authorize Net (Buy Now flow)

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.spec.ts
@@ -5,6 +5,7 @@ import {
     getAuthorizeNetPaymentMethodMock,
     getAuthorizeNetTokenizedPayload,
     getCheckoutMock,
+    getPaymentMethodMock,
 } from './googlepay.mock';
 
 describe('GooglePayAuthorizeNetInitializer', () => {
@@ -27,6 +28,24 @@ describe('GooglePayAuthorizeNetInitializer', () => {
             );
 
             expect(initialize).toEqual(getAuthorizeNetPaymentDataRequest());
+        });
+
+        it('initializes the google pay configuration for authorizenet with Buy Now Flow', async () => {
+            const paymentData = await googlePayInitializer.initialize(
+                undefined,
+                getPaymentMethodMock(),
+                false,
+            );
+
+            expect(paymentData).toEqual(
+                expect.objectContaining({
+                    transactionInfo: {
+                        currencyCode: '',
+                        totalPriceStatus: 'FINAL',
+                        totalPrice: '',
+                    },
+                }),
+            );
         });
     });
 

--- a/packages/core/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.ts
@@ -19,7 +19,7 @@ const baseRequest = {
 
 export default class GooglePayAuthorizeNetInitializer implements GooglePayInitializer {
     initialize(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
@@ -52,16 +52,14 @@ export default class GooglePayAuthorizeNetInitializer implements GooglePayInitia
     }
 
     private _getGooglePaymentDataRequest(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): GooglePayPaymentDataRequestV2 {
-        const {
-            outstandingBalance,
-            cart: {
-                currency: { code: currencyCode },
-            },
-        } = checkout;
+        const currencyCode = checkout?.cart.currency.code || '';
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, 2).toFixed(2)
+            : '';
 
         const {
             initializationData: {
@@ -85,7 +83,7 @@ export default class GooglePayAuthorizeNetInitializer implements GooglePayInitia
             allowedPaymentMethods: [cardPaymentMethod],
             transactionInfo: {
                 totalPriceStatus: 'FINAL',
-                totalPrice: round(outstandingBalance, 2).toFixed(2),
+                totalPrice,
                 currencyCode,
                 countryCode,
             },


### PR DESCRIPTION
## What?

Fixed GP initialization issue for authorizenet when we go through Buy Now Flow

<img width="681" alt="Screenshot 2023-02-21 at 14 09 40" src="https://user-images.githubusercontent.com/99336044/220360966-42d3c481-ddd2-47c5-abd2-247ab05ddb2c.png">


## Why?

When we go through Buy Now Flow to place an order from PDP we don't have `outstandingBalance` and `currencyCode` we get from `checkout` object. We don't have cart and we work with one item that has its own quate which creates by click on button. Information about collecting these variables is available here [googlepay-button-strategy.ts#L209](https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts#L209)

## Testing / Proof
Unit tests
Manual tests