### PR TITLE
feat(payment): PAYPAL-2449 added braintree-local-methods payment strategy

### DIFF
--- a/packages/braintree-integration/src/braintree-integration-service.spec.ts
+++ b/packages/braintree-integration/src/braintree-integration-service.spec.ts
@@ -293,6 +293,19 @@ describe('BraintreeIntegrationService', () => {
         });
     });
 
+    describe('loadBraintreeLocalMethods', () => {
+        it('loads local payment methods', async () => {
+            braintreeScriptLoader.loadBraintreeLocalMethods = jest
+                .fn()
+                .mockReturnValue({ create: jest.fn() });
+            braintreeScriptLoader.loadClient = jest.fn().mockReturnValue({ create: jest.fn() });
+            braintreeIntegrationService.initialize('client-token');
+            await braintreeIntegrationService.loadBraintreeLocalMethods(jest.fn(), '');
+
+            expect(braintreeScriptLoader.loadBraintreeLocalMethods).toHaveBeenCalled();
+        });
+    });
+
     describe('mapToLegacyBillingAddress()', () => {
         const detailsMock = {
             username: 'johndoe',

--- a/packages/braintree-integration/src/braintree-integration-service.ts
+++ b/packages/braintree-integration/src/braintree-integration-service.ts
@@ -21,6 +21,11 @@ import {
 import BraintreeScriptLoader from './braintree-script-loader';
 import isBraintreeError from './is-braintree-error';
 import { PAYPAL_COMPONENTS } from './paypal';
+import {
+    BraintreeLocalMethods,
+    GetLocalPaymentInstance,
+    LocalPaymentInstance,
+} from './braintree-local-payment-methods/braintree-local-methods-options';
 
 export default class BraintreeIntegrationService {
     private client?: Promise<BraintreeClient>;
@@ -31,6 +36,7 @@ export default class BraintreeIntegrationService {
     } = {};
     private paypalCheckout?: BraintreePaypalCheckout;
     private usBankAccount?: Promise<BraintreeBankAccount>;
+    private braintreeLocalMethods?: BraintreeLocalMethods;
 
     constructor(
         private braintreeScriptLoader: BraintreeScriptLoader,
@@ -93,6 +99,31 @@ export default class BraintreeIntegrationService {
         );
 
         return this.paypalCheckout;
+    }
+
+    async loadBraintreeLocalMethods(
+        getLocalPaymentInstance: GetLocalPaymentInstance,
+        merchantAccountId: string,
+    ) {
+        const client = await this.getClient();
+        const braintreeLocalMethods = await this.braintreeScriptLoader.loadBraintreeLocalMethods();
+
+        if (!this.braintreeLocalMethods) {
+            this.braintreeLocalMethods = braintreeLocalMethods.create(
+                {
+                    client,
+                    merchantAccountId,
+                },
+                (localPaymentErr: string, localPaymentInstance: LocalPaymentInstance) => {
+                    if (localPaymentErr) {
+                        throw new Error(localPaymentErr);
+                    }
+                    getLocalPaymentInstance(localPaymentInstance);
+                },
+            );
+        }
+
+        return this.braintreeLocalMethods;
     }
 
     async getUsBankAccount() {

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-options.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-options.ts
@@ -1,0 +1,67 @@
+export interface WithBraintreeLocalMethodsPaymentInitializeOptions {
+    braintreelocalmethods?: BraintreeLocalMethods;
+}
+
+export interface BraintreeLocalMethods {
+    /**
+     * The CSS selector of a container where the payment widget should be inserted into.
+     */
+    container: string;
+    /**
+     * Text that will be displayed on lpm button
+     */
+    buttonText: string;
+    /**
+     * A callback right before render Smart Payment Button that gets called when
+     * This callback can be used to hide the standard submit button.
+     */
+    onRenderButton?(): void;
+    /**
+     * A callback for submitting payment form that gets called
+     * when buyer approved PayPal account.
+     */
+    submitForm?(): void;
+    /**
+     * A callback for displaying error popup. This callback requires error object as parameter.
+     */
+    onError(error: unknown): void;
+}
+
+export interface LocalPaymentInstanceConfig {
+    paymentType: string;
+    amount: number;
+    fallback: {
+        url: string;
+        buttonText: string;
+    };
+    currencyCode: string;
+    shippingAddressRequired: boolean;
+    email: string;
+    givenName: string;
+    surname: string;
+    address: {
+        countryCode: string;
+    };
+    onPaymentStart(data: onPaymentStartData, start: () => Promise<void>): void;
+}
+
+export interface StartPaymentError {
+    code: string;
+}
+
+export interface onPaymentStartData {
+    paymentId: string;
+}
+
+export interface LocalPaymentsPayload {
+    nonce: string;
+}
+
+export interface LocalPaymentInstance {
+    startPayment(
+        config: LocalPaymentInstanceConfig,
+        callback: (startPaymentError: StartPaymentError, payload: LocalPaymentsPayload) => void,
+    ): void;
+}
+
+export type GetLocalPaymentInstance = (localPaymentInstance: LocalPaymentInstance) => void;

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
@@ -1,0 +1,228 @@
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    OrderFinalizationNotRequiredError,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getCheckout,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import BraintreeIntegrationService from '../braintree-integration-service';
+import BraintreeScriptLoader from '../braintree-script-loader';
+import {
+    getBraintreeLocalMethods,
+    getBraintreeLocalMethodsInitializationOptions,
+} from '../braintree.mock';
+import BraintreeLocalMethodsPaymentStrategy from './braintree-local-methods-payment-strategy';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+import { LocalPaymentInstance } from './braintree-local-methods-options';
+
+describe('BraintreeLocalMethodsPaymentStrategy', () => {
+    let strategy: BraintreeLocalMethodsPaymentStrategy;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let braintreeIntegrationService: BraintreeIntegrationService;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let paymentMethodMock: PaymentMethod;
+    let localPaymentInstanceMock: LocalPaymentInstance;
+    let lpmButton: HTMLButtonElement;
+
+    const initializationOptions: PaymentInitializeOptions = {
+        methodId: 'giropay',
+        gatewayId: 'braintreelocalmethods',
+        braintreelocalmethods: getBraintreeLocalMethodsInitializationOptions(),
+    };
+
+    beforeEach(() => {
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader(), window);
+        braintreeIntegrationService = new BraintreeIntegrationService(
+            braintreeScriptLoader,
+            window,
+        );
+        strategy = new BraintreeLocalMethodsPaymentStrategy(
+            paymentIntegrationService,
+            braintreeIntegrationService,
+            new LoadingIndicator(),
+        );
+
+        lpmButton = document.createElement('button');
+        lpmButton.id = 'giropay';
+        document.body.appendChild(lpmButton);
+
+        paymentMethodMock = {
+            ...getBraintreeLocalMethods(),
+            clientToken: 'token',
+        };
+
+        localPaymentInstanceMock = {
+            startPayment: jest.fn(
+                (_options: unknown, onPaymentStart: (payload: { paymentId: string }) => void) => {
+                    onPaymentStart({ paymentId: '123456' });
+                },
+            ),
+        };
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethodMock,
+        );
+
+        jest.spyOn(braintreeIntegrationService, 'getClient').mockReturnValue(
+            paymentMethodMock.clientToken,
+        );
+
+        jest.spyOn(braintreeIntegrationService, 'getSessionId').mockReturnValue(
+            paymentMethodMock.clientToken,
+        );
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getCheckoutOrThrow').mockReturnValue(
+            getCheckout(),
+        );
+
+        jest.spyOn(braintreeIntegrationService, 'loadBraintreeLocalMethods').mockReturnValue(
+            localPaymentInstanceMock,
+        );
+    });
+
+    afterEach(() => {
+        document.body.removeChild(lpmButton);
+    });
+
+    it('creates BraintreeLocalMethodsPaymentStrategy', () => {
+        expect(strategy).toBeInstanceOf(BraintreeLocalMethodsPaymentStrategy);
+    });
+
+    describe('#initialize', () => {
+        it('throws error if methodId is not provided', async () => {
+            const options = {} as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if clientToken is not provided', async () => {
+            paymentMethodMock.clientToken = '';
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethodMock);
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws error if gatewayId is not provided', async () => {
+            const options = {
+                methodId: 'giropay',
+            } as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws error if options.braintreelocalmethods is not provided', async () => {
+            const options = {
+                methodId: 'giropay',
+                gatewayId: 'barintreelocalmethods',
+            } as PaymentInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('loads Braintree Local Methods', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeIntegrationService.loadBraintreeLocalMethods).toHaveBeenCalled();
+        });
+    });
+
+    describe('#renderButton', () => {
+        it('creates button element with id', async () => {
+            await strategy.initialize(initializationOptions);
+            const button = document.getElementById('giropay');
+            expect(button).toBeDefined();
+        });
+    });
+
+    describe('#execute', () => {
+        it('throws an error if payload.payment is not provided', async () => {
+            try {
+                await strategy.execute({});
+            } catch (error) {
+                expect(error).toBeInstanceOf(PaymentArgumentInvalidError);
+            }
+        });
+
+        it('throws PaymentArgumentInvalidError if payment is not provided', async () => {
+            await expect(strategy.execute({})).rejects.toThrow(PaymentArgumentInvalidError);
+        });
+
+        it('submits order and payment', async () => {
+            const payload = {
+                payment: {
+                    methodId: 'giropay',
+                    gateway: 'braintreelocalmethods',
+                },
+            };
+
+            const setOrderId = (orderId: string) => {
+                Object.defineProperty(strategy, 'orderId', {
+                    value: orderId,
+                    writable: true,
+                });
+            };
+
+            // Set the orderId using the helper method
+            setOrderId('testOrderId');
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
+                methodId: 'giropay',
+                paymentData: {
+                    formattedPayload: {
+                        device_info: 'token',
+                        method: 'giropay',
+                        giropay_account: {
+                            email: 'foo@bar.com',
+                            token: undefined,
+                            order_id: 'testOrderId',
+                        },
+                        vault_payment_instrument: null,
+                        set_as_default_stored_instrument: null,
+                    },
+                },
+            });
+        });
+    });
+
+    describe('#deinitialize', () => {
+        it('deinitializes strategy', async () => {
+            await expect(strategy.deinitialize()).resolves.not.toThrow();
+        });
+    });
+
+    describe('#finalize', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            await expect(strategy.finalize()).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+});

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
@@ -1,0 +1,241 @@
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentInitializeOptions,
+    PaymentIntegrationService,
+    PaymentMethodInvalidError,
+    PaymentRequestOptions,
+    PaymentStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import BraintreeIntegrationService from '../braintree-integration-service';
+import {
+    BraintreeLocalMethods,
+    LocalPaymentInstance,
+    LocalPaymentsPayload,
+    onPaymentStartData,
+    StartPaymentError,
+    WithBraintreeLocalMethodsPaymentInitializeOptions,
+} from './braintree-local-methods-options';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStrategy {
+    private orderId?: string;
+    private localPaymentInstance?: LocalPaymentInstance;
+    private braintreeLocalMethods?: BraintreeLocalMethods;
+    private nonce?: string;
+    private loadingIndicatorContainer?: string;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private braintreeIntegrationService: BraintreeIntegrationService,
+        private loadingIndicator: LoadingIndicator,
+    ) {}
+
+    async initialize(
+        options: PaymentInitializeOptions & WithBraintreeLocalMethodsPaymentInitializeOptions,
+    ): Promise<void> {
+        const { gatewayId, methodId, braintreelocalmethods } = options;
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        if (!gatewayId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.gatewayId" argument is not provided.',
+            );
+        }
+
+        if (!braintreelocalmethods) {
+            throw new InvalidArgumentError(
+                `Unable to initialize payment because "options.braintreelocalmethods" argument is not provided.`,
+            );
+        }
+
+        this.braintreeLocalMethods = braintreelocalmethods;
+
+        this.loadingIndicatorContainer = braintreelocalmethods.container.split('#')[1];
+
+        await this.paymentIntegrationService.loadPaymentMethod(gatewayId);
+
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethodOrThrow(gatewayId);
+        const { merchantId } = paymentMethod.config;
+
+        if (!paymentMethod.clientToken) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        try {
+            this.braintreeIntegrationService.initialize(paymentMethod.clientToken);
+            await this.braintreeIntegrationService.loadBraintreeLocalMethods(
+                this.getLocalPaymentInstance.bind(this),
+                merchantId || '',
+            );
+        } catch (error: unknown) {
+            this.handleError(error);
+        }
+
+        this.renderButton(methodId);
+    }
+
+    finalize(): Promise<void> {
+        return Promise.reject(new OrderFinalizationNotRequiredError());
+    }
+
+    async deinitialize(): Promise<void> {
+        this.orderId = undefined;
+        this.toggleLoadingIndicator(false);
+
+        return Promise.resolve();
+    }
+
+    async execute(payload: OrderRequestBody, options?: PaymentRequestOptions): Promise<void> {
+        const { payment, ...order } = payload;
+        const state = this.paymentIntegrationService.getState();
+        const cart = state.getCartOrThrow();
+        const sessionId = await this.braintreeIntegrationService.getSessionId();
+
+        if (!payment) {
+            throw new PaymentArgumentInvalidError(['payment']);
+        }
+
+        if (!this.orderId) {
+            throw PaymentMethodInvalidError;
+        }
+
+        const paymentData = {
+            formattedPayload: {
+                device_info: sessionId || null,
+                method: payment.methodId,
+                [`${payment.methodId}_account`]: {
+                    email: cart.email,
+                    token: this.nonce,
+                    order_id: this.orderId,
+                },
+                vault_payment_instrument: null,
+                set_as_default_stored_instrument: null,
+            },
+        };
+
+        try {
+            await this.paymentIntegrationService.submitOrder(order, options);
+            await this.paymentIntegrationService.submitPayment({
+                methodId: payment.methodId,
+                paymentData,
+            });
+        } catch (error: unknown) {
+            this.handleError(error);
+        }
+    }
+
+    private getLocalPaymentInstance(localPaymentInstance: LocalPaymentInstance) {
+        if (!this.localPaymentInstance) {
+            this.localPaymentInstance = localPaymentInstance;
+        }
+    }
+
+    private renderButton(methodId: string) {
+        if (this.braintreeLocalMethods) {
+            let buttonContainer;
+            const { buttonText, container, onRenderButton } = this.braintreeLocalMethods;
+            const buttonContainerId = container.split('#')[1];
+            const lpmButton = document.createElement('button');
+            buttonContainer = document.getElementById(buttonContainerId);
+            const className = buttonContainer?.getAttribute('class');
+            lpmButton.setAttribute('class', className || '');
+            lpmButton.setAttribute('id', methodId);
+            lpmButton.innerText = buttonText;
+            lpmButton.addEventListener('click', (e) => this.handleClick(e, methodId));
+
+            if (onRenderButton && typeof onRenderButton === 'function') {
+                onRenderButton();
+            }
+
+            buttonContainer = document.getElementById(buttonContainerId);
+
+            if (buttonContainer) {
+                buttonContainer.append(lpmButton);
+            }
+        }
+    }
+
+    /**
+     *
+     * Loading Indicator methods
+     *
+     * */
+    private toggleLoadingIndicator(isLoading: boolean): void {
+        if (isLoading && this.loadingIndicatorContainer) {
+            this.loadingIndicator.show(this.loadingIndicatorContainer);
+        } else {
+            this.loadingIndicator.hide();
+        }
+    }
+
+    private handleClick(e: Event, methodId: string) {
+        e.preventDefault();
+        this.toggleLoadingIndicator(true);
+        const state = this.paymentIntegrationService.getState();
+        const cart = state.getCartOrThrow();
+        const billing = state.getBillingAddressOrThrow();
+        const { firstName, lastName, countryCode } = billing;
+        const { baseAmount, currency, email, lineItems } = cart;
+        const isShippingRequired = lineItems.physicalItems.length > 0;
+        const { submitForm } = this.braintreeLocalMethods || {};
+
+        if (!this.localPaymentInstance) {
+            throw new PaymentMethodInvalidError();
+        }
+
+        this.localPaymentInstance.startPayment(
+            {
+                paymentType: methodId,
+                amount: baseAmount,
+                fallback: {
+                    url: 'url-placeholder',
+                    buttonText: 'button placeholder',
+                },
+                currencyCode: currency.code,
+                shippingAddressRequired: isShippingRequired,
+                email,
+                givenName: firstName,
+                surname: lastName,
+                address: {
+                    countryCode,
+                },
+                onPaymentStart: (data: onPaymentStartData, start: () => void) => {
+                    // Call start to initiate the popup
+                    this.orderId = data.paymentId;
+                    start();
+                },
+            },
+            (startPaymentError: StartPaymentError, payload: LocalPaymentsPayload) => {
+                if (startPaymentError.code !== 'LOCAL_PAYMENT_WINDOW_CLOSED') {
+                    this.toggleLoadingIndicator(false);
+                    this.handleError(startPaymentError.code);
+                } else {
+                    this.nonce = payload.nonce;
+
+                    if (submitForm && typeof submitForm === 'function') {
+                        submitForm();
+                    }
+                }
+            },
+        );
+    }
+
+    private handleError(error: unknown) {
+        const { onError } = this.braintreeLocalMethods || {};
+        this.toggleLoadingIndicator(false);
+
+        if (onError && typeof onError === 'function') {
+            onError(error);
+        }
+    }
+}

--- a/packages/braintree-integration/src/braintree-local-payment-methods/create-braintree-local-methods-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/create-braintree-local-methods-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createBraintreeLocalMethodsPaymentStrategy from './create-braintree-local-methods-payment-strategy';
+import BraintreeLocalMethodsPaymentStrategy from './braintree-local-methods-payment-strategy';
+
+describe('createBraintreePaypalCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = <PaymentIntegrationService>new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates braintree local methods payment strategy', () => {
+        const strategy = createBraintreeLocalMethodsPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(BraintreeLocalMethodsPaymentStrategy);
+    });
+});

--- a/packages/braintree-integration/src/braintree-local-payment-methods/create-braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/create-braintree-local-methods-payment-strategy.ts
@@ -1,0 +1,31 @@
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BraintreeLocalMethodsPaymentStrategy from './braintree-local-methods-payment-strategy';
+import { BraintreeHostWindow } from '../braintree';
+import BraintreeIntegrationService from '../braintree-integration-service';
+import BraintreeScriptLoader from '../braintree-script-loader';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+const createBraintreeLocalMethodsPaymentStrategy: PaymentStrategyFactory<
+    BraintreeLocalMethodsPaymentStrategy
+> = (paymentIntegrationService) => {
+    const braintreeHostWindow: BraintreeHostWindow = window;
+    const braintreeIntegrationService = new BraintreeIntegrationService(
+        new BraintreeScriptLoader(getScriptLoader(), braintreeHostWindow),
+        braintreeHostWindow,
+    );
+
+    return new BraintreeLocalMethodsPaymentStrategy(
+        paymentIntegrationService,
+        braintreeIntegrationService,
+        new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
+    );
+};
+
+export default toResolvableModule(createBraintreeLocalMethodsPaymentStrategy, [
+    { gateway: 'braintreelocalmethods' },
+]);

--- a/packages/braintree-integration/src/braintree-script-loader.spec.ts
+++ b/packages/braintree-integration/src/braintree-script-loader.spec.ts
@@ -6,11 +6,13 @@ import {
     BraintreeClientCreator,
     BraintreeDataCollector,
     BraintreeHostWindow,
+    BraintreeLocalPayment,
     BraintreeModuleCreator,
     BraintreePaypalCheckoutCreator,
 } from './braintree';
 import BraintreeScriptLoader from './braintree-script-loader';
 import {
+    getBraintreeLocalPaymentMock,
     getClientMock,
     getDataCollectorMock,
     getModuleCreatorMock,
@@ -125,6 +127,29 @@ describe('BraintreeScriptLoader', () => {
             } catch (error) {
                 expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
             }
+        });
+    });
+
+    describe('#loadBraintreeLocalMethods', () => {
+        let localPayment: BraintreeLocalPayment;
+        beforeEach(() => {
+            localPayment = getBraintreeLocalPaymentMock();
+            scriptLoader.loadScript = jest.fn(() => {
+                if (mockWindow.braintree) {
+                    mockWindow.braintree.localPayment = localPayment;
+                }
+
+                return Promise.resolve();
+            });
+        });
+
+        it('loads local payment methods', async () => {
+            const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
+            await braintreeScriptLoader.loadBraintreeLocalMethods();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${VERSION}/js/local-payment.min.js`,
+            );
         });
     });
 

--- a/packages/braintree-integration/src/braintree-script-loader.ts
+++ b/packages/braintree-integration/src/braintree-script-loader.ts
@@ -42,6 +42,18 @@ export default class BraintreeScriptLoader {
         return this.braintreeHostWindow.braintree.paypalCheckout;
     }
 
+    async loadBraintreeLocalMethods() {
+        await this.scriptLoader.loadScript(
+            `//js.braintreegateway.com/web/${VERSION}/js/local-payment.min.js`,
+        );
+
+        if (!this.braintreeHostWindow.braintree?.localPayment) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this.braintreeHostWindow.braintree.localPayment;
+    }
+
     async loadDataCollector(): Promise<BraintreeDataCollectorCreator> {
         await this.scriptLoader.loadScript(
             `//js.braintreegateway.com/web/${VERSION}/js/data-collector.min.js`,

--- a/packages/braintree-integration/src/braintree.mock.ts
+++ b/packages/braintree-integration/src/braintree.mock.ts
@@ -4,6 +4,7 @@ import {
     BraintreeBankAccount,
     BraintreeClient,
     BraintreeDataCollector,
+    BraintreeLocalPayment,
     BraintreeModule,
     BraintreeModuleCreator,
     BraintreePaypalCheckout,
@@ -23,6 +24,13 @@ export function getDataCollectorMock(): BraintreeDataCollector {
     return {
         deviceData: getDeviceDataMock(),
         teardown: jest.fn(() => Promise.resolve()),
+    };
+}
+
+export function getBraintreeLocalPaymentMock(): BraintreeLocalPayment {
+    return {
+        VERSION: '3.81.0',
+        create: jest.fn(),
     };
 }
 
@@ -151,6 +159,28 @@ export function getBraintreeAch(): PaymentMethod {
     };
 }
 
+export function getBraintreeLocalMethodsInitializationOptions() {
+    return {
+        container: '#checkout-payment-continue',
+        onRenderButton: jest.fn(),
+        submitForm: jest.fn(),
+        onValidate: jest.fn(),
+        onError: jest.fn(),
+    };
+}
+
+export function getBraintreeLocalMethods() {
+    return {
+        id: 'braintreelocalmethods',
+        logoUrl: '',
+        method: 'giropay',
+        supportedCards: [],
+        config: {
+            displayName: 'Giropay',
+        },
+        type: 'PAYMENT_TYPE_API',
+    };
+}
 export function getBraintreeAddress(): BraintreeShippingAddressOverride {
     return {
         line1: '12345 Testing Way',

--- a/packages/braintree-integration/src/braintree.ts
+++ b/packages/braintree-integration/src/braintree.ts
@@ -1,4 +1,8 @@
 import { PaypalAuthorizeData, PaypalButtonOptions, PaypalButtonRender, PaypalSDK } from './paypal';
+import {
+    BraintreeLocalMethods,
+    LocalPaymentInstance,
+} from './braintree-local-payment-methods/braintree-local-methods-options';
 
 /**
  *
@@ -46,6 +50,25 @@ export interface BraintreeSDK {
     venmo?: BraintreeVenmoCheckoutCreator;
     // visaCheckout?: BraintreeVisaCheckoutCreator; // TODO: should be added in future migration
     usBankAccount?: BraintreeBankAccountCreator;
+    localPayment?: BraintreeLocalPayment;
+}
+
+export interface BraintreeLocalPayment {
+    VERSION: string;
+    create(
+        config: BraintreeLocalPaymentCreateConfig,
+        callback: BraintreeLocalPaymentCallback,
+    ): BraintreeLocalMethods;
+}
+
+export type BraintreeLocalPaymentCallback = (
+    localPaymentError: string,
+    localPaymentInstance: LocalPaymentInstance,
+) => void;
+
+export interface BraintreeLocalPaymentCreateConfig {
+    client: BraintreeClient;
+    merchantAccountId: string;
 }
 
 export interface BraintreeInitializationData {

--- a/packages/braintree-integration/src/index.ts
+++ b/packages/braintree-integration/src/index.ts
@@ -7,3 +7,6 @@ export { WithBraintreePaypalCustomerInitializeOptions } from './braintree-paypal
 
 export { default as createBraintreePaypalCustomerStrategy } from './braintree-paypal/create-braintree-paypal-customer-strategy';
 export { WithBraintreePaypalAchPaymentInitializeOptions } from './braintree-paypal-ach/braintree-paypal-ach-initialize-options';
+
+export { default as createBraintreeLocalMethodsPaymentStrategy } from './braintree-local-payment-methods/create-braintree-local-methods-payment-strategy';
+export { WithBraintreeLocalMethodsPaymentInitializeOptions } from './braintree-local-payment-methods/braintree-local-methods-options';


### PR DESCRIPTION
## What?
Created payment strategy for braintree local methods

## Why?
To add ability to submit order and payment via braintree local methods

## Testing / Proof
<img width="1680" alt="Screenshot 2023-05-29 at 11 52 12" src="https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/d6649e39-c4c0-448f-8730-4446f9806635">


@bigcommerce/checkout @bigcommerce/payments
