### PR TITLE
feat(payment): PAYPAL-2727 added Braintree Accelerated Checkout customer strategy

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -1,0 +1,327 @@
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    CustomerInitializeOptions,
+    InvalidArgumentError,
+    MissingDataError,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getBillingAddress,
+    getCustomer,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import { BraintreeConnect } from '../braintree';
+import BraintreeIntegrationService from '../braintree-integration-service';
+import BraintreeScriptLoader from '../braintree-script-loader';
+import {
+    getBraintreeAcceleratedCheckoutPaymentMethod,
+    getBraintreeConnectProfileDataMock,
+    getConnectMock,
+} from '../mocks/braintree.mock';
+
+import BraintreeAcceleratedCheckoutCustomerStrategy from './braintree-accelerated-checkout-customer-strategy';
+
+describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
+    let braintreeConnectMock: BraintreeConnect;
+    let braintreeIntegrationService: BraintreeIntegrationService;
+    let braintreeScriptLoader: BraintreeScriptLoader;
+    let paymentIntegrationService: PaymentIntegrationService;
+    let strategy: BraintreeAcceleratedCheckoutCustomerStrategy;
+
+    const customer = getCustomer();
+    const billingAddress = getBillingAddress();
+    const methodId = 'braintreeacceleratedcheckout';
+    const paymentMethod = getBraintreeAcceleratedCheckoutPaymentMethod();
+
+    const initializationOptions = { methodId };
+    const executionOptions = {
+        methodId,
+        continueWithCheckoutCallback: jest.fn(),
+    };
+
+    beforeEach(() => {
+        braintreeConnectMock = getConnectMock();
+
+        braintreeScriptLoader = new BraintreeScriptLoader(getScriptLoader(), window);
+        braintreeIntegrationService = new BraintreeIntegrationService(
+            braintreeScriptLoader,
+            window,
+        );
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        strategy = new BraintreeAcceleratedCheckoutCustomerStrategy(
+            paymentIntegrationService,
+            braintreeIntegrationService,
+        );
+
+        jest.spyOn(paymentIntegrationService, 'loadPaymentMethod');
+        jest.spyOn(paymentIntegrationService, 'updatePaymentProviderCustomer').mockImplementation(
+            jest.fn,
+        );
+        jest.spyOn(paymentIntegrationService.getState(), 'getCustomer').mockReturnValue(customer);
+        jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue(
+            billingAddress,
+        );
+        jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethodOrThrow').mockReturnValue(
+            paymentMethod,
+        );
+
+        jest.spyOn(braintreeIntegrationService, 'initialize');
+        jest.spyOn(braintreeIntegrationService, 'getBraintreeConnect').mockImplementation(
+            () => braintreeConnectMock,
+        );
+
+        jest.spyOn(braintreeConnectMock.identity, 'lookupCustomerByEmail').mockReturnValue({
+            customerId: 'customerId',
+        });
+        jest.spyOn(braintreeConnectMock.identity, 'triggerAuthenticationFlow').mockReturnValue({
+            authenticationState: 'succeeded',
+            profileData: getBraintreeConnectProfileDataMock(),
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('#initialize()', () => {
+        it('throws an error if methodId is not provided', async () => {
+            try {
+                await strategy.initialize({} as CustomerInitializeOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if clientToken is not defined', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                clientToken: undefined,
+            });
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('throws an error if initializationData is not defined', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockReturnValue({
+                ...paymentMethod,
+                initializationData: undefined,
+            });
+
+            try {
+                await strategy.initialize(initializationOptions);
+            } catch (error) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('initializes braintree integration service and loads braintree connect', async () => {
+            await strategy.initialize(initializationOptions);
+
+            expect(braintreeIntegrationService.initialize).toHaveBeenCalledWith(
+                paymentMethod.clientToken,
+                paymentMethod.initializationData,
+            );
+            expect(braintreeIntegrationService.getBraintreeConnect).toHaveBeenCalled();
+        });
+    });
+
+    describe('#executePaymentMethodCheckout()', () => {
+        it('throws an error if methodId is not provided', async () => {
+            await strategy.initialize(initializationOptions);
+
+            try {
+                await strategy.executePaymentMethodCheckout();
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('throws an error if continueWithCheckoutCallback is not provided or it is not a function', async () => {
+            await strategy.initialize(initializationOptions);
+
+            try {
+                await strategy.executePaymentMethodCheckout({ methodId });
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
+        it('calls continueWithCheckoutCallback callback', async () => {
+            await strategy.initialize(initializationOptions);
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(executionOptions.continueWithCheckoutCallback).toHaveBeenCalled();
+        });
+    });
+
+    describe('#authenticatePayPalConnectUser()', () => {
+        it('does not authenticate user if braintree connect is not loaded', async () => {
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).not.toHaveBeenCalled();
+        });
+
+        it('does not authenticate user if email is not defined', async () => {
+            const customerWithoutEmail = { ...customer, email: undefined };
+            const billingWithoutEmail = { ...billingAddress, email: undefined };
+
+            jest.spyOn(paymentIntegrationService.getState(), 'getCustomer').mockReturnValue(
+                customerWithoutEmail,
+            );
+            jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue(
+                billingWithoutEmail,
+            );
+
+            await strategy.initialize(initializationOptions);
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).not.toHaveBeenCalled();
+        });
+
+        it('checks if there is PP Connect account with customer email', async () => {
+            jest.spyOn(braintreeConnectMock.identity, 'lookupCustomerByEmail').mockReturnValue({});
+
+            await strategy.initialize(initializationOptions);
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(braintreeConnectMock.identity.lookupCustomerByEmail).toHaveBeenCalled();
+        });
+
+        it('does not authenticate user does not have PP Connect account', async () => {
+            jest.spyOn(braintreeConnectMock.identity, 'lookupCustomerByEmail').mockReturnValue({});
+
+            await strategy.initialize(initializationOptions);
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).not.toHaveBeenCalled();
+        });
+
+        it('triggers PP Connect authentication flow if customer is detected as PP Connect user', async () => {
+            await strategy.initialize(initializationOptions);
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(braintreeConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalled();
+        });
+
+        it('successfully authenticate customer with PP Connect', async () => {
+            await strategy.initialize(initializationOptions);
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(braintreeConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith({
+                authorizationStatus: 'succeeded',
+                addresses: [
+                    {
+                        firstName: 'John',
+                        lastName: 'Doe',
+                        company: '',
+                        address1: 'Hello World Address',
+                        address2: '',
+                        city: 'Bellingham',
+                        stateOrProvince: 'WA',
+                        stateOrProvinceCode: 'WA',
+                        countryCode: 'US',
+                        postalCode: '98225',
+                        phone: '',
+                        customFields: [],
+                    },
+                ],
+                instruments: [
+                    {
+                        bigpayToken: 'pp-vaulted-instrument-id',
+                        brand: 'VISA',
+                        defaultInstrument: false,
+                        expiryMonth: undefined,
+                        expiryYear: '02/2037',
+                        iin: '',
+                        last4: '1111',
+                        method: 'braintreeacceleratedcheckout',
+                        provider: 'braintreeacceleratedcheckout',
+                        trustedShippingAddress: false,
+                        type: 'card',
+                    },
+                ],
+            });
+        });
+
+        it('does not authenticate customer if the authentication was canceled or failed', async () => {
+            jest.spyOn(braintreeConnectMock.identity, 'triggerAuthenticationFlow').mockReturnValue({
+                authenticationState: 'canceled',
+                profileData: {},
+            });
+
+            await strategy.initialize(initializationOptions);
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(braintreeConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith({
+                authorizationStatus: 'canceled',
+                addresses: [],
+                instruments: [],
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('teardowns braintree sdk creator on strategy deinitialize', async () => {
+            braintreeIntegrationService.teardown = jest.fn();
+
+            await strategy.initialize(initializationOptions);
+            await strategy.deinitialize();
+
+            expect(braintreeIntegrationService.teardown).toHaveBeenCalled();
+        });
+    });
+
+    describe('#signIn()', () => {
+        it('calls default sign in method', async () => {
+            const credentials = {
+                email: 'test@test.com',
+                password: '123',
+            };
+
+            await strategy.initialize(initializationOptions);
+            await strategy.signIn(credentials);
+
+            expect(paymentIntegrationService.signInCustomer).toHaveBeenCalledWith(
+                credentials,
+                undefined,
+            );
+        });
+
+        it('authenticates the user with PayPal Connect after sign in', async () => {
+            const credentials = {
+                email: 'test@test.com',
+                password: '123',
+            };
+
+            await strategy.initialize(initializationOptions);
+            await strategy.signIn(credentials);
+
+            expect(braintreeConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalled();
+        });
+    });
+
+    describe('#signOut()', () => {
+        it('calls default sign out method', async () => {
+            await strategy.signOut();
+
+            expect(paymentIntegrationService.signOutCustomer).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -223,7 +223,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
 
             expect(braintreeConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
             expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith({
-                authorizationStatus: 'succeeded',
+                authenticationState: 'succeeded',
                 addresses: [
                     {
                         firstName: 'John',
@@ -269,7 +269,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
 
             expect(braintreeConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
             expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith({
-                authorizationStatus: 'canceled',
+                authenticationState: 'canceled',
                 addresses: [],
                 instruments: [],
             });

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
@@ -15,6 +15,7 @@ import {
 import {
     BraintreeConnect,
     BraintreeConnectAddress,
+    BraintreeConnectAuthenticationState,
     BraintreeConnectVaultedInstrument,
     BraintreeInitializationData,
 } from '../braintree';
@@ -103,20 +104,20 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
 
         const { authenticationState, profileData } = await triggerAuthenticationFlow(customerId);
 
-        if (authenticationState === 'succeeded') {
+        if (authenticationState === BraintreeConnectAuthenticationState.SUCCEEDED) {
             const addresses = profileData.addresses.map(this.mapPayPalConnectToBcAddress);
             const instruments = profileData.cards.map((instrument) =>
                 this.mapPayPalConnectToBcInstrument(instrument, methodId),
             );
 
             await this.paymentIntegrationService.updatePaymentProviderCustomer({
-                authenticationState: 'succeeded',
+                authenticationState: BraintreeConnectAuthenticationState.SUCCEEDED,
                 addresses,
                 instruments,
             });
         } else {
             await this.paymentIntegrationService.updatePaymentProviderCustomer({
-                authenticationState: 'canceled',
+                authenticationState: BraintreeConnectAuthenticationState.CANCELED,
                 addresses: [],
                 instruments: [],
             });

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
@@ -110,13 +110,13 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
             );
 
             await this.paymentIntegrationService.updatePaymentProviderCustomer({
-                authorizationStatus: 'succeeded',
+                authenticationState: 'succeeded',
                 addresses,
                 instruments,
             });
         } else {
             await this.paymentIntegrationService.updatePaymentProviderCustomer({
-                authorizationStatus: 'canceled',
+                authenticationState: 'canceled',
                 addresses: [],
                 instruments: [],
             });

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
@@ -1,0 +1,190 @@
+import {
+    AddressRequestBody,
+    CardInstrument,
+    CustomerCredentials,
+    CustomerInitializeOptions,
+    CustomerStrategy,
+    ExecutePaymentMethodCheckoutOptions,
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+    PaymentIntegrationService,
+    RequestOptions,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    BraintreeConnect,
+    BraintreeConnectAddress,
+    BraintreeConnectVaultedInstrument,
+    BraintreeInitializationData,
+} from '../braintree';
+import BraintreeIntegrationService from '../braintree-integration-service';
+
+export default class BraintreeAcceleratedCheckoutCustomerStrategy implements CustomerStrategy {
+    private braintreeConnect?: BraintreeConnect;
+    private methodId?: string;
+
+    constructor(
+        private paymentIntegrationService: PaymentIntegrationService,
+        private braintreeIntegrationService: BraintreeIntegrationService,
+    ) {}
+
+    async initialize(options: CustomerInitializeOptions): Promise<void> {
+        const methodId = this.setMethodIdOrThrow(options.methodId);
+
+        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+
+        const state = this.paymentIntegrationService.getState();
+        const { clientToken, initializationData } =
+            state.getPaymentMethodOrThrow<BraintreeInitializationData>(methodId);
+
+        if (!clientToken || !initializationData) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        this.braintreeIntegrationService.initialize(clientToken, initializationData);
+        this.braintreeConnect = await this.braintreeIntegrationService.getBraintreeConnect();
+    }
+
+    async deinitialize(): Promise<void> {
+        await this.braintreeIntegrationService.teardown();
+    }
+
+    async signIn(credentials: CustomerCredentials, options?: RequestOptions): Promise<void> {
+        await this.paymentIntegrationService.signInCustomer(credentials, options);
+
+        await this.authenticatePayPalConnectUserOrThrow(credentials.email);
+    }
+
+    async signOut(options?: RequestOptions): Promise<void> {
+        await this.paymentIntegrationService.signOutCustomer(options);
+    }
+
+    async executePaymentMethodCheckout(
+        options?: ExecutePaymentMethodCheckoutOptions,
+    ): Promise<void> {
+        const { continueWithCheckoutCallback } = options || {};
+
+        if (typeof continueWithCheckoutCallback !== 'function') {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "continueWithCheckoutCallback" argument is not provided and it must be a function.',
+            );
+        }
+
+        await this.authenticatePayPalConnectUserOrThrow();
+
+        continueWithCheckoutCallback();
+    }
+
+    private async authenticatePayPalConnectUserOrThrow(email?: string): Promise<void> {
+        try {
+            await this.authenticatePayPalConnectUser(email);
+        } catch (error) {
+            // TODO: we should figure out what to do here
+            // TODO: because we should not to stop the flow if the error occurs on paypal side
+        }
+    }
+
+    private async authenticatePayPalConnectUser(email?: string): Promise<void> {
+        const methodId = this.getMethodIdOrThrow();
+
+        const customerEmail = email || this.getEmail();
+
+        if (!this.braintreeConnect || !customerEmail) {
+            return;
+        }
+
+        const { lookupCustomerByEmail, triggerAuthenticationFlow } = this.braintreeConnect.identity;
+        const { customerId } = await lookupCustomerByEmail(customerEmail);
+
+        if (!customerId) {
+            return;
+        }
+
+        const { authenticationState, profileData } = await triggerAuthenticationFlow(customerId);
+
+        if (authenticationState === 'succeeded') {
+            const addresses = profileData.addresses.map(this.mapPayPalConnectToBcAddress);
+            const instruments = profileData.cards.map((instrument) =>
+                this.mapPayPalConnectToBcInstrument(instrument, methodId),
+            );
+
+            await this.paymentIntegrationService.updatePaymentProviderCustomer({
+                authorizationStatus: 'succeeded',
+                addresses,
+                instruments,
+            });
+        } else {
+            await this.paymentIntegrationService.updatePaymentProviderCustomer({
+                authorizationStatus: 'canceled',
+                addresses: [],
+                instruments: [],
+            });
+        }
+    }
+
+    private getEmail(): string {
+        const state = this.paymentIntegrationService.getState();
+        const customer = state.getCustomer();
+        const billingAddress = state.getBillingAddress();
+
+        return customer?.email || billingAddress?.email || '';
+    }
+
+    private getMethodIdOrThrow(): string {
+        if (!this.methodId) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "methodId" argument is not provided.',
+            );
+        }
+
+        return this.methodId;
+    }
+
+    private setMethodIdOrThrow(methodId?: string): string {
+        this.methodId = methodId;
+
+        return this.getMethodIdOrThrow();
+    }
+
+    private mapPayPalConnectToBcAddress(address: BraintreeConnectAddress): AddressRequestBody {
+        return {
+            firstName: address.firstName || '',
+            lastName: address.lastName || '',
+            company: address.company || '',
+            address1: address.streetAddress,
+            address2: address.extendedAddress || '',
+            city: address.locality,
+            stateOrProvince: address.region,
+            stateOrProvinceCode: address.region,
+            countryCode: address.countryCodeAlpha2,
+            postalCode: address.postalCode,
+            phone: '',
+            customFields: [],
+        };
+    }
+
+    private mapPayPalConnectToBcInstrument(
+        instrument: BraintreeConnectVaultedInstrument,
+        methodId: string,
+    ): CardInstrument {
+        const { id, paymentSource } = instrument;
+        const { brand, expiry, lastDigits } = paymentSource.card;
+
+        const [expiryYear, expiryMonth] = expiry.split('-');
+
+        return {
+            bigpayToken: id,
+            brand,
+            defaultInstrument: false,
+            expiryMonth,
+            expiryYear,
+            iin: '',
+            last4: lastDigits,
+            method: methodId,
+            provider: methodId,
+            trustedShippingAddress: false,
+            type: 'card',
+        };
+    }
+}

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
@@ -17,7 +17,10 @@ import {
 import { BraintreeConnect } from '../braintree';
 import BraintreeIntegrationService from '../braintree-integration-service';
 import BraintreeScriptLoader from '../braintree-script-loader';
-import { getBraintreeAcceleratedCheckoutPaymentMethod, getConnectMock } from '../braintree.mock';
+import {
+    getBraintreeAcceleratedCheckoutPaymentMethod,
+    getConnectMock,
+} from '../mocks/braintree.mock';
 
 import BraintreeAcceleratedCheckoutPaymentStrategy from './braintree-accelerated-checkout-payment-strategy';
 

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BraintreeAcceleratedCheckoutCustomerStrategy from './braintree-accelerated-checkout-customer-strategy';
+import createBraintreeAcceleratedCheckoutCustomerStrategy from './create-braintree-accelerated-checkout-customer-strategy';
+
+describe('createBraintreeAcceleratedCheckoutCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates braintree accelerated checkout customer strategy', () => {
+        const strategy =
+            createBraintreeAcceleratedCheckoutCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(BraintreeAcceleratedCheckoutCustomerStrategy);
+    });
+});

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
@@ -1,0 +1,31 @@
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import { BraintreeHostWindow } from '../braintree';
+import BraintreeIntegrationService from '../braintree-integration-service';
+import BraintreeScriptLoader from '../braintree-script-loader';
+
+import BraintreeAcceleratedCheckoutCustomerStrategy from './braintree-accelerated-checkout-customer-strategy';
+
+const createBraintreeAcceleratedCheckoutCustomerStrategy: CustomerStrategyFactory<
+    BraintreeAcceleratedCheckoutCustomerStrategy
+> = (paymentIntegrationService) => {
+    const braintreeHostWindow: BraintreeHostWindow = window;
+    const braintreeIntegrationService = new BraintreeIntegrationService(
+        new BraintreeScriptLoader(getScriptLoader(), braintreeHostWindow),
+        braintreeHostWindow,
+    );
+
+    return new BraintreeAcceleratedCheckoutCustomerStrategy(
+        paymentIntegrationService,
+        braintreeIntegrationService,
+    );
+};
+
+export default toResolvableModule(createBraintreeAcceleratedCheckoutCustomerStrategy, [
+    { id: 'braintreeacceleratedcheckout' },
+]);

--- a/packages/braintree-integration/src/braintree-integration-service.spec.ts
+++ b/packages/braintree-integration/src/braintree-integration-service.spec.ts
@@ -22,7 +22,7 @@ import {
     getModuleCreatorMock,
     getPayPalCheckoutCreatorMock,
     getPaypalCheckoutMock,
-} from './braintree.mock';
+} from './mocks/braintree.mock';
 import { PaypalSDK } from './paypal';
 
 describe('BraintreeIntegrationService', () => {

--- a/packages/braintree-integration/src/braintree-integration-service.ts
+++ b/packages/braintree-integration/src/braintree-integration-service.ts
@@ -8,7 +8,6 @@ import {
 import {
     BraintreeBankAccount,
     BraintreeClient,
-    BraintreeConnect,
     BraintreeDataCollector,
     BraintreeDetails,
     BraintreeEnv,
@@ -39,7 +38,6 @@ export default class BraintreeIntegrationService {
     private paypalCheckout?: BraintreePaypalCheckout;
     private usBankAccount?: Promise<BraintreeBankAccount>;
     private braintreeLocalMethods?: BraintreeLocalMethods;
-    private braintreeConnect?: BraintreeConnect;
 
     constructor(
         private braintreeScriptLoader: BraintreeScriptLoader,
@@ -55,21 +53,21 @@ export default class BraintreeIntegrationService {
         // TODO: should be removed after PayPal prepare stable Braintree SDK version with AXO implementation
         window.localStorage.setItem('axoEnv', 'test67');
 
-        if (!this.braintreeConnect) {
+        if (!this.braintreeHostWindow.braintreeConnect) {
             const clientToken = this.getClientTokenOrThrow();
             const client = await this.getClient();
             const deviceData = await this.getSessionId();
 
             const braintreeConnectCreator = await this.braintreeScriptLoader.loadConnect();
 
-            this.braintreeConnect = await braintreeConnectCreator.create({
+            this.braintreeHostWindow.braintreeConnect = await braintreeConnectCreator.create({
                 authorization: clientToken,
                 client,
                 deviceData,
             });
         }
 
-        return this.braintreeConnect;
+        return this.braintreeHostWindow.braintreeConnect;
     }
 
     async getClient(): Promise<BraintreeClient> {

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
@@ -20,7 +20,7 @@ import BraintreeScriptLoader from '../braintree-script-loader';
 import {
     getBraintreeLocalMethods,
     getBraintreeLocalMethodsInitializationOptions,
-} from '../braintree.mock';
+} from '../mocks/braintree.mock';
 
 import { LocalPaymentInstance } from './braintree-local-methods-options';
 import BraintreeLocalMethodsPaymentStrategy from './braintree-local-methods-payment-strategy';

--- a/packages/braintree-integration/src/braintree-paypal-ach/braintree-paypal-ach-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal-ach/braintree-paypal-ach-payment-strategy.spec.ts
@@ -19,7 +19,7 @@ import {
 import { BraintreeBankAccount } from '../braintree';
 import BraintreeIntegrationService from '../braintree-integration-service';
 import BraintreeScriptLoader from '../braintree-script-loader';
-import { getBankAccountMock, getBraintreeAch } from '../braintree.mock';
+import { getBankAccountMock, getBraintreeAch } from '../mocks/braintree.mock';
 
 import { WithBraintreePaypalAchPaymentInitializeOptions } from './braintree-paypal-ach-initialize-options';
 import BraintreePaypalAchPaymentStrategy from './braintree-paypal-ach-payment-strategy';

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
@@ -25,9 +25,9 @@ import {
     getDataCollectorMock,
     getPayPalCheckoutCreatorMock,
     getPaypalCheckoutMock,
-} from '../braintree.mock';
+} from '../mocks/braintree.mock';
+import { getPaypalSDKMock } from '../mocks/paypal.mock';
 import { PaypalButtonOptions, PaypalSDK } from '../paypal';
-import { getPaypalSDKMock } from '../paypal.mock';
 
 import BraintreePaypalCustomerInitializeOptions from './braintree-paypal-customer-options';
 import BraintreePaypalCustomerStrategy from './braintree-paypal-customer-strategy';

--- a/packages/braintree-integration/src/braintree-script-loader.spec.ts
+++ b/packages/braintree-integration/src/braintree-script-loader.spec.ts
@@ -19,7 +19,7 @@ import {
     getDataCollectorMock,
     getModuleCreatorMock,
     getPaypalCheckoutMock,
-} from './braintree.mock';
+} from './mocks/braintree.mock';
 
 const VERSION = '3.95.0';
 const ALPHA_VERSION = '3.95.0-connect-alpha.11';

--- a/packages/braintree-integration/src/braintree.ts
+++ b/packages/braintree-integration/src/braintree.ts
@@ -588,7 +588,7 @@ interface BraintreeConnectStylesOption {
 
 export interface BraintreeConnectAuthenticationCustomerResult {
     authenticationState: string; // 'succeeded'|'failed'|'canceled'
-    profileData?: BraintreeConnectProfileData;
+    profileData: BraintreeConnectProfileData;
 }
 
 export interface BraintreeConnectProfileData {
@@ -613,12 +613,10 @@ export interface BraintreeConnectAddress {
 }
 
 export interface BraintreeConnectCardPaymentSource {
-    // type: 'card'; // removed on PP side
     brand: string;
-    expiry: string; // "YYYY-MM"
-    lastDigits: string; // "1111"
+    expiry: string;
+    lastDigits: string;
     name?: string;
-    // isPreferred: boolean; // removed on PP side
     billingAddress: BraintreeConnectAddress;
 }
 
@@ -689,4 +687,5 @@ export interface BraintreeConnectCardComponent {
 export interface BraintreeHostWindow extends Window {
     braintree?: BraintreeSDK;
     paypal?: PaypalSDK;
+    braintreeConnect?: BraintreeConnect;
 }

--- a/packages/braintree-integration/src/braintree.ts
+++ b/packages/braintree-integration/src/braintree.ts
@@ -586,8 +586,14 @@ interface BraintreeConnectStylesOption {
     branding: 'light' | 'dark'; // default: 'light',
 }
 
+export enum BraintreeConnectAuthenticationState {
+    SUCCEEDED = 'succeeded',
+    FAILED = 'failed',
+    CANCELED = 'canceled',
+}
+
 export interface BraintreeConnectAuthenticationCustomerResult {
-    authenticationState: string; // 'succeeded'|'failed'|'canceled'
+    authenticationState: BraintreeConnectAuthenticationState;
     profileData: BraintreeConnectProfileData;
 }
 

--- a/packages/braintree-integration/src/index.ts
+++ b/packages/braintree-integration/src/index.ts
@@ -19,5 +19,6 @@ export { WithBraintreeLocalMethodsPaymentInitializeOptions } from './braintree-l
 /**
  * Braintree AXO strategies
  */
+export { default as createBraintreeAcceleratedCheckoutCustomerStrategy } from './braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy';
 export { default as createBraintreeAcceleratedCheckoutPaymentStrategy } from './braintree-accelerated-checkout/create-braintree-accelerated-checkout-payment-strategy';
 export { WithBraintreeAcceleratedCheckoutPaymentInitializeOptions } from './braintree-accelerated-checkout/braintree-accelerated-checkout-payment-initialize-options';

--- a/packages/braintree-integration/src/mocks/braintree.mock.ts
+++ b/packages/braintree-integration/src/mocks/braintree.mock.ts
@@ -13,7 +13,7 @@ import {
     BraintreePaypalCheckoutCreator,
     BraintreeShippingAddressOverride,
     BraintreeTokenizePayload,
-} from './braintree';
+} from '../braintree';
 
 export function getClientMock(): BraintreeClient {
     return {
@@ -81,9 +81,6 @@ export function getConnectMock(): BraintreeConnect {
         },
         ConnectCardComponent: jest.fn(),
     };
-
-    connectMock.ConnectCardComponent.tokenize = jest.fn();
-    connectMock.ConnectCardComponent.render = jest.fn();
 
     return connectMock;
 }

--- a/packages/braintree-integration/src/mocks/paypal.mock.ts
+++ b/packages/braintree-integration/src/mocks/paypal.mock.ts
@@ -1,4 +1,4 @@
-import { PaypalSDK } from './paypal';
+import { PaypalSDK } from '../paypal';
 
 export function getPaypalSDKMock(): PaypalSDK {
     return {


### PR DESCRIPTION
## What?
Added Braintree Accelerated Checkout customer strategy

## Why?
To authenticate user with PayPal Connect after user clicks on "Continue" (as Guest) or after login

## Testing / Proof
Unit tests
CI tests
Manual tests

<img width="881" alt="Screenshot 2023-07-31 at 17 05 17" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/c86f2127-c032-41ca-8de4-c95f7cbc9146">
