### PR TITLE
fix(payment): PAYPAL-2634 fixed issue when teardown is called twice

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
@@ -23,7 +23,7 @@ import {
     getVisaCheckoutMock,
 } from './braintree.mock';
 
-const version = '3.81.0';
+const version = '3.94.0';
 
 describe('BraintreeScriptLoader', () => {
     let braintreeScriptLoader: BraintreeScriptLoader;

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -15,7 +15,7 @@ import {
     BraintreeVisaCheckoutCreator,
 } from './braintree';
 
-const version = '3.81.0';
+const version = '3.94.0';
 
 export default class BraintreeScriptLoader {
     constructor(

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -233,6 +233,14 @@ export default class BraintreeSDKCreator {
     }
 
     private _teardown(module?: Promise<BraintreeModule>) {
-        return module ? module.then((mod) => mod.teardown()) : Promise.resolve();
+        return module
+            ? module
+                  .then((mod) => mod.teardown())
+                  .catch((error) => {
+                      if (error.code !== 'METHOD_CALLED_AFTER_TEARDOWN') {
+                          throw error;
+                      }
+                  })
+            : Promise.resolve();
     }
 }


### PR DESCRIPTION
## What?

Fixed issue when `teardown` is called twice

## Why?

To fix showing popup with unnecessary message for customer

Additional changes: bump braintree version for loading script to avoid version conflicts

## Testing / Proof

Before

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/0f1aa84c-6bd5-48d2-95fe-dd6b2120bd81

After

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/a90d8935-8bad-410a-b34c-a533ca5525a6


@bigcommerce/checkout @bigcommerce/payments
