### PR TITLE
feat(payment): PAYPAL-2856 added styles for PayPal Connect Credit Card component

### DIFF
--- a/packages/braintree-utils/src/braintree-integration-service.spec.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.spec.ts
@@ -78,6 +78,11 @@ describe('BraintreeIntegrationService', () => {
         );
     });
 
+    afterEach(() => {
+        jest.resetAllMocks();
+        jest.restoreAllMocks();
+    });
+
     describe('#initialize()', () => {
         it('initializes braintree script loader with provided initialization data', () => {
             braintreeIntegrationService.initialize(clientToken, initializationData);
@@ -135,6 +140,17 @@ describe('BraintreeIntegrationService', () => {
             expect(braintreeScriptLoader.loadClient).toHaveBeenCalled();
             expect(braintreeScriptLoader.loadDataCollector).toHaveBeenCalled();
             expect(braintreeScriptLoader.loadConnect).toHaveBeenCalled();
+
+            expect(braintreeConnectCreatorMock.create).toHaveBeenCalledWith({
+                authorization: clientToken,
+                client: clientMock,
+                deviceData: getDeviceDataMock(),
+                styles: {
+                    root: {
+                        backgroundColorPrimary: 'transparent',
+                    },
+                },
+            });
 
             expect(result).toEqual(braintreeConnectMock);
         });

--- a/packages/braintree-utils/src/braintree-integration-service.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.ts
@@ -63,6 +63,11 @@ export default class BraintreeIntegrationService {
                 authorization: clientToken,
                 client,
                 deviceData,
+                styles: {
+                    root: {
+                        backgroundColorPrimary: 'transparent',
+                    },
+                },
             });
         }
 

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -521,6 +521,7 @@ export interface BraintreeConnectConfig {
     authorization: string;
     client: BraintreeClient;
     deviceData?: string;
+    styles?: BraintreeConnectStylesOption;
 }
 
 export interface BraintreeConnect {
@@ -548,31 +549,31 @@ export interface BraintreeConnectAuthenticationOptions {
 }
 
 interface BraintreeConnectStylesOption {
-    root: {
-        backgroundColorPrimary: string; // default: #ffffff,
-        errorColor: string; // default: #C40B0B
-        fontFamily: string; // default: "Helvetica, Arial, sans-serif"
+    root?: {
+        backgroundColorPrimary?: string; // default: #ffffff,
+        errorColor?: string; // default: #C40B0B
+        fontFamily?: string; // default: "Helvetica, Arial, sans-serif"
     };
-    input: {
-        borderRadius: string; // default: 0.25rem
-        borderColor: string; // default: #9E9E9E
-        focusBorderColor: string; // default: #4496F6
+    input?: {
+        borderRadius?: string; // default: 0.25rem
+        borderColor?: string; // default: #9E9E9E
+        focusBorderColor?: string; // default: #4496F6
     };
-    toggle: {
-        colorPrimary: string; // default: #0F005E
-        colorSecondary: string; // default: #ffffff
+    toggle?: {
+        colorPrimary?: string; // default: #0F005E
+        colorSecondary?: string; // default: #ffffff
     };
-    text: {
-        body: {
-            color: string; // default: #222222
-            fontSize: string; // default: 1rem
+    text?: {
+        body?: {
+            color?: string; // default: #222222
+            fontSize?: string; // default: 1rem
         };
-        caption: {
-            color: string; // default: #515151
-            fontSize: string; // default: 0.875rem
+        caption?: {
+            color?: string; // default: #515151
+            fontSize?: string; // default: 0.875rem
         };
     };
-    branding: 'light' | 'dark'; // default: 'light',
+    branding?: 'light' | 'dark'; // default: 'light',
 }
 
 export enum BraintreeConnectAuthenticationState {
@@ -626,7 +627,6 @@ export interface BraintreeConnectVaultedInstrument {
 }
 
 export interface BraintreeConnectCardComponentOptions {
-    styles?: BraintreeConnectStylesOption;
     fields: BraintreeConnectCardComponentFields;
 }
 


### PR DESCRIPTION
## What?
Added styles for PayPal Connect Credit Card component

## Why?
All default PayPal Connect Credit Card component styles are ok for us, but we should update white component background and make it transparent to avoid differences between payment paywall and component background colors

## Testing / Proof
Unit tests
Manual tests

<img width="841" alt="Screenshot 2023-08-17 at 11 16 09" src="https://github.com/bigcommerce/checkout-js/assets/25133454/28c85443-a159-4d34-bfa0-351018f352ec">
<img width="686" alt="Screenshot 2023-08-17 at 11 27 08" src="https://github.com/bigcommerce/checkout-js/assets/25133454/16b076d8-173d-4eec-bbd0-5a12e5221492">
