### PR TITLE
fix(payment): PAYPAL-2552 Wrong Load of Credit card filed on Payment step of checkout page

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
@@ -233,7 +233,7 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
-                defaultGatewayId,
+                defaultMethodId,
             );
         });
     });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -80,8 +80,6 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
             );
         }
 
-        await this.paymentIntegrationService.loadPaymentMethod(gatewayId);
-
         const state = this.paymentIntegrationService.getState();
         const paymentMethod = state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(
             methodId,
@@ -99,7 +97,7 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
             return;
         }
 
-        await this.paypalCommerceIntegrationService.loadPayPalSdk(gatewayId);
+        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
 
         this.loadingIndicatorContainer = paypalOptions.container.split('#')[1];
 


### PR DESCRIPTION
## What?

Remove unnecessary code for `paypal-commerce-alternative-methods-payment-strategy.ts` to prevent loading redundant `Credit cart` filed in payments list on Checkout by calling `checkoutService.loadPaymentMethod`

## Why?

To fix problem with appearing redundant method

## Testing / Proof

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/db322966-fd49-49be-9c0c-65826cf15d8e

@bigcommerce/checkout @bigcommerce/payments
