### PR TITLE
feat(payment): PAYPAL-2039 added walletButtonStyle prop to init data in PPCP customer strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -25,6 +25,7 @@ import {
     PayPalCommerceButtonsOptions,
     PayPalSDK,
     StyleButtonColor,
+    StyleButtonLabel,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditCustomerInitializeOptions from './paypal-commerce-credit-customer-initialize-options';
@@ -221,6 +222,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                 style: {
                     height: 40,
                     color: StyleButtonColor.gold,
+                    label: StyleButtonLabel.checkout,
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
@@ -246,6 +248,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                 style: {
                     height: 40,
                     color: StyleButtonColor.gold,
+                    label: StyleButtonLabel.checkout,
                 },
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
@@ -286,6 +289,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
                 style: {
                     height: 40,
                     color: StyleButtonColor.gold,
+                    label: StyleButtonLabel.checkout,
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -21,6 +21,7 @@ import {
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
     StyleButtonColor,
+    StyleButtonLabel,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditCustomerInitializeOptions, {
@@ -94,8 +95,8 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { isHostedCheckoutEnabled } = paymentMethod.initializationData || {};
-
+        const { isHostedCheckoutEnabled, walletButtonStyle } =
+            paymentMethod.initializationData || {};
         const defaultCallbacks = {
             createOrder: () =>
                 this.paypalCommerceIntegrationService.createOrder('paypalcommercecredit'),
@@ -120,7 +121,8 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
                 const buttonRenderOptions: PayPalCommerceButtonsOptions = {
                     fundingSource,
                     style: this.paypalCommerceIntegrationService.getValidButtonStyle({
-                        color: StyleButtonColor.gold,
+                        color: walletButtonStyle?.color || StyleButtonColor.gold,
+                        label: walletButtonStyle?.label || StyleButtonLabel.checkout,
                     }),
                     ...defaultCallbacks,
                     ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -76,6 +76,7 @@ export interface PayPalCommerceInitializationData {
     attributionId?: string;
     availableAlternativePaymentMethods: FundingType;
     buttonStyle?: PayPalButtonStyleOptions;
+    walletButtonStyle?: PayPalButtonStyleOptions;
     buyerCountry?: string;
     clientId: string;
     clientToken?: string;

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -21,7 +21,12 @@ import {
     getShippingAddressFromOrderDetails,
 } from '../mocks';
 import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
-import { PayPalCommerceButtonsOptions, PayPalSDK } from '../paypal-commerce-types';
+import {
+    PayPalCommerceButtonsOptions,
+    PayPalSDK,
+    StyleButtonColor,
+    StyleButtonLabel,
+} from '../paypal-commerce-types';
 
 import PayPalCommerceCustomerInitializeOptions from './paypal-commerce-customer-initialize-options';
 import PayPalCommerceCustomerStrategy from './paypal-commerce-customer-strategy';
@@ -213,7 +218,11 @@ describe('PayPalCommerceCustomerStrategy', () => {
 
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: { height: 40 },
+                style: {
+                    color: StyleButtonColor.gold,
+                    label: StyleButtonLabel.checkout,
+                    height: 40,
+                },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
             });
@@ -235,7 +244,11 @@ describe('PayPalCommerceCustomerStrategy', () => {
 
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: { height: 40 },
+                style: {
+                    color: StyleButtonColor.gold,
+                    label: StyleButtonLabel.checkout,
+                    height: 40,
+                },
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -20,6 +20,8 @@ import {
     PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
+    StyleButtonColor,
+    StyleButtonLabel,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCustomerInitializeOptions, {
@@ -97,7 +99,8 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { isHostedCheckoutEnabled } = paymentMethod.initializationData || {};
+        const { isHostedCheckoutEnabled, walletButtonStyle } =
+            paymentMethod.initializationData || {};
 
         const defaultCallbacks = {
             createOrder: () => this.paypalCommerceIntegrationService.createOrder('paypalcommerce'),
@@ -116,7 +119,10 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
 
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.PAYPAL,
-            style: this.paypalCommerceIntegrationService.getValidButtonStyle(),
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle({
+                color: walletButtonStyle?.color || StyleButtonColor.gold,
+                label: walletButtonStyle?.label || StyleButtonLabel.checkout,
+            }),
             ...defaultCallbacks,
             ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),
         };


### PR DESCRIPTION
## What?
Added walletButtonStyle prop to initialization data in PPCP customer strategy.

## Why?
Because currently we do not support styling for top of checkout page PayPal.

## Testing / Proof
All tests has been passed.
