### PR TITLE
feat(payment): PAYPAL-1962 fixed paypal venmo button

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.spec.ts
@@ -26,6 +26,7 @@ import {
     PayPalCommerceButtonsOptions,
     PayPalCommerceHostWindow,
     PayPalSDK,
+    StyleButtonColor,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceVenmoButtonInitializeOptions from './paypal-commerce-venmo-button-initialize-options';
@@ -323,6 +324,32 @@ describe('PayPalCommerceVenmoButtonStrategy', () => {
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.VENMO,
                 style: paypalCommerceVenmoOptions.style,
+                createOrder: expect.any(Function),
+                onApprove: expect.any(Function),
+            });
+        });
+
+        it('render button with undefined color (uses default blue) when it receives gold color setting', async () => {
+            const initializationVenmoOptions = {
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    style: {
+                        height: 45,
+                        color: StyleButtonColor.gold,
+                    },
+                },
+            };
+
+            const expectedStyles = {
+                height: 45,
+                color: undefined,
+            };
+
+            await strategy.initialize(initializationVenmoOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: paypalSdk.FUNDING.VENMO,
+                style: expectedStyles,
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
             });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-button-strategy.ts
@@ -8,8 +8,10 @@ import {
 import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import {
     ApproveCallbackPayload,
+    PayPalButtonStyleOptions,
     PayPalBuyNowInitializeOptions,
     PayPalCommerceButtonsOptions,
+    StyleButtonColor,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceVenmoButtonInitializeOptions, {
@@ -110,7 +112,7 @@ export default class PayPalCommerceVenmoButtonStrategy implements CheckoutButton
 
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {
             fundingSource,
-            style: this.paypalCommerceIntegrationService.getValidButtonStyle(style),
+            style: this.getValidVenmoButtonStyles(style),
             ...defaultCallbacks,
             ...(buyNowInitializeOptions && buyNowFlowCallbacks),
         };
@@ -122,6 +124,19 @@ export default class PayPalCommerceVenmoButtonStrategy implements CheckoutButton
         } else {
             this.paypalCommerceIntegrationService.removeElement(containerId);
         }
+    }
+
+    private getValidVenmoButtonStyles(style: PayPalButtonStyleOptions | undefined) {
+        const validButtonStyle = this.paypalCommerceIntegrationService.getValidButtonStyle(style);
+
+        if (validButtonStyle.color === StyleButtonColor.gold) {
+            return {
+                ...validButtonStyle,
+                color: undefined,
+            };
+        }
+
+        return validButtonStyle;
     }
 
     private async handleClick(


### PR DESCRIPTION
## What?
Fixed venmo button appearance when gold color applied

## Why?
Because gold color is invalid for venmo button
According to task https://bigcommercecloud.atlassian.net/browse/PAYPAL-1962

## Testing / Proof
<img width="1680" alt="Screenshot 2023-03-14 at 09 58 58" src="https://user-images.githubusercontent.com/56301104/224937927-d1d4af90-6438-4b42-9f18-4b63d2cab6ca.png">
<img width="1680" alt="Screenshot 2023-03-13 at 21 33 34" src="https://user-images.githubusercontent.com/56301104/224937943-9762032d-dbcb-4691-af49-00c8866124d7.png">


@bigcommerce/checkout @bigcommerce/payments
