### PR TITLE
fix(payment): PAYPAL-1996 fixed GooglePay for CheckoutCom (Buy Now flow)

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.spec.ts
@@ -45,6 +45,24 @@ describe('GooglePayCheckoutcomInitializer', () => {
                 getGooglePayCheckoutcomPaymentDataRequestMock(),
             );
         });
+
+        it('initializes the google pay configuration for checkoutcom with Buy Now Flow', async () => {
+            const paymentData = await googlePayCheckoutcomInitializer.initialize(
+                undefined,
+                getPaymentMethodMock(),
+                false,
+            );
+
+            expect(paymentData).toEqual(
+                expect.objectContaining({
+                    transactionInfo: {
+                        currencyCode: '',
+                        totalPriceStatus: 'FINAL',
+                        totalPrice: '',
+                    },
+                }),
+            );
+        });
     });
 
     describe('#teardown', () => {

--- a/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
@@ -25,7 +25,7 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
     constructor(private _requestSender: RequestSender) {}
 
     async initialize(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
@@ -120,10 +120,15 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
     }
 
     private _mapGooglePayCheckoutcomDataRequestToGooglePayDataRequestV2(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         initializationData: any,
         hasShippingAddress: boolean,
     ): GooglePayPaymentDataRequestV2 {
+        const currencyCode = checkout?.cart.currency.code || '';
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, 2).toFixed(2)
+            : '';
+
         return {
             apiVersion: 2,
             apiVersionMinor: 0,
@@ -154,9 +159,9 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
                 },
             ],
             transactionInfo: {
-                currencyCode: checkout.cart.currency.code,
+                currencyCode,
                 totalPriceStatus: 'FINAL',
-                totalPrice: round(checkout.outstandingBalance, 2).toFixed(2),
+                totalPrice,
             },
             emailRequired: true,
             shippingAddressRequired: !hasShippingAddress,


### PR DESCRIPTION
## What?

Fixed GP initialization issue for checkoutcom when we go through Buy Now Flow

<img width="681" alt="Screenshot 2023-02-21 at 14 09 40" src="https://user-images.githubusercontent.com/99336044/220360757-3d3550f0-22bb-49f4-802d-5066b3491c17.png">

## Why?

When we go through Buy Now Flow to place an order from PDP we don't have `outstandingBalance` and `currencyCode` we get from `checkout` object. We don't have cart and we work with one item that has its own quate which creates by click on button. Information about collecting these variables is available here [googlepay-button-strategy.ts#L209](https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts#L209)

## Testing / Proof
Unit tests
Manual tests