### PR TITLE
feat(payment): PAYPAL-2773 added an ability to create shipping strategy in integration package

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-shipping-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-shipping-strategy.ts
@@ -1,0 +1,58 @@
+import {
+    AddressRequestBody,
+    InvalidArgumentError,
+    PaymentIntegrationService,
+    ShippingInitializeOptions,
+    ShippingRequestOptions,
+    ShippingStrategy,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+// TODO: this strategy will be updated in one of the future PR
+export default class BraintreeAcceleratedCheckoutShippingStrategy implements ShippingStrategy {
+    constructor(private paymentIntegrationService: PaymentIntegrationService) {}
+
+    initialize(options: ShippingInitializeOptions): Promise<void> {
+        const { methodId } = options;
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.methodId" argument is not provided.',
+            );
+        }
+
+        const state = this.paymentIntegrationService.getState();
+        const customer = state.getCustomer();
+
+        console.log('paymentIntegrationService -> customer:', customer);
+        console.log('BraintreeAcceleratedCheckoutShippingStrategy initialize options:', options);
+
+        return Promise.resolve();
+    }
+
+    deinitialize(options?: ShippingRequestOptions): Promise<void> {
+        console.log('BraintreeAcceleratedCheckoutShippingStrategy deinitialize options:', options);
+
+        return Promise.resolve();
+    }
+
+    updateAddress(
+        address: Partial<AddressRequestBody>,
+        options?: ShippingRequestOptions,
+    ): Promise<void> {
+        console.log('BraintreeAcceleratedCheckoutShippingStrategy updateAddress data:', {
+            address,
+            options,
+        });
+
+        return Promise.resolve();
+    }
+
+    selectOption(optionId: string, options?: ShippingRequestOptions): Promise<void> {
+        console.log('BraintreeAcceleratedCheckoutShippingStrategy selectOption data:', {
+            optionId,
+            options,
+        });
+
+        return Promise.resolve();
+    }
+}

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-shipping-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-shipping-strategy.ts
@@ -1,0 +1,16 @@
+import {
+    ShippingStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BraintreeAcceleratedCheckoutShippingStrategy from './braintree-accelerated-checkout-shipping-strategy';
+
+const createBraintreeAcceleratedCheckoutShippingStrategy: ShippingStrategyFactory<
+    BraintreeAcceleratedCheckoutShippingStrategy
+> = (paymentIntegrationService) => {
+    return new BraintreeAcceleratedCheckoutShippingStrategy(paymentIntegrationService);
+};
+
+export default toResolvableModule(createBraintreeAcceleratedCheckoutShippingStrategy, [
+    { id: 'braintreeacceleratedcheckout' },
+]);

--- a/packages/braintree-integration/src/index.ts
+++ b/packages/braintree-integration/src/index.ts
@@ -10,3 +10,5 @@ export { WithBraintreePaypalAchPaymentInitializeOptions } from './braintree-payp
 
 export { default as createBraintreeLocalMethodsPaymentStrategy } from './braintree-local-payment-methods/create-braintree-local-methods-payment-strategy';
 export { WithBraintreeLocalMethodsPaymentInitializeOptions } from './braintree-local-payment-methods/braintree-local-methods-options';
+
+export { default as createBraintreeAcceleratedCheckoutShippingStrategy } from './braintree-accelerated-checkout/create-braintree-accelerated-checkout-shipping-strategy';

--- a/packages/core/auto-export.config.json
+++ b/packages/core/auto-export.config.json
@@ -14,6 +14,11 @@
             "inputPath": "packages/*/src/index.ts",
             "outputPath": "packages/core/src/generated/checkout-button-strategies.ts",
             "memberPattern": "^create.+ButtonStrategy$"
+        },
+        {
+            "inputPath": "packages/*/src/index.ts",
+            "outputPath": "packages/core/src/generated/shipping-strategies.ts",
+            "memberPattern": "^create.+ShippingStrategy$"
         }
     ]
 }

--- a/packages/core/extend-interface.config.json
+++ b/packages/core/extend-interface.config.json
@@ -23,6 +23,14 @@
             "memberPattern": "^With.+ButtonInitializeOptions$",
             "targetPath": "packages/core/src/checkout-buttons/index.ts",
             "targetMemberName": "BaseCheckoutButtonInitializeOptions"
+        },
+        {
+            "inputPath": "packages/*/src/index.ts",
+            "outputPath": "packages/core/src/generated/shipping-initialize-options.ts",
+            "outputMemberName": "ShippingInitializeOptions",
+            "memberPattern": "^With.+ShippingInitializeOptions$",
+            "targetPath": "packages/core/src/shipping/index.ts",
+            "targetMemberName": "BaseShippingInitializeOptions"
         }
     ]
 }

--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -72,6 +72,7 @@ import {
     ConsignmentActionCreator,
     ConsignmentRequestSender,
     createShippingStrategyRegistry,
+    createShippingStrategyRegistryV2,
     PickupOptionActionCreator,
     PickupOptionRequestSender,
     ShippingCountryActionCreator,
@@ -368,6 +369,7 @@ describe('CheckoutService', () => {
 
         shippingStrategyActionCreator = new ShippingStrategyActionCreator(
             createShippingStrategyRegistry(store, requestSender),
+            createShippingStrategyRegistryV2(paymentIntegrationService),
         );
 
         errorActionCreator = new ErrorActionCreator();

--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -38,6 +38,7 @@ import {
     ConsignmentActionCreator,
     ConsignmentRequestSender,
     createShippingStrategyRegistry,
+    createShippingStrategyRegistryV2,
     PickupOptionActionCreator,
     PickupOptionRequestSender,
     ShippingCountryActionCreator,
@@ -128,12 +129,13 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         formFieldsActionCreator,
     );
     const paymentIntegrationService = createPaymentIntegrationService(store);
-    const registryV2 = createPaymentStrategyRegistryV2(
+    const paymentRegistryV2 = createPaymentStrategyRegistryV2(
         paymentIntegrationService,
         defaultPaymentStrategyFactories,
         { useFallback: true },
     );
     const customerRegistryV2 = createCustomerStrategyRegistryV2(paymentIntegrationService);
+    const shippingRegistryV2 = createShippingStrategyRegistryV2(paymentIntegrationService);
     const extensionActionCreator = new ExtensionActionCreator(
         new ExtensionRequestSender(requestSender),
     );
@@ -175,7 +177,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
                 spamProtection,
                 locale,
             ),
-            registryV2,
+            paymentRegistryV2,
             orderActionCreator,
             spamProtectionActionCreator,
         ),
@@ -183,7 +185,10 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
         new ShippingCountryActionCreator(
             new ShippingCountryRequestSender(requestSender, { locale }),
         ),
-        new ShippingStrategyActionCreator(createShippingStrategyRegistry(store, requestSender)),
+        new ShippingStrategyActionCreator(
+            createShippingStrategyRegistry(store, requestSender),
+            shippingRegistryV2,
+        ),
         new SignInEmailActionCreator(new SignInEmailRequestSender(requestSender)),
         spamProtectionActionCreator,
         new StoreCreditActionCreator(new StoreCreditRequestSender(requestSender)),

--- a/packages/core/src/shipping/create-shipping-strategy-registry-v2.spec.ts
+++ b/packages/core/src/shipping/create-shipping-strategy-registry-v2.spec.ts
@@ -1,0 +1,26 @@
+import {
+    PaymentIntegrationService,
+    ShippingStrategy,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import createShippingStrategyRegistryV2 from './create-shipping-strategy-registry-v2';
+
+describe('createShippingStrategyRegistryV2', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('creates registry with factories pre-registered', () => {
+        const fooStrategy = {} as ShippingStrategy;
+        const registry = createShippingStrategyRegistryV2(paymentIntegrationService, {
+            createFooStrategy: toResolvableModule(() => fooStrategy, [{ id: 'foo' }]),
+        });
+        const strategy = registry.get({ id: 'foo' });
+
+        expect(strategy).toEqual(fooStrategy);
+    });
+});

--- a/packages/core/src/shipping/create-shipping-strategy-registry-v2.ts
+++ b/packages/core/src/shipping/create-shipping-strategy-registry-v2.ts
@@ -1,0 +1,42 @@
+import {
+    isResolvableModule,
+    PaymentIntegrationService,
+    ShippingStrategy,
+    ShippingStrategyFactory,
+    ShippingStrategyResolveId,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { ResolveIdRegistry } from '../common/registry';
+import * as defaultShippingStrategyFactories from '../generated/shipping-strategies';
+
+export interface ShippingStrategyFactories {
+    [key: string]: ShippingStrategyFactory<ShippingStrategy>;
+}
+
+export default function createShippingStrategyRegistryV2(
+    paymentIntegrationService: PaymentIntegrationService,
+    shippingStrategyFactories: ShippingStrategyFactories = defaultShippingStrategyFactories,
+    options: { useFallback: boolean } = { useFallback: false },
+): ResolveIdRegistry<ShippingStrategy, ShippingStrategyResolveId> {
+    const { useFallback } = options;
+    const registry = new ResolveIdRegistry<ShippingStrategy, ShippingStrategyResolveId>(
+        useFallback,
+    );
+
+    for (const [, createShippingStrategy] of Object.entries(shippingStrategyFactories)) {
+        if (
+            !isResolvableModule<
+                ShippingStrategyFactory<ShippingStrategy>,
+                ShippingStrategyResolveId
+            >(createShippingStrategy)
+        ) {
+            continue;
+        }
+
+        for (const resolverId of createShippingStrategy.resolveIds) {
+            registry.register(resolverId, () => createShippingStrategy(paymentIntegrationService));
+        }
+    }
+
+    return registry;
+}

--- a/packages/core/src/shipping/create-shipping-strategy-registry.ts
+++ b/packages/core/src/shipping/create-shipping-strategy-registry.ts
@@ -4,11 +4,13 @@ import { getScriptLoader } from '@bigcommerce/script-loader';
 import { CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
 import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
+import { createPaymentIntegrationService } from '../payment-integration';
 import { createAmazonPayV2PaymentProcessor } from '../payment/strategies/amazon-pay-v2';
 import { StripeScriptLoader } from '../payment/strategies/stripe-upe';
 
 import ConsignmentActionCreator from './consignment-action-creator';
 import ConsignmentRequestSender from './consignment-request-sender';
+import createShippingStrategyRegistryV2 from './create-shipping-strategy-registry-v2';
 import ShippingStrategyActionCreator from './shipping-strategy-action-creator';
 import { ShippingStrategy } from './strategies';
 import { AmazonPayV2ShippingStrategy } from './strategies/amazon-pay-v2';
@@ -19,7 +21,9 @@ export default function createShippingStrategyRegistry(
     store: CheckoutStore,
     requestSender: RequestSender,
 ): Registry<ShippingStrategy> {
+    const paymentIntegrationService = createPaymentIntegrationService(store);
     const registry = new Registry<ShippingStrategy>();
+    const registryV2 = createShippingStrategyRegistryV2(paymentIntegrationService);
     const checkoutRequestSender = new CheckoutRequestSender(requestSender);
     const consignmentRequestSender = new ConsignmentRequestSender(requestSender);
     const consignmentActionCreator = new ConsignmentActionCreator(
@@ -39,7 +43,7 @@ export default function createShippingStrategyRegistry(
                 consignmentActionCreator,
                 new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
                 createAmazonPayV2PaymentProcessor(),
-                new ShippingStrategyActionCreator(registry),
+                new ShippingStrategyActionCreator(registry, registryV2),
             ),
     );
 

--- a/packages/core/src/shipping/index.ts
+++ b/packages/core/src/shipping/index.ts
@@ -1,7 +1,12 @@
 export * from './consignment-actions';
-export * from './shipping-request-options';
+export {
+    BaseShippingInitializeOptions,
+    ShippingInitializeOptions,
+    ShippingRequestOptions,
+} from './shipping-request-options';
 
 export { default as createShippingStrategyRegistry } from './create-shipping-strategy-registry';
+export { default as createShippingStrategyRegistryV2 } from './create-shipping-strategy-registry-v2';
 
 export {
     default as Consignment,

--- a/packages/core/src/shipping/shipping-request-options.ts
+++ b/packages/core/src/shipping/shipping-request-options.ts
@@ -3,6 +3,8 @@ import { RequestOptions } from '../common/http-request';
 import { AmazonPayV2ShippingInitializeOptions } from './strategies/amazon-pay-v2';
 import { StripeUPEShippingInitializeOptions } from './strategies/stripe-upe';
 
+export { ShippingInitializeOptions } from '../generated/shipping-initialize-options';
+
 /**
  * A set of options for configuring any requests related to the shipping step of
  * the current checkout flow.
@@ -26,7 +28,9 @@ export interface ShippingRequestOptions<T = {}> extends RequestOptions<T> {
  * need to provide additional information in order to initialize the shipping
  * step of checkout.
  */
-export interface ShippingInitializeOptions<T = {}> extends ShippingRequestOptions<T> {
+export interface BaseShippingInitializeOptions<T = {}> extends ShippingRequestOptions<T> {
+    [key: string]: unknown;
+
     /**
      * The options that are required to initialize the shipping step of checkout
      * when using AmazonPayV2.

--- a/packages/core/src/shipping/shipping-strategy-registry-v2.ts
+++ b/packages/core/src/shipping/shipping-strategy-registry-v2.ts
@@ -1,0 +1,10 @@
+import {
+    ShippingStrategy,
+    ShippingStrategyResolveId,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { ResolveIdRegistry } from '../common/registry';
+
+type ShippingStrategyRegistry = ResolveIdRegistry<ShippingStrategy, ShippingStrategyResolveId>;
+
+export default ShippingStrategyRegistry;

--- a/packages/core/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/amazon-pay-v2/amazon-pay-v2-shipping-strategy.spec.ts
@@ -9,6 +9,7 @@ import {
     ConsignmentActionType,
     ConsignmentRequestSender,
     createShippingStrategyRegistry,
+    createShippingStrategyRegistryV2,
     ShippingStrategyActionCreator,
 } from '../..';
 import { CheckoutRequestSender, CheckoutStore, createCheckoutStore } from '../../../checkout';
@@ -24,6 +25,7 @@ import {
     AmazonPayV2PaymentProcessor,
     createAmazonPayV2PaymentProcessor,
 } from '../../../payment/strategies/amazon-pay-v2';
+import { createPaymentIntegrationService } from '../../../payment-integration';
 import { getFlatRateOption } from '../../internal-shipping-options.mock';
 import {
     getShippingAddress,
@@ -54,6 +56,7 @@ describe('AmazonPayV2ShippingStrategy', () => {
         );
         shippingStrategyActionCreator = new ShippingStrategyActionCreator(
             createShippingStrategyRegistry(store, requestSender),
+            createShippingStrategyRegistryV2(createPaymentIntegrationService(store)),
         );
         amazonPayV2PaymentProcessor = createAmazonPayV2PaymentProcessor();
         requestSender = createRequestSender();

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -133,8 +133,13 @@ export { default as PaymentIntegrationService } from './payment-integration-serv
 export {
     Consignment,
     ShippingAddress,
+    ShippingInitializeOptions,
     ShippingOption,
     ShippingAddressRequestBody,
+    ShippingRequestOptions,
+    ShippingStrategy,
+    ShippingStrategyFactory,
+    ShippingStrategyResolveId,
 } from './shipping';
 export { RequestOptions, guard } from './util-types';
 export { default as ResolvableModule } from './resolvable-module';

--- a/packages/payment-integration-api/src/shipping/index.ts
+++ b/packages/payment-integration-api/src/shipping/index.ts
@@ -1,3 +1,8 @@
 export { default as Consignment } from './consignment';
 export { ShippingAddress, ShippingAddressRequestBody } from './shipping-address';
+export { ShippingInitializeOptions } from './shipping-initialize-options';
 export { default as ShippingOption } from './shipping-option';
+export { ShippingRequestOptions } from './shipping-request-options';
+export { default as ShippingStrategy } from './shipping-strategy';
+export { default as ShippingStrategyFactory } from './shipping-strategy-factory';
+export { default as ShippingStrategyResolveId } from './shipping-strategy-resolve-id';

--- a/packages/payment-integration-api/src/shipping/shipping-initialize-options.ts
+++ b/packages/payment-integration-api/src/shipping/shipping-initialize-options.ts
@@ -1,0 +1,5 @@
+import { ShippingRequestOptions } from './shipping-request-options';
+
+export interface ShippingInitializeOptions extends ShippingRequestOptions {
+    [key: string]: unknown;
+}

--- a/packages/payment-integration-api/src/shipping/shipping-request-options.ts
+++ b/packages/payment-integration-api/src/shipping/shipping-request-options.ts
@@ -1,0 +1,17 @@
+import { RequestOptions } from '../util-types';
+
+/**
+ * A set of options for configuring any requests related to the shipping step of
+ * the current checkout flow.
+ *
+ * Some payment methods have their own shipping configuration flow. Therefore,
+ * you need to specify the method you intend to use if you want to trigger a
+ * specific flow for setting the shipping address or option. Otherwise, these
+ * options are not required.
+ */
+export interface ShippingRequestOptions<T = {}> extends RequestOptions<T> {
+    /**
+     * The identifier of the payment method.
+     */
+    methodId?: string;
+}

--- a/packages/payment-integration-api/src/shipping/shipping-strategy-factory.ts
+++ b/packages/payment-integration-api/src/shipping/shipping-strategy-factory.ts
@@ -1,0 +1,9 @@
+import PaymentIntegrationService from '../payment-integration-service';
+
+import ShippingStrategy from './shipping-strategy';
+
+type ShippingStrategyFactory<TStrategy extends ShippingStrategy> = (
+    paymentIntegrationService: PaymentIntegrationService,
+) => TStrategy;
+
+export default ShippingStrategyFactory;

--- a/packages/payment-integration-api/src/shipping/shipping-strategy-resolve-id.ts
+++ b/packages/payment-integration-api/src/shipping/shipping-strategy-resolve-id.ts
@@ -1,0 +1,8 @@
+import { RequireAtLeastOne } from '../util-types';
+
+type ShippingStrategyResolveId = RequireAtLeastOne<{
+    id?: string;
+    gateway?: string;
+}>;
+
+export default ShippingStrategyResolveId;

--- a/packages/payment-integration-api/src/shipping/shipping-strategy.ts
+++ b/packages/payment-integration-api/src/shipping/shipping-strategy.ts
@@ -1,0 +1,16 @@
+import { AddressRequestBody } from '../address';
+
+import { ShippingRequestOptions } from './shipping-request-options';
+
+export default interface ShippingStrategy {
+    updateAddress(
+        address: Partial<AddressRequestBody>,
+        options?: ShippingRequestOptions,
+    ): Promise<void>;
+
+    selectOption(optionId: string, options?: ShippingRequestOptions): Promise<void>;
+
+    initialize(options?: ShippingRequestOptions): Promise<void>;
+
+    deinitialize(options?: ShippingRequestOptions): Promise<void>;
+}


### PR DESCRIPTION
## What?
Automatically register shipping strategies exported from payment integration packages and surface their initialisation options through the `CheckoutService` interface.

For example, if the entry point of the `braintreeacceleratedcheckout` package (i.e.: `index.ts`), exports a shipping strategy factory function (i.e.: `createBraintreeAcceleratedCheckoutShippingStrategy`), it will automatically be registered by an instance of `Registry<ShippingStrategy>` inside the `core` package. The factory will be registered against the `id` of a payment method as specified in the `braintree` package.

```ts
export default toResolvableModule(
    createBraintreeAcceleratedCheckoutShippingStrategy,
    [{ id: 'braintreeacceleratedcheckout' }]
);
```

## Why?
So that shipping strategies can be created in integration packages.

## Testing / Proof
Unit tests
Manual tests

Screenshots of generated files:
<img width="1475" alt="Screenshot 2023-07-21 at 16 43 46" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/8285b1ad-9c7f-452a-b6c7-7017b5039ea5">
<img width="1471" alt="Screenshot 2023-07-21 at 16 43 56" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/fc6fde87-59b8-4e50-b968-c2e8b80b355e">

Lets imagine that this is a BraintreeAcceleratedCheckoutShipping component presented on the screen:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/26903c0b-ce17-4328-a02d-9de544943c75




