### PR TITLE
feat(payment): PAYPAL-2500 captured device info for Braintree Apple Pay and Braintree Google Pay

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-script-loader.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-script-loader.spec.ts
@@ -1,0 +1,101 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    BraintreeClientCreator,
+    BraintreeDataCollector,
+    BraintreeModuleCreator,
+    HostWindow,
+} from './apple-pay';
+import ApplePayScriptLoader from './apple-pay-script-loader';
+import {
+    getBraintreeClientMock,
+    getBraintreeDataCollectorMock,
+    getModuleCreatorMock,
+} from './mocks/apple-pay-method.mock';
+
+const VERSION = '3.95.0';
+const ALPHA_VERSION = '3.95.0-connect-alpha.11';
+
+describe('BraintreeScriptLoader', () => {
+    let applePayScriptLoader: ApplePayScriptLoader;
+    let scriptLoader: ScriptLoader;
+    let mockWindow: HostWindow;
+
+    const initializationData = {
+        isAcceleratedCheckoutEnabled: true,
+    };
+
+    beforeEach(() => {
+        mockWindow = { braintree: {} } as HostWindow;
+        scriptLoader = {} as ScriptLoader;
+        applePayScriptLoader = new ApplePayScriptLoader(scriptLoader, mockWindow);
+    });
+
+    describe('#loadBraintreeClient()', () => {
+        let clientMock: BraintreeClientCreator;
+
+        beforeEach(() => {
+            clientMock = getModuleCreatorMock(getBraintreeClientMock());
+            scriptLoader.loadScript = jest.fn(() => {
+                if (mockWindow.braintree) {
+                    mockWindow.braintree.client = clientMock;
+                }
+
+                return Promise.resolve();
+            });
+        });
+
+        it('loads the client', async () => {
+            await applePayScriptLoader.loadBraintreeClient();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${VERSION}/js/client.min.js`,
+            );
+        });
+
+        it('returns the client from the window', async () => {
+            const client = await applePayScriptLoader.loadBraintreeClient();
+
+            expect(client).toBe(clientMock);
+        });
+    });
+
+    describe('#loadBraintreeDataCollector()', () => {
+        let dataCollectorMock: BraintreeModuleCreator<BraintreeDataCollector>;
+
+        beforeEach(() => {
+            dataCollectorMock = getModuleCreatorMock(getBraintreeDataCollectorMock());
+            scriptLoader.loadScript = jest.fn(() => {
+                if (mockWindow.braintree) {
+                    mockWindow.braintree.dataCollector = dataCollectorMock;
+                }
+
+                return Promise.resolve();
+            });
+        });
+
+        it('loads the data collector library', async () => {
+            await applePayScriptLoader.loadBraintreeDataCollector();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${VERSION}/js/data-collector.min.js`,
+            );
+        });
+
+        it('loads the data collector library with braintree sdk alpha version', async () => {
+            applePayScriptLoader.initialize(initializationData);
+
+            await applePayScriptLoader.loadBraintreeDataCollector();
+
+            expect(scriptLoader.loadScript).toHaveBeenCalledWith(
+                `//js.braintreegateway.com/web/${ALPHA_VERSION}/js/data-collector.min.js`,
+            );
+        });
+
+        it('returns the data collector from the window', async () => {
+            const dataCollector = await applePayScriptLoader.loadBraintreeDataCollector();
+
+            expect(dataCollector).toBe(dataCollectorMock);
+        });
+    });
+});

--- a/packages/apple-pay-integration/src/apple-pay-script-loader.ts
+++ b/packages/apple-pay-integration/src/apple-pay-script-loader.ts
@@ -1,0 +1,52 @@
+import { ScriptLoader } from '@bigcommerce/script-loader';
+
+import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import {
+    BraintreeClientCreator,
+    BraintreeDataCollectorCreator,
+    BraintreeInitializationData,
+    HostWindow,
+} from './apple-pay';
+
+const BraintreeSdkVersionStable = '3.95.0';
+
+export default class ApplePayScriptLoader {
+    private braintreeSdkVersion = BraintreeSdkVersionStable;
+
+    constructor(private scriptLoader: ScriptLoader, private hostWindow: HostWindow) {}
+
+    // TODO: this method is needed only for braintree AXO
+    // So can be removed after Beta state
+    initialize({ isAcceleratedCheckoutEnabled }: BraintreeInitializationData) {
+        this.braintreeSdkVersion = isAcceleratedCheckoutEnabled
+            ? '3.95.0-connect-alpha.11'
+            : BraintreeSdkVersionStable;
+    }
+
+    async loadBraintreeClient(): Promise<BraintreeClientCreator> {
+        await this.scriptLoader.loadScript(
+            `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/client.min.js`,
+        );
+
+        if (!this.hostWindow.braintree?.client) {
+            throw new PaymentMethodClientUnavailableError();
+        }
+
+        return this.hostWindow.braintree.client;
+    }
+
+    loadBraintreeDataCollector(): Promise<BraintreeDataCollectorCreator> {
+        return this.scriptLoader
+            .loadScript(
+                `//js.braintreegateway.com/web/${this.braintreeSdkVersion}/js/data-collector.min.js`,
+            )
+            .then(() => {
+                if (!this.hostWindow.braintree || !this.hostWindow.braintree.dataCollector) {
+                    throw new PaymentMethodClientUnavailableError();
+                }
+
+                return this.hostWindow.braintree.dataCollector;
+            });
+    }
+}

--- a/packages/apple-pay-integration/src/apple-pay.ts
+++ b/packages/apple-pay-integration/src/apple-pay.ts
@@ -1,0 +1,113 @@
+/**
+ *
+ * Common
+ *
+ */
+export interface BraintreeModuleCreator<
+    TInstance,
+    TOptions = BraintreeModuleCreatorConfig,
+    TError = BraintreeError,
+> {
+    create(
+        config: TOptions,
+        callback?: (error: TError, instance: TInstance) => void,
+    ): Promise<TInstance>;
+}
+
+export interface BraintreeModuleCreatorConfig {
+    client?: BraintreeClient;
+    authorization?: string;
+}
+
+export interface BraintreeError extends Error {
+    type: 'CUSTOMER' | 'MERCHANT' | 'NETWORK' | 'INTERNAL' | 'UNKNOWN';
+    code: string;
+    details?: unknown;
+}
+
+export interface BraintreeModule {
+    teardown(): Promise<void>;
+}
+
+export enum ApplePayGatewayType {
+    BRAINTREE = 'braintree',
+}
+
+/**
+ *
+ * Braintree Client
+ *
+ */
+export type BraintreeClientCreator = BraintreeModuleCreator<BraintreeClient>;
+
+export interface BraintreeClient {
+    request(payload: BraintreeRequestData): Promise<BraintreeTokenizeResponse>;
+    getVersion(): string | void;
+}
+
+export interface BraintreeRequestData {
+    data: {
+        creditCard: {
+            billingAddress?: {
+                countryCodeAlpha2: string;
+                locality: string;
+                countryName: string;
+                postalCode: string;
+                streetAddress: string;
+            };
+            cardholderName: string;
+            cvv?: string;
+            expirationDate: string;
+            number: string;
+            options: {
+                validate: boolean;
+            };
+        };
+    };
+    endpoint: string;
+    method: string;
+}
+
+export interface BraintreeTokenizeResponse {
+    creditCards: Array<{ nonce: string }>;
+}
+
+/**
+ *
+ * Braintree Data Collector
+ *
+ */
+export type BraintreeDataCollectorCreator = BraintreeModuleCreator<
+    BraintreeDataCollector,
+    BraintreeDataCollectorCreatorConfig
+>;
+
+export interface BraintreeDataCollectorCreatorConfig extends BraintreeModuleCreatorConfig {
+    kount?: boolean;
+    paypal?: boolean;
+}
+
+export interface BraintreeDataCollector extends BraintreeModule {
+    deviceData?: string;
+}
+
+/**
+ *
+ * Other
+ *
+ */
+
+export interface BraintreeSDK {
+    client?: BraintreeClientCreator;
+    dataCollector?: BraintreeDataCollectorCreator;
+}
+
+export interface HostWindow extends Window {
+    braintree?: BraintreeSDK;
+}
+
+export interface BraintreeInitializationData {
+    intent?: 'authorize' | 'order' | 'sale';
+    isCreditEnabled?: boolean;
+    isAcceleratedCheckoutEnabled?: boolean;
+}

--- a/packages/apple-pay-integration/src/create-apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/create-apple-pay-payment-strategy.ts
@@ -1,4 +1,5 @@
 import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import {
     PaymentStrategyFactory,
@@ -6,17 +7,20 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import ApplePayPaymentStrategy from './apple-pay-payment-strategy';
+import ApplePayScriptLoader from './apple-pay-script-loader';
 import ApplePaySessionFactory from './apple-pay-session-factory';
 
 const createApplePayPaymentStrategy: PaymentStrategyFactory<ApplePayPaymentStrategy> = (
     paymentIntegrationService,
 ) => {
     const { getHost } = paymentIntegrationService.getState();
+    const applePayScriptLoader = new ApplePayScriptLoader(getScriptLoader(), window);
 
     return new ApplePayPaymentStrategy(
         createRequestSender({ host: getHost() }),
         paymentIntegrationService,
         new ApplePaySessionFactory(),
+        applePayScriptLoader,
     );
 };
 

--- a/packages/apple-pay-integration/src/mocks/apple-pay-button.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-button.mock.ts
@@ -1,5 +1,4 @@
 import { CheckoutButtonInitializeOptions } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
 import { getBuyNowCartRequestBody } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import { WithApplePayButtonInitializeOptions } from '../apple-pay-button-initialize-options';

--- a/packages/apple-pay-integration/src/mocks/apple-pay-method.mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-method.mock.ts
@@ -1,3 +1,10 @@
+import {
+    BraintreeClient,
+    BraintreeDataCollector,
+    BraintreeModule,
+    BraintreeModuleCreator,
+} from '../apple-pay';
+
 export function getApplePay() {
     return {
         id: 'applepay',
@@ -29,5 +36,55 @@ export function getApplePay() {
             merchantId: 'abc',
             paymentsUrl: 'https://url',
         },
+    };
+}
+
+export function getBraintree() {
+    return {
+        id: 'braintree',
+        clientToken: 'clientToken',
+        logoUrl:
+            'https://cdn.bcapp.dev/rHEAD/modules/checkout/braintree/images/paypal_powered_braintree_horizontal.png',
+        method: 'credit-card',
+        supportedCards: ['VISA', 'MC', 'AMEX', 'DISCOVER', 'JCB', 'DINERS'],
+        config: {
+            displayName: 'Credit Card',
+            cardCode: true,
+            enablePaypal: true,
+            merchantId: '',
+            testMode: true,
+            isVisaCheckoutEnabled: false,
+        },
+        type: 'PAYMENT_TYPE_API',
+        initializationData: {
+            isAcceleratedCheckoutEnabled: false,
+            merchantAccountId: '100000',
+        },
+    };
+}
+
+export function getDeviceDataMock(): string {
+    return '{"device_session_id": "my_device_session_id", "fraud_merchant_id": "we_dont_use_this_field"}';
+}
+
+export function getModuleCreatorMock<T>(
+    module?: BraintreeModule | BraintreeClient,
+): BraintreeModuleCreator<T> {
+    return {
+        create: jest.fn(() => Promise.resolve(module || {})),
+    };
+}
+
+export function getBraintreeDataCollectorMock(): BraintreeDataCollector {
+    return {
+        deviceData: getDeviceDataMock(),
+        teardown: jest.fn(() => Promise.resolve()),
+    };
+}
+
+export function getBraintreeClientMock(): BraintreeClient {
+    return {
+        request: jest.fn(),
+        getVersion: jest.fn(),
     };
 }

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -182,6 +182,12 @@ export default class BraintreeSDKCreator {
         return cached;
     }
 
+    async getSessionId(): Promise<string | undefined> {
+        const { deviceData } = await this.getDataCollector();
+
+        return deviceData;
+    }
+
     getVisaCheckout(): Promise<BraintreeVisaCheckout> {
         if (!this._visaCheckout) {
             this._visaCheckout = Promise.all([

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -41,6 +41,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
     private _walletButton?: HTMLElement;
     private _paymentMethod?: PaymentMethod;
     private _is3dsEnabled?: boolean;
+    private _sessionId?: string;
     private _buttonClickEventHandler?: (event: Event) => Promise<InternalCheckoutSelectors>;
 
     constructor(
@@ -81,6 +82,8 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 this._paymentMethod.clientToken,
                 this._paymentMethod.initializationData,
             );
+
+            this._sessionId = await this._braintreeSDKCreator.getSessionId();
         }
 
         await this._googlePayPaymentProcessor.initialize(methodId);
@@ -175,6 +178,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 paymentData: {
                     ...payment.paymentData,
                     nonce: verification?.nonce || payment.paymentData.nonce,
+                    deviceSessionId: this._sessionId,
                 },
             };
 


### PR DESCRIPTION
## What?

Added `deviceSessionId` to the payment payload for the GP and AP strategies

## Why?

`Braintree Fraud Protection` requires deviceData to work correctly.
To do this we need to pass `deviceSessionId` and make sure that the device data captured in the transaction journal.

## Testing / Proof

Tested with a Braintree sandbox account

From transaction journal
<img width="486" alt="Screenshot 2023-08-09 at 18 39 35" src="https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/3025cec0-2c30-4be5-bd46-44ac31ce0dad">

Data Device Captured equals `true` for both (GP and AP) payment method

@bigcommerce/team-checkout @bigcommerce/team-payments
