### PR TITLE
refactor(payment): PAYPAL-000 added billing address mock to payment-integrations-test-utils package

### DIFF
--- a/packages/payment-integrations-test-utils/src/test-utils/billing-address.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/billing-address.mock.ts
@@ -1,0 +1,22 @@
+import { BillingAddress } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default function getBillingAddress(): BillingAddress {
+    return {
+        id: '55c96cda6f04c',
+        firstName: 'Test',
+        lastName: 'Tester',
+        email: 'test@bigcommerce.com',
+        company: 'Bigcommerce',
+        address1: '12345 Testing Way',
+        address2: '',
+        city: 'Some City',
+        stateOrProvince: 'California',
+        stateOrProvinceCode: 'CA',
+        country: 'United States',
+        countryCode: 'US',
+        postalCode: '95555',
+        shouldSaveAddress: true,
+        phone: '555-555-5555',
+        customFields: [],
+    };
+}

--- a/packages/payment-integrations-test-utils/src/test-utils/index.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/index.ts
@@ -1,5 +1,6 @@
 export { default as PaymentIntegrationServiceMock } from './payment-integration-service.mock';
 export { default as getBuyNowCartRequestBody } from './buy-now-cart-request-body.mock';
+export { default as getBillingAddress } from './billing-address.mock';
 export { default as getCart, getBuyNowCart } from './carts.mock';
 export { default as getCheckout, getCheckoutWithBuyNowCart } from './checkouts.mock';
 export { default as getConfig } from './config.mock';


### PR DESCRIPTION
## What?
Added billing address mock to payment-integrations-test-utils package

## Why?
To have an ability to use billing address mock in different integration packages

## Testing / Proof
CI tests
