### PR TITLE
feat(payment): PI-88 [Adyen] Klarna widget update

### DIFF
--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -83,6 +83,7 @@ describe('AdyenV3PaymentStrategy', () => {
                     handleOnChange(getComponentState());
                 }),
                 unmount: jest.fn(),
+                submit: jest.fn(),
             };
 
             cardVerificationComponent = {
@@ -91,6 +92,7 @@ describe('AdyenV3PaymentStrategy', () => {
                     handleOnError(getComponentState(false));
                 }),
                 unmount: jest.fn(),
+                submit: jest.fn(),
             };
 
             jest.spyOn(
@@ -171,6 +173,7 @@ describe('AdyenV3PaymentStrategy', () => {
                         });
                     }),
                     unmount: jest.fn(),
+                    submit: jest.fn(),
                 };
 
                 jest.spyOn(adyenCheckout, 'createFromAction').mockImplementation(
@@ -346,6 +349,7 @@ describe('AdyenV3PaymentStrategy', () => {
                         handleOnError(adyenError);
                     }),
                     unmount: jest.fn(),
+                    submit: jest.fn(),
                 };
 
                 jest.spyOn(adyenCheckout, 'createFromAction').mockImplementation(
@@ -437,6 +441,7 @@ describe('AdyenV3PaymentStrategy', () => {
                 additionalActionComponent = {
                     mount: jest.fn(),
                     unmount: jest.fn(),
+                    submit: jest.fn(),
                 };
 
                 jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -77,6 +77,17 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             paymentMethod.initializationData || {};
 
         this._adyenClient = await this._scriptLoader.load({
+            paymentMethodsConfiguration: {
+                klarna: {
+                    useKlarnaWidget: true,
+                },
+                klarna_account: {
+                    useKlarnaWidget: true,
+                },
+                klarna_paynow: {
+                    useKlarnaWidget: true,
+                },
+            },
             environment,
             locale: this._paymentIntegrationService.getState().getLocale(),
             clientKey,
@@ -121,6 +132,8 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             : { shouldSaveInstrument: false, shouldSetAsDefaultInstrument: false };
 
         this._validateCardData();
+
+        this._paymentComponent?.submit();
 
         await this._paymentIntegrationService.submitOrder(order, options);
 
@@ -273,7 +286,8 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             if (onBeforeLoad) {
                 onBeforeLoad(
                     adyenAction.type === AdyenActionType.ThreeDS2 ||
-                        adyenAction.type === AdyenActionType.QRCode,
+                        adyenAction.type === AdyenActionType.QRCode ||
+                        adyenAction.type === AdyenActionType.Sdk,
                 );
             }
 
@@ -363,6 +377,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                 showBrandsUnderCardNumber: false,
                 onChange: (componentState) => this._updateComponentState(componentState),
                 ...(billingAddress ? { data: this._mapAdyenPlaceholderData(billingAddress) } : {}),
+                onSubmit: (componentState) => this._updateComponentState(componentState),
             });
 
             try {

--- a/packages/adyen-integration/src/adyenv3/adyenv3.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3.ts
@@ -24,6 +24,11 @@ export enum AdyenActionType {
      * The Component displays the voucher which the shopper uses to complete the payment.
      * */
     Voucher = 'voucher',
+
+    /*
+     * The Component displays the widget which the shopper uses to complete the payment.
+     * */
+    Sdk = 'sdk',
 }
 
 export enum AdyenComponentType {
@@ -177,6 +182,11 @@ export interface AdyenComponentEvents {
     onChange?(state: AdyenV3ComponentState, component: AdyenComponent): void;
 
     /**
+     * Called when the shopper selects the Pay button and payment details are valid.
+     */
+    onSubmit?(state: AdyenV3ComponentState, component: AdyenComponent): void;
+
+    /**
      * Called in case of an invalid card number, invalid expiry date, or
      *  incomplete field. Called again when errors are cleared.
      */
@@ -206,6 +216,7 @@ export interface AdyenComponent {
     state?: CardState;
     mount(containerId: string): HTMLElement;
     unmount(): void;
+    submit(): void;
 }
 
 export interface AdyenConfiguration {
@@ -236,6 +247,21 @@ export interface AdyenConfiguration {
      * Component.
      */
     paymentMethodsResponse?: PaymentMethodsResponse;
+
+    /**
+     * Configuration for specific payment methods.
+     */
+    paymentMethodsConfiguration: {
+        klarna: {
+            useKlarnaWidget: boolean;
+        };
+        klarna_account: {
+            useKlarnaWidget: boolean;
+        };
+        klarna_paynow: {
+            useKlarnaWidget: boolean;
+        };
+    };
 
     showPayButton?: boolean;
 


### PR DESCRIPTION
## What?
Adding to Adyen component, the Klarna Widget configuration, so Klarna widget will appear when customer wants to pay with Klarna.
## Why?
To enable Klarna widget

## Testing / Proof
Videos showing actions after clicking on "CONTINUE WITH KLARNA" button.

Before changes:

https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/415e84bb-9403-4c66-b19e-74ad1bcb5d1c

After changes:

https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/1a0d96f5-b6c2-426a-a49f-89fd9bb20729

@bigcommerce/checkout @bigcommerce/payments
