### PR TITLE
feat(payment): PAYPAL-2731 added PaymentProviderCustomer state

### DIFF
--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -10,6 +10,7 @@ import { CountryState } from '../geography';
 import { OrderState } from '../order';
 import { OrderBillingAddressState } from '../order-billing-address';
 import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
+import { PaymentProviderCustomerState } from '../payment-provider-customer';
 import { InstrumentState } from '../payment/instrument';
 import { RemoteCheckoutState } from '../remote-checkout';
 import {
@@ -43,6 +44,7 @@ export default interface CheckoutStoreState {
     orderBillingAddress: OrderBillingAddressState;
     payment: PaymentState;
     paymentMethods: PaymentMethodState;
+    paymentProviderCustomer: PaymentProviderCustomerState;
     paymentStrategies: PaymentStrategyState;
     pickupOptions: PickupOptionState;
     remoteCheckout: RemoteCheckoutState;

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -130,6 +130,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         orderBillingAddress: getOrderBillingAddressState(),
         payment: getPaymentState(),
         paymentMethods: getPaymentMethodsState(),
+        paymentProviderCustomer: { data: {} },
         paymentStrategies: { data: {}, errors: {}, statuses: {} },
         pickupOptions: getPickupOptionsState(),
         remoteCheckout: getRemoteCheckoutState(),

--- a/packages/core/src/checkout/create-checkout-store-reducer.ts
+++ b/packages/core/src/checkout/create-checkout-store-reducer.ts
@@ -12,6 +12,7 @@ import { countryReducer } from '../geography';
 import { orderReducer } from '../order';
 import { orderBillingAddressReducer } from '../order-billing-address';
 import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
+import { paymentProviderCustomerReducer } from '../payment-provider-customer';
 import { instrumentReducer } from '../payment/instrument';
 import { remoteCheckoutReducer } from '../remote-checkout';
 import {
@@ -49,6 +50,7 @@ export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState
         paymentMethods: paymentMethodReducer,
         paymentStrategies: paymentStrategyReducer,
         pickupOptions: pickupOptionReducer,
+        paymentProviderCustomer: paymentProviderCustomerReducer,
         remoteCheckout: remoteCheckoutReducer,
         shippingCountries: shippingCountryReducer,
         shippingStrategies: shippingStrategyReducer,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -15,6 +15,7 @@ import {
     createPaymentSelectorFactory,
     createPaymentStrategySelectorFactory,
 } from '../payment';
+import { createPaymentProviderCustomerSelectorFactory } from '../payment-provider-customer';
 import { createInstrumentSelectorFactory } from '../payment/instrument';
 import { createRemoteCheckoutSelectorFactory } from '../remote-checkout';
 import {
@@ -53,6 +54,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createPaymentMethodSelector = createPaymentMethodSelectorFactory();
     const createPaymentStrategySelector = createPaymentStrategySelectorFactory();
     const createPickupOptionSelector = createPickupOptionSelectorFactory();
+    const createPaymentProviderCustomerSelector = createPaymentProviderCustomerSelectorFactory();
     const createRemoteCheckoutSelector = createRemoteCheckoutSelectorFactory();
     const createShippingAddressSelector = createShippingAddressSelectorFactory();
     const createShippingCountrySelector = createShippingCountrySelectorFactory();
@@ -81,6 +83,9 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const instruments = createInstrumentSelector(state.instruments);
         const orderBillingAddress = createOrderBillingAddressSelector(state.orderBillingAddress);
         const paymentMethods = createPaymentMethodSelector(state.paymentMethods);
+        const paymentProviderCustomer = createPaymentProviderCustomerSelector(
+            state.paymentProviderCustomer,
+        );
         const paymentStrategies = createPaymentStrategySelector(state.paymentStrategies);
         const pickupOptions = createPickupOptionSelector(state.pickupOptions);
         const remoteCheckout = createRemoteCheckoutSelector(state.remoteCheckout);
@@ -125,6 +130,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             orderBillingAddress,
             payment,
             paymentMethods,
+            paymentProviderCustomer,
             paymentStrategies,
             pickupOptions,
             remoteCheckout,

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -10,6 +10,7 @@ import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
+import { PaymentProviderCustomerSelector } from '../payment-provider-customer';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
 import {
@@ -45,6 +46,7 @@ export default interface InternalCheckoutSelectors {
     payment: PaymentSelector;
     paymentMethods: PaymentMethodSelector;
     paymentStrategies: PaymentStrategySelector;
+    paymentProviderCustomer: PaymentProviderCustomerSelector;
     pickupOptions: PickupOptionSelector;
     remoteCheckout: RemoteCheckoutSelector;
     shippingAddress: ShippingAddressSelector;

--- a/packages/core/src/common/error/errors/missing-data-error.ts
+++ b/packages/core/src/common/error/errors/missing-data-error.ts
@@ -14,6 +14,7 @@ export enum MissingDataErrorType {
     MissingPaymentId,
     MissingPaymentInstrument,
     MissingPaymentMethod,
+    MissingPaymentProviderCustomer,
     MissingPaymentRedirectUrl,
     MissingPaymentStatus,
     MissingPaymentToken,
@@ -69,6 +70,9 @@ function getErrorMessage(type: MissingDataErrorType): string {
 
         case MissingDataErrorType.MissingPaymentMethod:
             return 'Unable to proceed because payment method data is unavailable or not properly configured.';
+
+        case MissingDataErrorType.MissingPaymentProviderCustomer:
+            return 'Unable to proceed because payment provider customer is unavailable.';
 
         case MissingDataErrorType.MissingShippingAddress:
             return 'Unable to proceed because shipping address data is unavailable.';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,10 @@ export {
     PaymentMethodActionCreator,
     PaymentMethod,
 } from './payment';
+export {
+    BraintreeAcceleratedCheckoutCustomer,
+    PaymentProviderCustomer,
+} from './payment-provider-customer';
 export { getPayment } from './payment/payments.mock';
 export { CardInstrument } from './payment/instrument';
 export {

--- a/packages/core/src/payment-integration/create-payment-integration-selectors.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-selectors.ts
@@ -24,6 +24,7 @@ export default function createPaymentIntegrationSelectors({
         isPaymentDataRequired,
     },
     paymentMethods: { getPaymentMethod, getPaymentMethodOrThrow },
+    paymentProviderCustomer: { getPaymentProviderCustomer, getPaymentProviderCustomerOrThrow },
     paymentStrategies: { isInitialized: isPaymentMethodInitialized },
     shippingAddress: {
         getShippingAddress,
@@ -61,6 +62,8 @@ export default function createPaymentIntegrationSelectors({
         getPaymentRedirectUrlOrThrow,
         getPaymentMethod: clone(getPaymentMethod),
         getPaymentMethodOrThrow: clone(getPaymentMethodOrThrow),
+        getPaymentProviderCustomer: clone(getPaymentProviderCustomer),
+        getPaymentProviderCustomerOrThrow: clone(getPaymentProviderCustomerOrThrow),
         getShippingAddress: clone(getShippingAddress),
         getShippingAddressOrThrow: clone(getShippingAddressOrThrow),
         getShippingAddresses: clone(getShippingAddresses),

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -24,6 +24,7 @@ import {
     PaymentRequestSender,
     PaymentRequestTransformer,
 } from '../payment';
+import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
 import { ConsignmentActionCreator, ConsignmentRequestSender } from '../shipping';
 import {
     createSpamProtection,
@@ -107,6 +108,8 @@ export default function createPaymentIntegrationService(
 
     const cartRequestSender = new CartRequestSender(requestSender);
 
+    const paymentProviderCustomerActionCreator = new PaymentProviderCustomerActionCreator();
+
     return new DefaultPaymentIntegrationService(
         store,
         storeProjectionFactory,
@@ -121,5 +124,6 @@ export default function createPaymentIntegrationService(
         cartRequestSender,
         storeCreditActionCreator,
         spamProtectionActionCreator,
+        paymentProviderCustomerActionCreator,
     );
 }

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -23,6 +23,7 @@ import { CustomerActionCreator } from '../customer';
 import { HostedForm, HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator } from '../order';
 import { getOrder } from '../order/orders.mock';
+import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
 import { getPayment } from '../payment/payments.mock';
@@ -71,6 +72,7 @@ describe('DefaultPaymentIntegrationService', () => {
     let customerActionCreator: Pick<CustomerActionCreator, 'signInCustomer' | 'signOutCustomer'>;
     let cartRequestSender: CartRequestSender;
     let storeCreditActionCreator: Pick<StoreCreditActionCreator, 'applyStoreCredit'>;
+    let paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator;
 
     beforeEach(() => {
         requestSender = createRequestSender();
@@ -152,6 +154,12 @@ describe('DefaultPaymentIntegrationService', () => {
             ),
         };
 
+        paymentProviderCustomerActionCreator = {
+            updatePaymentProviderCustomer: jest.fn(
+                async () => () => createAction('UPDATE_PAYMENT_PROVIDER_CUSTOMER'),
+            ),
+        };
+
         subject = new DefaultPaymentIntegrationService(
             store as CheckoutStore,
             storeProjectionFactory as PaymentIntegrationStoreProjectionFactory,
@@ -166,6 +174,7 @@ describe('DefaultPaymentIntegrationService', () => {
             cartRequestSender,
             storeCreditActionCreator as StoreCreditActionCreator,
             spamProtectionActionCreator as SpamProtectionActionCreator,
+            paymentProviderCustomerActionCreator,
         );
     });
 

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -20,6 +20,7 @@ import { DataStoreProjection } from '../common/data-store';
 import { CustomerActionCreator, CustomerCredentials } from '../customer';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator } from '../order';
+import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
 import { ConsignmentActionCreator } from '../shipping';
@@ -45,6 +46,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _cartRequestSender: CartRequestSender,
         private _storeCreditActionCreator: StoreCreditActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator,
+        private _paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator,
     ) {
         this._storeProjection = this._storeProjectionFactory.create(this._store);
     }
@@ -210,6 +212,18 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
 
     async loadCurrentOrder(options?: RequestOptions): Promise<PaymentIntegrationSelectors> {
         await this._store.dispatch(this._orderActionCreator.loadCurrentOrder(options));
+
+        return this._storeProjection.getState();
+    }
+
+    async updatePaymentProviderCustomer<T>(
+        paymentProviderCustomer: T,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._paymentProviderCustomerActionCreator.updatePaymentProviderCustomer<T>(
+                paymentProviderCustomer,
+            ),
+        );
 
         return this._storeProjection.getState();
     }

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -20,7 +20,10 @@ import { DataStoreProjection } from '../common/data-store';
 import { CustomerActionCreator, CustomerCredentials } from '../customer';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator } from '../order';
-import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
+import {
+    PaymentProviderCustomer,
+    PaymentProviderCustomerActionCreator,
+} from '../payment-provider-customer';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
 import { ConsignmentActionCreator } from '../shipping';
@@ -216,11 +219,11 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         return this._storeProjection.getState();
     }
 
-    async updatePaymentProviderCustomer<T>(
-        paymentProviderCustomer: T,
+    async updatePaymentProviderCustomer(
+        paymentProviderCustomer: PaymentProviderCustomer,
     ): Promise<PaymentIntegrationSelectors> {
         await this._store.dispatch(
-            this._paymentProviderCustomerActionCreator.updatePaymentProviderCustomer<T>(
+            this._paymentProviderCustomerActionCreator.updatePaymentProviderCustomer(
                 paymentProviderCustomer,
             ),
         );

--- a/packages/core/src/payment-provider-customer/index.ts
+++ b/packages/core/src/payment-provider-customer/index.ts
@@ -1,0 +1,17 @@
+export { PaymentProviderCustomer } from './payment-provider-customer';
+export {
+    PaymentProviderCustomerType,
+    PaymentProviderCustomerAction,
+    UpdatePaymentProviderCustomerAction,
+} from './payment-provider-customer-actions';
+export { default as PaymentProviderCustomerActionCreator } from './payment-provider-customer-actions-creator';
+export { default as paymentProviderCustomerReducer } from './payment-provider-customer-reducer';
+export {
+    default as PaymentProviderCustomerSelector,
+    createPaymentProviderCustomerSelectorFactory,
+    PaymentProviderCustomerSelectorFactory,
+} from './payment-provider-customer-selector';
+export {
+    default as PaymentProviderCustomerState,
+    DEFAULT_STATE,
+} from './payment-provider-customer-state';

--- a/packages/core/src/payment-provider-customer/index.ts
+++ b/packages/core/src/payment-provider-customer/index.ts
@@ -1,4 +1,7 @@
-export { PaymentProviderCustomer } from './payment-provider-customer';
+export {
+    PaymentProviderCustomer,
+    BraintreeAcceleratedCheckoutCustomer,
+} from './payment-provider-customer';
 export {
     PaymentProviderCustomerType,
     PaymentProviderCustomerAction,

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-actions-creator.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-actions-creator.ts
@@ -8,8 +8,8 @@ import {
 } from './payment-provider-customer-actions';
 
 export default class PaymentProviderCustomerActionCreator {
-    updatePaymentProviderCustomer<T>(
-        providerCustomerData: PaymentProviderCustomer<T>,
+    updatePaymentProviderCustomer(
+        providerCustomerData: PaymentProviderCustomer,
     ): Observable<PaymentProviderCustomerAction> {
         return of(
             createAction(

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-actions-creator.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-actions-creator.ts
@@ -1,0 +1,21 @@
+import { createAction } from '@bigcommerce/data-store';
+import { Observable, of } from 'rxjs';
+
+import { PaymentProviderCustomer } from './payment-provider-customer';
+import {
+    PaymentProviderCustomerAction,
+    PaymentProviderCustomerType,
+} from './payment-provider-customer-actions';
+
+export default class PaymentProviderCustomerActionCreator {
+    updatePaymentProviderCustomer<T>(
+        providerCustomerData: PaymentProviderCustomer<T>,
+    ): Observable<PaymentProviderCustomerAction> {
+        return of(
+            createAction(
+                PaymentProviderCustomerType.UpdatePaymentProviderCustomer,
+                providerCustomerData,
+            ),
+        );
+    }
+}

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-actions.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-actions.ts
@@ -1,0 +1,11 @@
+import { Action } from '@bigcommerce/data-store';
+
+export enum PaymentProviderCustomerType {
+    UpdatePaymentProviderCustomer = 'UPDATE_PAYMENT_PROVIDER_CUSTOMER',
+}
+
+export type PaymentProviderCustomerAction = UpdatePaymentProviderCustomerAction;
+
+export interface UpdatePaymentProviderCustomerAction extends Action {
+    type: PaymentProviderCustomerType.UpdatePaymentProviderCustomer;
+}

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-reducer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-reducer.ts
@@ -1,0 +1,36 @@
+import { combineReducers } from '@bigcommerce/data-store';
+
+import { objectMerge } from '../common/utility';
+
+import { PaymentProviderCustomer } from './payment-provider-customer';
+import {
+    PaymentProviderCustomerType,
+    UpdatePaymentProviderCustomerAction,
+} from './payment-provider-customer-actions';
+import PaymentProviderCustomerState, { DEFAULT_STATE } from './payment-provider-customer-state';
+
+type ReducerActionType = UpdatePaymentProviderCustomerAction;
+
+export default function paymentProviderCustomerReducer(
+    state: PaymentProviderCustomerState = DEFAULT_STATE,
+    action: ReducerActionType,
+): PaymentProviderCustomerState {
+    const reducer = combineReducers<PaymentProviderCustomerState, ReducerActionType>({
+        data: dataReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: PaymentProviderCustomer | undefined,
+    action: ReducerActionType,
+): PaymentProviderCustomer | undefined {
+    switch (action.type) {
+        case PaymentProviderCustomerType.UpdatePaymentProviderCustomer:
+            return objectMerge(data, action.payload);
+
+        default:
+            return data;
+    }
+}

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-reducer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-reducer.ts
@@ -23,9 +23,9 @@ export default function paymentProviderCustomerReducer(
 }
 
 function dataReducer(
-    data: PaymentProviderCustomer | undefined,
+    data: PaymentProviderCustomer = DEFAULT_STATE.data,
     action: ReducerActionType,
-): PaymentProviderCustomer | undefined {
+): PaymentProviderCustomer {
     switch (action.type) {
         case PaymentProviderCustomerType.UpdatePaymentProviderCustomer:
             return objectMerge(data, action.payload);

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-selector.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-selector.ts
@@ -8,8 +8,8 @@ import PaymentProviderCustomerState, { DEFAULT_STATE } from './payment-provider-
 import { PaymentProviderCustomer } from './payment-provider-customer';
 
 export default interface PaymentProviderCustomerSelector {
-    getPaymentProviderCustomer<T>(): PaymentProviderCustomer<T> | undefined;
-    getPaymentProviderCustomerOrThrow<T>(): PaymentProviderCustomer<T>;
+    getPaymentProviderCustomer(): PaymentProviderCustomer | undefined;
+    getPaymentProviderCustomerOrThrow(): PaymentProviderCustomer;
 }
 
 export type PaymentProviderCustomerSelectorFactory = (

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-selector.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-selector.ts
@@ -1,0 +1,43 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { createSelector } from '../common/selector';
+import { guard } from '../common/utility';
+
+import PaymentProviderCustomerState, { DEFAULT_STATE } from './payment-provider-customer-state';
+import { PaymentProviderCustomer } from './payment-provider-customer';
+
+export default interface PaymentProviderCustomerSelector {
+    getPaymentProviderCustomer<T>(): PaymentProviderCustomer<T> | undefined;
+    getPaymentProviderCustomerOrThrow<T>(): PaymentProviderCustomer<T>;
+}
+
+export type PaymentProviderCustomerSelectorFactory = (
+    state: PaymentProviderCustomerState,
+) => PaymentProviderCustomerSelector;
+
+export function createPaymentProviderCustomerSelectorFactory(): PaymentProviderCustomerSelectorFactory {
+    const getPaymentProviderCustomer = createSelector(
+        (state: PaymentProviderCustomerState) => state.data,
+        (data) => () => data,
+    );
+
+    const getPaymentProviderCustomerOrThrow = createSelector(
+        getPaymentProviderCustomer,
+        (getPaymentProviderCustomer) => () => {
+            return guard(
+                getPaymentProviderCustomer(),
+                () => new MissingDataError(MissingDataErrorType.MissingPaymentProviderCustomer),
+            );
+        },
+    );
+
+    return memoizeOne(
+        (state: PaymentProviderCustomerState = DEFAULT_STATE): PaymentProviderCustomerSelector => {
+            return {
+                getPaymentProviderCustomer: getPaymentProviderCustomer(state),
+                getPaymentProviderCustomerOrThrow: getPaymentProviderCustomerOrThrow(state),
+            };
+        },
+    );
+}

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-state.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-state.ts
@@ -1,0 +1,9 @@
+import { PaymentProviderCustomer } from './payment-provider-customer';
+
+export default interface PaymentProviderCustomerState<T = any> {
+    data: PaymentProviderCustomer<T>;
+}
+
+export const DEFAULT_STATE = {
+    data: {},
+};

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-state.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-state.ts
@@ -1,7 +1,7 @@
 import { PaymentProviderCustomer } from './payment-provider-customer';
 
-export default interface PaymentProviderCustomerState<T = any> {
-    data: PaymentProviderCustomer<T>;
+export default interface PaymentProviderCustomerState {
+    data: PaymentProviderCustomer;
 }
 
 export const DEFAULT_STATE = {

--- a/packages/core/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,0 +1,1 @@
+export type PaymentProviderCustomer<T = {}> = T;

--- a/packages/core/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,1 +1,10 @@
-export type PaymentProviderCustomer<T = any> = T;
+import { AddressRequestBody } from '../address';
+import { CardInstrument } from '../payment/instrument/instrument';
+
+export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
+
+export interface BraintreeAcceleratedCheckoutCustomer {
+    authorizationStatus?: string;
+    addresses?: AddressRequestBody[];
+    instruments?: CardInstrument[];
+}

--- a/packages/core/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,1 +1,1 @@
-export type PaymentProviderCustomer<T = {}> = T;
+export type PaymentProviderCustomer<T = any> = T;

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -130,6 +130,7 @@ export {
 } from './payment';
 export { default as PaymentIntegrationSelectors } from './payment-integration-selectors';
 export { default as PaymentIntegrationService } from './payment-integration-service';
+export { PaymentProviderCustomer } from './payment-provider-customer';
 export {
     Consignment,
     ShippingAddress,

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -130,7 +130,10 @@ export {
 } from './payment';
 export { default as PaymentIntegrationSelectors } from './payment-integration-selectors';
 export { default as PaymentIntegrationService } from './payment-integration-service';
-export { PaymentProviderCustomer } from './payment-provider-customer';
+export {
+    BraintreeAcceleratedCheckoutCustomer,
+    PaymentProviderCustomer,
+} from './payment-provider-customer';
 export {
     Consignment,
     ShippingAddress,

--- a/packages/payment-integration-api/src/payment-integration-selectors.ts
+++ b/packages/payment-integration-api/src/payment-integration-selectors.ts
@@ -55,8 +55,8 @@ export default interface PaymentIntegrationSelectors {
     ): PaymentMethod<T> | undefined;
     getPaymentMethodOrThrow<T = unknown>(methodId: string, gatewayId?: string): PaymentMethod<T>;
 
-    getPaymentProviderCustomer<T>(): PaymentProviderCustomer<T> | undefined;
-    getPaymentProviderCustomerOrThrow<T>(): PaymentProviderCustomer<T>;
+    getPaymentProviderCustomer(): PaymentProviderCustomer | undefined;
+    getPaymentProviderCustomerOrThrow(): PaymentProviderCustomer;
 
     getShippingAddress(): ShippingAddress | undefined;
     getShippingAddressOrThrow(): ShippingAddress;

--- a/packages/payment-integration-api/src/payment-integration-selectors.ts
+++ b/packages/payment-integration-api/src/payment-integration-selectors.ts
@@ -4,6 +4,7 @@ import { Checkout } from './checkout';
 import { StoreConfig } from './config';
 import { Customer } from './customer';
 import { Order } from './order';
+import { PaymentProviderCustomer } from './payment-provider-customer';
 import { CardInstrument } from './payment/instrument';
 import PaymentMethod from './payment/payment-method';
 import { Consignment, ShippingAddress } from './shipping';
@@ -53,6 +54,9 @@ export default interface PaymentIntegrationSelectors {
         gatewayId?: string,
     ): PaymentMethod<T> | undefined;
     getPaymentMethodOrThrow<T = unknown>(methodId: string, gatewayId?: string): PaymentMethod<T>;
+
+    getPaymentProviderCustomer<T>(): PaymentProviderCustomer<T> | undefined;
+    getPaymentProviderCustomerOrThrow<T>(): PaymentProviderCustomer<T>;
 
     getShippingAddress(): ShippingAddress | undefined;
     getShippingAddressOrThrow(): ShippingAddress;

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -70,7 +70,7 @@ export default interface PaymentIntegrationService {
 
     createBuyNowCart(body: BuyNowCartRequestBody, options?: RequestOptions): Promise<Cart>;
 
-    updatePaymentProviderCustomer<T>(
-        paymentProviderCustomer: PaymentProviderCustomer<T>,
+    updatePaymentProviderCustomer(
+        paymentProviderCustomer: PaymentProviderCustomer,
     ): Promise<PaymentIntegrationSelectors>;
 }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -5,6 +5,7 @@ import { HostedForm, HostedFormOptions } from './hosted-form';
 import { OrderRequestBody } from './order';
 import { InitializeOffsitePaymentConfig, Payment } from './payment';
 import PaymentIntegrationSelectors from './payment-integration-selectors';
+import { PaymentProviderCustomer } from './payment-provider-customer';
 import { ShippingAddressRequestBody } from './shipping';
 import { RequestOptions } from './util-types';
 
@@ -68,4 +69,8 @@ export default interface PaymentIntegrationService {
     ): Promise<PaymentIntegrationSelectors>;
 
     createBuyNowCart(body: BuyNowCartRequestBody, options?: RequestOptions): Promise<Cart>;
+
+    updatePaymentProviderCustomer<T>(
+        paymentProviderCustomer: PaymentProviderCustomer<T>,
+    ): Promise<PaymentIntegrationSelectors>;
 }

--- a/packages/payment-integration-api/src/payment-provider-customer/index.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/index.ts
@@ -1,0 +1,1 @@
+export { PaymentProviderCustomer } from './payment-provider-customer';

--- a/packages/payment-integration-api/src/payment-provider-customer/index.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/index.ts
@@ -1,1 +1,4 @@
-export { PaymentProviderCustomer } from './payment-provider-customer';
+export {
+    BraintreeAcceleratedCheckoutCustomer,
+    PaymentProviderCustomer,
+} from './payment-provider-customer';

--- a/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,1 +1,10 @@
-export type PaymentProviderCustomer<T> = T;
+import { AddressRequestBody } from '../address';
+import { CardInstrument } from '../payment';
+
+export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
+
+export interface BraintreeAcceleratedCheckoutCustomer {
+    authorizationStatus?: string;
+    addresses?: AddressRequestBody[];
+    instruments?: CardInstrument[];
+}

--- a/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,0 +1,1 @@
+export type PaymentProviderCustomer<T> = T;

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -50,6 +50,7 @@ const signOutCustomer = jest.fn();
 const selectShippingOption = jest.fn();
 const applyStoreCredit = jest.fn();
 const verifyCheckoutSpamProtection = jest.fn();
+const updatePaymentProviderCustomer = jest.fn();
 
 const PaymentIntegrationServiceMock = jest
     .fn<PaymentIntegrationService>()
@@ -73,6 +74,7 @@ const PaymentIntegrationServiceMock = jest
             selectShippingOption,
             applyStoreCredit,
             verifyCheckoutSpamProtection,
+            updatePaymentProviderCustomer,
         };
     });
 


### PR DESCRIPTION
## What?
Added PaymentProviderCustomer state

## Why?
To be able to save provider specific data and use those data in separate strategies.

## Testing / Proof
Unit tests
Manual tests

// Info: the screenshots a bit out dated after the review, but it works almost the same (naming changed)
Here are some screenshots/proofs that it works (hardcoded only for example):
<img width="1512" alt="Screenshot 2023-07-24 at 11 51 26" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/db70e3f2-db33-44f5-a9a9-801155811568">
<img width="1512" alt="Screenshot 2023-07-24 at 11 51 44" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/0a82ed14-9e51-41e8-929e-b27b634f0f83">