### PR TITLE
feat(payment): INT-7573 Create Access Worldpay GooglePay strategy

### DIFF
--- a/packages/core/src/checkout-buttons/checkout-button-options.ts
+++ b/packages/core/src/checkout-buttons/checkout-button-options.ts
@@ -127,6 +127,12 @@ export interface BaseCheckoutButtonInitializeOptions extends CheckoutButtonOptio
     googlepayauthorizenet?: GooglePayButtonInitializeOptions;
 
     /**
+     * The options that are required to facilitate Worldpay GooglePay. They can be
+     * omitted unless you need to support Worldpay GooglePay.
+     */
+    googlepayworldpayaccess?: GooglePayButtonInitializeOptions;
+
+    /**
      * The options that are required to facilitate PayPal. They can be omitted
      * unless you need to support Paypal.
      */

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -36,6 +36,7 @@ import {
     GooglePayOrbitalInitializer,
     GooglePayStripeInitializer,
     GooglePayStripeUPEInitializer,
+    GooglePayWorldpayAccessInitializer,
 } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
@@ -326,6 +327,18 @@ export default function createCheckoutButtonRegistry(
                 new PaypalScriptLoader(scriptLoader),
                 formPoster,
                 host,
+            ),
+    );
+
+    registry.register(
+        CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+        () =>
+            new GooglePayButtonStrategy(
+                store,
+                formPoster,
+                checkoutActionCreator,
+                createGooglePayPaymentProcessor(store, new GooglePayWorldpayAccessInitializer()),
+                cartRequestSender,
             ),
     );
 

--- a/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
+++ b/packages/core/src/checkout-buttons/strategies/checkout-button-method-type.ts
@@ -15,6 +15,7 @@ export enum BaseCheckoutButtonMethodType {
     GOOGLEPAY_ORBITAL = 'googlepayorbital',
     GOOGLEPAY_STRIPE = 'googlepaystripe',
     GOOGLEPAY_STRIPEUPE = 'googlepaystripeupe',
+    GOOGLEPAY_WORLDPAYACCESS = 'googlepayworldpayaccess',
     MASTERPASS = 'masterpass',
     PAYPALEXPRESS = 'paypalexpress',
 }

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -182,6 +182,13 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
             return options.googlepaystripeupe;
         }
 
+        if (
+            options.methodId === CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS &&
+            options.googlepayworldpayaccess
+        ) {
+            return options.googlepayworldpayaccess;
+        }
+
         throw new InvalidArgumentError();
     }
 

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button.mock.ts
@@ -32,6 +32,7 @@ export enum Mode {
     GooglePayStripe,
     GooglePayStripeUPE,
     GooglePayBraintreeWithBuyNow,
+    GooglePayWorldpayAccess,
 }
 
 const buyNowCartRequestBody: BuyNowCartRequestBody = {
@@ -75,6 +76,7 @@ export function getCheckoutButtonOptions(
     const googlepayorbital = { googlepayorbital: { buttonType: ButtonType.Short } };
     const googlepaystripe = { googlepaystripe: { buttonType: ButtonType.Short } };
     const googlepaystripeupe = { googlepaystripeupe: { buttonType: ButtonType.Short } };
+    const googlepayworldpayaccess = { googlepayworldpayaccess: { buttonType: ButtonType.Short } };
 
     switch (mode) {
         case Mode.UndefinedContainer: {
@@ -127,6 +129,10 @@ export function getCheckoutButtonOptions(
 
         case Mode.GooglePayStripeUPE: {
             return { methodId, containerId, ...googlepaystripeupe };
+        }
+
+        case Mode.GooglePayWorldpayAccess: {
+            return { methodId, containerId, ...googlepayworldpayaccess };
         }
 
         default: {

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-worldpay-access-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-worldpay-access-button-strategy.spec.ts
@@ -1,0 +1,255 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+
+import { InvalidArgumentError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { Cart, CartRequestSender } from '../../../cart';
+import { getCart, getCartState } from '../../../cart/carts.mock';
+import {
+    CheckoutActionCreator,
+    CheckoutRequestSender,
+    CheckoutStore,
+    createCheckoutStore,
+} from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
+import { PaymentMethod } from '../../../payment';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import {
+    createGooglePayPaymentProcessor,
+    GooglePayPaymentProcessor,
+    GooglePayWorldpayAccessInitializer,
+} from '../../../payment/strategies/googlepay';
+import { getGooglePaymentDataMock } from '../../../payment/strategies/googlepay/googlepay.mock';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+import CheckoutButtonMethodType from '../checkout-button-method-type';
+
+import GooglePayButtonStrategy from './googlepay-button-strategy';
+import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
+
+describe('GooglePayCheckoutButtonStrategy', () => {
+    let cart: Cart;
+    let container: HTMLDivElement;
+    let formPoster: FormPoster;
+    let cartRequestSender: CartRequestSender;
+    let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+    let paymentMethod: PaymentMethod;
+    let paymentProcessor: GooglePayPaymentProcessor;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: GooglePayButtonStrategy;
+    let walletButton: HTMLAnchorElement;
+
+    beforeEach(() => {
+        paymentMethod = getPaymentMethod();
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        cart = getCart();
+        requestSender = createRequestSender();
+
+        checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender)),
+            new FormFieldsActionCreator(new FormFieldsRequestSender(requestSender)),
+        );
+
+        paymentProcessor = createGooglePayPaymentProcessor(
+            store,
+            new GooglePayWorldpayAccessInitializer(),
+        );
+
+        formPoster = createFormPoster();
+
+        cartRequestSender = new CartRequestSender(createRequestSender());
+
+        strategy = new GooglePayButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            paymentProcessor,
+            cartRequestSender,
+        );
+
+        jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(paymentProcessor, 'initialize').mockReturnValue(Promise.resolve());
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(
+            paymentMethod,
+        );
+
+        jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue(cart);
+
+        jest.spyOn(formPoster, 'postForm').mockReturnValue(Promise.resolve());
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
+        walletButton = document.createElement('a');
+        walletButton.setAttribute('id', 'mockButton');
+
+        jest.spyOn(paymentProcessor, 'createButton').mockImplementation(
+            (onClick: (event: Event) => Promise<void>) => {
+                walletButton.onclick = onClick;
+
+                return walletButton;
+            },
+        );
+
+        jest.spyOn(paymentProcessor, 'deinitialize');
+
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    describe('#initialize()', () => {
+        it('Creates the button', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(
+                CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+                Mode.GooglePayWorldpayAccess,
+            );
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.createButton).toHaveBeenCalled();
+        });
+
+        it('initializes paymentProcessor only once', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(
+                CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+                Mode.GooglePayWorldpayAccess,
+            );
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
+        });
+
+        it('fails to initialize the strategy if no container id is supplied', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(
+                CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+                Mode.UndefinedContainer,
+            );
+
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(
+                InvalidArgumentError,
+            );
+        });
+
+        it('fails to initialize the strategy if no valid container id is supplied', async () => {
+            checkoutButtonOptions = getCheckoutButtonOptions(
+                CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+                Mode.InvalidContainer,
+            );
+
+            await expect(strategy.initialize(checkoutButtonOptions)).rejects.toThrow(
+                InvalidArgumentError,
+            );
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        beforeAll(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions(
+                CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+                Mode.GooglePayWorldpayAccess,
+            );
+        });
+
+        it('check if googlepay payment processor deinitialize is called', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize();
+
+            expect(paymentProcessor.deinitialize).toHaveBeenCalled();
+        });
+
+        it('succesfully deinitializes the strategy', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize();
+
+            // tslint:disable-next-line:no-non-null-assertion
+            const button = document.getElementById(checkoutButtonOptions.containerId);
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+
+        it('Validates if strategy is loaded before call deinitialize', async () => {
+            await strategy.deinitialize();
+
+            // tslint:disable-next-line:no-non-null-assertion
+            const button = document.getElementById(checkoutButtonOptions.containerId);
+
+            expect(button).toHaveProperty('firstChild', null);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        const googlePaymentDataMock = getGooglePaymentDataMock();
+
+        beforeEach(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions(
+                CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+                Mode.GooglePayWorldpayAccess,
+            );
+
+            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(googlePaymentDataMock);
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(
+                Promise.resolve(),
+            );
+        });
+
+        it('handles wallet button event and updates shipping address', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(
+                CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+            );
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).toHaveBeenCalledWith(
+                googlePaymentDataMock.shippingAddress,
+            );
+        });
+
+        it('handles wallet button event and does not update shipping address if cart has digital products only', async () => {
+            cart.lineItems.physicalItems = [];
+
+            await strategy.initialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.initialize).toHaveBeenCalledWith(
+                CheckoutButtonMethodType.GOOGLEPAY_WORLDPAYACCESS,
+            );
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paymentProcessor.displayWallet).toHaveBeenCalled();
+            expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
+            expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/core/src/customer/create-customer-strategy-registry.ts
+++ b/packages/core/src/customer/create-customer-strategy-registry.ts
@@ -43,6 +43,7 @@ import {
     GooglePayOrbitalInitializer,
     GooglePayStripeInitializer,
     GooglePayStripeUPEInitializer,
+    GooglePayWorldpayAccessInitializer,
 } from '../payment/strategies/googlepay';
 import { MasterpassScriptLoader } from '../payment/strategies/masterpass';
 import { StripeScriptLoader } from '../payment/strategies/stripe-upe';
@@ -342,6 +343,17 @@ export default function createCustomerStrategyRegistry(
                 store,
                 remoteCheckoutActionCreator,
                 createGooglePayPaymentProcessor(store, new GooglePayStripeUPEInitializer()),
+                formPoster,
+            ),
+    );
+
+    registry.register(
+        'googlepayworldpayaccess',
+        () =>
+            new GooglePayCustomerStrategy(
+                store,
+                remoteCheckoutActionCreator,
+                createGooglePayPaymentProcessor(store, new GooglePayWorldpayAccessInitializer()),
                 formPoster,
             ),
     );

--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -145,6 +145,12 @@ export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
      * They can be omitted unless you need to support Customer Stripe Upe.
      */
     stripeupe?: StripeUPECustomerInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
+    googlepayworldpayaccess?: GooglePayCustomerInitializeOptions;
 }
 
 /**

--- a/packages/core/src/customer/strategies/googlepay/googlepay-customer-method-type.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-customer-method-type.ts
@@ -9,6 +9,7 @@ enum GooglePayCustomerMethodType {
     GOOGLEPAY_ORBITAL = 'googlepayorbital',
     GOOGLEPAY_STRIPE = 'googlepaystripe',
     GOOGLEPAY_STRIPEUPE = 'googlepaystripeupe',
+    GOOGLEPAY_WORLDPAYACCESS = 'googlepayworldpayaccess',
 }
 
 export default GooglePayCustomerMethodType;

--- a/packages/core/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -160,6 +160,12 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         if (options.methodId === MethodType.GOOGLEPAY_STRIPEUPE && options.googlepaystripeupe) {
             return options.googlepaystripeupe;
         }
+        if (
+            options.methodId === MethodType.GOOGLEPAY_WORLDPAYACCESS &&
+            options.googlepayworldpayaccess
+        ) {
+            return options.googlepayworldpayaccess;
+        }
 
         throw new InvalidArgumentError();
     }

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -100,6 +100,7 @@ import {
     GooglePayPaymentStrategy,
     GooglePayStripeInitializer,
     GooglePayStripeUPEInitializer,
+    GooglePayWorldpayAccessInitializer,
 } from './strategies/googlepay';
 import { HummPaymentStrategy } from './strategies/humm';
 import { KlarnaPaymentStrategy, KlarnaScriptLoader } from './strategies/klarna';
@@ -987,6 +988,20 @@ export default function createPaymentStrategyRegistry(
                 orderActionCreator,
                 paymentActionCreator,
                 hostedFormFactory,
+            ),
+    );
+
+    registry.register(
+        PaymentStrategyType.WORLDPAYACCESS_GOOGLE_PAY,
+        () =>
+            new GooglePayPaymentStrategy(
+                store,
+                checkoutActionCreator,
+                paymentMethodActionCreator,
+                paymentStrategyActionCreator,
+                paymentActionCreator,
+                orderActionCreator,
+                createGooglePayPaymentProcessor(store, new GooglePayWorldpayAccessInitializer()),
             ),
     );
 

--- a/packages/core/src/payment/payment-request-options.ts
+++ b/packages/core/src/payment/payment-request-options.ts
@@ -225,4 +225,10 @@ export interface BasePaymentInitializeOptions extends PaymentRequestOptions {
      * They can be omitted unless you need to support Worldpay.
      */
     worldpay?: WorldpayAccessPaymentInitializeOptions;
+
+    /**
+     * The options that are required to initialize the GooglePay Worldpay Access payment method.
+     * They can be omitted unless you need to support GooglePay.
+     */
+    googlepayworldpayaccess?: GooglePayPaymentInitializeOptions;
 }

--- a/packages/core/src/payment/payment-strategy-type.ts
+++ b/packages/core/src/payment/payment-strategy-type.ts
@@ -63,6 +63,7 @@ enum PaymentStrategyType {
     CHASE_PAY = 'chasepay',
     WE_PAY = 'wepay',
     WORLDPAYACCESS = 'worldpayaccess',
+    WORLDPAYACCESS_GOOGLE_PAY = 'googlepayworldpayaccess',
     MASTERPASS = 'masterpass',
     STRIPE_GOOGLE_PAY = 'googlepaystripe',
     SEZZLE = 'sezzle',

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -305,6 +305,13 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             return options.googlepaystripeupe;
         }
 
+        if (
+            options.methodId === PaymentStrategyType.WORLDPAYACCESS_GOOGLE_PAY &&
+            options.googlepayworldpayaccess
+        ) {
+            return options.googlepayworldpayaccess;
+        }
+
         throw new InvalidArgumentError(
             'Unable to initialize payment because "options.googlepay" argument is not provided.',
         );

--- a/packages/core/src/payment/strategies/googlepay/googlepay-worldpay-access-initializar.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-worldpay-access-initializar.spec.ts
@@ -1,0 +1,65 @@
+import GooglePayWorldpayInitializer from './googlepay-worldpay-access-initializer';
+import {
+    getCheckoutMock,
+    getGooglePayWorldpayAccessPaymentDataMock,
+    getGooglePayWorldpayAccessPaymentDataRequest,
+    getGooglePayWorldpayAccessPaymentMethodMock,
+    getGooglePayWorldpayAccessTokenizedPayload,
+} from './googlepay.mock';
+
+describe('GooglePayWorldpayInitializer', () => {
+    let googlePayInitializer: GooglePayWorldpayInitializer;
+
+    beforeEach(() => {
+        googlePayInitializer = new GooglePayWorldpayInitializer();
+    });
+
+    it('creates an instance of GooglePayWorldpayInitializer', () => {
+        expect(googlePayInitializer).toBeInstanceOf(GooglePayWorldpayInitializer);
+    });
+
+    describe('#initialize', () => {
+        it('initializes the google pay configuration for Worldpay', async () => {
+            const initialize = await googlePayInitializer.initialize(
+                getCheckoutMock(),
+                getGooglePayWorldpayAccessPaymentMethodMock(),
+                false,
+            );
+
+            expect(initialize).toEqual(getGooglePayWorldpayAccessPaymentDataRequest());
+        });
+
+        it('initializes the google pay configuration for worldpayaccess with Buy Now Flow', async () => {
+            const paymentDataRequest = {
+                ...getGooglePayWorldpayAccessPaymentDataRequest(),
+                transactionInfo: {
+                    ...getGooglePayWorldpayAccessPaymentDataRequest().transactionInfo,
+                    currencyCode: '',
+                    totalPrice: '',
+                },
+            };
+
+            await googlePayInitializer
+                .initialize(undefined, getGooglePayWorldpayAccessPaymentMethodMock(), false)
+                .then((response) => {
+                    expect(response).toEqual(paymentDataRequest);
+                });
+        });
+    });
+
+    describe('#teardown', () => {
+        it('teardown the initializer', () => {
+            expect(googlePayInitializer.teardown()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('#parseResponse', () => {
+        it('parses a response from google pay payload received', async () => {
+            const tokenizePayload = await googlePayInitializer.parseResponse(
+                getGooglePayWorldpayAccessPaymentDataMock(),
+            );
+
+            expect(tokenizePayload).toEqual(getGooglePayWorldpayAccessTokenizedPayload());
+        });
+    });
+});

--- a/packages/core/src/payment/strategies/googlepay/googlepay-worldpay-access-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-worldpay-access-initializer.ts
@@ -1,0 +1,113 @@
+import { round } from 'lodash';
+
+import { Checkout } from '../../../checkout';
+import PaymentMethod from '../../payment-method';
+
+import {
+    BillingAddressFormat,
+    GooglePayInitializer,
+    GooglePaymentData,
+    GooglePayPaymentDataRequestV2,
+    TokenizePayload,
+} from './googlepay';
+
+export default class GooglePayWorldpayAccessInitializer implements GooglePayInitializer {
+    initialize(
+        checkout: Checkout | undefined,
+        paymentMethod: PaymentMethod,
+        hasShippingAddress: boolean,
+    ): Promise<GooglePayPaymentDataRequestV2> {
+        return Promise.resolve(
+            this._getGooglePayPaymentDataRequest(checkout, paymentMethod, hasShippingAddress),
+        );
+    }
+
+    teardown(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    parseResponse(paymentData: GooglePaymentData): Promise<TokenizePayload> {
+        const {
+            paymentMethodData: {
+                type,
+                tokenizationData: { token },
+                info: { cardNetwork: cardType, cardDetails: lastFour },
+            },
+        } = paymentData;
+
+        return Promise.resolve({
+            nonce: btoa(token),
+            type,
+            details: {
+                cardType,
+                lastFour,
+            },
+        });
+    }
+
+    private _getGooglePayPaymentDataRequest(
+        checkout: Checkout | undefined,
+        paymentMethod: PaymentMethod,
+        hasShippingAddress: boolean,
+    ): GooglePayPaymentDataRequestV2 {
+        const currencyCode = checkout?.cart.currency.code || '';
+        const totalPrice = checkout?.outstandingBalance
+            ? round(checkout.outstandingBalance, 2).toFixed(2)
+            : '';
+
+        const {
+            initializationData: {
+                gatewayMerchantId,
+                storeCountry: countryCode,
+                googleMerchantName: merchantName,
+                googleMerchantId: merchantId,
+                platformToken: authJwt,
+            },
+            supportedCards,
+        } = paymentMethod;
+
+        return {
+            apiVersion: 2,
+            apiVersionMinor: 0,
+            merchantInfo: {
+                authJwt,
+                merchantId,
+                merchantName,
+            },
+            allowedPaymentMethods: [
+                {
+                    type: 'CARD',
+                    parameters: {
+                        allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                        allowedCardNetworks: supportedCards.map((card) =>
+                            card === 'MC' ? 'MASTERCARD' : card,
+                        ),
+                        billingAddressRequired: true,
+                        billingAddressParameters: {
+                            format: BillingAddressFormat.Full,
+                            phoneNumberRequired: true,
+                        },
+                    },
+                    tokenizationSpecification: {
+                        type: 'PAYMENT_GATEWAY',
+                        parameters: {
+                            gateway: 'worldpay',
+                            gatewayMerchantId,
+                        },
+                    },
+                },
+            ],
+            transactionInfo: {
+                countryCode,
+                currencyCode,
+                totalPriceStatus: 'FINAL',
+                totalPrice,
+            },
+            emailRequired: true,
+            shippingAddressRequired: !hasShippingAddress,
+            shippingAddressParameters: {
+                phoneNumberRequired: true,
+            },
+        };
+    }
+}

--- a/packages/core/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -759,3 +759,76 @@ export function getOrbitalTokenizedPayload(): TokenizePayload {
         },
     };
 }
+
+export function getGooglePayWorldpayAccessPaymentMethodMock(): PaymentMethod {
+    const paymentMethodMock = getPaymentMethodMock();
+
+    paymentMethodMock.initializationData.gatewayMerchantId = 'merchantId';
+
+    return paymentMethodMock;
+}
+
+export function getGooglePayWorldpayAccessPaymentDataRequest(): GooglePayPaymentDataRequestV2 {
+    return {
+        apiVersion: 2,
+        apiVersionMinor: 0,
+        merchantInfo: {
+            authJwt: 'platformToken',
+            merchantId: '123',
+            merchantName: 'name',
+        },
+        allowedPaymentMethods: [
+            {
+                type: 'CARD',
+                parameters: {
+                    allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+                    allowedCardNetworks: ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'],
+                    billingAddressRequired: true,
+                    billingAddressParameters: {
+                        format: BillingAddressFormat.Full,
+                        phoneNumberRequired: true,
+                    },
+                },
+                tokenizationSpecification: {
+                    type: 'PAYMENT_GATEWAY',
+                    parameters: {
+                        gateway: 'worldpay',
+                        gatewayMerchantId: 'merchantId',
+                    },
+                },
+            },
+        ],
+        transactionInfo: {
+            currencyCode: 'USD',
+            totalPriceStatus: 'FINAL',
+            totalPrice: '1.00',
+        },
+        emailRequired: true,
+        shippingAddressRequired: true,
+        shippingAddressParameters: {
+            phoneNumberRequired: true,
+        },
+    };
+}
+
+export function getGooglePayWorldpayAccessTokenizedPayload(): TokenizePayload {
+    return {
+        nonce: btoa(
+            '{"signature":"foo","protocolVersion":"ECv1","signedMessage":"{"encryptedMessage":"foo","ephemeralPublicKey":"foo"}"}',
+        ),
+        type: 'CARD',
+        details: {
+            cardType: 'MASTERCARD',
+            lastFour: '0304',
+        },
+    };
+}
+
+export function getGooglePayWorldpayAccessPaymentDataMock(): GooglePaymentData {
+    const googlePaymentDataMock = getGooglePaymentDataMock();
+
+    googlePaymentDataMock.paymentMethodData.tokenizationData.token =
+        '{"signature":"foo","protocolVersion":"ECv1","signedMessage":"{"encryptedMessage":"foo","ephemeralPublicKey":"foo"}"}';
+
+    return googlePaymentDataMock;
+}

--- a/packages/core/src/payment/strategies/googlepay/index.ts
+++ b/packages/core/src/payment/strategies/googlepay/index.ts
@@ -16,6 +16,7 @@ export { default as GooglePayOrbitalInitializer } from './googlepay-orbital-init
 export { default as GooglePayStripeInitializer } from './googlepay-stripe-initializer';
 export { default as GooglePayStripeUPEInitializer } from './googlepay-stripe-upe-initializer';
 export { default as GooglePayAuthorizeNetInitializer } from './googlepay-authorizenet-initializer';
+export { default as GooglePayWorldpayAccessInitializer } from './googlepay-worldpay-access-initializer';
 export { default as GooglePayPaymentInitializeOptions } from './googlepay-initialize-options';
 export { default as GooglePayPaymentProcessor } from './googlepay-payment-processor';
 export { default as createGooglePayPaymentProcessor } from './create-googlepay-payment-processor';


### PR DESCRIPTION
## What?
Created and modified files necessary for google pay initialization. Also unit tests were added.

## Why?
As a Merchant I want to enable Google Pay with Worldpay Access so that I can offer shoppers Google Pay as a payment method to my shoppers.

## Testing / Proof
<img width="1727" alt="googlepay2" src="https://user-images.githubusercontent.com/104527753/227593295-7485f585-1b2d-4e1b-92a8-9e0c0202b32c.png">

<img width="1727" alt="image" src="https://user-images.githubusercontent.com/104527753/227615498-33c081a9-c5d5-4062-b960-49be6d9d55d8.png">

<img width="1727" alt="googlepay" src="https://user-images.githubusercontent.com/104527753/227593289-8fb42651-88b4-4aba-9c45-56d885c48574.png">




@bigcommerce/checkout @bigcommerce/payments
