### PR TITLE
feat(payment): PAYPAL-2004 added ability to change style for amazonpay button

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-options.ts
@@ -1,5 +1,8 @@
 import { BuyNowCartRequestBody } from '../../../cart';
-import { AmazonPayV2ButtonParameters } from '../../../payment/strategies/amazon-pay-v2';
+import {
+    AmazonPayV2ButtonConfig,
+    AmazonPayV2ButtonParameters,
+} from '../../../payment/strategies/amazon-pay-v2';
 
 export function isWithBuyNowFeatures(options: unknown): options is WithBuyNowFeature {
     if (!(options instanceof Object)) {
@@ -9,7 +12,7 @@ export function isWithBuyNowFeatures(options: unknown): options is WithBuyNowFea
     return 'buyNowInitializeOptions' in options;
 }
 
-export interface WithBuyNowFeature {
+export interface WithBuyNowFeature extends AmazonPayV2ButtonConfig {
     /**
      * The options that are required to initialize Buy Now functionality.
      */

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.spec.ts
@@ -15,6 +15,7 @@ import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { getAmazonPayV2, getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import {
+    AmazonPayV2ButtonColor,
     AmazonPayV2PaymentProcessor,
     AmazonPayV2Placement,
     createAmazonPayV2PaymentProcessor,
@@ -127,6 +128,7 @@ describe('AmazonPayV2ButtonStrategy', () => {
             await strategy.initialize(checkoutButtonOptions);
 
             expect(paymentProcessor.renderAmazonPayButton).toHaveBeenCalledWith({
+                buttonColor: AmazonPayV2ButtonColor.Gold,
                 checkoutState: store.getState(),
                 containerId: 'amazonpayCheckoutButton',
                 methodId: 'amazonpay',

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button-strategy.ts
@@ -34,6 +34,7 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
 
     async initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
         const { methodId, containerId, amazonpay } = options;
+        const { buttonColor } = amazonpay || {};
 
         if (!methodId || !containerId) {
             throw new InvalidArgumentError(
@@ -73,6 +74,7 @@ export default class AmazonPayV2ButtonStrategy implements CheckoutButtonStrategy
             methodId,
             options: initializeAmazonButtonOptions,
             placement: AmazonPayV2Placement.Cart,
+            buttonColor,
         });
 
         if (this._buyNowCartRequestBody) {

--- a/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button.mock.ts
+++ b/packages/core/src/checkout-buttons/strategies/amazon-pay-v2/amazon-pay-v2-button.mock.ts
@@ -4,6 +4,10 @@ import BuyNowCartRequestBody from '../../../cart/buy-now-cart-request-body';
 import { getAmazonPayV2ButtonParamsMock } from '../../../payment/strategies/amazon-pay-v2/amazon-pay-v2.mock';
 import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
 import CheckoutButtonMethodType from '../checkout-button-method-type';
+import {
+    AmazonPayV2LedgerCurrency,
+    AmazonPayV2Placement,
+} from '../../../payment/strategies/amazon-pay-v2';
 
 export enum Mode {
     Full,
@@ -60,7 +64,16 @@ export function getAmazonPayV2CheckoutButtonOptions(
             return { ...getAmazonPayV2CheckoutButtonOptions(Mode.Full), amazonpay: undefined };
 
         case Mode.BuyNowFlow:
-            return { ...methodId, containerId, amazonpay: { ...amazonPayV2BuyNowOptions } };
+            return {
+                ...methodId,
+                containerId,
+                amazonpay: {
+                    ...amazonPayV2BuyNowOptions,
+                    merchantId: '',
+                    placement: AmazonPayV2Placement.Checkout,
+                    ledgerCurrency: AmazonPayV2LedgerCurrency.USD,
+                },
+            };
 
         default:
             return { ...methodId, containerId };

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -107,6 +107,7 @@ export default class AmazonPayV2PaymentProcessor {
     }
 
     renderAmazonPayButton({
+        buttonColor,
         checkoutState,
         containerId,
         decoupleCheckoutInitiation = false,
@@ -131,6 +132,7 @@ export default class AmazonPayV2PaymentProcessor {
                 methodId,
                 placement,
                 decoupleCheckoutInitiation,
+                buttonColor,
             );
 
         this.createButton(parentContainerId, amazonPayV2ButtonOptions);
@@ -194,6 +196,7 @@ export default class AmazonPayV2PaymentProcessor {
         methodId: string,
         placement: AmazonPayV2Placement,
         decoupleCheckoutInitiation = false,
+        buttonColor = AmazonPayV2ButtonColor.Gold,
     ): AmazonPayV2ButtonParameters {
         const {
             config: { merchantId, testMode },
@@ -216,7 +219,7 @@ export default class AmazonPayV2PaymentProcessor {
             ledgerCurrency,
             checkoutLanguage,
             placement,
-            buttonColor: AmazonPayV2ButtonColor.Gold,
+            buttonColor,
         };
 
         if (this._buyNowCartRequestBody) {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -244,6 +244,7 @@ export interface AmazonPayV2ButtonRenderingOptions {
     containerId: string;
     decoupleCheckoutInitiation?: boolean;
     methodId: string;
+    buttonColor?: AmazonPayV2ButtonColor;
     options?: AmazonPayV2ButtonParameters;
     placement: AmazonPayV2Placement;
 }


### PR DESCRIPTION
## What?
Added ability to change style for amazonpay button from Page Builder on PDP

## Why?
To make amazon SPB customisable 

## Testing / Proof
<img width="1680" alt="Screenshot 2023-03-20 at 19 15 43" src="https://user-images.githubusercontent.com/56301104/226417254-51418e1f-3984-4e4c-8538-729d5400be2f.png">
<img width="1680" alt="Screenshot 2023-03-20 at 19 15 29" src="https://user-images.githubusercontent.com/56301104/226417263-98e5aac0-817c-4fd8-9362-328ff2d64d5a.png">
<img width="1680" alt="Screenshot 2023-03-20 at 19 15 06" src="https://user-images.githubusercontent.com/56301104/226417267-73f7c21a-28a4-4643-bce9-5866f4fe6a14.png">


@bigcommerce/checkout @bigcommerce/payments @bc-peng @animesh1987 
