### PR TITLE
feat(payment): PAYPAL-2828 added shipping and billing address selected with PayPal AXO address after OTP

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -56,7 +56,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
         ).mockImplementation(jest.fn);
         jest.spyOn(
             braintreeAcceleratedCheckoutUtils,
-            'authenticatePayPalConnectUserOrThrow',
+            'runPayPalConnectAuthenticationFlowOrThrow',
         ).mockImplementation(jest.fn);
     });
 
@@ -93,10 +93,13 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
             }
         });
 
-        it('calls continueWithCheckoutCallback callback', async () => {
+        it('authenticates user with PayPal Connect and calls continueWithCheckoutCallback', async () => {
             await strategy.initialize(initializationOptions);
             await strategy.executePaymentMethodCheckout(executionOptions);
 
+            expect(
+                braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow,
+            ).toHaveBeenCalled();
             expect(executionOptions.continueWithCheckoutCallback).toHaveBeenCalled();
         });
     });
@@ -133,7 +136,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
             await strategy.signIn(credentials);
 
             expect(
-                braintreeAcceleratedCheckoutUtils.authenticatePayPalConnectUserOrThrow,
+                braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow,
             ).toHaveBeenCalledWith(credentials.email);
         });
     });

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
@@ -38,7 +38,7 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
 
     async signIn(credentials: CustomerCredentials, options?: RequestOptions): Promise<void> {
         await this.paymentIntegrationService.signInCustomer(credentials, options);
-        await this.braintreeAcceleratedCheckoutUtils.authenticatePayPalConnectUserOrThrow(
+        await this.braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow(
             credentials.email,
         );
     }
@@ -58,7 +58,7 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
             );
         }
 
-        await this.braintreeAcceleratedCheckoutUtils.authenticatePayPalConnectUserOrThrow();
+        await this.braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow();
 
         continueWithCheckoutCallback();
     }

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
@@ -104,8 +104,8 @@ describe('BraintreeAcceleratedCheckoutPaymentStrategy', () => {
         ).mockImplementation(jest.fn);
         jest.spyOn(
             braintreeAcceleratedCheckoutUtils,
-            'getBraintreeConnectOrThrow',
-        ).mockImplementation(() => braintreeConnectMock);
+            'getBraintreeConnectComponentOrThrow',
+        ).mockImplementation(() => braintreeConnectMock.ConnectCardComponent);
         jest.spyOn(braintreeAcceleratedCheckoutUtils, 'getDeviceSessionId').mockImplementation(
             () => deviceSessionId,
         );

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.ts
@@ -122,10 +122,10 @@ export default class BraintreeAcceleratedCheckoutPaymentStrategy implements Paym
             },
         };
 
-        const { ConnectCardComponent } =
-            this.braintreeAcceleratedCheckoutUtils.getBraintreeConnectOrThrow();
+        const paypalConnectCreditCardComponent =
+            this.braintreeAcceleratedCheckoutUtils.getBraintreeConnectComponentOrThrow();
 
-        this.braintreeConnectCardComponent = ConnectCardComponent(cardComponentOptions);
+        this.braintreeConnectCardComponent = paypalConnectCreditCardComponent(cardComponentOptions);
     }
 
     private renderBraintreeAXOComponent(container?: string) {

--- a/packages/braintree-integration/src/braintree.ts
+++ b/packages/braintree-integration/src/braintree.ts
@@ -590,6 +590,7 @@ export enum BraintreeConnectAuthenticationState {
     SUCCEEDED = 'succeeded',
     FAILED = 'failed',
     CANCELED = 'canceled',
+    UNRECOGNIZED = 'unrecognized', // Info: this is a custom authentication state used on BC side only for users without PayPal account
 }
 
 export interface BraintreeConnectAuthenticationCustomerResult {


### PR DESCRIPTION
## What?
Added shipping and billing address selected with PayPal AXO address after OTP

## Why?
I as a customer want to have shipping and billing addresses preselected with data from PayPal Connect Profile to speed up checkout process. Therefore if I want to change the address I can use Edit button, select any address in the Address select component or fill shipping form with new address as well.

## Testing / Proof
Unit tests
Manual tests


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/c9b4c9d7-0e09-4891-93c0-8ba5760866d1


