### PR TITLE
feat(payment): PI-585 Make an ability to use loadCurrentOrder action from core package in integration checkout-sdk packages

### DIFF
--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -50,7 +50,10 @@ describe('DefaultPaymentIntegrationService', () => {
         CheckoutActionCreator,
         'loadCheckout' | 'loadCurrentCheckout' | 'loadDefaultCheckout'
     >;
-    let orderActionCreator: Pick<OrderActionCreator, 'submitOrder' | 'finalizeOrder'>;
+    let orderActionCreator: Pick<
+        OrderActionCreator,
+        'submitOrder' | 'finalizeOrder' | 'loadCurrentOrder'
+    >;
     let billingAddressActionCreator: Pick<BillingAddressActionCreator, 'updateAddress'>;
     let consignmentActionCreator: Pick<
         ConsignmentActionCreator,
@@ -109,6 +112,7 @@ describe('DefaultPaymentIntegrationService', () => {
         orderActionCreator = {
             submitOrder: jest.fn(async () => () => createAction('SUBMIT_ORDER')),
             finalizeOrder: jest.fn(async () => () => createAction('FINALIZE_ORDER')),
+            loadCurrentOrder: jest.fn(async () => () => createAction('LOAD_CURRENT_ORDER')),
         };
 
         billingAddressActionCreator = {
@@ -403,6 +407,16 @@ describe('DefaultPaymentIntegrationService', () => {
                     params: {},
                 }),
             );
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#loadCurrentOrder', () => {
+        it('loads current order', async () => {
+            const output = await subject.loadCurrentOrder();
+
+            expect(orderActionCreator.loadCurrentOrder).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(orderActionCreator.loadCurrentOrder());
             expect(output).toEqual(paymentIntegrationSelectors);
         });
     });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -207,4 +207,10 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
 
         return this._storeProjection.getState();
     }
+
+    async loadCurrentOrder(options?: RequestOptions): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(this._orderActionCreator.loadCurrentOrder(options));
+
+        return this._storeProjection.getState();
+    }
 }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -31,6 +31,8 @@ export default interface PaymentIntegrationService {
         options?: RequestOptions,
     ): Promise<PaymentIntegrationSelectors>;
 
+    loadCurrentOrder(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;
+
     submitOrder(
         payload?: OrderRequestBody,
         options?: RequestOptions,


### PR DESCRIPTION
## What?
Add loadCurrentOrder to PaymentIntegrationService

## Why?
To get ability to use `orderActionCreator.loadCurrentOrder` from PaymentIntegrationService

## Testing / Proof
![Zrzut ekranu 2023-07-24 o 16 00 43](https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/8cfd0bdb-8b2d-439b-9759-19b70d7bff94)


@bigcommerce/team-checkout @bigcommerce/team-payments
