### PR TITLE
feat(payment): PAYPAL-000 updated paypal connect address mapper to receive CustomerAddress instead of Address

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -187,6 +187,8 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
                 authenticationState: 'succeeded',
                 addresses: [
                     {
+                        id: 123123,
+                        type: 'paypal-address',
                         firstName: 'John',
                         lastName: 'Doe',
                         company: '',

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -1,7 +1,7 @@
 import {
-    Address,
     BraintreeAcceleratedCheckoutCustomer,
     CardInstrument,
+    CustomerAddress,
     InvalidArgumentError,
     MissingDataError,
     MissingDataErrorType,
@@ -124,7 +124,9 @@ export default class BraintreeAcceleratedCheckoutUtils {
      * PayPal to BC data mappers
      *
      * */
-    private mapPayPalToBcAddress(addresses?: BraintreeConnectAddress[]): Address[] | undefined {
+    private mapPayPalToBcAddress(
+        addresses?: BraintreeConnectAddress[],
+    ): CustomerAddress[] | undefined {
         if (!addresses) {
             return;
         }
@@ -138,6 +140,8 @@ export default class BraintreeAcceleratedCheckoutUtils {
         };
 
         return addresses.map((address) => ({
+            id: Number(address.id),
+            type: 'paypal-address',
             firstName: address.firstName || '',
             lastName: address.lastName || '',
             company: address.company || '',

--- a/packages/braintree-integration/src/braintree.ts
+++ b/packages/braintree-integration/src/braintree.ts
@@ -605,6 +605,7 @@ export interface BraintreeConnectProfileData {
 }
 
 export interface BraintreeConnectAddress {
+    id?: string;
     firstName?: string;
     lastName?: string;
     company?: string;

--- a/packages/braintree-integration/src/mocks/braintree.mock.ts
+++ b/packages/braintree-integration/src/mocks/braintree.mock.ts
@@ -28,6 +28,7 @@ export function getBraintreeConnectProfileDataMock(): BraintreeConnectProfileDat
         connectCustomerId: 'asdasd',
         addresses: [
             {
+                id: '123123',
                 company: undefined,
                 extendedAddress: undefined,
                 firstName: 'John',

--- a/packages/core/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,10 +1,10 @@
-import { Address } from '../address';
+import { CustomerAddress } from '../customer';
 import { CardInstrument } from '../payment/instrument/instrument';
 
 export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
 
 export interface BraintreeAcceleratedCheckoutCustomer {
     authenticationState?: string;
-    addresses?: Address[];
+    addresses?: CustomerAddress[];
     instruments?: CardInstrument[];
 }

--- a/packages/payment-integration-api/src/customer/index.ts
+++ b/packages/payment-integration-api/src/customer/index.ts
@@ -1,4 +1,4 @@
-export { default as Customer } from './customer';
+export { default as Customer, CustomerAddress } from './customer';
 export { default as CustomerCredentials } from './customer-credentials';
 export { default as CustomerStrategy } from './customer-strategy';
 export { default as CustomerStrategyFactory } from './customer-strategy-factory';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -31,6 +31,7 @@ export {
     CustomerStrategyFactory,
     CustomerStrategyResolveId,
     Customer,
+    CustomerAddress,
     CustomerRequestOptions,
     CustomerInitializeOptions,
     ExecutePaymentMethodCheckoutOptions,

--- a/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,10 +1,10 @@
-import { Address } from '../address';
+import { CustomerAddress } from '../customer';
 import { CardInstrument } from '../payment';
 
 export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
 
 export interface BraintreeAcceleratedCheckoutCustomer {
     authenticationState?: string;
-    addresses?: Address[];
+    addresses?: CustomerAddress[];
     instruments?: CardInstrument[];
 }


### PR DESCRIPTION
## What?
Updated PayPal Connect address mapper to receive CustomerAddress instead of Address

## Why?
To avoid interface updates on the client side (checkout-js)

## Testing / Proof
Unit tests
CI
