### PR TITLE
chore(common): CHECKOUT-000 Update team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
-* @bigcommerce/checkout
+* @bigcommerce/team-checkout
 /packages/adyen-integration @bigcommerce/kyiv-payments-team
-/packages/apple-pay @bigcommerce/checkout
+/packages/apple-pay @bigcommerce/team-checkout
 /packages/bolt-integration @bigcommerce/kyiv-payments-team
 /packages/braintree-integration @bigcommerce/kyiv-payments-team
-/packages/core @bigcommerce/checkout
-/packages/payment-integration @bigcommerce/checkout
-/packages/payment-integration-test-utils @bigcommerce/checkout
+/packages/core @bigcommerce/team-checkout
+/packages/payment-integration @bigcommerce/team-checkout
+/packages/payment-integration-test-utils @bigcommerce/team-checkout
 /packages/paypal-commerce-integration @bigcommerce/kyiv-payments-team
 /packages/squarev2-integration @bigcommerce/apex-leads
 /packages/paypal-express-integration @bigcommerce/kyiv-payments-team

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 ## Testing / Proof
 ...
 
-@bigcommerce/checkout @bigcommerce/team-payments
+@bigcommerce/team-checkout @bigcommerce/team-payments


### PR DESCRIPTION
## What?
Update checkout team github name in codeowners.

## Why?
Conform to new standards for team names.

## Testing / Proof
N/A

@bigcommerce/team-checkout 