### PR TITLE
Revert "feat(payment): PAYPAL-2502 bump Braintree sdk version"

### DIFF
--- a/packages/braintree-integration/src/braintree-script-loader.spec.ts
+++ b/packages/braintree-integration/src/braintree-script-loader.spec.ts
@@ -19,7 +19,7 @@ import {
     getPaypalCheckoutMock,
 } from './braintree.mock';
 
-const VERSION = '3.94.0';
+const VERSION = '3.81.0';
 
 describe('BraintreeScriptLoader', () => {
     let scriptLoader: ScriptLoader;

--- a/packages/braintree-integration/src/braintree-script-loader.ts
+++ b/packages/braintree-integration/src/braintree-script-loader.ts
@@ -10,7 +10,7 @@ import {
     BraintreePaypalCheckoutCreator,
 } from './braintree';
 
-const VERSION = '3.94.0';
+const VERSION = '3.81.0';
 
 export default class BraintreeScriptLoader {
     constructor(


### PR DESCRIPTION
Reverts bigcommerce/checkout-sdk-js#2017

Due to the issues with braintree credit cards on checkout page.