### PR TITLE
refactor(payment): PAYPAL-2365 added PayPalCommerceVenmo payment strategy to paypal-commerce-integration package

### DIFF
--- a/packages/paypal-commerce-integration/src/index.ts
+++ b/packages/paypal-commerce-integration/src/index.ts
@@ -41,6 +41,9 @@ export { WithPayPalCommerceVenmoButtonInitializeOptions } from './paypal-commerc
 export { default as createPayPalCommerceVenmoCustomerStrategy } from './paypal-commerce-venmo/create-paypal-commerce-venmo-customer-strategy';
 export { WithPayPalCommerceVenmoCustomerInitializeOptions } from './paypal-commerce-venmo/paypal-commerce-venmo-customer-initialize-options';
 
+export { default as createPayPalCommerceVenmoPaymentStrategy } from './paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy';
+export { WithPayPalCommerceVenmoPaymentInitializeOptions } from './paypal-commerce-venmo/paypal-commerce-venmo-payment-initialize-options';
+
 /**
  *
  * PayPalCommerce Alternative methods strategies

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createPayPalCommerceVenmoPaymentStrategy from './create-paypal-commerce-venmo-payment-strategy';
+import PayPalCommerceVenmoPaymentStrategy from './paypal-commerce-venmo-payment-strategy';
+
+describe('createPayPalCommerceVenmoPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates paypal commerce venmo payment strategy', () => {
+        const strategy = createPayPalCommerceVenmoPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(PayPalCommerceVenmoPaymentStrategy);
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/create-paypal-commerce-venmo-payment-strategy.ts
@@ -1,0 +1,40 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+import {
+    PayPalCommerceIntegrationService,
+    PayPalCommerceRequestSender,
+    PayPalCommerceScriptLoader,
+} from '../index';
+
+import PayPalCommerceVenmoPaymentStrategy from './paypal-commerce-venmo-payment-strategy';
+
+const createPayPalCommerceVenmoPaymentStrategy: PaymentStrategyFactory<
+    PayPalCommerceVenmoPaymentStrategy
+> = (paymentIntegrationService) => {
+    const { getHost } = paymentIntegrationService.getState();
+
+    const paypalCommerceIntegrationService = new PayPalCommerceIntegrationService(
+        createFormPoster(),
+        paymentIntegrationService,
+        new PayPalCommerceRequestSender(createRequestSender({ host: getHost() })),
+        new PayPalCommerceScriptLoader(getScriptLoader()),
+    );
+
+    return new PayPalCommerceVenmoPaymentStrategy(
+        paymentIntegrationService,
+        paypalCommerceIntegrationService,
+        new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
+    );
+};
+
+export default toResolvableModule(createPayPalCommerceVenmoPaymentStrategy, [
+    { id: 'paypalcommercevenmo' },
+]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-initialize-options.ts
@@ -1,0 +1,83 @@
+/**
+ * A set of options that are required to initialize the PayPal Commerce payment
+ * method for presenting its PayPal button.
+ *
+ * Please note that the minimum version of checkout-sdk is 1.100
+ *
+ * Also, PayPal (also known as PayPal Commerce Platform) requires specific options to initialize the PayPal Smart Payment Button on checkout page that substitutes a standard submit button
+ * ```html
+ * <!-- This is where the PayPal button will be inserted -->
+ * <div id="container"></div>
+ * ```
+ *
+ * ```js
+ * service.initializePayment({
+ *     methodId: 'paypalcommercevenmo',
+ *     paypalcommercevenmo: {
+ *         container: '#container',
+ * // Callback for submitting payment form that gets called when a buyer approves PayPal payment
+ *         submitForm: () => {
+ *         // Example function
+ *             this.submitOrder(
+ *                {
+ *                   payment: { methodId: 'paypalcommercevenmo', }
+ *               }
+ *            );
+ *         },
+ * // Callback is used to define the state of the payment form, validate if it is applicable for submit.
+ *         onValidate: (resolve, reject) => {
+ *         // Example function
+ *             const isValid = this.validatePaymentForm();
+ *             if (isValid) {
+ *                 return resolve();
+ *             }
+ *             return reject();
+ *         },
+ * // Callback that is called right before render of a Smart Payment Button. It gets called when a buyer is eligible for use of the particular PayPal method. This callback can be used to hide the standard submit button.
+ *         onRenderButton: () => {
+ *         // Example function
+ *             this.hidePaymentSubmitButton();
+ *         }
+ *     },
+ * });
+ * ```
+ */
+export default interface PayPalCommerceVenmoPaymentInitializeOptions {
+    /**
+     * The CSS selector of a container where the payment widget should be inserted into.
+     */
+    container: string;
+
+    /**
+     * A callback for displaying error popup. This callback requires error object as parameter.
+     */
+    onError?(error: Error): void;
+
+    /**
+     * A callback right before render Smart Payment Button that gets called when
+     * Smart Payment Button is eligible. This callback can be used to hide the standard submit button.
+     */
+    onRenderButton?(): void;
+
+    /**
+     * A callback that gets called when a buyer click on Smart Payment Button
+     * and should validate payment form.
+     *
+     * @param resolve - A function, that gets called if form is valid.
+     * @param reject - A function, that gets called if form is not valid.
+     *
+     * @returns reject() or resolve()
+     */
+    onValidate(resolve: () => void, reject: () => void): Promise<void>;
+
+    /**
+     * A callback for submitting payment form that gets called
+     * when buyer approved PayPal account.
+     */
+    submitForm(): void;
+}
+
+export interface WithPayPalCommerceVenmoPaymentInitializeOptions {
+    paypalcommerce?: PayPalCommerceVenmoPaymentInitializeOptions; // FIXME: this option is deprecated
+    paypalcommercevenmo?: PayPalCommerceVenmoPaymentInitializeOptions;
+}

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.spec.ts
@@ -1,0 +1,459 @@
+import { EventEmitter } from 'events';
+
+import {
+    InvalidArgumentError,
+    OrderFinalizationNotRequiredError,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethod,
+    PaymentMethodInvalidError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+import {
+    getPayPalCommerceIntegrationServiceMock,
+    getPayPalCommercePaymentMethod,
+    getPayPalSDKMock,
+} from '../mocks';
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
+import {
+    PayPalCommerceButtonsOptions,
+    PayPalCommerceHostWindow,
+    PayPalSDK,
+} from '../paypal-commerce-types';
+
+import PayPalCommerceVenmoPaymentInitializeOptions from './paypal-commerce-venmo-payment-initialize-options';
+import PayPalCommerceVenmoPaymentStrategy from './paypal-commerce-venmo-payment-strategy';
+
+describe('PayPalCommerceVenmoPaymentStrategy', () => {
+    let eventEmitter: EventEmitter;
+    let loadingIndicator: LoadingIndicator;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let paymentMethod: PaymentMethod;
+    let paypalCommerceIntegrationService: PayPalCommerceIntegrationService;
+    let paypalSdk: PayPalSDK;
+    let strategy: PayPalCommerceVenmoPaymentStrategy;
+
+    const paypalOrderId = 'paypal123';
+
+    const fundingSource = 'venmo';
+    const defaultMethodId = 'paypalcommercevenmo';
+    const defaultContainerId = '#container';
+
+    const paypalCommerceVenmoOptions: PayPalCommerceVenmoPaymentInitializeOptions = {
+        container: defaultContainerId,
+        onValidate: jest.fn(),
+        submitForm: jest.fn(),
+    };
+
+    const initializationOptions: PaymentInitializeOptions = {
+        methodId: defaultMethodId,
+        paypalcommercevenmo: paypalCommerceVenmoOptions,
+    };
+
+    beforeEach(() => {
+        eventEmitter = new EventEmitter();
+
+        paypalSdk = getPayPalSDKMock();
+        paymentMethod = getPayPalCommercePaymentMethod();
+        paymentMethod.id = defaultMethodId;
+        paymentMethod.initializationData.orderId = undefined;
+
+        loadingIndicator = new LoadingIndicator();
+        paypalCommerceIntegrationService = getPayPalCommerceIntegrationServiceMock();
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+
+        strategy = new PayPalCommerceVenmoPaymentStrategy(
+            paymentIntegrationService,
+            paypalCommerceIntegrationService,
+            loadingIndicator,
+        );
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethod,
+        );
+
+        jest.spyOn(paypalCommerceIntegrationService, 'loadPayPalSdk').mockReturnValue(paypalSdk);
+        jest.spyOn(paypalCommerceIntegrationService, 'getPayPalSdkOrThrow').mockReturnValue(
+            paypalSdk,
+        );
+        jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockReturnValue(undefined);
+        jest.spyOn(paypalCommerceIntegrationService, 'submitPayment').mockReturnValue(undefined);
+
+        jest.spyOn(loadingIndicator, 'show').mockReturnValue(undefined);
+        jest.spyOn(loadingIndicator, 'hide').mockReturnValue(undefined);
+
+        jest.spyOn(paypalSdk, 'Buttons').mockImplementation(
+            (options: PayPalCommerceButtonsOptions) => {
+                eventEmitter.on('createOrder', () => {
+                    if (options.createOrder) {
+                        options.createOrder();
+                    }
+                });
+
+                eventEmitter.on('onClick', () => {
+                    if (options.onClick) {
+                        options.onClick(
+                            { fundingSource: 'venmo' },
+                            {
+                                reject: jest.fn(),
+                                resolve: jest.fn(),
+                            },
+                        );
+                    }
+                });
+
+                eventEmitter.on('onApprove', () => {
+                    if (options.onApprove) {
+                        options.onApprove(
+                            { orderID: paypalOrderId },
+                            {
+                                order: {
+                                    get: jest.fn(),
+                                },
+                            },
+                        );
+                    }
+                });
+
+                eventEmitter.on('onCancel', () => {
+                    if (options.onCancel) {
+                        options.onCancel();
+                    }
+                });
+
+                eventEmitter.on('onError', () => {
+                    if (options.onError) {
+                        options.onError(new Error());
+                    }
+                });
+
+                return {
+                    isEligible: jest.fn(() => true),
+                    render: jest.fn(),
+                    close: jest.fn(),
+                };
+            },
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PayPalCommerceHostWindow).paypal;
+    });
+
+    it('creates an instance of the PayPal Commerce Venmo payment strategy', () => {
+        expect(strategy).toBeInstanceOf(PayPalCommerceVenmoPaymentStrategy);
+    });
+
+    describe('#initialize()', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = {} as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('logs a warning message if options.paypalcommerce was not provided instead of options.paypalcommercealternativemethods', async () => {
+            const warnLogSpy = jest.spyOn(console, 'warn');
+
+            const options = {
+                methodId: defaultMethodId,
+                paypalcommerce: {
+                    container: defaultContainerId,
+                },
+            } as PaymentInitializeOptions;
+
+            await strategy.initialize(options);
+
+            expect(warnLogSpy).toHaveBeenCalled();
+        });
+
+        it('throws error if options.paypalcommercevenmo is not provided', async () => {
+            const options = {
+                methodId: defaultMethodId,
+            } as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('does not continues strategy initialization if order id is available in initializationData', async () => {
+            paymentMethod.initializationData.orderId = '1';
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceIntegrationService.loadPayPalSdk).not.toHaveBeenCalled();
+        });
+
+        it('loads paypal sdk', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
+                defaultMethodId,
+            );
+        });
+    });
+
+    describe('#renderButton()', () => {
+        it('initializes paypal button', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalSdk.Buttons).toHaveBeenCalledWith({
+                fundingSource,
+                style: {
+                    color: 'black',
+                    height: 55,
+                    label: 'pay',
+                },
+                createOrder: expect.any(Function),
+                onClick: expect.any(Function),
+                onApprove: expect.any(Function),
+                onCancel: expect.any(Function),
+                onError: expect.any(Function),
+            });
+        });
+
+        it('does not render paypal button if it is not eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+        });
+
+        it('renders paypal button if it is eligible', async () => {
+            const paypalCommerceSdkRenderMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => true),
+                render: paypalCommerceSdkRenderMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paypalCommerceSdkRenderMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('#createOrder button callback', () => {
+        it('creates paypal order', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceIntegrationService.createOrder).toHaveBeenCalledWith(
+                'paypalcommercevenmocheckout',
+            );
+        });
+    });
+
+    describe('#onClick button callback', () => {
+        it('calls validation callback with provided params', async () => {
+            const onValidateMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    ...paypalCommerceVenmoOptions,
+                    onValidate: onValidateMock,
+                },
+            });
+
+            eventEmitter.emit('onClick');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(onValidateMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onApprove button callback', () => {
+        it('submits form', async () => {
+            const submitFormMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    ...paypalCommerceVenmoOptions,
+                    submitForm: submitFormMock,
+                },
+            });
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(submitFormMock).toHaveBeenCalled();
+        });
+
+        it('hides loading indicator after form submit', async () => {
+            const submitFormMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    ...paypalCommerceVenmoOptions,
+                    submitForm: submitFormMock,
+                },
+            });
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(submitFormMock).toHaveBeenCalled();
+            expect(loadingIndicator.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onCancel button callback', () => {
+        it('hides loading indicator', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onCancel');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(loadingIndicator.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onError button callback', () => {
+        it('hides loading indicator', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onError');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(loadingIndicator.hide).toHaveBeenCalled();
+        });
+
+        it('calls onError callback if it is provided', async () => {
+            const onErrorMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                paypalcommercevenmo: {
+                    ...paypalCommerceVenmoOptions,
+                    onError: onErrorMock,
+                },
+            });
+
+            eventEmitter.emit('onError');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(loadingIndicator.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('#execute()', () => {
+        it('throws an error if payload.payment is not provided', async () => {
+            try {
+                await strategy.execute({});
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
+            }
+        });
+
+        it('throws an error if orderId is not defined', async () => {
+            const payload = {
+                payment: {
+                    methodId: defaultMethodId,
+                },
+            };
+
+            try {
+                await strategy.execute(payload);
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentMethodInvalidError);
+            }
+        });
+
+        it('submits order', async () => {
+            const payload = {
+                payment: {
+                    methodId: defaultMethodId,
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+        });
+
+        it('submits payment with provided data', async () => {
+            const payload = {
+                payment: {
+                    methodId: defaultMethodId,
+                },
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onApprove');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            await strategy.execute(payload);
+
+            expect(paypalCommerceIntegrationService.submitPayment).toHaveBeenCalledWith(
+                payload.payment.methodId,
+                paypalOrderId,
+            );
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('closes paypal button component on deinitialize strategy', async () => {
+            const paypalCommerceSdkCloseMock = jest.fn();
+
+            jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
+                isEligible: jest.fn(() => false),
+                render: jest.fn(),
+                close: paypalCommerceSdkCloseMock,
+            }));
+
+            await strategy.initialize(initializationOptions);
+            await strategy.deinitialize();
+
+            expect(paypalCommerceSdkCloseMock).toHaveBeenCalled();
+        });
+
+        it('deinitializes strategy', async () => {
+            const result = await strategy.deinitialize();
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+});

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
@@ -1,0 +1,203 @@
+import {
+    InvalidArgumentError,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethodInvalidError,
+    PaymentRequestOptions,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
+import {
+    ApproveCallbackPayload,
+    ClickCallbackActions,
+    PayPalCommerceButtons,
+    PayPalCommerceButtonsOptions,
+    PayPalCommerceInitializationData,
+} from '../paypal-commerce-types';
+
+import PayPalCommerceVenmoPaymentInitializeOptions, {
+    WithPayPalCommerceVenmoPaymentInitializeOptions,
+} from './paypal-commerce-venmo-payment-initialize-options';
+
+export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrategy {
+    private loadingIndicatorContainer?: string;
+    private orderId?: string;
+    private paypalButton?: PayPalCommerceButtons;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private paypalCommerceIntegrationService: PayPalCommerceIntegrationService,
+        private loadingIndicator: LoadingIndicator,
+    ) {}
+
+    async initialize(
+        options?: PaymentInitializeOptions & WithPayPalCommerceVenmoPaymentInitializeOptions,
+    ): Promise<void> {
+        const { methodId, paypalcommerce, paypalcommercevenmo } = options || {};
+
+        const paypalOptions = paypalcommercevenmo || paypalcommerce;
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (paypalcommerce) {
+            console.warn(
+                'The "options.paypalcommerce" option is deprecated for this strategy, please use "options.paypalcommercevenmo" instead',
+            );
+        }
+
+        if (!paypalOptions) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.paypalcommercevenmo" argument is not provided.`,
+            );
+        }
+
+        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+
+        // Info:
+        // The PayPal button and fields should not be rendered when shopper was redirected to Checkout page
+        // after using smart payment button on PDP or Cart page. In this case backend returns order id if
+        // it is available in checkout session. Therefore, it is not necessary to render PayPal button.
+        if (paymentMethod.initializationData?.orderId) {
+            this.orderId = paymentMethod.initializationData?.orderId;
+
+            return;
+        }
+
+        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+
+        this.loadingIndicatorContainer = paypalOptions.container.split('#')[1];
+
+        this.renderButton(methodId, paypalOptions);
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        const { payment, ...order } = payload;
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        if (!this.orderId) {
+            throw new PaymentMethodInvalidError();
+        }
+
+        await this.paymentIntegrationService.submitOrder(order, options);
+        await this.paypalCommerceIntegrationService.submitPayment(payment.methodId, this.orderId);
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    deinitialize(): Promise<void> {
+        this.orderId = undefined;
+
+        this.paypalButton?.close();
+
+        return Promise.resolve();
+    }
+
+    /**
+     *
+     * Button methods/callbacks
+     *
+     * */
+    private renderButton(
+        methodId: string,
+        paypalcommercevenmo: PayPalCommerceVenmoPaymentInitializeOptions,
+    ): void {
+        const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
+
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const { buttonStyle } = paymentMethod.initializationData || {};
+
+        const { container, onError, onRenderButton, onValidate, submitForm } = paypalcommercevenmo;
+
+        const buttonOptions: PayPalCommerceButtonsOptions = {
+            fundingSource: paypalSdk.FUNDING.VENMO,
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle(buttonStyle),
+            createOrder: () =>
+                this.paypalCommerceIntegrationService.createOrder('paypalcommercevenmocheckout'),
+            onClick: (_, actions) => this.handleClick(actions, onValidate),
+            onApprove: (data) => this.handleApprove(data, submitForm),
+            onCancel: () => this.toggleLoadingIndicator(false),
+            onError: (error) => this.handleError(error, onError),
+        };
+
+        this.paypalButton = paypalSdk.Buttons(buttonOptions);
+
+        if (!this.paypalButton.isEligible()) {
+            return;
+        }
+
+        if (onRenderButton && typeof onRenderButton === 'function') {
+            onRenderButton();
+        }
+
+        this.paypalButton.render(container);
+    }
+
+    private async handleClick(
+        actions: ClickCallbackActions,
+        onValidate: PayPalCommerceVenmoPaymentInitializeOptions['onValidate'],
+    ): Promise<void> {
+        const { resolve, reject } = actions;
+
+        const onValidationPassed = () => {
+            this.toggleLoadingIndicator(true);
+
+            return resolve();
+        };
+
+        await onValidate(onValidationPassed, reject);
+    }
+
+    private handleApprove(
+        { orderID }: ApproveCallbackPayload,
+        submitForm: PayPalCommerceVenmoPaymentInitializeOptions['submitForm'],
+    ): void {
+        this.orderId = orderID;
+
+        submitForm();
+        this.toggleLoadingIndicator(false);
+    }
+
+    private handleError(
+        error: Error,
+        onError: PayPalCommerceVenmoPaymentInitializeOptions['onError'],
+    ): void {
+        this.toggleLoadingIndicator(false);
+
+        if (onError && typeof onError === 'function') {
+            onError(error);
+        }
+    }
+
+    /**
+     *
+     * Loading Indicator methods
+     *
+     * */
+    private toggleLoadingIndicator(isLoading: boolean): void {
+        if (isLoading && this.loadingIndicatorContainer) {
+            this.loadingIndicator.show(this.loadingIndicatorContainer);
+        } else {
+            this.loadingIndicator.hide();
+        }
+    }
+}


### PR DESCRIPTION
## What?
Added PayPalCommerceVenmo payment strategy to paypal-commerce-integration package

## Why?
As part of paypal commerce code migration from core package to paypal-commerce-integration package

## Testing / Proof
Unit tests
CI tests
