### PR TITLE
fix(payments): PAYPAL-2634 fixed issue when teardown is called twice

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -233,6 +233,14 @@ export default class BraintreeSDKCreator {
     }
 
     private _teardown(module?: Promise<BraintreeModule>) {
-        return module ? module.then((mod) => mod.teardown()) : Promise.resolve();
+        return module
+            ? module
+                  .then((mod) => mod.teardown())
+                  .catch((error) => {
+                      if (error.code !== 'METHOD_CALLED_AFTER_TEARDOWN') {
+                          throw error;
+                      }
+                  })
+            : Promise.resolve();
     }
 }


### PR DESCRIPTION
## What?
Fixed issue when `teardown` is called twice

## Why?
To fix showing popup with unnecessary message for customer
Part of rolled back PR [https://github.com/bigcommerce/checkout-sdk-js/pull/2025](https://github.com/bigcommerce/checkout-sdk-js/pull/2025)

## Testing / Proof
Manually tested

@bigcommerce/team-checkout @bigcommerce/team-payments
