### PR TITLE
chore(common): BIG-0 Bump @bigcommerce/bigpay-client from v5.24.2 to v5.24.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.400.0",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.24.2",
+        "@bigcommerce/bigpay-client": "^5.24.4",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1412,9 +1412,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.2.tgz",
-      "integrity": "sha512-ANrPLpWHe60I/3CtP72144TzlicsIo3kVvG81iw+YNiLhaEytN7Gj4s86Y+Nh1vJSUs/T6rPepCObR63ZPDEIw==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.4.tgz",
+      "integrity": "sha512-f/2ZfKMYaD8WhCEPNV3Q4o6u2LxVB/vZVJat4nAlkPGQb9e2kFAjjjQEcA11/XPFyWiqPMc9tpBvEpFRpIMVRA==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -32153,9 +32153,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.2.tgz",
-      "integrity": "sha512-ANrPLpWHe60I/3CtP72144TzlicsIo3kVvG81iw+YNiLhaEytN7Gj4s86Y+Nh1vJSUs/T6rPepCObR63ZPDEIw==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.4.tgz",
+      "integrity": "sha512-f/2ZfKMYaD8WhCEPNV3Q4o6u2LxVB/vZVJat4nAlkPGQb9e2kFAjjjQEcA11/XPFyWiqPMc9tpBvEpFRpIMVRA==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.24.2",
+    "@bigcommerce/bigpay-client": "^5.24.4",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump @bigcommerce/bigpay-client from v5.24.2 to v5.24.4. Pulls in [these changes](https://github.com/bigcommerce/bigpay-client-js/compare/v5.24.2...v5.24.4). Those are just minor dependency updates and no big changes.

## Why?
Keeping up to date

## Testing / Proof
CI

@bigcommerce/team-checkout @bigcommerce/team-payments