### PR TITLE
feat(checkout): CHECKOUT-7250 Add `floatingLabelEnabled` to `UserExperienceSettings` interface

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -89,9 +89,10 @@ export interface StoreCurrency {
     thousandsSeparator: string;
 }
 
-export type UserExperienceSettingNames = 'walletButtonsOnTop';
-
-export type UserExperienceSettings = { [key in UserExperienceSettingNames]: boolean };
+export interface UserExperienceSettings {
+    walletButtonsOnTop: boolean;
+    floatingLabelEnabled: boolean;
+}
 
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -23,6 +23,7 @@ export function getConfig(): Config {
                 checkoutBillingSameAsShippingEnabled: true,
                 checkoutUserExperienceSettings: {
                     walletButtonsOnTop: false,
+                    floatingLabelEnabled: false,
                 },
                 enableOrderComments: true,
                 enableTermsAndConditions: false,

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -88,9 +88,10 @@ export interface StoreCurrency {
     thousandsSeparator: string;
 }
 
-export type UserExperienceSettingNames = 'walletButtonsOnTop';
-
-export type UserExperienceSettings = { [key in UserExperienceSettingNames]: boolean };
+export interface UserExperienceSettings {
+    walletButtonsOnTop: boolean;
+    floatingLabelEnabled: boolean;
+}
 
 export interface CheckoutSettings {
     features: { [featureName: string]: boolean };

--- a/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
@@ -20,6 +20,7 @@ export default function getConfig(): Config {
                 checkoutBillingSameAsShippingEnabled: true,
                 checkoutUserExperienceSettings: {
                     walletButtonsOnTop: false,
+                    floatingLabelEnabled: false,
                 },
                 enableOrderComments: true,
                 enableTermsAndConditions: false,


### PR DESCRIPTION
## What?
Add `floatingLabelEnabled` to the `UserExperienceSettings` interface.

## Why?
We've updated the BCapp to allow merchants to toggle floating label usage.

## Depends on
https://github.com/bigcommerce/bigcommerce/pull/51713

## Relates to
https://github.com/bigcommerce/checkout-settings-ui/pull/92
[place holder] a `checkout-js` PR uses this PR to display floating labels.

## Testing / Proof
CI.

@bigcommerce/checkout @bigcommerce/payments
