### PR TITLE
feat(payment): PAYPAL-1985 added loadDefaultCheckout onCancel to avoid potential errors

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.spec.ts
@@ -186,6 +186,12 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
                     }
                 });
 
+                eventEmitter.on('onCancel', () => {
+                    if (options.onCancel) {
+                        options.onCancel();
+                    }
+                });
+
                 return {
                     isEligible: jest.fn(() => true),
                     render: jest.fn(),
@@ -353,6 +359,7 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
+                onCancel: expect.any(Function),
             });
         });
 
@@ -466,6 +473,18 @@ describe('PayPalCommerceAlternativeMethodsButtonStrategy', () => {
                 defaultMethodId,
                 paypalOrderId,
             );
+        });
+    });
+
+    describe('#onCancel button callback', () => {
+        it('loads default checkout onCancel callback (buy now flow)', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onCancel');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.loadDefaultCheckout).toHaveBeenCalled();
         });
     });
 });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-strategy.ts
@@ -125,6 +125,7 @@ export default class PayPalCommerceAlternativeMethodsButtonStrategy
 
         const buyNowFlowCallbacks = {
             onClick: () => this.handleClick(buyNowInitializeOptions),
+            onCancel: () => this.paymentIntegrationService.loadDefaultCheckout(),
         };
 
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -233,6 +233,12 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                     }
                 });
 
+                eventEmitter.on('onCancel', () => {
+                    if (options.onCancel) {
+                        options.onCancel();
+                    }
+                });
+
                 eventEmitter.on('onShippingAddressChange', () => {
                     if (options.onShippingAddressChange) {
                         options.onShippingAddressChange({
@@ -422,6 +428,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
+                onCancel: expect.any(Function),
             });
         });
 
@@ -827,6 +834,18 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
             expect(paypalCommerceSdkRenderMock).toHaveBeenCalledWith(
                 `#${defaultMessageContainerId}`,
             );
+        });
+    });
+
+    describe('#onCancel button callback', () => {
+        it('loads default checkout onCancel callback (buy now flow)', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onCancel');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.loadDefaultCheckout).toHaveBeenCalled();
         });
     });
 });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -116,6 +116,7 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
 
         const buyNowFlowCallbacks = {
             onClick: () => this.handleClick(buyNowInitializeOptions),
+            onCancel: () => this.paymentIntegrationService.loadDefaultCheckout(),
         };
 
         const hostedCheckoutCallbacks = {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -190,6 +190,7 @@ export interface PayPalCommerceButtonsOptions {
     onComplete?(data: CompleteCallbackDataPayload): Promise<void>;
     onClick?(data: ClickCallbackPayload, actions?: ClickCallbackActions): Promise<void>;
     onError?(error: Error): void;
+    onCancel?(): void;
     onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;
     onShippingOptionsChange?(data: ShippingOptionChangeCallbackPayload): Promise<void>;
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
@@ -182,6 +182,12 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
                     }
                 });
 
+                eventEmitter.on('onCancel', () => {
+                    if (options.onCancel) {
+                        options.onCancel();
+                    }
+                });
+
                 return {
                     isEligible: jest.fn(() => true),
                     render: jest.fn(),
@@ -331,6 +337,7 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
+                onCancel: expect.any(Function),
             });
         });
 
@@ -425,6 +432,18 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
                 defaultMethodId,
                 paypalOrderId,
             );
+        });
+    });
+
+    describe('#onCancel button callback', () => {
+        it('loads default checkout onCancel callback (buy now flow)', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onCancel');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.loadDefaultCheckout).toHaveBeenCalled();
         });
     });
 });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
@@ -105,6 +105,7 @@ export default class PayPalCommerceVenmoButtonStrategy implements CheckoutButton
 
         const buyNowFlowCallbacks = {
             onClick: () => this.handleClick(buyNowInitializeOptions),
+            onCancel: () => this.paymentIntegrationService.loadDefaultCheckout(),
         };
 
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -225,6 +225,12 @@ describe('PayPalCommerceButtonStrategy', () => {
                     }
                 });
 
+                eventEmitter.on('onCancel', () => {
+                    if (options.onCancel) {
+                        options.onCancel();
+                    }
+                });
+
                 eventEmitter.on('onShippingAddressChange', () => {
                     if (options.onShippingAddressChange) {
                         options.onShippingAddressChange({
@@ -392,6 +398,7 @@ describe('PayPalCommerceButtonStrategy', () => {
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
                 onClick: expect.any(Function),
+                onCancel: expect.any(Function),
             });
         });
 
@@ -767,6 +774,18 @@ describe('PayPalCommerceButtonStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(paypalCommerceIntegrationService.updateOrder).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onCancel button callback', () => {
+        it('loads default checkout onCancel callback (buy now flow)', async () => {
+            await strategy.initialize(buyNowInitializationOptions);
+            eventEmitter.emit('onClick');
+            await new Promise((resolve) => process.nextTick(resolve));
+            eventEmitter.emit('onCancel');
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentIntegrationService.loadDefaultCheckout).toHaveBeenCalled();
         });
     });
 });

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -109,6 +109,7 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
 
         const buyNowFlowCallbacks = {
             onClick: () => this.handleClick(buyNowInitializeOptions),
+            onCancel: () => this.paymentIntegrationService.loadDefaultCheckout(),
         };
 
         const hostedCheckoutCallbacks = {


### PR DESCRIPTION
## What?
Load default checkout on PayPal Commerce button cancel callback call

## Why?
To avoid potential errors between BuyNow and Default flows we should load default checkout on cancel operation after Buy Now cart creation for each PayPal Commerce button. 

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments
