### PR TITLE
fix(payment): BOLT-577 Bolt initialization error on customer step

### DIFF
--- a/packages/bolt-integration/src/bolt-customer-strategy.ts
+++ b/packages/bolt-integration/src/bolt-customer-strategy.ts
@@ -19,12 +19,13 @@ import {
     RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import { BoltCheckout, BoltInitializationData } from './bolt';
+import { BoltCheckout, BoltHostWindow, BoltInitializationData } from './bolt';
 import { WithBoltCustomerInitializeOptions } from './bolt-customer-initialize-options';
 import BoltScriptLoader from './bolt-script-loader';
 
 export default class BoltCustomerStrategy implements CustomerStrategy {
     private boltClient?: BoltCheckout;
+    private boltHostWindow: BoltHostWindow = window;
 
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
@@ -170,7 +171,7 @@ export default class BoltCustomerStrategy implements CustomerStrategy {
     }
 
     private getBoltClientOrThrow() {
-        const boltClient = this.boltClient;
+        const boltClient = this.boltClient || this.boltHostWindow.BoltCheckout;
 
         if (!boltClient) {
             throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);


### PR DESCRIPTION
## What?
fix error after initialization Bolt on customer step

## Why?
This issue blocks payment process on checkout page with Bolt
Before:
<img width="2558" alt="Screenshot 2023-05-16 at 11 41 52" src="https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/aee890bd-474b-449a-b08a-06227bf1f7af">
After:
<img width="1227" alt="Screenshot 2023-05-16 at 11 49 40" src="https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/f4af2504-ab6d-4aa2-bcfa-2949d0fcee5b">


## Testing / Proof
Unit test and manual testing

@bigcommerce/checkout @bigcommerce/payments
