### PR TITLE
feat(payment): PAYPAL-000 added isStoredCreditCardFormFields typeguard to payment-integration-api package

### DIFF
--- a/packages/payment-integration-api/src/hosted-form/index.ts
+++ b/packages/payment-integration-api/src/hosted-form/index.ts
@@ -26,3 +26,4 @@ export {
     HostedInputValidateEvent,
     HostedInputValidateResults,
 } from './iframe-content';
+export { default as isStoredCreditCardFormFields } from './is-stored-credit-card-form-fields';

--- a/packages/payment-integration-api/src/hosted-form/is-stored-credit-card-form-fields.spec.ts
+++ b/packages/payment-integration-api/src/hosted-form/is-stored-credit-card-form-fields.spec.ts
@@ -1,0 +1,30 @@
+import HostedFieldType from './hosted-field-type';
+import isStoredCreditCardFormFields from './is-stored-credit-card-form-fields';
+
+describe('isStoredCreditCardFormFields', () => {
+    it('returns true if the fields object does not have default credit card form fields', () => {
+        expect(
+            isStoredCreditCardFormFields({
+                [HostedFieldType.CardCodeVerification]: {
+                    containerId: 'cardCodeContainerId',
+                    instrumentId: 'cardCodeInstrumentId',
+                },
+                [HostedFieldType.CardNumberVerification]: {
+                    containerId: 'cardNumberContainerId',
+                    instrumentId: 'cardNumberInstrumentId',
+                },
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false if the fields object has default credit card form fields', () => {
+        expect(
+            isStoredCreditCardFormFields({
+                [HostedFieldType.CardCode]: { containerId: 'cardCodeContainerId' },
+                [HostedFieldType.CardExpiry]: { containerId: 'cardExpiryContainerId' },
+                [HostedFieldType.CardName]: { containerId: 'cardNameContainerId' },
+                [HostedFieldType.CardNumber]: { containerId: 'cardNumberContainerId' },
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/payment-integration-api/src/hosted-form/is-stored-credit-card-form-fields.ts
+++ b/packages/payment-integration-api/src/hosted-form/is-stored-credit-card-form-fields.ts
@@ -1,0 +1,13 @@
+import HostedFieldType from './hosted-field-type';
+import { HostedCardFieldOptionsMap, HostedStoredCardFieldOptionsMap } from './hosted-form-options';
+
+export default function isStoredCreditCardFormFields(
+    fields: HostedCardFieldOptionsMap | HostedStoredCardFieldOptionsMap,
+): fields is HostedStoredCardFieldOptionsMap {
+    return (
+        !(HostedFieldType.CardNumber in fields) &&
+        !(HostedFieldType.CardName in fields) &&
+        !(HostedFieldType.CardCode in fields) &&
+        !(HostedFieldType.CardExpiry in fields)
+    );
+}

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -62,9 +62,14 @@ export {
 export {
     HostedCardFieldOptions,
     HostedCardFieldOptionsMap,
+    HostedFieldBlurEventData,
+    HostedFieldCardTypeChangeEventData,
+    HostedFieldEnterEventData,
+    HostedFieldFocusEventData,
     HostedFieldType,
     HostedFieldOptionsMap,
     HostedFieldStylesMap,
+    HostedFieldValidateEventData,
     HostedForm,
     HostedFormOptions,
     HostedInputBlurEvent,
@@ -80,6 +85,7 @@ export {
     HostedInputValidateResults,
     HostedStoredCardFieldOptions,
     HostedStoredCardFieldOptionsMap,
+    isStoredCreditCardFormFields,
 } from './hosted-form';
 export {
     GatewayOrderPayment,


### PR DESCRIPTION
## What?
Added isStoredCreditCardFormFields typeguard to payment-integration-api package

## Why?
We have a lot of hosted form implementation in different packages like paypal commerce and braintree where we should have an ability to detect what form is rendered. So I made a decision to create common typeguard to avoid code duplication in different packages.

## Testing / Proof
Unit tests
