### PR TITLE
feat(payment): INT-7698 GooglePay: Add button strategy

### DIFF
--- a/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayAuthorizeNetButtonStrategy from './create-google-pay-authorizenet-button-strategy';
+
+describe('createGooglePayAuthorizeNetButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay authorizenet button strategy', () => {
+        const strategy = createGooglePayAuthorizeNetButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-authorizenet-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayAuthorizeNetGateway from '../../gateways/google-pay-authorizenet-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayAuthorizeNetButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayAuthorizeNetGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayAuthorizeNetButtonStrategy, [
+    { id: 'googlepayauthorizenet' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayCheckoutComButtonStrategy from './create-google-pay-checkoutcom-button-strategy';
+
+describe('createGooglePayCheckoutComButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay checkoutcom button strategy', () => {
+        const strategy = createGooglePayCheckoutComButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-checkoutcom-button-strategy.ts
@@ -1,0 +1,32 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCheckoutComGateway from '../../gateways/google-pay-checkoutcom-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayCheckoutComButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) => {
+    const requestSender = createRequestSender();
+
+    return new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayCheckoutComGateway(paymentIntegrationService, requestSender),
+            requestSender,
+            createFormPoster(),
+        ),
+    );
+};
+
+export default toResolvableModule(createGooglePayCheckoutComButtonStrategy, [
+    { id: 'googlepaycheckoutcom' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayCybersourceButtonStrategy from './create-google-pay-cybersource-button-strategy';
+
+describe('createGooglePayCybersourceButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay cybersource button strategy', () => {
+        const strategy = createGooglePayCybersourceButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-cybersource-button-strategy.ts
@@ -1,0 +1,30 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayCybersourceGateway from '../../gateways/google-pay-cybersource-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayCybersourceButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayCybersourceGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayCybersourceButtonStrategy, [
+    { id: 'googlepaycybersourcev2' },
+    { id: 'googlepaybnz' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayOrbitalButtonStrategy from './create-google-pay-orbital-button-strategy';
+
+describe('createGooglePayOrbitalButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay orbital button strategy', () => {
+        const strategy = createGooglePayOrbitalButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-orbital-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayOrbitalGateway from '../../gateways/google-pay-orbital-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayOrbitalButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayOrbitalGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayOrbitalButtonStrategy, [
+    { id: 'googlepayorbital' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayStripeButtonStrategy from './create-google-pay-stripe-button-strategy';
+
+describe('createGooglePayStripeButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay stripe button strategy', () => {
+        const strategy = createGooglePayStripeButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-stripe-button-strategy.ts
@@ -1,0 +1,30 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayStripeGateway from '../../gateways/google-pay-stripe-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayStripeButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayStripeGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayStripeButtonStrategy, [
+    { id: 'googlepaystripe' },
+    { id: 'googlepaystripeupe' },
+]);

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+
+import createGooglePayWorldpayAccessButtonStrategy from './create-google-pay-worldpayaccess-button-strategy';
+
+describe('createGooglePayWorldpayAccessButtonStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay worldpayaccess button strategy', () => {
+        const strategy = createGooglePayWorldpayAccessButtonStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayButtonStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.ts
+++ b/packages/google-pay-integration/src/factories/button/create-google-pay-worldpayaccess-button-strategy.ts
@@ -1,0 +1,29 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+
+import {
+    CheckoutButtonStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayWorldpayAccessGateway from '../../gateways/google-pay-worldpayaccess-gateway';
+import GooglePayButtonStrategy from '../../google-pay-button-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayWorldpayAccessButtonStrategy: CheckoutButtonStrategyFactory<
+    GooglePayButtonStrategy
+> = (paymentIntegrationService) =>
+    new GooglePayButtonStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayWorldpayAccessGateway(paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        ),
+    );
+
+export default toResolvableModule(createGooglePayWorldpayAccessButtonStrategy, [
+    { id: 'googlepayworldpayaccess' },
+]);

--- a/packages/google-pay-integration/src/google-pay-button-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-button-initialize-options.ts
@@ -1,0 +1,34 @@
+import { GooglePayKey } from './google-pay-payment-initialize-options';
+import { GooglePayButtonColor, GooglePayButtonType } from './types';
+
+export default interface GooglePayButtonInitializeOptions {
+    /**
+     * All Google Pay payment buttons exist in two styles: dark (default) and light.
+     * To provide contrast, use dark buttons on light backgrounds and light buttons on dark or colorful backgrounds.
+     */
+    buttonColor?: GooglePayButtonColor;
+
+    /**
+     * Variant buttons:
+     * book: The "Book with Google Pay" payment button.
+     * buy: The "Buy with Google Pay" payment button.
+     * checkout: The "Checkout with Google Pay" payment button.
+     * donate: The "Donate with Google Pay" payment button.
+     * order: The "Order with Google Pay" payment button.
+     * pay: The "Pay with Google Pay" payment button.
+     * plain: The Google Pay payment button without the additional text (default).
+     * subscribe: The "Subscribe with Google Pay" payment button.
+     *
+     * Note: "long" and "short" button types have been renamed to "buy" and "plain", but are still valid button types
+     * for backwards compatability.
+     */
+    buttonType?: GooglePayButtonType;
+}
+
+/**
+ * The options that are required to initialize the GooglePay payment method.
+ * They can be omitted unless you need to support GooglePay.
+ */
+export type WithGooglePayButtonInitializeOptions = {
+    [k in GooglePayKey]?: GooglePayButtonInitializeOptions;
+};

--- a/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.spec.ts
@@ -1,0 +1,130 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    CheckoutButtonInitializeOptions,
+    InvalidArgumentError,
+    PaymentIntegrationService,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayGateway from './gateways/google-pay-gateway';
+import { WithGooglePayButtonInitializeOptions } from './google-pay-button-initialize-options';
+import GooglePayButtonStrategy from './google-pay-button-strategy';
+import GooglePayPaymentProcessor from './google-pay-payment-processor';
+import GooglePayScriptLoader from './google-pay-script-loader';
+import { getGeneric } from './mocks/google-pay-payment-method.mock';
+import { GooglePayInitializationData } from './types';
+
+describe('GooglePayButtonStrategy', () => {
+    const CONTAINER_ID = 'my_awesome_google_pay_button_container';
+
+    let paymentIntegrationService: PaymentIntegrationService;
+    let button: HTMLButtonElement;
+    let processor: GooglePayPaymentProcessor;
+    let strategy: GooglePayButtonStrategy;
+    let options: CheckoutButtonInitializeOptions & WithGooglePayButtonInitializeOptions;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            getGeneric(),
+        );
+
+        button = document.createElement('button');
+        jest.spyOn(button, 'remove');
+
+        processor = new GooglePayPaymentProcessor(
+            new GooglePayScriptLoader(createScriptLoader()),
+            new GooglePayGateway('example', paymentIntegrationService),
+            createRequestSender(),
+            createFormPoster(),
+        );
+        jest.spyOn(processor, 'initialize').mockResolvedValue(undefined);
+        jest.spyOn(processor, 'addPaymentButton').mockReturnValue(button);
+
+        strategy = new GooglePayButtonStrategy(paymentIntegrationService, processor);
+
+        options = {
+            methodId: 'googlepayworldpayaccess',
+            containerId: CONTAINER_ID,
+        };
+    });
+
+    describe('#initialize', () => {
+        it('should initialize the strategy', async () => {
+            const initialize = strategy.initialize(options);
+
+            await expect(initialize).resolves.toBeUndefined();
+        });
+
+        it('should call loadDefaultCheckout', async () => {
+            await strategy.initialize(options);
+
+            expect(paymentIntegrationService.loadDefaultCheckout).toHaveBeenCalled();
+        });
+
+        it('should initialize processor', async () => {
+            const getPaymentMethod = () =>
+                (
+                    (processor.initialize as jest.Mock).mock
+                        .calls[0][0] as () => PaymentMethod<GooglePayInitializationData>
+                )();
+            const paymentMethod = getGeneric();
+
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue(paymentMethod);
+
+            await strategy.initialize(options);
+
+            expect(getPaymentMethod()).toBe(paymentMethod);
+        });
+
+        it('should add payment button', async () => {
+            await strategy.initialize(options);
+
+            expect(processor.addPaymentButton).toHaveBeenCalledWith(CONTAINER_ID, {
+                buttonColor: 'default',
+                buttonType: 'plain',
+                onClick: expect.any(Function),
+            });
+        });
+
+        it('should add payment button once', async () => {
+            await strategy.initialize(options);
+            await strategy.initialize(options);
+
+            expect(processor.addPaymentButton).toHaveBeenCalledTimes(1);
+        });
+
+        describe('should fail if:', () => {
+            test('methodId is not a google pay key', async () => {
+                options.methodId = 'foo';
+
+                const initialize = strategy.initialize(options);
+
+                await expect(initialize).rejects.toThrow(InvalidArgumentError);
+            });
+        });
+    });
+
+    describe('#deinitialize', () => {
+        it('should deinitialize the strategy', async () => {
+            const deinitialize = strategy.deinitialize();
+
+            await expect(deinitialize).resolves.toBeUndefined();
+        });
+
+        it('should remove payment button', async () => {
+            await strategy.initialize(options);
+            await strategy.deinitialize();
+
+            expect(button.remove).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/google-pay-integration/src/google-pay-button-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-button-strategy.ts
@@ -1,0 +1,132 @@
+import {
+    CheckoutButtonInitializeOptions,
+    CheckoutButtonStrategy,
+    guard,
+    InvalidArgumentError,
+    NotInitializedError,
+    NotInitializedErrorType,
+    PaymentIntegrationService,
+    PaymentMethodCancelledError,
+    PaymentMethodFailedError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { WithGooglePayButtonInitializeOptions } from './google-pay-button-initialize-options';
+import GooglePayPaymentProcessor from './google-pay-payment-processor';
+import isGooglePayErrorObject from './guards/is-google-pay-error-object';
+import isGooglePayKey from './guards/is-google-pay-key';
+import { GooglePayButtonOptions, GooglePayInitializationData } from './types';
+
+export default class GooglePayButtonStrategy implements CheckoutButtonStrategy {
+    private _paymentButton?: HTMLElement;
+    private _methodId?: keyof WithGooglePayButtonInitializeOptions;
+
+    constructor(
+        private _paymentIntegrationService: PaymentIntegrationService,
+        private _googlePayPaymentProcessor: GooglePayPaymentProcessor,
+    ) {}
+
+    async initialize({
+        methodId,
+        containerId,
+        ...rest
+    }: CheckoutButtonInitializeOptions & WithGooglePayButtonInitializeOptions): Promise<void> {
+        if (!isGooglePayKey(methodId)) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "methodId" is not a valid key.',
+            );
+        }
+
+        this._methodId = methodId;
+
+        const googlePayOptions = rest[this._getMethodId()];
+
+        await this._paymentIntegrationService.loadDefaultCheckout();
+        await this._googlePayPaymentProcessor.initialize(() =>
+            this._paymentIntegrationService
+                .getState()
+                .getPaymentMethodOrThrow<GooglePayInitializationData>(this._getMethodId()),
+        );
+
+        this._addPaymentButton(containerId, googlePayOptions);
+    }
+
+    deinitialize(): Promise<void> {
+        this._paymentButton?.remove();
+        this._paymentButton = undefined;
+        this._methodId = undefined;
+
+        return Promise.resolve();
+    }
+
+    private _addPaymentButton(
+        walletButton: string,
+        {
+            buttonColor,
+            buttonType,
+        }: Pick<GooglePayButtonOptions, 'buttonColor' | 'buttonType'> = {},
+    ): void {
+        this._paymentButton =
+            this._paymentButton ??
+            this._googlePayPaymentProcessor.addPaymentButton(walletButton, {
+                buttonColor: buttonColor ?? 'default',
+                buttonType: buttonType ?? 'plain',
+                onClick: this._handleClick(),
+            });
+    }
+
+    private _handleClick(): (event: MouseEvent) => unknown {
+        return async (event: MouseEvent) => {
+            event.preventDefault();
+
+            // TODO: Dispatch Widget Actions
+            try {
+                await this._interactWithPaymentSheet();
+            } catch (error) {
+                if (isGooglePayErrorObject(error)) {
+                    if (error.statusCode === 'CANCELED') {
+                        throw new PaymentMethodCancelledError();
+                    }
+
+                    throw new PaymentMethodFailedError(JSON.stringify(error));
+                }
+
+                throw error;
+            }
+        };
+    }
+
+    private async _interactWithPaymentSheet(): Promise<void> {
+        await this._paymentIntegrationService.loadCheckout();
+
+        const response = await this._googlePayPaymentProcessor.showPaymentSheet();
+        const billingAddress =
+            this._googlePayPaymentProcessor.mapToBillingAddressRequestBody(response);
+        const shippingAddress =
+            this._googlePayPaymentProcessor.mapToShippingAddressRequestBody(response);
+        const siteLink =
+            window.location.pathname === '/embedded-checkout'
+                ? this._paymentIntegrationService.getState().getStoreConfigOrThrow().links.siteLink
+                : undefined;
+
+        if (billingAddress) {
+            await this._paymentIntegrationService.updateBillingAddress(billingAddress);
+        }
+
+        if (shippingAddress) {
+            await this._paymentIntegrationService.updateShippingAddress(shippingAddress);
+        }
+
+        await this._googlePayPaymentProcessor.setExternalCheckoutForm(
+            this._getMethodId(),
+            response,
+            siteLink,
+        );
+    }
+
+    private _getMethodId(): keyof WithGooglePayButtonInitializeOptions {
+        return guard(
+            this._methodId,
+            () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized),
+        );
+    }
+}

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -1,5 +1,6 @@
 export { WithGooglePayPaymentInitializeOptions } from './google-pay-payment-initialize-options';
 export { WithGooglePayCustomerInitializeOptions } from './google-pay-customer-initialize-options';
+export { WithGooglePayButtonInitializeOptions } from './google-pay-button-initialize-options';
 
 export { default as createGooglePayAuthorizeNetPaymentStrategy } from './factories/payment/create-google-pay-authorizenet-payment-strategy';
 export { default as createGooglePayCheckoutComPaymentStrategy } from './factories/payment/create-google-pay-checkoutcom-payment-strategy';
@@ -16,3 +17,10 @@ export { default as createGooglePayOrbitalCustomerStrategy } from './factories/c
 export { default as createGooglePayStripeCustomerStrategy } from './factories/customer/create-google-pay-stripe-customer-strategy';
 export { default as createGooglePayStripeUpeCustomerStrategy } from './factories/customer/create-google-pay-stripeupe-customer-strategy';
 export { default as createGooglePayWorldpayAccessCustomerStrategy } from './factories/customer/create-google-pay-worldpayaccess-customer-strategy';
+
+export { default as createGooglePayAuthorizeDotNetButtonStrategy } from './factories/button/create-google-pay-authorizenet-button-strategy';
+export { default as createGooglePayCheckoutComButtonStrategy } from './factories/button/create-google-pay-checkoutcom-button-strategy';
+export { default as createGooglePayCybersourceButtonStrategy } from './factories/button/create-google-pay-cybersource-button-strategy';
+export { default as createGooglePayOrbitalButtonStrategy } from './factories/button/create-google-pay-orbital-button-strategy';
+export { default as createGooglePayStripeButtonStrategy } from './factories/button/create-google-pay-stripe-button-strategy';
+export { default as createGooglePayWorldpayAccessButtonStrategy } from './factories/button/create-google-pay-worldpayaccess-button-strategy';


### PR DESCRIPTION
## What? [INT-7698](https://bigcommercecloud.atlassian.net/browse/INT-7698)

1. Add Google Pay button strategy for Worldpay Access
2. Refactor existing logic for:
    - Authorize Net
    - Checkout Com
    - Cybersource / BNZ
    - Orbital
    - Stripe v3 / Stripe UPE

## Why?
To checkout using Google Pay through Worldpay Access

## Testing / Proof
WOI

## Depends on
#1967 and #1994

@bigcommerce/checkout @bigcommerce/payments @bigcommerce/apex-integrations 

[INT-7698]: https://bigcommercecloud.atlassian.net/browse/INT-7698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ