### PR TITLE
fix(checkout): PI-101 Googlepay 3ds2 redirect flow for the adyen v3

### DIFF
--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -806,6 +806,10 @@ describe('GooglePayPaymentStrategy', () => {
         };
 
         beforeEach(() => {
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
+                initializationData,
+                method: 'googlepay',
+            });
             strategy = new GooglePayPaymentStrategy(
                 store,
                 checkoutActionCreator,
@@ -831,7 +835,7 @@ describe('GooglePayPaymentStrategy', () => {
             expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith({
                 methodId: 'googlepayadyenv2',
                 paymentData: {
-                    nonce: `{"type":"paywithgoogle","googlePayToken":"nonce","browser_info":{"color_depth":24,"java_enabled":false,"language":"en-US","screen_height":0,"screen_width":0,"time_zone_offset":"${new Date()
+                    nonce: `{"type":"googlepay","googlePayToken":"nonce","browser_info":{"color_depth":24,"java_enabled":false,"language":"en-US","screen_height":0,"screen_width":0,"time_zone_offset":"${new Date()
                         .getTimezoneOffset()
                         .toString()}"}}`,
                     method: 'googlepayadyenv2',

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -20,7 +20,6 @@ import PaymentMethod from '../../payment-method';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
 import PaymentStrategyActionCreator from '../../payment-strategy-action-creator';
-import { AdyenPaymentMethodType } from '../adyenv2';
 import {
     BraintreeGooglePayThreeDSecure,
     BraintreeSDKCreator,
@@ -355,7 +354,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     private async _encodeNonce(methodId: string, nonce: string) {
         if (methodId === PaymentStrategyType.ADYENV2_GOOGLEPAY) {
             return JSON.stringify({
-                type: AdyenPaymentMethodType.GooglePay,
+                type: this._paymentMethod?.method,
                 googlePayToken: nonce,
                 browser_info: getBrowserInfo(),
             });
@@ -363,8 +362,9 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         if (methodId === PaymentStrategyType.ADYENV3_GOOGLEPAY) {
             return JSON.stringify({
-                type: AdyenPaymentMethodType.GooglePay,
+                type: this._paymentMethod?.method,
                 googlePayToken: nonce,
+                browser_info: getBrowserInfo(),
             });
         }
 


### PR DESCRIPTION
## What?
Fixed Google pay 3ds2 redirect flow for the adyen v3

## Why?
3ds redirect doesn't work with adyen v3 googlepay

## Testing / Proof
Tested manually

@bigcommerce/checkout @bigcommerce/payments
