### PR TITLE
fix(payment): PAYPAL-2451 renaming instrument

### DIFF
--- a/packages/core/src/payment/instrument/index.ts
+++ b/packages/core/src/payment/instrument/index.ts
@@ -2,7 +2,7 @@ export {
     default as PaymentInstrument,
     AccountInstrument,
     CardInstrument,
-    BraintreeAchInstrument,
+    AchInstrument,
 } from './instrument';
 export { default as InstrumentActionCreator } from './instrument-action-creator';
 export { default as InstrumentRequestSender } from './instrument-request-sender';

--- a/packages/core/src/payment/instrument/instrument.ts
+++ b/packages/core/src/payment/instrument/instrument.ts
@@ -36,7 +36,7 @@ export interface PayPalInstrument extends BaseAccountInstrument {
     method: 'paypal';
 }
 
-export interface BraintreeAchInstrument extends BaseAccountInstrument {
+export interface AchInstrument extends BaseAccountInstrument {
     issuer: string;
     accountNumber: string;
     type: 'bank';
@@ -51,7 +51,7 @@ export interface BankInstrument extends BaseAccountInstrument {
     type: 'bank';
 }
 
-export type AccountInstrument = PayPalInstrument | BankInstrument | BraintreeAchInstrument;
+export type AccountInstrument = PayPalInstrument | BankInstrument | AchInstrument;
 
 export interface VaultAccessToken {
     vaultAccessToken: string;


### PR DESCRIPTION
## What?

Renaming instrument

## Why?

To make it more compatible and ready to use him like common interface for other packages


## Testing / Proof

All tests passed

@bigcommerce/checkout @bigcommerce/payments
