### PR TITLE
feat(payment): PAYPAL-2804 added country to each PayPal Connect customer address to use it on client side (BT AXO)

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
     getBillingAddress,
+    getCountries,
     getCustomer,
     PaymentIntegrationServiceMock,
 } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
@@ -30,6 +31,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
     let paymentIntegrationService: PaymentIntegrationService;
     let strategy: BraintreeAcceleratedCheckoutCustomerStrategy;
 
+    const countries = getCountries();
     const customer = getCustomer();
     const billingAddress = getBillingAddress();
     const methodId = 'braintreeacceleratedcheckout';
@@ -61,6 +63,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
             jest.fn,
         );
         jest.spyOn(paymentIntegrationService.getState(), 'getCustomer').mockReturnValue(customer);
+        jest.spyOn(paymentIntegrationService.getState(), 'getCountries').mockReturnValue(countries);
         jest.spyOn(paymentIntegrationService.getState(), 'getBillingAddress').mockReturnValue(
             billingAddress,
         );
@@ -234,6 +237,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
                         city: 'Bellingham',
                         stateOrProvince: 'WA',
                         stateOrProvinceCode: 'WA',
+                        country: 'United States',
                         countryCode: 'US',
                         postalCode: '98225',
                         phone: '',

--- a/packages/core/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,10 +1,10 @@
-import { AddressRequestBody } from '../address';
+import { Address } from '../address';
 import { CardInstrument } from '../payment/instrument/instrument';
 
 export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
 
 export interface BraintreeAcceleratedCheckoutCustomer {
     authenticationState?: string;
-    addresses?: AddressRequestBody[];
+    addresses?: Address[];
     instruments?: CardInstrument[];
 }

--- a/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,10 +1,10 @@
-import { AddressRequestBody } from '../address';
+import { Address } from '../address';
 import { CardInstrument } from '../payment';
 
 export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
 
 export interface BraintreeAcceleratedCheckoutCustomer {
     authenticationState?: string;
-    addresses?: AddressRequestBody[];
+    addresses?: Address[];
     instruments?: CardInstrument[];
 }


### PR DESCRIPTION
## What?
Added country to each PayPal Connect customer address to use it on client side (BT AXO)

## Why?
To be able to get country name without any extra effort on client side

## Testing / Proof
Unit tests
Manual tests