### PR TITLE
test(payment): PAYPAL-2737 added getPaymentProviderCustomer method mocks to PIS state mock in payment-integration-test-utils package

### DIFF
--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -32,6 +32,8 @@ const state = {
     getStoreConfigOrThrow: jest.fn(() => getConfig().storeConfig),
     getPaymentMethod: jest.fn(),
     getPaymentMethodOrThrow: jest.fn(),
+    getPaymentProviderCustomer: jest.fn(),
+    getPaymentProviderCustomerOrThrow: jest.fn(),
     getPaymentStatus: jest.fn(),
 };
 


### PR DESCRIPTION
## What?
Added getPaymentProviderCustomer method mocks to PIS state mock in payment-integration-test-utils package

## Why?
To be able to use those methods in test files in integration packages

## Testing / Proof
Unit tests
CI
