### PR TITLE
feat(checkout): CHECKOUT-7537 Render extensions

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -32,7 +32,13 @@ import {
     CustomerStrategyActionCreator,
 } from '../customer';
 import CustomerStrategyRegistryV2 from '../customer/customer-strategy-registry-v2';
-import { ExtensionActionCreator, ExtensionRequestSender, getExtensions } from '../extension';
+import {
+    ExtensionActionCreator,
+    ExtensionRegions,
+    ExtensionRequestSender,
+    getExtensions,
+} from '../extension';
+import { ExtensionActionType } from '../extension/extension-actions';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../form';
 import { getAddressFormFields, getFormFields } from '../form/form.mock';
 import { CountryActionCreator, CountryRequestSender } from '../geography';
@@ -1472,6 +1478,21 @@ describe('CheckoutService', () => {
             expect(store.dispatch).toHaveBeenCalledWith(expect.any(Function), {
                 queueId: 'extensions',
             });
+        });
+    });
+
+    describe('#renderExtension()', () => {
+        it('render extensions', async () => {
+            jest.spyOn(extensionActionCreator, 'renderExtension').mockReturnValue(
+                of(createAction(ExtensionActionType.RenderExtensionSucceeded)),
+            );
+
+            const container = 'checkout.extension';
+            const region = ExtensionRegions.ShippingShippingAddressFormBefore;
+
+            await checkoutService.renderExtension(container, region);
+
+            expect(extensionActionCreator.renderExtension).toHaveBeenCalledWith(container, region);
         });
     });
 });

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -34,7 +34,7 @@ import {
 import CustomerStrategyRegistryV2 from '../customer/customer-strategy-registry-v2';
 import {
     ExtensionActionCreator,
-    ExtensionRegions,
+    ExtensionRegion,
     ExtensionRequestSender,
     getExtensions,
 } from '../extension';
@@ -1488,7 +1488,7 @@ describe('CheckoutService', () => {
             );
 
             const container = 'checkout.extension';
-            const region = ExtensionRegions.ShippingShippingAddressFormBefore;
+            const region = ExtensionRegion.ShippingShippingAddressFormBefore;
 
             await checkoutService.renderExtension(container, region);
 

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -1396,7 +1396,7 @@ export default class CheckoutService {
     renderExtension(container: string, region: ExtensionRegion): Promise<CheckoutSelectors> {
         const action = this._extensionActionCreator.renderExtension(container, region);
 
-        return this._dispatch(action, { queueId: 'renderExtension' });
+        return this._dispatch(action, { queueId: 'extensions' });
     }
 
     /**

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -20,7 +20,7 @@ import {
     ExecutePaymentMethodCheckoutOptions,
     GuestCredentials,
 } from '../customer';
-import { ExtensionActionCreator, ExtensionRegions } from '../extension';
+import { ExtensionActionCreator, ExtensionRegion } from '../extension';
 import { FormFieldsActionCreator } from '../form';
 import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
@@ -1393,7 +1393,7 @@ export default class CheckoutService {
      * @param region The name of an area where the extension should be presented.
      * @returns A promise that resolves to the current state.
      */
-    renderExtension(container: string, region: ExtensionRegions): Promise<CheckoutSelectors> {
+    renderExtension(container: string, region: ExtensionRegion): Promise<CheckoutSelectors> {
         const action = this._extensionActionCreator.renderExtension(container, region);
 
         return this._dispatch(action, { queueId: 'renderExtension' });

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -20,7 +20,7 @@ import {
     ExecutePaymentMethodCheckoutOptions,
     GuestCredentials,
 } from '../customer';
-import { ExtensionActionCreator } from '../extension';
+import { ExtensionActionCreator, ExtensionRegions } from '../extension';
 import { FormFieldsActionCreator } from '../form';
 import { CountryActionCreator } from '../geography';
 import { OrderActionCreator, OrderRequestBody } from '../order';
@@ -1368,7 +1368,7 @@ export default class CheckoutService {
      * Loads a list of extensions available for checkout.
      *
      * ```js
-     * const state = service.loadExtensions();
+     * const state = await service.loadExtensions();
      *
      * console.log(state.data.getExtensions());
      * ```
@@ -1382,6 +1382,21 @@ export default class CheckoutService {
         const action = this._extensionActionCreator.loadExtensions(options);
 
         return this._dispatch(action, { queueId: 'extensions' });
+    }
+
+    /**
+     * Renders an extension for a checkout extension region.
+     * Currently, only one extension is allowed per region.
+     *
+     * @alpha
+     * @param container The ID of a container which the extension should be inserted.
+     * @param region The name of an area where the extension should be presented.
+     * @returns A promise that resolves to the current state.
+     */
+    renderExtension(container: string, region: ExtensionRegions): Promise<CheckoutSelectors> {
+        const action = this._extensionActionCreator.renderExtension(container, region);
+
+        return this._dispatch(action, { queueId: 'renderExtension' });
     }
 
     /**

--- a/packages/core/src/extension/errors/extension-not-found-error.ts
+++ b/packages/core/src/extension/errors/extension-not-found-error.ts
@@ -1,0 +1,10 @@
+import { StandardError } from '../../common/error/errors';
+
+export class ExtensionNotFoundError extends StandardError {
+    constructor(message?: string) {
+        super(message || 'Unable to proceed due to no extension configured for this region.');
+
+        this.name = 'ExtensionNotFoundError';
+        this.type = 'extension_not_found';
+    }
+}

--- a/packages/core/src/extension/errors/index.ts
+++ b/packages/core/src/extension/errors/index.ts
@@ -1,0 +1,2 @@
+export { InvalidExtensionConfigError } from './invalid-extension-config-error';
+export { ExtensionNotFoundError } from './extension-not-found-error';

--- a/packages/core/src/extension/errors/invalid-extension-config-error.ts
+++ b/packages/core/src/extension/errors/invalid-extension-config-error.ts
@@ -1,0 +1,12 @@
+import { StandardError } from '../../common/error/errors';
+
+export class InvalidExtensionConfigError extends StandardError {
+    constructor(message?: string) {
+        super(
+            message || 'Unable to proceed due to invalid configuration provided for the extension.',
+        );
+
+        this.name = 'InvalidExtensionConfigError';
+        this.type = 'invalid_extension_config';
+    }
+}

--- a/packages/core/src/extension/extension-action-creator.spec.ts
+++ b/packages/core/src/extension/extension-action-creator.spec.ts
@@ -9,7 +9,7 @@ import { getCheckout, getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { getErrorResponse, getResponse } from '../common/http-request/responses.mock';
 
 import { ExtensionNotFoundError, InvalidExtensionConfigError } from './errors';
-import { Extension, ExtensionRegions } from './extension';
+import { Extension, ExtensionRegion } from './extension';
 import { ExtensionActionCreator } from './extension-action-creator';
 import { ExtensionActionType } from './extension-actions';
 import { ExtensionRequestSender } from './extension-request-sender';
@@ -94,7 +94,7 @@ describe('ExtensionActionCreator', () => {
             const actions = await from(
                 extensionActionCreator.renderExtension(
                     'foo',
-                    ExtensionRegions.ShippingShippingAddressFormAfter,
+                    ExtensionRegion.ShippingShippingAddressFormAfter,
                 )(store),
             )
                 .pipe(catchError(errorHandler))
@@ -112,7 +112,7 @@ describe('ExtensionActionCreator', () => {
             const actions = await from(
                 extensionActionCreator.renderExtension(
                     'foo',
-                    ExtensionRegions.ShippingShippingAddressFormAfter,
+                    ExtensionRegion.ShippingShippingAddressFormAfter,
                 )(store),
             )
                 .pipe(toArray())
@@ -131,7 +131,7 @@ describe('ExtensionActionCreator', () => {
             const actions = await from(
                 extensionActionCreator.renderExtension(
                     'foo',
-                    ExtensionRegions.ShippingShippingAddressFormAfter,
+                    ExtensionRegion.ShippingShippingAddressFormAfter,
                 )(store),
             )
                 .pipe(catchError(errorHandler), toArray())

--- a/packages/core/src/extension/extension-action-creator.spec.ts
+++ b/packages/core/src/extension/extension-action-creator.spec.ts
@@ -13,7 +13,7 @@ import { Extension, ExtensionRegions } from './extension';
 import { ExtensionActionCreator } from './extension-action-creator';
 import { ExtensionActionType } from './extension-actions';
 import { ExtensionRequestSender } from './extension-request-sender';
-import { getExtensions } from './extension.mock';
+import { getExtensions, getExtensionState } from './extension.mock';
 
 describe('ExtensionActionCreator', () => {
     let errorResponse: Response<ErrorResponseBody>;
@@ -82,9 +82,13 @@ describe('ExtensionActionCreator', () => {
 
     describe('#renderExtension()', () => {
         it('throws error if unable to find an extension', async () => {
-            jest.spyOn(store.getState().extensions, 'getExtensions').mockReturnValue(
-                getExtensions().slice(0, 1),
-            );
+            store = createCheckoutStore({
+                ...getCheckoutStoreState(),
+                extensions: {
+                    ...getExtensionState(),
+                    data: getExtensions().slice(0, 1),
+                },
+            });
 
             const errorHandler = jest.fn((action) => of(action));
             const actions = await from(

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -5,7 +5,7 @@ import { InternalCheckoutSelectors } from '../checkout';
 import { RequestOptions } from '../common/http-request';
 
 import { ExtensionNotFoundError } from './errors';
-import { ExtensionRegions } from './extension';
+import { ExtensionRegion } from './extension';
 import { ExtensionAction, ExtensionActionType } from './extension-actions';
 import { ExtensionIframe } from './extension-iframe';
 import { ExtensionRequestSender } from './extension-request-sender';
@@ -40,7 +40,7 @@ export class ExtensionActionCreator {
 
     renderExtension(
         container: string,
-        region: ExtensionRegions,
+        region: ExtensionRegion,
     ): ThunkAction<ExtensionAction, InternalCheckoutSelectors> {
         return (store) =>
             Observable.create((observer: Observer<ExtensionAction>) => {

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -58,7 +58,7 @@ export class ExtensionActionCreator {
                 observer.next(createAction(ExtensionActionType.RenderExtensionRequested));
 
                 try {
-                    const iframe = new ExtensionIframe(container, extension, cart.id);
+                    const iframe = new ExtensionIframe(container, extension, cartId);
 
                     iframe.attach();
 

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -46,8 +46,7 @@ export class ExtensionActionCreator {
             Observable.create((observer: Observer<ExtensionAction>) => {
                 const state = store.getState();
                 const { id: cartId } = state.cart.getCartOrThrow();
-                const extensions = state.extensions.getExtensions();
-                const extension = extensions?.filter((e) => e.region === region)[0];
+                const extension = state.extensions.getExtensionByRegion(region);
 
                 if (!extension) {
                     throw new ExtensionNotFoundError(

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -45,7 +45,7 @@ export class ExtensionActionCreator {
         return (store) =>
             Observable.create((observer: Observer<ExtensionAction>) => {
                 const state = store.getState();
-                const cart = state.cart.getCartOrThrow();
+                const { id: cartId } = state.cart.getCartOrThrow();
                 const extensions = state.extensions.getExtensions();
                 const extension = extensions?.filter((e) => e.region === region)[0];
 

--- a/packages/core/src/extension/extension-actions.ts
+++ b/packages/core/src/extension/extension-actions.ts
@@ -6,12 +6,18 @@ export enum ExtensionActionType {
     LoadExtensionsRequested = 'LOAD_EXTENSIONS_REQUESTED',
     LoadExtensionsSucceeded = 'LOAD_EXTENSIONS_SUCCEEDED',
     LoadExtensionsFailed = 'LOAD_EXTENSIONS_FAILED',
+    RenderExtensionRequested = 'RENDER_EXTENSION_REQUESTED',
+    RenderExtensionSucceeded = 'RENDER_EXTENSION_SUCCEEDED',
+    RenderExtensionFailed = 'RENDER_EXTENSION_FAILED',
 }
 
 export type ExtensionAction =
     | LoadExtensionsRequestedAction
     | LoadExtensionsSucceededAction
-    | LoadExtensionsFailedAction;
+    | LoadExtensionsFailedAction
+    | RenderExtensionRequestedAction
+    | RenderExtensionSucceededAction
+    | RenderExtensionFailedAction;
 
 export interface LoadExtensionsRequestedAction extends Action {
     type: ExtensionActionType.LoadExtensionsRequested;
@@ -23,4 +29,16 @@ export interface LoadExtensionsSucceededAction extends Action<Extension[]> {
 
 export interface LoadExtensionsFailedAction extends Action<Error> {
     type: ExtensionActionType.LoadExtensionsFailed;
+}
+
+export interface RenderExtensionRequestedAction extends Action {
+    type: ExtensionActionType.RenderExtensionRequested;
+}
+
+export interface RenderExtensionSucceededAction extends Action<Extension> {
+    type: ExtensionActionType.RenderExtensionSucceeded;
+}
+
+export interface RenderExtensionFailedAction extends Action<Error> {
+    type: ExtensionActionType.RenderExtensionFailed;
 }

--- a/packages/core/src/extension/extension-iframe.spec.ts
+++ b/packages/core/src/extension/extension-iframe.spec.ts
@@ -1,0 +1,51 @@
+import { Cart } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { getCart } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { InvalidExtensionConfigError } from './errors';
+import { Extension } from './extension';
+import { ExtensionIframe } from './extension-iframe';
+import { getExtensions } from './extension.mock';
+
+describe('ExtensionIframe', () => {
+    let cart: Cart;
+    let container: HTMLDivElement;
+    let extension: Extension;
+    let extensionIframe: ExtensionIframe;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'containerId';
+        document.getElementById = jest.fn().mockReturnValue(container);
+
+        cart = getCart();
+        extension = getExtensions()[0];
+        extensionIframe = new ExtensionIframe('containerId', extension, cart.id);
+    });
+
+    afterEach(() => {
+        container.innerHTML = '';
+    });
+
+    it('attaches iframe to the container', () => {
+        const appendChild = jest.spyOn(container, 'appendChild');
+
+        extensionIframe.attach();
+
+        expect(appendChild).toHaveBeenCalled();
+    });
+
+    it('throws InvalidExtensionConfigError when container ID is invalid', () => {
+        document.getElementById = jest.fn().mockReturnValue(null);
+
+        expect(() => extensionIframe.attach()).toThrow(InvalidExtensionConfigError);
+    });
+
+    it('detaches the iframe from its parent', () => {
+        const removeChild = jest.spyOn(container, 'removeChild');
+
+        extensionIframe.attach();
+        extensionIframe.detach();
+
+        expect(removeChild).toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/extension/extension-iframe.ts
+++ b/packages/core/src/extension/extension-iframe.ts
@@ -1,0 +1,44 @@
+import { InvalidExtensionConfigError } from './errors';
+import { Extension } from './extension';
+
+export class ExtensionIframe {
+    private _iframe: HTMLIFrameElement;
+
+    constructor(
+        private _containerId: string,
+        private _extension: Extension,
+        private _cartId: string,
+    ) {
+        const url = new URL(this._extension.url);
+
+        url.searchParams.set('extensionId', this._extension.id);
+        url.searchParams.set('cartId', this._cartId);
+
+        this._iframe = document.createElement('iframe');
+        this._iframe.src = url.toString();
+        this._iframe.style.border = 'none';
+        this._iframe.style.height = '100%';
+        this._iframe.style.overflow = 'hidden';
+        this._iframe.style.width = '100%';
+    }
+
+    attach(): void {
+        const container = document.getElementById(this._containerId);
+
+        if (!container) {
+            throw new InvalidExtensionConfigError(
+                'Unable to proceed because the provided container ID is invalid.',
+            );
+        }
+
+        container.appendChild(this._iframe);
+    }
+
+    detach(): void {
+        if (!this._iframe.parentElement) {
+            return;
+        }
+
+        this._iframe.parentElement.removeChild(this._iframe);
+    }
+}

--- a/packages/core/src/extension/extension-selector.spec.ts
+++ b/packages/core/src/extension/extension-selector.spec.ts
@@ -3,11 +3,13 @@ import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
+import { ExtensionRegions } from './extension';
 import {
     createExtensionSelectorFactory,
     ExtensionSelector,
     ExtensionSelectorFactory,
 } from './extension-selector';
+import { getExtensions } from './extension.mock';
 
 describe('ExtensionSelector', () => {
     let createExtensionSelector: ExtensionSelectorFactory;
@@ -33,6 +35,46 @@ describe('ExtensionSelector', () => {
             });
 
             expect(extensionSelector.getExtensions()).toEqual([]);
+        });
+    });
+
+    describe('#getExtensionByRegion()', () => {
+        it('returns the extension for the specified region', () => {
+            extensionSelector = createExtensionSelector(state.extensions);
+
+            const extension = extensionSelector.getExtensionByRegion(
+                ExtensionRegions.ShippingShippingAddressFormBefore,
+            );
+
+            expect(extension).toEqual(getExtensions()[0]);
+        });
+
+        it('returns the first extension if multiple extensions match the region', () => {
+            const extensions = getExtensions().slice(0, 1);
+
+            extensionSelector = createExtensionSelector({
+                ...state.extensions,
+                data: extensions,
+            });
+
+            const extension = extensionSelector.getExtensionByRegion(
+                ExtensionRegions.ShippingShippingAddressFormBefore,
+            );
+
+            expect(extension).toEqual(extensions[0]);
+        });
+
+        it('returns undefined if no extension matches the region', () => {
+            extensionSelector = createExtensionSelector({
+                ...state.extensions,
+                data: getExtensions().slice(0, 1),
+            });
+
+            const extension = extensionSelector.getExtensionByRegion(
+                ExtensionRegions.ShippingShippingAddressFormAfter,
+            );
+
+            expect(extension).toBeUndefined();
         });
     });
 

--- a/packages/core/src/extension/extension-selector.spec.ts
+++ b/packages/core/src/extension/extension-selector.spec.ts
@@ -3,7 +3,7 @@ import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import { ExtensionRegions } from './extension';
+import { ExtensionRegion } from './extension';
 import {
     createExtensionSelectorFactory,
     ExtensionSelector,
@@ -43,7 +43,7 @@ describe('ExtensionSelector', () => {
             extensionSelector = createExtensionSelector(state.extensions);
 
             const extension = extensionSelector.getExtensionByRegion(
-                ExtensionRegions.ShippingShippingAddressFormBefore,
+                ExtensionRegion.ShippingShippingAddressFormBefore,
             );
 
             expect(extension).toEqual(getExtensions()[0]);
@@ -58,7 +58,7 @@ describe('ExtensionSelector', () => {
             });
 
             const extension = extensionSelector.getExtensionByRegion(
-                ExtensionRegions.ShippingShippingAddressFormBefore,
+                ExtensionRegion.ShippingShippingAddressFormBefore,
             );
 
             expect(extension).toEqual(extensions[0]);
@@ -71,7 +71,7 @@ describe('ExtensionSelector', () => {
             });
 
             const extension = extensionSelector.getExtensionByRegion(
-                ExtensionRegions.ShippingShippingAddressFormAfter,
+                ExtensionRegion.ShippingShippingAddressFormAfter,
             );
 
             expect(extension).toBeUndefined();

--- a/packages/core/src/extension/extension-selector.spec.ts
+++ b/packages/core/src/extension/extension-selector.spec.ts
@@ -3,7 +3,7 @@ import { getCheckoutStoreState } from '../checkout/checkouts.mock';
 import { RequestError } from '../common/error/errors';
 import { getErrorResponse } from '../common/http-request/responses.mock';
 
-import { ExtensionRegion } from './extension';
+import { Extension, ExtensionRegion } from './extension';
 import {
     createExtensionSelectorFactory,
     ExtensionSelector,
@@ -43,14 +43,20 @@ describe('ExtensionSelector', () => {
             extensionSelector = createExtensionSelector(state.extensions);
 
             const extension = extensionSelector.getExtensionByRegion(
-                ExtensionRegion.ShippingShippingAddressFormBefore,
+                ExtensionRegion.ShippingShippingAddressFormAfter,
             );
 
-            expect(extension).toEqual(getExtensions()[0]);
+            expect(extension).toEqual(getExtensions()[1]);
         });
 
         it('returns the first extension if multiple extensions match the region', () => {
-            const extensions = getExtensions().slice(0, 1);
+            const extensions = [
+                ...getExtensions().slice(0, 1),
+                {
+                    ...getExtensions().slice(0, 1),
+                    id: '789',
+                },
+            ] as Extension[];
 
             extensionSelector = createExtensionSelector({
                 ...state.extensions,

--- a/packages/core/src/extension/extension-selector.ts
+++ b/packages/core/src/extension/extension-selector.ts
@@ -2,11 +2,12 @@ import { memoizeOne } from '@bigcommerce/memoize';
 
 import { createSelector } from '../common/selector';
 
-import { Extension } from './extension';
+import { Extension, ExtensionRegions } from './extension';
 import { DEFAULT_STATE, ExtensionState } from './extension-state';
 
 export interface ExtensionSelector {
     getExtensions(): Extension[] | undefined;
+    getExtensionByRegion(region: ExtensionRegions): Extension | undefined;
     getLoadError(): Error | undefined;
     isLoading(): boolean;
 }
@@ -17,6 +18,11 @@ export function createExtensionSelectorFactory(): ExtensionSelectorFactory {
     const getExtensions = createSelector(
         (state: ExtensionState) => state.data,
         (data) => () => data,
+    );
+
+    const getExtensionByRegion = createSelector(
+        (state: ExtensionState) => state.data,
+        (data) => (region: ExtensionRegions) => data?.filter((e) => e.region === region)[0],
     );
 
     const getLoadError = createSelector(
@@ -32,6 +38,7 @@ export function createExtensionSelectorFactory(): ExtensionSelectorFactory {
     return memoizeOne((state: ExtensionState = DEFAULT_STATE): ExtensionSelector => {
         return {
             getExtensions: getExtensions(state),
+            getExtensionByRegion: getExtensionByRegion(state),
             getLoadError: getLoadError(state),
             isLoading: isLoading(state),
         };

--- a/packages/core/src/extension/extension-selector.ts
+++ b/packages/core/src/extension/extension-selector.ts
@@ -2,12 +2,12 @@ import { memoizeOne } from '@bigcommerce/memoize';
 
 import { createSelector } from '../common/selector';
 
-import { Extension, ExtensionRegions } from './extension';
+import { Extension, ExtensionRegion } from './extension';
 import { DEFAULT_STATE, ExtensionState } from './extension-state';
 
 export interface ExtensionSelector {
     getExtensions(): Extension[] | undefined;
-    getExtensionByRegion(region: ExtensionRegions): Extension | undefined;
+    getExtensionByRegion(region: ExtensionRegion): Extension | undefined;
     getLoadError(): Error | undefined;
     isLoading(): boolean;
 }
@@ -22,7 +22,7 @@ export function createExtensionSelectorFactory(): ExtensionSelectorFactory {
 
     const getExtensionByRegion = createSelector(
         (state: ExtensionState) => state.data,
-        (data) => (region: ExtensionRegions) => data?.filter((e) => e.region === region)[0],
+        (data) => (region: ExtensionRegion) => data?.filter((e) => e.region === region)[0],
     );
 
     const getLoadError = createSelector(

--- a/packages/core/src/extension/extension-selector.ts
+++ b/packages/core/src/extension/extension-selector.ts
@@ -22,7 +22,7 @@ export function createExtensionSelectorFactory(): ExtensionSelectorFactory {
 
     const getExtensionByRegion = createSelector(
         (state: ExtensionState) => state.data,
-        (data) => (region: ExtensionRegion) => data?.filter((e) => e.region === region)[0],
+        (data) => (region: ExtensionRegion) => data?.find((e) => e.region === region),
     );
 
     const getLoadError = createSelector(

--- a/packages/core/src/extension/extension.mock.ts
+++ b/packages/core/src/extension/extension.mock.ts
@@ -1,4 +1,4 @@
-import { Extension, ExtensionRegions } from './extension';
+import { Extension, ExtensionRegion } from './extension';
 import { ExtensionState } from './extension-state';
 
 export function getExtensions(): Extension[] {
@@ -6,13 +6,13 @@ export function getExtensions(): Extension[] {
         {
             id: '123',
             name: 'Foo',
-            region: ExtensionRegions.ShippingShippingAddressFormBefore,
+            region: ExtensionRegion.ShippingShippingAddressFormBefore,
             url: 'https://widget.foo.com/',
         },
         {
             id: '456',
             name: 'Bar',
-            region: ExtensionRegions.ShippingShippingAddressFormAfter,
+            region: ExtensionRegion.ShippingShippingAddressFormAfter,
             url: 'https://widget.bar.com/',
         },
     ];

--- a/packages/core/src/extension/extension.ts
+++ b/packages/core/src/extension/extension.ts
@@ -1,11 +1,11 @@
 export interface Extension {
     id: string;
     name: string;
-    region: ExtensionRegions;
+    region: ExtensionRegion;
     url: string;
 }
 
-export enum ExtensionRegions {
+export enum ExtensionRegion {
     ShippingShippingAddressFormBefore = 'shipping.shippingAddressForm.before',
     ShippingShippingAddressFormAfter = 'shipping.shippingAddressForm.after',
 }

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -1,4 +1,4 @@
-export { Extension } from './extension';
+export { Extension, ExtensionRegions } from './extension';
 export { ExtensionActionCreator } from './extension-action-creator';
 export { extensionReducer } from './extension-reducer';
 export { ExtensionRequestSender } from './extension-request-sender';
@@ -9,3 +9,4 @@ export {
 } from './extension-selector';
 export { ExtensionState } from './extension-state';
 export { getExtensions } from './extension.mock';
+export { ExtensionIframe } from './extension-iframe';

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -1,4 +1,4 @@
-export { Extension, ExtensionRegions } from './extension';
+export { Extension, ExtensionRegion } from './extension';
 export { ExtensionActionCreator } from './extension-action-creator';
 export { extensionReducer } from './extension-reducer';
 export { ExtensionRequestSender } from './extension-request-sender';


### PR DESCRIPTION
## What?
- Retrieve all extension configs from the checkout state.
- Render an extension’s iframe based its config.

## Why?
Efficiently utilize extensions.

## Testing / Proof
- CI checks.

@bigcommerce/checkout @bigcommerce/team-payments
