### PR TITLE
fix(payment): PAYPAL-000 updated Braintree Accelerated Checkout Customer interface key naming

### DIFF
--- a/packages/core/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer.ts
@@ -4,7 +4,7 @@ import { CardInstrument } from '../payment/instrument/instrument';
 export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
 
 export interface BraintreeAcceleratedCheckoutCustomer {
-    authorizationStatus?: string;
+    authenticationState?: string;
     addresses?: AddressRequestBody[];
     instruments?: CardInstrument[];
 }

--- a/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
@@ -4,7 +4,7 @@ import { CardInstrument } from '../payment';
 export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
 
 export interface BraintreeAcceleratedCheckoutCustomer {
-    authorizationStatus?: string;
+    authenticationState?: string;
     addresses?: AddressRequestBody[];
     instruments?: CardInstrument[];
 }


### PR DESCRIPTION
## What?
Updated Braintree Accelerated Checkout Customer interface key naming

## Why?
To match our naming with PayPal Connect to avoid dev confusion in the future

## Testing / Proof
Unit tests
