### PR TITLE
chore(deps): bump @bigcommerce/bigpay-client from 5.22.0 to 5.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.374.8",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.22.0",
+        "@bigcommerce/bigpay-client": "^5.23.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1420,9 +1420,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.22.0.tgz",
-      "integrity": "sha512-M3xr9mo6DEKuiEU6WrXon+WSUVj8OoazmUoXk1KxO9uWAT3iyXixRw3zbhcTKwLu+MfTs3TJ4ksxfztLtVTGDQ==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.23.0.tgz",
+      "integrity": "sha512-KBhxoHCFVnAjMvXIqOPlaW+JDJVY8oK4YvpVE2ALsljbJuXYiBGhIwYWeWeGKn63DxiFWhPiimXmdVDjMQZLOw==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -32172,9 +32172,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.22.0.tgz",
-      "integrity": "sha512-M3xr9mo6DEKuiEU6WrXon+WSUVj8OoazmUoXk1KxO9uWAT3iyXixRw3zbhcTKwLu+MfTs3TJ4ksxfztLtVTGDQ==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.23.0.tgz",
+      "integrity": "sha512-KBhxoHCFVnAjMvXIqOPlaW+JDJVY8oK4YvpVE2ALsljbJuXYiBGhIwYWeWeGKn63DxiFWhPiimXmdVDjMQZLOw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.22.0",
+    "@bigcommerce/bigpay-client": "^5.23.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?

Bump **bigpay-client-js** to newer version

## Why?

To keep up to date
https://github.com/bigcommerce/bigpay-client-js/pull/185

## Testing / Proof
...

@bigcommerce/checkout @bigcommerce/payments
