### PR TITLE
fix(payment): PAYPAL-2036 added shippingAddressEditable option to Braintree payment configuration

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -38,6 +38,7 @@ export interface PaypalConfig {
     currency: string;
     locale: string;
     offerCredit?: boolean;
+    shippingAddressEditable?: boolean;
     shippingAddressOverride?: BraintreeShippingAddressOverride;
     shouldSaveInstrument?: boolean;
 }

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -185,6 +185,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 currency: 'USD',
                 shouldSaveInstrument: false,
                 offerCredit: false,
+                shippingAddressEditable: false,
                 shippingAddressOverride,
             });
 
@@ -213,6 +214,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 currency: 'USD',
                 shouldSaveInstrument: false,
                 offerCredit: false,
+                shippingAddressEditable: false,
                 shippingAddressOverride,
             });
 
@@ -224,6 +226,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 locale: 'en_US',
                 currency: 'USD',
                 shouldSaveInstrument: false,
+                shippingAddressEditable: false,
                 offerCredit: false,
                 shippingAddressOverride,
             });
@@ -385,6 +388,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                     currency: 'USD',
                     shouldSaveInstrument: false,
                     offerCredit: true,
+                    shippingAddressEditable: false,
                     shippingAddressOverride,
                 });
                 expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(expected);

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -188,6 +188,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                 offerCredit: this._credit,
                 shippingAddressOverride,
                 shouldSaveInstrument: shouldSaveInstrument || false,
+                shippingAddressEditable: false,
             }),
             this._braintreePaymentProcessor.getSessionId(),
         ]).then(([{ nonce, details } = {} as any, sessionId]) => ({


### PR DESCRIPTION
## What?
Added `shippingAddressEditable` option to Braintree payment configuration.

`shippingAddressEditable` is optional, because it is `true` by default on Braintree side

## Why?
To remove an ability to change shipping address by shoppers who use braintree in payment section of checkout page

## Testing / Proof
Unit tests
Manual tests

Before:
https://user-images.githubusercontent.com/25133454/234507334-8419ef8d-8660-4fd4-9d9b-d5484a67ecba.mov

After:
https://user-images.githubusercontent.com/25133454/234507271-46fd0aa1-8cf2-4a74-989b-80eb4bec95e4.mov
