### PR TITLE
feat(payment): INT-5659 GooglePay: Add customer strategy

### DIFF
--- a/packages/core/src/payment-integration/create-payment-integration-selectors.spec.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-selectors.spec.ts
@@ -314,6 +314,13 @@ describe('createPaymentIntegrationSelectors', () => {
             expect(() => subject.getShippingAddressOrThrow()).toThrow();
         });
 
+        it('returns copy of shipping countries', () => {
+            const output = subject.getShippingCountries();
+
+            expect(output).toEqual(internalSelectors.shippingCountries.getShippingCountries());
+            expect(output).not.toBe(internalSelectors.shippingCountries.getShippingCountries());
+        });
+
         it('returns is payment data required', () => {
             const output = subject.isPaymentDataRequired();
 

--- a/packages/core/src/payment-integration/create-payment-integration-selectors.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-selectors.ts
@@ -33,6 +33,7 @@ export default function createPaymentIntegrationSelectors({
         getShippingAddresses,
         getShippingAddressesOrThrow,
     },
+    shippingCountries: { getShippingCountries },
 }: InternalCheckoutSelectors): PaymentIntegrationSelectors {
     return {
         getHost: clone(getHost),
@@ -70,6 +71,7 @@ export default function createPaymentIntegrationSelectors({
         getShippingAddressOrThrow: clone(getShippingAddressOrThrow),
         getShippingAddresses: clone(getShippingAddresses),
         getShippingAddressesOrThrow: clone(getShippingAddressesOrThrow),
+        getShippingCountries: clone(getShippingCountries),
         isPaymentDataRequired,
         isPaymentMethodInitialized,
     };

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -25,7 +25,12 @@ import {
     PaymentRequestTransformer,
 } from '../payment';
 import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
-import { ConsignmentActionCreator, ConsignmentRequestSender } from '../shipping';
+import {
+    ConsignmentActionCreator,
+    ConsignmentRequestSender,
+    ShippingCountryActionCreator,
+    ShippingCountryRequestSender,
+} from '../shipping';
 import {
     createSpamProtection,
     PaymentHumanVerificationHandler,
@@ -43,7 +48,7 @@ export default function createPaymentIntegrationService(
     store: CheckoutStore,
 ): PaymentIntegrationService {
     const {
-        config: { getHost },
+        config: { getHost, getLocale },
     } = store.getState();
 
     const requestSender = createRequestSender({ host: getHost() });
@@ -110,6 +115,10 @@ export default function createPaymentIntegrationService(
 
     const paymentProviderCustomerActionCreator = new PaymentProviderCustomerActionCreator();
 
+    const shippingCountryActionCreator = new ShippingCountryActionCreator(
+        new ShippingCountryRequestSender(requestSender, { locale: getLocale() }),
+    );
+
     return new DefaultPaymentIntegrationService(
         store,
         storeProjectionFactory,
@@ -125,5 +134,6 @@ export default function createPaymentIntegrationService(
         storeCreditActionCreator,
         spamProtectionActionCreator,
         paymentProviderCustomerActionCreator,
+        shippingCountryActionCreator,
     );
 }

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -27,7 +27,7 @@ import { PaymentProviderCustomerActionCreator } from '../payment-provider-custom
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
 import { getPayment } from '../payment/payments.mock';
-import { ConsignmentActionCreator } from '../shipping';
+import { ConsignmentActionCreator, ShippingCountryActionCreator } from '../shipping';
 import { getShippingAddress } from '../shipping/shipping-addresses.mock';
 import { SpamProtectionActionCreator } from '../spam-protection';
 import { StoreCreditActionCreator } from '../store-credit';
@@ -73,6 +73,7 @@ describe('DefaultPaymentIntegrationService', () => {
     let cartRequestSender: CartRequestSender;
     let storeCreditActionCreator: Pick<StoreCreditActionCreator, 'applyStoreCredit'>;
     let paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator;
+    let shippingCountryActionCreator: Pick<ShippingCountryActionCreator, 'loadCountries'>;
 
     beforeEach(() => {
         requestSender = createRequestSender();
@@ -160,6 +161,12 @@ describe('DefaultPaymentIntegrationService', () => {
             ),
         };
 
+        shippingCountryActionCreator = {
+            loadCountries: jest.fn(
+                async () => () => createAction('LOAD_SHIPPING_COUNTRIES_REQUESTED'),
+            ),
+        };
+
         subject = new DefaultPaymentIntegrationService(
             store as CheckoutStore,
             storeProjectionFactory as PaymentIntegrationStoreProjectionFactory,
@@ -175,6 +182,7 @@ describe('DefaultPaymentIntegrationService', () => {
             storeCreditActionCreator as StoreCreditActionCreator,
             spamProtectionActionCreator as SpamProtectionActionCreator,
             paymentProviderCustomerActionCreator,
+            shippingCountryActionCreator as ShippingCountryActionCreator,
         );
     });
 
@@ -426,6 +434,18 @@ describe('DefaultPaymentIntegrationService', () => {
 
             expect(orderActionCreator.loadCurrentOrder).toHaveBeenCalled();
             expect(store.dispatch).toHaveBeenCalledWith(orderActionCreator.loadCurrentOrder());
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#loadShippingCountries', () => {
+        it('loads shipping countries', async () => {
+            const output = await subject.loadShippingCountries();
+
+            expect(shippingCountryActionCreator.loadCountries).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(
+                shippingCountryActionCreator.loadCountries(),
+            );
             expect(output).toEqual(paymentIntegrationSelectors);
         });
     });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -26,7 +26,7 @@ import {
 } from '../payment-provider-customer';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
-import { ConsignmentActionCreator } from '../shipping';
+import { ConsignmentActionCreator, ShippingCountryActionCreator } from '../shipping';
 import { SpamProtectionActionCreator } from '../spam-protection';
 import { StoreCreditActionCreator } from '../store-credit';
 
@@ -50,6 +50,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _storeCreditActionCreator: StoreCreditActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator,
         private _paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator,
+        private _shippingCountryActionCreator: ShippingCountryActionCreator,
     ) {
         this._storeProjection = this._storeProjectionFactory.create(this._store);
     }
@@ -227,6 +228,12 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
                 paymentProviderCustomer,
             ),
         );
+
+        return this._storeProjection.getState();
+    }
+
+    async loadShippingCountries(options?: RequestOptions): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(this._shippingCountryActionCreator.loadCountries(options));
 
         return this._storeProjection.getState();
     }

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-authorizenet-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-authorizenet-customer-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+
+import createGooglePayAuthorizeDotNetCustomerStrategy from './create-google-pay-authorizenet-customer-strategy';
+
+describe('createGooglePayAuthorizeDotNetCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay authorizenet customer strategy', () => {
+        const strategy = createGooglePayAuthorizeDotNetCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-authorizenet-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-authorizenet-customer-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayAuthorizeNetGateway from '../../gateways/google-pay-authorizenet-gateway';
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayAuthorizeDotNetCustomerStrategy: CustomerStrategyFactory<
+    GooglePayCustomerStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayCustomerStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayAuthorizeNetGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayAuthorizeDotNetCustomerStrategy, [
+    { id: 'googlepayauthorizenet' },
+]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-bnz-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-bnz-customer-strategy.spec.ts
@@ -6,26 +6,26 @@ import {
 
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 
-import createGooglePayAuthorizeDotNetCustomerStrategy from './create-google-pay-authorizenet-customer-strategy';
+import createGooglePayBnzCustomerStrategy from './create-google-pay-bnz-customer-strategy';
 
-describe('createGooglePayAuthorizeDotNetCustomerStrategy', () => {
+describe('createGooglePayBnzCustomerStrategy', () => {
     let paymentIntegrationService: PaymentIntegrationService;
 
     beforeEach(() => {
         paymentIntegrationService = new PaymentIntegrationServiceMock();
     });
 
-    it('instantiates google pay authorizenet customer strategy', () => {
+    it('instantiates google pay bnz customer strategy', () => {
         const storeConfigMock = getConfig().storeConfig;
 
         storeConfigMock.checkoutSettings.features = {
-            'INT-5659.authorizenet_use_new_googlepay_customer_strategy': true,
+            'INT-5659.bnz_use_new_googlepay_customer_strategy': true,
         };
         jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValueOnce(
             storeConfigMock,
         );
 
-        const strategy = createGooglePayAuthorizeDotNetCustomerStrategy(paymentIntegrationService);
+        const strategy = createGooglePayBnzCustomerStrategy(paymentIntegrationService);
 
         expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
     });

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-bnz-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-bnz-customer-strategy.ts
@@ -6,32 +6,30 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import GooglePayAuthorizeNetGateway from '../../gateways/google-pay-authorizenet-gateway';
+import GooglePayCybersourceGateway from '../../gateways/google-pay-cybersource-gateway';
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
 import createGooglePayScriptLoader from '../create-google-pay-script-loader';
 
-const createGooglePayAuthorizeDotNetCustomerStrategy: CustomerStrategyFactory<
-    GooglePayCustomerStrategy
-> = (paymentIntegrationService) => {
+const createGooglePayBnzCustomerStrategy: CustomerStrategyFactory<GooglePayCustomerStrategy> = (
+    paymentIntegrationService,
+) => {
     const useRegistryV1 = !paymentIntegrationService.getState().getStoreConfig()?.checkoutSettings
-        .features['INT-5659.authorizenet_use_new_googlepay_customer_strategy'];
+        .features['INT-5659.bnz_use_new_googlepay_customer_strategy'];
 
     if (useRegistryV1) {
-        throw new Error('googlepayauthorizenet requires using registryV1');
+        throw new Error('googlepaybnz requires using registryV1');
     }
 
     return new GooglePayCustomerStrategy(
         paymentIntegrationService,
         new GooglePayPaymentProcessor(
             createGooglePayScriptLoader(),
-            new GooglePayAuthorizeNetGateway(paymentIntegrationService),
+            new GooglePayCybersourceGateway(paymentIntegrationService),
             createRequestSender(),
             createFormPoster(),
         ),
     );
 };
 
-export default toResolvableModule(createGooglePayAuthorizeDotNetCustomerStrategy, [
-    { id: 'googlepayauthorizenet' },
-]);
+export default toResolvableModule(createGooglePayBnzCustomerStrategy, [{ id: 'googlepaybnz' }]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-checkoutcom-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-checkoutcom-customer-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+
+import createGooglePayCheckoutComCustomerStrategy from './create-google-pay-checkoutcom-customer-strategy';
+
+describe('createGooglePayCheckoutComCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay checkoutcom customer strategy', () => {
+        const strategy = createGooglePayCheckoutComCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-checkoutcom-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-checkoutcom-customer-strategy.spec.ts
@@ -1,5 +1,8 @@
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 
@@ -13,6 +16,15 @@ describe('createGooglePayCheckoutComCustomerStrategy', () => {
     });
 
     it('instantiates google pay checkoutcom customer strategy', () => {
+        const storeConfigMock = getConfig().storeConfig;
+
+        storeConfigMock.checkoutSettings.features = {
+            'INT-5659.checkoutcom_use_new_googlepay_customer_strategy': true,
+        };
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValueOnce(
+            storeConfigMock,
+        );
+
         const strategy = createGooglePayCheckoutComCustomerStrategy(paymentIntegrationService);
 
         expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-checkoutcom-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-checkoutcom-customer-strategy.ts
@@ -14,6 +14,13 @@ import createGooglePayScriptLoader from '../create-google-pay-script-loader';
 const createGooglePayCheckoutComCustomerStrategy: CustomerStrategyFactory<
     GooglePayCustomerStrategy
 > = (paymentIntegrationService) => {
+    const useRegistryV1 = !paymentIntegrationService.getState().getStoreConfig()?.checkoutSettings
+        .features['INT-5659.checkoutcom_use_new_googlepay_customer_strategy'];
+
+    if (useRegistryV1) {
+        throw new Error('googlepaycheckoutcom requires using registryV1');
+    }
+
     const requestSender = createRequestSender();
 
     return new GooglePayCustomerStrategy(

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-checkoutcom-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-checkoutcom-customer-strategy.ts
@@ -1,0 +1,32 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCheckoutComGateway from '../../gateways/google-pay-checkoutcom-gateway';
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayCheckoutComCustomerStrategy: CustomerStrategyFactory<
+    GooglePayCustomerStrategy
+> = (paymentIntegrationService) => {
+    const requestSender = createRequestSender();
+
+    return new GooglePayCustomerStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayCheckoutComGateway(paymentIntegrationService, requestSender),
+            requestSender,
+            createFormPoster(),
+        ),
+    );
+};
+
+export default toResolvableModule(createGooglePayCheckoutComCustomerStrategy, [
+    { id: 'googlepaycheckoutcom' },
+]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-cybersource-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-cybersource-customer-strategy.spec.ts
@@ -1,5 +1,8 @@
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 
@@ -13,6 +16,15 @@ describe('createGooglePayCybersourceCustomerStrategy', () => {
     });
 
     it('instantiates google pay cybersource customer strategy', () => {
+        const storeConfigMock = getConfig().storeConfig;
+
+        storeConfigMock.checkoutSettings.features = {
+            'INT-5659.cybersourcev2_use_new_googlepay_customer_strategy': true,
+        };
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValueOnce(
+            storeConfigMock,
+        );
+
         const strategy = createGooglePayCybersourceCustomerStrategy(paymentIntegrationService);
 
         expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-cybersource-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-cybersource-customer-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+
+import createGooglePayCybersourceCustomerStrategy from './create-google-pay-cybersource-customer-strategy';
+
+describe('createGooglePayCybersourceCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay cybersource customer strategy', () => {
+        const strategy = createGooglePayCybersourceCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-cybersource-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-cybersource-customer-strategy.ts
@@ -13,8 +13,15 @@ import createGooglePayScriptLoader from '../create-google-pay-script-loader';
 
 const createGooglePayCybersourceCustomerStrategy: CustomerStrategyFactory<
     GooglePayCustomerStrategy
-> = (paymentIntegrationService) =>
-    new GooglePayCustomerStrategy(
+> = (paymentIntegrationService) => {
+    const useRegistryV1 = !paymentIntegrationService.getState().getStoreConfig()?.checkoutSettings
+        .features['INT-5659.cybersourcev2_use_new_googlepay_customer_strategy'];
+
+    if (useRegistryV1) {
+        throw new Error('googlepaycybersourcev2 requires using registryV1');
+    }
+
+    return new GooglePayCustomerStrategy(
         paymentIntegrationService,
         new GooglePayPaymentProcessor(
             createGooglePayScriptLoader(),
@@ -23,8 +30,8 @@ const createGooglePayCybersourceCustomerStrategy: CustomerStrategyFactory<
             createFormPoster(),
         ),
     );
+};
 
 export default toResolvableModule(createGooglePayCybersourceCustomerStrategy, [
     { id: 'googlepaycybersourcev2' },
-    { id: 'googlepaybnz' },
 ]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-cybersource-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-cybersource-customer-strategy.ts
@@ -1,0 +1,30 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCybersourceGateway from '../../gateways/google-pay-cybersource-gateway';
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayCybersourceCustomerStrategy: CustomerStrategyFactory<
+    GooglePayCustomerStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayCustomerStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayCybersourceGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayCybersourceCustomerStrategy, [
+    { id: 'googlepaycybersourcev2' },
+    { id: 'googlepaybnz' },
+]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-orbital-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-orbital-customer-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+
+import createGooglePayOrbitalCustomerStrategy from './create-google-pay-orbital-customer-strategy';
+
+describe('createGooglePayOrbitalCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay orbital customer strategy', () => {
+        const strategy = createGooglePayOrbitalCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-orbital-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-orbital-customer-strategy.spec.ts
@@ -1,5 +1,8 @@
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 
@@ -13,6 +16,15 @@ describe('createGooglePayOrbitalCustomerStrategy', () => {
     });
 
     it('instantiates google pay orbital customer strategy', () => {
+        const storeConfigMock = getConfig().storeConfig;
+
+        storeConfigMock.checkoutSettings.features = {
+            'INT-5659.orbital_use_new_googlepay_customer_strategy': true,
+        };
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValueOnce(
+            storeConfigMock,
+        );
+
         const strategy = createGooglePayOrbitalCustomerStrategy(paymentIntegrationService);
 
         expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-orbital-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-orbital-customer-strategy.ts
@@ -13,8 +13,15 @@ import createGooglePayScriptLoader from '../create-google-pay-script-loader';
 
 const createGooglePayOrbitalCustomerStrategy: CustomerStrategyFactory<GooglePayCustomerStrategy> = (
     paymentIntegrationService,
-) =>
-    new GooglePayCustomerStrategy(
+) => {
+    const useRegistryV1 = !paymentIntegrationService.getState().getStoreConfig()?.checkoutSettings
+        .features['INT-5659.orbital_use_new_googlepay_customer_strategy'];
+
+    if (useRegistryV1) {
+        throw new Error('googlepayorbital requires using registryV1');
+    }
+
+    return new GooglePayCustomerStrategy(
         paymentIntegrationService,
         new GooglePayPaymentProcessor(
             createGooglePayScriptLoader(),
@@ -23,6 +30,7 @@ const createGooglePayOrbitalCustomerStrategy: CustomerStrategyFactory<GooglePayC
             createFormPoster(),
         ),
     );
+};
 
 export default toResolvableModule(createGooglePayOrbitalCustomerStrategy, [
     { id: 'googlepayorbital' },

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-orbital-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-orbital-customer-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayOrbitalGateway from '../../gateways/google-pay-orbital-gateway';
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayOrbitalCustomerStrategy: CustomerStrategyFactory<GooglePayCustomerStrategy> = (
+    paymentIntegrationService,
+) =>
+    new GooglePayCustomerStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayOrbitalGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayOrbitalCustomerStrategy, [
+    { id: 'googlepayorbital' },
+]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-stripe-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-stripe-customer-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+
+import createGooglePayStripeCustomerStrategy from './create-google-pay-stripe-customer-strategy';
+
+describe('createGooglePayStripeCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay stripe customer strategy', () => {
+        const strategy = createGooglePayStripeCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-stripe-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-stripe-customer-strategy.spec.ts
@@ -1,5 +1,8 @@
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 
@@ -13,6 +16,15 @@ describe('createGooglePayStripeCustomerStrategy', () => {
     });
 
     it('instantiates google pay stripe customer strategy', () => {
+        const storeConfigMock = getConfig().storeConfig;
+
+        storeConfigMock.checkoutSettings.features = {
+            'INT-5659.stripe_use_new_googlepay_customer_strategy': true,
+        };
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValueOnce(
+            storeConfigMock,
+        );
+
         const strategy = createGooglePayStripeCustomerStrategy(paymentIntegrationService);
 
         expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-stripe-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-stripe-customer-strategy.ts
@@ -13,8 +13,15 @@ import createGooglePayScriptLoader from '../create-google-pay-script-loader';
 
 const createGooglePayStripeCustomerStrategy: CustomerStrategyFactory<GooglePayCustomerStrategy> = (
     paymentIntegrationService,
-) =>
-    new GooglePayCustomerStrategy(
+) => {
+    const useRegistryV1 = !paymentIntegrationService.getState().getStoreConfig()?.checkoutSettings
+        .features['INT-5659.stripe_use_new_googlepay_customer_strategy'];
+
+    if (useRegistryV1) {
+        throw new Error('googlepaystripe requires using registryV1');
+    }
+
+    return new GooglePayCustomerStrategy(
         paymentIntegrationService,
         new GooglePayPaymentProcessor(
             createGooglePayScriptLoader(),
@@ -23,8 +30,8 @@ const createGooglePayStripeCustomerStrategy: CustomerStrategyFactory<GooglePayCu
             createFormPoster(),
         ),
     );
+};
 
 export default toResolvableModule(createGooglePayStripeCustomerStrategy, [
     { id: 'googlepaystripe' },
-    { id: 'googlepaystripeupe' },
 ]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-stripe-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-stripe-customer-strategy.ts
@@ -1,0 +1,30 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayStripeGateway from '../../gateways/google-pay-stripe-gateway';
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayStripeCustomerStrategy: CustomerStrategyFactory<GooglePayCustomerStrategy> = (
+    paymentIntegrationService,
+) =>
+    new GooglePayCustomerStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayStripeGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayStripeCustomerStrategy, [
+    { id: 'googlepaystripe' },
+    { id: 'googlepaystripeupe' },
+]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-stripeupe-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-stripeupe-customer-strategy.spec.ts
@@ -6,26 +6,26 @@ import {
 
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 
-import createGooglePayAuthorizeDotNetCustomerStrategy from './create-google-pay-authorizenet-customer-strategy';
+import createGooglePayStripeUpeCustomerStrategy from './create-google-pay-stripeupe-customer-strategy';
 
-describe('createGooglePayAuthorizeDotNetCustomerStrategy', () => {
+describe('createGooglePayStripeUpeCustomerStrategy', () => {
     let paymentIntegrationService: PaymentIntegrationService;
 
     beforeEach(() => {
         paymentIntegrationService = new PaymentIntegrationServiceMock();
     });
 
-    it('instantiates google pay authorizenet customer strategy', () => {
+    it('instantiates google pay stripe upe customer strategy', () => {
         const storeConfigMock = getConfig().storeConfig;
 
         storeConfigMock.checkoutSettings.features = {
-            'INT-5659.authorizenet_use_new_googlepay_customer_strategy': true,
+            'INT-5659.stripeupe_use_new_googlepay_customer_strategy': true,
         };
         jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValueOnce(
             storeConfigMock,
         );
 
-        const strategy = createGooglePayAuthorizeDotNetCustomerStrategy(paymentIntegrationService);
+        const strategy = createGooglePayStripeUpeCustomerStrategy(paymentIntegrationService);
 
         expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
     });

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-stripeupe-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-stripeupe-customer-strategy.ts
@@ -6,32 +6,32 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import GooglePayAuthorizeNetGateway from '../../gateways/google-pay-authorizenet-gateway';
+import GooglePayStripeGateway from '../../gateways/google-pay-stripe-gateway';
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
 import createGooglePayScriptLoader from '../create-google-pay-script-loader';
 
-const createGooglePayAuthorizeDotNetCustomerStrategy: CustomerStrategyFactory<
+const createGooglePayStripeUpeCustomerStrategy: CustomerStrategyFactory<
     GooglePayCustomerStrategy
 > = (paymentIntegrationService) => {
     const useRegistryV1 = !paymentIntegrationService.getState().getStoreConfig()?.checkoutSettings
-        .features['INT-5659.authorizenet_use_new_googlepay_customer_strategy'];
+        .features['INT-5659.stripeupe_use_new_googlepay_customer_strategy'];
 
     if (useRegistryV1) {
-        throw new Error('googlepayauthorizenet requires using registryV1');
+        throw new Error('googlepaystripeupe requires using registryV1');
     }
 
     return new GooglePayCustomerStrategy(
         paymentIntegrationService,
         new GooglePayPaymentProcessor(
             createGooglePayScriptLoader(),
-            new GooglePayAuthorizeNetGateway(paymentIntegrationService),
+            new GooglePayStripeGateway(paymentIntegrationService),
             createRequestSender(),
             createFormPoster(),
         ),
     );
 };
 
-export default toResolvableModule(createGooglePayAuthorizeDotNetCustomerStrategy, [
-    { id: 'googlepayauthorizenet' },
+export default toResolvableModule(createGooglePayStripeUpeCustomerStrategy, [
+    { id: 'googlepaystripeupe' },
 ]);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-worldpayaccess-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-worldpayaccess-customer-strategy.spec.ts
@@ -1,5 +1,8 @@
 import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
 
@@ -13,6 +16,15 @@ describe('createGooglePayWorldpayAccessCustomerStrategy', () => {
     });
 
     it('instantiates google pay worldpayaccess customer strategy', () => {
+        const storeConfigMock = getConfig().storeConfig;
+
+        storeConfigMock.checkoutSettings.features = {
+            'INT-5659.worldpayaccess_use_new_googlepay_customer_strategy': true,
+        };
+        jest.spyOn(paymentIntegrationService.getState(), 'getStoreConfig').mockReturnValueOnce(
+            storeConfigMock,
+        );
+
         const strategy = createGooglePayWorldpayAccessCustomerStrategy(paymentIntegrationService);
 
         expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-worldpayaccess-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-worldpayaccess-customer-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+
+import createGooglePayWorldpayAccessCustomerStrategy from './create-google-pay-worldpayaccess-customer-strategy';
+
+describe('createGooglePayWorldpayAccessCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay worldpayaccess customer strategy', () => {
+        const strategy = createGooglePayWorldpayAccessCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-worldpayaccess-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-worldpayaccess-customer-strategy.ts
@@ -13,8 +13,15 @@ import createGooglePayScriptLoader from '../create-google-pay-script-loader';
 
 const createGooglePayWorldpayAccessCustomerStrategy: CustomerStrategyFactory<
     GooglePayCustomerStrategy
-> = (paymentIntegrationService) =>
-    new GooglePayCustomerStrategy(
+> = (paymentIntegrationService) => {
+    const useRegistryV1 = !paymentIntegrationService.getState().getStoreConfig()?.checkoutSettings
+        .features['INT-5659.worldpayaccess_use_new_googlepay_customer_strategy'];
+
+    if (useRegistryV1) {
+        throw new Error('googlepayworldpayaccess requires using registryV1');
+    }
+
+    return new GooglePayCustomerStrategy(
         paymentIntegrationService,
         new GooglePayPaymentProcessor(
             createGooglePayScriptLoader(),
@@ -23,6 +30,7 @@ const createGooglePayWorldpayAccessCustomerStrategy: CustomerStrategyFactory<
             createFormPoster(),
         ),
     );
+};
 
 export default toResolvableModule(createGooglePayWorldpayAccessCustomerStrategy, [
     { id: 'googlepayworldpayaccess' },

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-worldpayaccess-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-worldpayaccess-customer-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayWorldpayAccessGateway from '../../gateways/google-pay-worldpayaccess-gateway';
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayWorldpayAccessCustomerStrategy: CustomerStrategyFactory<
+    GooglePayCustomerStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayCustomerStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayWorldpayAccessGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayWorldpayAccessCustomerStrategy, [
+    { id: 'googlepayworldpayaccess' },
+]);

--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.spec.ts
@@ -17,6 +17,10 @@ describe('GooglePayGateway', () => {
     beforeEach(() => {
         paymentIntegrationService = new PaymentIntegrationServiceMock();
 
+        jest.spyOn(paymentIntegrationService, 'loadShippingCountries').mockReturnValue(
+            paymentIntegrationService.getState(),
+        );
+
         gateway = new GooglePayGateway('example', paymentIntegrationService);
     });
 
@@ -138,6 +142,40 @@ describe('GooglePayGateway', () => {
             await gateway.initialize(getGeneric);
 
             expect(gateway.getMerchantInfo()).toStrictEqual(expectedInfo);
+        });
+    });
+
+    describe('#getRequiredData', () => {
+        it('should only require email', async () => {
+            const expectedRequiredData = {
+                emailRequired: true,
+            };
+
+            await gateway.initialize(getGeneric);
+
+            await expect(gateway.getRequiredData()).resolves.toStrictEqual(expectedRequiredData);
+        });
+
+        // TODO: etc...
+
+        it('should require email and shipping address', async () => {
+            const expectedRequiredData = {
+                emailRequired: true,
+                shippingAddressRequired: true,
+                shippingAddressParameters: {
+                    phoneNumberRequired: true,
+                    allowedCountryCodes: ['AU', 'US', 'JP'],
+                },
+            };
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getShippingAddress',
+            ).mockReturnValueOnce(undefined);
+
+            await gateway.initialize(getGeneric);
+
+            await expect(gateway.getRequiredData()).resolves.toStrictEqual(expectedRequiredData);
         });
     });
 

--- a/packages/google-pay-integration/src/google-pay-customer-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-initialize-options.ts
@@ -1,0 +1,48 @@
+import { GooglePayKey } from './google-pay-payment-initialize-options';
+import { GooglePayButtonColor, GooglePayButtonType } from './types';
+
+export default interface GooglePayCustomerInitializeOptions {
+    /**
+     * This container is used to set an event listener, provide an element ID if you want users to be able to launch
+     * the GooglePay wallet modal by clicking on a button. It should be an HTML element.
+     */
+    container: string;
+
+    /**
+     * All Google Pay payment buttons exist in two styles: dark (default) and light.
+     * To provide contrast, use dark buttons on light backgrounds and light buttons on dark or colorful backgrounds.
+     */
+    buttonColor?: GooglePayButtonColor;
+
+    /**
+     * Variant buttons:
+     * book: The "Book with Google Pay" payment button.
+     * buy: The "Buy with Google Pay" payment button.
+     * checkout: The "Checkout with Google Pay" payment button.
+     * donate: The "Donate with Google Pay" payment button.
+     * order: The "Order with Google Pay" payment button.
+     * pay: The "Pay with Google Pay" payment button.
+     * plain: The Google Pay payment button without the additional text (default).
+     * subscribe: The "Subscribe with Google Pay" payment button.
+     *
+     * Note: "long" and "short" button types have been renamed to "buy" and "plain", but are still valid button types
+     * for backwards compatability.
+     */
+    buttonType?: GooglePayButtonType;
+
+    /**
+     * A callback that gets called when GooglePay fails to initialize or
+     * selects a payment option.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onError?(error: Error): void;
+}
+
+/**
+ * The options that are required to initialize the GooglePay payment method.
+ * They can be omitted unless you need to support GooglePay.
+ */
+export type WithGooglePayCustomerInitializeOptions = {
+    [k in GooglePayKey]?: GooglePayCustomerInitializeOptions;
+};

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
@@ -1,0 +1,196 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    CustomerInitializeOptions,
+    InvalidArgumentError,
+    NotImplementedError,
+    PaymentIntegrationService,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayGateway from './gateways/google-pay-gateway';
+import { WithGooglePayCustomerInitializeOptions } from './google-pay-customer-initialize-options';
+import GooglePayCustomerStrategy from './google-pay-customer-strategy';
+import GooglePayPaymentProcessor from './google-pay-payment-processor';
+import GooglePayScriptLoader from './google-pay-script-loader';
+import { getGeneric } from './mocks/google-pay-payment-method.mock';
+import { GooglePayInitializationData } from './types';
+
+describe('GooglePayCustomerStrategy', () => {
+    const CONTAINER_ID = 'my_awesome_google_pay_button_container';
+
+    let paymentIntegrationService: PaymentIntegrationService;
+    let button: HTMLButtonElement;
+    let processor: GooglePayPaymentProcessor;
+    let strategy: GooglePayCustomerStrategy;
+    let options: CustomerInitializeOptions & WithGooglePayCustomerInitializeOptions;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            getGeneric(),
+        );
+
+        button = document.createElement('button');
+        jest.spyOn(button, 'remove');
+
+        processor = new GooglePayPaymentProcessor(
+            new GooglePayScriptLoader(createScriptLoader()),
+            new GooglePayGateway('example', paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        );
+        jest.spyOn(processor, 'initialize').mockResolvedValue(undefined);
+        jest.spyOn(processor, 'addPaymentButton').mockReturnValue(button);
+        jest.spyOn(processor, 'signOut').mockResolvedValue(undefined);
+
+        strategy = new GooglePayCustomerStrategy(paymentIntegrationService, processor);
+
+        options = {
+            methodId: 'googlepayworldpayaccess',
+            googlepayworldpayaccess: {
+                container: CONTAINER_ID,
+            },
+        };
+    });
+
+    describe('#initialize', () => {
+        it('should initialize the strategy', async () => {
+            const initialize = strategy.initialize(options);
+
+            await expect(initialize).resolves.toBeUndefined();
+        });
+
+        it('should call loadPaymentMethod', async () => {
+            await strategy.initialize(options);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                'googlepayworldpayaccess',
+            );
+        });
+
+        it('should initialize processor', async () => {
+            const getPaymentMethod = () =>
+                (
+                    (processor.initialize as jest.Mock).mock
+                        .calls[0][0] as () => PaymentMethod<GooglePayInitializationData>
+                )();
+            const paymentMethod = getGeneric();
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethod);
+
+            await strategy.initialize(options);
+
+            expect(getPaymentMethod()).toBe(paymentMethod);
+        });
+
+        it('should fail silently if Google Pay is not supported', async () => {
+            jest.spyOn(processor, 'initialize').mockRejectedValue(
+                new Error('Google Pay is not supported'),
+            );
+
+            await strategy.initialize(options);
+
+            expect(processor.addPaymentButton).not.toHaveBeenCalled();
+        });
+
+        it('should add payment button', async () => {
+            await strategy.initialize(options);
+
+            expect(processor.addPaymentButton).toHaveBeenCalledWith(CONTAINER_ID, {
+                buttonColor: 'default',
+                buttonType: 'plain',
+                onClick: expect.any(Function),
+            });
+        });
+
+        it('should add payment button once', async () => {
+            await strategy.initialize(options);
+            await strategy.initialize(options);
+
+            expect(processor.addPaymentButton).toHaveBeenCalledTimes(1);
+        });
+
+        describe('should fail if:', () => {
+            test('options is missing', async () => {
+                const initialize = strategy.initialize();
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+
+            test('methodId is empty', async () => {
+                options.methodId = '';
+
+                const initialize = strategy.initialize(options);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+
+            test('methodId is not a google pay key', async () => {
+                options.methodId = 'foo';
+
+                const initialize = strategy.initialize(options);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+
+            test('googlePayOptions is missing', async () => {
+                delete options.googlepayworldpayaccess;
+
+                const initialize = strategy.initialize(options);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+        });
+    });
+
+    describe('#signIn', () => {
+        it('should not signIn programmatically', async () => {
+            const signIn = strategy.signIn();
+
+            await expect(signIn).rejects.toThrow(NotImplementedError);
+        });
+    });
+
+    describe('#signOut', () => {
+        it('should signOut', async () => {
+            const signOut = strategy.signOut();
+
+            await expect(signOut).resolves.toBeUndefined();
+        });
+    });
+
+    describe('#executePaymentMethodCheckout', () => {
+        it('runs continue callback automatically on execute payment method checkout', async () => {
+            const continueWithCheckoutCallback = jest.fn();
+
+            await strategy.executePaymentMethodCheckout({
+                continueWithCheckoutCallback,
+            });
+
+            expect(continueWithCheckoutCallback).toHaveBeenCalled();
+        });
+    });
+
+    describe('#deinitialize', () => {
+        it('should deinitialize the strategy', async () => {
+            const deinitialize = strategy.deinitialize();
+
+            await expect(deinitialize).resolves.toBeUndefined();
+        });
+
+        it('should remove payment button', async () => {
+            await strategy.initialize(options);
+            await strategy.deinitialize();
+
+            expect(button.remove).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.ts
@@ -1,0 +1,174 @@
+import {
+    CustomerInitializeOptions,
+    CustomerStrategy,
+    ExecutePaymentMethodCheckoutOptions,
+    guard,
+    InvalidArgumentError,
+    NotImplementedError,
+    NotInitializedError,
+    NotInitializedErrorType,
+    PaymentIntegrationService,
+    PaymentMethodCancelledError,
+    PaymentMethodFailedError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCustomerInitializeOptions, {
+    WithGooglePayCustomerInitializeOptions,
+} from './google-pay-customer-initialize-options';
+import GooglePayPaymentProcessor from './google-pay-payment-processor';
+import isGooglePayErrorObject from './guards/is-google-pay-error-object';
+import isGooglePayKey from './guards/is-google-pay-key';
+import { GooglePayInitializationData } from './types';
+
+export default class GooglePayCustomerStrategy implements CustomerStrategy {
+    private _paymentButton?: HTMLElement;
+    private _methodId?: keyof WithGooglePayCustomerInitializeOptions;
+
+    constructor(
+        private _paymentIntegrationService: PaymentIntegrationService,
+        private _googlePayPaymentProcessor: GooglePayPaymentProcessor,
+    ) {}
+
+    async initialize(
+        options?: CustomerInitializeOptions & WithGooglePayCustomerInitializeOptions,
+    ): Promise<void> {
+        if (!options?.methodId || !isGooglePayKey(options.methodId)) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "methodId" is not a valid key.',
+            );
+        }
+
+        this._methodId = options.methodId;
+
+        const googlePayOptions = options[this._getMethodId()];
+
+        if (!googlePayOptions) {
+            throw new InvalidArgumentError('Unable to proceed without valid options.');
+        }
+
+        await this._paymentIntegrationService.loadPaymentMethod(this._getMethodId());
+
+        try {
+            await this._googlePayPaymentProcessor.initialize(() =>
+                this._paymentIntegrationService
+                    .getState()
+                    .getPaymentMethodOrThrow<GooglePayInitializationData>(this._getMethodId()),
+            );
+        } catch {
+            return;
+        }
+
+        this._addPaymentButton(googlePayOptions);
+    }
+
+    signIn(): Promise<void> {
+        return Promise.reject(
+            new NotImplementedError(
+                'In order to sign in via Google Pay, the shopper must click on "Google Pay" button.',
+            ),
+        );
+    }
+
+    async signOut(): Promise<void> {
+        const providerId = this._paymentIntegrationService.getState().getPaymentId()?.providerId;
+
+        if (providerId) {
+            await this._googlePayPaymentProcessor.signOut(providerId);
+        }
+    }
+
+    executePaymentMethodCheckout(options?: ExecutePaymentMethodCheckoutOptions): Promise<void> {
+        options?.continueWithCheckoutCallback?.();
+
+        return Promise.resolve();
+    }
+
+    deinitialize(): Promise<void> {
+        this._paymentButton?.remove();
+        this._paymentButton = undefined;
+        this._methodId = undefined;
+
+        return Promise.resolve();
+    }
+
+    private _addPaymentButton({
+        container,
+        buttonColor,
+        buttonType,
+        onError,
+    }: GooglePayCustomerInitializeOptions): void {
+        this._paymentButton =
+            this._paymentButton ??
+            this._googlePayPaymentProcessor.addPaymentButton(container, {
+                buttonColor: buttonColor ?? 'default',
+                buttonType: buttonType ?? 'plain',
+                onClick: this._handleClick(onError),
+            });
+    }
+
+    private _handleClick(
+        onError: GooglePayCustomerInitializeOptions['onError'],
+    ): (event: MouseEvent) => unknown {
+        return async (event: MouseEvent) => {
+            event.preventDefault();
+
+            // TODO: Dispatch Widget Actions
+            try {
+                await this._interactWithPaymentSheet();
+            } catch (error) {
+                let err: unknown = error;
+
+                if (isGooglePayErrorObject(error)) {
+                    if (error.statusCode === 'CANCELED') {
+                        throw new PaymentMethodCancelledError();
+                    }
+
+                    err = new PaymentMethodFailedError(JSON.stringify(error));
+                }
+
+                onError?.(
+                    new PaymentMethodFailedError(
+                        'An error occurred while requesting your Google Pay payment details.',
+                    ),
+                );
+
+                throw err;
+            }
+        };
+    }
+
+    private async _interactWithPaymentSheet(): Promise<void> {
+        await this._paymentIntegrationService.loadCheckout();
+
+        const response = await this._googlePayPaymentProcessor.showPaymentSheet();
+        const billingAddress =
+            this._googlePayPaymentProcessor.mapToBillingAddressRequestBody(response);
+        const shippingAddress =
+            this._googlePayPaymentProcessor.mapToShippingAddressRequestBody(response);
+        const siteLink =
+            window.location.pathname === '/embedded-checkout'
+                ? this._paymentIntegrationService.getState().getStoreConfigOrThrow().links.siteLink
+                : undefined;
+
+        if (billingAddress) {
+            await this._paymentIntegrationService.updateBillingAddress(billingAddress);
+        }
+
+        if (shippingAddress) {
+            await this._paymentIntegrationService.updateShippingAddress(shippingAddress);
+        }
+
+        await this._googlePayPaymentProcessor.setExternalCheckoutForm(
+            this._getMethodId(),
+            response,
+            siteLink,
+        );
+    }
+
+    private _getMethodId(): keyof WithGooglePayCustomerInitializeOptions {
+        return guard(
+            this._methodId,
+            () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized),
+        );
+    }
+}

--- a/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.spec.ts
@@ -45,6 +45,7 @@ describe('GooglePayPaymentProcessor', () => {
         jest.spyOn(gateway, 'getPaymentGatewayParameters');
         jest.spyOn(gateway, 'getTransactionInfo');
         jest.spyOn(gateway, 'getMerchantInfo');
+        jest.spyOn(gateway, 'getRequiredData');
         jest.spyOn(gateway, 'mapToExternalCheckoutData');
         jest.spyOn(gateway, 'mapToBillingAddressRequestBody');
         jest.spyOn(gateway, 'mapToShippingAddressRequestBody');
@@ -86,6 +87,7 @@ describe('GooglePayPaymentProcessor', () => {
             expect(gateway.getPaymentGatewayParameters).toHaveBeenCalled();
             expect(gateway.getTransactionInfo).toHaveBeenCalled();
             expect(gateway.getMerchantInfo).toHaveBeenCalled();
+            expect(gateway.getRequiredData).toHaveBeenCalled();
         });
 
         it('should determine readiness to pay', async () => {
@@ -145,6 +147,25 @@ describe('GooglePayPaymentProcessor', () => {
                     totalPriceStatus: 'FINAL',
                 },
             };
+
+            await processor.initialize(getGeneric);
+
+            expect(paymentsClient.prefetchPaymentData).toHaveBeenCalledWith(expectedRequest);
+        });
+
+        it('should prefetch google payment data with shipping address', async () => {
+            const expectedRequest = expect.objectContaining({
+                shippingAddressRequired: true,
+                shippingAddressParameters: {
+                    phoneNumberRequired: true,
+                    allowedCountryCodes: ['AU', 'US', 'JP'],
+                },
+            });
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getShippingAddress',
+            ).mockReturnValueOnce(undefined);
 
             await processor.initialize(getGeneric);
 
@@ -305,6 +326,26 @@ describe('GooglePayPaymentProcessor', () => {
                     totalPriceStatus: 'FINAL',
                 },
             };
+
+            await processor.initialize(getGeneric);
+            await processor.showPaymentSheet();
+
+            expect(paymentsClient.loadPaymentData).toHaveBeenCalledWith(expectedRequest);
+        });
+
+        it('should load payment data with shipping address', async () => {
+            const expectedRequest = expect.objectContaining({
+                shippingAddressRequired: true,
+                shippingAddressParameters: {
+                    phoneNumberRequired: true,
+                    allowedCountryCodes: ['AU', 'US', 'JP'],
+                },
+            });
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getShippingAddress',
+            ).mockReturnValueOnce(undefined);
 
             await processor.initialize(getGeneric);
             await processor.showPaymentSheet();

--- a/packages/google-pay-integration/src/google-pay-payment-processor.ts
+++ b/packages/google-pay-integration/src/google-pay-payment-processor.ts
@@ -52,7 +52,7 @@ export default class GooglePayPaymentProcessor {
 
         await this._gateway.initialize(getPaymentMethod);
 
-        this._buildPayloads();
+        await this._buildPayloads();
 
         await this._determineReadinessToPay();
 
@@ -188,7 +188,7 @@ export default class GooglePayPaymentProcessor {
         }
     }
 
-    private _buildPayloads(): void {
+    private async _buildPayloads(): Promise<void> {
         this._baseCardPaymentMethod = {
             type: 'CARD',
             parameters: this._gateway.getCardParameters(),
@@ -205,7 +205,7 @@ export default class GooglePayPaymentProcessor {
             allowedPaymentMethods: [this._cardPaymentMethod],
             transactionInfo: this._gateway.getTransactionInfo(),
             merchantInfo: this._gateway.getMerchantInfo(),
-            emailRequired: true,
+            ...(await this._gateway.getRequiredData()),
         };
         this._isReadyToPayRequest = {
             ...this._baseRequest,

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -2,6 +2,7 @@ export { WithGooglePayPaymentInitializeOptions } from './google-pay-payment-init
 
 export { default as createGooglePayAuthorizeNetPaymentStrategy } from './factories/payment/create-google-pay-authorizenet-payment-strategy';
 export { default as createGooglePayCheckoutComPaymentStrategy } from './factories/payment/create-google-pay-checkoutcom-payment-strategy';
+export { default as createGooglePayCybersourcePaymentStrategy } from './factories/payment/create-google-pay-cybersource-payment-strategy';
 export { default as createGooglePayOrbitalPaymentStrategy } from './factories/payment/create-google-pay-orbital-payment-strategy';
 export { default as createGooglePayStripePaymentStrategy } from './factories/payment/create-google-pay-stripe-payment-strategy';
 export { default as createGooglePayWorldpayAccessPaymentStrategy } from './factories/payment/create-google-pay-worldpayaccess-payment-strategy';

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -1,4 +1,5 @@
 export { WithGooglePayPaymentInitializeOptions } from './google-pay-payment-initialize-options';
+export { WithGooglePayCustomerInitializeOptions } from './google-pay-customer-initialize-options';
 
 export { default as createGooglePayAuthorizeNetPaymentStrategy } from './factories/payment/create-google-pay-authorizenet-payment-strategy';
 export { default as createGooglePayCheckoutComPaymentStrategy } from './factories/payment/create-google-pay-checkoutcom-payment-strategy';
@@ -6,3 +7,10 @@ export { default as createGooglePayCybersourcePaymentStrategy } from './factorie
 export { default as createGooglePayOrbitalPaymentStrategy } from './factories/payment/create-google-pay-orbital-payment-strategy';
 export { default as createGooglePayStripePaymentStrategy } from './factories/payment/create-google-pay-stripe-payment-strategy';
 export { default as createGooglePayWorldpayAccessPaymentStrategy } from './factories/payment/create-google-pay-worldpayaccess-payment-strategy';
+
+export { default as createGooglePayAuthorizeDotNetCustomerStrategy } from './factories/customer/create-google-pay-authorizenet-customer-strategy';
+export { default as createGooglePayCheckoutComCustomerStrategy } from './factories/customer/create-google-pay-checkoutcom-customer-strategy';
+export { default as createGooglePayCybersourceCustomerStrategy } from './factories/customer/create-google-pay-cybersource-customer-strategy';
+export { default as createGooglePayOrbitalCustomerStrategy } from './factories/customer/create-google-pay-orbital-customer-strategy';
+export { default as createGooglePayStripeCustomerStrategy } from './factories/customer/create-google-pay-stripe-customer-strategy';
+export { default as createGooglePayWorldpayAccessCustomerStrategy } from './factories/customer/create-google-pay-worldpayaccess-customer-strategy';

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -11,6 +11,8 @@ export { default as createGooglePayWorldpayAccessPaymentStrategy } from './facto
 export { default as createGooglePayAuthorizeDotNetCustomerStrategy } from './factories/customer/create-google-pay-authorizenet-customer-strategy';
 export { default as createGooglePayCheckoutComCustomerStrategy } from './factories/customer/create-google-pay-checkoutcom-customer-strategy';
 export { default as createGooglePayCybersourceCustomerStrategy } from './factories/customer/create-google-pay-cybersource-customer-strategy';
+export { default as createGooglePayBnzCustomerStrategy } from './factories/customer/create-google-pay-bnz-customer-strategy';
 export { default as createGooglePayOrbitalCustomerStrategy } from './factories/customer/create-google-pay-orbital-customer-strategy';
 export { default as createGooglePayStripeCustomerStrategy } from './factories/customer/create-google-pay-stripe-customer-strategy';
+export { default as createGooglePayStripeUpeCustomerStrategy } from './factories/customer/create-google-pay-stripeupe-customer-strategy';
 export { default as createGooglePayWorldpayAccessCustomerStrategy } from './factories/customer/create-google-pay-worldpayaccess-customer-strategy';

--- a/packages/google-pay-integration/src/types.ts
+++ b/packages/google-pay-integration/src/types.ts
@@ -86,10 +86,15 @@ export interface GooglePayPaymentDataRequest extends GooglePayGatewayBaseRequest
     emailRequired?: boolean;
     shippingAddressRequired?: boolean;
     shippingAddressParameters?: {
-        allowedCountryCodes: string[];
+        allowedCountryCodes?: string[];
         phoneNumberRequired?: boolean;
     };
 }
+
+export type GooglePayRequiredPaymentData = Pick<
+    GooglePayPaymentDataRequest,
+    'emailRequired' | 'shippingAddressRequired' | 'shippingAddressParameters'
+>;
 
 interface GooglePayMinBillingAddress {
     name: string;
@@ -144,6 +149,8 @@ interface GooglePayIsReadyToPayResponse {
 export interface GooglePayButtonOptions {
     onClick: (event: MouseEvent) => void;
     allowedPaymentMethods: [GooglePayBaseCardPaymentMethod];
+    buttonColor?: GooglePayButtonColor;
+    buttonType?: GooglePayButtonType;
 }
 
 export interface GooglePaymentsClient {
@@ -236,3 +243,16 @@ export interface GooglePayThreeDSecureResult {
         code: string;
     };
 }
+
+export type GooglePayButtonColor = 'default' | 'black' | 'white';
+export type GooglePayButtonType =
+    | 'book'
+    | 'buy'
+    | 'checkout'
+    | 'donate'
+    | 'order'
+    | 'pay'
+    | 'plain'
+    | 'subscribe'
+    | 'long'
+    | 'short';

--- a/packages/google-pay-integration/src/utils/items-require-shipping.spec.ts
+++ b/packages/google-pay-integration/src/utils/items-require-shipping.spec.ts
@@ -1,0 +1,36 @@
+import { Cart, StoreConfig } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { getCart, getConfig } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import itemsRequireShipping from './items-require-shipping';
+
+describe('itemsRequireShipping()', () => {
+    let cart: Cart;
+    let config: StoreConfig;
+
+    beforeEach(() => {
+        cart = getCart();
+        config = getConfig().storeConfig;
+        config.checkoutSettings.features['CHECKOUT-4936.enable_custom_item_shipping'] = true;
+    });
+
+    it('returns false if there are no physical items or custom items', () => {
+        cart.lineItems.physicalItems = [];
+        cart.lineItems.customItems = [];
+
+        expect(itemsRequireShipping(cart, config)).toBe(false);
+    });
+
+    it('returns false if there is no cart', () => {
+        expect(itemsRequireShipping(undefined, config)).toBe(false);
+    });
+
+    it('returns true if there are physical items', () => {
+        expect(itemsRequireShipping(cart, config)).toBe(true);
+    });
+
+    it('returns true if there are only custom items', () => {
+        cart.lineItems.physicalItems = [];
+
+        expect(itemsRequireShipping(cart, config)).toBe(true);
+    });
+});

--- a/packages/google-pay-integration/src/utils/items-require-shipping.ts
+++ b/packages/google-pay-integration/src/utils/items-require-shipping.ts
@@ -1,0 +1,23 @@
+import { Cart, StoreConfig } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+const itemsRequireShipping = (cart?: Cart, config?: StoreConfig) => {
+    if (!cart) {
+        return false;
+    }
+
+    if (cart.lineItems.physicalItems.some((lineItem) => lineItem.isShippingRequired)) {
+        return true;
+    }
+
+    if (
+        config &&
+        config.checkoutSettings.features['CHECKOUT-4936.enable_custom_item_shipping'] &&
+        cart.lineItems.customItems
+    ) {
+        return cart.lineItems.customItems.length > 0;
+    }
+
+    return false;
+};
+
+export default itemsRequireShipping;

--- a/packages/payment-integration-api/src/cart/index.ts
+++ b/packages/payment-integration-api/src/cart/index.ts
@@ -2,5 +2,5 @@ export { default as BuyNowCartRequestBody } from './buy-now-cart-request-body';
 export { default as Cart } from './cart';
 export { CartSource } from './cart-source';
 export { default as InternalLineItem } from './internal-line-item';
-export { PhysicalItem, DigitalItem, GiftCertificateItem } from './line-item';
+export { PhysicalItem, DigitalItem, GiftCertificateItem, CustomItem } from './line-item';
 export { default as LineItemMap } from './line-item-map';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -10,6 +10,7 @@ export {
     BuyNowCartRequestBody,
     Cart,
     CartSource,
+    CustomItem,
     DigitalItem,
     GiftCertificateItem,
     LineItemMap,

--- a/packages/payment-integration-api/src/payment-integration-selectors.ts
+++ b/packages/payment-integration-api/src/payment-integration-selectors.ts
@@ -66,6 +66,8 @@ export default interface PaymentIntegrationSelectors {
     getShippingAddresses(): ShippingAddress[];
     getShippingAddressesOrThrow(): ShippingAddress[];
 
+    getShippingCountries(): Country[] | undefined;
+
     isPaymentDataRequired(useStoreCredit?: boolean): boolean;
     isPaymentMethodInitialized(query: { methodId: string; gatewayId?: string }): boolean;
 }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -73,4 +73,6 @@ export default interface PaymentIntegrationService {
     updatePaymentProviderCustomer(
         paymentProviderCustomer: PaymentProviderCustomer,
     ): Promise<PaymentIntegrationSelectors>;
+
+    loadShippingCountries(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
 }

--- a/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/carts.mock.ts
@@ -3,7 +3,12 @@ import { Cart, CartSource } from '@bigcommerce/checkout-sdk/payment-integration-
 import { getCoupon } from './coupons.mock';
 import { getCurrency } from './currency.mock';
 import { getDiscount } from './discounts.mock';
-import { getDigitalItem, getGiftCertificateItem, getPhysicalItem } from './line-items.mock';
+import {
+    getCustomItem,
+    getDigitalItem,
+    getGiftCertificateItem,
+    getPhysicalItem,
+} from './line-items.mock';
 
 export default function getCart(): Cart {
     return {
@@ -21,7 +26,7 @@ export default function getCart(): Cart {
             physicalItems: [getPhysicalItem()],
             digitalItems: [getDigitalItem()],
             giftCertificates: [getGiftCertificateItem()],
-            customItems: [],
+            customItems: [getCustomItem()],
         },
         createdTime: '2018-03-06T04:41:49+00:00',
         updatedTime: '2018-03-07T03:44:51+00:00',

--- a/packages/payment-integrations-test-utils/src/test-utils/line-items.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/line-items.mock.ts
@@ -1,8 +1,20 @@
 import {
+    CustomItem,
     DigitalItem,
     GiftCertificateItem,
     PhysicalItem,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export function getCustomItem(): CustomItem {
+    return {
+        id: '55e11c8f-7dce-4da3-9413-b649533f8bad',
+        listPrice: 10,
+        extendedListPrice: 20,
+        name: 'Custom item',
+        quantity: 2,
+        sku: 'custom-sku',
+    };
+}
 
 export function getPhysicalItem(): PhysicalItem {
     return {

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-id.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-id.mock.ts
@@ -1,0 +1,6 @@
+export default function getPaymentId(): { providerId: string; gatewayId?: string } {
+    return {
+        providerId: 'foo',
+        gatewayId: 'bar',
+    };
+}

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -30,6 +30,7 @@ const state = {
     getOrderOrThrow: jest.fn(() => getOrder()),
     getShippingAddress: jest.fn(() => getAddress()),
     getShippingAddressOrThrow: jest.fn(() => getAddress()),
+    getShippingCountries: jest.fn(() => getCountries()),
     getStoreConfig: jest.fn(() => getConfig().storeConfig),
     getStoreConfigOrThrow: jest.fn(() => getConfig().storeConfig),
     getPaymentMethod: jest.fn(),
@@ -47,6 +48,7 @@ const initializeOffsitePayment = jest.fn();
 const loadCheckout = jest.fn();
 const loadDefaultCheckout = jest.fn();
 const loadPaymentMethod = jest.fn();
+const loadShippingCountries = jest.fn(() => state);
 const loadCurrentOrder = jest.fn();
 const submitOrder = jest.fn();
 const submitPayment = jest.fn();
@@ -72,6 +74,7 @@ const PaymentIntegrationServiceMock = jest
             loadCheckout,
             loadDefaultCheckout,
             loadPaymentMethod,
+            loadShippingCountries,
             loadCurrentOrder,
             submitOrder,
             submitPayment,

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -8,6 +8,7 @@ import getConsignment from './consignment.mock';
 import getCountries from './countries.mock';
 import { getCustomer } from './customer.mock';
 import { getOrder } from './orders.mock';
+import getPaymentId from './payment-id.mock';
 import { getCardInstrument } from './payments.mock';
 
 const subscribe = jest.fn();
@@ -33,6 +34,7 @@ const state = {
     getShippingCountries: jest.fn(() => getCountries()),
     getStoreConfig: jest.fn(() => getConfig().storeConfig),
     getStoreConfigOrThrow: jest.fn(() => getConfig().storeConfig),
+    getPaymentId: jest.fn(() => getPaymentId()),
     getPaymentMethod: jest.fn(),
     getPaymentMethodOrThrow: jest.fn(),
     getPaymentProviderCustomer: jest.fn(),


### PR DESCRIPTION
## What? [INT-5659](https://bigcommercecloud.atlassian.net/browse/INT-5659)

1. Add Google Pay customer strategy for Worldpay Access
2. Refactor existing logic for:
    - Authorize Net
    - Checkout Com
    - Cybersource / BNZ
    - Orbital
    - Stripe v3 / Stripe UPE

## Why?
To checkout using Google Pay through Worldpay Access

## Testing / Proof
https://github.com/bigcommerce/checkout-sdk-js/assets/4843328/5635bc87-89a3-474d-94d3-768449f823b9

## Depends on
👉 #1967
👉 https://github.com/bigcommerce/bigcommerce/pull/54353

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 

[INT-5659]: https://bigcommercecloud.atlassian.net/browse/INT-5659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ