### PR TITLE
fix(payment): PAYPAL-2575 fixed the issue with PayPalCommerceVenmo button eligibility

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.spec.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 
 import {
     InvalidArgumentError,
+    NotImplementedError,
     OrderFinalizationNotRequiredError,
     PaymentArgumentInvalidError,
     PaymentInitializeOptions,
@@ -223,7 +224,7 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
             });
         });
 
-        it('does not render paypal button if it is not eligible', async () => {
+        it('throws an error if paypal button is not eligible', async () => {
             const paypalCommerceSdkRenderMock = jest.fn();
 
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
@@ -231,9 +232,11 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
                 render: paypalCommerceSdkRenderMock,
             }));
 
-            await strategy.initialize(initializationOptions);
-
-            expect(paypalCommerceSdkRenderMock).not.toHaveBeenCalled();
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(NotImplementedError);
+            }
         });
 
         it('renders paypal button if it is eligible', async () => {
@@ -433,7 +436,7 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
             const paypalCommerceSdkCloseMock = jest.fn();
 
             jest.spyOn(paypalSdk, 'Buttons').mockImplementation(() => ({
-                isEligible: jest.fn(() => false),
+                isEligible: jest.fn(() => true),
                 render: jest.fn(),
                 close: paypalCommerceSdkCloseMock,
             }));

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
@@ -1,5 +1,6 @@
 import {
     InvalidArgumentError,
+    NotImplementedError,
     OrderFinalizationNotRequiredError,
     OrderRequestBody,
     PaymentArgumentInvalidError,
@@ -142,7 +143,9 @@ export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrate
         this.paypalButton = paypalSdk.Buttons(buttonOptions);
 
         if (!this.paypalButton.isEligible()) {
-            return;
+            throw new NotImplementedError(
+                `PayPal Venmo is not available for your region. Please use PayPal Checkout instead.`,
+            );
         }
 
         if (onRenderButton && typeof onRenderButton === 'function') {


### PR DESCRIPTION
## What?
We should inform the user that PayPal Venmo does not supports in theirs region instead of giving users an ability to continue what causes an order creation error on submit.

## Why?
Because the order creation error occurs when the users try to submit order in regions where PayPal Venmo is not eligible.

## Testing / Proof
Unit tests
Manual tests
