### PR TITLE
feat(payment): PAYPAL-2560 Add internalLabel for braintree hosted form

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-hosted-form.ts
@@ -186,14 +186,17 @@ export default class BraintreeHostedForm {
                     number: {
                         container: `#${fields.cardNumber.containerId}`,
                         placeholder: fields.cardNumber.placeholder,
+                        internalLabel: fields.cardNumber.accessibilityLabel,
                     },
                     expirationDate: {
                         container: `#${fields.cardExpiry.containerId}`,
                         placeholder: fields.cardExpiry.placeholder,
+                        internalLabel: fields.cardExpiry.accessibilityLabel,
                     },
                     cvv: fields.cardCode && {
                         container: `#${fields.cardCode.containerId}`,
                         placeholder: fields.cardCode.placeholder,
+                        internalLabel: fields.cardCode.accessibilityLabel,
                     },
                 },
                 isNil,

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -280,6 +280,7 @@ export interface BraintreeHostedFieldOption {
     prefill?: string;
     rejectUnsupportedCards?: boolean;
     supportedCardBrands?: { [key: string]: boolean };
+    internalLabel?: string;
 }
 
 export interface BraintreeHostedFieldsState {


### PR DESCRIPTION
## What?

Add an `internalLabel` for each braintree hosted field

## Why?

In a Braintree Hosted Form, there is no option to add an `area-label` attribute for each field.
For screen reader uses `internalLabel`

Screen reader can read default values in **hosted form**
You can see it here: https://braintree.github.io/braintree-web/current/module-braintree-web_hosted-fields.html#~field

Default values can change via `internalLabel`

## Testing / Proof

Have been tested with [Google Chrome Screen Reader extension](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en).

<img width="682" alt="Screenshot 2023-05-24 at 23 50 00" src="https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/c4feb4fb-4e11-47ac-8497-0dc1ed885020">

<img width="663" alt="Screenshot 2023-05-24 at 23 52 12" src="https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/381ac834-9ada-4ea6-bd2a-3a07e67e9355">

@bigcommerce/checkout @bigcommerce/payments
