### PR TITLE
feat(orders): ORDERS-5715 add OrderFee interface, add fees field to Order interface

### DIFF
--- a/packages/core/src/order/order.ts
+++ b/packages/core/src/order/order.ts
@@ -34,6 +34,15 @@ export default interface Order {
     taxes: Tax[];
     taxTotal: number;
     channelId: number;
+    fees: OrderFee[];
+}
+
+export interface OrderFee {
+    id: number;
+    type: string;
+    customerDisplayName: string;
+    cost: number;
+    source: string;
 }
 
 export type OrderPayments = Array<GatewayOrderPayment | GiftCertificateOrderPayment>;

--- a/packages/core/src/order/orders.mock.ts
+++ b/packages/core/src/order/orders.mock.ts
@@ -52,6 +52,7 @@ export function getOrder(): Order {
         ],
         taxTotal: 3,
         channelId: 1,
+        fees: [],
     };
 }
 


### PR DESCRIPTION
## What?
This PR adds an `OrderFee` interface and a `fees` field to the `Order` interface in `order.ts`.

## Why?
This adds some interfaces for fees specific to the Orders domain to provide separation between Checkout and Orders, as each domain's definitions of fees are likely to drift further apart over time.

## Testing / Proof
N/A

@bigcommerce/team-checkout @bigcommerce/team-orders