### PR TITLE
feat(payment): INT-7217 Adding channel name to send in stripe metadata

### DIFF
--- a/packages/core/src/payment/payment.ts
+++ b/packages/core/src/payment/payment.ts
@@ -242,4 +242,5 @@ export interface StripeV3FormattedPayload {
     bigpay_token?: {
         token: string;
     };
+    channel_name?: string;
 }

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -388,6 +388,7 @@ describe('StripeUPEPaymentStrategy', () => {
                                 confirm: false,
                                 client_token: 'myToken',
                                 set_as_default_stored_instrument: true,
+                                channel_name: 'store-k1drp8k8.bcapp.dev/',
                             },
                         },
                     });

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -238,6 +238,11 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         }
     }
 
+    private _getChannelName() {
+        const channel_link = this._store.getState().config.getStoreConfigOrThrow().links.siteLink;
+        return channel_link.split('://')[1];
+    }
+
     private async _executeWithAPM(methodId: string): Promise<InternalCheckoutSelectors> {
         const paymentMethod = this._store
             .getState()
@@ -250,6 +255,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                     vault_payment_instrument: false,
                     confirm: false,
                     set_as_default_stored_instrument: false,
+                    channel_name: this._getChannelName(),
                 },
             },
         };
@@ -279,6 +285,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                     vault_payment_instrument: shouldSaveInstrument,
                     confirm: false,
                     set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
+                    channel_name: this._getChannelName(),
                 },
             },
         };
@@ -315,6 +322,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                         confirm: false,
                         client_token: paymentMethod.clientToken,
                         set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
+                        channel_name: this._getChannelName(),
                     },
                 },
             };
@@ -499,6 +507,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                             confirm: false,
                             vault_payment_instrument: shouldSaveInstrument,
                             set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
+                            channel_name: this._getChannelName(),
                         },
                     },
                 };
@@ -559,6 +568,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                         },
                         confirm: false,
                         set_as_default_stored_instrument: shouldSetAsDefaultInstrument,
+                        channel_name: this._getChannelName(),
                     },
                 },
             };


### PR DESCRIPTION
## What? [INT-7217](https://bigcommercecloud.atlassian.net/browse/INT-7217)
Adding channel name to payment payload formated data to send it in the metadata to stripe dashboard

## Why?
More Information to the store owners

## Testing / Proof
<img width="467" alt="Screenshot 2023-02-23 at 12 48 09" src="https://user-images.githubusercontent.com/106765049/221002023-29cffea6-bce1-4210-81e5-a8f0460e1861.png">


## Dependency of
https://github.com/bigcommerce/bigpay/pull/6724

@bigcommerce/checkout @bigcommerce/payments


[INT-7217]: https://bigcommercecloud.atlassian.net/browse/INT-7217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ