### PR TITLE
refactor(checkout): CHECKOUT-7304 Change PayPal wallet buttons height

### DIFF
--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-options.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-options.ts
@@ -7,6 +7,8 @@ export default interface BraintreePaypalCreditCustomerInitializeOptions {
      */
     container: string;
 
+    buttonHeight?: number;
+
     /**
      * A callback that gets called on any error instead of submit payment or authorization errors.
      *

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
@@ -324,6 +324,28 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             });
         });
 
+        it('renders braintree paylater button with a customized height', async () => {
+            await strategy.initialize({
+                ...initializationOptions,
+                braintreepaypalcredit: {
+                    ...braintreePaypalCreditOptions,
+                    buttonHeight: 100,
+                },
+            });
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                commit: false,
+                createOrder: expect.any(Function),
+                env: 'sandbox',
+                fundingSource: paypalSdkMock.FUNDING.PAYLATER,
+                onApprove: expect.any(Function),
+                style: {
+                    height: 100,
+                    color: PaypalButtonStyleColorOption.GOLD,
+                },
+            });
+        });
+
         it('renders braintree credit button if paylater is not eligible', async () => {
             jest.spyOn(paypalSdkMock, 'Buttons').mockImplementationOnce(() => {
                 return {

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -141,9 +141,11 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         let hasRenderedSmartButton = false;
 
         if (paypal) {
+            const checkoutUserExperienceSettings = this._store.getState().config.getConfig()
+                ?.storeConfig.checkoutSettings.checkoutUserExperienceSettings;
             const fundingSources = [paypal.FUNDING.PAYLATER, paypal.FUNDING.CREDIT];
             const commonButtonStyle = {
-                height: 40,
+                height: checkoutUserExperienceSettings?.walletButtonsOnTop ? 36 : 40,
                 color: PaypalButtonStyleColorOption.GOLD,
             };
 

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -47,7 +47,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
 
     async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { braintreepaypalcredit, methodId } = options;
-        const { container } = braintreepaypalcredit || {};
+        const { container, buttonHeight = 40 } = braintreepaypalcredit || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -88,6 +88,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
                 braintreepaypalcredit,
                 methodId,
                 Boolean(paymentMethod.config.testMode),
+                buttonHeight,
             );
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this._handleError(error, braintreepaypalcredit);
@@ -134,6 +135,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         braintreepaypalcredit: BraintreePaypalCreditCustomerInitializeOptions,
         methodId: string,
         testMode: boolean,
+        buttonHeight: number,
     ): void {
         const { container } = braintreepaypalcredit;
         const { paypal } = this._window;
@@ -141,11 +143,9 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         let hasRenderedSmartButton = false;
 
         if (paypal) {
-            const checkoutUserExperienceSettings = this._store.getState().config.getConfig()
-                ?.storeConfig.checkoutSettings.checkoutUserExperienceSettings;
             const fundingSources = [paypal.FUNDING.PAYLATER, paypal.FUNDING.CREDIT];
             const commonButtonStyle = {
-                height: checkoutUserExperienceSettings?.walletButtonsOnTop ? 36 : 40,
+                height: buttonHeight,
                 color: PaypalButtonStyleColorOption.GOLD,
             };
 

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-options.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-options.ts
@@ -7,6 +7,8 @@ export default interface BraintreePaypalCustomerInitializeOptions {
      */
     container: string;
 
+    buttonHeight?: number;
+
     /**
      * A callback that gets called on any error instead of submit payment or authorization errors.
      *

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.spec.ts
@@ -309,6 +309,27 @@ describe('BraintreePaypalCustomerStrategy', () => {
             });
         });
 
+        it('renders PayPal checkout button with a customized height', async () => {
+            await strategy.initialize({
+                ...initializationOptions,
+                braintreepaypal: {
+                    ...braintreePaypalOptions,
+                    buttonHeight: 100,
+                },
+            });
+
+            expect(paypalSdkMock.Buttons).toHaveBeenCalledWith({
+                env: 'sandbox',
+                commit: false,
+                fundingSource: paypalSdkMock.FUNDING.PAYPAL,
+                style: {
+                    height: 100,
+                },
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
         it('renders PayPal checkout button in production environment if payment method is in test mode', async () => {
             paymentMethodMock.config.testMode = false;
 

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.ts
@@ -140,12 +140,14 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
         const fundingSource = paypal?.FUNDING.PAYPAL;
 
         if (paypal && fundingSource) {
+            const checkoutUserExperienceSettings = this._store.getState().config.getConfig()
+                ?.storeConfig.checkoutSettings.checkoutUserExperienceSettings;
             const paypalButtonRender = paypal.Buttons({
                 env: testMode ? 'sandbox' : 'production',
                 commit: false,
                 fundingSource,
                 style: {
-                    height: 40,
+                    height: checkoutUserExperienceSettings?.walletButtonsOnTop ? 36 : 40,
                 },
                 createOrder: () =>
                     this._setupPayment(braintreePaypalCheckout, braintreepaypal, methodId),

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-customer-strategy.ts
@@ -43,7 +43,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
 
     async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { braintreepaypal, methodId } = options;
-        const { container, onError } = braintreepaypal || {};
+        const { container, onError, buttonHeight = 40 } = braintreepaypal || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -87,6 +87,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
                 container,
                 methodId,
                 Boolean(paymentMethod.config.testMode),
+                buttonHeight,
             );
         };
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
@@ -135,19 +136,18 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
         containerId: string,
         methodId: string,
         testMode: boolean,
+        buttonHeight: number,
     ): void {
         const { paypal } = this._window;
         const fundingSource = paypal?.FUNDING.PAYPAL;
 
         if (paypal && fundingSource) {
-            const checkoutUserExperienceSettings = this._store.getState().config.getConfig()
-                ?.storeConfig.checkoutSettings.checkoutUserExperienceSettings;
             const paypalButtonRender = paypal.Buttons({
                 env: testMode ? 'sandbox' : 'production',
                 commit: false,
                 fundingSource,
                 style: {
-                    height: checkoutUserExperienceSettings?.walletButtonsOnTop ? 36 : 40,
+                    height: buttonHeight,
                 },
                 createOrder: () =>
                     this._setupPayment(braintreePaypalCheckout, braintreepaypal, methodId),


### PR DESCRIPTION
## What?
Set the height of the PayPal buttons at the top of the checkout page to `36px` rather than `40px`.

## Why?
So we can provide a standardised wallet button UI to shoppers.

## Testing / Proof
<img src="https://user-images.githubusercontent.com/88361607/220784786-49d90bea-0bd5-4249-83b0-f31c28e5dcc2.png" width=500 />


@bigcommerce/checkout @bigcommerce/payments
