### PR TITLE
fix(payment): CHECKOUT-000 Expose hosted form error to exported typings

### DIFF
--- a/packages/core/src/hosted-form/hosted-form-options.ts
+++ b/packages/core/src/hosted-form/hosted-form-options.ts
@@ -18,6 +18,22 @@ export default interface HostedFormOptions {
     onValidate?(data: HostedFieldValidateEventData): void;
 }
 
+export type HostedFormErrorDataKeys =
+    | 'number'
+    | 'expirationDate'
+    | 'expirationMonth'
+    | 'expirationYear'
+    | 'cvv'
+    | 'postalCode';
+
+export interface HostedFormErrorData {
+    isEmpty: boolean;
+    isPotentiallyValid: boolean;
+    isValid: boolean;
+}
+
+export type HostedFormErrorsData = Partial<Record<HostedFormErrorDataKeys, HostedFormErrorData>>;
+
 export type HostedFieldBlurEventData = HostedInputBlurEvent['payload'];
 export type HostedFieldCardTypeChangeEventData = HostedInputCardTypeChangeEvent['payload'];
 export type HostedFieldEnterEventData = HostedInputEnterEvent['payload'];

--- a/packages/core/src/hosted-form/iframe-content/hosted-input-events.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input-events.ts
@@ -6,6 +6,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import HostedFieldType from '../hosted-field-type';
+import { HostedFormErrorData } from '../hosted-form-options';
 
 import HostedInputInitializeErrorData from './hosted-input-initialize-error-data';
 import HostedInputValidateResults from './hosted-input-validate-results';
@@ -76,6 +77,7 @@ export interface HostedInputBlurEvent {
     type: HostedInputEventType.Blurred;
     payload: {
         fieldType: HostedFieldType;
+        errors?: HostedFormErrorData;
     };
 }
 

--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -482,6 +482,7 @@ export default class BraintreeHostedForm {
             case 'cardholderName':
             case 'cardType':
                 return true;
+
             default:
                 return false;
         }

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -1,3 +1,4 @@
+import { Omit } from '../../../common/types';
 import {
     GooglePayBraintreeDataRequest,
     GooglePayBraintreePaymentDataRequestV1,
@@ -6,7 +7,7 @@ import {
     TokenizePayload,
 } from '../googlepay';
 import { PaypalAuthorizeData, PaypalButtonOptions, PaypalButtonRender, PaypalSDK } from '../paypal';
-import { Omit } from '../../../common/types';
+
 import {
     VisaCheckoutInitOptions,
     VisaCheckoutPaymentSuccessPayload,


### PR DESCRIPTION
## What?
As above

## Why?
We have a feature to expose errors on blur for hosted forms added for braintree form in https://github.com/bigcommerce/checkout-sdk-js/pull/1883 PR.

But since Braintree form component uses the HOC for HostedForm we need to expose the errors as part of interface.

## Testing / Proof
- Cirlce

@bigcommerce/checkout @bigcommerce/payments
