### PR TITLE
fix(payment): PAYPAL-2684 bump braintree version in core

### DIFF
--- a/packages/braintree-integration/src/braintree.mock.ts
+++ b/packages/braintree-integration/src/braintree.mock.ts
@@ -29,7 +29,7 @@ export function getDataCollectorMock(): BraintreeDataCollector {
 
 export function getBraintreeLocalPaymentMock(): BraintreeLocalPayment {
     return {
-        VERSION: '3.81.0',
+        VERSION: '3.94.0',
         create: jest.fn(),
     };
 }

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
@@ -23,7 +23,7 @@ import {
     getVisaCheckoutMock,
 } from './braintree.mock';
 
-const version = '3.81.0';
+const version = '3.94.0';
 
 describe('BraintreeScriptLoader', () => {
     let braintreeScriptLoader: BraintreeScriptLoader;

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -15,7 +15,7 @@ import {
     BraintreeVisaCheckoutCreator,
 } from './braintree';
 
-const version = '3.81.0';
+const version = '3.94.0';
 
 export default class BraintreeScriptLoader {
     constructor(


### PR DESCRIPTION
## What?
Bumped Braintree version in core part

## Why?
To make it same as in integrations and avoid version conflicts

## Testing / Proof


@bigcommerce/checkout @bigcommerce/team-payments
