### PR TITLE
feat(payment): PAYPAL-2851 trigger authentication flow on BT AXO payment method initialization

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-customer-strategy.ts
@@ -1,4 +1,3 @@
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
 import {
@@ -10,6 +9,7 @@ import {
     CustomerStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import BraintreeAcceleratedCheckoutCustomerStrategy from './braintree-accelerated-checkout-customer-strategy';
 import BraintreeAcceleratedCheckoutUtils from './braintree-accelerated-checkout-utils';

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/create-braintree-accelerated-checkout-payment-strategy.ts
@@ -9,10 +9,10 @@ import {
     PaymentStrategyFactory,
     toResolvableModule,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 import BraintreeAcceleratedCheckoutPaymentStrategy from './braintree-accelerated-checkout-payment-strategy';
 import BraintreeAcceleratedCheckoutUtils from './braintree-accelerated-checkout-utils';
-import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
 const createBraintreeAcceleratedCheckoutPaymentStrategy: PaymentStrategyFactory<
     BraintreeAcceleratedCheckoutPaymentStrategy
@@ -33,6 +33,7 @@ const createBraintreeAcceleratedCheckoutPaymentStrategy: PaymentStrategyFactory<
     return new BraintreeAcceleratedCheckoutPaymentStrategy(
         paymentIntegrationService,
         braintreeAcceleratedCheckoutUtils,
+        browserStorage,
     );
 };
 


### PR DESCRIPTION
## What?
Trigger authentication flow on BT AXO payment method initialization for customers who triggered the flow before and leave the checkout page to update the cart or reload a page.

## Why?
To get valid PayPal Connect Profile data and you them in checkout flow

## Testing / Proof
Unit tests
Manual tests


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/28e62fc6-11b2-41e7-8079-0458f6130061

