### PR TITLE
feat(payment): PAYPAL-1962 fixed paypalcommerce venmo button

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
@@ -8,6 +8,7 @@ import {
 import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import {
     ApproveCallbackPayload,
+    PayPalButtonStyleOptions,
     PayPalBuyNowInitializeOptions,
     PayPalCommerceButtonsOptions,
 } from '../paypal-commerce-types';
@@ -110,7 +111,9 @@ export default class PayPalCommerceVenmoButtonStrategy implements CheckoutButton
 
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {
             fundingSource,
-            style: this.paypalCommerceIntegrationService.getValidButtonStyle(style),
+            style: this.getValidVenmoButtonStyles(
+                this.paypalCommerceIntegrationService.getValidButtonStyle(style),
+            ),
             ...defaultCallbacks,
             ...(buyNowInitializeOptions && buyNowFlowCallbacks),
         };
@@ -122,6 +125,17 @@ export default class PayPalCommerceVenmoButtonStrategy implements CheckoutButton
         } else {
             this.paypalCommerceIntegrationService.removeElement(containerId);
         }
+    }
+
+    private getValidVenmoButtonStyles(style: PayPalButtonStyleOptions) {
+        if (style?.color === 'gold') {
+            return {
+                ...style,
+                color: undefined,
+            };
+        }
+
+        return style;
     }
 
     private async handleClick(


### PR DESCRIPTION
## What?
Fixed venmo button appearance  when gold color applied

## Why?
Because gold color is invalid for venmo button
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1962

## Testing / Proof
<img width="1680" alt="Screenshot 2023-03-14 at 09 58 58" src="https://user-images.githubusercontent.com/56301104/224934399-038f723f-e229-49e6-976d-c12c9c7dbd21.png">
<img width="1680" alt="Screenshot 2023-03-13 at 21 33 34" src="https://user-images.githubusercontent.com/56301104/224934405-e991dcf9-1f6d-4729-9690-9a5768f3b13a.png">

@bigcommerce/checkout @bigcommerce/payments
