### PR TITLE
fix(payment): PAYPAL-000 fixed backup payment method loading for braintree accelerated checkout strategies

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -23,7 +23,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
     let strategy: BraintreeAcceleratedCheckoutCustomerStrategy;
 
     const methodId = 'braintreeacceleratedcheckout';
-    const backuptMethodId = 'braintree';
+    const backupMethodId = 'braintree';
 
     const initializationOptions = { methodId };
     const executionOptions = {
@@ -225,11 +225,11 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
 
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
-                backuptMethodId,
+                backupMethodId,
             );
             expect(
                 braintreeAcceleratedCheckoutUtils.initializeBraintreeConnectOrThrow,
-            ).toHaveBeenCalledWith(methodId);
+            ).toHaveBeenCalledWith(backupMethodId);
             expect(
                 braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow,
             ).toHaveBeenCalledWith(credentials.email);


### PR DESCRIPTION
## What?
Fixed backup payment method loading for Braintree accelerated checkout strategies

## Why?
There was an error detected due to the A/B testing feature. When the main payment method (`braintree`) is disabled we should load backup one (`braintreeacceleratedcheckout`), but I forgot to cover case with braintree connect initialization method, that it tries to get payment method that did not loaded before.. So this Pr fixes that issue.

## Testing / Proof
Unit tests
Manual tests
