### PR TITLE
feat(analytics): data-10908, data10928 Add shipping and payment details provided events for BODL

### DIFF
--- a/packages/core/src/bodl/bodl-emitter-service.ts
+++ b/packages/core/src/bodl/bodl-emitter-service.ts
@@ -4,7 +4,12 @@ import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 
 import { AnalyticStepOrder, AnalyticStepType } from './analytics-steps';
 import BodlService from './bodl-service';
-import { BodlEventsCheckout, BodlEventsPayload, BODLProduct } from './bodl-window';
+import {
+    BodlEventsCheckout,
+    BodlEventsPayload,
+    BODLProduct,
+    CommonCheckoutData,
+} from './bodl-window';
 
 export default class BodlEmitterService implements BodlService {
     private _checkoutStarted = false;
@@ -33,29 +38,13 @@ export default class BodlEmitterService implements BodlService {
     }
 
     checkoutBegin(): void {
-        if (this._checkoutStarted) {
+        const data = this._getCommonCheckoutData();
+
+        if (this._checkoutStarted || !data) {
             return;
         }
 
-        const checkout = this.state?.getCheckout();
-
-        if (!checkout) {
-            return;
-        }
-
-        const {
-            cart: { cartAmount, currency, lineItems, id, coupons },
-            channelId,
-        } = checkout;
-
-        this.bodlEvents.emitCheckoutBeginEvent({
-            event_id: id,
-            currency: currency.code,
-            cart_value: cartAmount,
-            coupon_codes: coupons.map((coupon) => coupon.code.toUpperCase()),
-            line_items: this._getProducts(lineItems, currency.code),
-            channel_id: channelId,
-        });
+        this.bodlEvents.emitCheckoutBeginEvent(data);
 
         this._checkoutStarted = true;
     }
@@ -142,7 +131,16 @@ export default class BodlEmitterService implements BodlService {
     }
 
     selectedPaymentMethod(paymentOption?: string) {
-        this.bodlEvents.emit('bodl_checkout_payment_method_selected', { paymentOption });
+        const commonData = this._getCommonCheckoutData();
+
+        if (!commonData || !paymentOption) {
+            return;
+        }
+
+        this.bodlEvents.emitPaymentDetailsProvidedEvent({
+            ...commonData,
+            payment_type: paymentOption,
+        });
     }
 
     clickPayButton(payload?: BodlEventsPayload) {
@@ -159,6 +157,57 @@ export default class BodlEmitterService implements BodlService {
 
     exitCheckout() {
         this.bodlEvents.emit('bodl_checkout_exit');
+    }
+
+    private _trackCompletedStep(step: AnalyticStepType) {
+        this._completedSteps[step] = true;
+
+        const bodlEventsMap: { [key in AnalyticStepType]?: () => void } = {
+            [AnalyticStepType.SHIPPING]: this._trackShippingStepCompleted.bind(this),
+        };
+        const emit = bodlEventsMap[step];
+
+        if (emit) {
+            emit();
+        } else {
+            this.bodlEvents.emit('bodl_checkout_step_completed', { step });
+        }
+    }
+
+    private _trackShippingStepCompleted(): void {
+        const shippingMethod = this.state?.getSelectedShippingOption()?.description;
+        const commonData = this._getCommonCheckoutData();
+
+        if (!commonData || !shippingMethod) {
+            return;
+        }
+
+        this.bodlEvents.emitShippingDetailsProvidedEvent({
+            ...commonData,
+            shipping_method: shippingMethod,
+        });
+    }
+
+    private _getCommonCheckoutData(): CommonCheckoutData | null {
+        const checkout = this.state?.getCheckout();
+
+        if (!checkout) {
+            return null;
+        }
+
+        const {
+            cart: { cartAmount, currency, lineItems, id, coupons },
+            channelId,
+        } = checkout;
+
+        return {
+            event_id: id,
+            currency: currency.code,
+            cart_value: cartAmount,
+            coupon_codes: coupons.map((coupon) => coupon.code.toUpperCase()),
+            line_items: this._getProducts(lineItems, currency.code),
+            channel_id: channelId,
+        };
     }
 
     private _getProducts(lineItems: LineItemMap, currencyCode: string): BODLProduct[] {
@@ -216,11 +265,6 @@ export default class BodlEmitterService implements BodlService {
         });
 
         return [...customItems, ...physicalAndDigitalItems, ...giftCertificateItems];
-    }
-
-    private _trackCompletedStep(step: AnalyticStepType) {
-        this._completedSteps[step] = true;
-        this.bodlEvents.emit('bodl_checkout_step_completed', { step });
     }
 
     private _hasStepCompleted(step: AnalyticStepType): boolean {

--- a/packages/core/src/bodl/bodl-events-service.spec.ts
+++ b/packages/core/src/bodl/bodl-events-service.spec.ts
@@ -6,6 +6,7 @@ import { getOrder } from '../order/orders.mock';
 import { AnalyticStepType } from './analytics-steps';
 import BodlEmitterService from './bodl-emitter-service';
 import { BodlEventsCheckout, BodlEventsPayload } from './bodl-window';
+import { getShippingOption } from '../shipping/shipping-options.mock';
 
 describe('BodlEmitterService', () => {
     let checkoutService: CheckoutService;
@@ -17,6 +18,8 @@ describe('BodlEmitterService', () => {
         bodlEvents = {
             emitOrderPurchasedEvent: jest.fn(),
             emitCheckoutBeginEvent: jest.fn(),
+            emitShippingDetailsProvidedEvent: jest.fn(),
+            emitPaymentDetailsProvidedEvent: jest.fn(),
             emit: jest.fn(),
         };
 
@@ -33,6 +36,11 @@ describe('BodlEmitterService', () => {
         jest.spyOn(checkoutService.getState().data, 'getConfig').mockReturnValue(
             getConfig().storeConfig,
         );
+
+        jest.spyOn(checkoutService.getState().data, 'getSelectedShippingOption').mockReturnValue({
+            ...getShippingOption(),
+            description: 'foo',
+        });
 
         bodlEmitterService = new BodlEmitterService(subscriber, bodlEvents);
     });
@@ -251,81 +259,301 @@ describe('BodlEmitterService', () => {
     });
 
     describe('#stepCompleted(step)', () => {
-        it('no step has not completed yet', () => {
-            bodlEmitterService.stepCompleted();
+        const SHIPPING_STEP = AnalyticStepType.SHIPPING;
 
-            expect(bodlEvents.emit).not.toHaveBeenCalled();
+        describe('Shipping Step', () => {
+            beforeEach(() => {
+                bodlEmitterService.stepCompleted(SHIPPING_STEP);
+            });
+
+            it('only tracks event once', () => {
+                bodlEmitterService.stepCompleted(SHIPPING_STEP);
+                bodlEmitterService.stepCompleted(SHIPPING_STEP);
+
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalledTimes(1);
+            });
+
+            it('tracks the event id', () => {
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        event_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                    }),
+                );
+            });
+
+            it('tracks the currency', () => {
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        currency: 'USD',
+                    }),
+                );
+            });
+
+            it('tracks the cart value', () => {
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        cart_value: 190,
+                    }),
+                );
+            });
+
+            it('tracks the coupon_codes array', () => {
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        coupon_codes: ['SAVEBIG2015', '279F507D817E3E7'],
+                    }),
+                );
+            });
+
+            it('tracks the channel id', () => {
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        channel_id: 1,
+                    }),
+                );
+            });
+
+            it('tracks the selected shipping method', () => {
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        shipping_method: 'foo',
+                    }),
+                );
+            });
+
+            it('tracks products', () => {
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        coupon_codes: ['SAVEBIG2015', '279F507D817E3E7'],
+                        cart_value: 190,
+                        currency: 'USD',
+                        event_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                        line_items: [
+                            {
+                                product_id: 103,
+                                sku: 'CLC',
+                                product_name: 'Canvas Laundry Cart',
+                                base_price: 200,
+                                sale_price: 190,
+                                purchase_price: 190,
+                                quantity: 1,
+                                brand_name: 'OFS',
+                                discount: 10,
+                                category_names: ['Cat 1'],
+                                variant_id: 71,
+                                currency: 'USD',
+                            },
+                            {
+                                product_id: 104,
+                                sku: 'CLX',
+                                product_name: 'Digital Book',
+                                base_price: 200,
+                                purchase_price: 200,
+                                sale_price: 200,
+                                quantity: 1,
+                                discount: 0,
+                                brand_name: 'Digitalia',
+                                category_names: ['Ebooks', 'Audio Books'],
+                                variant_id: 72,
+                                currency: 'USD',
+                            },
+                            {
+                                gift_certificate_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                                gift_certificate_name: '$100 Gift Certificate',
+                                gift_certificate_theme: 'General',
+                                product_name: '$100 Gift Certificate',
+                                base_price: 100,
+                                purchase_price: 100,
+                                sale_price: 100,
+                                product_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                                quantity: 1,
+                                currency: 'USD',
+                            },
+                        ],
+                    }),
+                );
+            });
         });
 
-        it('First step completed', () => {
-            bodlEmitterService.stepCompleted('customer' as AnalyticStepType);
+        describe('Steps ordering', () => {
+            it('no step has not completed yet', () => {
+                bodlEmitterService.stepCompleted();
 
-            expect(bodlEvents.emit).toHaveBeenCalledTimes(1);
-            expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'customer',
+                expect(bodlEvents.emit).not.toHaveBeenCalled();
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).not.toHaveBeenCalled();
             });
-            expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'shipping',
+
+            it('First step completed', () => {
+                bodlEmitterService.stepCompleted(AnalyticStepType.CUSTOMER);
+
+                expect(bodlEvents.emit).toHaveBeenCalledTimes(1);
+                expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'customer',
+                });
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).not.toHaveBeenCalled();
+                expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'billing',
+                });
+                expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'payment',
+                });
             });
-            expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'billing',
+
+            it('Complete the same step three times', () => {
+                bodlEmitterService.stepCompleted(AnalyticStepType.CUSTOMER);
+                bodlEmitterService.stepCompleted(AnalyticStepType.CUSTOMER);
+                bodlEmitterService.stepCompleted(AnalyticStepType.CUSTOMER);
+
+                expect(bodlEvents.emit).toHaveBeenCalledTimes(1);
+                expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'customer',
+                });
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).not.toHaveBeenCalled();
             });
-            expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'payment',
+
+            it('Manually complete three steps', () => {
+                bodlEmitterService.stepCompleted(AnalyticStepType.CUSTOMER);
+                bodlEmitterService.stepCompleted(AnalyticStepType.SHIPPING);
+                bodlEmitterService.stepCompleted(AnalyticStepType.BILLING);
+
+                expect(bodlEvents.emit).toHaveBeenCalledTimes(2);
+                expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'customer',
+                });
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalled();
+                expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'billing',
+                });
+                expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'payment',
+                });
+            });
+
+            it('First and third step completed manually, second - autocompleted', () => {
+                bodlEmitterService.stepCompleted(AnalyticStepType.CUSTOMER);
+                bodlEmitterService.stepCompleted(AnalyticStepType.BILLING);
+
+                expect(bodlEvents.emit).toHaveBeenCalledTimes(2);
+                expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'customer',
+                });
+                expect(bodlEvents.emitShippingDetailsProvidedEvent).toHaveBeenCalled();
+                expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'billing',
+                });
+                expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
+                    step: 'payment',
+                });
             });
         });
+    });
 
-        it('Complete the same step three times', () => {
-            bodlEmitterService.stepCompleted('customer' as AnalyticStepType);
-            bodlEmitterService.stepCompleted('customer' as AnalyticStepType);
-            bodlEmitterService.stepCompleted('customer' as AnalyticStepType);
+    describe('#selectedPaymentMethod(method)', () => {
+        const PAYMENT_OPTION = 'Credit Card';
 
-            expect(bodlEvents.emit).toHaveBeenCalledTimes(1);
-            expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'customer',
-            });
-            expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'shipping',
-            });
+        beforeEach(() => {
+            bodlEmitterService.selectedPaymentMethod(PAYMENT_OPTION);
         });
 
-        it('Manually complete three steps', () => {
-            bodlEmitterService.stepCompleted('customer' as AnalyticStepType);
-            bodlEmitterService.stepCompleted('shipping' as AnalyticStepType);
-            bodlEmitterService.stepCompleted('billing' as AnalyticStepType);
-
-            expect(bodlEvents.emit).toHaveBeenCalledTimes(3);
-            expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'customer',
-            });
-            expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'shipping',
-            });
-            expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'billing',
-            });
-            expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'payment',
-            });
+        it('tracks the event id', () => {
+            expect(bodlEvents.emitPaymentDetailsProvidedEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    event_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                }),
+            );
         });
 
-        it('First and third step completed manually, second - autocompleted', () => {
-            bodlEmitterService.stepCompleted('customer' as AnalyticStepType);
-            bodlEmitterService.stepCompleted('billing' as AnalyticStepType);
+        it('tracks the currency', () => {
+            expect(bodlEvents.emitPaymentDetailsProvidedEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    currency: 'USD',
+                }),
+            );
+        });
 
-            expect(bodlEvents.emit).toHaveBeenCalledTimes(3);
-            expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'customer',
-            });
-            expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'shipping',
-            });
-            expect(bodlEvents.emit).toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'billing',
-            });
-            expect(bodlEvents.emit).not.toHaveBeenCalledWith('bodl_checkout_step_completed', {
-                step: 'payment',
-            });
+        it('tracks the cart value', () => {
+            expect(bodlEvents.emitPaymentDetailsProvidedEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    cart_value: 190,
+                }),
+            );
+        });
+
+        it('tracks the coupon_codes array', () => {
+            expect(bodlEvents.emitPaymentDetailsProvidedEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    coupon_codes: ['SAVEBIG2015', '279F507D817E3E7'],
+                }),
+            );
+        });
+
+        it('tracks the channel id', () => {
+            expect(bodlEvents.emitPaymentDetailsProvidedEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    channel_id: 1,
+                }),
+            );
+        });
+
+        it('tracks the selected method', () => {
+            expect(bodlEvents.emitPaymentDetailsProvidedEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    payment_type: PAYMENT_OPTION,
+                }),
+            );
+        });
+
+        it('tracks products', () => {
+            expect(bodlEvents.emitPaymentDetailsProvidedEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    coupon_codes: ['SAVEBIG2015', '279F507D817E3E7'],
+                    cart_value: 190,
+                    currency: 'USD',
+                    event_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
+                    line_items: [
+                        {
+                            product_id: 103,
+                            sku: 'CLC',
+                            product_name: 'Canvas Laundry Cart',
+                            base_price: 200,
+                            sale_price: 190,
+                            purchase_price: 190,
+                            quantity: 1,
+                            brand_name: 'OFS',
+                            discount: 10,
+                            category_names: ['Cat 1'],
+                            variant_id: 71,
+                            currency: 'USD',
+                        },
+                        {
+                            product_id: 104,
+                            sku: 'CLX',
+                            product_name: 'Digital Book',
+                            base_price: 200,
+                            purchase_price: 200,
+                            sale_price: 200,
+                            quantity: 1,
+                            discount: 0,
+                            brand_name: 'Digitalia',
+                            category_names: ['Ebooks', 'Audio Books'],
+                            variant_id: 72,
+                            currency: 'USD',
+                        },
+                        {
+                            gift_certificate_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                            gift_certificate_name: '$100 Gift Certificate',
+                            gift_certificate_theme: 'General',
+                            product_name: '$100 Gift Certificate',
+                            base_price: 100,
+                            purchase_price: 100,
+                            sale_price: 100,
+                            product_id: 'bd391ead-8c58-4105-b00e-d75d233b429a',
+                            quantity: 1,
+                            currency: 'USD',
+                        },
+                    ],
+                }),
+            );
         });
     });
 
@@ -393,15 +621,6 @@ describe('BodlEmitterService', () => {
                     expectedData: [
                         'bodl_checkout_customer_payment_method_executed',
                         { test: 'data' },
-                    ],
-                },
-                {
-                    eventMethod: (paymentOption: string) =>
-                        bodlEmitterService.selectedPaymentMethod(paymentOption),
-                    methodArguments: 'paymentOptionDisplayName',
-                    expectedData: [
-                        'bodl_checkout_payment_method_selected',
-                        { paymentOption: 'paymentOptionDisplayName' },
                     ],
                 },
                 {

--- a/packages/core/src/bodl/bodl-window.ts
+++ b/packages/core/src/bodl/bodl-window.ts
@@ -17,7 +17,7 @@ export interface BODLProduct {
     currency?: string;
 }
 
-export interface CheckoutBeginData {
+export interface CommonCheckoutData {
     event_id: string;
     currency: string;
     channel_id: number;
@@ -26,20 +26,24 @@ export interface CheckoutBeginData {
     line_items: BODLProduct[];
 }
 
-export interface OrderPurchasedData {
-    event_id: string;
-    currency: string;
+export interface OrderPurchasedData extends CommonCheckoutData {
     tax: number;
-    channel_id: number;
     order_id: number;
-    cart_value: number;
-    coupon_codes: string[];
     shipping_cost: number;
-    line_items: BODLProduct[];
+}
+
+export interface ShippingDetailsProvidedData extends CommonCheckoutData {
+    shipping_method: string;
+}
+
+export interface BillingDetailsProvidedData extends CommonCheckoutData {
+    payment_type: string;
 }
 
 export interface BodlEventsCheckout {
-    emitCheckoutBeginEvent(data: CheckoutBeginData): boolean;
+    emitShippingDetailsProvidedEvent(data: ShippingDetailsProvidedData): boolean;
+    emitPaymentDetailsProvidedEvent(data: BillingDetailsProvidedData): boolean;
+    emitCheckoutBeginEvent(data: CommonCheckoutData): boolean;
     emitOrderPurchasedEvent(data: OrderPurchasedData): boolean;
     emit(name: string, data?: BodlEventsPayload): void;
 }


### PR DESCRIPTION
## What? [DATA-10908](https://bigcommercecloud.atlassian.net/browse/DATA-10908), [DATA-10928](https://bigcommercecloud.atlassian.net/browse/DATA-10928)
- Emit `shipping_details_provided` BODL event with the correct payload
- Emit `payment_details_provided` BODL event with the correct payload
- Update unit tests

## Why?
As a phase 3 of GA4 integration implementation we need to implement these 2 events. So that we need those events to be emitted by BODL with proper payload. Previously both events were triggered with some minimal mock data

## Testing / Proof
- Manually on dev store
- Unit tests

@bigcommerce/checkout @bigcommerce/payments


[DATA-10908]: https://bigcommercecloud.atlassian.net/browse/DATA-10908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATA-10928]: https://bigcommercecloud.atlassian.net/browse/DATA-10928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ