### PR TITLE
feat(payment): PI-120 Autofilling of holderName to be configurable

### DIFF
--- a/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.ts
@@ -308,7 +308,10 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         });
     }
 
-    private _mapAdyenPlaceholderData(billingAddress?: BillingAddress): AdyenPlaceholderData {
+    private _mapAdyenPlaceholderData(
+        billingAddress?: BillingAddress,
+        prefillCardHolderName?: boolean,
+    ): AdyenPlaceholderData {
         if (!billingAddress) {
             return {};
         }
@@ -325,7 +328,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         } = billingAddress;
 
         return {
-            holderName: `${firstName} ${lastName}`,
+            holderName: prefillCardHolderName ? `${firstName} ${lastName}` : '',
             billingAddress: {
                 street,
                 houseNumberOrName,
@@ -383,11 +386,11 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                     const billingAddress = this._paymentIntegrationService
                         .getState()
                         .getBillingAddress();
-
+                    const { prefillCardHolderName } = paymentMethod.initializationData;
                     paymentComponent = adyenClient.create(paymentMethod.method, {
                         ...adyenv2.options,
                         onChange: (componentState) => this._updateComponentState(componentState),
-                        data: this._mapAdyenPlaceholderData(billingAddress),
+                        data: this._mapAdyenPlaceholderData(billingAddress, prefillCardHolderName),
                     });
 
                     try {

--- a/packages/adyen-integration/src/adyenv2/adyenv2.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2.ts
@@ -271,6 +271,7 @@ export interface AdyenConfiguration {
 
 export interface AdyenPlaceholderData {
     holderName?: string;
+    prefillCardHolderName?: boolean;
     billingAddress?: {
         street: string;
         houseNumberOrName: string;
@@ -901,4 +902,5 @@ export interface AdyenPaymentMethodInitializationData {
     clientKey?: string;
     environment?: string;
     paymentMethodsResponse?: PaymentMethodsResponse;
+    prefillCardHolderName?: boolean;
 }

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -482,6 +482,71 @@ describe('AdyenV3PaymentStrategy', () => {
                 expect(additionalActionComponent.unmount).toHaveBeenCalledTimes(1);
             });
 
+            it('prefills holderName with billingAddress data if prefillCardHolderName is true', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...getAdyenV3(),
+                    initializationData: {
+                        ...getAdyenV3().initializationData,
+                        prefillCardHolderName: true,
+                    },
+                });
+                await strategy.initialize(options);
+
+                expect(adyenCheckout.create).toHaveBeenNthCalledWith(
+                    1,
+                    'scheme',
+                    expect.objectContaining({
+                        data: {
+                            billingAddress: {
+                                city: 'Some City',
+                                country: 'US',
+                                houseNumberOrName: '',
+                                postalCode: '95555',
+                                stateOrProvince: 'CA',
+                                street: '12345 Testing Way',
+                            },
+                            holderName: 'Test Tester',
+                        },
+                    }),
+                );
+            });
+
+            it('does not prefill holderName with billingAddress data if prefillCardHolderName is false', async () => {
+                jest.spyOn(
+                    paymentIntegrationService.getState(),
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue({
+                    ...getAdyenV3(),
+                    initializationData: {
+                        ...getAdyenV3().initializationData,
+                        prefillCardHolderName: false,
+                    },
+                });
+
+                await strategy.initialize(options);
+
+                expect(adyenCheckout.create).toHaveBeenNthCalledWith(
+                    1,
+                    'scheme',
+                    expect.objectContaining({
+                        data: {
+                            billingAddress: {
+                                city: 'Some City',
+                                country: 'US',
+                                houseNumberOrName: '',
+                                postalCode: '95555',
+                                stateOrProvince: 'CA',
+                                street: '12345 Testing Way',
+                            },
+                            holderName: '',
+                        },
+                    }),
+                );
+            });
+
             describe('submitPayment fails with identifyShopperError', () => {
                 beforeEach(async () => {
                     await strategy.initialize(options);

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -302,7 +302,10 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         });
     }
 
-    private _mapAdyenPlaceholderData(billingAddress?: BillingAddress): AdyenPlaceholderData {
+    private _mapAdyenPlaceholderData(
+        billingAddress?: BillingAddress,
+        prefillCardHolderName?: boolean,
+    ): AdyenPlaceholderData {
         if (!billingAddress) {
             return {};
         }
@@ -319,7 +322,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         } = billingAddress;
 
         return {
-            holderName: `${firstName} ${lastName}`,
+            holderName: prefillCardHolderName ? `${firstName} ${lastName}` : '',
             billingAddress: {
                 street,
                 houseNumberOrName,
@@ -372,12 +375,16 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         return new Promise((resolve, reject) => {
             const billingAddress = this._paymentIntegrationService.getState().getBillingAddress();
 
+            const { prefillCardHolderName } = paymentMethod.initializationData;
+
             paymentComponent = adyenClient.create(paymentMethod.method, {
                 ...adyenv3.options,
                 showBrandsUnderCardNumber: false,
                 onChange: (componentState) => this._updateComponentState(componentState),
-                ...(billingAddress ? { data: this._mapAdyenPlaceholderData(billingAddress) } : {}),
                 onSubmit: (componentState) => this._updateComponentState(componentState),
+                ...(billingAddress
+                    ? { data: this._mapAdyenPlaceholderData(billingAddress, prefillCardHolderName) }
+                    : {}),
             });
 
             try {

--- a/packages/adyen-integration/src/adyenv3/adyenv3.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3.ts
@@ -297,6 +297,7 @@ export interface AdyenConfiguration {
 
 export interface AdyenPlaceholderData {
     holderName?: string;
+    prefillCardHolderName?: boolean;
     billingAddress?: {
         street: string;
         houseNumberOrName: string;
@@ -912,4 +913,5 @@ export interface AdyenPaymentMethodInitializationData {
     clientKey?: string;
     environment?: string;
     paymentMethodsResponse?: PaymentMethodsResponse;
+    prefillCardHolderName?: boolean;
 }


### PR DESCRIPTION
## What?

Autofilling of holderName to be configurable.
Checkbox is available in Adyen Settings in CP allowing merchants to avoid auto populating of billing name to the card holder name

Checkbox state is enabled by default for both existing and new merchants

## Why?

At the moment, Merchants using Adyen will see that the credit card holder name is being autofilled from the Shoppers selected billing address at checkout.

 We send shopperName from billing address, holderName (from card) is sent directly as is to card form (for Adyen V3)

## Testing / Proof

<img width="1000" alt="Screenshot 2023-06-13 at 16 30 11" src="https://github.com/bigcommerce/checkout-sdk-js/assets/130754705/d37c8e6f-1f29-4bb4-9d68-322d10095aae">

@bigcommerce/checkout @bigcommerce/payments
