### PR TITLE
fix(payment): PAYPAL-1993 make StripeUPE  Google Pay compatible with Buy Now cart

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-upe-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-upe-initializer.spec.ts
@@ -28,6 +28,23 @@ describe('GooglePayStripeUPEInitializer', () => {
 
             expect(initialize).toEqual(getStripePaymentDataRequest());
         });
+
+        it('initializes the google pay configuration for stripe-upe with Buy Now Flow', async () => {
+            const paymentDataRequest = {
+                ...getStripePaymentDataRequest(),
+                transactionInfo: {
+                    ...getStripePaymentDataRequest().transactionInfo,
+                    currencyCode: '',
+                    totalPrice: '',
+                },
+            };
+
+            await googlePayInitializer
+                .initialize(undefined, getStripePaymentMethodMock(), false)
+                .then((response) => {
+                    expect(response).toEqual(paymentDataRequest);
+                });
+        });
     });
 
     describe('#teardown', () => {

--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-upe-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-upe-initializer.ts
@@ -16,7 +16,7 @@ import {
 
 export default class GooglePayStripeUPEInitializer implements GooglePayInitializer {
     initialize(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
@@ -59,16 +59,15 @@ export default class GooglePayStripeUPEInitializer implements GooglePayInitializ
     }
 
     private _getGooglePayPaymentDataRequest(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): GooglePayPaymentDataRequestV2 {
-        const {
-            outstandingBalance,
-            cart: {
-                currency: { code: currencyCode, decimalPlaces },
-            },
-        } = checkout;
+        const currencyCode = checkout?.cart.currency.code || '';
+        const decimalPlaces = checkout?.cart.currency.decimalPlaces || 2;
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, decimalPlaces).toFixed(decimalPlaces)
+            : '';
 
         const {
             initializationData: {
@@ -117,7 +116,7 @@ export default class GooglePayStripeUPEInitializer implements GooglePayInitializ
             transactionInfo: {
                 currencyCode,
                 totalPriceStatus: 'FINAL',
-                totalPrice: round(outstandingBalance, decimalPlaces).toFixed(decimalPlaces),
+                totalPrice,
             },
             emailRequired: true,
             shippingAddressRequired: !hasShippingAddress,


### PR DESCRIPTION
## What?
Make StripeUPE  Google Pay compatible with Buy Now cart
Fixed GooglePayStripeUPEInitializer to make it work with buyNowCart

## Why?
To Make StripeUPE Google Pay compatible with Buy Now cart


## Testing / Proof
Unit tests
