### PR TITLE
fix(checkout): PI-657 fixed validation for stored bluesnap direct card verification fields

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-constants.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-constants.ts
@@ -36,11 +36,6 @@ export const CREDIT_CARD_ERRORS = {
             message: 'CVV is required',
             type: 'required',
         },
-        [HostedFieldType.CardCodeVerification]: {
-            fieldType: 'cardCode',
-            message: 'CVV is required',
-            type: 'required',
-        },
         [HostedFieldType.CardName]: {
             fieldType: 'cardName',
             message: 'Full name is required',
@@ -64,11 +59,6 @@ export const CREDIT_CARD_ERRORS = {
             type: 'invalid_card_expiry',
         },
         [HostedFieldType.CardCode]: {
-            fieldType: 'cardCode',
-            message: 'CVV must be valid',
-            type: 'invalid_card_code',
-        },
-        [HostedFieldType.CardCodeVerification]: {
             fieldType: 'cardCode',
             message: 'CVV must be valid',
             type: 'invalid_card_code',

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-form.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-form.spec.ts
@@ -57,7 +57,6 @@ describe('BlueSnapDirectHostedForm', () => {
         hostedInputValidator = new BlueSnapHostedInputValidator();
         jest.spyOn(hostedInputValidator, 'initialize');
         jest.spyOn(hostedInputValidator, 'initializeValidationFields');
-        jest.spyOn(hostedInputValidator, 'initializeValidationCVVFields');
         jest.spyOn(hostedInputValidator, 'validate');
 
         hostedForm = new BlueSnapDirectHostedForm(
@@ -111,19 +110,6 @@ describe('BlueSnapDirectHostedForm', () => {
             await hostedForm.initialize(false, ccOptionsMock.form.fields);
 
             expect(hostedInputValidator.initialize).toHaveBeenCalled();
-            expect(scriptLoader.load).toHaveBeenCalledWith(false);
-        });
-
-        it('should initialize hosted form for stored card successfully with cvv only validation', async () => {
-            await hostedForm.initialize(false, {
-                [HostedFieldType.CardNumberVerification]: undefined,
-                [HostedFieldType.CardCodeVerification]: {
-                    containerId: optionsMocks.ccCvvContainerId,
-                    instrumentId: 'instrumentId',
-                },
-            });
-
-            expect(hostedInputValidator.initializeValidationCVVFields).toHaveBeenCalled();
             expect(scriptLoader.load).toHaveBeenCalledWith(false);
         });
 

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-form.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-form.ts
@@ -67,18 +67,8 @@ export default class BlueSnapDirectHostedForm {
             return;
         }
 
-        if (
-            isHostedStoredCardFieldOptionsMap(fields) &&
-            !!fields.cardNumberVerification &&
-            !!fields.cardCodeVerification
-        ) {
+        if (isHostedStoredCardFieldOptionsMap(fields) && !!fields.cardNumberVerification) {
             this._hostedInputValidator.initializeValidationFields();
-
-            return;
-        }
-
-        if (isHostedStoredCardFieldOptionsMap(fields) && !!fields.cardCodeVerification) {
-            this._hostedInputValidator.initializeValidationCVVFields();
         }
     }
 

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-input-validator.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-input-validator.spec.ts
@@ -76,4 +76,23 @@ describe('BlueSnapHostedInputValidator', () => {
 
         expect(validator.validate()).toStrictEqual(expectedResult);
     });
+
+    it('should return an invalid result for stored cards', () => {
+        validator = new BlueSnapHostedInputValidator();
+        validator.initializeValidationFields();
+
+        const expectedResult = {
+            isValid: false,
+            errors: {
+                cardNumberVerification: [CREDIT_CARD_ERRORS.invalid.cardNumber],
+            },
+        };
+
+        validator.validate({
+            tagId: HostedFieldTagId.CardNumber,
+            errorDescription: SubmitErrorDescription.INVALID,
+        });
+
+        expect(validator.validate()).toStrictEqual(expectedResult);
+    });
 });

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-input-validator.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-input-validator.ts
@@ -1,4 +1,5 @@
 import {
+    HostedFieldType,
     HostedInputValidateErrorData,
     HostedInputValidateErrorDataMap,
     HostedInputValidateResults,
@@ -24,14 +25,7 @@ export default class BlueSnapHostedInputValidator {
 
     initializeValidationFields(): void {
         this._errors = {
-            cardNumber: [CREDIT_CARD_ERRORS.empty.cardNumber],
-            cardCode: [CREDIT_CARD_ERRORS.empty.cardCode],
-        };
-    }
-
-    initializeValidationCVVFields(): void {
-        this._errors = {
-            cardCode: [CREDIT_CARD_ERRORS.empty.cardCode],
+            cardNumberVerification: [CREDIT_CARD_ERRORS.empty.cardNumber],
         };
     }
 
@@ -52,7 +46,9 @@ export default class BlueSnapHostedInputValidator {
     }
 
     private _updateErrors(tagId: HostedFieldTagId, errorDescription?: ErrorDescription): void {
-        const fieldType = BlueSnapHostedFieldType[tagId];
+        const fieldType = this._errors.cardNumberVerification
+            ? HostedFieldType.CardNumberVerification
+            : BlueSnapHostedFieldType[tagId];
 
         this._errors[fieldType] = errorDescription
             ? [CREDIT_CARD_ERRORS[errorDescription][fieldType]]


### PR DESCRIPTION
## What?
Fixed validation for stored bluesnap direct card verification fields

## Why?
Due to the absence UI notifications in validation error cases 

## Testing / Proof
manually/units
Before: 

![image](https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/3dc7ea86-0fd7-4d58-89a4-eeac6b95df74)

After:

![image](https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/af61988d-0ceb-4290-9e0d-02649fc37791)


@bigcommerce/team-checkout @bigcommerce/team-payments
