### PR TITLE
feat(payment): PAYPAL-2690 added braintree ach vaulting instrument confirmation feature

### DIFF
--- a/packages/braintree-integration/src/braintree.mock.ts
+++ b/packages/braintree-integration/src/braintree.mock.ts
@@ -154,7 +154,7 @@ export function getBraintreeAch(): PaymentMethod {
         supportedCards: [],
         config: {
             displayName: 'Braintree ACH',
-            isVaultingEnabled: false,
+            isVaultingEnabled: true,
         },
         type: 'PAYMENT_TYPE_API',
     };


### PR DESCRIPTION
## What?
Added braintree ach vaulting instrument confirmation feature

## Why?
To avoid creating a new instrument with the same data in cases where customer tries to use untrusted vaulting instrument to make Braintree ACH transaction

## Testing / Proof
Unit tests
Manual tests

## Sibling PR
checkout-js: https://github.com/bigcommerce/checkout-js/pull/1360

<img width="742" alt="Screenshot 2023-07-04 at 17 04 54" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/061367a3-21f2-4554-aca4-3796cc60df81">

