### PR TITLE
fix(payment): INT-7650 retrieve payment intent if an error is caught at the time of confirming the payment

### DIFF
--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer.mock.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer.mock.ts
@@ -15,6 +15,7 @@ export function getCustomerStripeUPEJsMock(returnElement?: StripeElement): Strip
         })),
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
+        retrievePaymentIntent: jest.fn(),
     };
 }
 

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -71,6 +71,7 @@ import StripeUPEScriptLoader from './stripe-upe-script-loader';
 import {
     getConfirmPaymentResponse,
     getFailingStripeUPEJsMock,
+    getRetrievePaymentIntentResponse,
     getStripeUPEInitializeOptionsMock,
     getStripeUPEJsMock,
     getStripeUPEOrderRequestBodyMock,
@@ -910,6 +911,10 @@ describe('StripeUPEPaymentStrategy', () => {
                             Promise.reject(new Error('Error with 3ds')),
                         );
 
+                        stripeUPEJsMock.retrievePaymentIntent = jest.fn(() =>
+                            Promise.resolve(getRetrievePaymentIntentResponse()),
+                        );
+
                         await strategy.execute(getStripeUPEOrderRequestBodyMock());
 
                         expect(orderActionCreator.submitOrder).toHaveBeenCalled();
@@ -1154,6 +1159,10 @@ describe('StripeUPEPaymentStrategy', () => {
                             Promise.reject(new Error('Error with 3ds')),
                         );
 
+                        stripeUPEJsMock.retrievePaymentIntent = jest.fn(() =>
+                            Promise.resolve(getRetrievePaymentIntentResponse()),
+                        );
+
                         await strategy.execute(getStripeUPEOrderRequestBodyVaultMock());
 
                         expect(orderActionCreator.submitOrder).toHaveBeenCalled();
@@ -1172,12 +1181,13 @@ describe('StripeUPEPaymentStrategy', () => {
                             expect.objectContaining({
                                 paymentData: expect.objectContaining({
                                     formattedPayload: expect.objectContaining({
-                                        credit_card_token: { token: 'token' },
+                                        credit_card_token: { token: 'pi_1234' },
                                     }),
                                 }),
                             }),
                         );
                         expect(stripeUPEJsMock.confirmCardPayment).toHaveBeenCalled();
+                        expect(stripeUPEJsMock.retrievePaymentIntent).toHaveBeenCalled();
                     });
                 });
 

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -472,7 +472,11 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                 try {
                     result = await this._stripeUPEClient.confirmPayment(stripePaymentData);
                 } catch (error) {
-                    catchedConfirmError = true;
+                    try {
+                        result = await this._stripeUPEClient.retrievePaymentIntent(token);
+                    } catch (error) {
+                        catchedConfirmError = true;
+                    }
                 }
 
                 if (result?.error) {
@@ -533,7 +537,11 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             try {
                 result = await this._stripeUPEClient.confirmCardPayment(clientSecret);
             } catch (error) {
-                catchedConfirmError = true;
+                try {
+                    result = await this._stripeUPEClient.retrievePaymentIntent(clientSecret);
+                } catch (error) {
+                    catchedConfirmError = true;
+                }
             }
 
             if (result?.error) {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
@@ -19,6 +19,7 @@ export function getStripeUPEJsMock(): StripeUPEClient {
         })),
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
+        retrievePaymentIntent: jest.fn(),
     };
 }
 
@@ -37,6 +38,7 @@ export function getFailingStripeUPEJsMock(): StripeUPEClient {
         })),
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
+        retrievePaymentIntent: jest.fn(),
     };
 }
 
@@ -115,6 +117,14 @@ export function getOrderRequestBodyVaultedCC(): OrderRequestBody {
 }
 
 export function getConfirmPaymentResponse(): unknown {
+    return {
+        paymentIntent: {
+            id: 'pi_1234',
+        },
+    };
+}
+
+export function getRetrievePaymentIntentResponse(): unknown {
     return {
         paymentIntent: {
             id: 'pi_1234',

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -322,21 +322,27 @@ export interface StripeUPEClient {
      * When called, confirmPayment will attempt to complete any required actions,
      * such as authenticating your user by displaying a 3DS dialog or redirecting them to a bank authorization page.
      */
-    confirmPayment(
-        options: StripeConfirmPaymentData,
-    ): Promise<{ paymentIntent?: PaymentIntent; error?: StripeError }>;
+    confirmPayment(options: StripeConfirmPaymentData): Promise<StripeUpeResult>;
 
     /**
      * When called, it will confirm the PaymentIntent with data you provide and carry out 3DS or other next actions if they are required.
      */
-    confirmCardPayment(
-        clientSecret: string,
-    ): Promise<{ paymentIntent?: PaymentIntent; error?: StripeError }>;
+    confirmCardPayment(clientSecret: string): Promise<StripeUpeResult>;
+
+    /**
+     * Retrieve a PaymentIntent using its client secret.
+     */
+    retrievePaymentIntent(clientSecret: string): Promise<StripeUpeResult>;
 
     /**
      * Create an `Elements` instance, which manages a group of elements.
      */
     elements(options: StripeElementsOptions): StripeElements;
+}
+
+interface StripeUpeResult {
+    paymentIntent?: PaymentIntent;
+    error?: StripeError;
 }
 
 export interface StripeHostWindow extends Window {

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
@@ -16,6 +16,7 @@ export function getShippingStripeUPEJsMock(): StripeUPEClient {
         })),
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
+        retrievePaymentIntent: jest.fn(),
     };
 }
 
@@ -29,6 +30,7 @@ export function getShippingStripeUPEJsOnMock(returnElement?: StripeElement): Str
         })),
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
+        retrievePaymentIntent: jest.fn(),
     };
 }
 
@@ -52,6 +54,7 @@ export function getShippingStripeUPEJsMockWithAnElementCreated(): StripeUPEClien
         })),
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
+        retrievePaymentIntent: jest.fn(),
     };
 }
 


### PR DESCRIPTION
## What? [STRIPE-7650](https://bigcommercecloud.atlassian.net/browse/INT-7650) 

The payment intent is retrieved if an error is caught at the time of confirming the payment

## Why?

Some cards with 3DS2 skip the 3ds verification https://site-admin.stripe.com/guides/strong-customer-authentication#exemptions-to-strong-customer-authentication  which is causing an error to occur on the frontend but the charges are being completed on Stripe's side.

## Testing / Proof

https://github.com/bigcommerce/checkout-sdk-js/assets/69487174/98df6726-587b-4ed8-96d1-88ad62f38c79


ping @bigcommerce/payments @bigcommerce/apex-integrations @bigcommerce/kyiv-payments-team 
