### PR TITLE
feat(payment): PAYPAL-2729 updated ExecutePaymentMethodCheckoutOptions with an optional email field

### DIFF
--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -151,6 +151,7 @@ export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
  *
  */
 export interface ExecutePaymentMethodCheckoutOptions extends CustomerRequestOptions {
+    email?: string;
     checkoutPaymentMethodExecuted?(data?: CheckoutPaymentMethodExecutedOptions): void;
     continueWithCheckoutCallback?(): void;
 }

--- a/packages/payment-integration-api/src/customer/customer-request-options.ts
+++ b/packages/payment-integration-api/src/customer/customer-request-options.ts
@@ -9,6 +9,7 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
 }
 
 export interface ExecutePaymentMethodCheckoutOptions extends CustomerRequestOptions {
+    email?: string;
     checkoutPaymentMethodExecuted?(data?: CheckoutPaymentMethodExecutedOptions): void;
     continueWithCheckoutCallback?(): void;
 }


### PR DESCRIPTION
## What?
Updated ExecutePaymentMethodCheckoutOptions with an optional email field

## Why?
To be able to use customer's email in customer strategy execution method.
It might be helpful for cases when we need to call execution method right after sign up.

## Testing / Proof
Unit tests
Manual tests
