### PR TITLE
refactor(payment): BOLT-000 add generic type for getPaymentMethod

### DIFF
--- a/packages/adyen-integration/src/adyenv2/adyenv2.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2.ts
@@ -894,3 +894,10 @@ export function isAccountState(param: any): param is AccountState {
 
     return bankSupported.indexOf(param.data.paymentMethod.type) !== -1;
 }
+
+export interface AdyenPaymentMethodInitializationData {
+    originKey?: string;
+    clientKey?: string;
+    environment?: string;
+    paymentMethodsResponse?: PaymentMethodsResponse;
+}

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -33,6 +33,7 @@ import {
     AdyenComponent,
     AdyenComponentType,
     AdyenError,
+    AdyenPaymentMethodInitializationData,
     AdyenPaymentMethodType,
     AdyenPlaceholderData,
     AdyenV3ComponentState,
@@ -71,10 +72,9 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
 
         const paymentMethod = this._paymentIntegrationService
             .getState()
-            .getPaymentMethodOrThrow(options.methodId);
-        const {
-            initializationData: { environment, clientKey, paymentMethodsResponse },
-        } = paymentMethod;
+            .getPaymentMethodOrThrow<AdyenPaymentMethodInitializationData>(options.methodId);
+        const { environment, clientKey, paymentMethodsResponse } =
+            paymentMethod.initializationData || {};
 
         this._adyenClient = await this._scriptLoader.load({
             environment,

--- a/packages/adyen-integration/src/adyenv3/adyenv3.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3.ts
@@ -881,3 +881,9 @@ export function isCardState(param: unknown): param is CardState {
         typeof (param as CardState).data.paymentMethod.encryptedExpiryMonth === 'string'
     );
 }
+
+export interface AdyenPaymentMethodInitializationData {
+    clientKey?: string;
+    environment?: string;
+    paymentMethodsResponse?: PaymentMethodsResponse;
+}

--- a/packages/payment-integration-api/src/payment-integration-selectors.ts
+++ b/packages/payment-integration-api/src/payment-integration-selectors.ts
@@ -48,8 +48,11 @@ export default interface PaymentIntegrationSelectors {
     getPaymentRedirectUrl(): string | undefined;
     getPaymentRedirectUrlOrThrow(): string;
 
-    getPaymentMethod(methodId: string, gatewayId?: string): PaymentMethod | undefined;
-    getPaymentMethodOrThrow(methodId: string, gatewayId?: string): PaymentMethod;
+    getPaymentMethod<T = unknown>(
+        methodId: string,
+        gatewayId?: string,
+    ): PaymentMethod<T> | undefined;
+    getPaymentMethodOrThrow<T = unknown>(methodId: string, gatewayId?: string): PaymentMethod<T>;
 
     getShippingAddress(): ShippingAddress | undefined;
     getShippingAddressOrThrow(): ShippingAddress;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -13,6 +13,7 @@ import {
     ApproveCallbackPayload,
     PayPalBuyNowInitializeOptions,
     PayPalCommerceButtonsOptions,
+    PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
@@ -104,8 +105,9 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
-        const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const { isHostedCheckoutEnabled } = paymentMethod.initializationData || {};
 
         const defaultCallbacks = {
             createOrder: () =>

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -17,6 +17,7 @@ import {
     ApproveCallbackActions,
     ApproveCallbackPayload,
     PayPalCommerceButtonsOptions,
+    PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
     StyleButtonColor,
@@ -91,8 +92,9 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
-        const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const { isHostedCheckoutEnabled } = paymentMethod.initializationData || {};
 
         const defaultCallbacks = {
             createOrder: () =>

--- a/packages/paypal-commerce-integration/src/paypal-commerce-inline/paypal-commerce-inline-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-inline/paypal-commerce-inline-button-strategy.ts
@@ -17,6 +17,7 @@ import {
     ApproveCallbackPayload,
     CompleteCallbackDataPayload,
     PayPalCommerceButtonsOptions,
+    PayPalCommerceInitializationData,
     PayPalCommerceIntent,
     PayPalSDK,
     ShippingAddressChangeCallbackPayload,
@@ -63,7 +64,8 @@ export default class PayPalCommerceInlineButtonStrategy implements CheckoutButto
 
         const state = this.paymentIntegrationService.getState();
         const currencyCode = state.getCartOrThrow().currency.code;
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
 
         this.paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
             paymentMethod,
@@ -232,8 +234,9 @@ export default class PayPalCommerceInlineButtonStrategy implements CheckoutButto
         callback?: () => void,
     ): Promise<void> {
         const state = this.paymentIntegrationService.getState();
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
-        const { intent } = paymentMethod.initializationData;
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const { intent } = paymentMethod.initializationData || {};
 
         if (intent === PayPalCommerceIntent.CAPTURE) {
             await this.submitPayment(methodId, data.orderID);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -19,6 +19,7 @@ import PayPalCommerceScriptLoader from './paypal-commerce-script-loader';
 import {
     PayPalButtonStyleOptions,
     PayPalBuyNowInitializeOptions,
+    PayPalCommerceInitializationData,
     PayPalOrderDetails,
     PayPalSDK,
     StyleButtonColor,
@@ -48,7 +49,8 @@ export default class PayPalCommerceIntegrationService {
     ): Promise<PayPalSDK> {
         const state = this.paymentIntegrationService.getState();
         const currencyCode = providedCurrencyCode || state.getCartOrThrow().currency.code;
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
 
         this.paypalSdk = await this.paypalCommerceScriptLoader.getPayPalSDK(
             paymentMethod,

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -13,6 +13,7 @@ import {
     ApproveCallbackPayload,
     PayPalBuyNowInitializeOptions,
     PayPalCommerceButtonsOptions,
+    PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
@@ -98,8 +99,9 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
-        const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const { isHostedCheckoutEnabled } = paymentMethod.initializationData || {};
 
         const defaultCallbacks = {
             createOrder: () => this.paypalCommerceIntegrationService.createOrder('paypalcommerce'),

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -17,6 +17,7 @@ import {
     ApproveCallbackActions,
     ApproveCallbackPayload,
     PayPalCommerceButtonsOptions,
+    PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
 } from '../paypal-commerce-types';
@@ -94,8 +95,9 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
-        const paymentMethod = state.getPaymentMethodOrThrow(methodId);
-        const { isHostedCheckoutEnabled } = paymentMethod.initializationData;
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const { isHostedCheckoutEnabled } = paymentMethod.initializationData || {};
 
         const defaultCallbacks = {
             createOrder: () => this.paypalCommerceIntegrationService.createOrder('paypalcommerce'),

--- a/packages/squarev2-integration/src/types.ts
+++ b/packages/squarev2-integration/src/types.ts
@@ -1,1 +1,6 @@
 export * from '@square/web-payments-sdk-types';
+
+export interface SquarePaymentMethodInitializationData {
+    applicationId: string;
+    locationId?: string;
+}


### PR DESCRIPTION
## What?
Add generic type for `getPaymentMethod` & `getPaymentMethodOrThrow` in payment-integration-api

## Why?
Because this methods return instance of `PaymentMethod` and this interface has generic type for `initializationData`
[https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/payment-integration-api/src/payment/payment-method.ts](https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/payment-integration-api/src/payment/payment-method.ts)

If we want to describe correct type for `PaymentMethod.initializationData` we need to call this methods with generic type.
`unknown` - by default, for cases when we need `PaymentMethod` but don't use `initializationData` from it

## Testing / Proof
unit tests

@bigcommerce/checkout @bigcommerce/payments
