### PR TITLE
fix(payment): PAYPAL-1999 make Stripe Google Pay compatible with BuyNow cart

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.spec.ts
@@ -31,6 +31,23 @@ describe('GooglePayStripeInitializer', () => {
             expect(initialize).toEqual(getStripePaymentDataRequest());
         });
 
+        it('initializes the google pay configuration for stripe with Buy Now Flow', async () => {
+            const paymentDataRequest = {
+                ...getStripePaymentDataRequest(),
+                transactionInfo: {
+                    ...getStripePaymentDataRequest().transactionInfo,
+                    currencyCode: '',
+                    totalPrice: '',
+                },
+            };
+
+            await googlePayInitializer
+                .initialize(undefined, getStripePaymentMethodMock(), false)
+                .then((response) => {
+                    expect(response).toEqual(paymentDataRequest);
+                });
+        });
+
         it('should not require shipping address when BOPIS is enabled', async () => {
             const checkout = {
                 ...getCheckoutMock(),

--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
@@ -14,7 +14,7 @@ import {
 
 export default class GooglePayStripeInitializer implements GooglePayInitializer {
     initialize(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
@@ -45,17 +45,15 @@ export default class GooglePayStripeInitializer implements GooglePayInitializer 
     }
 
     private _getGooglePayPaymentDataRequest(
-        checkout: Checkout,
+        checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): GooglePayPaymentDataRequestV2 {
-        const {
-            outstandingBalance,
-            cart: {
-                currency: { code: currencyCode },
-            },
-            consignments,
-        } = checkout;
+        const currencyCode = checkout?.cart.currency.code || '';
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, 2).toFixed(2)
+            : '';
+        const consignments = checkout?.consignments || [];
 
         const {
             initializationData: {
@@ -107,7 +105,7 @@ export default class GooglePayStripeInitializer implements GooglePayInitializer 
             transactionInfo: {
                 currencyCode,
                 totalPriceStatus: 'FINAL',
-                totalPrice: round(outstandingBalance, 2).toFixed(2),
+                totalPrice,
             },
             emailRequired: true,
             shippingAddressRequired:


### PR DESCRIPTION
## What?
Make Stripe Google Pay compatible with BuyNow cart
Fixed GooglePayStripeInitializer to make it work with buyNowCart

## Why?
Fixed GooglePayStripeUPEInitializer to make it work with buyNowCart

## Testing / Proof
Unit tests
