### PR TITLE
refactor(payment): PAYPAL-1894 added PayPalCommerceAlternativeMethodsPaymentStrategy to paypal-commerce-integration package

### DIFF
--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -43,6 +43,9 @@ export { WithPayPalCommerceVenmoCustomerInitializeOptions } from './paypal-comme
 export { default as createPayPalCommerceAlternativeMethodsButtonStrategy } from './paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-button-strategy';
 export { WithPayPalCommerceAlternativeMethodsButtonOptions } from './paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-button-initialize-options';
 
+export { default as createPayPalCommerceAlternativeMethodsPaymentStrategy } from './paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy';
+export { WithPayPalCommerceAlternativeMethodsPaymentOptions } from './paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-initialize-options';
+
 /**
  *
  * PayPalCommerce Credit Cards strategies

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createPayPalCommerceAlternativeMethodsPaymentStrategy from './create-paypal-commerce-alternative-methods-payment-strategy';
+import PayPalCommerceAlternativeMethodsPaymentStrategy from './paypal-commerce-alternative-methods-payment-strategy';
+
+describe('createPayPalCommerceAlternativeMethodsPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates paypal commerce alternative methods payment strategy', () => {
+        const strategy =
+            createPayPalCommerceAlternativeMethodsPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(PayPalCommerceAlternativeMethodsPaymentStrategy);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy.ts
@@ -1,0 +1,40 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+import {
+    PayPalCommerceIntegrationService,
+    PayPalCommerceRequestSender,
+    PayPalCommerceScriptLoader,
+} from '../index';
+
+import PayPalCommerceAlternativeMethodsPaymentStrategy from './paypal-commerce-alternative-methods-payment-strategy';
+
+const createPayPalCommerceAlternativeMethodsPaymentStrategy: PaymentStrategyFactory<
+    PayPalCommerceAlternativeMethodsPaymentStrategy
+> = (paymentIntegrationService) => {
+    const { getHost } = paymentIntegrationService.getState();
+
+    const paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
+        createFormPoster(),
+        paymentIntegrationService,
+        new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
+        new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+
+    return new PayPalCommerceAlternativeMethodsPaymentStrategy(
+        paymentIntegrationService,
+        paypalCommerceIntegrationService,
+        new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
+    );
+};
+
+export default toResolvableModule(createPayPalCommerceAlternativeMethodsPaymentStrategy, [
+    { gateway: 'paypalcommercealternativemethods' },
+]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-initialize-options.ts
@@ -1,0 +1,122 @@
+import { PayPalCommerceFieldsStyleOptions } from '../paypal-commerce-types';
+
+/**
+ * A set of options that are required to initialize the PayPal Commerce payment
+ * method for presenting its PayPal button.
+ *
+ * Please note that the minimum version of checkout-sdk is 1.100
+ *
+ * Also, PayPal (also known as PayPal Commerce Platform) requires specific options to initialize the PayPal Smart Payment Button on checkout page that substitutes a standard submit button
+ * ```html
+ * <!-- This is where the PayPal button will be inserted -->
+ * <div id="container"></div>
+ * <!-- This is where the PayPal alternative payment methods fields will be inserted.  -->
+ * <div id="apm-fields-container"></div>
+ * ```
+ *
+ * ```js
+ * service.initializePayment({
+ *     gatewayId: 'paypalcommercealternativemethods',
+ *     methodId: 'sepa',
+ *     paypalcommercealternativemethods: {
+ *         container: '#container',
+ *         apmFieldsContainer: '#apm-fields-container',
+ *         apmFieldsStyles: {
+ *             base: {
+ *                 backgroundColor: 'transparent',
+ *             },
+ *             input: {
+ *                 backgroundColor: 'white',
+ *                 fontSize: '1rem',
+ *                 color: '#333',
+ *                 borderColor: '#d9d9d9',
+ *                 borderRadius: '4px',
+ *                 borderWidth: '1px',
+ *                 padding: '1rem',
+ *             },
+ *             invalid: {
+ *                 color: '#ed6a6a',
+ *             },
+ *             active: {
+ *                 color: '#4496f6',
+ *             },
+ *         },
+ *         clientId: 'YOUR_CLIENT_ID',
+ * // Callback for submitting payment form that gets called when a buyer approves PayPal payment
+ *         submitForm: () => {
+ *         // Example function
+ *             this.submitOrder(
+ *                {
+ *                   payment: { methodId: 'paypalcommercealternativemethods', }
+ *               }
+ *            );
+ *         },
+ * // Callback is used to define the state of the payment form, validate if it is applicable for submit.
+ *         onValidate: (resolve, reject) => {
+ *         // Example function
+ *             const isValid = this.validatePaymentForm();
+ *             if (isValid) {
+ *                 return resolve();
+ *             }
+ *             return reject();
+ *         },
+ * // Callback that is called right before render of a Smart Payment Button. It gets called when a buyer is eligible for use of the particular PayPal method. This callback can be used to hide the standard submit button.
+ *         onRenderButton: () => {
+ *         // Example function
+ *             this.hidePaymentSubmitButton();
+ *         }
+ *     },
+ * });
+ * ```
+ */
+export default interface PayPalCommerceAlternativeMethodsPaymentOptions {
+    /**
+     * The CSS selector of a container where the payment widget should be inserted into.
+     */
+    container: string;
+
+    /**
+     * The CSS selector of a container where the alternative payment methods fields widget should be inserted into.
+     * It's necessary to specify this parameter when using Alternative Payment Methods.
+     * Without it alternative payment methods will not work.
+     */
+    apmFieldsContainer?: string;
+
+    /**
+     * Object with styles to customize alternative payment methods fields.
+     */
+    apmFieldsStyles?: PayPalCommerceFieldsStyleOptions;
+
+    /**
+     * A callback for displaying error popup. This callback requires error object as parameter.
+     */
+    onError?(error: Error): void;
+
+    /**
+     * A callback right before render Smart Payment Button that gets called when
+     * Smart Payment Button is eligible. This callback can be used to hide the standard submit button.
+     */
+    onRenderButton?(): void;
+
+    /**
+     * A callback that gets called when a buyer click on Smart Payment Button
+     * and should validate payment form.
+     *
+     * @param resolve - A function, that gets called if form is valid.
+     * @param reject - A function, that gets called if form is not valid.
+     *
+     * @returns reject() or resolve()
+     */
+    onValidate(resolve: () => void, reject: () => void): Promise<void>;
+
+    /**
+     * A callback for submitting payment form that gets called
+     * when buyer approved PayPal account.
+     */
+    submitForm(): void;
+}
+
+export interface WithPayPalCommerceAlternativeMethodsPaymentOptions {
+    paypalcommerce?: PayPalCommerceAlternativeMethodsPaymentOptions; // FIXME: this option is deprecated
+    paypalcommercealternativemethods?: PayPalCommerceAlternativeMethodsPaymentOptions;
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
@@ -1,0 +1,677 @@
+import { EventEmitter } from 'events';
+
+import {
+    BillingAddress,
+    InvalidArgumentError,
+    OrderFinalizationNotRequiredError,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentMethodInvalidError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getBillingAddress,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+import {
+    getPayPalCommerceIntegrationServiceMock,
+    getPayPalCommercePaymentMethod,
+    getPayPalSDKMock,
+} from '../mocks';
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
+import {
+    NonInstantAlternativePaymentMethods,
+    PayPalCommerceButtonsOptions,
+    PayPalCommerceHostWindow,
+    PayPalOrderStatus,
+    PayPalSDK,
+} from '../paypal-commerce-types';
+
+import PayPalCommerceAlternativeMethodsPaymentOptions from './paypal-commerce-alternative-methods-payment-initialize-options';
+import PayPalCommerceAlternativeMethodsPaymentStrategy from './paypal-commerce-alternative-methods-payment-strategy';
+
+describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
+    let billingAddress: BillingAddress;
+    let eventEmitter: EventEmitter;
+    let loadingIndicator: LoadingIndicator;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paymentMethod: PaymentMethod;
+    let paypalCommerceIntegrationService: PayPalCommerceIntegrationService;
+    let paypalSdk: PayPalSDK;
+    let strategy: PayPalCommerceAlternativeMethodsPaymentStrategy;
+
+    const paypalOrderId = 'paypal123';
+
+    const defaultMethodId = 'sepa';
+    const defaultGatewayId = 'paypalcommercealternativemethods';
+    const defaultContainerId = '#container';
+    const defaultApmFieldsContainerId = '#container';
+
+    const paypalCommerceAlternativeMethodsOptions: PayPalCommerceAlternativeMethodsPaymentOptions =
+        {
+            container: defaultContainerId,
+            apmFieldsContainer: defaultApmFieldsContainerId,
+            onValidate: jest.fn(),
+            submitForm: jest.fn(),
+        };
+
+    const initializationOptions: PaymentInitializeOptions = {
+        methodId: defaultMethodId,
+        gatewayId: defaultGatewayId,
+        paypalcommercealternativemethods: paypalCommerceAlternativeMethodsOptions,
+    };
+
+    beforeEach(() => {
+        eventEmitter = new EventEmitter();
+
+        billingAddress = getBillingAddress();
+        paypalSdk = getPayPalSDKMock();
+        paymentMethod = getPayPalCommercePaymentMethod();
+        paymentMethod.id = defaultGatewayId;
+        paymentMethod.initializationData.orderId = undefined;
+
+        loadingIndicator = new LoadingIndicator();
+        paypalCommerceIntegrationService = getPayPalCommerceIntegrationServiceMock();
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+
+        strategy = new PayPalCommerceAlternativeMethodsPaymentStrategy(
+            paymentIntegrationService,
+            paypalCommerceIntegrationService,
+            loadingIndicator,
+        );
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethod,
+        );
+        jest.spyOn(
+            paymentIntegrationService.getState(),
+            'getBillingAddressOrThrow',
+        ).mockReturnValue(billingAddress);
+
+        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
+            paypalSdk,
+        );
+        jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockReturnValue(undefined);
+        jest.spyOn(paypalCommerceIntegrationService, 'submitPayment').mockReturnValue(undefined);
+        jest.spyOn(paypalCommerceIntegrationService, 'getOrderStatus').mockReturnValue(
+            PayPalOrderStatus.Approved,
+        );
+
+        jest.spyOn(loadingIndicator, 'show').mockReturnValue(undefined);
+        jest.spyOn(loadingIndicator, 'hide').mockReturnValue(undefined);
+
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+            (options: PayPalCommerceButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder();
+                    }
+                });
+
+                eventEmitter.on('onClick', () => {
+                    if (options.onClick) {
+                        options.onClick(
+                            { fundingSource: defaultMethodId },
+                            {
+                                reject: jest.fn(),
+                                resolve: jest.fn(),
+                            },
+                        );
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove(
+                            { orderID: paypalOrderId },
+                            {
+                                order: {
+                                    get: jest.fn(),
+                                },
+                            },
+                        );
+                    }
+                });
+
+                eventEmitter.on('onCancel', () => {
+                    if (options.onCancel) {
+                        options.onCancel();
+                    }
+                });
+
+                eventEmitter.on('onError', () => {
+                    if (options.onError) {
+                        options.onError(new Error());
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                    close: jest.fn(),
+                };
+            },
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PayPalCommerceHostWindow).paypal;
+    });
+
+    it('creates an instance of the PayPal Commerce Alternative Methods payment strategy', () => {
+        expect(strategy).toBeInstanceOf(PayPalCommerceAlternativeMethodsPaymentStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = {} as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if gatewayId is not provided', async () => {
+            const options = {
+                methodId: defaultMethodId,
+            } as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if options.paypalcommercealternativemethods or options.paypalcommerce is not provided', async () => {
+            const options = {
+                methodId: defaultMethodId,
+                gatewayId: defaultGatewayId,
+            } as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('logs a warning message if options.paypalcommerce was not provided instead of options.paypalcommercealternativemethods', async () => {
+            const warnLogSpy = jest.spyOn(console, 'warn');
+
+            const options = {
+                methodId: defaultMethodId,
+                gatewayId: defaultGatewayId,
+                paypalcommerce: {
+                    container: defaultContainerId,
+                    apmFieldsContainer: defaultApmFieldsContainerId,
+                },
+            } as PaymentInitializeOptions;
+
+            await strategy.initialize(options);
+
+            expect(warnLogSpy).toHaveBeenCalled();
+        });
+
+        it('does not continues strategy initialization if order id is available in initializationData', async () => {
+            paymentMethod.initializationData.orderId = '1';
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
+        });
+
+        it('loads paypal sdk', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
+                defaultGatewayId,
+            );
+        });
+    });
+
+    describe('#renderButton()', () => {
+        it('initializes paypal button', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource: defaultMethodId,
+                style: {
+                    color: 'black',
+                    height: 55,
+                    label: 'pay',
+                },
+                createOrder: expect.any(Function),
+                onClick: expect.any(Function),
+                onApprove: expect.any(Function),
+                onCancel: expect.any(Function),
+                onError: expect.any(Function),
+            });
+        });
+
+        it('does not render paypal button if it is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
+        it('renders paypal button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => true),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('#createOrder button callback', () => {
+        it('creates paypal order', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.createOrder).toHaveBeenCalledWith(
+                'paypalcommercealternativemethodscheckout',
+            );
+        });
+    });
+
+    describe('#onClick button callback', () => {
+        it('does not initialize polling mechanism for non instant payment methods before validation', async () => {
+            const submitFormMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                methodId: NonInstantAlternativePaymentMethods.OXXO,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    submitForm: submitFormMock,
+                },
+            });
+
+            eventEmitter.emit('onClick');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(submitFormMock).not.toHaveBeenCalled();
+        });
+
+        it('initializes polling mechanism for non instant payment methods before validation', async () => {
+            const submitFormMock = jest.fn();
+
+            jest.useFakeTimers();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    submitForm: submitFormMock,
+                },
+            });
+
+            eventEmitter.emit('onClick');
+
+            jest.runAllTimers();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(submitFormMock).toHaveBeenCalled();
+        });
+
+        it('calls validation callback with provided params', async () => {
+            const onValidateMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                methodId: NonInstantAlternativePaymentMethods.OXXO,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    onValidate: onValidateMock,
+                },
+            });
+
+            eventEmitter.emit('onClick');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(onValidateMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onApprove button callback', () => {
+        it('deinitializes polling mechanism', async () => {
+            jest.spyOn(global, 'clearTimeout');
+            jest.useFakeTimers();
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            jest.runAllTimers();
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(clearTimeout).toHaveBeenCalled();
+        });
+
+        it('submits form', async () => {
+            const submitFormMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    submitForm: submitFormMock,
+                },
+            });
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(submitFormMock).toHaveBeenCalled();
+        });
+
+        it('hides loading indicator after form submit', async () => {
+            const submitFormMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    submitForm: submitFormMock,
+                },
+            });
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(submitFormMock).toHaveBeenCalled();
+            expect(loadingIndicator.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onCancel button callback', () => {
+        it('deinitializes polling mechanism', async () => {
+            jest.spyOn(global, 'clearTimeout');
+            jest.useFakeTimers();
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            jest.runAllTimers();
+
+            eventEmitter.emit('onCancel');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(clearTimeout).toHaveBeenCalled();
+        });
+
+        it('hides loading indicator', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onCancel');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(loadingIndicator.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onError button callback', () => {
+        it('deinitializes polling mechanism', async () => {
+            jest.spyOn(global, 'clearTimeout');
+            jest.useFakeTimers();
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            jest.runAllTimers();
+
+            eventEmitter.emit('onError');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(clearTimeout).toHaveBeenCalled();
+        });
+
+        it('hides loading indicator', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onError');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(loadingIndicator.hide).toHaveBeenCalled();
+        });
+
+        it('calls onError callback if it is provided', async () => {
+            const onErrorMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    onError: onErrorMock,
+                },
+            });
+
+            eventEmitter.emit('onError');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(loadingIndicator.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('#renderFields()', () => {
+        it('throws an error if apmFieldsContainer is not provided', async () => {
+            paymentMethod.initializationData.shouldRenderFields = true;
+
+            const options = {
+                methodId: defaultMethodId,
+                gatewayId: defaultGatewayId,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    apmFieldsContainer: undefined,
+                },
+            };
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('renders apm payment fields', async () => {
+            const paymentFieldsRenderMock = jest.fn();
+            const fieldContainer = document.createElement('div');
+
+            fieldContainer.id = defaultApmFieldsContainerId.split('#')[1];
+            document.body.appendChild(fieldContainer);
+
+            jest.spyOn(paypalSdk, 'PaymentFields').mockImplementation(() => ({
+                render: paymentFieldsRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.PaymentFields).toHaveBeenCalledWith({
+                fundingSource: defaultMethodId,
+                style: {},
+                fields: {
+                    name: {
+                        value: `${billingAddress.firstName} ${billingAddress.lastName}`,
+                    },
+                    email: {
+                        value: billingAddress.email,
+                    },
+                },
+            });
+            expect(paymentFieldsRenderMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('#execute()', () => {
+        it('throws an error if payload.payment is not provided', async () => {
+            try {
+                await strategy.execute({});
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
+            }
+        });
+
+        it('throws an error if orderId is not defined', async () => {
+            const payload = {
+                payment: {
+                    methodId: defaultMethodId,
+                    gatewayId: defaultGatewayId,
+                },
+            };
+
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodInvalidError);
+            }
+        });
+
+        it('does not submit order for non instant payment methods', async () => {
+            const payload = {
+                payment: {
+                    methodId: NonInstantAlternativePaymentMethods.OXXO,
+                    gatewayId: defaultGatewayId,
+                },
+            };
+
+            await strategy.initialize({
+                ...initializationOptions,
+                methodId: NonInstantAlternativePaymentMethods.OXXO,
+            });
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+        });
+
+        it('submits order for instant payment methods', async () => {
+            const payload = {
+                payment: {
+                    methodId: defaultMethodId,
+                    gatewayId: defaultGatewayId,
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+        });
+
+        it('submits payment with provided data', async () => {
+            const payload = {
+                payment: {
+                    methodId: defaultMethodId,
+                    gatewayId: defaultGatewayId,
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            await strategy.execute(payload);
+
+            expect(paypalCommerceIntegrationService.submitPayment).toHaveBeenCalledWith(
+                payload.payment.methodId,
+                paypalOrderId,
+            );
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes polling mechanism', async () => {
+            jest.spyOn(global, 'clearTimeout');
+            jest.useFakeTimers();
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            jest.runAllTimers();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            await strategy.deinitialize();
+
+            expect(clearTimeout).toHaveBeenCalled();
+        });
+
+        it('closes paypal button component on deinitialize strategy', async () => {
+            const paypalCommerceSdkCloseMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: jest.fn(),
+                close: paypalCommerceSdkCloseMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+            await strategy.deinitialize();
+
+            expect(paypalCommerceSdkCloseMock).toHaveBeenCalled();
+        });
+
+        it('deinitializes strategy', async () => {
+            const result = await strategy.deinitialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -1,0 +1,372 @@
+import { noop } from 'lodash';
+
+import {
+    InvalidArgumentError,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethodInvalidError,
+    PaymentRequestOptions,
+    PaymentStrategy,
+    TimeoutError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
+import {
+    ApproveCallbackPayload,
+    ClickCallbackActions,
+    NonInstantAlternativePaymentMethods,
+    PayPalCommerceButtons,
+    PayPalCommerceButtonsOptions,
+    PayPalCommerceInitializationData,
+    PayPalOrderStatus,
+} from '../paypal-commerce-types';
+
+import PayPalCommerceAlternativeMethodsPaymentOptions, {
+    WithPayPalCommerceAlternativeMethodsPaymentOptions,
+} from './paypal-commerce-alternative-methods-payment-initialize-options';
+
+export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements PaymentStrategy {
+    private loadingIndicatorContainer?: string;
+    private orderId?: string;
+    private paypalButton?: PayPalCommerceButtons;
+    private pollingTimer = 0;
+    private stopPolling = noop;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private paypalCommerceIntegrationService: PayPalCommerceIntegrationService,
+        private loadingIndicator: LoadingIndicator,
+        private pollingInterval = 3000,
+        private maxPollingTime = 600000,
+    ) {}
+
+    async initialize(
+        options: PaymentInitializeOptions & WithPayPalCommerceAlternativeMethodsPaymentOptions,
+    ): Promise<void> {
+        const {
+            gatewayId,
+            methodId,
+            paypalcommerce, // FIXME: this option is deprecated
+            paypalcommercealternativemethods,
+        } = options;
+        const paypalOptions = paypalcommercealternativemethods || paypalcommerce;
+
+        if (paypalcommerce) {
+            console.warn(
+                'The "options.paypalcommerce" option is deprecated for this strategy, please use "options.paypalcommercealternativemethods" instead',
+            );
+        }
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!gatewayId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.gatewayId" argument is not provided.',
+            );
+        }
+
+        if (!paypalOptions) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommercealternativemethods" argument is not provided.`,
+            );
+        }
+
+        await this.paymentIntegrationService.loadPaymentMethod(gatewayId);
+
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(
+            methodId,
+            gatewayId,
+        );
+        const { orderId, shouldRenderFields } = paymentMethod.initializationData || {};
+
+        // Info:
+        // The PayPal button and fields should not be rendered when shopper was redirected to Checkout page
+        // after using smart payment button on PDP or Cart page. In this case backend returns order id if
+        // it is available in checkout session. Therefore, it is not necessary to render PayPal button.
+        if (orderId) {
+            this.orderId = orderId;
+
+            return;
+        }
+
+        await this.paypalCommerceIntegrationService.loadPayPalSdk(gatewayId);
+
+        this.loadingIndicatorContainer = paypalOptions.container.split('#')[1];
+
+        this.renderButton(methodId, gatewayId, paypalOptions);
+
+        if (shouldRenderFields) {
+            this.renderFields(methodId, paypalOptions);
+        }
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        const { payment, ...order } = payload;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        if (!this.orderId) {
+            throw new PaymentMethodInvalidError();
+        }
+
+        if (!this.isNonInstantPaymentMethod(payment.methodId)) {
+            await this.paymentIntegrationService.submitOrder(order, options);
+        }
+
+        await this.paypalCommerceIntegrationService.submitPayment(payment.methodId, this.orderId);
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<void> {
+        this.deinitializePollingMechanism();
+
+        this.orderId = undefined;
+
+        this.paypalButton?.close();
+
+        return Promise.resolve();
+    }
+
+    private async reinitializeStrategy(
+        options: PaymentInitializeOptions & WithPayPalCommerceAlternativeMethodsPaymentOptions,
+    ): Promise<void> {
+        await this.deinitialize();
+        await this.initialize(options);
+    }
+
+    /**
+     *
+     * Button methods/callbacks
+     *
+     * */
+    private renderButton(
+        methodId: string,
+        gatewayId: string,
+        paypalOptions: PayPalCommerceAlternativeMethodsPaymentOptions,
+    ): void {
+        const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
+
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(
+            methodId,
+            gatewayId,
+        );
+        const { buttonStyle } = paymentMethod.initializationData || {};
+
+        const { container, onError, onRenderButton, submitForm } = paypalOptions;
+
+        const buttonOptions: PayPalCommerceButtonsOptions = {
+            fundingSource: methodId,
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle(buttonStyle),
+            createOrder: () =>
+                this.paypalCommerceIntegrationService.createOrder(
+                    'paypalcommercealternativemethodscheckout',
+                ),
+            onClick: (_, actions) => this.handleClick(methodId, gatewayId, paypalOptions, actions),
+            onApprove: (data) => this.handleApprove(data, submitForm),
+            onCancel: () => this.resetPollingMechanism(),
+            onError: (error) => this.handleError(error, onError),
+        };
+
+        this.paypalButton = paypalSdk.Buttons(buttonOptions);
+
+        if (!this.paypalButton.isEligible()) {
+            return;
+        }
+
+        if (onRenderButton && typeof onRenderButton === 'function') {
+            onRenderButton();
+        }
+
+        this.paypalButton.render(container);
+    }
+
+    private async handleClick(
+        methodId: string,
+        gatewayId: string,
+        paypalOptions: PayPalCommerceAlternativeMethodsPaymentOptions,
+        actions: ClickCallbackActions,
+    ): Promise<void> {
+        const { onValidate } = paypalOptions;
+        const { resolve, reject } = actions;
+
+        if (!this.isNonInstantPaymentMethod(methodId)) {
+            await this.initializePollingMechanism(methodId, gatewayId, paypalOptions);
+        }
+
+        const onValidationPassed = () => {
+            this.toggleLoadingIndicator(true);
+
+            return resolve();
+        };
+
+        await onValidate(onValidationPassed, reject);
+    }
+
+    private handleApprove(
+        { orderID }: ApproveCallbackPayload,
+        submitForm: PayPalCommerceAlternativeMethodsPaymentOptions['submitForm'],
+    ): void {
+        this.orderId = orderID;
+
+        this.deinitializePollingMechanism();
+        submitForm();
+        this.toggleLoadingIndicator(false);
+    }
+
+    private handleError(
+        error: Error,
+        onError: PayPalCommerceAlternativeMethodsPaymentOptions['onError'],
+    ): void {
+        this.resetPollingMechanism();
+
+        if (onError && typeof onError === 'function') {
+            onError(error);
+        }
+    }
+
+    /**
+     *
+     * Fields methods
+     *
+     * */
+    private renderFields(
+        methodId: string,
+        paypalOptions: PayPalCommerceAlternativeMethodsPaymentOptions,
+    ): void {
+        const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
+        const state = this.paymentIntegrationService.getState();
+        const { firstName, lastName, email } = state.getBillingAddressOrThrow();
+
+        const { apmFieldsContainer, apmFieldsStyles } = paypalOptions;
+
+        if (!apmFieldsContainer) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.paypalcommercealternativemethods" argument should contain "apmFieldsContainer".',
+            );
+        }
+
+        const fieldContainerElement = document.querySelector(apmFieldsContainer);
+
+        if (fieldContainerElement) {
+            fieldContainerElement.innerHTML = '';
+        }
+
+        const fieldsOptions = {
+            fundingSource: methodId,
+            style: apmFieldsStyles || {},
+            fields: {
+                name: {
+                    value: `${firstName} ${lastName}`,
+                },
+                email: {
+                    value: email,
+                },
+            },
+        };
+
+        const paypalPaymentFields = paypalSdk.PaymentFields(fieldsOptions);
+
+        paypalPaymentFields.render(apmFieldsContainer);
+    }
+
+    /**
+     *
+     * Polling mechanism
+     *
+     *
+     * */
+    private async initializePollingMechanism(
+        methodId: string,
+        gatewayId: string,
+        paypalOptions: PayPalCommerceAlternativeMethodsPaymentOptions,
+    ): Promise<void> {
+        const { onError, submitForm } = paypalOptions;
+
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(resolve, this.pollingInterval);
+
+            this.stopPolling = () => {
+                clearTimeout(timeout);
+                reject();
+            };
+        });
+
+        try {
+            this.pollingTimer += this.pollingInterval;
+
+            const orderStatus = await this.paypalCommerceIntegrationService.getOrderStatus();
+
+            const isOrderApproved = orderStatus === PayPalOrderStatus.Approved;
+            const isOrderPending =
+                orderStatus === PayPalOrderStatus.Created ||
+                orderStatus === PayPalOrderStatus.PayerActionRequired;
+
+            if (isOrderApproved) {
+                this.deinitializePollingMechanism();
+
+                return submitForm();
+            }
+
+            if (isOrderPending && this.pollingTimer < this.maxPollingTime) {
+                return await this.initializePollingMechanism(methodId, gatewayId, paypalOptions);
+            }
+
+            await this.reinitializeStrategy({
+                methodId,
+                gatewayId,
+                paypalcommercealternativemethods: paypalOptions,
+            });
+
+            throw new TimeoutError();
+        } catch (error) {
+            this.handleError(error, onError);
+        }
+    }
+
+    private deinitializePollingMechanism(): void {
+        this.stopPolling();
+        this.pollingTimer = 0;
+    }
+
+    private resetPollingMechanism(): void {
+        this.deinitializePollingMechanism();
+        this.toggleLoadingIndicator(false);
+    }
+
+    /**
+     *
+     * Loading Indicator methods
+     *
+     * */
+    private toggleLoadingIndicator(isLoading: boolean): void {
+        if (isLoading && this.loadingIndicatorContainer) {
+            this.loadingIndicator.show(this.loadingIndicatorContainer);
+        } else {
+            this.loadingIndicator.hide();
+        }
+    }
+
+    /**
+     *
+     * Utils
+     *
+     * */
+    private isNonInstantPaymentMethod(methodId: string): boolean {
+        return methodId.toUpperCase() in NonInstantAlternativePaymentMethods;
+    }
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
@@ -32,6 +32,7 @@ import PayPalCommerceIntegrationService from './paypal-commerce-integration-serv
 import PayPalCommerceRequestSender from './paypal-commerce-request-sender';
 import PayPalCommerceScriptLoader from './paypal-commerce-script-loader';
 import {
+    PayPalOrderStatus,
     PayPalSDK,
     StyleButtonColor,
     StyleButtonLabel,
@@ -224,6 +225,30 @@ describe('PayPalCommerceIntegrationService', () => {
 
             try {
                 await subject.updateOrder();
+            } catch (error) {
+                expect(error).toBeInstanceOf(RequestError);
+            }
+        });
+    });
+
+    describe('#getOrderStatus', () => {
+        it('successfully updates order', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'getOrderStatus').mockReturnValue({
+                status: PayPalOrderStatus.Approved,
+            });
+
+            await subject.getOrderStatus();
+
+            expect(paypalCommerceRequestSender.getOrderStatus).toHaveBeenCalled();
+        });
+
+        it('throws an error if something went wrong during requesting order status', async () => {
+            jest.spyOn(paypalCommerceRequestSender, 'getOrderStatus').mockImplementation(() =>
+                Promise.reject(new Error()),
+            );
+
+            try {
+                await subject.getOrderStatus();
             } catch (error) {
                 expect(error).toBeInstanceOf(RequestError);
             }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -22,6 +22,7 @@ import {
     PayPalCommerceInitializationData,
     PayPalCreateOrderRequestBody,
     PayPalOrderDetails,
+    PayPalOrderStatus,
     PayPalSDK,
     StyleButtonColor,
     StyleButtonLabel,
@@ -93,7 +94,7 @@ export default class PayPalCommerceIntegrationService {
 
     /**
      *
-     * Order creation methods
+     * Order methods
      *
      */
     async createOrder(
@@ -121,6 +122,16 @@ export default class PayPalCommerceIntegrationService {
                 cartId: cart.id,
                 selectedShippingOption: consignment.selectedShippingOption,
             });
+        } catch (_error) {
+            throw new RequestError();
+        }
+    }
+
+    async getOrderStatus(): Promise<PayPalOrderStatus> {
+        try {
+            const { status } = await this.paypalCommerceRequestSender.getOrderStatus();
+
+            return status;
         } catch (_error) {
             throw new RequestError();
         }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-request-sender.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-request-sender.spec.ts
@@ -22,6 +22,7 @@ describe('PayPalCommerceRequestSender', () => {
             },
         };
 
+        jest.spyOn(requestSender, 'get').mockReturnValue(Promise.resolve(requestResponseMock));
         jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve(requestResponseMock));
         jest.spyOn(requestSender, 'put').mockReturnValue(Promise.resolve(requestResponseMock));
     });
@@ -79,6 +80,23 @@ describe('PayPalCommerceRequestSender', () => {
             '/api/storefront/initialization/paypalcommerce',
             expect.objectContaining({
                 body: updateOrderRequestBody,
+                headers,
+            }),
+        );
+    });
+
+    it('requests order status', async () => {
+        const headers = {
+            'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            'Content-Type': ContentType.Json,
+            ...SDK_VERSION_HEADERS,
+        };
+
+        await paypalCommerceRequestSender.getOrderStatus();
+
+        expect(requestSender.get).toHaveBeenCalledWith(
+            '/api/storefront/initialization/paypalcommerce',
+            expect.objectContaining({
                 headers,
             }),
         );

--- a/packages/paypal-commerce-integration/src/paypal-commerce-request-sender.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-request-sender.ts
@@ -9,6 +9,7 @@ import {
 import {
     PayPalCreateOrderRequestBody,
     PayPalOrderData,
+    PayPalOrderStatusData,
     PayPalUpdateOrderRequestBody,
 } from './paypal-commerce-types';
 
@@ -32,6 +33,7 @@ export default class PayPalCommerceRequestSender {
         return res.body;
     }
 
+    // TODO: add response type interface Promise<something> in another task
     async updateOrder(requestBody: PayPalUpdateOrderRequestBody) {
         const url = `/api/storefront/initialization/paypalcommerce`;
         const body = requestBody;
@@ -42,6 +44,19 @@ export default class PayPalCommerceRequestSender {
         };
 
         const res = await this.requestSender.put(url, { headers, body });
+
+        return res.body;
+    }
+
+    async getOrderStatus(): Promise<PayPalOrderStatusData> {
+        const url = '/api/storefront/initialization/paypalcommerce';
+        const headers = {
+            'X-API-INTERNAL': INTERNAL_USE_ONLY,
+            'Content-Type': ContentType.Json,
+            ...SDK_VERSION_HEADERS,
+        };
+
+        const res = await this.requestSender.get<PayPalOrderStatusData>(url, { headers });
 
         return res.body;
     }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -73,18 +73,21 @@ export interface PayPalCommerceHostWindow extends Window {
  *
  */
 export interface PayPalCommerceInitializationData {
-    clientId: string;
-    merchantId?: string;
+    attributionId?: string;
+    availableAlternativePaymentMethods: FundingType;
+    buttonStyle?: PayPalButtonStyleOptions;
     buyerCountry?: string;
+    clientId: string;
+    clientToken?: string;
+    enabledAlternativePaymentMethods: FundingType;
     isDeveloperModeApplicable?: boolean;
     intent?: PayPalCommerceIntent;
     isHostedCheckoutEnabled?: boolean;
     isPayPalCreditAvailable?: boolean;
-    availableAlternativePaymentMethods: FundingType;
-    enabledAlternativePaymentMethods: FundingType;
-    clientToken?: string;
-    attributionId?: string;
     isVenmoEnabled?: boolean;
+    merchantId?: string;
+    orderId?: string;
+    shouldRenderFields?: boolean;
 }
 
 /**
@@ -191,7 +194,7 @@ export interface PayPalCommerceButtonsOptions {
         actions: ApproveCallbackActions,
     ): Promise<boolean | void> | void;
     onComplete?(data: CompleteCallbackDataPayload): Promise<void>;
-    onClick?(data: ClickCallbackPayload, actions?: ClickCallbackActions): Promise<void>;
+    onClick?(data: ClickCallbackPayload, actions: ClickCallbackActions): Promise<void>;
     onError?(error: Error): void;
     onCancel?(): void;
     onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;
@@ -203,8 +206,8 @@ export interface ClickCallbackPayload {
 }
 
 export interface ClickCallbackActions {
-    reject(): Promise<void>;
-    resolve(): Promise<void>;
+    reject(): void;
+    resolve(): void;
 }
 
 export interface ShippingAddressChangeCallbackPayload {
@@ -372,6 +375,10 @@ export interface PayPalCommerceMessagesStyleOptions {
  * Other
  *
  */
+export enum NonInstantAlternativePaymentMethods {
+    OXXO = 'oxxo',
+}
+
 export interface PayPalOrderData {
     orderId: string;
     approveUrl: string;
@@ -385,4 +392,14 @@ export interface PayPalUpdateOrderRequestBody {
 
 export interface PayPalCreateOrderRequestBody extends HostedInstrument, VaultedInstrument {
     cartId: string;
+}
+
+export enum PayPalOrderStatus {
+    Approved = 'APPROVED',
+    Created = 'CREATED',
+    PayerActionRequired = 'PAYER_ACTION_REQUIRED',
+}
+
+export interface PayPalOrderStatusData {
+    status: PayPalOrderStatus;
 }


### PR DESCRIPTION
## What?
Added PayPalCommerceAlternativeMethodsPaymentStrategy to paypal-commerce-integration package

## Why?
As part of paypal commerce code migration from core package to paypal-commerce-integration package

## Testing / Proof
Unit tests
Manual tests