### PR TITLE
fix(payment): PAYPAL-2868 clean up prev provider customer data from checkout state BT AXO

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -1,6 +1,7 @@
 import {
     BraintreeConnect,
     BraintreeConnectAddress,
+    BraintreeConnectAuthenticationState,
     BraintreeConnectVaultedInstrument,
     BraintreeInitializationData,
     BraintreeIntegrationService,
@@ -86,13 +87,16 @@ export default class BraintreeAcceleratedCheckoutUtils {
 
             const customerEmail = email || customer?.email || billingAddress?.email || '';
 
-            if (!customerEmail) {
-                return;
-            }
-
             const { customerContextId } = await lookupCustomerByEmail(customerEmail);
 
             if (!customerContextId) {
+                // Info: we should clean up previous experience with default data and related authenticationState
+                await this.paymentIntegrationService.updatePaymentProviderCustomer({
+                    authenticationState: BraintreeConnectAuthenticationState.UNRECOGNIZED,
+                    addresses: [],
+                    instruments: [],
+                });
+
                 return;
             }
 

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -579,6 +579,7 @@ export enum BraintreeConnectAuthenticationState {
     SUCCEEDED = 'succeeded',
     FAILED = 'failed',
     CANCELED = 'canceled',
+    UNRECOGNIZED = 'unrecognized',
 }
 
 export interface BraintreeConnectAuthenticationCustomerResult {


### PR DESCRIPTION
## What?
Clean up prev provider customer data from checkout state for cases when the customer comes back to customer step and updates an email with new one, that does not recognized in PP Connect system

## Why?
Recognized by PP COnnect customer returns to customer step to update the email field -> customer can see the data from PayPal Connect like vaulted instruments in payment step. So we should clean up provider customer data for cases, if the email was changed.

## Testing / Proof
Unit tests
Manual tests