### PR TITLE
feat(payment): PAYMENTS-8527 expose interface for Braintree real time host form filed validation

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -316,7 +316,29 @@ describe('BraintreeHostedForm', () => {
         it('notifies when field loses focus', () => {
             cardFieldsEventEmitter.emit('blur', { emittedBy: 'cvv' });
 
-            expect(handleBlur).toHaveBeenCalledWith({ fieldType: 'cardCode' });
+            expect(handleBlur).toHaveBeenCalledWith({ fieldType: 'cardCode', errors: {} });
+        });
+
+        describe('when event fields are provided', () => {
+            it('notifies with proper errors', () => {
+                cardFieldsEventEmitter.emit('blur', {
+                    emittedBy: 'cvv',
+                    fields: { cvv: { isEmpty: true, isPotentialyValid: true, isValid: false } },
+                });
+
+                expect(handleBlur).toHaveBeenCalledWith({
+                    fieldType: 'cardCode',
+                    errors: {
+                        cvv: {
+                            cvv: {
+                                isEmpty: true,
+                                isPotentialyValid: true,
+                                isValid: false,
+                            },
+                        },
+                    },
+                });
+            });
         });
 
         it('notifies when input receives submit event', () => {

--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.spec.ts
@@ -323,18 +323,16 @@ describe('BraintreeHostedForm', () => {
             it('notifies with proper errors', () => {
                 cardFieldsEventEmitter.emit('blur', {
                     emittedBy: 'cvv',
-                    fields: { cvv: { isEmpty: true, isPotentialyValid: true, isValid: false } },
+                    fields: { cvv: { isEmpty: true, isPotentiallyValid: true, isValid: false } },
                 });
 
                 expect(handleBlur).toHaveBeenCalledWith({
                     fieldType: 'cardCode',
                     errors: {
                         cvv: {
-                            cvv: {
-                                isEmpty: true,
-                                isPotentialyValid: true,
-                                isValid: false,
-                            },
+                            isEmpty: true,
+                            isPotentiallyValid: true,
+                            isValid: false,
                         },
                     },
                 });

--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -7,6 +7,8 @@ import { NonceInstrument } from '../../payment';
 
 import {
     BraintreeBillingAddressRequestData,
+    BraintreeFormErrorDataKeys,
+    BraintreeFormErrorsData,
     BraintreeHostedFields,
     BraintreeHostedFieldsCreatorConfig,
     BraintreeHostedFieldsState,
@@ -254,20 +256,20 @@ export default class BraintreeHostedForm {
         }
     }
 
-    private _mapErrors(fields: any): any {
-        const errors = {};
+    private _mapErrors(fields: BraintreeHostedFieldsState['fields']): BraintreeFormErrorsData {
+        const errors: BraintreeFormErrorsData = {};
 
         if (fields) {
             for (const [key, value] of Object.entries(fields)) {
-                const { isValid, isEmpty, isPotentialyValid } = value as any;
+                if (value && this._isValidParam(key)) {
+                    const { isValid, isEmpty, isPotentiallyValid } = value;
 
-                (errors as any)[key] = {
-                    [key]: {
+                    errors[key] = {
                         isValid,
                         isEmpty,
-                        isPotentialyValid,
-                    },
-                };
+                        isPotentiallyValid,
+                    };
+                }
             }
         }
 
@@ -449,7 +451,7 @@ export default class BraintreeHostedForm {
         this._formOptions?.onCardTypeChange?.({
             cardType:
                 event.cards.length === 1
-                ? event.cards[0].type.replace(/^master\-card$/, 'mastercard') /* eslint-disable-line */
+                    ? event.cards[0].type.replace(/^master\-card$/, 'mastercard',) /* eslint-disable-line */
                     : undefined,
         });
     };
@@ -468,4 +470,20 @@ export default class BraintreeHostedForm {
             errors: this._mapValidationErrors(event.fields),
         });
     };
+
+    private _isValidParam(
+        formErrorDataKey: string,
+    ): formErrorDataKey is BraintreeFormErrorDataKeys {
+        switch (formErrorDataKey) {
+            case 'number':
+            case 'cvv':
+            case 'expirationDate':
+            case 'postalCode':
+            case 'cardholderName':
+            case 'cardType':
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -254,6 +254,26 @@ export default class BraintreeHostedForm {
         }
     }
 
+    private _mapErrors(fields: any): any {
+        const errors = {};
+
+        if (fields) {
+            for (const [key, value] of Object.entries(fields)) {
+                const { isValid, isEmpty, isPotentialyValid } = value as any;
+
+                (errors as any)[key] = {
+                    [key]: {
+                        isValid,
+                        isEmpty,
+                        isPotentialyValid,
+                    },
+                };
+            }
+        }
+
+        return errors;
+    }
+
     private _mapValidationErrors(
         fields: BraintreeHostedFieldsState['fields'],
     ): BraintreeFormFieldValidateEventData['errors'] {
@@ -403,6 +423,7 @@ export default class BraintreeHostedForm {
     private _handleBlur: (event: BraintreeHostedFieldsState) => void = (event) => {
         this._formOptions?.onBlur?.({
             fieldType: this._mapFieldType(event.emittedBy),
+            errors: this._mapErrors(event.fields),
         });
     };
 

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
@@ -1,4 +1,4 @@
-import { BraintreeVerifyPayload } from './braintree';
+import { BraintreeFormErrorsData, BraintreeVerifyPayload } from './braintree';
 
 /**
  * A set of options that are required to initialize the Braintree payment
@@ -173,7 +173,7 @@ export type BraintreeFormFieldStyles = Partial<
 
 export interface BraintreeFormFieldKeyboardEventData {
     fieldType: string;
-    errors?: any;
+    errors?: BraintreeFormErrorsData;
 }
 
 export type BraintreeFormFieldBlurEventData = BraintreeFormFieldKeyboardEventData;

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-options.ts
@@ -173,6 +173,7 @@ export type BraintreeFormFieldStyles = Partial<
 
 export interface BraintreeFormFieldKeyboardEventData {
     fieldType: string;
+    errors?: any;
 }
 
 export type BraintreeFormFieldBlurEventData = BraintreeFormFieldKeyboardEventData;

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -6,7 +6,7 @@ import {
     TokenizePayload,
 } from '../googlepay';
 import { PaypalAuthorizeData, PaypalButtonOptions, PaypalButtonRender, PaypalSDK } from '../paypal';
-
+import { Omit } from '../../../common/types';
 import {
     VisaCheckoutInitOptions,
     VisaCheckoutPaymentSuccessPayload,
@@ -300,13 +300,30 @@ export interface BraintreeHostedFieldsCard {
     code: { name: string; size: number };
 }
 
-export interface BraintreeHostedFieldsFieldData {
-    container: HTMLElement;
+export interface BraintreeFormFieldState {
     isFocused: boolean;
     isEmpty: boolean;
     isPotentiallyValid: boolean;
     isValid: boolean;
 }
+
+export interface BraintreeHostedFieldsFieldData extends BraintreeFormFieldState {
+    container: HTMLElement;
+}
+
+export type BraintreeFormErrorData = Omit<BraintreeFormFieldState, 'isFocused'>;
+
+export type BraintreeFormErrorDataKeys =
+    | 'number'
+    | 'expirationDate'
+    | 'expirationMonth'
+    | 'expirationYear'
+    | 'cvv'
+    | 'postalCode';
+
+export type BraintreeFormErrorsData = Partial<
+    Record<BraintreeFormErrorDataKeys, BraintreeFormErrorData>
+>;
 
 export interface BraintreeHostedFieldsTokenizeOptions {
     vault?: boolean;


### PR DESCRIPTION
## What?
This is the following PR for the POC to expose the interface for Braintree real-time host form filed validation
https://github.com/bigcommerce/checkout-sdk-js/pull/1848

## Why?
RealReal would like the Braintree host form filed to have the real-time validation interface. This PR expose it.

## Testing / Proof
Unit tests
Error status
<img width="569" alt="image" src="https://user-images.githubusercontent.com/79880337/222990595-ebc727f0-5429-40fd-91b8-dd8d85cdab4b.png">

@bigcommerce/checkout @bigcommerce/payments
