### PR TITLE
feat(payment): PAYPAL-2050 fixed google pay button for safari and mozilla

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -24,6 +24,7 @@ import { PaymentMethod } from '../../../payment';
 import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
 import {
+    CallbackTriggerType,
     createGooglePayPaymentProcessor,
     GooglePayBraintreeInitializer,
     GooglePayPaymentProcessor,
@@ -34,6 +35,7 @@ import CheckoutButtonMethodType from '../checkout-button-method-type';
 
 import GooglePayButtonStrategy from './googlepay-button-strategy';
 import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-button.mock';
+import { EventEmitter } from 'events';
 
 describe('GooglePayCheckoutButtonStrategy', () => {
     let cart: Cart;
@@ -41,6 +43,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
     let formPoster: FormPoster;
     let cartRequestSender: CartRequestSender;
     let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+    let eventEmitter: EventEmitter;
     let paymentMethod: PaymentMethod;
     let paymentProcessor: GooglePayPaymentProcessor;
     let checkoutActionCreator: CheckoutActionCreator;
@@ -65,6 +68,8 @@ describe('GooglePayCheckoutButtonStrategy', () => {
             cart: getCartState(),
             paymentMethods: getPaymentMethodsState(),
         });
+
+        eventEmitter = new EventEmitter();
 
         cart = getCart();
         requestSender = createRequestSender();
@@ -179,24 +184,41 @@ describe('GooglePayCheckoutButtonStrategy', () => {
 
             expect(paymentProcessor.initialize).toHaveBeenCalledWith(
                 CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE,
+                {
+                    environment: 'TEST',
+                    paymentDataCallbacks: {
+                        onPaymentDataChanged: expect.any(Function),
+                    },
+                },
             );
             expect(checkoutActionCreator.loadDefaultCheckout).not.toHaveBeenCalled();
         });
 
         it('creates order with Buy Now cart id (Buy Now flow)', async () => {
-            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({
-                body: buyNowCartMock,
-            });
-            jest.spyOn(paymentProcessor, 'displayWallet').mockResolvedValue(
-                getGooglePaymentDataMock(),
-            );
-            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
             jest.spyOn(paymentProcessor, 'updateShippingAddress').mockReturnValue(
                 Promise.resolve(),
             );
             jest.spyOn(paymentProcessor, 'updatePaymentDataRequest').mockReturnValue(
                 Promise.resolve(),
             );
+            jest.spyOn(cartRequestSender, 'createBuyNowCart').mockReturnValue({
+                body: buyNowCartMock,
+            });
+            jest.spyOn(paymentProcessor, 'handleSuccess').mockReturnValue(Promise.resolve());
+            jest.spyOn(paymentProcessor, 'initialize').mockImplementation(
+                (_methodId, googlePayClientOptions) => {
+                    eventEmitter.on('onPaymentDataChanged', () => {
+                        googlePayClientOptions.paymentDataCallbacks.onPaymentDataChanged({
+                            callbackTrigger: CallbackTriggerType.INITIALIZE,
+                        });
+                    });
+                },
+            );
+            jest.spyOn(paymentProcessor, 'displayWallet').mockImplementation(() => {
+                eventEmitter.emit('onPaymentDataChanged');
+
+                return getGooglePaymentDataMock();
+            });
 
             checkoutButtonOptions = getCheckoutButtonOptions(
                 CheckoutButtonMethodType.GOOGLEPAY_BRAINTREE,

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-options.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-options.ts
@@ -1,5 +1,5 @@
-import { BuyNowCartRequestBody } from '../../../cart';
 import { ButtonColor, ButtonType } from '../../../payment/strategies/googlepay';
+import { GooglePayBuyNowInitializeOptions } from './googlepay-button-types';
 
 export interface GooglePayButtonInitializeOptions {
     /**
@@ -20,7 +20,5 @@ export interface GooglePayButtonInitializeOptions {
     /**
      * The options that are required to initialize Buy Now functionality.
      */
-    buyNowInitializeOptions?: {
-        getBuyNowCartRequestBody?(): BuyNowCartRequestBody | void;
-    };
+    buyNowInitializeOptions?: GooglePayBuyNowInitializeOptions;
 }

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-types.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-button-types.ts
@@ -1,0 +1,5 @@
+import { BuyNowCartRequestBody } from '../../../cart';
+
+export interface GooglePayBuyNowInitializeOptions {
+    getBuyNowCartRequestBody?(): BuyNowCartRequestBody;
+}

--- a/packages/core/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -172,8 +172,10 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         const hasPhysicalItems = getShippableItemsCount(cart) > 0;
 
         const payloadToUpdate = {
-            currencyCode: cart.currency.code,
-            totalPrice: String(cart.cartAmount),
+            transactionInfo: {
+                currencyCode: cart.currency.code,
+                totalPrice: String(cart.cartAmount),
+            },
         };
 
         this._googlePayPaymentProcessor.updatePaymentDataRequest(payloadToUpdate);

--- a/packages/core/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-adyenv2-initializer.ts
@@ -9,6 +9,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 export default class GooglePayAdyenV2Initializer implements GooglePayInitializer {
@@ -100,7 +101,7 @@ export default class GooglePayAdyenV2Initializer implements GooglePayInitializer
             transactionInfo: {
                 countryCode,
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-adyenv3-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-adyenv3-initializer.ts
@@ -9,6 +9,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 export default class GooglePayAdyenV3Initializer implements GooglePayInitializer {
@@ -100,7 +101,7 @@ export default class GooglePayAdyenV3Initializer implements GooglePayInitializer
             transactionInfo: {
                 countryCode,
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-authorizenet-initializer.ts
@@ -10,6 +10,7 @@ import {
     GooglePayPaymentDataRequestV2,
     TokenizationSpecification,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 const baseRequest = {
@@ -82,7 +83,7 @@ export default class GooglePayAuthorizeNetInitializer implements GooglePayInitia
             ...baseRequest,
             allowedPaymentMethods: [cardPaymentMethod],
             transactionInfo: {
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
                 currencyCode,
                 countryCode,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-bnz-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-bnz-initializer.ts
@@ -9,6 +9,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 export default class GooglePayBNZInitializer implements GooglePayInitializer {
@@ -98,7 +99,7 @@ export default class GooglePayBNZInitializer implements GooglePayInitializer {
             ],
             transactionInfo: {
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -11,6 +11,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 import {
     GooglePayBraintreeDataRequest,
@@ -89,7 +90,7 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
             },
             transactionInfo: {
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             cardRequirements: {

--- a/packages/core/src/payment/strategies/googlepay/googlepay-braintree.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-braintree.ts
@@ -1,4 +1,5 @@
-type TotalPriceStatus = 'ESTIMATED' | 'FINAL' | 'NOT_CURRENTLY_KNOWN';
+import { TotalPriceStatusType } from './googlepay';
+
 type AddressFormat = 'FULL' | 'MIN';
 
 export interface GooglePayBraintreeDataRequest {
@@ -9,7 +10,7 @@ export interface GooglePayBraintreeDataRequest {
     };
     transactionInfo: {
         currencyCode: string;
-        totalPriceStatus: TotalPriceStatus;
+        totalPriceStatus: TotalPriceStatusType;
         totalPrice: string;
     };
     cardRequirements: {
@@ -55,6 +56,6 @@ export interface GooglePayBraintreePaymentDataRequestV1 {
     transactionInfo: {
         currencyCode: string;
         totalPrice: string;
-        totalPriceStatus: string;
+        totalPriceStatus: TotalPriceStatusType;
     };
 }

--- a/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-checkoutcom-initializer.ts
@@ -15,6 +15,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 export default class GooglePayCheckoutcomInitializer implements GooglePayInitializer {
@@ -160,7 +161,7 @@ export default class GooglePayCheckoutcomInitializer implements GooglePayInitial
             ],
             transactionInfo: {
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-cybersourcev2-initializer.ts
@@ -9,6 +9,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 export default class GooglePayCybersourceV2Initializer implements GooglePayInitializer {
@@ -98,7 +99,7 @@ export default class GooglePayCybersourceV2Initializer implements GooglePayIniti
             ],
             transactionInfo: {
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-orbital-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-orbital-initializer.ts
@@ -9,6 +9,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 export default class GooglePayOrbitalInitializer implements GooglePayInitializer {
@@ -98,7 +99,7 @@ export default class GooglePayOrbitalInitializer implements GooglePayInitializer
             ],
             transactionInfo: {
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
@@ -30,6 +30,7 @@ import {
     GooglePayIsReadyToPayResponse,
     GooglePaymentsError,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 import GooglePayBraintreeInitializer from './googlepay-braintree-initializer';
 import GooglePayPaymentProcessor from './googlepay-payment-processor';
@@ -538,12 +539,14 @@ describe('GooglePayPaymentProcessor', () => {
         it('should updates payment data request', async () => {
             const googlePaymentDataMock = getGooglePayPaymentDataRequestMock();
             const payloadToUpdate = {
-                currencyCode: 'EUR',
-                totalPrice: '1.02',
+                transactionInfo: {
+                    currencyCode: 'EUR',
+                    totalPrice: '1.02',
+                    totalPriceStatus: TotalPriceStatusType.FINAL,
+                },
             };
 
-            googlePaymentDataMock.transactionInfo.currencyCode = payloadToUpdate.currencyCode;
-            googlePaymentDataMock.transactionInfo.totalPrice = payloadToUpdate.totalPrice;
+            googlePaymentDataMock.transactionInfo = payloadToUpdate.transactionInfo;
 
             await processor.initialize('googlepay');
 

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -391,8 +391,10 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             const cart = this._store.getState().cart.getCartOrThrow();
 
             const payloadToUpdate = {
-                currencyCode: cart.currency.code,
-                totalPrice: String(cart.cartAmount),
+                transactionInfo: {
+                    currencyCode: cart.currency.code,
+                    totalPrice: String(cart.cartAmount),
+                },
             };
 
             this._googlePayPaymentProcessor.updatePaymentDataRequest(payloadToUpdate);

--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-initializer.ts
@@ -10,6 +10,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 export default class GooglePayStripeInitializer implements GooglePayInitializer {
@@ -104,7 +105,7 @@ export default class GooglePayStripeInitializer implements GooglePayInitializer 
             ],
             transactionInfo: {
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-stripe-upe-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-stripe-upe-initializer.ts
@@ -12,6 +12,7 @@ import {
     GooglePaymentData,
     GooglePayPaymentDataRequestV2,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 
 export default class GooglePayStripeUPEInitializer implements GooglePayInitializer {
@@ -115,7 +116,7 @@ export default class GooglePayStripeUPEInitializer implements GooglePayInitializ
             ],
             transactionInfo: {
                 currencyCode,
-                totalPriceStatus: 'FINAL',
+                totalPriceStatus: TotalPriceStatusType.FINAL,
                 totalPrice,
             },
             emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay.mock.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay.mock.ts
@@ -17,6 +17,7 @@ import {
     GooglePayPaymentDataRequestV2,
     GooglePaySDK,
     TokenizePayload,
+    TotalPriceStatusType,
 } from './googlepay';
 import { GooglePayBraintreePaymentDataRequestV1 } from './googlepay-braintree';
 
@@ -133,6 +134,7 @@ export function getGooglePayPaymentDataRequestMock(): GooglePayPaymentDataReques
         apiVersion: 2,
         apiVersionMinor: 0,
         merchantInfo: {},
+        shippingAddressParameters: {},
         allowedPaymentMethods: [
             {
                 type: 'type',
@@ -144,7 +146,7 @@ export function getGooglePayPaymentDataRequestMock(): GooglePayPaymentDataReques
         ],
         transactionInfo: {
             currencyCode: 'USD',
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
         },
     };
 }
@@ -184,7 +186,7 @@ export function getAdyenV2PaymentDataRequest(): GooglePayPaymentDataRequestV2 {
             },
         ],
         transactionInfo: {
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
             totalPrice: '1.00',
             currencyCode: 'USD',
         },
@@ -246,7 +248,7 @@ export function getAuthorizeNetPaymentDataRequest(): GooglePayPaymentDataRequest
             },
         ],
         transactionInfo: {
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
             totalPrice: '1.00',
             currencyCode: 'USD',
             countryCode: 'US',
@@ -342,7 +344,7 @@ export function getBNZPaymentDataRequest(): GooglePayPaymentDataRequestV2 {
         ],
         transactionInfo: {
             currencyCode: 'USD',
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
             totalPrice: '1.00',
         },
         emailRequired: true,
@@ -392,7 +394,7 @@ export function getBraintreePaymentDataPayload() {
         transactionInfo: {
             currencyCode: 'USD',
             totalPrice: '1.00',
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
         },
     };
 }
@@ -432,7 +434,7 @@ export function getBraintreePaymentDataRequest(): GooglePayBraintreePaymentDataR
         transactionInfo: {
             currencyCode: '',
             totalPrice: '',
-            totalPriceStatus: '',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
         },
     };
 }
@@ -471,7 +473,7 @@ export function getStripePaymentDataRequest(): GooglePayPaymentDataRequestV2 {
         ],
         transactionInfo: {
             currencyCode: 'USD',
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
             totalPrice: '1.00',
         },
         emailRequired: true,
@@ -569,7 +571,7 @@ export function getGooglePayCheckoutcomPaymentDataRequestMock(): GooglePayPaymen
         ],
         transactionInfo: {
             currencyCode: 'USD',
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
             totalPrice: '1.00',
         },
         emailRequired: true,
@@ -663,7 +665,7 @@ export function getCybersourceV2PaymentDataRequest(): GooglePayPaymentDataReques
         ],
         transactionInfo: {
             currencyCode: 'USD',
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
             totalPrice: '1.00',
         },
         emailRequired: true,
@@ -736,7 +738,7 @@ export function getOrbitalPaymentDataRequest(): GooglePayPaymentDataRequestV2 {
         ],
         transactionInfo: {
             currencyCode: 'USD',
-            totalPriceStatus: 'FINAL',
+            totalPriceStatus: TotalPriceStatusType.FINAL,
             totalPrice: '1.00',
         },
         emailRequired: true,

--- a/packages/core/src/payment/strategies/googlepay/googlepay.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay.ts
@@ -7,6 +7,26 @@ import {
     GooglePayBraintreeSDK,
 } from '../braintree';
 
+export enum CallbackTriggerType {
+    INITIALIZE = 'INITIALIZE',
+    SHIPPING_OPTION = 'SHIPPING_OPTION',
+    SHIPPING_ADDRESS = 'SHIPPING_ADDRESS',
+    OFFER = 'OFFER',
+}
+
+export enum TotalPriceStatusType {
+    ESTIMATED = 'ESTIMATED',
+    FINAL = 'FINAL',
+    NOT_CURRENTLY_KNOWN = 'NOT_CURRENTLY_KNOWN',
+}
+
+export enum CallbackIntentsType {
+    OFFER = 'OFFER',
+    PAYMENT_AUTHORIZATION = 'PAYMENT_AUTHORIZATION',
+    SHIPPING_ADDRESS = 'SHIPPING_ADDRESS',
+    SHIPPING_OPTION = 'SHIPPING_OPTION',
+}
+
 export type EnvironmentType = 'PRODUCTION' | 'TEST';
 export type TokenizeType = 'AndroidPayCard' | 'CreditCard' | 'CARD';
 
@@ -30,6 +50,11 @@ export type GooglePayCreator = BraintreeModuleCreator<GooglePayBraintreeSDK>;
 
 export interface GooglePayPaymentOptions {
     environment: EnvironmentType;
+    paymentDataCallbacks?: {
+        onPaymentDataChanged(
+            intermediatePaymentData: IntermediatePaymentData,
+        ): Promise<NewTransactionInfo | void>;
+    };
 }
 
 export type GooglePayVerifyPayload = BraintreeVerifyPayload | undefined;
@@ -194,16 +219,69 @@ export interface GooglePayPaymentDataRequestV2 {
     transactionInfo: {
         currencyCode: string;
         countryCode?: string;
-        totalPriceStatus: string;
+        totalPriceStatus?: TotalPriceStatusType;
         totalPrice?: string;
         checkoutOption?: string;
     };
+    callbackIntents?: CallbackIntentsType[];
     emailRequired?: boolean;
     shippingAddressRequired?: boolean;
     shippingAddressParameters?: {
         allowedCountryCodes?: string[];
         phoneNumberRequired?: boolean;
     };
+}
+
+export interface UpdatePaymentDataRequestPayload {
+    apiVersion?: number;
+    apiVersionMinor?: number;
+    merchantInfo?: {
+        authJwt?: string;
+        merchantId?: string;
+        merchantName?: string;
+    };
+    allowedPaymentMethods?: [
+        {
+            type: string;
+            parameters: {
+                allowedAuthMethods: string[];
+                allowedCardNetworks: string[];
+                allowPrepaidCards?: boolean;
+                billingAddressRequired?: boolean;
+                billingAddressParameters?: {
+                    format?: BillingAddressFormat;
+                    phoneNumberRequired?: boolean;
+                };
+            };
+            tokenizationSpecification?: TokenizationSpecification;
+        },
+    ];
+    transactionInfo?: {
+        currencyCode: string;
+        countryCode?: string;
+        totalPriceStatus?: TotalPriceStatusType;
+        totalPrice?: string;
+        checkoutOption?: string;
+    };
+    callbackIntents?: CallbackIntentsType[];
+    emailRequired?: boolean;
+    shippingAddressRequired?: boolean;
+    shippingAddressParameters?: {
+        allowedCountryCodes?: string[];
+        phoneNumberRequired?: boolean;
+    };
+}
+
+export interface NewTransactionInfo {
+    newTransactionInfo: {
+        currencyCode: string;
+        totalPrice: string;
+        totalPriceStatus: TotalPriceStatusType;
+    };
+}
+
+export interface IntermediatePaymentData {
+    callbackTrigger: CallbackTriggerType;
 }
 
 export type GooglePayTransactionInfo = Pick<GooglePayPaymentDataRequestV2, 'transactionInfo'>;


### PR DESCRIPTION
## What?
Fixed google pay button for safari and mozilla

## Why?
Google pay button didn't work on PDP in Safari and Mozilla. Safari and Mozilla showed developer issue. The reason was that we need to loadPaymentData from googleClient before any API calls. 
So we are passing to google client creation
```
paymentDataCallbacks: {
                        onPaymentDataChanged(callbackTrigger): // callback that triggers multiple times (we usecallbackTrigger  === INITIALIZE to createBuyNowCart) and then return newTransactionInfo object that contains new totalPrice and googlepay popup being updated with new price
                    },
```
Such way we are avoiding issue that doesn't allow us to make api right after click on googlepay button. 
## Testing / Proof
Tested on Dev And Integration


https://user-images.githubusercontent.com/56301104/230553647-a8740498-6e09-4550-86ba-afb5329b7587.mov


@bigcommerce/checkout @bigcommerce/payments
