### PR TITLE
chore(common): CHECKOUT-7279 Update resource class for running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ orbs:
 jobs:
   test-packages:
     <<: *node_executor
+    resource_class: medium+
     steps:
       - ci/pre-setup
       - node/npm-install


### PR DESCRIPTION
## What?
Update resource class for test-packages job in CI

## Why?
At the moment the job fails intermittently, as CPU/memory is maxed out 
<img width="817" alt="Screen Shot 2023-04-04 at 3 16 54 pm" src="https://user-images.githubusercontent.com/7134802/229693588-6210e7fd-c4ad-4f71-ae2a-207c9771bf3e.png">

## Testing / Proof
- CI

@bigcommerce/checkout @bigcommerce/payments
