### PR TITLE
feat(payment): PAYPAL-000 add an ability to use getPaymentProviderCustomer method on the client side

### DIFF
--- a/packages/core/src/checkout/checkout-store-selector.spec.ts
+++ b/packages/core/src/checkout/checkout-store-selector.spec.ts
@@ -290,4 +290,10 @@ describe('CheckoutStoreSelector', () => {
     it('returns extensions', () => {
         expect(selector.getExtensions()).toEqual(internalSelectors.extensions.getExtensions());
     });
+
+    it('returns payment provider customer data', () => {
+        expect(selector.getPaymentProviderCustomer()).toEqual(
+            internalSelectors.paymentProviderCustomer.getPaymentProviderCustomer(),
+        );
+    });
 });

--- a/packages/core/src/checkout/checkout-store-selector.ts
+++ b/packages/core/src/checkout/checkout-store-selector.ts
@@ -14,6 +14,7 @@ import { FormField } from '../form';
 import { Country } from '../geography';
 import { Order } from '../order';
 import { PaymentMethod } from '../payment';
+import { PaymentProviderCustomer } from '../payment-provider-customer';
 import { CardInstrument, PaymentInstrument } from '../payment/instrument';
 import { Consignment, PickupOptionResult, SearchArea, ShippingOption } from '../shipping';
 import { SignInEmail } from '../signin-email';
@@ -284,6 +285,14 @@ export default interface CheckoutStoreSelector {
      * @returns The list of extensions if it is loaded, otherwise undefined.
      */
     getExtensions(): Extension[] | undefined;
+
+    /**
+     * Gets payment provider customers data.
+     *
+     * @alpha
+     * @returns The object with payment provider customer data
+     */
+    getPaymentProviderCustomer(): PaymentProviderCustomer | undefined;
 }
 
 export type CheckoutStoreSelectorFactory = (
@@ -558,6 +567,12 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
         (getExtensions) => clone(getExtensions),
     );
 
+    const getPaymentProviderCustomer = createSelector(
+        ({ paymentProviderCustomer }: InternalCheckoutSelectors) =>
+            paymentProviderCustomer.getPaymentProviderCustomer,
+        (getPaymentProviderCustomer) => clone(getPaymentProviderCustomer),
+    );
+
     return memoizeOne((state: InternalCheckoutSelectors): CheckoutStoreSelector => {
         return {
             getCheckout: getCheckout(state),
@@ -588,6 +603,7 @@ export function createCheckoutStoreSelectorFactory(): CheckoutStoreSelectorFacto
             getShippingAddressFields: getShippingAddressFields(state),
             getPickupOptions: getPickupOptions(state),
             getUserExperienceSettings: getUserExperienceSettings(state),
+            getPaymentProviderCustomer: getPaymentProviderCustomer(state),
         };
     });
 }


### PR DESCRIPTION
## What?
Add an ability to use getPaymentProviderCustomer method on the client side

## Why?
To be able to use getPaymentProviderCustomer method in checkout js project

## Testing / Proof
Unit tests
Manual tests

<img width="1512" alt="Screenshot 2023-08-01 at 16 13 50" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/bda1a449-4b3d-45dc-b3c8-2c81762d5576">

