### PR TITLE
feat(payment): PAYPAL-2013 fixed braintree paylater button

### DIFF
--- a/packages/braintree-integration/src/braintree-integration-service.ts
+++ b/packages/braintree-integration/src/braintree-integration-service.ts
@@ -73,6 +73,7 @@ export default class BraintreeIntegrationService {
             const paypalSdkLoadCallback = () => onSuccess(braintreePaypalCheckout);
             const paypalSdkLoadConfig = {
                 currency: config.currency,
+                ...(config.isCreditEnabled && { 'enable-funding': 'paylater' }),
                 components: PAYPAL_COMPONENTS.toString(),
                 intent: config.intent,
             };

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
@@ -223,6 +223,29 @@ describe('BraintreePaypalCustomerStrategy', () => {
             expect(braintreeIntegrationService.getPaypalCheckout).toHaveBeenCalled();
         });
 
+        it('calls braintreeSdk with proper options', async () => {
+            braintreeIntegrationService.initialize = jest.fn();
+            braintreeIntegrationService.getPaypalCheckout = jest.fn();
+            paymentMethodMock.initializationData = {
+                ...paymentMethodMock.initializationData,
+                isCreditEnabled: true,
+                currency: 'USD',
+                intent: undefined,
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeIntegrationService.getPaypalCheckout).toHaveBeenCalledWith(
+                {
+                    currency: 'USD',
+                    isCreditEnabled: true,
+                    intent: undefined,
+                },
+                expect.any(Function),
+                expect.any(Function),
+            );
+        });
+
         it('calls onError callback option if the error was caught on paypal checkout creation', async () => {
             braintreeIntegrationService.getPaypalCheckout = getSDKPaypalCheckoutMock();
 

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -76,6 +76,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
         const paypalCheckoutOptions: Partial<BraintreePaypalSdkCreatorConfig> = {
             currency: currencyCode,
             intent: paymentMethod.initializationData?.intent,
+            isCreditEnabled: paymentMethod.initializationData?.isCreditEnabled,
         };
 
         const paypalCheckoutSuccessCallback = (

--- a/packages/braintree-integration/src/braintree.ts
+++ b/packages/braintree-integration/src/braintree.ts
@@ -49,6 +49,7 @@ export interface BraintreeSDK {
 
 export interface BraintreeInitializationData {
     intent?: 'authorize' | 'order' | 'sale';
+    isCreditEnabled?: boolean;
 }
 
 export interface BraintreePaypalRequest {
@@ -424,6 +425,7 @@ export interface BraintreePaypalSdkCreatorConfig {
     components?: string;
     currency?: string;
     intent?: string;
+    isCreditEnabled?: boolean;
 }
 
 /**

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -287,6 +287,29 @@ describe('BraintreePaypalButtonStrategy', () => {
             expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
         });
 
+        it('calls braintreeSdk with proper options', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+            paymentMethodMock.initializationData = {
+                ...paymentMethodMock.initializationData,
+                isCreditEnabled: true,
+                currency: 'USD',
+                intent: undefined,
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalledWith(
+                {
+                    currency: 'USD',
+                    isCreditEnabled: true,
+                    intent: undefined,
+                },
+                expect.any(Function),
+                expect.any(Function),
+            );
+        });
+
         it('does not load default checkout for BuyNowFlow', async () => {
             await strategy.initialize(buyNowInitializationOptions);
 

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -94,6 +94,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         const paypalCheckoutOptions: Partial<BraintreePaypalSdkCreatorConfig> = {
             currency: currencyCode,
             intent: paymentMethod.initializationData?.intent,
+            isCreditEnabled: paymentMethod.initializationData?.isCreditEnabled,
         };
 
         const paypalCheckoutSuccessCallback = (

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -232,6 +232,29 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
             }
         });
 
+        it('calls braintreeSdk with proper options', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+            paymentMethodMock.initializationData = {
+                ...paymentMethodMock.initializationData,
+                isCreditEnabled: true,
+                currency: 'USD',
+                intent: undefined,
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalledWith(
+                {
+                    currency: 'USD',
+                    isCreditEnabled: true,
+                    intent: undefined,
+                },
+                expect.any(Function),
+                expect.any(Function),
+            );
+        });
+
         it('throws an error if braintreepaypalcredit is not provided', async () => {
             const options = {
                 containerId: defaultButtonContainerId,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -97,6 +97,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         const paypalCheckoutOptions: Partial<BraintreePaypalSdkCreatorConfig> = {
             currency: currencyCode,
             intent: paymentMethod.initializationData?.intent,
+            isCreditEnabled: paymentMethod.initializationData?.isCreditEnabled,
         };
 
         const paypalCheckoutCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) =>

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
@@ -244,6 +244,29 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             }
         });
 
+        it('calls braintreeSdk with proper options', async () => {
+            braintreeSDKCreator.initialize = jest.fn();
+            braintreeSDKCreator.getPaypalCheckout = jest.fn();
+            paymentMethodMock.initializationData = {
+                ...paymentMethodMock.initializationData,
+                isCreditEnabled: true,
+                currency: 'USD',
+                intent: undefined,
+            };
+
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalledWith(
+                {
+                    currency: 'USD',
+                    isCreditEnabled: true,
+                    intent: undefined,
+                },
+                expect.any(Function),
+                expect.any(Function),
+            );
+        });
+
         it('throws error if client token is missing', async () => {
             paymentMethodMock.clientToken = undefined;
 

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -80,6 +80,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         const paypalCheckoutOptions: Partial<BraintreePaypalSdkCreatorConfig> = {
             currency: currencyCode,
             intent: paymentMethod.initializationData?.intent,
+            isCreditEnabled: paymentMethod.initializationData?.isCreditEnabled,
         };
 
         const paypalCheckoutCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) =>

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -91,6 +91,7 @@ export default class BraintreeSDKCreator {
             const paypalSdkLoadCallback = () => onSuccess(braintreePaypalCheckout);
             const paypalSdkLoadConfig = {
                 currency: config.currency,
+                ...(config.isCreditEnabled && { 'enable-funding': 'paylater' }),
                 components: PAYPAL_COMPONENTS.toString(),
                 intent: config.intent,
             };

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -455,6 +455,7 @@ export interface BraintreePaypalSdkCreatorConfig {
     components?: string;
     currency?: string;
     intent?: string;
+    isCreditEnabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What?
Fixed PayLater SPB. Added 'enable-funding' field to getPaypalCheckout request in order to display PayLater SPB properly

## Why?
Button didn't display for EUR currency for Germany
BCAPP PR: https://github.com/bigcommerce/bigcommerce/pull/52308

## Testing / Proof

<img width="1680" alt="Screenshot 2023-04-24 at 14 11 35" src="https://user-images.githubusercontent.com/56301104/234052966-53f8fbb4-e391-4632-bf04-fcf644b373de.png">

@bigcommerce/checkout @bigcommerce/payments
