### PR TITLE
feat(payment): PAYPAL-2797 save customers data to local storage after authentication (Braintree AXO)

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
@@ -4,6 +4,7 @@ import {
     CustomerStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import { BraintreeHostWindow } from '../braintree';
 import BraintreeIntegrationService from '../braintree-integration-service';
@@ -19,10 +20,12 @@ const createBraintreeAcceleratedCheckoutCustomerStrategy: CustomerStrategyFactor
         new BraintreeScriptLoader(getScriptLoader(), braintreeHostWindow),
         braintreeHostWindow,
     );
+    const browserStorage = new BrowserStorage('paypal-connect');
 
     return new BraintreeAcceleratedCheckoutCustomerStrategy(
         paymentIntegrationService,
         braintreeIntegrationService,
+        browserStorage,
     );
 };
 


### PR DESCRIPTION
## What?
Save customers data to local storage after authentication (Braintree AXO)

## Why?
To be able to use PayPal Connect profile data in shipping and billing steps of checkout when customer reloads the page.

## Testing / Proof
Unit tests
Manual tests

<img width="1512" alt="Screenshot 2023-08-02 at 13 23 36" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/9a0548c7-8baa-4a94-a7e1-a03c4844df35">
