### PR TITLE
fix(payment): PAYPAL-1998 make Orbital  Google Pay compatible with Buy Now cart

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-orbital-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-orbital-initializer.spec.ts
@@ -28,6 +28,23 @@ describe('GooglePayCybersourceV2Initializer', () => {
 
             expect(initialize).toEqual(getOrbitalPaymentDataRequest());
         });
+
+        it('initializes the google pay configuration for orbital with Buy Now Flow', async () => {
+            const paymentDataRequest = {
+                ...getOrbitalPaymentDataRequest(),
+                transactionInfo: {
+                    ...getOrbitalPaymentDataRequest().transactionInfo,
+                    currencyCode: '',
+                    totalPrice: '',
+                },
+            };
+
+            await googlePayInitializer
+                .initialize(undefined, getOrbitalPaymentMethodMock(), false)
+                .then((response) => {
+                    expect(response).toEqual(paymentDataRequest);
+                });
+        });
     });
 
     describe('#teardown', () => {

--- a/packages/core/src/payment/strategies/googlepay/googlepay-orbital-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-orbital-initializer.ts
@@ -13,7 +13,7 @@ import {
 
 export default class GooglePayOrbitalInitializer implements GooglePayInitializer {
     initialize(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
@@ -46,16 +46,14 @@ export default class GooglePayOrbitalInitializer implements GooglePayInitializer
     }
 
     private _getGooglePayPaymentDataRequest(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): GooglePayPaymentDataRequestV2 {
-        const {
-            outstandingBalance,
-            cart: {
-                currency: { code: currencyCode },
-            },
-        } = checkout;
+        const currencyCode = checkout?.cart.currency.code || '';
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, 2).toFixed(2)
+            : '';
 
         const {
             initializationData: {
@@ -101,7 +99,7 @@ export default class GooglePayOrbitalInitializer implements GooglePayInitializer
             transactionInfo: {
                 currencyCode,
                 totalPriceStatus: 'FINAL',
-                totalPrice: round(outstandingBalance, 2).toFixed(2),
+                totalPrice,
             },
             emailRequired: true,
             shippingAddressRequired: !hasShippingAddress,


### PR DESCRIPTION
Make Orbital  Google Pay compatible with Buy Now cart

## What?
Fixed GooglePayOrbitalInitializer to make it work with buyNowCart

## Why?
To Make Orbital Google Pay compatible with Buy Now cart

## Testing / Proof
Unit tests
