### PR TITLE
fix(order): DATA-11056 Populate category names for BODL purchase event

### DIFF
--- a/packages/core/src/bodl/bodl-emitter-service.ts
+++ b/packages/core/src/bodl/bodl-emitter-service.ts
@@ -1,4 +1,4 @@
-import { LineItemMap } from '../cart';
+import { LineItem, LineItemMap } from '../cart';
 import { CheckoutSelectors, CheckoutStoreSelector } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 
@@ -241,6 +241,18 @@ export default class BodlEmitterService implements BodlService {
             ...lineItems.physicalItems,
             ...lineItems.digitalItems,
         ].map((item) => {
+            const getCategoryNames = (lineItem: LineItem): string[] => {
+                if (Array.isArray(lineItem.categoryNames)) {
+                    return lineItem.categoryNames;
+                } else if (Array.isArray(lineItem.categories)) {
+                    return Array.prototype.concat
+                        .apply([], lineItem.categories)
+                        .map(({ name }) => name);
+                }
+
+                return [];
+            };
+
             let itemAttributes;
 
             if (item.options && item.options.length) {
@@ -260,7 +272,7 @@ export default class BodlEmitterService implements BodlService {
                 discount: item.discountAmount,
                 brand_name: item.brand,
                 currency: currencyCode,
-                category_names: item.categoryNames || [],
+                category_names: getCategoryNames(item),
                 retail_price: item.retailPrice,
             };
         });

--- a/packages/core/src/bodl/bodl-emitter-service.ts
+++ b/packages/core/src/bodl/bodl-emitter-service.ts
@@ -1,6 +1,7 @@
 import { LineItem, LineItemMap } from '../cart';
 import { CheckoutSelectors, CheckoutStoreSelector } from '../checkout';
 import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { flatten } from 'lodash';
 
 import { AnalyticStepOrder, AnalyticStepType } from './analytics-steps';
 import BodlService from './bodl-service';
@@ -245,9 +246,7 @@ export default class BodlEmitterService implements BodlService {
                 if (Array.isArray(lineItem.categoryNames)) {
                     return lineItem.categoryNames;
                 } else if (Array.isArray(lineItem.categories)) {
-                    return Array.prototype.concat
-                        .apply([], lineItem.categories)
-                        .map(({ name }) => name);
+                    return flatten(lineItem.categories).map(({ name }) => name);
                 }
 
                 return [];

--- a/packages/core/src/bodl/bodl-events-service.spec.ts
+++ b/packages/core/src/bodl/bodl-events-service.spec.ts
@@ -155,7 +155,10 @@ describe('BodlEmitterService', () => {
 
     describe('#orderPurchased()', () => {
         beforeEach(() => {
-            jest.spyOn(checkoutService.getState().data, 'getOrder').mockReturnValue(getOrder());
+            const orderMock = getOrder();
+            delete orderMock.lineItems.physicalItems[0].categoryNames;
+
+            jest.spyOn(checkoutService.getState().data, 'getOrder').mockReturnValue(orderMock);
 
             bodlEmitterService.orderPurchased();
         });
@@ -239,7 +242,7 @@ describe('BodlEmitterService', () => {
                             quantity: 1,
                             brand_name: 'OFS',
                             discount: 10,
-                            category_names: ['Cat 1'],
+                            category_names: ['Cat 1', 'Furniture', 'Bed'],
                             variant_id: 71,
                             currency: 'USD',
                         },

--- a/packages/core/src/order/index.ts
+++ b/packages/core/src/order/index.ts
@@ -10,7 +10,6 @@ export {
 export { default as InternalOrderRequestBody } from './internal-order-request-body';
 
 export { default as OrderActionCreator } from './order-action-creator';
-export { default as OrderParams, OrderIncludes } from './order-params';
 export { default as orderReducer } from './order-reducer';
 export {
     default as OrderRequestBody,

--- a/packages/core/src/order/order-params.ts
+++ b/packages/core/src/order/order-params.ts
@@ -1,8 +1,0 @@
-export enum OrderIncludes {
-    DigitalItemsCategories = 'lineItems.digitalItems.categories',
-    PhysicalItemsCategories = 'lineItems.physicalItems.categories',
-}
-
-export default interface OrderParams {
-    include?: OrderIncludes[];
-}

--- a/packages/core/src/order/order-request-sender.spec.ts
+++ b/packages/core/src/order/order-request-sender.spec.ts
@@ -8,7 +8,6 @@ import { OrderTaxProviderUnavailableError } from './errors';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import { getCompleteOrderResponseBody } from './internal-orders.mock';
 import Order from './order';
-import { OrderIncludes } from './order-params';
 import OrderRequestSender from './order-request-sender';
 import { getOrder } from './orders.mock';
 
@@ -18,8 +17,10 @@ describe('OrderRequestSender', () => {
         'payments',
         'lineItems.physicalItems.socialMedia',
         'lineItems.physicalItems.options',
+        'lineItems.physicalItems.categories',
         'lineItems.digitalItems.socialMedia',
         'lineItems.digitalItems.options',
+        'lineItems.digitalItems.categories',
     ].join(',');
 
     const requestSender = createRequestSender();
@@ -74,33 +75,6 @@ describe('OrderRequestSender', () => {
                     ...SDK_VERSION_HEADERS,
                 },
                 params: { include },
-                timeout: undefined,
-            });
-        });
-
-        it('loads order including item categories', async () => {
-            const categoryIncludes = [
-                OrderIncludes.PhysicalItemsCategories,
-                OrderIncludes.DigitalItemsCategories,
-            ].join(',');
-
-            await orderRequestSender.loadOrder(295, {
-                params: {
-                    include: [
-                        OrderIncludes.PhysicalItemsCategories,
-                        OrderIncludes.DigitalItemsCategories,
-                    ],
-                },
-            });
-
-            const expectedInclude = `${include},${categoryIncludes}`;
-
-            expect(requestSender.get).toHaveBeenCalledWith('/api/storefront/orders/295', {
-                headers: {
-                    Accept: ContentType.JsonV1,
-                    ...SDK_VERSION_HEADERS,
-                },
-                params: { include: expectedInclude },
                 timeout: undefined,
             });
         });

--- a/packages/core/src/order/order-request-sender.ts
+++ b/packages/core/src/order/order-request-sender.ts
@@ -13,7 +13,6 @@ import { OrderTaxProviderUnavailableError } from './errors';
 import InternalOrderRequestBody from './internal-order-request-body';
 import { InternalOrderResponseBody } from './internal-order-responses';
 import Order from './order';
-import OrderParams from './order-params';
 
 export interface SubmitOrderRequestOptions extends RequestOptions {
     headers?: {
@@ -24,10 +23,7 @@ export interface SubmitOrderRequestOptions extends RequestOptions {
 export default class OrderRequestSender {
     constructor(private _requestSender: RequestSender) {}
 
-    loadOrder(
-        orderId: number,
-        { timeout, params }: RequestOptions<OrderParams> = {},
-    ): Promise<Response<Order>> {
+    loadOrder(orderId: number, { timeout }: RequestOptions = {}): Promise<Response<Order>> {
         const url = `/api/storefront/orders/${orderId}`;
         const headers = {
             Accept: ContentType.JsonV1,
@@ -37,13 +33,15 @@ export default class OrderRequestSender {
             'payments',
             'lineItems.physicalItems.socialMedia',
             'lineItems.physicalItems.options',
+            'lineItems.physicalItems.categories',
             'lineItems.digitalItems.socialMedia',
             'lineItems.digitalItems.options',
+            'lineItems.digitalItems.categories',
         ];
 
         return this._requestSender.get(url, {
             params: {
-                include: joinIncludes([...include, ...((params && params.include) || [])]),
+                include: joinIncludes(include),
             },
             headers,
             timeout,

--- a/packages/core/src/payment/strategies/affirm/affirm-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/affirm/affirm-payment-strategy.ts
@@ -9,7 +9,7 @@ import {
     NotInitializedErrorType,
 } from '../../../common/error/errors';
 import { AmountTransformer } from '../../../common/utility';
-import { Order, OrderActionCreator, OrderIncludes, OrderRequestBody } from '../../../order';
+import { Order, OrderActionCreator, OrderRequestBody } from '../../../order';
 import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { Consignment } from '../../../shipping';
 import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
@@ -80,18 +80,8 @@ export default class AffirmPaymentStrategy implements PaymentStrategy {
             throw new PaymentArgumentInvalidError(['payment.methodId']);
         }
 
-        const requestOptions = {
-            ...options,
-            params: {
-                include: [
-                    OrderIncludes.PhysicalItemsCategories,
-                    OrderIncludes.DigitalItemsCategories,
-                ],
-            },
-        };
-
         return this._store
-            .dispatch(this._orderActionCreator.submitOrder({ useStoreCredit }, requestOptions))
+            .dispatch(this._orderActionCreator.submitOrder({ useStoreCredit }, options))
             .then<AffirmSuccessResponse>(() => {
                 _affirm.checkout(this._getCheckoutInformation());
 


### PR DESCRIPTION
## What? [DATA-11056](https://bigcommercecloud.atlassian.net/browse/DATA-11056)
- Include categories when loading order by default
- Update `BODL` line item transform logic to handle `line.item.categories`
- Update unit tests

## Why?
1. `BODL` only looked for `categoryNames` in line items. This works for checkout, since the `checkout` request includes `categoryNames` by default. However, for the `order` request, there is no `categoryNames` key in line items, but there is `categories` key instead with different structure. So we need to handle it on BODL end. 2. Another part is that categories were not included for `order` request by default. They were included only for the `affirm-payment-strategy` though. BODL should work with any payment method, and it should include categories for the `purchase` event. So that we need to always include categories when loading order.

## Testing / Proof
- Manually on dev store
- Unit tests
<img width="1042" alt="image" src="https://github.com/bigcommerce/checkout-sdk-js/assets/94108505/d04c5a99-a04e-4695-aa8d-673a8102b12f">


@bigcommerce/checkout @bigcommerce/team-payments


[DATA-11056]: https://bigcommercecloud.atlassian.net/browse/DATA-11056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ