### PR TITLE
feat(payment): PAYPAL-2827 add a condition to check when to run PayPal Connect authentication flow in BT customer strategy (A/B testing coverage)

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -23,6 +23,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
     let strategy: BraintreeAcceleratedCheckoutCustomerStrategy;
 
     const methodId = 'braintreeacceleratedcheckout';
+    const backuptMethodId = 'braintree';
 
     const initializationOptions = { methodId };
     const executionOptions = {
@@ -201,6 +202,31 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
             await strategy.signIn(credentials);
 
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
+            expect(
+                braintreeAcceleratedCheckoutUtils.initializeBraintreeConnectOrThrow,
+            ).toHaveBeenCalledWith(methodId);
+            expect(
+                braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow,
+            ).toHaveBeenCalledWith(credentials.email);
+        });
+
+        it('loads different payment method due to the A/B testing flow', async () => {
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockRejectedValueOnce(
+                new Error(),
+            );
+
+            const credentials = {
+                email: 'test@test.com',
+                password: '123',
+            };
+
+            await strategy.initialize({ methodId });
+            await strategy.signIn(credentials);
+
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                backuptMethodId,
+            );
             expect(
                 braintreeAcceleratedCheckoutUtils.initializeBraintreeConnectOrThrow,
             ).toHaveBeenCalledWith(methodId);

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
@@ -8,19 +8,18 @@ import {
     RequestOptions,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
+import { BraintreeInitializationData } from '../braintree';
+
 import BraintreeAcceleratedCheckoutUtils from './braintree-accelerated-checkout-utils';
 
 export default class BraintreeAcceleratedCheckoutCustomerStrategy implements CustomerStrategy {
+    private methodId?: string;
+
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private braintreeAcceleratedCheckoutUtils: BraintreeAcceleratedCheckoutUtils,
     ) {}
 
-    /**
-     *
-     * Default methods
-     *
-     */
     async initialize({ methodId }: CustomerInitializeOptions): Promise<void> {
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -28,8 +27,9 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
             );
         }
 
-        await this.paymentIntegrationService.loadPaymentMethod(methodId);
-        await this.braintreeAcceleratedCheckoutUtils.initializeBraintreeConnectOrThrow(methodId);
+        this.methodId = methodId;
+
+        return Promise.resolve();
     }
 
     async deinitialize(): Promise<void> {
@@ -38,9 +38,10 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
 
     async signIn(credentials: CustomerCredentials, options?: RequestOptions): Promise<void> {
         await this.paymentIntegrationService.signInCustomer(credentials, options);
-        await this.braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow(
-            credentials.email,
-        );
+
+        if (await this.shouldRunAuthenticationFlow()) {
+            await this.runPayPalConnectAuthenticationFlowOrThrow(credentials.email);
+        }
     }
 
     async signOut(options?: RequestOptions): Promise<void> {
@@ -58,8 +59,45 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
             );
         }
 
-        await this.braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow();
+        if (await this.shouldRunAuthenticationFlow()) {
+            await this.runPayPalConnectAuthenticationFlowOrThrow();
+        }
 
         continueWithCheckoutCallback();
+    }
+
+    // Info: we should load payment method and check the shouldRunAcceleratedCheckout flag only for A/B testing purposes
+    // when the A/B testing finished, we can move paymentIntegrationService.loadPaymentMethod and
+    // braintreeAcceleratedCheckoutUtils.initializeBraintreeConnectOrThrow to the initialize method
+    private async shouldRunAuthenticationFlow(): Promise<boolean> {
+        const methodId = this.getMethodIdOrThrow();
+
+        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethodOrThrow<BraintreeInitializationData>(methodId);
+        const { shouldRunAcceleratedCheckout, isAcceleratedCheckoutEnabled } =
+            paymentMethod.initializationData || {};
+
+        return !!(isAcceleratedCheckoutEnabled && shouldRunAcceleratedCheckout);
+    }
+
+    private async runPayPalConnectAuthenticationFlowOrThrow(email?: string): Promise<void> {
+        const methodId = this.getMethodIdOrThrow();
+
+        await this.braintreeAcceleratedCheckoutUtils.initializeBraintreeConnectOrThrow(methodId);
+        await this.braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow(
+            email,
+        );
+    }
+
+    private getMethodIdOrThrow(): string {
+        if (!this.methodId) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "methodId" argument is not provided.',
+            );
+        }
+
+        return this.methodId;
     }
 }

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
@@ -34,6 +34,11 @@ const createBraintreeAcceleratedCheckoutCustomerStrategy: CustomerStrategyFactor
     );
 };
 
+// Info: braintree method id was added only for A/B testing purposes.
+// The main reason why we can't go in other way, because braintreeacceleratedcheckout
+// may be turned on only when BE knows customer's email address (to understand should we show the feature for the user or not).
+// So { id: 'braintree' }, should be removed after A/B testing
 export default toResolvableModule(createBraintreeAcceleratedCheckoutCustomerStrategy, [
     { id: 'braintreeacceleratedcheckout' },
+    { id: 'braintree' },
 ]);

--- a/packages/braintree-integration/src/braintree.ts
+++ b/packages/braintree-integration/src/braintree.ts
@@ -75,6 +75,7 @@ export interface BraintreeInitializationData {
     intent?: 'authorize' | 'order' | 'sale';
     isCreditEnabled?: boolean;
     isAcceleratedCheckoutEnabled?: boolean;
+    shouldRunAcceleratedCheckout?: boolean; // TODO: only for BT AXO A/B testing purposes, hence should be removed after testing
 }
 
 export interface BraintreePaypalRequest {


### PR DESCRIPTION
## What?
Updated `BraintreeAcceleratedCheckout` customer  strategy with a condition to check when to run PayPal Connect authentication flow in BT customer strategy

## Why?
We should run PayPal Connect authentication flow for 20% of store shoppers. The calculations to whom we should run authentication flow is implemented on BE side, so the BE should return `shouldRunAuthenticationFlow` flag `true/false` in payment method `initializationData`, when the email set in quota.

## Testing / Proof
Unit tests
Manual tests
