### PR TITLE
feat(payment): PAYPAL-2449 fixed preloader in braintree LPM payment strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.386.1",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.23.0",
+        "@bigcommerce/bigpay-client": "^5.24.2",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1420,9 +1420,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.23.0.tgz",
-      "integrity": "sha512-KBhxoHCFVnAjMvXIqOPlaW+JDJVY8oK4YvpVE2ALsljbJuXYiBGhIwYWeWeGKn63DxiFWhPiimXmdVDjMQZLOw==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.2.tgz",
+      "integrity": "sha512-ANrPLpWHe60I/3CtP72144TzlicsIo3kVvG81iw+YNiLhaEytN7Gj4s86Y+Nh1vJSUs/T6rPepCObR63ZPDEIw==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -32172,9 +32172,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.23.0.tgz",
-      "integrity": "sha512-KBhxoHCFVnAjMvXIqOPlaW+JDJVY8oK4YvpVE2ALsljbJuXYiBGhIwYWeWeGKn63DxiFWhPiimXmdVDjMQZLOw==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.2.tgz",
+      "integrity": "sha512-ANrPLpWHe60I/3CtP72144TzlicsIo3kVvG81iw+YNiLhaEytN7Gj4s86Y+Nh1vJSUs/T6rPepCObR63ZPDEIw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.23.0",
+    "@bigcommerce/bigpay-client": "^5.24.2",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
@@ -215,10 +215,12 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
                     start();
                 },
             },
-            (startPaymentError: StartPaymentError, payload: LocalPaymentsPayload) => {
-                if (startPaymentError.code !== 'LOCAL_PAYMENT_WINDOW_CLOSED') {
+            (startPaymentError: StartPaymentError | null, payload: LocalPaymentsPayload) => {
+                if (startPaymentError) {
+                    if (startPaymentError.code !== 'LOCAL_PAYMENT_WINDOW_CLOSED') {
+                        this.handleError(startPaymentError.code);
+                    }
                     this.toggleLoadingIndicator(false);
-                    this.handleError(startPaymentError.code);
                 } else {
                     this.nonce = payload.nonce;
 


### PR DESCRIPTION
## What?
Fixed preloader  in braintree lpm strategy and bumped bigpay-client-js version

## Why?
When click cancel on LPM popup preloader doesn't disappear 

## Testing / Proof
Tested on dev and integration env

@bigcommerce/checkout @bigcommerce/payments
