### PR TITLE
Revert "fix(order): DATA-11056 Populate category names for BODL purchase event"

### DIFF
--- a/packages/core/src/bodl/bodl-emitter-service.ts
+++ b/packages/core/src/bodl/bodl-emitter-service.ts
@@ -1,4 +1,4 @@
-import { LineItem, LineItemMap } from '../cart';
+import { LineItemMap } from '../cart';
 import { CheckoutSelectors, CheckoutStoreSelector } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 
@@ -241,18 +241,6 @@ export default class BodlEmitterService implements BodlService {
             ...lineItems.physicalItems,
             ...lineItems.digitalItems,
         ].map((item) => {
-            const getCategoryNames = (lineItem: LineItem): string[] => {
-                if (Array.isArray(lineItem.categoryNames)) {
-                    return lineItem.categoryNames;
-                } else if (Array.isArray(lineItem.categories)) {
-                    return Array.prototype.concat
-                        .apply([], lineItem.categories)
-                        .map(({ name }) => name);
-                }
-
-                return [];
-            };
-
             let itemAttributes;
 
             if (item.options && item.options.length) {
@@ -272,7 +260,7 @@ export default class BodlEmitterService implements BodlService {
                 discount: item.discountAmount,
                 brand_name: item.brand,
                 currency: currencyCode,
-                category_names: getCategoryNames(item),
+                category_names: item.categoryNames || [],
                 retail_price: item.retailPrice,
             };
         });

--- a/packages/core/src/bodl/bodl-events-service.spec.ts
+++ b/packages/core/src/bodl/bodl-events-service.spec.ts
@@ -155,10 +155,7 @@ describe('BodlEmitterService', () => {
 
     describe('#orderPurchased()', () => {
         beforeEach(() => {
-            const orderMock = getOrder();
-            delete orderMock.lineItems.physicalItems[0].categoryNames;
-
-            jest.spyOn(checkoutService.getState().data, 'getOrder').mockReturnValue(orderMock);
+            jest.spyOn(checkoutService.getState().data, 'getOrder').mockReturnValue(getOrder());
 
             bodlEmitterService.orderPurchased();
         });
@@ -242,7 +239,7 @@ describe('BodlEmitterService', () => {
                             quantity: 1,
                             brand_name: 'OFS',
                             discount: 10,
-                            category_names: ['Cat 1', 'Furniture', 'Bed'],
+                            category_names: ['Cat 1'],
                             variant_id: 71,
                             currency: 'USD',
                         },

--- a/packages/core/src/order/index.ts
+++ b/packages/core/src/order/index.ts
@@ -10,6 +10,7 @@ export {
 export { default as InternalOrderRequestBody } from './internal-order-request-body';
 
 export { default as OrderActionCreator } from './order-action-creator';
+export { default as OrderParams, OrderIncludes } from './order-params';
 export { default as orderReducer } from './order-reducer';
 export {
     default as OrderRequestBody,

--- a/packages/core/src/order/order-params.ts
+++ b/packages/core/src/order/order-params.ts
@@ -1,0 +1,8 @@
+export enum OrderIncludes {
+    DigitalItemsCategories = 'lineItems.digitalItems.categories',
+    PhysicalItemsCategories = 'lineItems.physicalItems.categories',
+}
+
+export default interface OrderParams {
+    include?: OrderIncludes[];
+}

--- a/packages/core/src/order/order-request-sender.spec.ts
+++ b/packages/core/src/order/order-request-sender.spec.ts
@@ -8,6 +8,7 @@ import { OrderTaxProviderUnavailableError } from './errors';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import { getCompleteOrderResponseBody } from './internal-orders.mock';
 import Order from './order';
+import { OrderIncludes } from './order-params';
 import OrderRequestSender from './order-request-sender';
 import { getOrder } from './orders.mock';
 
@@ -17,10 +18,8 @@ describe('OrderRequestSender', () => {
         'payments',
         'lineItems.physicalItems.socialMedia',
         'lineItems.physicalItems.options',
-        'lineItems.physicalItems.categories',
         'lineItems.digitalItems.socialMedia',
         'lineItems.digitalItems.options',
-        'lineItems.digitalItems.categories',
     ].join(',');
 
     const requestSender = createRequestSender();
@@ -75,6 +74,33 @@ describe('OrderRequestSender', () => {
                     ...SDK_VERSION_HEADERS,
                 },
                 params: { include },
+                timeout: undefined,
+            });
+        });
+
+        it('loads order including item categories', async () => {
+            const categoryIncludes = [
+                OrderIncludes.PhysicalItemsCategories,
+                OrderIncludes.DigitalItemsCategories,
+            ].join(',');
+
+            await orderRequestSender.loadOrder(295, {
+                params: {
+                    include: [
+                        OrderIncludes.PhysicalItemsCategories,
+                        OrderIncludes.DigitalItemsCategories,
+                    ],
+                },
+            });
+
+            const expectedInclude = `${include},${categoryIncludes}`;
+
+            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
+                headers: {
+                    Accept: ContentType.JsonV1,
+                    ...SDK_VERSION_HEADERS,
+                },
+                params: { include: expectedInclude },
                 timeout: undefined,
             });
         });

--- a/packages/core/src/order/order-request-sender.ts
+++ b/packages/core/src/order/order-request-sender.ts
@@ -13,6 +13,7 @@ import { OrderTaxProviderUnavailableError } from './errors';
 import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import Order from './order';
+import OrderParams from './order-params';
 
 export interface SubmitOrderRequestOptions extends RequestOptions {
     headers?: {
@@ -23,7 +24,10 @@ export interface SubmitOrderRequestOptions extends RequestOptions {
 export default class OrderRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
-    loadOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response<Order>> {
+    loadOrder(
+        orderId: number,
+        { timeout, params }: RequestOptions<OrderParams> = {},
+    ): Promise<Response<Order>> {
         const url = `/api/storefront/orders/${orderId}`;
         const headers = {
             Accept: ContentType.JsonV1,
@@ -33,15 +37,13 @@ export default class OrderRequestSender {
             'payments',
             'lineItems.physicalItems.socialMedia',
             'lineItems.physicalItems.options',
-            'lineItems.physicalItems.categories',
             'lineItems.digitalItems.socialMedia',
             'lineItems.digitalItems.options',
-            'lineItems.digitalItems.categories',
         ];
 
         return this._requestSender.get(url, {
             params: {
-                include: joinIncludes(include),
+                include: joinIncludes([...include, ...((params && params.include) || [])]),
             },
             headers,
             timeout,

--- a/packages/core/src/payment/strategies/affirm/affirm-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/affirm/affirm-payment-strategy.ts
@@ -9,7 +9,7 @@ import {
     NotInitializedErrorType,
 } from '../../../common/error/errors';
 import { AmountTransformer } from '../../../common/utility';
-import { Order, OrderActionCreator, OrderRequestBody } from '../../../order';
+import { Order, OrderActionCreator, OrderIncludes, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { Consignment } from '../../../shipping';
 import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
@@ -80,8 +80,18 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             throw new PaymentArgumentInvalidError(['payment.methodId']);
         }
 
+        const requestOptions = {
+            ...options,
+            params: {
+                include: [
+                    OrderIncludes.PhysicalItemsCategories,
+                    OrderIncludes.DigitalItemsCategories,
+                ],
+            },
+        };
+
         return this._store
-            .dispatch(this._orderActionCreator.submitOrder({ useStoreCredit }, options))
+            .dispatch(this._orderActionCreator.submitOrder({ useStoreCredit }, requestOptions))
             .then<AffirmSuccessResponse>(() => {
                 _affirm.checkout(this._getCheckoutInformation());
 


### PR DESCRIPTION
Reverts bigcommerce/checkout-sdk-js#2032

## Why
There are some e2e tests in checkout-js failing with this version of sdk. We are going to investigate this with @bc-peng as per discussion with @animesh1987. For now reverting