### PR TITLE
fix(provider): INT-7463 Fixed problem with cards vaulted with 3ds in the hosted form flow

### DIFF
--- a/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.spec.ts
@@ -1499,6 +1499,7 @@ describe('StripeV3PaymentStrategy', () => {
         let initializeOptions: PaymentInitializeOptions;
         let loadOrderAction: Observable<LoadOrderSucceededAction>;
         let state: InternalCheckoutSelectors;
+        const stripeV3JsMock = getStripeV3JsMock();
 
         beforeEach(() => {
             form = {
@@ -1530,6 +1531,8 @@ describe('StripeV3PaymentStrategy', () => {
             jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockReturnValue(
                 loadPaymentMethodAction,
             );
+
+            jest.spyOn(stripeScriptLoader, 'load').mockReturnValue(Promise.resolve(stripeV3JsMock));
         });
 
         it('creates hosted form', async () => {

--- a/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripev3/stripev3-payment-strategy.ts
@@ -96,6 +96,10 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         const form = this._getInitializeOptions().form;
 
         this._useIndividualCardFields = useIndividualCardFields;
+        this._stripeV3Client = await this._loadStripeJs(
+            stripePublishableKey,
+            stripeConnectedAccount,
+        );
 
         if (
             this._isCreditCard(methodId) &&
@@ -104,10 +108,6 @@ export default class StripeV3PaymentStrategy implements PaymentStrategy {
         ) {
             this._hostedForm = await this._mountCardVerificationFields(form);
         } else {
-            this._stripeV3Client = await this._loadStripeJs(
-                stripePublishableKey,
-                stripeConnectedAccount,
-            );
             this._stripeElement = await this._mountCardFields(methodId);
         }
 


### PR DESCRIPTION
## What? [INT-7463](https://bigcommercecloud.atlassian.net/browse/INT-7463) 

The stripe component for the hosted form flow was initialized

## Why?

When I try to place an order using a 3DS vaulted card, a message error appears.

## Testing / Proof


https://user-images.githubusercontent.com/69487174/221064151-95dcd7a3-0819-4cd0-9ec8-fd0008e3a508.mov



@bigcommerce/checkout @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team 


[INT-7463]: https://bigcommercecloud.atlassian.net/browse/INT-7463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ