### PR TITLE
feat(payment): PAYPAL-2729 added an ability to trigger PP Connect authentication flow by passing an email through customer execution options

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -90,6 +90,20 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
             }
         });
 
+        it('authenticates user with PayPal Connect with provided email', async () => {
+            const email = 'customer@email.com';
+
+            await strategy.initialize({ methodId });
+            await strategy.executePaymentMethodCheckout({
+                ...executionOptions,
+                email,
+            });
+
+            expect(
+                braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow,
+            ).toHaveBeenCalledWith(email);
+        });
+
         it('authenticates user with PayPal Connect and calls continueWithCheckoutCallback', async () => {
             await strategy.initialize({ methodId });
             await strategy.executePaymentMethodCheckout(executionOptions);

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
@@ -46,7 +46,7 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
     async executePaymentMethodCheckout(
         options?: ExecutePaymentMethodCheckoutOptions,
     ): Promise<void> {
-        const { continueWithCheckoutCallback } = options || {};
+        const { continueWithCheckoutCallback, email } = options || {};
 
         if (typeof continueWithCheckoutCallback !== 'function') {
             throw new InvalidArgumentError(
@@ -55,7 +55,7 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
         }
 
         if (await this.shouldRunAuthenticationFlow()) {
-            await this.runPayPalConnectAuthenticationFlowOrThrow();
+            await this.runPayPalConnectAuthenticationFlowOrThrow(email);
         }
 
         continueWithCheckoutCallback();

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
@@ -1,4 +1,3 @@
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import {
@@ -10,6 +9,7 @@ import {
     CustomerStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import BraintreeAcceleratedCheckoutCustomerStrategy from './braintree-accelerated-checkout-customer-strategy';
 import BraintreeAcceleratedCheckoutUtils from './braintree-accelerated-checkout-utils';

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-payment-strategy.ts
@@ -9,10 +9,10 @@ import {
     PaymentStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import BraintreeAcceleratedCheckoutPaymentStrategy from './braintree-accelerated-checkout-payment-strategy';
 import BraintreeAcceleratedCheckoutUtils from './braintree-accelerated-checkout-utils';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 const createBraintreeAcceleratedCheckoutPaymentStrategy: PaymentStrategyFactory<
     BraintreeAcceleratedCheckoutPaymentStrategy

--- a/packages/core/src/customer/customer-request-options.ts
+++ b/packages/core/src/customer/customer-request-options.ts
@@ -151,6 +151,7 @@ export interface BaseCustomerInitializeOptions extends CustomerRequestOptions {
  *
  */
 export interface ExecutePaymentMethodCheckoutOptions extends CustomerRequestOptions {
+    email?: string;
     checkoutPaymentMethodExecuted?(data?: CheckoutPaymentMethodExecutedOptions): void;
     continueWithCheckoutCallback?(): void;
 }

--- a/packages/payment-integration-api/src/customer/customer-request-options.ts
+++ b/packages/payment-integration-api/src/customer/customer-request-options.ts
@@ -9,6 +9,7 @@ export interface CustomerInitializeOptions extends CustomerRequestOptions {
 }
 
 export interface ExecutePaymentMethodCheckoutOptions extends CustomerRequestOptions {
+    email?: string;
     checkoutPaymentMethodExecuted?(data?: CheckoutPaymentMethodExecutedOptions): void;
     continueWithCheckoutCallback?(): void;
 }


### PR DESCRIPTION
## What?
Added an ability to trigger PP Connect authentication flow by passing an email through customer execution options

## Why?
To be able to trigger PP Connect authentication flow right after customer's sign up

## Testing / Proof
Unit tests
Manual tests


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/bb9db428-0db0-4901-949c-41e2c4cafdd4


