### PR TITLE
fix(payment): INT-7044 BlueSnapDirect: Change identifier for credit card

### DIFF
--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-credit-card-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-credit-card-payment-strategy.ts
@@ -24,5 +24,5 @@ const createBlueSnapDirectCreditCardPaymentStrategy: PaymentStrategyFactory<
     );
 
 export default toResolvableModule(createBlueSnapDirectCreditCardPaymentStrategy, [
-    { id: 'credit_card', gateway: 'bluesnapdirect' },
+    { gateway: 'bluesnapdirect' },
 ]);


### PR DESCRIPTION
## What?
Change the identifier of BlueSnap's credit card module.

## Why?
Because other modules are not specific enough:

https://github.com/bigcommerce/checkout-sdk-js/blob/de30fd838791151d5dc503d56b9f266a5c1e760b/packages/offsite-integration/src/create-offsite-payment-strategy.ts#L12

And Barclaycard, for example, is loading BlueSnap's cc strategy instead because also has an id = 'credit_card' and also was registered first. Example:

```js
const query = '{"id":"credit_card","gateway":"barclaycard","type":"PAYMENT_TYPE_HOSTED"}'

const matched = [
    {token: '{"id":"credit_card","gateway":"bluesnapdirect"}', matches: 1}, // it matches `id`
    {token: '{"type":"PAYMENT_TYPE_HOSTED"}', matches: 1}, // it matches `type`
];

result = matched[0];
```

The result is due to this algorithm:

https://github.com/bigcommerce/checkout-sdk-js/blob/de30fd838791151d5dc503d56b9f266a5c1e760b/packages/core/src/common/registry/resolve-id-registry.ts#L30-L68

So this is a workaround that works in the meanwhile but needs to be handled soon because we need to introduce BlueSnap ACH/ECP and would be necessary to reintroduce the original change to differentiate strategies.

## Testing / Proof


@bigcommerce/checkout @bigcommerce/payments
