### PR TITLE
feat(checkout): CHECKOUT-7595 Add client extension service

### DIFF
--- a/packages/core/src/bundles/extension.ts
+++ b/packages/core/src/bundles/extension.ts
@@ -1,0 +1,1 @@
+export { initializeExtensionService } from '../extension';

--- a/packages/core/src/extension/create-extension-service.ts
+++ b/packages/core/src/extension/create-extension-service.ts
@@ -1,0 +1,74 @@
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+
+import ExtensionService from './extension-service';
+
+export interface CreateExtensionServiceOptions {
+    extensionId: number;
+    parentOrigin: string;
+}
+
+export enum ExtensionListenEventType {
+    BroadcastCart = 'BROADCAST_CART',
+    ShippingCountryChange = 'SHIPPING_COUNTRY_CHANGE',
+}
+
+export interface ExtensionListenEventMap {
+    [ExtensionListenEventType.BroadcastCart]: {
+        type: ExtensionListenEventType.BroadcastCart;
+    };
+    [ExtensionListenEventType.ShippingCountryChange]: {
+        type: ExtensionListenEventType.ShippingCountryChange;
+        payload: {
+            countryCode: string;
+        };
+    };
+}
+
+export enum ExtensionPostEventType {
+    FRAME_LOADED = 'FRAME_LOADED',
+    RELOAD_CHECKOUT = 'RELOAD_CHECKOUT',
+    SHOW_LOADING_INDICATOR = 'SHOW_LOADING_INDICATOR',
+}
+
+export interface BaseEventPayload {
+    payload: {
+        extensionId: number;
+    };
+}
+
+export interface ExtensionReloadEvent extends BaseEventPayload {
+    type: ExtensionPostEventType.RELOAD_CHECKOUT;
+    payload: {
+        extensionId: number;
+    };
+}
+
+export interface ExtensionShowLoadingIndicatorEvent extends BaseEventPayload {
+    type: ExtensionPostEventType.SHOW_LOADING_INDICATOR;
+    payload: {
+        extensionId: number;
+    };
+}
+
+export interface ExtensionFrameLoadedEvent extends BaseEventPayload {
+    type: ExtensionPostEventType.FRAME_LOADED;
+}
+
+export type ExtensionPostEvent =
+    | ExtensionReloadEvent
+    | ExtensionShowLoadingIndicatorEvent
+    | ExtensionFrameLoadedEvent;
+
+export default function initializeExtensionService(options: CreateExtensionServiceOptions) {
+    const { extensionId, parentOrigin } = options;
+
+    const extension = new ExtensionService(
+        new IframeEventListener<ExtensionListenEventMap>(parentOrigin),
+        new IframeEventPoster<ExtensionPostEvent>(parentOrigin),
+    );
+
+    extension.initialize(extensionId);
+    extension.post({ type: ExtensionPostEventType.FRAME_LOADED, payload: { extensionId } });
+
+    return extension;
+}

--- a/packages/core/src/extension/create-extension-service.ts
+++ b/packages/core/src/extension/create-extension-service.ts
@@ -7,7 +7,7 @@ export interface CreateExtensionServiceOptions {
     parentOrigin: string;
 }
 
-export enum ExtensionListenEventType {
+export const enum ExtensionListenEventType {
     BroadcastCart = 'BROADCAST_CART',
     ShippingCountryChange = 'SHIPPING_COUNTRY_CHANGE',
 }
@@ -24,7 +24,7 @@ export interface ExtensionListenEventMap {
     };
 }
 
-export enum ExtensionPostEventType {
+export const enum ExtensionPostEventType {
     FRAME_LOADED = 'FRAME_LOADED',
     RELOAD_CHECKOUT = 'RELOAD_CHECKOUT',
     SHOW_LOADING_INDICATOR = 'SHOW_LOADING_INDICATOR',
@@ -32,22 +32,16 @@ export enum ExtensionPostEventType {
 
 export interface BaseEventPayload {
     payload: {
-        extensionId: number;
+        extensionId?: number;
     };
 }
 
 export interface ExtensionReloadEvent extends BaseEventPayload {
     type: ExtensionPostEventType.RELOAD_CHECKOUT;
-    payload: {
-        extensionId: number;
-    };
 }
 
 export interface ExtensionShowLoadingIndicatorEvent extends BaseEventPayload {
     type: ExtensionPostEventType.SHOW_LOADING_INDICATOR;
-    payload: {
-        extensionId: number;
-    };
 }
 
 export interface ExtensionFrameLoadedEvent extends BaseEventPayload {

--- a/packages/core/src/extension/extension-client.ts
+++ b/packages/core/src/extension/extension-client.ts
@@ -1,5 +1,5 @@
 export interface InitializeExtensionServiceOptions {
-    extensionId: number;
+    extensionId: string;
     parentOrigin: string;
 }
 
@@ -28,7 +28,7 @@ export const enum ExtensionPostEventType {
 
 export interface BaseEventPayload {
     payload: {
-        extensionId?: number;
+        extensionId?: string;
     };
 }
 

--- a/packages/core/src/extension/extension-client.ts
+++ b/packages/core/src/extension/extension-client.ts
@@ -3,7 +3,7 @@ export interface InitializeExtensionServiceOptions {
     parentOrigin: string;
 }
 
-export const enum ExtensionListenEventType {
+export enum ExtensionListenEventType {
     BroadcastCart = 'BROADCAST_CART',
     ShippingCountryChange = 'SHIPPING_COUNTRY_CHANGE',
 }
@@ -20,7 +20,7 @@ export interface ExtensionListenEventMap {
     };
 }
 
-export const enum ExtensionPostEventType {
+export enum ExtensionPostEventType {
     FRAME_LOADED = 'FRAME_LOADED',
     RELOAD_CHECKOUT = 'RELOAD_CHECKOUT',
     SHOW_LOADING_INDICATOR = 'SHOW_LOADING_INDICATOR',

--- a/packages/core/src/extension/extension-client.ts
+++ b/packages/core/src/extension/extension-client.ts
@@ -4,27 +4,27 @@ export interface InitializeExtensionServiceOptions {
 }
 
 export enum ExtensionListenEventType {
-    BroadcastCart = 'BROADCAST_CART',
+    CheckoutLoaded = 'CHECKOUT_LOADED',
     ShippingCountryChange = 'SHIPPING_COUNTRY_CHANGE',
 }
 
-export interface BroadcastCartEvent {
-    type: ExtensionListenEventType.BroadcastCart;
+export interface CheckoutLoadedEvent {
+    type: ExtensionListenEventType.CheckoutLoaded;
 }
 
 export interface ShippingCountryChangeEvent {
-    type: ExtensionListenEventType.BroadcastCart;
+    type: ExtensionListenEventType.CheckoutLoaded;
     payload: {
         countryCode: string;
     };
 }
 
 export interface ExtensionListenEventMap {
-    [ExtensionListenEventType.BroadcastCart]: BroadcastCartEvent;
+    [ExtensionListenEventType.CheckoutLoaded]: CheckoutLoadedEvent;
     [ExtensionListenEventType.ShippingCountryChange]: ShippingCountryChangeEvent;
 }
 
-export enum ExtensionPostEventType {
+export enum ExtensionCommandType {
     FRAME_LOADED = 'FRAME_LOADED',
     RELOAD_CHECKOUT = 'RELOAD_CHECKOUT',
     SHOW_LOADING_INDICATOR = 'SHOW_LOADING_INDICATOR',
@@ -36,19 +36,19 @@ export interface BaseEventPayload {
     };
 }
 
-export interface ExtensionReloadEvent extends BaseEventPayload {
-    type: ExtensionPostEventType.RELOAD_CHECKOUT;
+export interface ExtensionReloadCommand extends BaseEventPayload {
+    type: ExtensionCommandType.RELOAD_CHECKOUT;
 }
 
-export interface ExtensionShowLoadingIndicatorEvent extends BaseEventPayload {
-    type: ExtensionPostEventType.SHOW_LOADING_INDICATOR;
+export interface ExtensionShowLoadingIndicatorCommand extends BaseEventPayload {
+    type: ExtensionCommandType.SHOW_LOADING_INDICATOR;
 }
 
-export interface ExtensionFrameLoadedEvent extends BaseEventPayload {
-    type: ExtensionPostEventType.FRAME_LOADED;
+export interface ExtensionFrameLoadedCommand extends BaseEventPayload {
+    type: ExtensionCommandType.FRAME_LOADED;
 }
 
-export type ExtensionPostEvent =
-    | ExtensionReloadEvent
-    | ExtensionShowLoadingIndicatorEvent
-    | ExtensionFrameLoadedEvent;
+export type ExtensionPostCommand =
+    | ExtensionReloadCommand
+    | ExtensionShowLoadingIndicatorCommand
+    | ExtensionFrameLoadedCommand;

--- a/packages/core/src/extension/extension-client.ts
+++ b/packages/core/src/extension/extension-client.ts
@@ -3,25 +3,25 @@ export interface InitializeExtensionServiceOptions {
     parentOrigin: string;
 }
 
-export enum ExtensionListenEventType {
+export enum ExtensionEventType {
     CheckoutLoaded = 'CHECKOUT_LOADED',
     ShippingCountryChange = 'SHIPPING_COUNTRY_CHANGE',
 }
 
 export interface CheckoutLoadedEvent {
-    type: ExtensionListenEventType.CheckoutLoaded;
+    type: ExtensionEventType.CheckoutLoaded;
 }
 
 export interface ShippingCountryChangeEvent {
-    type: ExtensionListenEventType.CheckoutLoaded;
+    type: ExtensionEventType.ShippingCountryChange;
     payload: {
         countryCode: string;
     };
 }
 
-export interface ExtensionListenEventMap {
-    [ExtensionListenEventType.CheckoutLoaded]: CheckoutLoadedEvent;
-    [ExtensionListenEventType.ShippingCountryChange]: ShippingCountryChangeEvent;
+export interface ExtensionEventMap {
+    [ExtensionEventType.CheckoutLoaded]: CheckoutLoadedEvent;
+    [ExtensionEventType.ShippingCountryChange]: ShippingCountryChangeEvent;
 }
 
 export enum ExtensionCommandType {
@@ -48,7 +48,7 @@ export interface ExtensionFrameLoadedCommand extends BaseEventPayload {
     type: ExtensionCommandType.FRAME_LOADED;
 }
 
-export type ExtensionPostCommand =
+export type ExtensionCommand =
     | ExtensionReloadCommand
     | ExtensionShowLoadingIndicatorCommand
     | ExtensionFrameLoadedCommand;

--- a/packages/core/src/extension/extension-client.ts
+++ b/packages/core/src/extension/extension-client.ts
@@ -1,8 +1,4 @@
-import { IframeEventListener, IframeEventPoster } from '../common/iframe';
-
-import ExtensionService from './extension-service';
-
-export interface CreateExtensionServiceOptions {
+export interface InitializeExtensionServiceOptions {
     extensionId: number;
     parentOrigin: string;
 }
@@ -52,17 +48,3 @@ export type ExtensionPostEvent =
     | ExtensionReloadEvent
     | ExtensionShowLoadingIndicatorEvent
     | ExtensionFrameLoadedEvent;
-
-export default function initializeExtensionService(options: CreateExtensionServiceOptions) {
-    const { extensionId, parentOrigin } = options;
-
-    const extension = new ExtensionService(
-        new IframeEventListener<ExtensionListenEventMap>(parentOrigin),
-        new IframeEventPoster<ExtensionPostEvent>(parentOrigin),
-    );
-
-    extension.initialize(extensionId);
-    extension.post({ type: ExtensionPostEventType.FRAME_LOADED, payload: { extensionId } });
-
-    return extension;
-}

--- a/packages/core/src/extension/extension-client.ts
+++ b/packages/core/src/extension/extension-client.ts
@@ -8,16 +8,20 @@ export enum ExtensionListenEventType {
     ShippingCountryChange = 'SHIPPING_COUNTRY_CHANGE',
 }
 
+export interface BroadcastCartEvent {
+    type: ExtensionListenEventType.BroadcastCart;
+}
+
+export interface ShippingCountryChangeEvent {
+    type: ExtensionListenEventType.BroadcastCart;
+    payload: {
+        countryCode: string;
+    };
+}
+
 export interface ExtensionListenEventMap {
-    [ExtensionListenEventType.BroadcastCart]: {
-        type: ExtensionListenEventType.BroadcastCart;
-    };
-    [ExtensionListenEventType.ShippingCountryChange]: {
-        type: ExtensionListenEventType.ShippingCountryChange;
-        payload: {
-            countryCode: string;
-        };
-    };
+    [ExtensionListenEventType.BroadcastCart]: BroadcastCartEvent;
+    [ExtensionListenEventType.ShippingCountryChange]: ShippingCountryChangeEvent;
 }
 
 export enum ExtensionPostEventType {

--- a/packages/core/src/extension/extension-origin-event.ts
+++ b/packages/core/src/extension/extension-origin-event.ts
@@ -23,7 +23,7 @@ export interface ReloadCheckoutEvent {
 }
 
 export interface ShowLoadingIndicatorEvent {
-    type: ExtensionCommand.ReloadCheckout;
+    type: ExtensionCommand.ShowLoadingIndicator;
     payload: {
         extensionId: string;
         show: boolean;
@@ -31,7 +31,7 @@ export interface ShowLoadingIndicatorEvent {
 }
 
 export interface SetIframeStylePayload {
-    type: ExtensionCommand.ReloadCheckout;
+    type: ExtensionCommand.SetIframeStyle;
     payload: {
         extensionId: string;
         style: {

--- a/packages/core/src/extension/extension-service.spec.ts
+++ b/packages/core/src/extension/extension-service.spec.ts
@@ -28,19 +28,19 @@ describe('ExtensionService', () => {
     });
 
     it('#initializes success fully', () => {
-        extensionService.initialize(1);
+        extensionService.initialize('test');
 
         expect(eventListener.listen).toHaveBeenCalled();
     });
 
     it('#initialize throws error if no extension Id is passed', () => {
-        expect(() => extensionService.initialize(undefined as unknown as number)).toThrow(
+        expect(() => extensionService.initialize(undefined as unknown as string)).toThrow(
             new Error('Extension Id not found.'),
         );
     });
 
     it('#post throws error if extension id is not set', () => {
-        extensionService.initialize(1);
+        extensionService.initialize('test');
 
         const event: ExtensionPostEvent = {
             type: ExtensionPostEventType.FRAME_LOADED,
@@ -58,7 +58,7 @@ describe('ExtensionService', () => {
     });
 
     it('#addListener adds callback as noop if no callback method is passed', () => {
-        extensionService.initialize(1);
+        extensionService.initialize('test');
 
         extensionService.addListener(ExtensionListenEventType.BroadcastCart);
 
@@ -69,7 +69,7 @@ describe('ExtensionService', () => {
     });
 
     it('#addListener is called correctly with params', () => {
-        extensionService.initialize(1);
+        extensionService.initialize('test');
 
         const callbackFn = jest.fn();
 

--- a/packages/core/src/extension/extension-service.spec.ts
+++ b/packages/core/src/extension/extension-service.spec.ts
@@ -1,0 +1,83 @@
+import { noop } from 'lodash';
+
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+
+import {
+    ExtensionListenEventMap,
+    ExtensionListenEventType,
+    ExtensionPostEvent,
+    ExtensionPostEventType,
+} from './create-extension-service';
+import ExtensionService from './extension-service';
+
+describe('ExtensionService', () => {
+    let extensionService: ExtensionService;
+    let eventListener: IframeEventListener<ExtensionListenEventMap>;
+    let eventPoster: IframeEventPoster<ExtensionPostEvent>;
+
+    beforeEach(() => {
+        eventListener = new IframeEventListener('https://mybigcommerce.com');
+        eventPoster = new IframeEventPoster('https://mybigcommerce.com');
+
+        jest.spyOn(eventListener, 'listen');
+        jest.spyOn(eventListener, 'addListener');
+        jest.spyOn(eventPoster, 'post');
+        jest.spyOn(eventPoster, 'post');
+
+        extensionService = new ExtensionService(eventListener, eventPoster);
+    });
+
+    it('#initializes success fully', () => {
+        extensionService.initialize(1);
+
+        expect(eventListener.listen).toHaveBeenCalled();
+    });
+
+    it('#initialize throws error if no extension Id is passed', () => {
+        expect(() => extensionService.initialize(undefined as unknown as number)).toThrow(
+            new Error('Extension Id not found.'),
+        );
+    });
+
+    it('#post throws error if extension id is not set', () => {
+        extensionService.initialize(1);
+
+        const event: ExtensionPostEvent = {
+            type: ExtensionPostEventType.FRAME_LOADED,
+            payload: {},
+        };
+
+        extensionService.post(event);
+
+        expect(eventPoster.post).toHaveBeenCalledWith({
+            type: ExtensionPostEventType.FRAME_LOADED,
+            payload: {
+                extensionId: 1,
+            },
+        });
+    });
+
+    it('#addListener adds callback as noop if no callback method is passed', () => {
+        extensionService.initialize(1);
+
+        extensionService.addListener(ExtensionListenEventType.BroadcastCart);
+
+        expect(eventListener.addListener).toHaveBeenCalledWith(
+            ExtensionListenEventType.BroadcastCart,
+            noop,
+        );
+    });
+
+    it('#addListener is called correctly with params', () => {
+        extensionService.initialize(1);
+
+        const callbackFn = jest.fn();
+
+        extensionService.addListener(ExtensionListenEventType.BroadcastCart, callbackFn);
+
+        expect(eventListener.addListener).toHaveBeenCalledWith(
+            ExtensionListenEventType.BroadcastCart,
+            callbackFn,
+        );
+    });
+});

--- a/packages/core/src/extension/extension-service.spec.ts
+++ b/packages/core/src/extension/extension-service.spec.ts
@@ -3,17 +3,17 @@ import { noop } from 'lodash';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 
 import {
+    ExtensionCommandType,
     ExtensionListenEventMap,
     ExtensionListenEventType,
-    ExtensionPostEvent,
-    ExtensionPostEventType,
+    ExtensionPostCommand,
 } from './extension-client';
 import ExtensionService from './extension-service';
 
 describe('ExtensionService', () => {
     let extensionService: ExtensionService;
     let eventListener: IframeEventListener<ExtensionListenEventMap>;
-    let eventPoster: IframeEventPoster<ExtensionPostEvent>;
+    let eventPoster: IframeEventPoster<ExtensionPostCommand>;
 
     beforeEach(() => {
         eventListener = new IframeEventListener('https://mybigcommerce.com');
@@ -42,15 +42,15 @@ describe('ExtensionService', () => {
     it('#post throws error if extension id is not set', () => {
         extensionService.initialize('test');
 
-        const event: ExtensionPostEvent = {
-            type: ExtensionPostEventType.FRAME_LOADED,
+        const event: ExtensionPostCommand = {
+            type: ExtensionCommandType.FRAME_LOADED,
             payload: {},
         };
 
         extensionService.post(event);
 
         expect(eventPoster.post).toHaveBeenCalledWith({
-            type: ExtensionPostEventType.FRAME_LOADED,
+            type: ExtensionCommandType.FRAME_LOADED,
             payload: {
                 extensionId: 'test',
             },
@@ -60,8 +60,8 @@ describe('ExtensionService', () => {
     it('#post throws error if event name is not passed correctly', () => {
         extensionService.initialize('test');
 
-        const event: ExtensionPostEvent = {
-            type: 'some-event' as ExtensionPostEventType,
+        const event: ExtensionPostCommand = {
+            type: 'some-event' as ExtensionCommandType,
             payload: {},
         };
 
@@ -71,10 +71,10 @@ describe('ExtensionService', () => {
     it('#addListener adds callback as noop if no callback method is passed', () => {
         extensionService.initialize('test');
 
-        extensionService.addListener(ExtensionListenEventType.BroadcastCart);
+        extensionService.addListener(ExtensionListenEventType.CheckoutLoaded);
 
         expect(eventListener.addListener).toHaveBeenCalledWith(
-            ExtensionListenEventType.BroadcastCart,
+            ExtensionListenEventType.CheckoutLoaded,
             noop,
         );
     });
@@ -92,10 +92,10 @@ describe('ExtensionService', () => {
 
         const callbackFn = jest.fn();
 
-        extensionService.addListener(ExtensionListenEventType.BroadcastCart, callbackFn);
+        extensionService.addListener(ExtensionListenEventType.CheckoutLoaded, callbackFn);
 
         expect(eventListener.addListener).toHaveBeenCalledWith(
-            ExtensionListenEventType.BroadcastCart,
+            ExtensionListenEventType.CheckoutLoaded,
             callbackFn,
         );
     });

--- a/packages/core/src/extension/extension-service.spec.ts
+++ b/packages/core/src/extension/extension-service.spec.ts
@@ -3,17 +3,17 @@ import { noop } from 'lodash';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 
 import {
+    ExtensionCommand,
     ExtensionCommandType,
-    ExtensionListenEventMap,
-    ExtensionListenEventType,
-    ExtensionPostCommand,
+    ExtensionEventMap,
+    ExtensionEventType,
 } from './extension-client';
 import ExtensionService from './extension-service';
 
 describe('ExtensionService', () => {
     let extensionService: ExtensionService;
-    let eventListener: IframeEventListener<ExtensionListenEventMap>;
-    let eventPoster: IframeEventPoster<ExtensionPostCommand>;
+    let eventListener: IframeEventListener<ExtensionEventMap>;
+    let eventPoster: IframeEventPoster<ExtensionCommand>;
 
     beforeEach(() => {
         eventListener = new IframeEventListener('https://mybigcommerce.com');
@@ -42,7 +42,7 @@ describe('ExtensionService', () => {
     it('#post throws error if extension id is not set', () => {
         extensionService.initialize('test');
 
-        const event: ExtensionPostCommand = {
+        const event: ExtensionCommand = {
             type: ExtensionCommandType.FRAME_LOADED,
             payload: {},
         };
@@ -60,7 +60,7 @@ describe('ExtensionService', () => {
     it('#post throws error if event name is not passed correctly', () => {
         extensionService.initialize('test');
 
-        const event: ExtensionPostCommand = {
+        const event: ExtensionCommand = {
             type: 'some-event' as ExtensionCommandType,
             payload: {},
         };
@@ -71,10 +71,10 @@ describe('ExtensionService', () => {
     it('#addListener adds callback as noop if no callback method is passed', () => {
         extensionService.initialize('test');
 
-        extensionService.addListener(ExtensionListenEventType.CheckoutLoaded);
+        extensionService.addListener(ExtensionEventType.CheckoutLoaded);
 
         expect(eventListener.addListener).toHaveBeenCalledWith(
-            ExtensionListenEventType.CheckoutLoaded,
+            ExtensionEventType.CheckoutLoaded,
             noop,
         );
     });
@@ -82,7 +82,7 @@ describe('ExtensionService', () => {
     it('#addListener is not called if event name is not correct', () => {
         extensionService.initialize('test');
 
-        expect(() => extensionService.addListener('someevent' as ExtensionListenEventType)).toThrow(
+        expect(() => extensionService.addListener('someevent' as ExtensionEventType)).toThrow(
             'someevent is not supported.',
         );
     });
@@ -92,10 +92,10 @@ describe('ExtensionService', () => {
 
         const callbackFn = jest.fn();
 
-        extensionService.addListener(ExtensionListenEventType.CheckoutLoaded, callbackFn);
+        extensionService.addListener(ExtensionEventType.CheckoutLoaded, callbackFn);
 
         expect(eventListener.addListener).toHaveBeenCalledWith(
-            ExtensionListenEventType.CheckoutLoaded,
+            ExtensionEventType.CheckoutLoaded,
             callbackFn,
         );
     });

--- a/packages/core/src/extension/extension-service.spec.ts
+++ b/packages/core/src/extension/extension-service.spec.ts
@@ -7,7 +7,7 @@ import {
     ExtensionListenEventType,
     ExtensionPostEvent,
     ExtensionPostEventType,
-} from './create-extension-service';
+} from './extension-client';
 import ExtensionService from './extension-service';
 
 describe('ExtensionService', () => {

--- a/packages/core/src/extension/extension-service.spec.ts
+++ b/packages/core/src/extension/extension-service.spec.ts
@@ -82,9 +82,9 @@ describe('ExtensionService', () => {
     it('#addListener is not called if event name is not correct', () => {
         extensionService.initialize('test');
 
-        extensionService.addListener('someevent' as ExtensionListenEventType);
-
-        expect(eventListener.addListener).not.toHaveBeenCalled();
+        expect(() => extensionService.addListener('someevent' as ExtensionListenEventType)).toThrow(
+            'someevent is not supported.',
+        );
     });
 
     it('#addListener is called correctly with params', () => {

--- a/packages/core/src/extension/extension-service.spec.ts
+++ b/packages/core/src/extension/extension-service.spec.ts
@@ -52,9 +52,20 @@ describe('ExtensionService', () => {
         expect(eventPoster.post).toHaveBeenCalledWith({
             type: ExtensionPostEventType.FRAME_LOADED,
             payload: {
-                extensionId: 1,
+                extensionId: 'test',
             },
         });
+    });
+
+    it('#post throws error if event name is not passed correctly', () => {
+        extensionService.initialize('test');
+
+        const event: ExtensionPostEvent = {
+            type: 'some-event' as ExtensionPostEventType,
+            payload: {},
+        };
+
+        expect(() => extensionService.post(event)).toThrow('some-event is not supported.');
     });
 
     it('#addListener adds callback as noop if no callback method is passed', () => {
@@ -66,6 +77,14 @@ describe('ExtensionService', () => {
             ExtensionListenEventType.BroadcastCart,
             noop,
         );
+    });
+
+    it('#addListener is not called if event name is not correct', () => {
+        extensionService.initialize('test');
+
+        extensionService.addListener('someevent' as ExtensionListenEventType);
+
+        expect(eventListener.addListener).not.toHaveBeenCalled();
     });
 
     it('#addListener is called correctly with params', () => {

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -9,14 +9,14 @@ import {
 } from './extension-client';
 
 export default class ExtensionService {
-    private _extensionId?: number;
+    private _extensionId?: string;
 
     constructor(
         private _eventListener: IframeEventListener<ExtensionListenEventMap>,
         private _eventPoster: IframeEventPoster<ExtensionPostEvent>,
     ) {}
 
-    initialize(extensionId: number) {
+    initialize(extensionId: string) {
         if (!extensionId) {
             throw new Error('Extension Id not found.');
         }

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -6,6 +6,7 @@ import {
     ExtensionListenEventMap,
     ExtensionListenEventType,
     ExtensionPostEvent,
+    ExtensionPostEventType,
 } from './extension-client';
 
 export default class ExtensionService {
@@ -33,6 +34,10 @@ export default class ExtensionService {
 
         this._eventPoster.setTarget(window.parent);
 
+        if (!Object.values(ExtensionPostEventType).includes(event.type)) {
+            throw new Error(`${event.type} is not supported.`);
+        }
+
         const payload = {
             ...event.payload,
             extensionId: this._extensionId,
@@ -42,6 +47,10 @@ export default class ExtensionService {
     }
 
     addListener(eventType: ExtensionListenEventType, callback: () => void = noop): void {
+        if (!Object.values(ExtensionListenEventType).includes(eventType)) {
+            return;
+        }
+
         this._eventListener.addListener(eventType, callback);
     }
 }

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -46,11 +46,13 @@ export default class ExtensionService {
         this._eventPoster.post({ ...event, payload });
     }
 
-    addListener(eventType: ExtensionListenEventType, callback: () => void = noop): void {
+    addListener(eventType: ExtensionListenEventType, callback: () => void = noop): () => void {
         if (!Object.values(ExtensionListenEventType).includes(eventType)) {
-            return;
+            return noop;
         }
 
         this._eventListener.addListener(eventType, callback);
+
+        return () => this._eventListener.removeListener(eventType, callback);
     }
 }

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -19,7 +19,7 @@ export default class ExtensionService {
         this._eventPoster.setTarget(window.parent);
     }
 
-    initialize(extensionId: string) {
+    initialize(extensionId: string): void {
         if (!extensionId) {
             throw new Error('Extension Id not found.');
         }
@@ -48,7 +48,7 @@ export default class ExtensionService {
 
     addListener(eventType: ExtensionListenEventType, callback: () => void = noop): () => void {
         if (!Object.values(ExtensionListenEventType).includes(eventType)) {
-            return noop;
+            throw new Error(`${eventType} is not supported.`);
         }
 
         this._eventListener.addListener(eventType, callback);

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -15,7 +15,9 @@ export default class ExtensionService {
     constructor(
         private _eventListener: IframeEventListener<ExtensionListenEventMap>,
         private _eventPoster: IframeEventPoster<ExtensionPostEvent>,
-    ) {}
+    ) {
+        this._eventPoster.setTarget(window.parent);
+    }
 
     initialize(extensionId: string) {
         if (!extensionId) {
@@ -31,8 +33,6 @@ export default class ExtensionService {
         if (!this._extensionId) {
             return;
         }
-
-        this._eventPoster.setTarget(window.parent);
 
         if (!Object.values(ExtensionPostEventType).includes(event.type)) {
             throw new Error(`${event.type} is not supported.`);

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -3,10 +3,10 @@ import { noop } from 'lodash';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 
 import {
+    ExtensionCommandType,
     ExtensionListenEventMap,
     ExtensionListenEventType,
-    ExtensionPostEvent,
-    ExtensionPostEventType,
+    ExtensionPostCommand,
 } from './extension-client';
 
 export default class ExtensionService {
@@ -14,7 +14,7 @@ export default class ExtensionService {
 
     constructor(
         private _eventListener: IframeEventListener<ExtensionListenEventMap>,
-        private _eventPoster: IframeEventPoster<ExtensionPostEvent>,
+        private _eventPoster: IframeEventPoster<ExtensionPostCommand>,
     ) {
         this._eventPoster.setTarget(window.parent);
     }
@@ -29,12 +29,12 @@ export default class ExtensionService {
         this._eventListener.listen();
     }
 
-    post(event: ExtensionPostEvent): void {
+    post(event: ExtensionPostCommand): void {
         if (!this._extensionId) {
             return;
         }
 
-        if (!Object.values(ExtensionPostEventType).includes(event.type)) {
+        if (!Object.values(ExtensionCommandType).includes(event.type)) {
             throw new Error(`${event.type} is not supported.`);
         }
 

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -3,18 +3,18 @@ import { noop } from 'lodash';
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 
 import {
+    ExtensionCommand,
     ExtensionCommandType,
-    ExtensionListenEventMap,
-    ExtensionListenEventType,
-    ExtensionPostCommand,
+    ExtensionEventMap,
+    ExtensionEventType,
 } from './extension-client';
 
 export default class ExtensionService {
     private _extensionId?: string;
 
     constructor(
-        private _eventListener: IframeEventListener<ExtensionListenEventMap>,
-        private _eventPoster: IframeEventPoster<ExtensionPostCommand>,
+        private _eventListener: IframeEventListener<ExtensionEventMap>,
+        private _eventPoster: IframeEventPoster<ExtensionCommand>,
     ) {
         this._eventPoster.setTarget(window.parent);
     }
@@ -29,7 +29,7 @@ export default class ExtensionService {
         this._eventListener.listen();
     }
 
-    post(event: ExtensionPostCommand): void {
+    post(event: ExtensionCommand): void {
         if (!this._extensionId) {
             return;
         }
@@ -46,8 +46,8 @@ export default class ExtensionService {
         this._eventPoster.post({ ...event, payload });
     }
 
-    addListener(eventType: ExtensionListenEventType, callback: () => void = noop): () => void {
-        if (!Object.values(ExtensionListenEventType).includes(eventType)) {
+    addListener(eventType: ExtensionEventType, callback: () => void = noop): () => void {
+        if (!Object.values(ExtensionEventType).includes(eventType)) {
             throw new Error(`${eventType} is not supported.`);
         }
 

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -1,5 +1,7 @@
 // imports types
 
+import { noop } from 'lodash';
+
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 
 import {
@@ -17,6 +19,10 @@ export default class ExtensionService {
     ) {}
 
     initialize(extensionId: number) {
+        if (!extensionId) {
+            throw new Error('Extension Id not found.');
+        }
+
         this._extensionId = extensionId;
 
         this._eventListener.listen();
@@ -24,7 +30,7 @@ export default class ExtensionService {
 
     post(event: ExtensionPostEvent): void {
         if (!this._extensionId) {
-            throw new Error('Extension Id not found.');
+            return;
         }
 
         this._eventPoster.setTarget(window.parent);
@@ -37,7 +43,7 @@ export default class ExtensionService {
         this._eventPoster.post({ ...event, payload });
     }
 
-    addListener(eventType: ExtensionListenEventType, callback: () => void): void {
+    addListener(eventType: ExtensionListenEventType, callback: () => void = noop): void {
         this._eventListener.addListener(eventType, callback);
     }
 }

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -1,5 +1,3 @@
-// imports types
-
 import { noop } from 'lodash';
 
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
@@ -8,7 +6,7 @@ import {
     ExtensionListenEventMap,
     ExtensionListenEventType,
     ExtensionPostEvent,
-} from './create-extension-service';
+} from './extension-client';
 
 export default class ExtensionService {
     private _extensionId?: number;

--- a/packages/core/src/extension/extension-service.ts
+++ b/packages/core/src/extension/extension-service.ts
@@ -1,0 +1,43 @@
+// imports types
+
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+
+import {
+    ExtensionListenEventMap,
+    ExtensionListenEventType,
+    ExtensionPostEvent,
+} from './create-extension-service';
+
+export default class ExtensionService {
+    private _extensionId?: number;
+
+    constructor(
+        private _eventListener: IframeEventListener<ExtensionListenEventMap>,
+        private _eventPoster: IframeEventPoster<ExtensionPostEvent>,
+    ) {}
+
+    initialize(extensionId: number) {
+        this._extensionId = extensionId;
+
+        this._eventListener.listen();
+    }
+
+    post(event: ExtensionPostEvent): void {
+        if (!this._extensionId) {
+            throw new Error('Extension Id not found.');
+        }
+
+        this._eventPoster.setTarget(window.parent);
+
+        const payload = {
+            ...event.payload,
+            extensionId: this._extensionId,
+        };
+
+        this._eventPoster.post({ ...event, payload });
+    }
+
+    addListener(eventType: ExtensionListenEventType, callback: () => void): void {
+        this._eventListener.addListener(eventType, callback);
+    }
+}

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -13,5 +13,6 @@ export {
     ExtensionSelectorFactory,
     createExtensionSelectorFactory,
 } from './extension-selector';
+export { default as initializeExtensionService } from './initialize-extension-service';
 export { ExtensionState } from './extension-state';
 export { HostOriginEvent } from './host-origin-event';

--- a/packages/core/src/extension/initialize-extension-service.spec.ts
+++ b/packages/core/src/extension/initialize-extension-service.spec.ts
@@ -1,0 +1,16 @@
+import { InitializeExtensionServiceOptions } from './extension-client';
+import ExtensionService from './extension-service';
+import initializeExtensionService from './initialize-extension-service';
+
+describe('initializeExtensionService', () => {
+    it('initializes extension service correctly', () => {
+        const options: InitializeExtensionServiceOptions = {
+            extensionId: 1,
+            parentOrigin: 'https://test.com',
+        };
+
+        const extensionService = initializeExtensionService(options);
+
+        expect(extensionService).toBeInstanceOf(ExtensionService);
+    });
+});

--- a/packages/core/src/extension/initialize-extension-service.spec.ts
+++ b/packages/core/src/extension/initialize-extension-service.spec.ts
@@ -5,7 +5,7 @@ import initializeExtensionService from './initialize-extension-service';
 describe('initializeExtensionService', () => {
     it('initializes extension service correctly', () => {
         const options: InitializeExtensionServiceOptions = {
-            extensionId: 1,
+            extensionId: 'test',
             parentOrigin: 'https://test.com',
         };
 

--- a/packages/core/src/extension/initialize-extension-service.ts
+++ b/packages/core/src/extension/initialize-extension-service.ts
@@ -1,9 +1,9 @@
 import { IframeEventListener, IframeEventPoster } from '../common/iframe';
 
 import {
-    ExtensionListenEventMap,
-    ExtensionPostEvent,
-    ExtensionPostEventType,
+    ExtensionCommand,
+    ExtensionCommandType,
+    ExtensionEventMap,
     InitializeExtensionServiceOptions,
 } from './extension-client';
 import ExtensionService from './extension-service';
@@ -12,12 +12,12 @@ export default function initializeExtensionService(options: InitializeExtensionS
     const { extensionId, parentOrigin } = options;
 
     const extension = new ExtensionService(
-        new IframeEventListener<ExtensionListenEventMap>(parentOrigin),
-        new IframeEventPoster<ExtensionPostEvent>(parentOrigin),
+        new IframeEventListener<ExtensionEventMap>(parentOrigin),
+        new IframeEventPoster<ExtensionCommand>(parentOrigin),
     );
 
     extension.initialize(extensionId);
-    extension.post({ type: ExtensionPostEventType.FRAME_LOADED, payload: { extensionId } });
+    extension.post({ type: ExtensionCommandType.FRAME_LOADED, payload: { extensionId } });
 
     return extension;
 }

--- a/packages/core/src/extension/initialize-extension-service.ts
+++ b/packages/core/src/extension/initialize-extension-service.ts
@@ -1,0 +1,23 @@
+import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+
+import {
+    ExtensionListenEventMap,
+    ExtensionPostEvent,
+    ExtensionPostEventType,
+    InitializeExtensionServiceOptions,
+} from './extension-client';
+import ExtensionService from './extension-service';
+
+export default function initializeExtensionService(options: InitializeExtensionServiceOptions) {
+    const { extensionId, parentOrigin } = options;
+
+    const extension = new ExtensionService(
+        new IframeEventListener<ExtensionListenEventMap>(parentOrigin),
+        new IframeEventPoster<ExtensionPostEvent>(parentOrigin),
+    );
+
+    extension.initialize(extensionId);
+    extension.post({ type: ExtensionPostEventType.FRAME_LOADED, payload: { extensionId } });
+
+    return extension;
+}

--- a/packages/core/src/extension/initialize-extension-service.ts
+++ b/packages/core/src/extension/initialize-extension-service.ts
@@ -1,4 +1,8 @@
-import { IframeEventListener, IframeEventPoster } from '../common/iframe';
+import {
+    IframeEventListener,
+    IframeEventPoster,
+    setupContentWindowForIframeResizer,
+} from '../common/iframe';
 
 import {
     ExtensionCommand,
@@ -10,6 +14,8 @@ import ExtensionService from './extension-service';
 
 export default function initializeExtensionService(options: InitializeExtensionServiceOptions) {
     const { extensionId, parentOrigin } = options;
+
+    setupContentWindowForIframeResizer();
 
     const extension = new ExtensionService(
         new IframeEventListener<ExtensionEventMap>(parentOrigin),

--- a/webpack-common.config.js
+++ b/webpack-common.config.js
@@ -1,7 +1,10 @@
 const path = require('path');
 const { DefinePlugin } = require('webpack');
 
-const { getNextVersion, packageLoaderRules : { aliasMap: alias, tsSrcPackages } } = require('./scripts/webpack');
+const {
+    getNextVersion,
+    packageLoaderRules: { aliasMap: alias, tsSrcPackages },
+} = require('./scripts/webpack');
 
 const libraryName = 'checkoutKit';
 
@@ -11,6 +14,7 @@ const libraryEntries = {
     'checkout-sdk': path.join(coreSrcPath, 'bundles', 'checkout-sdk.ts'),
     'checkout-button': path.join(coreSrcPath, 'bundles', 'checkout-button.ts'),
     'embedded-checkout': path.join(coreSrcPath, 'bundles', 'embedded-checkout.ts'),
+    extension: path.join(coreSrcPath, 'bundles', 'extension.ts'),
     'hosted-form': path.join(coreSrcPath, 'bundles', 'hosted-form.ts'),
     'internal-mappers': path.join(coreSrcPath, 'bundles', 'internal-mappers.ts'),
 };
@@ -19,7 +23,7 @@ async function getBaseConfig() {
     return {
         stats: {
             errorDetails: true,
-            logging: 'verbose'
+            logging: 'verbose',
         },
         devtool: 'source-map',
         mode: 'production',
@@ -39,25 +43,22 @@ async function getBaseConfig() {
                     enforce: 'pre',
                     loader: require.resolve('source-map-loader'),
                 },
-                ...tsSrcPackages
+                ...tsSrcPackages,
             ],
         },
         plugins: [
             new DefinePlugin({
-                'LIBRARY_VERSION': JSON.stringify(await getNextVersion()),
+                LIBRARY_VERSION: JSON.stringify(await getNextVersion()),
             }),
         ],
     };
-};
+}
 
 const babelEnvPreset = [
     '@babel/preset-env',
     {
         corejs: 3,
-        targets: [
-            'defaults',
-            'ie 11',
-        ],
+        targets: ['defaults', 'ie 11'],
         useBuiltIns: 'usage',
     },
 ];
@@ -68,25 +69,18 @@ const babelLoaderRules = [
         loader: 'babel-loader',
         include: coreSrcPath,
         options: {
-            presets: [
-                babelEnvPreset,
-            ],
+            presets: [babelEnvPreset],
         },
     },
     {
         test: /\.js$/,
         loader: 'babel-loader',
         include: path.join(__dirname, 'node_modules'),
-        exclude: [
-            /\/node_modules\/core-js\//,
-            /\/node_modules\/webpack\//,
-        ],
+        exclude: [/\/node_modules\/core-js\//, /\/node_modules\/webpack\//],
         options: {
-            presets: [
-                babelEnvPreset,
-            ],
+            presets: [babelEnvPreset],
             sourceType: 'unambiguous',
-        }
+        },
     },
 ];
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,12 @@ const path = require('path');
 const { DefinePlugin } = require('webpack');
 const nodeExternals = require('webpack-node-externals');
 
-const { babelLoaderRules, getBaseConfig, libraryEntries, libraryName } = require('./webpack-common.config');
+const {
+    babelLoaderRules,
+    getBaseConfig,
+    libraryEntries,
+    libraryName,
+} = require('./webpack-common.config');
 
 const outputPath = path.join(__dirname, 'dist');
 
@@ -20,10 +25,7 @@ async function getUmdConfig(options, argv) {
             path: outputPath,
         },
         module: {
-            rules: [
-                ...babelLoaderRules,
-                ...baseConfig.module.rules,
-            ],
+            rules: [...babelLoaderRules, ...baseConfig.module.rules],
         },
     };
 }
@@ -35,9 +37,7 @@ async function getCjsConfig(options, argv) {
         ...baseConfig,
         name: 'cjs',
         entry: libraryEntries,
-        externals: [
-            nodeExternals()
-        ],
+        externals: [nodeExternals()],
         output: {
             filename: '[name].js',
             libraryTarget: 'commonjs2',
@@ -53,10 +53,7 @@ async function getCjsConfig(options, argv) {
 }
 
 async function getConfigs(options, argv) {
-    return [
-        await getCjsConfig(options, argv),
-        await getUmdConfig(options, argv),
-    ];
+    return [await getCjsConfig(options, argv), await getUmdConfig(options, argv)];
 }
 
 module.exports = getConfigs;


### PR DESCRIPTION
## What?
Add client extension service

## Why?
Add a client extension service that is shipped out as a separate bundle that extensions can import and use for messaging to and from with checkout.

## Testing / Proof
- CI

@bigcommerce/team-checkout
