### PR TITLE
refactor(payment): PAYPAL-1893 added PayPalCommerceCreditCardsPaymentStrategy to paypal-commerce-integration package

### DIFF
--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -50,3 +50,11 @@ export { WithPayPalCommerceVenmoCustomerInitializeOptions } from './paypal-comme
  */
 export { default as createPayPalCommerceAlternativeMethodsButtonStrategy } from './paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-button-strategy';
 export { WithPayPalCommerceAlternativeMethodsButtonOptions } from './paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-initialize-options';
+
+/**
+ *
+ * PayPalCommerce Credit Cards strategies
+ *
+ */
+export { default as createPayPalCommerceCreditCardsPaymentStrategy } from './paypal-commerce-credit-card/create-paypal-commerce-credit-cards-payment-strategy';
+export { WithPayPalCommerceCreditCardsPaymentInitializeOptions } from './paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-initialize-options';

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/create-paypal-commerce-credit-cards-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/create-paypal-commerce-credit-cards-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createPayPalCommerceCreditCardsPaymentStrategy from './create-paypal-commerce-credit-cards-payment-strategy';
+import PayPalCommerceCreditCardsPaymentStrategy from './paypal-commerce-credit-cards-payment-strategy';
+
+describe('createPayPalCommerceCreditCardsPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates paypal commerce credit cards button strategy', () => {
+        const strategy = createPayPalCommerceCreditCardsPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(PayPalCommerceCreditCardsPaymentStrategy);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/create-paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/create-paypal-commerce-credit-cards-payment-strategy.ts
@@ -1,0 +1,38 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    PayPalCommerceIntegrationService,
+    PayPalCommerceRequestSender,
+    PayPalCommerceScriptLoader,
+} from '../index';
+
+import PayPalCommerceCreditCardsPaymentStrategy from './paypal-commerce-credit-cards-payment-strategy';
+
+const createPaypalCommerceCreditCardsPaymentStrategy: PaymentStrategyFactory<
+    PayPalCommerceCreditCardsPaymentStrategy
+> = (paymentIntegrationService) => {
+    const { getHost } = paymentIntegrationService.getState();
+
+    const paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
+        createFormPoster(),
+        paymentIntegrationService,
+        new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
+        new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+
+    return new PayPalCommerceCreditCardsPaymentStrategy(
+        paymentIntegrationService,
+        paypalCommerceIntegrationService,
+    );
+};
+
+export default toResolvableModule(createPaypalCommerceCreditCardsPaymentStrategy, [
+    { id: 'paypalcommercecreditcards' },
+]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-initialize-options.ts
@@ -1,0 +1,98 @@
+import { HostedFormOptions } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+/**
+ * A set of options that are required to initialize the PayPal Commerce payment
+ * method for presenting its credit card form.
+ *
+ * ```html
+ * <!-- These containers are where the hosted (iframed) credit card fields will be inserted -->
+ * <div id="card-number"></div>
+ * <div id="card-name"></div>
+ * <div id="card-expiry"></div>
+ * <div id="card-code"></div>
+ * ```
+ *
+ * ```js
+ * service.initializePayment({
+ *     methodId: 'paypalcommercecreditcard',
+ *     paypalcommercecreditcard: {
+ *         form: {
+ *             fields: {
+ *                 cardNumber: { containerId: 'card-number' },
+ *                 cardName: { containerId: 'card-name' },
+ *                 cardExpiry: { containerId: 'card-expiry' },
+ *                 cardCode: { containerId: 'card-code' },
+ *             },
+ *         },
+ *     },
+ * });
+ * ```
+ *
+ * Additional options can be passed in to customize the fields and register
+ * event callbacks.
+ *
+ * ```js
+ * service.initializePayment({
+ *     methodId: 'paypalcommercecreditcard',
+ *     paypalcommercecreditcard: {
+ *         form: {
+ *             fields: {
+ *                 cardNumber: { containerId: 'card-number', placeholder: 'Number of card' },
+ *                 cardName: { containerId: 'card-name', placeholder: 'Name of card' },
+ *                 cardExpiry: { containerId: 'card-expiry', placeholder: 'Expiry of card' },
+ *                 cardCode: { containerId: 'card-code', placeholder: 'Code of card' },
+ *             },
+ *             styles: {
+ *                 default: {
+ *                     color: '#000',
+ *                 },
+ *                 error: {
+ *                     color: '#f00',
+ *                 },
+ *                 focus: {
+ *                     color: '#0f0',
+ *                 },
+ *             },
+ *             onBlur({ fieldType }) {
+ *                 console.log(fieldType);
+ *             },
+ *             onFocus({ fieldType }) {
+ *                 console.log(fieldType);
+ *             },
+ *             onEnter({ fieldType }) {
+ *                 console.log(fieldType);
+ *             },
+ *             onCardTypeChange({ cardType }) {
+ *                 console.log(cardType);
+ *             },
+ *             onValidate({ errors, isValid }) {
+ *                 console.log(errors);
+ *                 console.log(isValid);
+ *             },
+ *         },
+ *     },
+ * });
+ * ```
+ */
+export default interface PayPalCommerceCreditCardsPaymentInitializeOptions {
+    /**
+     * The form is data for Credit Card Form
+     */
+    form: HostedFormOptions;
+}
+
+// TODO: this interface should be removed
+// We should give some time for other developers to update their PPC CC components
+// with paypalcommercecreditcard.form instead of paypalcommerce.form.
+// The interface can be removed after 14.06.2023
+export interface DeprecatedPayPalCommerceCreditCardsPaymentInitializeOptions {
+    /**
+     * The form is data for Credit Card Form
+     */
+    form?: HostedFormOptions;
+}
+
+export interface WithPayPalCommerceCreditCardsPaymentInitializeOptions {
+    paypalcommercecreditcards?: PayPalCommerceCreditCardsPaymentInitializeOptions;
+    paypalcommerce?: DeprecatedPayPalCommerceCreditCardsPaymentInitializeOptions; // FIXME: the option is deprecated
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
@@ -1,0 +1,546 @@
+import { isNil, omitBy } from 'lodash';
+
+import {
+    HostedCardFieldOptions,
+    HostedCardFieldOptionsMap,
+    HostedFieldBlurEventData,
+    HostedFieldCardTypeChangeEventData,
+    HostedFieldEnterEventData,
+    HostedFieldFocusEventData,
+    HostedFieldStylesMap,
+    HostedFieldType,
+    HostedFieldValidateEventData,
+    HostedFormOptions,
+    HostedInputStyles,
+    HostedInputValidateErrorData,
+    HostedInputValidateErrorDataMap,
+    HostedInstrument,
+    HostedStoredCardFieldOptionsMap,
+    InvalidArgumentError,
+    isCreditCardFormFields,
+    isHostedInstrumentLike,
+    isVaultedInstrument,
+    NotInitializedError,
+    NotInitializedErrorType,
+    objectWithKebabCaseKeys,
+    OrderFinalizationNotRequiredError,
+    OrderPaymentRequestBody,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentInvalidFormError,
+    PaymentInvalidFormErrorDetails,
+    PaymentMethodFailedError,
+    PaymentRequestOptions,
+    PaymentStrategy,
+    VaultedInstrument,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
+import {
+    PayPalCommerceHostedFields,
+    PayPalCommerceHostedFieldsRenderOptions,
+    PayPalCommerceHostedFieldsState,
+    PayPalCommerceHostedFieldsSubmitOptions,
+} from '../paypal-commerce-types';
+
+import { WithPayPalCommerceCreditCardsPaymentInitializeOptions } from './paypal-commerce-credit-cards-payment-initialize-options';
+
+export default class PayPalCommerceCreditCardsPaymentStrategy implements PaymentStrategy {
+    private executionPaymentData?: OrderPaymentRequestBody['paymentData'];
+    private isCreditCardForm?: boolean;
+    private hostedFields?: PayPalCommerceHostedFields;
+    private hostedFormOptions?: HostedFormOptions;
+    private cardNameField?: HTMLInputElement;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private paypalCommerceIntegrationService: PayPalCommerceIntegrationService,
+    ) {}
+
+    async initialize(
+        options: PaymentInitializeOptions & WithPayPalCommerceCreditCardsPaymentInitializeOptions,
+    ): Promise<void> {
+        const { methodId, paypalcommercecreditcards, paypalcommerce } = options;
+        const form = paypalcommercecreditcards?.form || paypalcommerce?.form;
+
+        if (paypalcommerce) {
+            console.warn(
+                'The "options.paypalcommerce" option is deprecated for PayPal Commerce Credit Card form, please use "options.paypalcommercecreditcards" instead',
+            );
+        }
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!form) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "options.paypalcommercecreditcards.form" argument is not provided.',
+            );
+        }
+
+        this.hostedFormOptions = form;
+        this.isCreditCardForm = isCreditCardFormFields(form.fields);
+
+        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+
+        await this.renderFields(form);
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        const { payment, ...order } = payload;
+        const { methodId, paymentData } = payment || {};
+
+        if (!payment || !methodId) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        this.executionPaymentData = paymentData;
+
+        this.validateHostedFormOrThrow();
+
+        const orderId = await this.submitHostedForm(methodId);
+
+        await this.paymentIntegrationService.submitOrder(order, options);
+        await this.paypalCommerceIntegrationService.submitPayment(methodId, orderId);
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    private async renderFields(formOptions: HostedFormOptions): Promise<void> {
+        const { fields, styles } = formOptions;
+
+        const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
+
+        const hostedFieldsOptions = {
+            fields: this.mapFieldOptions(fields),
+            styles: styles ? this.mapStyleOptions(styles) : {},
+            paymentsSDK: true,
+            createOrder: () =>
+                this.paypalCommerceIntegrationService.createOrder(
+                    'paypalcommercecreditcardscheckout',
+                    this.getInstrumentParams(),
+                ),
+        };
+
+        if (paypalSdk.HostedFields.isEligible()) {
+            this.hostedFields = await paypalSdk.HostedFields.render(hostedFieldsOptions);
+
+            this.setFormFieldEvents(this.hostedFields, formOptions);
+
+            if (isCreditCardFormFields(fields)) {
+                this.renderCardNameField(fields.cardName, styles);
+            }
+        } else {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+    }
+
+    /**
+     *
+     * Card Name field methods
+     *
+     */
+    private renderCardNameField(
+        field: HostedCardFieldOptions,
+        styles?: HostedFieldStylesMap,
+    ): void {
+        const container = document.getElementById(field.containerId);
+
+        if (!container) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "options.paypalcommercecreditcards.form.fields.cardName.containerId" argument is not provided or the item is not defined in the dom.',
+            );
+        }
+
+        const cardNameFiledStylesPreset = {
+            backgroundColor: 'transparent',
+            border: 0,
+            display: 'block',
+            height: '100%',
+            margin: 0,
+            outline: 'none',
+            padding: 0,
+            width: '100%',
+        };
+
+        const defaultCardNameFiledStyles = {
+            ...cardNameFiledStylesPreset,
+            ...styles?.default,
+        };
+
+        const focusCardNameFiledStyles = {
+            ...cardNameFiledStylesPreset,
+            ...styles?.focus,
+        };
+
+        const defaultStyleProperties = this.getValidStyleString(defaultCardNameFiledStyles);
+        const focusStyleProperties = this.getValidStyleString(focusCardNameFiledStyles);
+
+        this.cardNameField = document.createElement('input');
+
+        this.setFieldStyleAttribute(defaultStyleProperties, this.cardNameField);
+
+        this.cardNameField.addEventListener('blur', () =>
+            this.setFieldStyleAttribute(defaultStyleProperties, this.cardNameField),
+        );
+        this.cardNameField.addEventListener('focus', () =>
+            this.setFieldStyleAttribute(focusStyleProperties, this.cardNameField),
+        );
+
+        container.appendChild(this.cardNameField);
+    }
+
+    private setFieldStyleAttribute(style: string, item?: HTMLInputElement): void {
+        item?.setAttribute('style', style);
+    }
+
+    /**
+     *
+     * Instrument params method
+     *
+     */
+    private getInstrumentParams(): HostedInstrument | VaultedInstrument {
+        if (!this.executionPaymentData) {
+            return {};
+        }
+
+        if (isHostedInstrumentLike(this.executionPaymentData)) {
+            const { shouldSaveInstrument, shouldSetAsDefaultInstrument } =
+                this.executionPaymentData;
+
+            return {
+                shouldSaveInstrument,
+                shouldSetAsDefaultInstrument,
+            };
+        }
+
+        if (isVaultedInstrument(this.executionPaymentData)) {
+            const { instrumentId } = this.executionPaymentData;
+
+            return {
+                instrumentId,
+            };
+        }
+
+        return {};
+    }
+
+    /**
+     *
+     * Hosted form events
+     *
+     */
+    private setFormFieldEvents(
+        hostedFields: PayPalCommerceHostedFields,
+        formOptions: HostedFormOptions,
+    ): void {
+        const eventsData = [
+            {
+                eventName: 'blur',
+                formCallback: formOptions?.onBlur,
+                eventHandler: (event: PayPalCommerceHostedFieldsState) =>
+                    formOptions?.onBlur?.(this.getFieldTypeByEmittedField(event)),
+            },
+            {
+                eventName: 'focus',
+                formCallback: formOptions?.onFocus,
+                eventHandler: (event: PayPalCommerceHostedFieldsState) =>
+                    formOptions?.onFocus?.(this.getFieldTypeByEmittedField(event)),
+            },
+            {
+                eventName: 'inputSubmitRequest',
+                formCallback: formOptions?.onEnter,
+                eventHandler: (event: PayPalCommerceHostedFieldsState) =>
+                    formOptions?.onEnter?.(this.getFieldTypeByEmittedField(event)),
+            },
+            {
+                eventName: 'cardTypeChange',
+                formCallback: formOptions?.onCardTypeChange,
+                eventHandler: (event: PayPalCommerceHostedFieldsState) =>
+                    formOptions?.onCardTypeChange?.(this.getCardTypeByEvent(event)),
+            },
+            {
+                eventName: 'validityChange',
+                formCallback: formOptions?.onValidate,
+                eventHandler: (event: PayPalCommerceHostedFieldsState) =>
+                    formOptions?.onValidate?.(this.getValidityData(event)),
+            },
+        ];
+
+        eventsData.forEach(({ eventName, eventHandler, formCallback }) => {
+            if (formCallback && typeof formCallback === 'function') {
+                hostedFields.on(eventName, eventHandler);
+            }
+        });
+    }
+
+    private getFieldTypeByEmittedField({
+        emittedBy,
+    }: PayPalCommerceHostedFieldsState):
+        | HostedFieldBlurEventData
+        | HostedFieldEnterEventData
+        | HostedFieldFocusEventData {
+        return {
+            fieldType: this.mapFieldType(emittedBy),
+        };
+    }
+
+    private getCardTypeByEvent({
+        cards,
+    }: PayPalCommerceHostedFieldsState): HostedFieldCardTypeChangeEventData {
+        return {
+            cardType: cards?.[0]?.type,
+        };
+    }
+
+    /**
+     *
+     * Hosted form submit method
+     *
+     * */
+    private async submitHostedForm(methodId: string): Promise<string> {
+        const hostedFields = this.getHostedFieldsOrThrow();
+
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        const { is3dsEnabled } = paymentMethod.config;
+
+        const options: PayPalCommerceHostedFieldsSubmitOptions = {
+            ...(this.cardNameField?.value && {
+                cardholderName: this.cardNameField.value,
+            }),
+            ...(is3dsEnabled && {
+                contingencies: ['3D_SECURE'],
+            }),
+        };
+
+        const { liabilityShift, orderId } = await hostedFields.submit(options);
+
+        if (is3dsEnabled && (liabilityShift === 'NO' || liabilityShift === 'UNKNOWN')) {
+            // FIXME: we should throw another error to have an ability to translate it
+            throw new PaymentMethodFailedError(
+                'Failed authentication. Please try to authorize again.',
+            );
+        }
+
+        return orderId;
+    }
+
+    /**
+     *
+     * Validation and errors
+     *
+     */
+    private validateHostedFormOrThrow(): void {
+        const hostedFields = this.getHostedFieldsOrThrow();
+        const hostedFieldState = hostedFields.getState();
+        const validationData = this.getValidityData(hostedFieldState);
+
+        if (validationData.isValid) {
+            return;
+        }
+
+        this.hostedFormOptions?.onValidate?.(validationData);
+
+        throw new PaymentInvalidFormError(this.mapValidationErrors(validationData.errors));
+    }
+
+    private getValidityData({
+        fields,
+    }: PayPalCommerceHostedFieldsState): HostedFieldValidateEventData {
+        const fieldsKeys = Object.keys(fields) as Array<
+            keyof PayPalCommerceHostedFieldsState['fields']
+        >;
+
+        const isValid = fieldsKeys.every((key) => fields[key]?.isValid);
+        const errors = fieldsKeys.reduce((fieldsErrors, key) => {
+            const fieldType = this.mapFieldType(key);
+
+            return {
+                ...fieldsErrors,
+                [fieldType]: fields[key]?.isValid
+                    ? undefined
+                    : [this.getInvalidErrorByFieldType(fieldType)],
+            };
+        }, {});
+
+        return { isValid, errors };
+    }
+
+    private getInvalidErrorByFieldType(fieldType: string): HostedInputValidateErrorData {
+        switch (fieldType) {
+            case HostedFieldType.CardCode:
+            case HostedFieldType.CardCodeVerification:
+                return {
+                    fieldType,
+                    message: 'Invalid card code',
+                    type: 'invalid_card_code',
+                };
+
+            case HostedFieldType.CardNumber:
+            case HostedFieldType.CardNumberVerification:
+                return {
+                    fieldType,
+                    message: 'Invalid card number',
+                    type: 'invalid_card_number',
+                };
+
+            case HostedFieldType.CardExpiry:
+                return {
+                    fieldType,
+                    message: 'Invalid card expiry',
+                    type: 'invalid_card_expiry',
+                };
+
+            default:
+                return {
+                    fieldType,
+                    message: 'Invalid field',
+                    type: 'invalid',
+                };
+        }
+    }
+
+    private mapValidationErrors(
+        validationErrors: HostedInputValidateErrorDataMap = {},
+    ): PaymentInvalidFormErrorDetails {
+        const errors: PaymentInvalidFormErrorDetails = {};
+        const validationErrorsKeys = Object.keys(validationErrors) as Array<
+            keyof HostedInputValidateErrorDataMap
+        >;
+
+        validationErrorsKeys.forEach((key) => {
+            errors[key] = [
+                {
+                    message: validationErrors[key]?.[0]?.message || '',
+                    type: key,
+                },
+            ];
+        });
+
+        return errors;
+    }
+
+    /**
+     *
+     * Fields mappers
+     *
+     */
+    private mapFieldType(type: string): HostedFieldType {
+        switch (type) {
+            case 'number':
+                return this.isCreditCardForm
+                    ? HostedFieldType.CardNumber
+                    : HostedFieldType.CardNumberVerification;
+
+            case 'expirationDate':
+                return HostedFieldType.CardExpiry;
+
+            case 'cvv':
+                return this.isCreditCardForm
+                    ? HostedFieldType.CardCode
+                    : HostedFieldType.CardCodeVerification;
+
+            default:
+                throw new Error('Unexpected field type');
+        }
+    }
+
+    private mapFieldOptions(
+        fields: HostedCardFieldOptionsMap | HostedStoredCardFieldOptionsMap,
+    ): PayPalCommerceHostedFieldsRenderOptions['fields'] {
+        if (isCreditCardFormFields(fields)) {
+            const { cardNumber, cardExpiry, cardCode } = fields;
+
+            return {
+                ...(cardNumber && {
+                    number: {
+                        selector: `#${cardNumber.containerId}`,
+                        placeholder: cardNumber.placeholder,
+                    },
+                }),
+                ...(cardExpiry && {
+                    expirationDate: {
+                        selector: `#${cardExpiry.containerId}`,
+                        placeholder: cardExpiry.placeholder,
+                    },
+                }),
+                ...(cardCode && {
+                    cvv: {
+                        selector: `#${cardCode.containerId}`,
+                        placeholder: cardCode.placeholder,
+                    },
+                }),
+            };
+        }
+
+        const { cardNumberVerification, cardCodeVerification } = fields;
+
+        return {
+            ...(cardNumberVerification && {
+                number: {
+                    selector: `#${cardNumberVerification.containerId}`,
+                    placeholder: cardNumberVerification.placeholder,
+                },
+            }),
+            ...(cardCodeVerification && {
+                cvv: {
+                    selector: `#${cardCodeVerification.containerId}`,
+                    placeholder: cardCodeVerification.placeholder,
+                },
+            }),
+        };
+    }
+
+    /**
+     *
+     * Styles mappers
+     *
+     */
+    private mapStyleOptions(
+        styles: HostedFieldStylesMap,
+    ): PayPalCommerceHostedFieldsRenderOptions['styles'] {
+        return {
+            input: this.mapStyles(styles.default),
+            '.invalid': this.mapStyles(styles.error),
+            ':focus': this.mapStyles(styles.focus),
+        };
+    }
+
+    private mapStyles(styles: HostedInputStyles = {}): { [key: string]: string } {
+        return omitBy(objectWithKebabCaseKeys(styles), isNil);
+    }
+
+    private getValidStyleString(styles: HostedInputStyles = {}): string {
+        const validStyles = this.mapStyles(styles);
+
+        return Object.keys(validStyles)
+            .map((key) => `${key}: ${validStyles[key]}`)
+            .join(';');
+    }
+
+    /**
+     *
+     * Utils
+     *
+     */
+    private getHostedFieldsOrThrow(): PayPalCommerceHostedFields {
+        if (!this.hostedFields) {
+            throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
+        }
+
+        return this.hostedFields;
+    }
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-strategy.spec.ts
@@ -1,0 +1,620 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    HostedCardFieldOptionsMap,
+    HostedFieldType,
+    HostedStoredCardFieldOptionsMap,
+    InvalidArgumentError,
+    NotInitializedError,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentInvalidFormError,
+    PaymentMethod,
+    PaymentMethodFailedError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { getPayPalCommercePaymentMethod } from '../mocks/paypal-commerce-payment-method.mock';
+import { getPayPalSDKMock } from '../mocks/paypal-sdk.mock';
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
+import PayPalCommerceRequestSender from '../paypal-commerce-request-sender';
+import PayPalCommerceScriptLoader from '../paypal-commerce-script-loader';
+import { PayPalCommerceHostWindow, PayPalSDK } from '../paypal-commerce-types';
+
+import PayPalCommerceCreditCardsPaymentInitializeOptions from './paypal-commerce-credit-cards-payment-initialize-options';
+import PayPalCommerceCreditCardsPaymentStrategy from './paypal-commerce-credit-cards-payment-strategy';
+
+describe('PayPalCommerceCreditCardsPaymentStrategy', () => {
+    let formPoster: FormPoster;
+    let requestSender: RequestSender;
+    let strategy: PayPalCommerceCreditCardsPaymentStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paymentMethod: PaymentMethod;
+    let paypalCommerceIntegrationService: PayPalCommerceIntegrationService;
+    let paypalCommerceRequestSender: PayPalCommerceRequestSender;
+    let paypalCommerceScriptLoader: PayPalCommerceScriptLoader;
+    let paypalSdk: PayPalSDK;
+
+    let paypalCardNameFieldElement: HTMLDivElement;
+
+    const methodId = 'paypalcommercecreditcards';
+
+    const paypalCardNameFieldContainerId = 'card-name';
+
+    const creditCardFormFields = {
+        [HostedFieldType.CardNumber]: { containerId: 'card-number' },
+        [HostedFieldType.CardExpiry]: { containerId: 'card-expiry' },
+        [HostedFieldType.CardCode]: { containerId: 'card-code' },
+        [HostedFieldType.CardName]: { containerId: paypalCardNameFieldContainerId },
+    };
+
+    const storedCreditCardFormFields = {
+        [HostedFieldType.CardCodeVerification]: { containerId: 'card-code-verification' },
+        [HostedFieldType.CardNumberVerification]: { containerId: 'card-number-verification' },
+    } as HostedStoredCardFieldOptionsMap;
+
+    const paypalCommerceCreditCardsOptions: PayPalCommerceCreditCardsPaymentInitializeOptions = {
+        form: {
+            fields: creditCardFormFields,
+        },
+    };
+
+    const paypalCommerceStoredCreditCardsOptions: PayPalCommerceCreditCardsPaymentInitializeOptions =
+        {
+            form: {
+                fields: storedCreditCardFormFields,
+            },
+        };
+
+    const initializationOptions: PaymentInitializeOptions = {
+        methodId,
+        paypalcommercecreditcards: paypalCommerceCreditCardsOptions,
+    };
+
+    const initializationOptionsForStoredCreditCardsForm: PaymentInitializeOptions = {
+        methodId,
+        paypalcommercecreditcards: paypalCommerceStoredCreditCardsOptions,
+    };
+
+    const defaultExecutePayload = {
+        payment: {
+            methodId: 'paypalcommercecreditcards',
+            paymentData: {},
+        },
+    };
+
+    const getHostedFieldSateMock = (isValid = true) => ({
+        cards: [],
+        emittedBy: 'number',
+        fields: {
+            number: {
+                container: 'containerId',
+                isFocused: false,
+                isEmpty: true,
+                isPotentiallyValid: false,
+                isValid,
+            },
+        },
+    });
+
+    beforeEach(() => {
+        paymentMethod = { ...getPayPalCommercePaymentMethod(), id: methodId };
+        paypalSdk = getPayPalSDKMock();
+
+        formPoster = createFormPoster();
+        requestSender = createRequestSender();
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+        paypalCommerceRequestSender = new PayPalCommerceRequestSender(requestSender);
+        paypalCommerceScriptLoader = new PayPalCommerceScriptLoader(getScriptLoader());
+
+        // TODO: create a mock method to create paypalCommerceIntegrationService with only one method
+        // without adding a lot of unnecessary imports to each test file
+        paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
+            formPoster,
+            paymentIntegrationService,
+            paypalCommerceRequestSender,
+            paypalCommerceScriptLoader,
+        );
+
+        strategy = new PayPalCommerceCreditCardsPaymentStrategy(
+            paymentIntegrationService,
+            paypalCommerceIntegrationService,
+        );
+
+        paypalCardNameFieldElement = document.createElement('div');
+        paypalCardNameFieldElement.id = paypalCardNameFieldContainerId;
+        document.body.appendChild(paypalCardNameFieldElement);
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethod,
+        );
+
+        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
+            paypalSdk,
+        );
+        jest.spyOn(paypalCommerceIntegrationService, 'submitPayment').mockImplementation(jest.fn());
+
+        jest.spyOn(paypalSdk.HostedFields, 'isEligible').mockReturnValue(true);
+        jest.spyOn(paypalSdk.HostedFields, 'render').mockImplementation(jest.fn());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PayPalCommerceHostWindow).paypal;
+
+        if (document.getElementById(paypalCardNameFieldContainerId)) {
+            document.body.removeChild(paypalCardNameFieldElement);
+        }
+    });
+
+    it('creates an interface of the PayPal Commerce Credit Cards payment strategy', () => {
+        expect(strategy).toBeInstanceOf(PayPalCommerceCreditCardsPaymentStrategy);
+    });
+
+    describe('#initialize', () => {
+        it('throws an error if methodId is not provided', async () => {
+            const options = {} as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if paypalcommercecreditcards.form option is not provided', async () => {
+            const options = { methodId } as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error and logs a warning if paypalcommerce.form option is not provided', async () => {
+            const warnLogSpy = jest.spyOn(console, 'warn');
+            const options = {
+                methodId,
+                paypalcommerce: {},
+            };
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(warnLogSpy).toHaveBeenCalled();
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('loads paypalcommercecreditcards payment method', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
+        });
+
+        it('loads paypal sdk', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(methodId);
+        });
+    });
+
+    describe('#renderFields', () => {
+        it('throws an error if hosted field is not eligible', async () => {
+            jest.spyOn(paypalSdk.HostedFields, 'isEligible').mockReturnValue(false);
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotInitializedError);
+            }
+        });
+
+        it('renders hosted fields if they are eligible', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.HostedFields.render).toHaveBeenCalled();
+        });
+
+        it('renders hosted fields with credit card fields', async () => {
+            const { fields } = paypalCommerceCreditCardsOptions.form;
+            const formFields = fields as HostedCardFieldOptionsMap;
+
+            const expectedCreditCardFormFields = {
+                number: {
+                    selector: `#${formFields[HostedFieldType.CardNumber].containerId}`,
+                    placeholder: undefined,
+                },
+                expirationDate: {
+                    selector: `#${formFields[HostedFieldType.CardExpiry].containerId}`,
+                    placeholder: undefined,
+                },
+                cvv: {
+                    selector: `#${formFields[HostedFieldType.CardCode]?.containerId || ''}`,
+                    placeholder: undefined,
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.HostedFields.render).toHaveBeenCalledWith({
+                fields: expectedCreditCardFormFields,
+                styles: {},
+                paymentsSDK: true,
+                createOrder: expect.any(Function),
+            });
+        });
+
+        it('renders hosted fields with stored credit fields', async () => {
+            const { fields } = paypalCommerceStoredCreditCardsOptions.form;
+            const formFields = fields as HostedStoredCardFieldOptionsMap;
+
+            const numberSelector =
+                formFields[HostedFieldType.CardNumberVerification]?.containerId || '';
+            const cvvSelector = formFields[HostedFieldType.CardCodeVerification]?.containerId || '';
+
+            const expectedCreditCardFormFields = {
+                number: {
+                    selector: `#${numberSelector}`,
+                    placeholder: undefined,
+                },
+                cvv: {
+                    selector: `#${cvvSelector}`,
+                    placeholder: undefined,
+                },
+            };
+
+            await strategy.initialize(initializationOptionsForStoredCreditCardsForm);
+
+            expect(paypalSdk.HostedFields.render).toHaveBeenCalledWith({
+                fields: expectedCreditCardFormFields,
+                styles: {},
+                paymentsSDK: true,
+                createOrder: expect.any(Function),
+            });
+        });
+
+        it('renders hosted fields with valid styles', async () => {
+            const initializationOptionsWithStyles = {
+                methodId,
+                paypalcommercecreditcards: {
+                    form: {
+                        fields: paypalCommerceCreditCardsOptions.form.fields,
+                        styles: {
+                            default: {
+                                color: 'gray',
+                                fontFamily: 'bigFont',
+                                fontSize: '14px',
+                                fontWeight: '400',
+                            },
+                            error: {
+                                color: 'red',
+                                fontFamily: 'bigFont',
+                                fontSize: '14px',
+                                fontWeight: '400',
+                            },
+                            focus: {
+                                color: 'black',
+                                fontFamily: 'bigFont',
+                                fontSize: '14px',
+                                fontWeight: '400',
+                            },
+                        },
+                    },
+                },
+            };
+
+            const { fields } = paypalCommerceCreditCardsOptions.form;
+            const formFields = fields as HostedCardFieldOptionsMap;
+
+            const numberSelector = formFields[HostedFieldType.CardNumber].containerId;
+            const expirationDateSelector = formFields[HostedFieldType.CardExpiry].containerId;
+            const cvvSelector = formFields[HostedFieldType.CardCode]?.containerId || '';
+
+            const expectedCreditCardFormFields = {
+                number: {
+                    selector: `#${numberSelector}`,
+                    placeholder: undefined,
+                },
+                expirationDate: {
+                    selector: `#${expirationDateSelector}`,
+                    placeholder: undefined,
+                },
+                cvv: {
+                    selector: `#${cvvSelector}`,
+                    placeholder: undefined,
+                },
+            };
+
+            await strategy.initialize(initializationOptionsWithStyles);
+
+            expect(paypalSdk.HostedFields.render).toHaveBeenCalledWith({
+                fields: expectedCreditCardFormFields,
+                styles: {
+                    input: {
+                        color: 'gray',
+                        'font-family': 'bigFont',
+                        'font-size': '14px',
+                        'font-weight': '400',
+                    },
+                    '.invalid': {
+                        color: 'red',
+                        'font-family': 'bigFont',
+                        'font-size': '14px',
+                        'font-weight': '400',
+                    },
+                    ':focus': {
+                        color: 'black',
+                        'font-family': 'bigFont',
+                        'font-size': '14px',
+                        'font-weight': '400',
+                    },
+                },
+                paymentsSDK: true,
+                createOrder: expect.any(Function),
+            });
+        });
+
+        it('sets hosted form events if related callbacks were provided', async () => {
+            const hostedFieldOn = jest.fn();
+
+            jest.spyOn(paypalSdk.HostedFields, 'render').mockImplementation(() =>
+                Promise.resolve({
+                    on: hostedFieldOn,
+                }),
+            );
+
+            const initializationOptionsWithStyles = {
+                methodId,
+                paypalcommercecreditcards: {
+                    form: {
+                        fields: paypalCommerceCreditCardsOptions.form.fields,
+                        onBlur: jest.fn(),
+                        onFocus: jest.fn(),
+                        onEnter: jest.fn(),
+                        onCardTypeChange: jest.fn(),
+                        onValidate: jest.fn(),
+                    },
+                },
+            };
+
+            await strategy.initialize(initializationOptionsWithStyles);
+
+            expect(hostedFieldOn).toHaveBeenCalledWith('blur', expect.any(Function));
+            expect(hostedFieldOn).toHaveBeenCalledWith('focus', expect.any(Function));
+            expect(hostedFieldOn).toHaveBeenCalledWith('inputSubmitRequest', expect.any(Function));
+            expect(hostedFieldOn).toHaveBeenCalledWith('cardTypeChange', expect.any(Function));
+            expect(hostedFieldOn).toHaveBeenCalledWith('validityChange', expect.any(Function));
+        });
+
+        it('throws an error if an element with provided card name container id is not defined', async () => {
+            document.body.removeChild(paypalCardNameFieldElement);
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('renders card name field for credit card form', async () => {
+            await strategy.initialize(initializationOptions);
+
+            const cardNameContainer = document.getElementById(paypalCardNameFieldContainerId);
+            const cardNameField = cardNameContainer?.getElementsByTagName('input')[0];
+
+            expect(cardNameField).toBeDefined();
+        });
+
+        it('does not render card name field for stored credit card form', async () => {
+            await strategy.initialize(initializationOptionsForStoredCreditCardsForm);
+
+            const cardNameContainer = document.getElementById(paypalCardNameFieldContainerId);
+            const cardNameField = cardNameContainer?.getElementsByTagName('input')[0];
+
+            expect(cardNameField).toBeUndefined();
+        });
+    });
+
+    describe('#execute', () => {
+        it('throws an error if payment object is not provided as execution data', async () => {
+            await strategy.initialize(initializationOptions);
+
+            const payload = {};
+
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
+            }
+        });
+
+        it('throws an error if methodId is not provided as execution payment payload', async () => {
+            await strategy.initialize(initializationOptions);
+
+            const payload = {
+                payment: {
+                    paymentData: {},
+                },
+            } as OrderRequestBody;
+
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
+            }
+        });
+
+        it('submits an order', async () => {
+            const hostedFormSubmitFnMock = jest.fn(() => ({
+                liabilityShift: undefined,
+                orderId: 'orderId',
+            }));
+
+            jest.spyOn(paypalSdk.HostedFields, 'render').mockImplementation(() =>
+                Promise.resolve({
+                    getState: () => getHostedFieldSateMock(),
+                    submit: hostedFormSubmitFnMock,
+                }),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            await strategy.execute(defaultExecutePayload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+        });
+
+        it('submits payment', async () => {
+            const hostedFormOrderId = 'hostedFormOrderId';
+
+            const hostedFormSubmitFnMock = jest.fn(() => ({
+                liabilityShift: undefined,
+                orderId: hostedFormOrderId,
+            }));
+
+            jest.spyOn(paypalSdk.HostedFields, 'render').mockImplementation(() =>
+                Promise.resolve({
+                    getState: () => getHostedFieldSateMock(),
+                    submit: hostedFormSubmitFnMock,
+                }),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            await strategy.execute(defaultExecutePayload);
+
+            expect(paypalCommerceIntegrationService.submitPayment).toHaveBeenCalledWith(
+                methodId,
+                hostedFormOrderId,
+            );
+        });
+    });
+
+    describe('#submitHostedForm()', () => {
+        it('throws an error if the hosted form is not valid on form submit', async () => {
+            jest.spyOn(paypalSdk.HostedFields, 'render').mockImplementation(() =>
+                Promise.resolve({
+                    getState: () => getHostedFieldSateMock(false),
+                    submit: jest.fn(),
+                }),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            try {
+                await strategy.execute(defaultExecutePayload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentInvalidFormError);
+            }
+        });
+
+        it('submits hosted form', async () => {
+            const hostedFormSubmitFnMock = jest.fn(() => ({
+                liabilityShift: undefined,
+                orderId: 'orderId',
+            }));
+
+            jest.spyOn(paypalSdk.HostedFields, 'render').mockImplementation(() =>
+                Promise.resolve({
+                    getState: () => getHostedFieldSateMock(),
+                    submit: hostedFormSubmitFnMock,
+                }),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            await strategy.execute(defaultExecutePayload);
+
+            expect(hostedFormSubmitFnMock).toHaveBeenCalled();
+        });
+
+        it('submits hosted form with 3DS contingencies', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                config: {
+                    ...paymentMethod.config,
+                    is3dsEnabled: true,
+                },
+            });
+
+            const hostedFormSubmitFnMock = jest.fn(() => ({
+                liabilityShift: undefined,
+                orderId: 'orderId',
+            }));
+
+            jest.spyOn(paypalSdk.HostedFields, 'render').mockImplementation(() =>
+                Promise.resolve({
+                    getState: () => getHostedFieldSateMock(),
+                    submit: hostedFormSubmitFnMock,
+                }),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            await strategy.execute(defaultExecutePayload);
+
+            expect(hostedFormSubmitFnMock).toHaveBeenCalledWith({
+                contingencies: ['3D_SECURE'],
+            });
+        });
+
+        it('throws an error if liabilityShift is "NO" or "UNKNOWN" on submit hosted form while 3DS enabled', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                config: {
+                    ...paymentMethod.config,
+                    is3dsEnabled: true,
+                },
+            });
+
+            const hostedFormSubmitFnMock = jest.fn(() => ({
+                liabilityShift: 'NO',
+                orderId: 'orderId',
+            }));
+
+            jest.spyOn(paypalSdk.HostedFields, 'render').mockImplementation(() =>
+                Promise.resolve({
+                    getState: () => getHostedFieldSateMock(),
+                    submit: hostedFormSubmitFnMock,
+                }),
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            try {
+                await strategy.execute(defaultExecutePayload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodFailedError);
+            }
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes strategy', async () => {
+            const result = await strategy.deinitialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
@@ -184,6 +184,22 @@ describe('PayPalCommerceIntegrationService', () => {
             });
             expect(output).toBe(mockedOrderId);
         });
+
+        it('successfully creates paypal order with provided instrument data', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'createOrder').mockReturnValue({
+                orderId: mockedOrderId,
+            });
+
+            const vaultedInstrumentData = { instrumentId: 'vaultedInstrumentIdMock' };
+
+            const output = await subject.createOrder(defaultMethodId, vaultedInstrumentData);
+
+            expect(paypalCommerceRequestSender.createOrder).toHaveBeenCalledWith(defaultMethodId, {
+                cartId: cart.id,
+                instrumentId: vaultedInstrumentData.instrumentId,
+            });
+            expect(output).toBe(mockedOrderId);
+        });
     });
 
     describe('#updateOrder', () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -20,6 +20,7 @@ import {
     PayPalButtonStyleOptions,
     PayPalBuyNowInitializeOptions,
     PayPalCommerceInitializationData,
+    PayPalCreateOrderRequestBody,
     PayPalOrderDetails,
     PayPalSDK,
     StyleButtonColor,
@@ -95,11 +96,15 @@ export default class PayPalCommerceIntegrationService {
      * Order creation methods
      *
      */
-    async createOrder(providerId: string): Promise<string> {
+    async createOrder(
+        providerId: string,
+        requestBody?: Partial<PayPalCreateOrderRequestBody>,
+    ): Promise<string> {
         const cartId = this.paymentIntegrationService.getState().getCartOrThrow().id;
 
         const { orderId } = await this.paypalCommerceRequestSender.createOrder(providerId, {
             cartId,
+            ...requestBody,
         });
 
         return orderId;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-request-sender.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-request-sender.spec.ts
@@ -27,9 +27,12 @@ describe('PayPalCommerceRequestSender', () => {
     });
 
     it('creates order with provided data', async () => {
-        await paypalCommerceRequestSender.createOrder('paypalcommerce', {
+        const requestBody = {
             cartId: 'abc',
-        });
+            instrumentId: 'vaultedInstrumentId',
+        };
+
+        await paypalCommerceRequestSender.createOrder('paypalcommerce', requestBody);
 
         const headers = {
             'X-API-INTERNAL': INTERNAL_USE_ONLY,
@@ -40,7 +43,7 @@ describe('PayPalCommerceRequestSender', () => {
         expect(requestSender.post).toHaveBeenCalledWith(
             '/api/storefront/payment/paypalcommerce',
             expect.objectContaining({
-                body: { cartId: 'abc' },
+                body: requestBody,
                 headers,
             }),
         );

--- a/packages/paypal-commerce-integration/src/paypal-commerce-request-sender.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-request-sender.ts
@@ -17,7 +17,7 @@ export default class PayPalCommerceRequestSender {
 
     async createOrder(
         providerId: string,
-        requestBody: PayPalCreateOrderRequestBody,
+        requestBody: Partial<PayPalCreateOrderRequestBody>,
     ): Promise<PayPalOrderData> {
         const url = `/api/storefront/payment/${providerId}`;
         const body = requestBody;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -1,6 +1,8 @@
 import {
     BuyNowCartRequestBody,
+    HostedInstrument,
     ShippingOption,
+    VaultedInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 /**
@@ -122,7 +124,9 @@ export interface PayPalCommerceHostedFieldOption {
 }
 
 export interface PayPalCommerceHostedFields {
-    submit(options?: PayPalCommerceHostedFieldsSubmitOptions): PayPalCommerceHostedFieldsApprove;
+    submit(
+        options?: PayPalCommerceHostedFieldsSubmitOptions,
+    ): Promise<PayPalCommerceHostedFieldsApprove>;
     getState(): PayPalCommerceHostedFieldsState;
     on(eventName: string, callback: (event: PayPalCommerceHostedFieldsState) => void): void;
 }
@@ -134,7 +138,7 @@ export interface PayPalCommerceHostedFieldsSubmitOptions {
 
 export interface PayPalCommerceHostedFieldsApprove {
     orderId: string;
-    liabilityShift: 'POSSIBLE' | 'NO' | 'UNKNOWN';
+    liabilityShift?: 'POSSIBLE' | 'NO' | 'UNKNOWN';
 }
 
 export interface PayPalCommerceHostedFieldsState {
@@ -388,6 +392,6 @@ export interface PayPalUpdateOrderRequestBody {
     selectedShippingOption?: ShippingOption;
 }
 
-export interface PayPalCreateOrderRequestBody {
+export interface PayPalCreateOrderRequestBody extends HostedInstrument, VaultedInstrument {
     cartId: string;
 }


### PR DESCRIPTION
## What?
Added PayPalCommerceCreditCardsPaymentStrategy to paypal-commerce-integration package

## Why?
We are moving related to paypal commerce code from core package to paypal-commerce-integration package, to avoid any custom code in core. 

## Testing / Proof
Unit tests
Manual tests
CI tests

<img width="689" alt="Screenshot 2023-03-17 at 18 06 11" src="https://user-images.githubusercontent.com/25133454/225960029-794c32ac-dde6-4022-9e9e-d5037c06ddb8.png">
