### PR TITLE
feat(payment): INT-7173 BlueSnapDirect: Create payment strategy for ACH/ECP

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-ecp-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-ecp-payment-strategy.spec.ts
@@ -1,0 +1,114 @@
+import {
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BlueSnapDirectEcpPaymentStrategy from './bluesnap-direct-ecp-payment-strategy';
+
+describe('BlueSnapDirectCreditCardPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+    let strategy: BlueSnapDirectEcpPaymentStrategy;
+
+    beforeEach(() => {
+        paymentIntegrationService =
+            new PaymentIntegrationServiceMock() as PaymentIntegrationService;
+
+        strategy = new BlueSnapDirectEcpPaymentStrategy(paymentIntegrationService);
+    });
+
+    describe('#initialize()', () => {
+        it('initializes the strategy successfully', async () => {
+            const initialize = strategy.initialize();
+
+            await expect(initialize).resolves.toBeUndefined();
+        });
+    });
+
+    describe('#execute()', () => {
+        let payload: OrderRequestBody;
+
+        beforeEach(async () => {
+            payload = {
+                payment: {
+                    gatewayId: 'bluesnapdirect',
+                    methodId: 'ecp',
+                    paymentData: {
+                        accountNumber: '223344556',
+                        accountType: 'CONSUMER_CHECKING',
+                        shopperPermission: true,
+                        routingNumber: '998877665',
+                    },
+                },
+            };
+
+            await strategy.initialize();
+        });
+
+        afterEach(() => {
+            (paymentIntegrationService.submitOrder as jest.Mock).mockClear();
+            (paymentIntegrationService.submitPayment as jest.Mock).mockClear();
+        });
+
+        it('executes the strategy successfully', async () => {
+            const execute = strategy.execute(payload);
+
+            await expect(execute).resolves.toBeUndefined();
+        });
+
+        it('should submit the order', async () => {
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+        });
+
+        it('should submit the payment', async () => {
+            const expectedPayment = {
+                gatewayId: 'bluesnapdirect',
+                methodId: 'ecp',
+                paymentData: {
+                    formattedPayload: {
+                        ecp: {
+                            account_number: '223344556',
+                            account_type: 'CONSUMER_CHECKING',
+                            routing_number: '998877665',
+                            shopper_permission: true,
+                        },
+                    },
+                },
+            };
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        });
+
+        describe('should fail if...', () => {
+            test('payload.payment is not en ECP instrument', async () => {
+                const execute = () => strategy.execute({ ...payload, payment: undefined });
+
+                await expect(execute()).rejects.toThrow(PaymentArgumentInvalidError);
+                expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            const finalize = strategy.finalize();
+
+            await expect(finalize).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes the strategy successfully', async () => {
+            const deinitialize = strategy.deinitialize();
+
+            await expect(deinitialize).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-ecp-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-ecp-payment-strategy.ts
@@ -1,0 +1,43 @@
+import {
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentIntegrationService,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import assertBlueSnapDirectEcpInstrument from './is-bluesnap-direct-ecp-instrument';
+
+export default class BlueSnapDirectEcpPaymentStrategy implements PaymentStrategy {
+    constructor(private _paymentIntegrationService: PaymentIntegrationService) {}
+
+    initialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    async execute({ payment }: OrderRequestBody): Promise<void> {
+        assertBlueSnapDirectEcpInstrument(payment?.paymentData);
+
+        await this._paymentIntegrationService.submitOrder();
+        await this._paymentIntegrationService.submitPayment({
+            ...payment,
+            paymentData: {
+                formattedPayload: {
+                    ecp: {
+                        account_number: payment.paymentData.accountNumber,
+                        account_type: payment.paymentData.accountType,
+                        shopper_permission: payment.paymentData.shopperPermission,
+                        routing_number: payment.paymentData.routingNumber,
+                    },
+                },
+            },
+        });
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<void> {
+        return Promise.resolve();
+    }
+}

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-credit-card-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-credit-card-payment-strategy.ts
@@ -24,5 +24,5 @@ const createBlueSnapDirectCreditCardPaymentStrategy: PaymentStrategyFactory<
     );
 
 export default toResolvableModule(createBlueSnapDirectCreditCardPaymentStrategy, [
-    { gateway: 'bluesnapdirect' },
+    { id: 'credit_card', gateway: 'bluesnapdirect' },
 ]);

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-ecp-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-ecp-payment-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BlueSnapDirectEcpPaymentStrategy from './bluesnap-direct-ecp-payment-strategy';
+import createBlueSnapDirectEcpPaymentStrategy from './create-bluesnap-direct-ecp-payment-strategy';
+
+describe('createBlueSnapDirectEcpPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService =
+            new PaymentIntegrationServiceMock() as PaymentIntegrationService;
+    });
+
+    it('instantiates bluesnapdirect ecp payment strategy', () => {
+        const strategy = createBlueSnapDirectEcpPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(BlueSnapDirectEcpPaymentStrategy);
+    });
+});

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-ecp-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-ecp-payment-strategy.ts
@@ -1,0 +1,14 @@
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BlueSnapDirectEcpPaymentStrategy from './bluesnap-direct-ecp-payment-strategy';
+
+const createBlueSnapDirectEcpPaymentStrategy: PaymentStrategyFactory<
+    BlueSnapDirectEcpPaymentStrategy
+> = (paymentIntegrationService) => new BlueSnapDirectEcpPaymentStrategy(paymentIntegrationService);
+
+export default toResolvableModule(createBlueSnapDirectEcpPaymentStrategy, [
+    { id: 'ecp', gateway: 'bluesnapdirect' },
+]);

--- a/packages/bluesnap-direct-integration/src/index.ts
+++ b/packages/bluesnap-direct-integration/src/index.ts
@@ -1,1 +1,2 @@
 export { default as createBlueSnapDirectCreditCardPaymentStrategy } from './create-bluesnap-direct-credit-card-payment-strategy';
+export { default as createBlueSnapDirectEcpPaymentStrategy } from './create-bluesnap-direct-ecp-payment-strategy';

--- a/packages/bluesnap-direct-integration/src/is-bluesnap-direct-ecp-instrument.ts
+++ b/packages/bluesnap-direct-integration/src/is-bluesnap-direct-ecp-instrument.ts
@@ -1,0 +1,28 @@
+import {
+    BlueSnapDirectEcpInstrument,
+    OrderPaymentRequestBody,
+    PaymentArgumentInvalidError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+function isBlueSnapDirectEcpInstrument(
+    data: OrderPaymentRequestBody['paymentData'],
+): data is BlueSnapDirectEcpInstrument {
+    if (data === undefined) {
+        return false;
+    }
+
+    return (
+        'accountNumber' in data &&
+        'accountType' in data &&
+        'shopperPermission' in data &&
+        'routingNumber' in data
+    );
+}
+
+export default function assertBlueSnapDirectEcpInstrument(
+    data: OrderPaymentRequestBody['paymentData'],
+): asserts data is BlueSnapDirectEcpInstrument {
+    if (!isBlueSnapDirectEcpInstrument(data)) {
+        throw new PaymentArgumentInvalidError();
+    }
+}

--- a/packages/core/src/order/order-request-body.ts
+++ b/packages/core/src/order/order-request-body.ts
@@ -1,4 +1,7 @@
-import { WithAccountCreation } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    BlueSnapDirectEcpInstrument,
+    WithAccountCreation,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import {
     CreditCardInstrument,
@@ -41,6 +44,7 @@ export type OrderPaymentInstrument =
     | HostedVaultedInstrument
     | NonceInstrument
     | VaultedInstrument
+    | BlueSnapDirectEcpInstrument
     | (CreditCardInstrument & WithDocumentInstrument)
     | (CreditCardInstrument & WithCheckoutcomFawryInstrument)
     | (CreditCardInstrument & WithCheckoutcomSEPAInstrument)

--- a/packages/core/src/payment/payment.ts
+++ b/packages/core/src/payment/payment.ts
@@ -1,4 +1,8 @@
-import { WithAccountCreation } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    BlueSnapDirectEcpInstrument,
+    BlueSnapDirectEcpPayload,
+    WithAccountCreation,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { BrowserInfo } from '../common/browser-info';
 import { Omit } from '../common/types';
@@ -13,6 +17,7 @@ export default interface Payment {
 }
 
 export type PaymentInstrument =
+    | BlueSnapDirectEcpInstrument
     | CreditCardInstrument
     | (CreditCardInstrument & WithHostedFormNonce)
     | (CreditCardInstrument & WithDocumentInstrument)
@@ -23,6 +28,7 @@ export type PaymentInstrument =
     | FormattedPayload<
           | AdyenV2Instrument
           | AppleInstrument
+          | BlueSnapDirectEcpPayload
           | BoltInstrument
           | PaypalInstrument
           | FormattedHostedInstrument

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -101,6 +101,8 @@ export {
     OrderRequestBody,
 } from './order';
 export {
+    BlueSnapDirectEcpInstrument,
+    BlueSnapDirectEcpPayload,
     CardInstrument,
     CreditCardInstrument,
     isVaultedInstrument,

--- a/packages/payment-integration-api/src/order/order-request-body.ts
+++ b/packages/payment-integration-api/src/order/order-request-body.ts
@@ -1,4 +1,5 @@
 import {
+    BlueSnapDirectEcpInstrument,
     CreditCardInstrument,
     HostedCreditCardInstrument,
     HostedInstrument,
@@ -59,6 +60,7 @@ export interface OrderPaymentRequestBody {
         | HostedVaultedInstrument
         | NonceInstrument
         | VaultedInstrument
+        | BlueSnapDirectEcpInstrument
         | (CreditCardInstrument & WithDocumentInstrument)
         | (CreditCardInstrument & WithCheckoutcomFawryInstrument)
         | (CreditCardInstrument & WithCheckoutcomSEPAInstrument)

--- a/packages/payment-integration-api/src/payment/index.ts
+++ b/packages/payment-integration-api/src/payment/index.ts
@@ -3,6 +3,8 @@ export { AccountInstrument, CardInstrument } from './instrument';
 
 export {
     default as Payment,
+    BlueSnapDirectEcpInstrument,
+    BlueSnapDirectEcpPayload,
     CreditCardInstrument,
     WithCheckoutcomiDealInstrument,
     WithCheckoutcomFawryInstrument,

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -11,6 +11,7 @@ export default interface Payment {
 }
 
 export type PaymentInstrument =
+    | BlueSnapDirectEcpInstrument
     | CreditCardInstrument
     | (CreditCardInstrument & WithHostedFormNonce)
     | (CreditCardInstrument & WithDocumentInstrument)
@@ -22,6 +23,7 @@ export type PaymentInstrument =
           | AdyenV2Instrument
           | AppleInstrument
           | BlueSnapDirectCreditCardInstrument
+          | BlueSnapDirectEcpPayload
           | BoltInstrument
           | PaypalInstrument
           | FormattedHostedInstrument
@@ -200,6 +202,28 @@ interface AdyenV2Card {
 interface BlueSnapDirectCreditCardInstrument {
     credit_card_token: {
         token: string;
+    };
+}
+
+type BlueSnapDirectEcpAccountType =
+    | 'CONSUMER_CHECKING'
+    | 'CONSUMER_SAVINGS'
+    | 'CORPORATE_CHECKING'
+    | 'CORPORATE_SAVINGS';
+
+export interface BlueSnapDirectEcpInstrument {
+    accountNumber: string;
+    accountType: BlueSnapDirectEcpAccountType;
+    shopperPermission: boolean;
+    routingNumber: string;
+}
+
+export interface BlueSnapDirectEcpPayload {
+    ecp: {
+        account_number: string;
+        account_type: BlueSnapDirectEcpAccountType;
+        shopper_permission: boolean;
+        routing_number: string;
     };
 }
 


### PR DESCRIPTION
## What? [INT-7173](https://bigcommercecloud.atlassian.net/browse/INT-7173)
Add a payment strategy for [ACH/ECP with BlueSnap](https://developers.bluesnap.com/reference/ach-ecp).

**UPDATE:** Also reverted #1917 due to #1946 which solved the problem.

## Why?
To offer shoppers an alternative to credit card payments.

## Testing / Proof
https://user-images.githubusercontent.com/4843328/227052142-e4caff0a-a9c8-4458-a039-64af68b77e34.mp4

## Dependency of:
👉 https://github.com/bigcommerce/checkout-js/pull/1218

@bigcommerce/checkout @bigcommerce/payments


[INT-7173]: https://bigcommercecloud.atlassian.net/browse/INT-7173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ