### PR TITLE
chore(payment): PAYPAL-2726 bump bigpay-client version from 5.24.4 to 5.25.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.405.0",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.24.4",
+        "@bigcommerce/bigpay-client": "^5.25.1",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1412,9 +1412,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.24.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.4.tgz",
-      "integrity": "sha512-f/2ZfKMYaD8WhCEPNV3Q4o6u2LxVB/vZVJat4nAlkPGQb9e2kFAjjjQEcA11/XPFyWiqPMc9tpBvEpFRpIMVRA==",
+      "version": "5.25.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.25.1.tgz",
+      "integrity": "sha512-5HdF8xdDSP7gUa8xXCYBuM6gmW7WtZds8r/GpdFYHZnZdCfhMGB3MHMk1PnERsSk7fsQXuc914yYigxLfuqI8g==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -32153,9 +32153,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.24.4",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.24.4.tgz",
-      "integrity": "sha512-f/2ZfKMYaD8WhCEPNV3Q4o6u2LxVB/vZVJat4nAlkPGQb9e2kFAjjjQEcA11/XPFyWiqPMc9tpBvEpFRpIMVRA==",
+      "version": "5.25.1",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.25.1.tgz",
+      "integrity": "sha512-5HdF8xdDSP7gUa8xXCYBuM6gmW7WtZds8r/GpdFYHZnZdCfhMGB3MHMk1PnERsSk7fsQXuc914yYigxLfuqI8g==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.24.4",
+    "@bigcommerce/bigpay-client": "^5.25.1",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump bigpay-client version from 5.24.4 to 5.25.1

The release contains:
- dependency updates;
- braintreeacceleratedcheckout to braintree mapper;

## Why?
To keep bigpay-client-js dependency up to date

## Testing / Proof
Manual tests
Unit tests

Made several orders with different payment methods and everything working as expected