### PR TITLE
refactor(checkout): CHECKOUT-7634 Improvements for extension

### DIFF
--- a/packages/core/src/checkout/checkout-service.spec.ts
+++ b/packages/core/src/checkout/checkout-service.spec.ts
@@ -1502,8 +1502,8 @@ describe('CheckoutService', () => {
         });
     });
 
-    describe('#listenExtensionCommand()', () => {
-        it('listens for extension commands', () => {
+    describe('#handleExtensionCommand()', () => {
+        it('handles extension commands', () => {
             const extensions = getExtensions();
             const handler = jest.fn();
 

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -22,8 +22,7 @@ import {
 } from '../customer';
 import {
     ExtensionActionCreator,
-    ExtensionCommandHandler,
-    ExtensionCommandType,
+    ExtensionCommandMap,
     ExtensionMessenger,
     ExtensionRegion,
 } from '../extension';
@@ -1415,10 +1414,10 @@ export default class CheckoutService {
      * @param handler - The handler function for the extension command.
      * @returns A function that, when called, will deregister the command handler.
      */
-    handleExtensionCommand(
+    handleExtensionCommand<T extends keyof ExtensionCommandMap>(
         extensionId: string,
-        command: ExtensionCommandType,
-        handler: ExtensionCommandHandler,
+        command: T,
+        handler: (command: ExtensionCommandMap[T]) => void,
     ): () => void {
         return this._extensionMessenger.listen(extensionId, command, handler);
     }

--- a/packages/core/src/checkout/checkout-store-selector.spec.ts
+++ b/packages/core/src/checkout/checkout-store-selector.spec.ts
@@ -15,6 +15,7 @@ import CheckoutStoreState from './checkout-store-state';
 import { getCheckoutStoreStateWithOrder } from './checkouts.mock';
 import createInternalCheckoutSelectors from './create-internal-checkout-selectors';
 import InternalCheckoutSelectors from './internal-checkout-selectors';
+import { ExtensionRegion } from '../extension';
 
 describe('CheckoutStoreSelector', () => {
     let createCheckoutStoreSelector: CheckoutStoreSelectorFactory;
@@ -294,6 +295,16 @@ describe('CheckoutStoreSelector', () => {
     it('returns payment provider customer data', () => {
         expect(selector.getPaymentProviderCustomer()).toEqual(
             internalSelectors.paymentProviderCustomer.getPaymentProviderCustomer(),
+        );
+    });
+
+    it('returns the extension of a given region', () => {
+        expect(
+            selector.getExtensionByRegion(ExtensionRegion.ShippingShippingAddressFormBefore),
+        ).toEqual(
+            internalSelectors.extensions.getExtensionByRegion(
+                ExtensionRegion.ShippingShippingAddressFormBefore,
+            ),
         );
     });
 });

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -9,7 +9,7 @@ import { cloneResult as clone } from '../common/utility';
 import { FlashMessage, FlashMessageType, StoreConfig, UserExperienceSettings } from '../config';
 import { Coupon, GiftCertificate } from '../coupon';
 import { Customer } from '../customer';
-import { Extension } from '../extension';
+import { Extension, ExtensionRegion } from '../extension';
 import { FormField } from '../form';
 import { Country } from '../geography';
 import { Order } from '../order';
@@ -293,6 +293,15 @@ export default interface CheckoutStoreSelector {
      * @returns The object with payment provider customer data
      */
     getPaymentProviderCustomer(): PaymentProviderCustomer | undefined;
+
+    /**
+     * Gets the extension associated with a given region.
+     *
+     * @alpha
+     * @param region - A checkout extension region.
+     * @returns The extension corresponding to the specified region, otherwise undefined.
+     */
+    getExtensionByRegion(region: ExtensionRegion): Extension | undefined;
 }
 
 export type CheckoutStoreSelectorFactory = (
@@ -573,12 +582,18 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getPaymentProviderCustomer) => clone(getPaymentProviderCustomer),
     );
 
+    const getExtensionByRegion = createSelector(
+        ({ extensions }: InternalCheckoutSelectors) => extensions.getExtensionByRegion,
+        (getExtensionByRegion) => clone(getExtensionByRegion),
+    );
+
     return memoizeOne((state: InternalCheckoutSelectors): CheckoutStoreSelector => {
         return {
             getCheckout: getCheckout(state),
             getOrder: getOrder(state),
             getConfig: getConfig(state),
             getExtensions: getExtensions(state),
+            getExtensionByRegion: getExtensionByRegion(state),
             getFlashMessages: getFlashMessages(state),
             getShippingAddress: getShippingAddress(state),
             getShippingOptions: getShippingOptions(state),

--- a/packages/core/src/extension/extension-action-creator.spec.ts
+++ b/packages/core/src/extension/extension-action-creator.spec.ts
@@ -3,7 +3,8 @@ import { EventEmitter } from 'events';
 import { from, of } from 'rxjs';
 import { catchError, toArray } from 'rxjs/operators';
 
-import { ErrorResponseBody } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { ErrorResponseBody, StoreConfig } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { getConfig } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import { CheckoutStore, createCheckoutStore } from '../checkout';
 import { getCheckout, getCheckoutStoreState } from '../checkout/checkouts.mock';
@@ -15,7 +16,7 @@ import { Extension, ExtensionRegion } from './extension';
 import { ExtensionActionCreator } from './extension-action-creator';
 import { ExtensionActionType } from './extension-actions';
 import { ExtensionRequestSender } from './extension-request-sender';
-import { getExtensionCommand, getExtensions, getExtensionState } from './extension.mock';
+import { getExtensionCommand, getExtensions } from './extension.mock';
 
 describe('ExtensionActionCreator', () => {
     let errorResponse: Response<ErrorResponseBody>;
@@ -23,15 +24,22 @@ describe('ExtensionActionCreator', () => {
     let extensionRequestSender: ExtensionRequestSender;
     let extensionsResponse: Response<Extension[]>;
     let store: CheckoutStore;
+    let storeConfig: StoreConfig;
 
     beforeEach(() => {
         errorResponse = getErrorResponse();
         extensionsResponse = getResponse(getExtensions());
         store = createCheckoutStore(getCheckoutStoreState());
+        storeConfig = getConfig().storeConfig;
+
+        storeConfig.checkoutSettings.features = {
+            'PROJECT-5029.checkout_extension': true,
+        };
 
         extensionRequestSender = new ExtensionRequestSender(createRequestSender());
         extensionActionCreator = new ExtensionActionCreator(extensionRequestSender);
 
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(storeConfig);
         jest.spyOn(extensionRequestSender, 'loadExtensions').mockReturnValue(
             Promise.resolve(extensionsResponse),
         );
@@ -84,13 +92,9 @@ describe('ExtensionActionCreator', () => {
 
     describe('#renderExtension()', () => {
         it('throws error if unable to find an extension', async () => {
-            store = createCheckoutStore({
-                ...getCheckoutStoreState(),
-                extensions: {
-                    ...getExtensionState(),
-                    data: getExtensions().slice(0, 1),
-                },
-            });
+            jest.spyOn(store.getState().extensions, 'getExtensionByRegion').mockReturnValue(
+                undefined,
+            );
 
             const errorHandler = jest.fn((action) => of(action));
 

--- a/packages/core/src/extension/extension-action-creator.spec.ts
+++ b/packages/core/src/extension/extension-action-creator.spec.ts
@@ -166,5 +166,23 @@ describe('ExtensionActionCreator', () => {
                 },
             ]);
         });
+
+        it('does nothing if the experiment is off', async () => {
+            storeConfig.checkoutSettings.features = {};
+            jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(
+                storeConfig,
+            );
+
+            const actions = await from(
+                extensionActionCreator.renderExtension(
+                    'foo',
+                    ExtensionRegion.ShippingShippingAddressFormBefore,
+                )(store),
+            )
+                .pipe(toArray())
+                .toPromise();
+
+            expect(actions).toEqual([]);
+        });
     });
 });

--- a/packages/core/src/extension/extension-action-creator.ts
+++ b/packages/core/src/extension/extension-action-creator.ts
@@ -49,7 +49,13 @@ export class ExtensionActionCreator {
                 const { id: cartId } = state.cart.getCartOrThrow();
                 const {
                     links: { checkoutLink },
+                    checkoutSettings: { features },
                 } = state.config.getStoreConfigOrThrow();
+
+                if (!features['PROJECT-5029.checkout_extension']) {
+                    return observer.complete();
+                }
+
                 const extension = state.extensions.getExtensionByRegion(region);
 
                 try {

--- a/packages/core/src/extension/extension-command-handler.ts
+++ b/packages/core/src/extension/extension-command-handler.ts
@@ -1,3 +1,0 @@
-import { ExtensionCommand } from './extension-command';
-
-export type ExtensionCommandHandler = (data: ExtensionCommand) => void;

--- a/packages/core/src/extension/extension-messenger.spec.ts
+++ b/packages/core/src/extension/extension-messenger.spec.ts
@@ -7,13 +7,13 @@ import { UnsupportedExtensionCommandError } from './errors/unsupported-extension
 import { Extension } from './extension';
 import { ExtensionEvent } from './extension-client';
 import { ExtensionCommandMap, ExtensionCommandType } from './extension-command';
-import { ExtensionCommandHandler } from './extension-command-handler';
 import { ExtensionMessenger } from './extension-messenger';
 import { getExtensionEvent, getExtensions } from './extension.mock';
 
 describe('ExtensionMessenger', () => {
+    const extensionCommandHandler = jest.fn();
+
     let extension: Extension;
-    let extensionCommandHandler: ExtensionCommandHandler;
     let extensionMessenger: ExtensionMessenger;
     let event: {
         origin: string;
@@ -25,8 +25,6 @@ describe('ExtensionMessenger', () => {
         store = createCheckoutStore(getCheckoutStoreState());
         extension = getExtensions()[0];
         event = getExtensionEvent();
-
-        extensionCommandHandler = jest.fn();
     });
 
     describe('#listen() and #stopListen()', () => {

--- a/packages/core/src/extension/extension-messenger.ts
+++ b/packages/core/src/extension/extension-messenger.ts
@@ -93,18 +93,21 @@ export class ExtensionMessenger {
     }
 
     private _validateCommand<T extends keyof ExtensionCommandMap>(command: string): T {
-        switch (command) {
-            case 'RELOAD_CHECKOUT':
-                return ExtensionCommandType.ReloadCheckout as T;
-
-            case 'SHOW_LOADING_INDICATOR':
-                return ExtensionCommandType.ShowLoadingIndicator as T;
-
-            case 'SET_IFRAME_STYLE':
-                return ExtensionCommandType.SetIframeStyle as T;
-
-            default:
-                throw new UnsupportedExtensionCommandError();
+        if (this._isExtensionCommandType<T>(command)) {
+            return command;
         }
+
+        throw new UnsupportedExtensionCommandError();
+    }
+
+    private _isExtensionCommandType<T extends keyof ExtensionCommandMap>(
+        command: string,
+    ): command is T {
+        return (
+            command === ExtensionCommandType.FrameLoaded ||
+            command === ExtensionCommandType.ReloadCheckout ||
+            command === ExtensionCommandType.ShowLoadingIndicator ||
+            command === ExtensionCommandType.SetIframeStyle
+        );
     }
 }

--- a/packages/core/src/extension/extension-messenger.ts
+++ b/packages/core/src/extension/extension-messenger.ts
@@ -6,7 +6,6 @@ import { UnsupportedExtensionCommandError } from './errors/unsupported-extension
 import { Extension } from './extension';
 import { ExtensionEvent } from './extension-client';
 import { ExtensionCommandMap, ExtensionCommandType } from './extension-command';
-import { ExtensionCommandHandler } from './extension-command-handler';
 
 export class ExtensionMessenger {
     private _extensions: Extension[] | undefined;
@@ -17,10 +16,10 @@ export class ExtensionMessenger {
         private _posters: { [extensionId: string]: IframeEventPoster<ExtensionEvent> },
     ) {}
 
-    listen(
+    listen<T extends keyof ExtensionCommandMap>(
         extensionId: string,
-        command: ExtensionCommandType,
-        extensionCommandHandler: ExtensionCommandHandler,
+        command: T,
+        extensionCommandHandler: (command: ExtensionCommandMap[T]) => void,
     ): () => void {
         const extension = this._getExtensionById(extensionId);
 
@@ -32,7 +31,7 @@ export class ExtensionMessenger {
 
         listener.listen();
 
-        const validCommandType = this._validateCommand(command);
+        const validCommandType = this._validateCommand<T>(command);
 
         listener.addListener(validCommandType, extensionCommandHandler);
 
@@ -93,16 +92,16 @@ export class ExtensionMessenger {
         return extension;
     }
 
-    private _validateCommand(command: string): ExtensionCommandType {
+    private _validateCommand<T extends keyof ExtensionCommandMap>(command: string): T {
         switch (command) {
             case 'RELOAD_CHECKOUT':
-                return ExtensionCommandType.ReloadCheckout;
+                return ExtensionCommandType.ReloadCheckout as T;
 
             case 'SHOW_LOADING_INDICATOR':
-                return ExtensionCommandType.ShowLoadingIndicator;
+                return ExtensionCommandType.ShowLoadingIndicator as T;
 
             case 'SET_IFRAME_STYLE':
-                return ExtensionCommandType.SetIframeStyle;
+                return ExtensionCommandType.SetIframeStyle as T;
 
             default:
                 throw new UnsupportedExtensionCommandError();

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -2,10 +2,9 @@ export { ExtensionRegion, Extension } from './extension';
 export { getExtensions } from './extension.mock';
 export { ExtensionActionType } from './extension-actions';
 export { ExtensionActionCreator } from './extension-action-creator';
-export { ExtensionCommandHandler } from './extension-command-handler';
 export { ExtensionIframe } from './extension-iframe';
 export { ExtensionMessenger } from './extension-messenger';
-export { ExtensionCommandType, ExtensionCommand } from './extension-command';
+export { ExtensionCommand, ExtensionCommandType, ExtensionCommandMap } from './extension-command';
 export { extensionReducer } from './extension-reducer';
 export { ExtensionRequestSender } from './extension-request-sender';
 export {


### PR DESCRIPTION
## What?

- Task 1: Make `getExtensionByRegion` a public selector to enable `checkout-js` consumption.
- Task 2: Move extension experiment check to `ExtensionService#renderExtension`.
- Task 3: Map command type to handler signature in `handleExtensionCommand`.

## Why?
Improve code structure and developer experience.

## Testing / Proof
- CI checks.