### PR TITLE
feat(payment): PAYPAL-2003 fixed google pay button styles

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-options.ts
@@ -23,4 +23,12 @@ export interface GooglePayButtonInitializeOptions {
     buyNowInitializeOptions?: {
         getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
     };
+
+    /**
+     * This option contains button styles
+     */
+    style?: {
+        color: ButtonColor;
+        size: 'string';
+    };
 }

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-strategy.ts
@@ -82,7 +82,8 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
         currencyCode?: string,
     ): HTMLElement {
         const container = document.getElementById(containerId);
-        const { buttonType, buttonColor, buyNowInitializeOptions } = buttonOptions;
+        const { buttonType, buttonColor, buyNowInitializeOptions, style } = buttonOptions;
+        const { color } = style || {};
 
         if (!container) {
             throw new InvalidArgumentError(
@@ -96,7 +97,7 @@ export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
         const googlePayButton = this._googlePayPaymentProcessor.createButton(
             handleValidButtonClick,
             buttonType,
-            buttonColor,
+            buttonColor || color,
         );
 
         container.appendChild(googlePayButton);


### PR DESCRIPTION
## What?
Fixed googlepay button styles on PDP. Now it's styles applied from page builder

## Why?
Googlepay button didn't change styles before (default styles applied)

## Testing / Proof
<img width="1680" alt="Screenshot 2023-03-16 at 20 11 44" src="https://user-images.githubusercontent.com/56301104/225714681-2752911d-3054-4e52-8af0-cfd85cd2bc45.png">
<img width="1680" alt="Screenshot 2023-03-16 at 20 11 15" src="https://user-images.githubusercontent.com/56301104/225714703-c78f622c-a322-44b6-90f6-439eebc6b394.png">


@bigcommerce/checkout @bigcommerce/payments @serhii-tkachenko 
