### PR TITLE
feat(payment): PAYPAL-2737 updated Braintree AXO strategy with vaulted instruments implementation

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-initialize-options.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-initialize-options.ts
@@ -13,7 +13,7 @@
  * service.initializePayment({
  *     methodId: 'braintreeacceleratedcheckout',
  *     braintreeacceleratedcheckout: {
- *         container: '#container',
+ *         onInit: (renderPayPalComponentMethod) => renderPayPalComponentMethod('#container-id');
  *     },
  * });
  * ```
@@ -22,7 +22,7 @@ export default interface BraintreeAcceleratedCheckoutPaymentInitializeOptions {
     /**
      * The CSS selector of a container where the payment widget should be inserted into.
      */
-    container: string;
+    onInit?: (renderPayPalComponentMethod: (container: string) => void) => void;
 }
 
 export interface WithBraintreeAcceleratedCheckoutPaymentInitializeOptions {

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -70,6 +70,7 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
         );
 
         jest.spyOn(braintreeIntegrationService, 'initialize');
+        jest.spyOn(braintreeIntegrationService, 'getSessionId').mockImplementation(jest.fn);
         jest.spyOn(braintreeIntegrationService, 'getBraintreeConnect').mockImplementation(
             () => braintreeConnectMock,
         );
@@ -255,6 +256,15 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
                 email: customer.email,
                 ...updatePaymentProviderCustomerPayload,
             });
+        });
+    });
+
+    describe('#getDeviceSessionId', () => {
+        it('returns device session id', async () => {
+            await subject.initializeBraintreeConnectOrThrow(methodId);
+            await subject.getDeviceSessionId();
+
+            expect(braintreeIntegrationService.getSessionId).toHaveBeenCalled();
         });
     });
 });

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -28,6 +28,10 @@ export default class BraintreeAcceleratedCheckoutUtils {
         private browserStorage: BrowserStorage,
     ) {}
 
+    async getDeviceSessionId(): Promise<string | undefined> {
+        return this.braintreeIntegrationService.getSessionId();
+    }
+
     getBraintreeConnectOrThrow(): BraintreeConnect {
         if (!this.braintreeConnect) {
             throw new PaymentMethodClientUnavailableError();


### PR DESCRIPTION
## What?
Updated Braintree AXO strategy with vaulted instruments implementation

## Why?
PayPal team request us to add vaulted instruments implementation to give PayPal Connect customers an ability to use PP saved instruments

## Testing / Proof
Unit tests
Manual tests

<img width="723" alt="Screenshot 2023-08-08 at 10 27 55" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/ff563a58-3885-47a4-8202-72872f92ded3">
<img width="686" alt="Screenshot 2023-08-08 at 10 28 15" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/9a8d08ca-f24d-4446-8258-26769fd1bab0">
<img width="648" alt="Screenshot 2023-08-08 at 10 28 03" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/dc28bcfe-6a5d-4b0a-9799-02f719acd89a">
