### PR TITLE
core(deps): GITHUB-1972 bump yup to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@types/iframe-resizer": "^3.5.9",
         "@types/reselect": "^2.2.0",
         "@types/shallowequal": "^1.1.1",
-        "@types/yup": "^0.26.24",
         "card-validator": "^6.2.0",
         "core-js": "^3.25.2",
         "current-script-polyfill": "^1.0.0",
@@ -33,7 +32,7 @@
         "rxjs": "^6.6.7",
         "shallowequal": "^1.1.0",
         "tslib": "^1.10.0",
-        "yup": "^0.27.0"
+        "yup": "^1.1.1"
       },
       "devDependencies": {
         "@babel/core": "^7.6.2",
@@ -69,6 +68,7 @@
         "jest-junit": "^15.0.0",
         "nx": "^13.10.3",
         "prettier": "^2.6.2",
+        "regenerator-runtime": "^0.13.3",
         "request": "^2.83.0",
         "semver": "^7.1.1",
         "source-map-loader": "^0.2.4",
@@ -1316,14 +1316,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.2"
       }
     },
     "node_modules/@babel/runtime-corejs3": {
@@ -14102,11 +14094,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
-    "node_modules/@types/yup": {
-      "version": "0.26.24",
-      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.24.tgz",
-      "integrity": "sha512-x0bhHnYjH5mZit4HivUYbTMO4LouOTGwp/LLxSL1mbJYVwNJtHYESH0ed2bwM1lkI2yDmsoCDYJnWEgHeJDACg=="
-    },
     "node_modules/@types/z-schema": {
       "version": "3.16.31",
       "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz",
@@ -19558,14 +19545,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
-    },
-    "node_modules/fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
@@ -26522,9 +26501,9 @@
       "dev": true
     },
     "node_modules/property-expr": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -26852,7 +26831,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.1",
@@ -28718,11 +28698,6 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
-    "node_modules/synchronous-promise": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.10.tgz",
-      "integrity": "sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A=="
-    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -29041,6 +29016,11 @@
       "dependencies": {
         "readable-stream": "3"
       }
+    },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -31082,16 +31062,25 @@
       }
     },
     "node_modules/yup": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
-      "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.1.1.tgz",
+      "integrity": "sha512-KfCGHdAErqFZWA5tZf7upSUnGKuTOnsI3hUsLr7fgVtx+DK04NPV01A68/FslI4t3s/ZWpvXJmgXhd7q6ICnag==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.11",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.6",
-        "toposort": "^2.0.2"
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/z-schema": {
@@ -32078,14 +32067,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
-      }
-    },
-    "@babel/runtime": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/runtime-corejs3": {
@@ -42095,11 +42076,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
-    "@types/yup": {
-      "version": "0.26.24",
-      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.24.tgz",
-      "integrity": "sha512-x0bhHnYjH5mZit4HivUYbTMO4LouOTGwp/LLxSL1mbJYVwNJtHYESH0ed2bwM1lkI2yDmsoCDYJnWEgHeJDACg=="
-    },
     "@types/z-schema": {
       "version": "3.16.31",
       "resolved": "https://registry.npmjs.org/@types/z-schema/-/z-schema-3.16.31.tgz",
@@ -46200,11 +46176,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
-    },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
     },
     "follow-redirects": {
       "version": "1.15.2",
@@ -51537,9 +51508,9 @@
       }
     },
     "property-expr": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -51794,7 +51765,8 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",
@@ -53204,11 +53176,6 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
-    "synchronous-promise": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.10.tgz",
-      "integrity": "sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A=="
-    },
     "tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -53442,6 +53409,11 @@
       "requires": {
         "readable-stream": "3"
       }
+    },
+    "tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q=="
     },
     "tmp": {
       "version": "0.2.1",
@@ -54967,16 +54939,21 @@
       "dev": true
     },
     "yup": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
-      "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.1.1.tgz",
+      "integrity": "sha512-KfCGHdAErqFZWA5tZf7upSUnGKuTOnsI3hUsLr7fgVtx+DK04NPV01A68/FslI4t3s/ZWpvXJmgXhd7q6ICnag==",
       "requires": {
-        "@babel/runtime": "^7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.11",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.6",
-        "toposort": "^2.0.2"
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
       }
     },
     "z-schema": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@types/iframe-resizer": "^3.5.9",
     "@types/reselect": "^2.2.0",
     "@types/shallowequal": "^1.1.1",
-    "@types/yup": "^0.26.24",
     "card-validator": "^6.2.0",
     "core-js": "^3.25.2",
     "current-script-polyfill": "^1.0.0",
@@ -76,7 +75,7 @@
     "rxjs": "^6.6.7",
     "shallowequal": "^1.1.0",
     "tslib": "^1.10.0",
-    "yup": "^0.27.0"
+    "yup": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",
@@ -112,6 +111,7 @@
     "jest-junit": "^15.0.0",
     "nx": "^13.10.3",
     "prettier": "^2.6.2",
+    "regenerator-runtime": "^0.13.3",
     "request": "^2.83.0",
     "semver": "^7.1.1",
     "source-map-loader": "^0.2.4",

--- a/packages/core/src/hosted-form/iframe-content/hosted-input-validator.ts
+++ b/packages/core/src/hosted-form/iframe-content/hosted-input-validator.ts
@@ -1,55 +1,39 @@
 import { creditCardType, cvv, expirationDate, number } from 'card-validator';
-import { includes } from 'lodash';
-import { object, string, StringSchema, ValidationError } from 'yup';
+import { object, ObjectShape, string, StringSchema, ValidationError } from 'yup';
 
 import { CardInstrument } from '../../payment/instrument';
-import HostedFieldType from '../hosted-field-type';
 
 import { HostedInputValidateErrorDataMap } from './hosted-input-validate-error-data';
 import HostedInputValidateResults from './hosted-input-validate-results';
 import HostedInputValues from './hosted-input-values';
 
 export default class HostedInputValidator {
+    private readonly _completeSchema: ObjectShape = {
+        cardCode: this._getCardCodeSchema(),
+        cardCodeVerification: this._getCardCodeVerificationSchema(),
+        cardExpiry: this._getCardExpirySchema(),
+        cardName: this._getCardNameSchema(),
+        cardNumber: this._getCardNumberSchema(),
+        cardNumberVerification: this._getCardNumberVerificationSchema(),
+    };
+
     constructor(private _cardInstrument?: CardInstrument) {
         this._configureCardValidator();
     }
 
     async validate(values: HostedInputValues): Promise<HostedInputValidateResults> {
-        const requiredFields = Object.keys(values);
-        const schemas: { [key in keyof HostedInputValues]: StringSchema } = {};
+        const schemas: ObjectShape = {};
         const results: HostedInputValidateResults = {
             errors: {},
             isValid: true,
         };
 
-        if (includes(requiredFields, HostedFieldType.CardCode)) {
-            schemas.cardCode = this._getCardCodeSchema();
-            results.errors.cardCode = [];
-        }
-
-        if (includes(requiredFields, HostedFieldType.CardCodeVerification)) {
-            schemas.cardCodeVerification = this._getCardCodeVerificationSchema();
-            results.errors.cardCodeVerification = [];
-        }
-
-        if (includes(requiredFields, HostedFieldType.CardExpiry)) {
-            schemas.cardExpiry = this._getCardExpirySchema();
-            results.errors.cardExpiry = [];
-        }
-
-        if (includes(requiredFields, HostedFieldType.CardName)) {
-            schemas.cardName = this._getCardNameSchema();
-            results.errors.cardName = [];
-        }
-
-        if (includes(requiredFields, HostedFieldType.CardNumber)) {
-            schemas.cardNumber = this._getCardNumberSchema();
-            results.errors.cardNumber = [];
-        }
-
-        if (includes(requiredFields, HostedFieldType.CardNumberVerification)) {
-            schemas.cardNumberVerification = this._getCardNumberVerificationSchema();
-            results.errors.cardNumberVerification = [];
+        let requiredField: keyof HostedInputValues;
+        for (requiredField in values) {
+            if (Object.prototype.hasOwnProperty.call(values, requiredField)) {
+                schemas[requiredField] = this._completeSchema[requiredField];
+                results.errors[requiredField] = [];
+            }
         }
 
         try {


### PR DESCRIPTION
Closes: #1153 

## What?
- Bumps yup to 1.1.1.
- Make the previously implicit dependency on regenerator-runtime explicit

## Why?
- [CVE-2020-7707: Prototype Pollution in property-expr (Critical severity)](https://github.com/advisories/GHSA-6fw4-hr69-g3rv)

## Testing / Proof
- ✅ Tests pass

@bigcommerce/checkout @bigcommerce/payments