### PR TITLE
feat(checkout): PI-286 bluesnapdirect 3ds for stored cards without hosted fields

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-3ds.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-3ds.spec.ts
@@ -1,0 +1,74 @@
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentMethodInvalidError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BlueSnapDirect3ds from './bluesnap-direct-3ds';
+import BlueSnapDirectScriptLoader from './bluesnap-direct-script-loader';
+import getBlueSnapDirectSdkMock, {
+    previouslyUsedCardDataMock,
+    threeDSdata,
+} from './mocks/bluesnap-direct-sdk.mock';
+import { BlueSnapDirectSdk } from './types';
+
+describe('BlueSnapDirectHostedForm', () => {
+    let sdkMocks: ReturnType<typeof getBlueSnapDirectSdkMock>;
+    let blueSnapDirectSdkMock: BlueSnapDirectSdk;
+    let scriptLoader: BlueSnapDirectScriptLoader;
+    let threeDSChallange: BlueSnapDirect3ds;
+
+    beforeEach(() => {
+        sdkMocks = getBlueSnapDirectSdkMock();
+        blueSnapDirectSdkMock = sdkMocks.sdk;
+        scriptLoader = new BlueSnapDirectScriptLoader(createScriptLoader());
+        jest.spyOn(scriptLoader, 'load').mockResolvedValue(blueSnapDirectSdkMock);
+
+        threeDSChallange = new BlueSnapDirect3ds(scriptLoader);
+    });
+
+    describe('#initialize', () => {
+        it('should initialize bluesnap library for 3ds challange successfully', async () => {
+            await threeDSChallange.initialize(false);
+
+            expect(scriptLoader.load).toHaveBeenCalledWith(false);
+        });
+    });
+
+    describe('#initialize3ds', () => {
+        it('should create hosted payment fields with 3DS enabled', async () => {
+            await threeDSChallange.initialize(false);
+            await threeDSChallange.initialize3ds('pfToken', previouslyUsedCardDataMock);
+
+            expect(blueSnapDirectSdkMock.threeDsPaymentsSetup).toHaveBeenCalledWith(
+                'pfToken',
+                expect.anything(),
+            );
+            expect(blueSnapDirectSdkMock.threeDsPaymentsSubmitData).toHaveBeenCalledWith(
+                previouslyUsedCardDataMock,
+            );
+        });
+
+        it('should resolves with threeDSecureReferenceId value', async () => {
+            await threeDSChallange.initialize(false);
+
+            const result = await threeDSChallange.initialize3ds(
+                'pfToken',
+                previouslyUsedCardDataMock,
+            );
+
+            expect(result).toBe(threeDSdata.threeDSecure.threeDSecureReferenceId);
+        });
+
+        it('should throw an error if response code different from "1"', async () => {
+            sdkMocks = getBlueSnapDirectSdkMock('0');
+            blueSnapDirectSdkMock = sdkMocks.sdk;
+            jest.spyOn(scriptLoader, 'load').mockResolvedValue(blueSnapDirectSdkMock);
+
+            threeDSChallange = new BlueSnapDirect3ds(scriptLoader);
+            await threeDSChallange.initialize(false);
+
+            await expect(
+                threeDSChallange.initialize3ds('pfToken', previouslyUsedCardDataMock),
+            ).rejects.toThrow(PaymentMethodInvalidError);
+        });
+    });
+});

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-3ds.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-3ds.ts
@@ -1,0 +1,47 @@
+import {
+    guard,
+    NotInitializedError,
+    NotInitializedErrorType,
+    PaymentMethodInvalidError,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BlueSnapDirectScriptLoader from './bluesnap-direct-script-loader';
+import { BlueSnapDirectPreviouslyUsedCard, BlueSnapDirectSdk } from './types';
+
+export default class BlueSnapDirect3ds {
+    private _blueSnapSdk?: BlueSnapDirectSdk;
+
+    constructor(private _scriptLoader: BlueSnapDirectScriptLoader) {}
+
+    async initialize(testMode = false): Promise<void> {
+        this._blueSnapSdk = await this._scriptLoader.load(testMode);
+    }
+
+    async initialize3ds(
+        token: string,
+        cardData: BlueSnapDirectPreviouslyUsedCard,
+    ): Promise<string> {
+        const blueSnapSdk = this._getBlueSnapSdk();
+
+        return new Promise((resolve, reject) => {
+            blueSnapSdk.threeDsPaymentsSetup(token, (sdkResponse) => {
+                const code = sdkResponse.code;
+
+                if (code === '1') {
+                    return resolve(sdkResponse.threeDSecure.threeDSecureReferenceId);
+                }
+
+                return reject(new PaymentMethodInvalidError());
+            });
+
+            blueSnapSdk.threeDsPaymentsSubmitData(cardData);
+        });
+    }
+
+    private _getBlueSnapSdk(): BlueSnapDirectSdk {
+        return guard(
+            this._blueSnapSdk,
+            () => new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized),
+        );
+    }
+}

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-credit-card-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-credit-card-payment-strategy.ts
@@ -40,7 +40,7 @@ export default class BlueSnapDirectCreditCardPaymentStrategy implements PaymentS
         }
 
         const state = await this._paymentIntegrationService.loadPaymentMethod(gatewayId, {
-            params: { method: methodId },
+            params: { method: methodId, bigpayToken: creditCard.bigpayToken },
         });
 
         const {

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-credit-card-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-credit-card-payment-strategy.ts
@@ -5,6 +5,7 @@ import {
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import BlueSnapDirect3ds from './bluesnap-direct-3ds';
 import BlueSnapDirectCreditCardPaymentStrategy from './bluesnap-direct-credit-card-payment-strategy';
 import BlueSnapDirectHostedForm from './bluesnap-direct-hosted-form';
 import BlueSnapHostedInputValidator from './bluesnap-direct-hosted-input-validator';
@@ -21,6 +22,7 @@ const createBlueSnapDirectCreditCardPaymentStrategy: PaymentStrategyFactory<
             new BluesnapDirectNameOnCardInput(),
             new BlueSnapHostedInputValidator(),
         ),
+        new BlueSnapDirect3ds(new BlueSnapDirectScriptLoader(getScriptLoader())),
     );
 
 export default toResolvableModule(createBlueSnapDirectCreditCardPaymentStrategy, [

--- a/packages/bluesnap-direct-integration/src/mocks/bluesnap-direct-sdk.mock.ts
+++ b/packages/bluesnap-direct-integration/src/mocks/bluesnap-direct-sdk.mock.ts
@@ -1,4 +1,8 @@
-import { BlueSnapDirectCallbackResults, BlueSnapDirectHostedPaymentFieldsOptions } from '../types';
+import {
+    BlueSnapDirect3dsCallbackResponse,
+    BlueSnapDirectCallbackResults,
+    BlueSnapDirectHostedPaymentFieldsOptions,
+} from '../types';
 
 const data = {
     cardData: {
@@ -15,6 +19,31 @@ const data = {
     statusCode: '1',
     transactionFraudInfo: {
         fraudSessionId: 'qwerty123',
+    },
+};
+
+export const previouslyUsedCardDataMock = {
+    last4Digits: '1111',
+    ccType: 'visa',
+    amount: 10,
+    currency: 'USD',
+    billingFirstName: 'string',
+    billingLastName: 'string',
+    billingCountry: 'string',
+    billingState: 'string',
+    billingCity: 'string',
+    billingAddress: 'string',
+    billingZip: 'string',
+    email: 'string',
+    phone: '11111111111',
+};
+
+export const threeDSdata = {
+    code: '1',
+    cardData: data.cardData,
+    threeDSecure: {
+        authResult: 'string',
+        threeDSecureReferenceId: '1111',
     },
 };
 
@@ -61,6 +90,18 @@ export default function getBlueSnapDirectSdkMock(errorCode?: keyof typeof errors
                 (callback: (results: BlueSnapDirectCallbackResults) => void) =>
                     callback(errorCode ? errors[errorCode] : data),
             ),
+            threeDsPaymentsSetup: jest.fn(
+                (
+                    _token: string,
+                    callback: (results: BlueSnapDirect3dsCallbackResponse) => void,
+                ) => {
+                    return setTimeout(
+                        () => callback(errorCode ? { ...threeDSdata, code: '0' } : threeDSdata),
+                        0,
+                    );
+                },
+            ),
+            threeDsPaymentsSubmitData: jest.fn(),
         },
         callbackResults: errorCode ? errors[errorCode].error : data.cardData,
     };

--- a/packages/bluesnap-direct-integration/src/types.ts
+++ b/packages/bluesnap-direct-integration/src/types.ts
@@ -165,6 +165,43 @@ export interface BlueSnapDirectSdk {
         callback: (results: BlueSnapDirectCallbackResults) => void,
         threeDSecureData?: BlueSnapDirectThreeDSecureData,
     ): void;
+    threeDsPaymentsSetup(
+        token: string,
+        callback: (reponse: BlueSnapDirect3dsCallbackResponse) => void,
+    ): void;
+    threeDsPaymentsSubmitData(cardData: BlueSnapDirectPreviouslyUsedCard): void;
+}
+
+export interface BlueSnapDirectPreviouslyUsedCard {
+    last4Digits?: string;
+    ccType?: string;
+    amount: number;
+    currency: string;
+    billingFirstName?: string;
+    billingLastName?: string;
+    billingCountry?: string;
+    billingState?: string;
+    billingCity?: string;
+    billingAddress?: string;
+    billingZip?: string;
+    shippingFirstName?: string;
+    shippingLastName?: string;
+    shippingCountry?: string;
+    shippingState?: string;
+    shippingCity?: string;
+    shippingAddress?: string;
+    shippingZip?: string;
+    email?: string;
+    phone?: string;
+}
+
+export interface BlueSnapDirect3dsCallbackResponse {
+    code: string;
+    cardData: BlueSnapDirectCallbackCardData;
+    threeDSecure: {
+        authResult: string;
+        threeDSecureReferenceId: string;
+    };
 }
 
 export interface BlueSnapDirectHostWindow extends Window {

--- a/packages/credit-card-integration/src/credit-card-payment-initialize-options.ts
+++ b/packages/credit-card-integration/src/credit-card-payment-initialize-options.ts
@@ -79,6 +79,7 @@ import { HostedFormOptions } from '@bigcommerce/checkout-sdk/payment-integration
  */
 export interface CreditCardPaymentInitializeOptions {
     form: HostedFormOptions;
+    bigpayToken?: string;
 }
 
 export interface WithCreditCardPaymentInitializeOptions {

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -7,6 +7,7 @@ import getConfig from './config.mock';
 import getConsignment from './consignment.mock';
 import { getCustomer } from './customer.mock';
 import { getOrder } from './orders.mock';
+import { getCardInstrument } from './payments.mock';
 
 const subscribe = jest.fn();
 const state = {
@@ -14,6 +15,7 @@ const state = {
     getBillingAddressOrThrow: jest.fn(() => getBillingAddress()),
     getCart: jest.fn(() => getCart()),
     getCartOrThrow: jest.fn(() => getCart()),
+    getCardInstrumentOrThrow: jest.fn(() => getCardInstrument()),
     getCheckout: jest.fn(() => getCheckout()),
     getCheckoutOrThrow: jest.fn(() => getCheckout()),
     getConsignments: jest.fn(() => [getConsignment()]),

--- a/packages/payment-integrations-test-utils/src/test-utils/payments.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payments.mock.ts
@@ -1,4 +1,5 @@
 import {
+    CardInstrument,
     CreditCardInstrument,
     Payment,
     PaymentMethod,
@@ -36,6 +37,22 @@ export function getCreditCardInstrument(): CreditCardInstrument {
         ccName: 'BigCommerce',
         ccNumber: '4111111111111111',
         ccCvv: '123',
+    };
+}
+
+export function getCardInstrument(): CardInstrument {
+    return {
+        bigpayToken: '123',
+        defaultInstrument: true,
+        provider: 'bigcommerce',
+        trustedShippingAddress: true,
+        method: 'bigcommerce',
+        brand: 'visa',
+        expiryMonth: '04',
+        expiryYear: '30',
+        iin: '1234',
+        last4: '1111',
+        type: 'card',
     };
 }
 


### PR DESCRIPTION
## What?
Bluesnapdirect 3ds challenge for stored cards without hosted fields

## Why?
Because 3ds challenge doesn't appear for stored cards without bluesnap hosted fields. That's why we need to implement manual trigger of 3ds challenge for stored card without card number validation



## Testing / Proof
Tested manually/units
![image](https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/e2cff0e5-fd13-4fde-a2cb-6a824145f28c)


@bigcommerce/team-checkout @bigcommerce/team-payments
