### PR TITLE
feat(payment): PAYPAL-2451 Updated AccountInstrument type

### DIFF
--- a/packages/core/src/payment/instrument/instrument.mock.ts
+++ b/packages/core/src/payment/instrument/instrument.mock.ts
@@ -72,7 +72,6 @@ export function getInstruments(): PaymentInstrument[] {
             type: 'bank',
             method: 'bank',
             iban: 'DEFDEF',
-            externalId: 'test@external-id.com',
         },
         {
             bigpayToken: '56789',

--- a/packages/core/src/payment/instrument/instrument.ts
+++ b/packages/core/src/payment/instrument/instrument.ts
@@ -1,4 +1,4 @@
-type PaymentInstrument = CardInstrument | AccountInstrument | BraintreeAchInstrument;
+type PaymentInstrument = CardInstrument | AccountInstrument;
 
 export default PaymentInstrument;
 
@@ -27,16 +27,16 @@ export interface CardInstrument extends BaseInstrument {
 }
 
 interface BaseAccountInstrument extends BaseInstrument {
-    externalId: string;
     method: string;
     type: 'account' | 'bank';
 }
 
 export interface PayPalInstrument extends BaseAccountInstrument {
+    externalId: string;
     method: 'paypal';
 }
 
-export interface BraintreeAchInstrument extends BaseInstrument {
+export interface BraintreeAchInstrument extends BaseAccountInstrument {
     issuer: string;
     accountNumber: string;
     type: 'bank';
@@ -51,7 +51,7 @@ export interface BankInstrument extends BaseAccountInstrument {
     type: 'bank';
 }
 
-export type AccountInstrument = PayPalInstrument | BankInstrument;
+export type AccountInstrument = PayPalInstrument | BankInstrument | BraintreeAchInstrument;
 
 export interface VaultAccessToken {
     vaultAccessToken: string;

--- a/packages/core/src/payment/instrument/map-to-bank-instrument.spec.ts
+++ b/packages/core/src/payment/instrument/map-to-bank-instrument.spec.ts
@@ -25,7 +25,6 @@ describe('mapToBankInstrument', () => {
             accountNumber: '1234',
             iban: 'ZXY',
             issuer: 'Some Issuer',
-            externalId: 'test@external-id.com',
         });
     });
 });

--- a/packages/core/src/payment/instrument/map-to-bank-instrument.ts
+++ b/packages/core/src/payment/instrument/map-to-bank-instrument.ts
@@ -6,7 +6,6 @@ export function mapToBankInstrument(instrument: BankInternalInstrument): BankIns
         bigpayToken: instrument.bigpay_token,
         defaultInstrument: instrument.default_instrument,
         provider: instrument.provider,
-        externalId: instrument.external_id,
         trustedShippingAddress: instrument.trusted_shipping_address,
         accountNumber: instrument.account_number,
         issuer: instrument.issuer,


### PR DESCRIPTION
## What?

Updated `AccountInstrument` type

## Why?

`BankInstrument` doesn't have an `externalId`, it is the legacy
`externalId` can only have an instrument with type `account`

## Testing / Proof

All tests passed 

@bigcommerce/checkout @bigcommerce/payments
