### PR TITLE
feat(payment): PAYPAL-2876 added session id to the local storage after customer's OTP BT AXO

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -15,6 +15,7 @@ import {
     PaymentIntegrationService,
     PaymentMethodClientUnavailableError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 export default class BraintreeAcceleratedCheckoutUtils {
     private braintreeConnect?: BraintreeConnect;
@@ -23,6 +24,7 @@ export default class BraintreeAcceleratedCheckoutUtils {
     constructor(
         private paymentIntegrationService: PaymentIntegrationService,
         private braintreeIntegrationService: BraintreeIntegrationService,
+        private browserStorage: BrowserStorage,
     ) {}
 
     async getDeviceSessionId(): Promise<string | undefined> {
@@ -90,6 +92,8 @@ export default class BraintreeAcceleratedCheckoutUtils {
             const { customerContextId } = await lookupCustomerByEmail(customerEmail);
 
             if (!customerContextId) {
+                this.browserStorage.removeItem('sessionId');
+
                 // Info: we should clean up previous experience with default data and related authenticationState
                 await this.paymentIntegrationService.updatePaymentProviderCustomer({
                     authenticationState: BraintreeConnectAuthenticationState.UNRECOGNIZED,
@@ -106,6 +110,8 @@ export default class BraintreeAcceleratedCheckoutUtils {
 
             const addresses = this.mapPayPalToBcAddress(profileData.addresses) || [];
             const instruments = this.mapPayPalToBcInstrument(methodId, profileData.cards) || [];
+
+            this.browserStorage.setItem('sessionId', cart.id);
 
             await this.paymentIntegrationService.updatePaymentProviderCustomer({
                 authenticationState,

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
@@ -1,3 +1,4 @@
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import {
@@ -21,9 +22,11 @@ const createBraintreeAcceleratedCheckoutCustomerStrategy: CustomerStrategyFactor
         new BraintreeScriptLoader(getScriptLoader(), braintreeHostWindow),
         braintreeHostWindow,
     );
+    const browserStorage = new BrowserStorage('paypalConnect');
     const braintreeAcceleratedCheckoutUtils = new BraintreeAcceleratedCheckoutUtils(
         paymentIntegrationService,
         braintreeIntegrationService,
+        browserStorage,
     );
 
     return new BraintreeAcceleratedCheckoutCustomerStrategy(

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-payment-strategy.ts
@@ -12,6 +12,7 @@ import {
 
 import BraintreeAcceleratedCheckoutPaymentStrategy from './braintree-accelerated-checkout-payment-strategy';
 import BraintreeAcceleratedCheckoutUtils from './braintree-accelerated-checkout-utils';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 const createBraintreeAcceleratedCheckoutPaymentStrategy: PaymentStrategyFactory<
     BraintreeAcceleratedCheckoutPaymentStrategy
@@ -21,10 +22,12 @@ const createBraintreeAcceleratedCheckoutPaymentStrategy: PaymentStrategyFactory<
         new BraintreeScriptLoader(getScriptLoader(), braintreeHostWindow),
         braintreeHostWindow,
     );
+    const browserStorage = new BrowserStorage('paypalConnect');
 
     const braintreeAcceleratedCheckoutUtils = new BraintreeAcceleratedCheckoutUtils(
         paymentIntegrationService,
         braintreeIntegrationService,
+        browserStorage,
     );
 
     return new BraintreeAcceleratedCheckoutPaymentStrategy(


### PR DESCRIPTION
## What?
Added session id to the local storage after customer's OTP BT AXO

## Why?
To be able to trigger OTP after customer comes back to checkout page (only for customers who already triggered authentication flow before)

## Testing / Proof
Unit tests
