### PR TITLE
feat(checkout): PI-520 Stripe UPE - Provide AVS results

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -687,6 +687,38 @@ describe('StripeUPEPaymentStrategy', () => {
                         expect(response).toBe(store.getState());
                     });
 
+                    it('with a guest user with line1', async () => {
+                        jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(
+                            undefined,
+                        );
+                        jest.spyOn(
+                            store.getState().shippingAddress,
+                            'getShippingAddress',
+                        ).mockReturnValue({
+                            ...getShippingAddress(),
+                            line1: '12345 Testing Way',
+                        });
+
+                        const response = await strategy.execute(getStripeUPEOrderRequestBodyMock());
+
+                        expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+                        expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalled();
+                        expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                        expect(response).toBe(store.getState());
+                    });
+
+                    it('with a guest user with line2', async () => {
+                        jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(
+                            undefined,
+                        );
+                        jest.spyOn(
+                            store.getState().shippingAddress,
+                            'getShippingAddress',
+                        ).mockReturnValue({
+                            ...getShippingAddress(),
+                            line2: '123456 Testing Way',
+                        });
+
                     it('without shipping address if there is not physical items in cart', async () => {
                         jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
                             ...store.getState().cart.getCart(),

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -687,7 +687,7 @@ describe('StripeUPEPaymentStrategy', () => {
                         expect(response).toBe(store.getState());
                     });
 
-                    it('with a guest user with line1', async () => {
+                    it('with a guest user with address line1', async () => {
                         jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(
                             undefined,
                         );
@@ -696,7 +696,7 @@ describe('StripeUPEPaymentStrategy', () => {
                             'getShippingAddress',
                         ).mockReturnValue({
                             ...getShippingAddress(),
-                            line1: '12345 Testing Way',
+                            line1: '12345',
                         });
 
                         const response = await strategy.execute(getStripeUPEOrderRequestBodyMock());
@@ -707,7 +707,7 @@ describe('StripeUPEPaymentStrategy', () => {
                         expect(response).toBe(store.getState());
                     });
 
-                    it('with a guest user with line2', async () => {
+                    it('with a guest user with address line2', async () => {
                         jest.spyOn(store.getState().customer, 'getCustomer').mockReturnValue(
                             undefined,
                         );
@@ -716,8 +716,16 @@ describe('StripeUPEPaymentStrategy', () => {
                             'getShippingAddress',
                         ).mockReturnValue({
                             ...getShippingAddress(),
-                            line2: '123456 Testing Way',
+                            line2: '123456',
                         });
+
+                        const response = await strategy.execute(getStripeUPEOrderRequestBodyMock());
+
+                        expect(orderActionCreator.submitOrder).toHaveBeenCalled();
+                        expect(paymentMethodActionCreator.loadPaymentMethod).toHaveBeenCalled();
+                        expect(paymentActionCreator.submitPayment).toHaveBeenCalled();
+                        expect(response).toBe(store.getState());
+                    });
 
                     it('without shipping address if there is not physical items in cart', async () => {
                         jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -579,9 +579,15 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
 
     private _mapStripeAddress(address?: Address): AddressOptions {
         if (address) {
-            const { city, countryCode: country, postalCode } = address;
+            const { city, address1, address2, countryCode: country, postalCode } = address;
 
-            return { city, country, postal_code: postalCode };
+            return {
+                city,
+                country,
+                postal_code: postalCode,
+                line1: address1,
+                line2: address2,
+            };
         }
 
         throw new MissingDataError(MissingDataErrorType.MissingBillingAddress);


### PR DESCRIPTION
## What?
Jira issue: https://bigcommercecloud.atlassian.net/browse/PI-520
As a merchant, I want Address Line and Zip/Post Code responses for failures to manually review orders and see if I want to accept them. Currently, we only provide when they match and not when they don’t - Even though Stripe has the information and sends it via webhooks. 

## Why?
SportsShoes have requested this information, it's part of their internal fraud review process. Orders can be flagged for review for a number of reasons (e.g. high value order, high risk items etc). Having AVS details helps the staff to decide what to do with the order. 

## Testing / Proof
...

@bigcommerce/team-checkout @bigcommerce/team-payments
