### PR TITLE
feat(payment): PAYPAL-2725 added an ability to switch braintree sdk version (core part)

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -272,6 +272,7 @@ describe('BraintreePaypalButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
         });
 
@@ -283,6 +284,7 @@ describe('BraintreePaypalButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
             expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -87,14 +87,16 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
             currencyCode = state.cart.getCartOrThrow().currency.code;
         }
 
-        if (!paymentMethod.clientToken) {
+        const { clientToken, initializationData } = paymentMethod;
+
+        if (!clientToken || !initializationData) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         const paypalCheckoutOptions: Partial<BraintreePaypalSdkCreatorConfig> = {
             currency: currencyCode,
-            intent: paymentMethod.initializationData?.intent,
-            isCreditEnabled: paymentMethod.initializationData?.isCreditEnabled,
+            intent: initializationData.intent,
+            isCreditEnabled: initializationData.isCreditEnabled,
         };
 
         const paypalCheckoutSuccessCallback = (
@@ -111,7 +113,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this._handleError(error, containerId, messagingContainerId, onError);
 
-        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        this._braintreeSDKCreator.initialize(clientToken, initializationData);
         await this._braintreeSDKCreator.getPaypalCheckout(
             paypalCheckoutOptions,
             paypalCheckoutSuccessCallback,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -286,6 +286,7 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
         });
 
@@ -297,6 +298,7 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
             expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -90,14 +90,16 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
             currencyCode = state.cart.getCartOrThrow().currency.code;
         }
 
-        if (!paymentMethod.clientToken) {
+        const { clientToken, initializationData } = paymentMethod;
+
+        if (!clientToken || !initializationData) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         const paypalCheckoutOptions: Partial<BraintreePaypalSdkCreatorConfig> = {
             currency: currencyCode,
-            intent: paymentMethod.initializationData?.intent,
-            isCreditEnabled: paymentMethod.initializationData?.isCreditEnabled,
+            intent: initializationData.intent,
+            isCreditEnabled: initializationData.isCreditEnabled,
         };
 
         const paypalCheckoutCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) =>
@@ -111,7 +113,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this._handleError(error, containerId, braintreepaypalcredit.onError);
 
-        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        this._braintreeSDKCreator.initialize(clientToken, initializationData);
         await this._braintreeSDKCreator.getPaypalCheckout(
             paypalCheckoutOptions,
             paypalCheckoutCallback,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
@@ -211,6 +211,7 @@ describe('BraintreeVenmoButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
         });
 
@@ -224,6 +225,7 @@ describe('BraintreeVenmoButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
             expect(braintreeSDKCreator.getVenmoCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
@@ -71,8 +71,9 @@ export default class BraintreeVenmoButtonStrategy implements CheckoutButtonStrat
             this._paymentMethodActionCreator.loadPaymentMethod(methodId),
         );
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const { clientToken, initializationData } = paymentMethod;
 
-        if (!paymentMethod.clientToken) {
+        if (!clientToken || !initializationData) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
@@ -84,7 +85,7 @@ export default class BraintreeVenmoButtonStrategy implements CheckoutButtonStrat
 
         this._onError = braintreevenmo?.onError || this._handleError;
 
-        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        this._braintreeSDKCreator.initialize(clientToken, initializationData);
         await this._braintreeSDKCreator.getVenmoCheckout(
             (braintreeVenmoCheckout) =>
                 this._handleInitializationVenmoSuccess(

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
@@ -285,6 +285,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
         });
 
@@ -296,6 +297,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
             );
             expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -71,16 +71,17 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
             this._paymentMethodActionCreator.loadPaymentMethod(methodId),
         );
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const { clientToken, initializationData } = paymentMethod;
 
-        if (!paymentMethod.clientToken) {
+        if (!clientToken || !initializationData) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         const currencyCode = state.cart.getCartOrThrow().currency.code;
         const paypalCheckoutOptions: Partial<BraintreePaypalSdkCreatorConfig> = {
             currency: currencyCode,
-            intent: paymentMethod.initializationData?.intent,
-            isCreditEnabled: paymentMethod.initializationData?.isCreditEnabled,
+            intent: initializationData.intent,
+            isCreditEnabled: initializationData.isCreditEnabled,
         };
 
         const paypalCheckoutCallback = (braintreePaypalCheckout: BraintreePaypalCheckout) =>
@@ -94,7 +95,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this._handleError(error, braintreepaypalcredit);
 
-        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        this._braintreeSDKCreator.initialize(clientToken, initializationData);
         await this._braintreeSDKCreator.getPaypalCheckout(
             paypalCheckoutOptions,
             paypalCheckoutCallback,

--- a/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
@@ -36,7 +36,6 @@ import { CustomerInitializeOptions } from '../../customer-request-options';
 import CustomerStrategyActionCreator from '../../customer-strategy-action-creator';
 import { CustomerStrategyActionType } from '../../customer-strategy-actions';
 import { getRemoteCustomer } from '../../internal-customers.mock';
-import CustomerStrategy from '../customer-strategy';
 
 import BraintreeVisaCheckoutCustomerStrategy from './braintree-visacheckout-customer-strategy';
 
@@ -49,7 +48,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
     let paymentMethodMock: PaymentMethod;
     let remoteCheckoutActionCreator: RemoteCheckoutActionCreator;
     let store: CheckoutStore;
-    let strategy: CustomerStrategy;
+    let strategy: BraintreeVisaCheckoutCustomerStrategy;
     let visaCheckoutScriptLoader: VisaCheckoutScriptLoader;
     let visaCheckoutSDK: VisaCheckoutSDK;
     let formPoster: FormPoster;
@@ -65,12 +64,12 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         braintreeVisaCheckoutPaymentProcessor.initialize = jest.fn(() => Promise.resolve());
         braintreeVisaCheckoutPaymentProcessor.handleSuccess = jest.fn(() => Promise.resolve());
 
-        paymentMethodMock = { ...getBraintreeVisaCheckout(), clientToken: 'clientToken' };
+        paymentMethodMock = getBraintreeVisaCheckout();
 
         store = createCheckoutStore(getCheckoutStoreState());
 
         jest.spyOn(store, 'dispatch').mockReturnValue(Promise.resolve(store.getState()));
-        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod').mockReturnValue(
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
             paymentMethodMock,
         );
 
@@ -181,6 +180,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
 
             expect(braintreeVisaCheckoutPaymentProcessor.initialize).toHaveBeenCalledWith(
                 'clientToken',
+                {},
                 {
                     collectShipping: true,
                     currencyCode: 'USD',
@@ -292,7 +292,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
         });
 
         it('throws error if trying to sign in programmatically', () => {
-            expect(() => strategy.signIn({ email: 'foo@bar.com', password: 'foobar' })).toThrow();
+            expect(() => strategy.signIn()).toThrow();
         });
     });
 

--- a/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
@@ -49,7 +49,8 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
         return this._store
             .dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
             .then((state) => {
-                this._paymentMethod = state.paymentMethods.getPaymentMethod(methodId);
+                this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+                const { clientToken, initializationData } = this._paymentMethod;
 
                 const checkout = state.checkout.getCheckout();
                 const storeConfig = state.config.getStoreConfig();
@@ -62,7 +63,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
                     throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
                 }
 
-                if (!this._paymentMethod || !this._paymentMethod.clientToken) {
+                if (!clientToken || !initializationData) {
                     throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                 }
 
@@ -78,7 +79,8 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
                 return Promise.all([
                     this._visaCheckoutScriptLoader.load(this._paymentMethod.config.testMode),
                     this._braintreeVisaCheckoutPaymentProcessor.initialize(
-                        this._paymentMethod.clientToken,
+                        clientToken,
+                        initializationData,
                         initOptions,
                     ),
                 ])

--- a/packages/core/src/payment/payment-methods.mock.ts
+++ b/packages/core/src/payment/payment-methods.mock.ts
@@ -4,6 +4,7 @@ import PaymentMethodState from './payment-method-state';
 export function getBraintree(): PaymentMethod {
     return {
         id: 'braintree',
+        clientToken: 'clientToken',
         logoUrl:
             'https://cdn.bcapp.dev/rHEAD/modules/checkout/braintree/images/paypal_powered_braintree_horizontal.png',
         method: 'credit-card',
@@ -17,6 +18,10 @@ export function getBraintree(): PaymentMethod {
             isVisaCheckoutEnabled: false,
         },
         type: 'PAYMENT_TYPE_API',
+        initializationData: {
+            isAcceleratedCheckoutEnabled: false,
+            merchantAccountId: '100000',
+        },
     };
 }
 
@@ -74,6 +79,7 @@ export function getBraintreePaypalCredit(): PaymentMethod {
 export function getBraintreeVisaCheckout(): PaymentMethod {
     return {
         id: 'braintreevisacheckout',
+        clientToken: 'clientToken',
         logoUrl: '',
         method: 'paypal',
         supportedCards: [],
@@ -81,6 +87,7 @@ export function getBraintreeVisaCheckout(): PaymentMethod {
             testMode: false,
             isVisaCheckoutEnabled: true,
         },
+        initializationData: {},
         type: 'PAYMENT_TYPE_API',
     };
 }

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -86,13 +86,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
             Promise.resolve('my_session_id'),
         );
 
-        paymentMethodMock = {
-            ...getBraintree(),
-            clientToken: 'myToken',
-            initializationData: {
-                merchantAccountId: '100000',
-            },
-        };
+        paymentMethodMock = getBraintree();
 
         store = createCheckoutStore(getCheckoutStoreState());
 
@@ -132,6 +126,10 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
             loadPaymentMethodAction,
         );
 
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethodMock,
+        );
+
         braintreeCreditCardPaymentStrategy = new BraintreeCreditCardPaymentStrategy(
             store,
             orderActionCreator,
@@ -169,6 +167,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
 
             expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
                 options.braintree,
             );
             expect(braintreePaymentProcessorMock.initializeHostedForm).not.toHaveBeenCalled();
@@ -196,6 +195,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
 
             expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
                 options.braintree,
             );
             expect(braintreePaymentProcessorMock.initializeHostedForm).toHaveBeenCalledWith(

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -42,15 +42,18 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
             this._paymentMethodActionCreator.loadPaymentMethod(options.methodId),
         );
 
-        this._paymentMethod = state.paymentMethods.getPaymentMethod(options.methodId);
+        this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
 
-        if (!this._paymentMethod?.clientToken) {
+        const { clientToken, initializationData } = this._paymentMethod;
+
+        if (!clientToken || !initializationData) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         try {
             this._braintreePaymentProcessor.initialize(
-                this._paymentMethod.clientToken,
+                clientToken,
+                initializationData,
                 options.braintree,
             );
 

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -32,6 +32,11 @@ describe('BraintreePaymentProcessor', () => {
     let braintreeHostedForm: BraintreeHostedForm;
     let overlay: Overlay;
 
+    const clientToken = 'clientToken';
+    const initializationData = {
+        isAcceleratedCheckoutEnabled: false,
+    };
+
     beforeEach(() => {
         braintreeSDKCreator = {} as BraintreeSDKCreator;
         braintreeHostedForm = {} as BraintreeHostedForm;
@@ -58,9 +63,12 @@ describe('BraintreePaymentProcessor', () => {
                 overlay,
             );
 
-            braintreePaymentProcessor.initialize('clientToken');
+            braintreePaymentProcessor.initialize(clientToken, initializationData);
 
-            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith('clientToken');
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
+                clientToken,
+                initializationData,
+            );
         });
     });
 
@@ -537,7 +545,7 @@ describe('BraintreePaymentProcessor', () => {
                 overlay,
             );
 
-            braintreePaymentProcessor.initialize('clientToken', {
+            braintreePaymentProcessor.initialize(clientToken, initializationData, {
                 threeDSecure: {
                     ...getThreeDSecureOptionsMock(),
                     addFrame: (_error, _iframe, cancel) => {

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -16,6 +16,7 @@ import {
 import { CreditCardInstrument, NonceInstrument } from '../../payment';
 
 import {
+    BraintreeInitializationData,
     BraintreePaypal,
     BraintreeRequestData,
     BraintreeShippingAddressOverride,
@@ -53,8 +54,12 @@ export default class BraintreePaymentProcessor {
         private _overlay: Overlay,
     ) {}
 
-    initialize(clientToken: string, options?: BraintreePaymentInitializeOptions): void {
-        this._braintreeSDKCreator.initialize(clientToken);
+    initialize(
+        clientToken: string,
+        initializationData: BraintreeInitializationData,
+        options?: BraintreePaymentInitializeOptions,
+    ): void {
+        this._braintreeSDKCreator.initialize(clientToken, initializationData);
         this._threeDSecureOptions = options?.threeDSecure;
     }
 

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -47,7 +47,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
         braintreePaymentProcessorMock.getSessionId = jest.fn(() => 'my_session_id');
         braintreePaymentProcessorMock.deinitialize = jest.fn();
 
-        paymentMethodMock = { ...getBraintreePaypal(), clientToken: 'myToken' };
+        paymentMethodMock = getBraintreePaypal();
         submitOrderAction = of(createAction(OrderActionType.SubmitOrderRequested));
         submitPaymentAction = of(createAction(PaymentActionType.SubmitPaymentRequested));
         loadPaymentMethodAction = of(
@@ -89,7 +89,8 @@ describe('BraintreePaypalPaymentStrategy', () => {
             await braintreePaypalPaymentStrategy.initialize(options);
 
             expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith(
-                'foo',
+                paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
                 options.braintree,
             );
         });

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -226,13 +226,16 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     private _loadPaypal(
         braintreeOptions?: BraintreePaymentInitializeOptions,
     ): Promise<InternalCheckoutSelectors> {
-        if (!this._paymentMethod || !this._paymentMethod.clientToken) {
+        const { clientToken, initializationData } = this._paymentMethod || {};
+
+        if (!clientToken || !initializationData) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         try {
             this._braintreePaymentProcessor.initialize(
-                this._paymentMethod.clientToken,
+                clientToken,
+                initializationData,
                 braintreeOptions,
             );
 

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
@@ -23,12 +23,17 @@ import {
     getVisaCheckoutMock,
 } from './braintree.mock';
 
-const version = '3.95.0';
+const VERSION = '3.95.0';
+const ALPHA_VERSION = '3.95.0-connect-alpha.7';
 
 describe('BraintreeScriptLoader', () => {
     let braintreeScriptLoader: BraintreeScriptLoader;
     let scriptLoader: ScriptLoader;
     let mockWindow: BraintreeHostWindow;
+
+    const initializationData = {
+        isAcceleratedCheckoutEnabled: true,
+    };
 
     beforeEach(() => {
         mockWindow = { braintree: {} } as BraintreeHostWindow;
@@ -54,7 +59,17 @@ describe('BraintreeScriptLoader', () => {
             await braintreeScriptLoader.loadClient();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-                `//js.braintreegateway.com/web/${version}/js/client.min.js`,
+                `//js.braintreegateway.com/web/${VERSION}/js/client.min.js`,
+            );
+        });
+
+        it('loads the client with braintree sdk alpha version', async () => {
+            braintreeScriptLoader.initialize(initializationData);
+
+            await braintreeScriptLoader.loadClient();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/client.min.js`,
             );
         });
 
@@ -83,7 +98,17 @@ describe('BraintreeScriptLoader', () => {
             await braintreeScriptLoader.load3DS();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-                `//js.braintreegateway.com/web/${version}/js/three-d-secure.min.js`,
+                `//js.braintreegateway.com/web/${VERSION}/js/three-d-secure.min.js`,
+            );
+        });
+
+        it('loads the ThreeDSecure library with braintree sdk alpha version', async () => {
+            braintreeScriptLoader.initialize(initializationData);
+
+            await braintreeScriptLoader.load3DS();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/three-d-secure.min.js`,
             );
         });
 
@@ -112,7 +137,17 @@ describe('BraintreeScriptLoader', () => {
             await braintreeScriptLoader.loadDataCollector();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-                `//js.braintreegateway.com/web/${version}/js/data-collector.min.js`,
+                `//js.braintreegateway.com/web/${VERSION}/js/data-collector.min.js`,
+            );
+        });
+
+        it('loads the data collector library with braintree sdk alpha version', async () => {
+            braintreeScriptLoader.initialize(initializationData);
+
+            await braintreeScriptLoader.loadDataCollector();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/data-collector.min.js`,
             );
         });
 
@@ -141,7 +176,17 @@ describe('BraintreeScriptLoader', () => {
             await braintreeScriptLoader.loadVisaCheckout();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-                `//js.braintreegateway.com/web/${version}/js/visa-checkout.min.js`,
+                `//js.braintreegateway.com/web/${VERSION}/js/visa-checkout.min.js`,
+            );
+        });
+
+        it('loads the VisaCheckout library with braintree sdk alpha version', async () => {
+            braintreeScriptLoader.initialize(initializationData);
+
+            await braintreeScriptLoader.loadVisaCheckout();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/visa-checkout.min.js`,
             );
         });
 
@@ -170,7 +215,17 @@ describe('BraintreeScriptLoader', () => {
             await braintreeScriptLoader.loadGooglePayment();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-                `//js.braintreegateway.com/web/${version}/js/google-payment.min.js`,
+                `//js.braintreegateway.com/web/${VERSION}/js/google-payment.min.js`,
+            );
+        });
+
+        it('loads the GooglePay library with braintree sdk alpha version', async () => {
+            braintreeScriptLoader.initialize(initializationData);
+
+            await braintreeScriptLoader.loadGooglePayment();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/google-payment.min.js`,
             );
         });
 
@@ -216,7 +271,17 @@ describe('BraintreeScriptLoader', () => {
             await braintreeScriptLoader.loadHostedFields();
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(
-                `//js.braintreegateway.com/web/${version}/js/hosted-fields.min.js`,
+                `//js.braintreegateway.com/web/${VERSION}/js/hosted-fields.min.js`,
+            );
+        });
+
+        it('loads hosted fields module with braintree sdk alpha version', async () => {
+            braintreeScriptLoader.initialize(initializationData);
+
+            await braintreeScriptLoader.loadHostedFields();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/hosted-fields.min.js`,
             );
         });
 

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -8,6 +8,7 @@ import {
     BraintreeDataCollectorCreator,
     BraintreeHostedFieldsCreator,
     BraintreeHostWindow,
+    BraintreeInitializationData,
     BraintreePaypalCheckoutCreator,
     BraintreePaypalCreator,
     BraintreeThreeDSecureCreator,
@@ -15,17 +16,29 @@ import {
     BraintreeVisaCheckoutCreator,
 } from './braintree';
 
-const version = '3.95.0';
+const BraintreeSdkVersionStable = '3.95.0';
 
 export default class BraintreeScriptLoader {
+    private braintreeSdkVersion = BraintreeSdkVersionStable;
+
     constructor(
         private _scriptLoader: ScriptLoader,
         private _window: BraintreeHostWindow = window,
     ) {}
 
+    // TODO: this method is needed only for braintree AXO
+    // So can be removed after Beta stage
+    initialize({ isAcceleratedCheckoutEnabled }: BraintreeInitializationData) {
+        this.braintreeSdkVersion = isAcceleratedCheckoutEnabled
+            ? '3.95.0-connect-alpha.7'
+            : BraintreeSdkVersionStable;
+    }
+
     loadClient(): Promise<BraintreeClientCreator> {
         return this._scriptLoader
-            .loadScript(`//js.braintreegateway.com/web/${version}/js/client.min.js`)
+            .loadScript(
+                `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/client.min.js`,
+            )
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.client) {
                     throw new PaymentMethodClientUnavailableError();
@@ -37,7 +50,9 @@ export default class BraintreeScriptLoader {
 
     load3DS(): Promise<BraintreeThreeDSecureCreator> {
         return this._scriptLoader
-            .loadScript(`//js.braintreegateway.com/web/${version}/js/three-d-secure.min.js`)
+            .loadScript(
+                `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/three-d-secure.min.js`,
+            )
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.threeDSecure) {
                     throw new PaymentMethodClientUnavailableError();
@@ -49,7 +64,9 @@ export default class BraintreeScriptLoader {
 
     loadDataCollector(): Promise<BraintreeDataCollectorCreator> {
         return this._scriptLoader
-            .loadScript(`//js.braintreegateway.com/web/${version}/js/data-collector.min.js`)
+            .loadScript(
+                `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/data-collector.min.js`,
+            )
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.dataCollector) {
                     throw new PaymentMethodClientUnavailableError();
@@ -61,7 +78,9 @@ export default class BraintreeScriptLoader {
 
     loadPaypal(): Promise<BraintreePaypalCreator> {
         return this._scriptLoader
-            .loadScript(`//js.braintreegateway.com/web/${version}/js/paypal.min.js`)
+            .loadScript(
+                `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/paypal.min.js`,
+            )
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.paypal) {
                     throw new PaymentMethodClientUnavailableError();
@@ -73,7 +92,9 @@ export default class BraintreeScriptLoader {
 
     loadPaypalCheckout(): Promise<BraintreePaypalCheckoutCreator> {
         return this._scriptLoader
-            .loadScript(`//js.braintreegateway.com/web/${version}/js/paypal-checkout.min.js`)
+            .loadScript(
+                `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/paypal-checkout.min.js`,
+            )
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.paypalCheckout) {
                     throw new PaymentMethodClientUnavailableError();
@@ -85,7 +106,9 @@ export default class BraintreeScriptLoader {
 
     loadVisaCheckout(): Promise<BraintreeVisaCheckoutCreator> {
         return this._scriptLoader
-            .loadScript(`//js.braintreegateway.com/web/${version}/js/visa-checkout.min.js`)
+            .loadScript(
+                `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/visa-checkout.min.js`,
+            )
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.visaCheckout) {
                     throw new PaymentMethodClientUnavailableError();
@@ -97,7 +120,7 @@ export default class BraintreeScriptLoader {
 
     loadVenmoCheckout(): Promise<BraintreeVenmoCheckoutCreator> {
         return this._scriptLoader
-            .loadScript(`//js.braintreegateway.com/web/${version}/js/venmo.min.js`)
+            .loadScript(`//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/venmo.min.js`)
             .then(() => {
                 if (!this._window.braintree?.venmo) {
                     throw new PaymentMethodClientUnavailableError();
@@ -109,7 +132,9 @@ export default class BraintreeScriptLoader {
 
     loadGooglePayment(): Promise<GooglePayCreator> {
         return this._scriptLoader
-            .loadScript(`//js.braintreegateway.com/web/${version}/js/google-payment.min.js`)
+            .loadScript(
+                `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/google-payment.min.js`,
+            )
             .then(() => {
                 if (!this._window.braintree || !this._window.braintree.googlePayment) {
                     throw new PaymentMethodClientUnavailableError();
@@ -121,7 +146,7 @@ export default class BraintreeScriptLoader {
 
     async loadHostedFields(): Promise<BraintreeHostedFieldsCreator> {
         await this._scriptLoader.loadScript(
-            `//js.braintreegateway.com/web/${version}/js/hosted-fields.min.js`,
+            `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/hosted-fields.min.js`,
         );
 
         if (!this._window.braintree || !this._window.braintree.hostedFields) {

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
@@ -33,6 +33,8 @@ describe('Braintree SDK Creator', () => {
         clientMock = getClientMock();
         clientCreatorMock = getModuleCreatorMock(clientMock);
         braintreeScriptLoader = {} as BraintreeScriptLoader;
+
+        braintreeScriptLoader.initialize = jest.fn();
     });
 
     describe('#constructor()', () => {
@@ -53,7 +55,7 @@ describe('Braintree SDK Creator', () => {
         it('uses the right arguments to create the client', async () => {
             const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
 
-            braintreeSDKCreator.initialize('clientToken');
+            braintreeSDKCreator.initialize('clientToken', {});
             await braintreeSDKCreator.getClient();
 
             expect(clientCreatorMock.create).toHaveBeenCalledWith({ authorization: 'clientToken' });
@@ -62,7 +64,7 @@ describe('Braintree SDK Creator', () => {
         it('returns a copy of the client', async () => {
             const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
 
-            braintreeSDKCreator.initialize('clientToken');
+            braintreeSDKCreator.initialize('clientToken', {});
 
             const client = await braintreeSDKCreator.getClient();
 
@@ -72,7 +74,7 @@ describe('Braintree SDK Creator', () => {
         it('always returns the same instance of the client', async () => {
             const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
 
-            braintreeSDKCreator.initialize('clientToken');
+            braintreeSDKCreator.initialize('clientToken', {});
 
             const client1 = await braintreeSDKCreator.getClient();
             const client2 = await braintreeSDKCreator.getClient();
@@ -373,7 +375,7 @@ describe('Braintree SDK Creator', () => {
                 Promise.resolve(hostedFieldsCreatorMock),
             );
 
-            braintreeSDKCreator.initialize('client_token');
+            braintreeSDKCreator.initialize('client_token', {});
 
             expect(await braintreeSDKCreator.createHostedFields({ fields: {} })).toEqual(
                 hostedFieldsMock,
@@ -386,7 +388,7 @@ describe('Braintree SDK Creator', () => {
             braintreeScriptLoader.loadClient = jest.fn(() => Promise.resolve(clientCreatorMock));
             braintreeScriptLoader.loadHostedFields = jest.fn(() => Promise.reject(error));
 
-            braintreeSDKCreator.initialize('client_token');
+            braintreeSDKCreator.initialize('client_token', {});
 
             try {
                 await braintreeSDKCreator.createHostedFields({ fields: {} });
@@ -426,7 +428,7 @@ describe('Braintree SDK Creator', () => {
                 .mockReturnValue(Promise.resolve(getModuleCreatorMock(braintreeVenmoCheckout)));
 
             braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
-            braintreeSDKCreator.initialize('clientToken');
+            braintreeSDKCreator.initialize('clientToken', {});
         });
 
         it('calls teardown in all the dependencies', async () => {

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -11,6 +11,7 @@ import {
     BraintreeError,
     BraintreeHostedFields,
     BraintreeHostedFieldsCreatorConfig,
+    BraintreeInitializationData,
     BraintreeModule,
     BraintreePaypal,
     BraintreePaypalCheckout,
@@ -42,8 +43,9 @@ export default class BraintreeSDKCreator {
         this._window = window;
     }
 
-    initialize(clientToken: string) {
+    initialize(clientToken: string, initializationData: BraintreeInitializationData) {
         this._clientToken = clientToken;
+        this._braintreeScriptLoader.initialize(initializationData);
     }
 
     getClient(): Promise<BraintreeClient> {

--- a/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.spec.ts
@@ -106,7 +106,10 @@ describe('BraintreeVenmoPaymentStrategy', () => {
 
             await braintreeVenmoPaymentStrategy.initialize(options);
 
-            expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith('myToken');
+            expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith(
+                paymentMethodMock.clientToken,
+                paymentMethodMock.initializationData,
+            );
             expect(braintreePaymentProcessorMock.getVenmoCheckout).toHaveBeenCalled();
         });
 

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.spec.ts
@@ -56,9 +56,9 @@ describe('BraintreeVisaCheckoutPaymentProcessor', () => {
 
         it('initializes the sdk creator with the client token', () => {
             braintreeSDKCreator.initialize = jest.fn();
-            visaCheckoutPaymentProcessor.initialize('clientToken', {});
+            visaCheckoutPaymentProcessor.initialize('clientToken', {}, {});
 
-            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith('clientToken');
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith('clientToken', {});
         });
 
         it('maps the init options to the ones required by the braintree visacheckout module', async () => {
@@ -67,12 +67,16 @@ describe('BraintreeVisaCheckoutPaymentProcessor', () => {
                 requestSender,
             );
 
-            await visaCheckoutPaymentProcessor.initialize('clientToken', {
-                locale: 'es_ES',
-                collectShipping: true,
-                subtotal: 15,
-                currencyCode: '$',
-            });
+            await visaCheckoutPaymentProcessor.initialize(
+                'clientToken',
+                {},
+                {
+                    locale: 'es_ES',
+                    collectShipping: true,
+                    subtotal: 15,
+                    currencyCode: '$',
+                },
+            );
 
             expect(visaCheckoutMock.createInitOptions).toHaveBeenCalledWith({
                 paymentRequest: {

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
@@ -4,7 +4,7 @@ import { Address, LegacyAddress } from '@bigcommerce/checkout-sdk/payment-integr
 
 import { SDK_VERSION_HEADERS } from '../../../common/http-request';
 
-import { BraintreeDataCollector } from './braintree';
+import { BraintreeDataCollector, BraintreeInitializationData } from './braintree';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 import {
     VisaCheckoutAddress,
@@ -21,9 +21,10 @@ export default class BraintreeVisaCheckoutPaymentProcessor {
 
     initialize(
         clientToken: string,
+        initializationData: BraintreeInitializationData,
         options: VisaCheckoutInitializeOptions,
     ): Promise<VisaCheckoutInitOptions> {
-        this._braintreeSDKCreator.initialize(clientToken);
+        this._braintreeSDKCreator.initialize(clientToken, initializationData);
 
         return this._braintreeSDKCreator.getVisaCheckout().then((visaCheckout) =>
             visaCheckout.createInitOptions({

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -189,6 +189,7 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
 
             expect(braintreeVisaCheckoutPaymentProcessor.initialize).toHaveBeenCalledWith(
                 'clientToken',
+                {},
                 {
                     collectShipping: false,
                     currencyCode: 'USD',

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
@@ -60,7 +60,9 @@ export default class BraintreeVisaCheckoutPaymentStrategy implements PaymentStra
                     throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
                 }
 
-                if (!this._paymentMethod || !this._paymentMethod.clientToken) {
+                const { clientToken, config, initializationData } = this._paymentMethod || {};
+
+                if (!clientToken || !initializationData) {
                     throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                 }
 
@@ -74,9 +76,10 @@ export default class BraintreeVisaCheckoutPaymentStrategy implements PaymentStra
                 };
 
                 return Promise.all([
-                    this._visaCheckoutScriptLoader.load(this._paymentMethod.config.testMode),
+                    this._visaCheckoutScriptLoader.load(config?.testMode),
                     this._braintreeVisaCheckoutPaymentProcessor.initialize(
-                        this._paymentMethod.clientToken,
+                        clientToken,
+                        initializationData,
                         initOptions,
                     ),
                 ]).then(([visaCheckout, visaInitOptions]) => {

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -506,3 +506,9 @@ export interface BraintreeHostWindow extends Window {
     braintree?: BraintreeSDK;
     paypal?: PaypalSDK;
 }
+
+export interface BraintreeInitializationData {
+    intent?: 'authorize' | 'order' | 'sale';
+    isCreditEnabled?: boolean;
+    isAcceleratedCheckoutEnabled?: boolean;
+}

--- a/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -28,11 +28,13 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
-        if (!paymentMethod.clientToken) {
+        const { clientToken, initializationData } = paymentMethod;
+
+        if (!clientToken || !initializationData) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        this._braintreeSDKCreator.initialize(paymentMethod.clientToken);
+        this._braintreeSDKCreator.initialize(clientToken, initializationData);
 
         return this._braintreeSDKCreator
             .getGooglePaymentComponent()

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -326,10 +326,7 @@ describe('GooglePayPaymentStrategy', () => {
             });
 
             it('initialize brainTreeSDK on clientToken', async () => {
-                jest.spyOn(
-                    store.getState().paymentMethods,
-                    'getPaymentMethodOrThrow',
-                ).mockReturnValue({
+                const updatedPaymentMethod = {
                     initializationData: {
                         ...initializationData,
                         card_information: {
@@ -339,11 +336,19 @@ describe('GooglePayPaymentStrategy', () => {
                         isThreeDSecureEnabled: false,
                     },
                     clientToken: 'clienttoken',
-                });
+                };
+
+                jest.spyOn(
+                    store.getState().paymentMethods,
+                    'getPaymentMethodOrThrow',
+                ).mockReturnValue(updatedPaymentMethod);
 
                 await strategy.initialize(googlePayOptions);
 
-                expect(initializeBraintreeSDK).toHaveBeenCalledWith('clienttoken');
+                expect(initializeBraintreeSDK).toHaveBeenCalledWith(
+                    'clienttoken',
+                    updatedPaymentMethod.initializationData,
+                );
             });
 
             it('throws error if element doesnt exist in the DOM', async () => {

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -72,8 +72,15 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
 
         this._buttonClickEventHandler = this._handleButtonClickedEvent(methodId);
 
-        if (this._paymentMethod.clientToken) {
-            this._braintreeSDKCreator?.initialize(this._paymentMethod.clientToken);
+        if (
+            this._braintreeSDKCreator &&
+            this._paymentMethod.clientToken &&
+            this._paymentMethod.initializationData
+        ) {
+            this._braintreeSDKCreator.initialize(
+                this._paymentMethod.clientToken,
+                this._paymentMethod.initializationData,
+            );
         }
 
         await this._googlePayPaymentProcessor.initialize(methodId);


### PR DESCRIPTION
## What?
Added an ability to switch braintree sdk version

## Why?
To use braintree sdk alpha version when braintree accelerated checkout is enabled

## Testing / Proof
Unit tests
Manual tests

## Sibling PR
checkout-sdk (package part): https://github.com/bigcommerce/checkout-sdk-js/pull/2063
