### PR TITLE
feat(payment): PAYPAL-2853 added riskCorrelationId to data collector for PayPal Analytics

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -127,7 +127,7 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
                 paymentMethod.clientToken,
                 paymentMethod.initializationData,
             );
-            expect(braintreeIntegrationService.getBraintreeConnect).toHaveBeenCalled();
+            expect(braintreeIntegrationService.getBraintreeConnect).toHaveBeenCalledWith(cart.id);
         });
     });
 

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -25,7 +25,9 @@ export default class BraintreeAcceleratedCheckoutUtils {
     ) {}
 
     async getDeviceSessionId(): Promise<string | undefined> {
-        return this.braintreeIntegrationService.getSessionId();
+        const cart = this.paymentIntegrationService.getState().getCart();
+
+        return this.braintreeIntegrationService.getSessionId(cart?.id);
     }
 
     /**
@@ -35,6 +37,7 @@ export default class BraintreeAcceleratedCheckoutUtils {
      */
     async initializeBraintreeConnectOrThrow(methodId: string) {
         const state = this.paymentIntegrationService.getState();
+        const cart = state.getCart();
         const { clientToken, initializationData } =
             state.getPaymentMethodOrThrow<BraintreeInitializationData>(methodId);
 
@@ -45,7 +48,9 @@ export default class BraintreeAcceleratedCheckoutUtils {
         this.methodId = methodId;
 
         this.braintreeIntegrationService.initialize(clientToken, initializationData);
-        this.braintreeConnect = await this.braintreeIntegrationService.getBraintreeConnect();
+        this.braintreeConnect = await this.braintreeIntegrationService.getBraintreeConnect(
+            cart?.id,
+        );
     }
 
     /**

--- a/packages/braintree-utils/src/braintree-integration-service.spec.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.spec.ts
@@ -436,6 +436,21 @@ describe('BraintreeIntegrationService', () => {
         });
     });
 
+    describe('#getSessionId', () => {
+        it('provides riskCorrelationId to data collector', async () => {
+            const cartIdMock = 'cartId-asdasd';
+
+            braintreeIntegrationService.initialize(clientToken, initializationData);
+            await braintreeIntegrationService.getSessionId(cartIdMock);
+
+            expect(dataCollectorCreatorMock.create).toHaveBeenCalledWith({
+                client: clientMock,
+                kount: true,
+                riskCorrelationId: cartIdMock,
+            });
+        });
+    });
+
     describe('#teardown()', () => {
         it('calls teardown in all the dependencies', async () => {
             braintreeIntegrationService.initialize(clientToken, initializationData);

--- a/packages/braintree-utils/src/braintree-integration-service.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.ts
@@ -9,6 +9,7 @@ import {
     BraintreeBankAccount,
     BraintreeClient,
     BraintreeDataCollector,
+    BraintreeDataCollectorCreatorConfig,
     BraintreeDetails,
     BraintreeEnv,
     BraintreeError,
@@ -48,14 +49,14 @@ export default class BraintreeIntegrationService {
         this.braintreeScriptLoader.initialize(initializationData);
     }
 
-    async getBraintreeConnect() {
+    async getBraintreeConnect(cardId?: string) {
         // TODO: should be removed after PayPal prepare stable Braintree SDK version with AXO implementation
         window.localStorage.setItem('axoEnv', 'test67');
 
         if (!this.braintreeHostWindow.braintreeConnect) {
             const clientToken = this.getClientTokenOrThrow();
             const client = await this.getClient();
-            const deviceData = await this.getSessionId();
+            const deviceData = await this.getSessionId(cardId);
 
             const braintreeConnectCreator = await this.braintreeScriptLoader.loadConnect();
 
@@ -160,7 +161,9 @@ export default class BraintreeIntegrationService {
         return this.usBankAccount;
     }
 
-    async getDataCollector(options?: { paypal: boolean }): Promise<BraintreeDataCollector> {
+    async getDataCollector(
+        options?: Partial<BraintreeDataCollectorCreatorConfig>,
+    ): Promise<BraintreeDataCollector> {
         const cacheKey: keyof DataCollectors = options?.paypal ? 'paypal' : 'default';
 
         let cached = this.dataCollectors[cacheKey];
@@ -170,7 +173,13 @@ export default class BraintreeIntegrationService {
                 const client = await this.getClient();
                 const dataCollector = await this.braintreeScriptLoader.loadDataCollector();
 
-                cached = await dataCollector.create({ client, kount: true, ...options });
+                const dataCollectorConfig: BraintreeDataCollectorCreatorConfig = {
+                    client,
+                    kount: true,
+                    ...options,
+                };
+
+                cached = await dataCollector.create(dataCollectorConfig);
             } catch (error) {
                 if (isBraintreeError(error) && error.code === 'DATA_COLLECTOR_KOUNT_NOT_ENABLED') {
                     cached = {
@@ -251,8 +260,10 @@ export default class BraintreeIntegrationService {
         }
     }
 
-    async getSessionId(): Promise<string | undefined> {
-        const { deviceData } = await this.getDataCollector();
+    async getSessionId(cartId?: string): Promise<string | undefined> {
+        const { deviceData } = await this.getDataCollector({
+            riskCorrelationId: cartId,
+        });
 
         return deviceData;
     }

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -211,6 +211,7 @@ export type BraintreeDataCollectorCreator = BraintreeModuleCreator<
 export interface BraintreeDataCollectorCreatorConfig extends BraintreeModuleCreatorConfig {
     kount?: boolean;
     paypal?: boolean;
+    riskCorrelationId?: string; // Info: the option is needed for PayPal Analytics
 }
 
 export interface BraintreeDataCollector extends BraintreeModule {


### PR DESCRIPTION
## What?
Added riskCorrelationId to data collector for PayPal Analytics

## Why?
PayPal wants to match device session id on FE side to match the session with the Analytics data that we send to PayPal on BE side. So we should add riskCorrelationId option to the data collector config to make it works

## Testing / Proof
Unit tests

Here is an example of device data:
`"{"device_session_id":"516559b8ab0214fa7a1648bc8542e2bd","fraud_merchant_id":null,"correlation_id":"9106fa8b-8196-4def-9944-ec3ab79a1f79"}"`

As you can see `correlation_id` is already there.

