### PR TITLE
feat(payment): PAYPAL-2725 added an ability to switch braintree sdk version (package part)

### DIFF
--- a/packages/braintree-integration/src/braintree-integration-service.spec.ts
+++ b/packages/braintree-integration/src/braintree-integration-service.spec.ts
@@ -30,6 +30,11 @@ describe('BraintreeIntegrationService', () => {
     let braintreeHostWindowMock: BraintreeHostWindow;
     let braintreeIntegrationService: BraintreeIntegrationService;
 
+    const clientToken = 'clientToken';
+    const initializationData = {
+        isAcceleratedCheckoutEnabled: false,
+    };
+
     beforeEach(() => {
         clientMock = getClientMock();
         braintreeScriptLoader = {} as BraintreeScriptLoader;
@@ -39,6 +44,16 @@ describe('BraintreeIntegrationService', () => {
             braintreeScriptLoader,
             braintreeHostWindowMock,
         );
+
+        braintreeScriptLoader.initialize = jest.fn();
+    });
+
+    describe('#initialize()', () => {
+        it('initializes braintree script loader with provided initialization data', () => {
+            braintreeIntegrationService.initialize(clientToken, initializationData);
+
+            expect(braintreeScriptLoader.initialize).toHaveBeenCalledWith(initializationData);
+        });
     });
 
     describe('#getClient()', () => {
@@ -50,7 +65,7 @@ describe('BraintreeIntegrationService', () => {
         });
 
         it('uses the right arguments to create the client', async () => {
-            braintreeIntegrationService.initialize('clientToken');
+            braintreeIntegrationService.initialize(clientToken, initializationData);
 
             const client = await braintreeIntegrationService.getClient();
 
@@ -59,7 +74,7 @@ describe('BraintreeIntegrationService', () => {
         });
 
         it('always returns the same instance of the client', async () => {
-            braintreeIntegrationService.initialize('clientToken');
+            braintreeIntegrationService.initialize(clientToken, initializationData);
 
             const client1 = await braintreeIntegrationService.getClient();
             const client2 = await braintreeIntegrationService.getClient();
@@ -299,7 +314,7 @@ describe('BraintreeIntegrationService', () => {
                 .fn()
                 .mockReturnValue({ create: jest.fn() });
             braintreeScriptLoader.loadClient = jest.fn().mockReturnValue({ create: jest.fn() });
-            braintreeIntegrationService.initialize('client-token');
+            braintreeIntegrationService.initialize(clientToken, initializationData);
             await braintreeIntegrationService.loadBraintreeLocalMethods(jest.fn(), '');
 
             expect(braintreeScriptLoader.loadBraintreeLocalMethods).toHaveBeenCalled();
@@ -415,7 +430,7 @@ describe('BraintreeIntegrationService', () => {
                 .fn()
                 .mockReturnValue(Promise.resolve(getModuleCreatorMock(clientMock)));
 
-            braintreeIntegrationService.initialize('clientToken');
+            braintreeIntegrationService.initialize(clientToken, initializationData);
         });
 
         it('calls teardown in all the dependencies', async () => {

--- a/packages/braintree-integration/src/braintree-integration-service.ts
+++ b/packages/braintree-integration/src/braintree-integration-service.ts
@@ -13,19 +13,20 @@ import {
     BraintreeEnv,
     BraintreeError,
     BraintreeHostWindow,
+    BraintreeInitializationData,
     BraintreeModule,
     BraintreePaypalCheckout,
     BraintreePaypalSdkCreatorConfig,
     BraintreeShippingAddressOverride,
 } from './braintree';
-import BraintreeScriptLoader from './braintree-script-loader';
-import isBraintreeError from './is-braintree-error';
-import { PAYPAL_COMPONENTS } from './paypal';
 import {
     BraintreeLocalMethods,
     GetLocalPaymentInstance,
     LocalPaymentInstance,
 } from './braintree-local-payment-methods/braintree-local-methods-options';
+import BraintreeScriptLoader from './braintree-script-loader';
+import isBraintreeError from './is-braintree-error';
+import { PAYPAL_COMPONENTS } from './paypal';
 
 export default class BraintreeIntegrationService {
     private client?: Promise<BraintreeClient>;
@@ -43,8 +44,9 @@ export default class BraintreeIntegrationService {
         private braintreeHostWindow: BraintreeHostWindow,
     ) {}
 
-    initialize(clientToken: string) {
+    initialize(clientToken: string, initializationData: BraintreeInitializationData) {
         this.clientToken = clientToken;
+        this.braintreeScriptLoader.initialize(initializationData);
     }
 
     async getClient(): Promise<BraintreeClient> {
@@ -118,6 +120,7 @@ export default class BraintreeIntegrationService {
                     if (localPaymentErr) {
                         throw new Error(localPaymentErr);
                     }
+
                     getLocalPaymentInstance(localPaymentInstance);
                 },
             );

--- a/packages/braintree-integration/src/braintree-local-payment-methods/create-braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/create-braintree-local-methods-payment-strategy.ts
@@ -1,14 +1,16 @@
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
 import {
     PaymentStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
-import BraintreeLocalMethodsPaymentStrategy from './braintree-local-methods-payment-strategy';
 import { BraintreeHostWindow } from '../braintree';
 import BraintreeIntegrationService from '../braintree-integration-service';
 import BraintreeScriptLoader from '../braintree-script-loader';
-import { getScriptLoader } from '@bigcommerce/script-loader';
-import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
+import BraintreeLocalMethodsPaymentStrategy from './braintree-local-methods-payment-strategy';
 
 const createBraintreeLocalMethodsPaymentStrategy: PaymentStrategyFactory<
     BraintreeLocalMethodsPaymentStrategy

--- a/packages/braintree-integration/src/braintree-paypal-ach/braintree-paypal-ach-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal-ach/braintree-paypal-ach-payment-strategy.spec.ts
@@ -161,12 +161,23 @@ describe('BraintreePaypalAchPaymentStrategy', () => {
             }
         });
 
+        it('throws error if initialization data is missing', async () => {
+            paymentMethodMock.initializationData = undefined;
+
+            try {
+                await strategy.initialize(mockOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
         it('successfully initialization payment strategy', async () => {
             await strategy.initialize(mockOptions);
 
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
             expect(braintreeIntegrationService.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
             expect(braintreeIntegrationService.getUsBankAccount).toHaveBeenCalled();
         });

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
@@ -211,6 +211,16 @@ describe('BraintreePaypalCustomerStrategy', () => {
             }
         });
 
+        it('throws error if initialization data is missing', async () => {
+            paymentMethodMock.initializationData = undefined;
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
         it('initializes braintree paypal checkout', async () => {
             braintreeIntegrationService.initialize = jest.fn();
             braintreeIntegrationService.getPaypalCheckout = jest.fn();
@@ -219,6 +229,7 @@ describe('BraintreePaypalCustomerStrategy', () => {
 
             expect(braintreeIntegrationService.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
             expect(braintreeIntegrationService.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/braintree-integration/src/braintree-script-loader.spec.ts
+++ b/packages/braintree-integration/src/braintree-script-loader.spec.ts
@@ -20,10 +20,15 @@ import {
 } from './braintree.mock';
 
 const VERSION = '3.95.0';
+const ALPHA_VERSION = '3.95.0-connect-alpha.7';
 
 describe('BraintreeScriptLoader', () => {
     let scriptLoader: ScriptLoader;
     let mockWindow: BraintreeHostWindow;
+
+    const braintreeInitializationData = {
+        isAcceleratedCheckoutEnabled: true,
+    };
 
     beforeEach(() => {
         mockWindow = { braintree: {} } as BraintreeHostWindow;
@@ -50,6 +55,19 @@ describe('BraintreeScriptLoader', () => {
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
                 `//js.braintreegateway.com/web/${VERSION}/js/client.min.js`,
+            );
+            expect(client).toBe(clientMock);
+        });
+
+        it('loads the client with braintree sdk alpha version', async () => {
+            const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
+
+            braintreeScriptLoader.initialize(braintreeInitializationData);
+
+            const client = await braintreeScriptLoader.loadClient();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/client.min.js`,
             );
             expect(client).toBe(clientMock);
         });
@@ -104,6 +122,19 @@ describe('BraintreeScriptLoader', () => {
             expect(paypalCheckout).toBe(paypalCheckoutMock);
         });
 
+        it('loads PayPal checkout with braintree sdk alpha version', async () => {
+            const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
+
+            braintreeScriptLoader.initialize(braintreeInitializationData);
+
+            const paypalCheckout = await braintreeScriptLoader.loadPaypalCheckout();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/paypal-checkout.min.js`,
+            );
+            expect(paypalCheckout).toBe(paypalCheckoutMock);
+        });
+
         it('loads PayPal checkout throw error if braintree does not exist in window', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(
                 scriptLoader,
@@ -132,6 +163,7 @@ describe('BraintreeScriptLoader', () => {
 
     describe('#loadBraintreeLocalMethods', () => {
         let localPayment: BraintreeLocalPayment;
+
         beforeEach(() => {
             localPayment = getBraintreeLocalPaymentMock();
             scriptLoader.loadScript = jest.fn(() => {
@@ -145,10 +177,23 @@ describe('BraintreeScriptLoader', () => {
 
         it('loads local payment methods', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
+
             await braintreeScriptLoader.loadBraintreeLocalMethods();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
                 `//js.braintreegateway.com/web/${VERSION}/js/local-payment.min.js`,
+            );
+        });
+
+        it('loads local payment methods with braintree sdk alpha version', async () => {
+            const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
+
+            braintreeScriptLoader.initialize(braintreeInitializationData);
+
+            await braintreeScriptLoader.loadBraintreeLocalMethods();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/local-payment.min.js`,
             );
         });
     });
@@ -173,6 +218,19 @@ describe('BraintreeScriptLoader', () => {
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
                 `//js.braintreegateway.com/web/${VERSION}/js/data-collector.min.js`,
+            );
+            expect(dataCollector).toBe(dataCollectorMock);
+        });
+
+        it('loads the data collector library with braintree sdk alpha version', async () => {
+            const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
+
+            braintreeScriptLoader.initialize(braintreeInitializationData);
+
+            const dataCollector = await braintreeScriptLoader.loadDataCollector();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/data-collector.min.js`,
             );
             expect(dataCollector).toBe(dataCollectorMock);
         });

--- a/packages/braintree-integration/src/braintree-script-loader.ts
+++ b/packages/braintree-integration/src/braintree-script-loader.ts
@@ -7,20 +7,31 @@ import {
     BraintreeClientCreator,
     BraintreeDataCollectorCreator,
     BraintreeHostWindow,
+    BraintreeInitializationData,
     BraintreePaypalCheckoutCreator,
 } from './braintree';
 
-const VERSION = '3.95.0';
+const BraintreeSdkVersionStable = '3.95.0';
 
 export default class BraintreeScriptLoader {
+    private braintreeSdkVersion = BraintreeSdkVersionStable;
+
     constructor(
         private scriptLoader: ScriptLoader,
         private braintreeHostWindow: BraintreeHostWindow,
     ) {}
 
+    // TODO: this method is needed only for braintree AXO
+    // So can be removed after Beta state
+    initialize({ isAcceleratedCheckoutEnabled }: BraintreeInitializationData) {
+        this.braintreeSdkVersion = isAcceleratedCheckoutEnabled
+            ? '3.95.0-connect-alpha.7'
+            : BraintreeSdkVersionStable;
+    }
+
     async loadClient(): Promise<BraintreeClientCreator> {
         await this.scriptLoader.loadScript(
-            `//js.braintreegateway.com/web/${VERSION}/js/client.min.js`,
+            `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/client.min.js`,
         );
 
         if (!this.braintreeHostWindow.braintree?.client) {
@@ -32,7 +43,7 @@ export default class BraintreeScriptLoader {
 
     async loadPaypalCheckout(): Promise<BraintreePaypalCheckoutCreator> {
         await this.scriptLoader.loadScript(
-            `//js.braintreegateway.com/web/${VERSION}/js/paypal-checkout.min.js`,
+            `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/paypal-checkout.min.js`,
         );
 
         if (!this.braintreeHostWindow.braintree?.paypalCheckout) {
@@ -44,7 +55,7 @@ export default class BraintreeScriptLoader {
 
     async loadBraintreeLocalMethods() {
         await this.scriptLoader.loadScript(
-            `//js.braintreegateway.com/web/${VERSION}/js/local-payment.min.js`,
+            `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/local-payment.min.js`,
         );
 
         if (!this.braintreeHostWindow.braintree?.localPayment) {
@@ -56,7 +67,7 @@ export default class BraintreeScriptLoader {
 
     async loadDataCollector(): Promise<BraintreeDataCollectorCreator> {
         await this.scriptLoader.loadScript(
-            `//js.braintreegateway.com/web/${VERSION}/js/data-collector.min.js`,
+            `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/data-collector.min.js`,
         );
 
         if (!this.braintreeHostWindow.braintree?.dataCollector) {
@@ -68,7 +79,7 @@ export default class BraintreeScriptLoader {
 
     async loadUsBankAccount(): Promise<BraintreeBankAccountCreator> {
         await this.scriptLoader.loadScript(
-            `//js.braintreegateway.com/web/${VERSION}/js/us-bank-account.min.js`,
+            `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/us-bank-account.min.js`,
         );
 
         if (

--- a/packages/braintree-integration/src/braintree.mock.ts
+++ b/packages/braintree-integration/src/braintree.mock.ts
@@ -29,7 +29,6 @@ export function getDataCollectorMock(): BraintreeDataCollector {
 
 export function getBraintreeLocalPaymentMock(): BraintreeLocalPayment {
     return {
-        VERSION: '3.81.0',
         create: jest.fn(),
     };
 }
@@ -142,6 +141,9 @@ export function getBraintree(): PaymentMethod {
             testMode: true,
             isVisaCheckoutEnabled: false,
         },
+        initializationData: {
+            isAcceleratedCheckoutEnabled: false,
+        },
         type: 'PAYMENT_TYPE_API',
     };
 }
@@ -155,6 +157,9 @@ export function getBraintreeAch(): PaymentMethod {
         config: {
             displayName: 'Braintree ACH',
             isVaultingEnabled: true,
+        },
+        initializationData: {
+            isAcceleratedCheckoutEnabled: false,
         },
         type: 'PAYMENT_TYPE_API',
     };
@@ -179,9 +184,13 @@ export function getBraintreeLocalMethods() {
         config: {
             displayName: 'Giropay',
         },
+        initializationData: {
+            isAcceleratedCheckoutEnabled: false,
+        },
         type: 'PAYMENT_TYPE_API',
     };
 }
+
 export function getBraintreeAddress(): BraintreeShippingAddressOverride {
     return {
         line1: '12345 Testing Way',

--- a/packages/braintree-integration/src/braintree.ts
+++ b/packages/braintree-integration/src/braintree.ts
@@ -1,8 +1,8 @@
-import { PaypalAuthorizeData, PaypalButtonOptions, PaypalButtonRender, PaypalSDK } from './paypal';
 import {
     BraintreeLocalMethods,
     LocalPaymentInstance,
 } from './braintree-local-payment-methods/braintree-local-methods-options';
+import { PaypalAuthorizeData, PaypalButtonOptions, PaypalButtonRender, PaypalSDK } from './paypal';
 
 /**
  *
@@ -54,7 +54,6 @@ export interface BraintreeSDK {
 }
 
 export interface BraintreeLocalPayment {
-    VERSION: string;
     create(
         config: BraintreeLocalPaymentCreateConfig,
         callback: BraintreeLocalPaymentCallback,
@@ -74,6 +73,7 @@ export interface BraintreeLocalPaymentCreateConfig {
 export interface BraintreeInitializationData {
     intent?: 'authorize' | 'order' | 'sale';
     isCreditEnabled?: boolean;
+    isAcceleratedCheckoutEnabled?: boolean;
 }
 
 export interface BraintreePaypalRequest {


### PR DESCRIPTION
## What?
Added an ability to switch braintree sdk version to alpha due to the settings in cp

## Why?
To use braintree sdk apha version if braintree axo feature is enabled

## Siblint PR
checkout-sdk (core part): https://github.com/bigcommerce/checkout-sdk-js/pull/2065

## Testing / Proof
Unit tests
Manual tests

Screenshots:
<img width="1512" alt="Screenshot 2023-07-18 at 19 04 52" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/e574ad7a-bae4-44af-8ae2-93d892de5d1c">
<img width="1512" alt="Screenshot 2023-07-18 at 19 05 01" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/67f42154-3cd8-41d0-921c-f3d55e41583f">

