### PR TITLE
fix(payment): PAYPAL-2719 fix amazon pay button for buy now flow

### DIFF
--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -1,10 +1,7 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
-import { CartSource } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
 import { PaymentMethod } from '../../';
 import { getConfig, getConfigState } from '../../../../src/config/configs.mock';
-import { BuyNowCartRequestBody } from '../../../cart';
 import { getCart } from '../../../cart/carts.mock';
 import { CheckoutStore, createCheckoutStore } from '../../../checkout';
 import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
@@ -428,20 +425,6 @@ describe('AmazonPayV2PaymentProcessor', () => {
         });
 
         describe('should use the new button params from API Version 2:', () => {
-            const buyNowRequestBody: BuyNowCartRequestBody = {
-                source: CartSource.BuyNow,
-                lineItems: [
-                    {
-                        productId: 1,
-                        quantity: 2,
-                        optionSelections: {
-                            optionId: 11,
-                            optionValue: 11,
-                        },
-                    },
-                ],
-            };
-
             beforeEach(() => {
                 const storeConfigMock = getConfig().storeConfig;
 
@@ -465,7 +448,7 @@ describe('AmazonPayV2PaymentProcessor', () => {
                 );
 
                 await processor.initialize(amazonPayV2Mock);
-                processor.setCartRequestBody(buyNowRequestBody);
+                processor.updateBuyNowFlowFlag(true);
                 renderAmazonPayButton();
 
                 expect(amazonPayV2SDKMock.Pay.renderButton).toHaveBeenCalledWith(


### PR DESCRIPTION
## What?

Fix Amazon Pay button for buy now flow on PDP

## Why?

To keep up-to-date data during the quota creation process

## Testing / Proof

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/999b12ee-4570-4b08-b912-0c5f2134b4c4

@bigcommerce/team-checkout @bigcommerce/team-payments
