### PR TITLE
refactor(payment): PAYPAL-0000 added export for getBillingAddress method in payment-integration-test-utils

### DIFF
--- a/packages/payment-integrations-test-utils/src/index.ts
+++ b/packages/payment-integrations-test-utils/src/index.ts
@@ -1,5 +1,6 @@
 export {
     PaymentIntegrationServiceMock,
+    getBillingAddress,
     getBuyNowCart,
     getBuyNowCartRequestBody,
     getCart,


### PR DESCRIPTION
## What?
Added export for getBillingAddress method in payment-integration-test-utils

## Why?
To make an ability to use this method in different integration packages

## Testing / Proof
Unit tests
