### PR TITLE
feat(payment): PAYPAL-2576 added specific button styles for each PayPal buttons

### DIFF
--- a/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-payment-method.mock.ts
+++ b/packages/paypal-commerce-integration/src/mocks/get-paypal-commerce-payment-method.mock.ts
@@ -17,6 +17,25 @@ export default function getPayPalCommercePaymentMethod(): PaymentMethod {
                 color: 'black',
                 label: 'pay',
             },
+            paymentButtonStyles: {
+                cartButtonStyles: {
+                    color: 'black',
+                    label: 'checkout',
+                },
+                pdpButtonStyles: {
+                    color: 'black',
+                    label: 'checkout',
+                },
+                checkoutTopButtonStyles: {
+                    color: 'silver',
+                    label: 'checkout',
+                },
+                checkoutPaymentButtonStyles: {
+                    color: 'black',
+                    label: 'pay',
+                    height: 55,
+                },
+            },
             clientId: 'abc',
             merchantId: 'JTS4DY7XFSQZE',
             orderId: '3U4171152W1482642',

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -219,8 +219,9 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYLATER,
                 style: {
-                    height: 40,
-                    color: StyleButtonColor.gold,
+                    height: 36,
+                    color: StyleButtonColor.silver,
+                    label: 'checkout',
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
@@ -244,8 +245,9 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYLATER,
                 style: {
-                    height: 40,
-                    color: StyleButtonColor.gold,
+                    height: 36,
+                    color: StyleButtonColor.silver,
+                    label: 'checkout',
                 },
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
@@ -284,8 +286,9 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.CREDIT,
                 style: {
-                    height: 40,
-                    color: StyleButtonColor.gold,
+                    height: 36,
+                    color: StyleButtonColor.silver,
+                    label: 'checkout',
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -20,7 +20,6 @@ import {
     PayPalCommerceInitializationData,
     ShippingAddressChangeCallbackPayload,
     ShippingOptionChangeCallbackPayload,
-    StyleButtonColor,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditCustomerInitializeOptions, {
@@ -94,7 +93,9 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { isHostedCheckoutEnabled } = paymentMethod.initializationData || {};
+        const { isHostedCheckoutEnabled, paymentButtonStyles } =
+            paymentMethod.initializationData || {};
+        const { checkoutTopButtonStyles } = paymentButtonStyles || {};
 
         const defaultCallbacks = {
             createOrder: () =>
@@ -120,7 +121,8 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
                 const buttonRenderOptions: PayPalCommerceButtonsOptions = {
                     fundingSource,
                     style: this.paypalCommerceIntegrationService.getValidButtonStyle({
-                        color: StyleButtonColor.gold,
+                        ...checkoutTopButtonStyles,
+                        height: 36,
                     }),
                     ...defaultCallbacks,
                     ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
@@ -125,7 +125,8 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { buttonStyle } = paymentMethod.initializationData || {};
+        const { paymentButtonStyles } = paymentMethod.initializationData || {};
+        const { checkoutPaymentButtonStyles } = paymentButtonStyles || {};
 
         const { container, onError, onRenderButton, onValidate, submitForm } = paypalOptions;
 
@@ -139,7 +140,9 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
 
             const buttonOptions: PayPalCommerceButtonsOptions = {
                 fundingSource,
-                style: this.paypalCommerceIntegrationService.getValidButtonStyle(buttonStyle),
+                style: this.paypalCommerceIntegrationService.getValidButtonStyle(
+                    checkoutPaymentButtonStyles,
+                ),
                 createOrder: () =>
                     this.paypalCommerceIntegrationService.createOrder(
                         'paypalcommercecreditcheckout',

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -88,6 +88,7 @@ export interface PayPalCommerceInitializationData {
     merchantId?: string;
     orderId?: string;
     shouldRenderFields?: boolean;
+    paymentButtonStyles?: Record<string, PayPalButtonStyleOptions>;
 }
 
 /**

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
@@ -181,7 +181,9 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.VENMO,
                 style: {
-                    height: 40,
+                    color: 'silver',
+                    height: 36,
+                    label: 'checkout',
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
@@ -9,7 +9,11 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
-import { ApproveCallbackPayload, PayPalCommerceButtonsOptions } from '../paypal-commerce-types';
+import {
+    ApproveCallbackPayload,
+    PayPalCommerceButtonsOptions,
+    PayPalCommerceInitializationData,
+} from '../paypal-commerce-types';
 
 import { WithPayPalCommerceVenmoCustomerInitializeOptions } from './paypal-commerce-venmo-customer-initialize-options';
 
@@ -68,10 +72,18 @@ export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStra
 
     private renderButton(methodId: string, containerId: string): void {
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod =
+            state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+        const { paymentButtonStyles } = paymentMethod.initializationData || {};
+        const { checkoutTopButtonStyles } = paymentButtonStyles || {};
 
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.VENMO,
-            style: this.paypalCommerceIntegrationService.getValidButtonStyle(),
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle({
+                ...checkoutTopButtonStyles,
+                height: 36,
+            }),
             createOrder: () =>
                 this.paypalCommerceIntegrationService.createOrder('paypalcommercevenmo'),
             onApprove: ({ orderID }: ApproveCallbackPayload) =>

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
@@ -124,13 +124,16 @@ export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrate
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { buttonStyle } = paymentMethod.initializationData || {};
+        const { paymentButtonStyles } = paymentMethod.initializationData || {};
+        const { checkoutPaymentButtonStyles } = paymentButtonStyles || {};
 
         const { container, onError, onRenderButton, onValidate, submitForm } = paypalcommercevenmo;
 
         const buttonOptions: PayPalCommerceButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.VENMO,
-            style: this.paypalCommerceIntegrationService.getValidButtonStyle(buttonStyle),
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle(
+                checkoutPaymentButtonStyles,
+            ),
             createOrder: () =>
                 this.paypalCommerceIntegrationService.createOrder('paypalcommercevenmocheckout'),
             onClick: (_, actions) => this.handleClick(actions, onValidate),

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -21,7 +21,11 @@ import {
     getShippingAddressFromOrderDetails,
 } from '../mocks';
 import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
-import { PayPalCommerceButtonsOptions, PayPalSDK } from '../paypal-commerce-types';
+import {
+    PayPalCommerceButtonsOptions,
+    PayPalSDK,
+    StyleButtonColor,
+} from '../paypal-commerce-types';
 
 import PayPalCommerceCustomerInitializeOptions from './paypal-commerce-customer-initialize-options';
 import PayPalCommerceCustomerStrategy from './paypal-commerce-customer-strategy';
@@ -213,7 +217,7 @@ describe('PayPalCommerceCustomerStrategy', () => {
 
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: { height: 40 },
+                style: { height: 36, color: StyleButtonColor.silver, label: 'checkout' },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
             });
@@ -235,7 +239,7 @@ describe('PayPalCommerceCustomerStrategy', () => {
 
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: { height: 40 },
+                style: { height: 36, color: StyleButtonColor.silver, label: 'checkout' },
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -97,7 +97,9 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { isHostedCheckoutEnabled } = paymentMethod.initializationData || {};
+        const { isHostedCheckoutEnabled, paymentButtonStyles } =
+            paymentMethod.initializationData || {};
+        const { checkoutTopButtonStyles } = paymentButtonStyles || {};
 
         const defaultCallbacks = {
             createOrder: () => this.paypalCommerceIntegrationService.createOrder('paypalcommerce'),
@@ -116,7 +118,10 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
 
         const buttonRenderOptions: PayPalCommerceButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.PAYPAL,
-            style: this.paypalCommerceIntegrationService.getValidButtonStyle(),
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle({
+                ...checkoutTopButtonStyles,
+                height: 36,
+            }),
             ...defaultCallbacks,
             ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),
         };

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -116,13 +116,15 @@ export default class PayPalCommercePaymentStrategy implements PaymentStrategy {
         const state = this.paymentIntegrationService.getState();
         const paymentMethod =
             state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
-        const { buttonStyle } = paymentMethod.initializationData || {};
-
+        const { paymentButtonStyles } = paymentMethod.initializationData || {};
+        const { checkoutPaymentButtonStyles } = paymentButtonStyles || {};
         const { container, onError, onRenderButton, onValidate, submitForm } = paypalcommerce;
 
         const buttonOptions: PayPalCommerceButtonsOptions = {
             fundingSource: paypalSdk.FUNDING.PAYPAL,
-            style: this.paypalCommerceIntegrationService.getValidButtonStyle(buttonStyle),
+            style: this.paypalCommerceIntegrationService.getValidButtonStyle(
+                checkoutPaymentButtonStyles,
+            ),
             createOrder: () =>
                 this.paypalCommerceIntegrationService.createOrder('paypalcommercecheckout'),
             onClick: (_, actions) => this.handleClick(actions, onValidate),


### PR DESCRIPTION
## What?
Added PayPal payment buttons styles coming from backend in:
- PDP (product details page);
- Cart page + mini cart popup (in header) + Add to cart (PDP add to cart modal);
- Checkout on top;
- Checkout in payment step (Complete order button);

This PR depends to https://github.com/bigcommerce/bigcommerce/pull/52892

## Why?
Because now we don't have a possibility to change PayPal styles in different places.

## Testing / Proof
All tests have been passed