### PR TITLE
feat(payment): INT-7169 BlueSnapDirect: Add payment strategy for ACH/ECP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 /packages/payment-integration-test-utils @bigcommerce/checkout
 /packages/paypal-commerce-integration @bigcommerce/kyiv-payments-team
 /packages/squarev2-integration @bigcommerce/apex-leads
+/packages/bluesnap-direct-integration @bigcommerce/apex-leads

--- a/packages/bluesnap-direct-integration/.eslintrc.json
+++ b/packages/bluesnap-direct-integration/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": ["../../.eslintrc.json"]
+}

--- a/packages/bluesnap-direct-integration/.eslintrc.json
+++ b/packages/bluesnap-direct-integration/.eslintrc.json
@@ -1,3 +1,18 @@
 {
-    "extends": ["../../.eslintrc.json"]
+    "extends": ["../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {
+                "@typescript-eslint/naming-convention": "off"
+            }
+        },
+        {
+            "files": ["*.spec.ts"],
+            "rules": {
+                "@typescript-eslint/consistent-type-assertions": "off"
+            }
+        }
+    ]
 }

--- a/packages/bluesnap-direct-integration/README.md
+++ b/packages/bluesnap-direct-integration/README.md
@@ -1,0 +1,11 @@
+# bluesnap-direct-integration
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test bluesnap-direct-integration` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint bluesnap-direct-integration` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/bluesnap-direct-integration/jest.config.js
+++ b/packages/bluesnap-direct-integration/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+    displayName: 'bluesnap-direct-integration',
+    preset: '../../jest.preset.js',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json',
+            diagnostics: false,
+        },
+    },
+    setupFilesAfterEnv: ['../../jest-setup.js'],
+    coverageDirectory: '../../coverage/packages/bluesnap-direct-integration',
+};

--- a/packages/bluesnap-direct-integration/project.json
+++ b/packages/bluesnap-direct-integration/project.json
@@ -14,8 +14,7 @@
             "executor": "@nrwl/jest:jest",
             "outputs": ["coverage/packages/bluesnap-direct-integration"],
             "options": {
-                "jestConfig": "packages/bluesnap-direct-integration/jest.config.js",
-                "passWithNoTests": true
+                "jestConfig": "packages/bluesnap-direct-integration/jest.config.js"
             }
         }
     },

--- a/packages/bluesnap-direct-integration/project.json
+++ b/packages/bluesnap-direct-integration/project.json
@@ -1,0 +1,23 @@
+{
+    "root": "packages/bluesnap-direct-integration",
+    "sourceRoot": "packages/bluesnap-direct-integration/src",
+    "projectType": "library",
+    "targets": {
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/bluesnap-direct-integration/**/*.ts"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/bluesnap-direct-integration"],
+            "options": {
+                "jestConfig": "packages/bluesnap-direct-integration/jest.config.js",
+                "passWithNoTests": true
+            }
+        }
+    },
+    "tags": ["scope:integration"]
+}

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-ecp-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-ecp-payment-strategy.spec.ts
@@ -1,0 +1,108 @@
+import {
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BlueSnapDirectEcpPaymentStrategy from './bluesnap-direct-ecp-payment-strategy';
+
+describe('BlueSnapDirectCreditCardPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+    let strategy: BlueSnapDirectEcpPaymentStrategy;
+
+    beforeEach(() => {
+        paymentIntegrationService =
+            new PaymentIntegrationServiceMock() as PaymentIntegrationService;
+
+        strategy = new BlueSnapDirectEcpPaymentStrategy(paymentIntegrationService);
+    });
+
+    describe('#initialize()', () => {
+        it('initializes the strategy successfully', async () => {
+            await expect(strategy.initialize()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('#execute()', () => {
+        let payload: OrderRequestBody;
+
+        beforeEach(async () => {
+            payload = {
+                payment: {
+                    gatewayId: 'bluesnapdirect',
+                    methodId: 'ecp',
+                    paymentData: {
+                        accountNumber: '223344556',
+                        accountType: 'CONSUMER_CHECKING',
+                        shopperPermission: true,
+                        routingNumber: '998877665',
+                    },
+                },
+            };
+
+            await strategy.initialize();
+        });
+
+        afterEach(() => {
+            (paymentIntegrationService.submitOrder as jest.Mock).mockClear();
+            (paymentIntegrationService.submitPayment as jest.Mock).mockClear();
+        });
+
+        it('executes the strategy successfully', async () => {
+            const execute = strategy.execute(payload);
+
+            await expect(execute).resolves.toBeUndefined();
+        });
+
+        it('should submit the order', async () => {
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+        });
+
+        it('should submit the payment', async () => {
+            const expectedPayment = {
+                gatewayId: 'bluesnapdirect',
+                methodId: 'ecp',
+                paymentData: {
+                    formattedPayload: {
+                        ecp: {
+                            account_number: '223344556',
+                            account_type: 'CONSUMER_CHECKING',
+                            routing_number: '998877665',
+                            shopper_permission: true,
+                        },
+                    },
+                },
+            };
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        });
+
+        describe('should fail if...', () => {
+            test('payload.payment is not en ECP instrument', async () => {
+                const execute = () => strategy.execute({ ...payload, payment: undefined });
+
+                await expect(execute()).rejects.toThrow(PaymentArgumentInvalidError);
+                expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('finalizes the strategy successfully', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes the strategy successfully', async () => {
+            await expect(strategy.deinitialize()).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-ecp-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-ecp-payment-strategy.ts
@@ -1,0 +1,43 @@
+import {
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentIntegrationService,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import assertBlueSnapDirectEcpInstrument from './is-bluesnap-direct-ecp-instrument';
+
+export default class BlueSnapDirectEcpPaymentStrategy implements PaymentStrategy {
+    constructor(private _paymentIntegrationService: PaymentIntegrationService) {}
+
+    initialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    async execute({ payment }: OrderRequestBody): Promise<void> {
+        assertBlueSnapDirectEcpInstrument(payment?.paymentData);
+
+        await this._paymentIntegrationService.submitOrder();
+        await this._paymentIntegrationService.submitPayment({
+            ...payment,
+            paymentData: {
+                formattedPayload: {
+                    ecp: {
+                        account_number: payment.paymentData.accountNumber,
+                        account_type: payment.paymentData.accountType,
+                        shopper_permission: payment.paymentData.shopperPermission,
+                        routing_number: payment.paymentData.routingNumber,
+                    },
+                },
+            },
+        });
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+}

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-ecp-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-ecp-payment-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BlueSnapDirectEcpPaymentStrategy from './bluesnap-direct-ecp-payment-strategy';
+import createBlueSnapDirectEcpPaymentStrategy from './create-bluesnap-direct-ecp-payment-strategy';
+
+describe('createBlueSnapDirectEcpPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService =
+            new PaymentIntegrationServiceMock() as PaymentIntegrationService;
+    });
+
+    it('instantiates bluesnapdirect ecp payment strategy', () => {
+        const strategy = createBlueSnapDirectEcpPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(BlueSnapDirectEcpPaymentStrategy);
+    });
+});

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-ecp-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-ecp-payment-strategy.ts
@@ -1,0 +1,14 @@
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BlueSnapDirectEcpPaymentStrategy from './bluesnap-direct-ecp-payment-strategy';
+
+const createBlueSnapDirectEcpPaymentStrategy: PaymentStrategyFactory<
+    BlueSnapDirectEcpPaymentStrategy
+> = (paymentIntegrationService) => new BlueSnapDirectEcpPaymentStrategy(paymentIntegrationService);
+
+export default toResolvableModule(createBlueSnapDirectEcpPaymentStrategy, [
+    { id: 'ecp', gateway: 'bluesnapdirect' },
+]);

--- a/packages/bluesnap-direct-integration/src/index.ts
+++ b/packages/bluesnap-direct-integration/src/index.ts
@@ -1,0 +1,1 @@
+export { default as createBlueSnapDirectEcpPaymentStrategy } from './create-bluesnap-direct-ecp-payment-strategy';

--- a/packages/bluesnap-direct-integration/src/is-bluesnap-direct-ecp-instrument.ts
+++ b/packages/bluesnap-direct-integration/src/is-bluesnap-direct-ecp-instrument.ts
@@ -1,0 +1,28 @@
+import {
+    BlueSnapDirectEcpInstrument,
+    OrderPaymentRequestBody,
+    PaymentArgumentInvalidError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+function isBlueSnapDirectEcpInstrument(
+    data: OrderPaymentRequestBody['paymentData'],
+): data is BlueSnapDirectEcpInstrument {
+    if (data === undefined) {
+        return false;
+    }
+
+    return (
+        'accountNumber' in data &&
+        'accountType' in data &&
+        'shopperPermission' in data &&
+        'routingNumber' in data
+    );
+}
+
+export default function assertBlueSnapDirectEcpInstrument(
+    data: OrderPaymentRequestBody['paymentData'],
+): asserts data is BlueSnapDirectEcpInstrument {
+    if (!isBlueSnapDirectEcpInstrument(data)) {
+        throw new PaymentArgumentInvalidError();
+    }
+}

--- a/packages/bluesnap-direct-integration/tsconfig.json
+++ b/packages/bluesnap-direct-integration/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.base.json"
+}

--- a/packages/bluesnap-direct-integration/tsconfig.lib.json
+++ b/packages/bluesnap-direct-integration/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": []
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.spec.ts"]
+}

--- a/packages/bluesnap-direct-integration/tsconfig.spec.json
+++ b/packages/bluesnap-direct-integration/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/packages/core/src/order/order-request-body.ts
+++ b/packages/core/src/order/order-request-body.ts
@@ -1,4 +1,5 @@
 import {
+    BlueSnapDirectEcpInstrument,
     CreditCardInstrument,
     HostedCreditCardInstrument,
     HostedInstrument,
@@ -40,6 +41,7 @@ export type OrderPaymentInstrument =
     | HostedVaultedInstrument
     | NonceInstrument
     | VaultedInstrument
+    | BlueSnapDirectEcpInstrument
     | (CreditCardInstrument & WithDocumentInstrument)
     | (CreditCardInstrument & WithCheckoutcomFawryInstrument)
     | (CreditCardInstrument & WithCheckoutcomSEPAInstrument)

--- a/packages/core/src/payment/index.ts
+++ b/packages/core/src/payment/index.ts
@@ -21,6 +21,7 @@ export { default as withAccountCreation } from './with-account-creation';
 export { default as PaymentActionCreator } from './payment-action-creator';
 export {
     default as Payment,
+    BlueSnapDirectEcpInstrument,
     CreditCardInstrument,
     WithCheckoutcomiDealInstrument,
     WithCheckoutcomFawryInstrument,

--- a/packages/core/src/payment/payment.ts
+++ b/packages/core/src/payment/payment.ts
@@ -11,6 +11,7 @@ export default interface Payment {
 }
 
 export type PaymentInstrument =
+    | BlueSnapDirectEcpInstrument
     | CreditCardInstrument
     | (CreditCardInstrument & WithHostedFormNonce)
     | (CreditCardInstrument & WithDocumentInstrument)
@@ -21,6 +22,7 @@ export type PaymentInstrument =
     | FormattedPayload<
           | AdyenV2Instrument
           | AppleInstrument
+          | BlueSnapDirectEcpPayload
           | BoltInstrument
           | PaypalInstrument
           | FormattedHostedInstrument
@@ -195,6 +197,30 @@ interface AdyenV2Card {
         token: string;
     };
     bigpay_token?: void;
+}
+
+export interface BlueSnapDirectEcpInstrument {
+    accountNumber: string;
+    accountType:
+        | 'CONSUMER_CHECKING'
+        | 'CONSUMER_SAVINGS'
+        | 'CORPORATE_CHECKING'
+        | 'CORPORATE_SAVINGS';
+    shopperPermission: boolean;
+    routingNumber: string;
+}
+
+export interface BlueSnapDirectEcpPayload {
+    ecp: {
+        account_number: string;
+        account_type:
+            | 'CONSUMER_CHECKING'
+            | 'CONSUMER_SAVINGS'
+            | 'CORPORATE_CHECKING'
+            | 'CORPORATE_SAVINGS';
+        shopper_permission: boolean;
+        routing_number: string;
+    };
 }
 
 interface StripeV3Intent {

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -70,6 +70,7 @@ export {
     OrderRequestBody,
 } from './order';
 export {
+    BlueSnapDirectEcpInstrument,
     CardInstrument,
     CreditCardInstrument,
     isVaultedInstrument,

--- a/packages/payment-integration-api/src/order/order-request-body.ts
+++ b/packages/payment-integration-api/src/order/order-request-body.ts
@@ -1,4 +1,5 @@
 import {
+    BlueSnapDirectEcpInstrument,
     CreditCardInstrument,
     HostedCreditCardInstrument,
     HostedInstrument,
@@ -59,6 +60,7 @@ export interface OrderPaymentRequestBody {
         | HostedVaultedInstrument
         | NonceInstrument
         | VaultedInstrument
+        | BlueSnapDirectEcpInstrument
         | (CreditCardInstrument & WithDocumentInstrument)
         | (CreditCardInstrument & WithCheckoutcomFawryInstrument)
         | (CreditCardInstrument & WithCheckoutcomSEPAInstrument)

--- a/packages/payment-integration-api/src/payment/index.ts
+++ b/packages/payment-integration-api/src/payment/index.ts
@@ -3,6 +3,7 @@ export { AccountInstrument, CardInstrument } from './instrument';
 
 export {
     default as Payment,
+    BlueSnapDirectEcpInstrument,
     CreditCardInstrument,
     WithCheckoutcomiDealInstrument,
     WithCheckoutcomFawryInstrument,

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -11,6 +11,7 @@ export default interface Payment {
 }
 
 export type PaymentInstrument =
+    | BlueSnapDirectEcpInstrument
     | CreditCardInstrument
     | (CreditCardInstrument & WithHostedFormNonce)
     | (CreditCardInstrument & WithDocumentInstrument)
@@ -22,6 +23,7 @@ export type PaymentInstrument =
           | AdyenV2Instrument
           | AppleInstrument
           | BoltInstrument
+          | BlueSnapDirectEcpPayload
           | PaypalInstrument
           | FormattedHostedInstrument
           | FormattedVaultedInstrument
@@ -194,6 +196,30 @@ interface AdyenV2Card {
         token: string;
     };
     bigpay_token?: void;
+}
+
+export interface BlueSnapDirectEcpInstrument {
+    accountNumber: string;
+    accountType:
+        | 'CONSUMER_CHECKING'
+        | 'CONSUMER_SAVINGS'
+        | 'CORPORATE_CHECKING'
+        | 'CORPORATE_SAVINGS';
+    shopperPermission: boolean;
+    routingNumber: string;
+}
+
+export interface BlueSnapDirectEcpPayload {
+    ecp: {
+        account_number: string;
+        account_type:
+            | 'CONSUMER_CHECKING'
+            | 'CONSUMER_SAVINGS'
+            | 'CORPORATE_CHECKING'
+            | 'CORPORATE_SAVINGS';
+        shopper_permission: boolean;
+        routing_number: string;
+    };
 }
 
 interface StripeV3Intent {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,9 @@
             "@bigcommerce/checkout-sdk/apple-pay-integration": [
                 "packages/apple-pay-integration/src/index.ts"
             ],
+            "@bigcommerce/checkout-sdk/bluesnap-direct-integration": [
+                "packages/bluesnap-direct-integration/src/index.ts"
+            ],
             "@bigcommerce/checkout-sdk/core": ["packages/core/src/index.ts"],
             "@bigcommerce/checkout-sdk/credit-card-integration": [
                 "packages/credit-card-integration/src/index.ts"

--- a/workspace.json
+++ b/workspace.json
@@ -4,6 +4,7 @@
         "adyen-integration": "packages/adyen-integration",
         "analytics": "packages/analytics",
         "apple-pay-integration": "packages/apple-pay-integration",
+        "bluesnap-direct-integration": "packages/bluesnap-direct-integration",
         "core": "packages/core",
         "credit-card-integration": "packages/credit-card-integration",
         "external-integration": "packages/external-integration",


### PR DESCRIPTION
## What? [INT-7169](https://bigcommercecloud.atlassian.net/browse/INT-7169)
Add a payment strategy for ACH/ECP through BlueSnap.

## Why?
To allow shoppers to pay with ACH/ECP through BlueSnap.

## Testing / Proof
Unit by the moment.

## Dependency of:
👉 https://github.com/bigcommerce/checkout-js/pull/1218

@bigcommerce/checkout @bigcommerce/payments


[INT-7169]: https://bigcommercecloud.atlassian.net/browse/INT-7169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ