### PR TITLE
feat(payment): PAYPAL-2195 added buttonClassName

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-button-strategy.ts
@@ -107,7 +107,7 @@ export default class ApplePayButtonStrategy implements CheckoutButtonStrategy {
 
         const button = document.createElement('div');
 
-        button.classList.add(buttonClassName);
+        button.setAttribute('class', buttonClassName);
         button.setAttribute('role', 'button');
         button.setAttribute('aria-label', 'Apple Pay button');
         container.appendChild(button);


### PR DESCRIPTION
## What?
Added className attribute

## Why?
To make applepay button styles configurable from page builder

## Testing / Proof
<img width="1678" alt="Screenshot 2023-04-06 at 14 24 45" src="https://user-images.githubusercontent.com/56301104/231102313-8683a3e4-e1c3-4ce6-ab52-257af0528c9e.png">
<img width="1678" alt="Screenshot 2023-04-06 at 14 24 13" src="https://user-images.githubusercontent.com/56301104/231102322-50f0e824-bb88-43a8-b8f1-b8855f916671.png">
<img width="1678" alt="Screenshot 2023-04-06 at 14 23 38" src="https://user-images.githubusercontent.com/56301104/231102331-babafdcd-9278-4806-a830-a19e5349bb40.png">


@bigcommerce/checkout @bigcommerce/payments
