### PR TITLE
feat(payment): PAYPAL-2728 create shipping strategy for Braintree AXO

### DIFF
--- a/packages/core/src/shipping/create-shipping-strategy-registry.spec.ts
+++ b/packages/core/src/shipping/create-shipping-strategy-registry.spec.ts
@@ -6,6 +6,7 @@ import { Registry } from '../common/registry';
 import createShippingStrategyRegistry from './create-shipping-strategy-registry';
 import { ShippingStrategy } from './strategies';
 import { AmazonPayV2ShippingStrategy } from './strategies/amazon-pay-v2';
+import { BraintreeAcceleratedCheckoutShippingStrategy } from './strategies/braintree';
 
 describe('CreateShippingStrategyRegistry', () => {
     let registry: Registry<ShippingStrategy>;
@@ -21,5 +22,11 @@ describe('CreateShippingStrategyRegistry', () => {
         const shippingStrategy = registry.get('amazonpay');
 
         expect(shippingStrategy).toBeInstanceOf(AmazonPayV2ShippingStrategy);
+    });
+
+    it('can instantiate braintree accelerated checkout', () => {
+        const shippingStrategy = registry.get('braintreeacceleratedcheckout');
+
+        expect(shippingStrategy).toBeInstanceOf(BraintreeAcceleratedCheckoutShippingStrategy);
     });
 });

--- a/packages/core/src/shipping/shipping-request-options.ts
+++ b/packages/core/src/shipping/shipping-request-options.ts
@@ -1,6 +1,7 @@
 import { RequestOptions } from '../common/http-request';
 
 import { AmazonPayV2ShippingInitializeOptions } from './strategies/amazon-pay-v2';
+import { BraintreeAcceleratedCheckoutInitializeOptions } from './strategies/braintree';
 import { StripeUPEShippingInitializeOptions } from './strategies/stripe-upe';
 
 /**
@@ -38,4 +39,10 @@ export interface ShippingInitializeOptions<T = {}> extends ShippingRequestOption
      * when using Stripe Upe Link.
      */
     stripeupe?: StripeUPEShippingInitializeOptions;
+
+    /**
+     * The options that are required to initialize the shipping step of checkout
+     * when using Braintree Accelerated Checkout.
+     */
+    braintreeacceleratedcheckout?: BraintreeAcceleratedCheckoutInitializeOptions;
 }

--- a/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-initialize-options.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-initialize-options.ts
@@ -1,0 +1,10 @@
+/**
+ * A set of options that are required to initialize the shipping step of
+ * checkout in order to support Braintree Accelerated Checkout.
+ */
+export default interface BraintreeAcceleratedCheckoutInitializeOptions {
+    /**
+     * The identifier of the payment method.
+     */
+    methodId: string;
+}

--- a/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.spec.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.spec.ts
@@ -1,0 +1,395 @@
+import { BraintreeIntegrationService } from '@bigcommerce/checkout-sdk/braintree-utils';
+import { PaymentMethod } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    getBillingAddress,
+    getCart,
+    getPaymentMethod,
+    getShippingAddress,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+
+import { BillingAddressActionCreator } from '../../../billing';
+import { CheckoutStore, createCheckoutStore } from '../../../checkout';
+import { InvalidArgumentError } from '../../../common/error/errors';
+import { PaymentMethodActionCreator } from '../../../payment';
+import { PaymentProviderCustomerActionCreator } from '../../../payment-provider-customer';
+import ConsignmentActionCreator from '../../consignment-action-creator';
+import { getFlatRateOption } from '../../internal-shipping-options.mock';
+
+import BraintreeAcceleratedCheckoutInitializeOptions from './braintree-accelerated-checkout-initialize-options';
+import BraintreeAcceleratedCheckoutShippingStrategy from './braintree-accelerated-checkout-shipping-strategy';
+
+const BRAINTREE_AXO_METHOD_ID = 'braintreeacceleratedcheckout';
+
+class PaymentMethodActionCreatorMock {
+    loadPaymentMethod(methodId: string): PaymentMethod | undefined {
+        return {
+            ...getPaymentMethod(),
+            id: methodId,
+        };
+    }
+}
+
+class PaymentProviderCustomerActionCreatorMock {
+    updatePaymentProviderCustomer() {}
+}
+
+class BraintreeIntegrationServiceMock {
+    initialize() {}
+    getBraintreeConnect() {}
+}
+
+class BillingAddressActionCreatorMock {
+    updateAddress() {}
+}
+
+class ConsignmentActionCreatorMock {
+    updateAddress() {}
+    selectShippingOption() {}
+}
+
+describe('BraintreeAcceleratedCheckoutShippingStrategy', () => {
+    let store: CheckoutStore;
+    let billingAddressActionCreator: BillingAddressActionCreatorMock;
+    let consignmentActionCreator: ConsignmentActionCreatorMock;
+    let paymentMethodActionCreator: PaymentMethodActionCreatorMock;
+    let paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreatorMock;
+    let braintreeIntegrationServiceMock: BraintreeIntegrationServiceMock;
+    const defaultOptions = {
+        methodId: BRAINTREE_AXO_METHOD_ID,
+    };
+    const ppAddress = {
+        id: '123',
+        firstName: 'firstName',
+        lastName: 'lastName',
+        company: 'company',
+        streetAddress: 'streetAddress',
+        extendedAddress: 'extendedAddress',
+        locality: 'locality',
+        region: 'region',
+        countryCodeAlpha2: 'countryCodeAlpha2',
+        postalCode: 'postalCode',
+    };
+    const mappedAddress = {
+        id: 123,
+        type: 'paypal-address',
+        firstName: 'firstName',
+        lastName: 'lastName',
+        company: 'company',
+        address1: 'streetAddress',
+        address2: 'extendedAddress',
+        city: 'locality',
+        stateOrProvince: 'region',
+        stateOrProvinceCode: 'region',
+        country: '',
+        countryCode: 'countryCodeAlpha2',
+        postalCode: 'postalCode',
+        phone: '',
+        customFields: [],
+    };
+    const createStrategy = () => {
+        return new BraintreeAcceleratedCheckoutShippingStrategy(
+            store,
+            billingAddressActionCreator as unknown as BillingAddressActionCreator,
+            consignmentActionCreator as unknown as ConsignmentActionCreator,
+            paymentMethodActionCreator as unknown as PaymentMethodActionCreator,
+            paymentProviderCustomerActionCreator as unknown as PaymentProviderCustomerActionCreator,
+            braintreeIntegrationServiceMock as unknown as BraintreeIntegrationService,
+        );
+    };
+
+    beforeEach(() => {
+        store = createCheckoutStore();
+        paymentMethodActionCreator = new PaymentMethodActionCreatorMock();
+        paymentProviderCustomerActionCreator = new PaymentProviderCustomerActionCreatorMock();
+        braintreeIntegrationServiceMock = new BraintreeIntegrationServiceMock();
+        jest.spyOn(store, 'dispatch').mockImplementation((args) => args);
+        billingAddressActionCreator = new BillingAddressActionCreatorMock();
+        consignmentActionCreator = new ConsignmentActionCreatorMock();
+
+        jest.spyOn(store.getState().cart, 'getCart').mockReturnValue({
+            ...getCart(),
+        });
+        jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue({
+            ...getCart(),
+        });
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
+            clientToken: 'clientToken',
+            initializationData: {},
+        });
+        jest.spyOn(store.getState().billingAddress, 'getBillingAddress').mockReturnValue({
+            ...getBillingAddress(),
+        });
+        jest.spyOn(BrowserStorage.prototype, 'getItem').mockReturnValue(getCart().id);
+        jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeConnect').mockReturnValue({
+            identity: {
+                lookupCustomerByEmail: () => ({ customerContextId: 'customerContextId' }),
+                triggerAuthenticationFlow: () =>
+                    Promise.resolve({
+                        authenticationState: 'authenticationState',
+                        profileData: { addresses: [ppAddress] },
+                    }),
+            },
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('updateAddress', () => {
+        it('updates shipping address', async () => {
+            const address = getShippingAddress();
+            const options = {};
+            const updateAction = jest.fn();
+
+            jest.spyOn(consignmentActionCreator, 'updateAddress').mockImplementation(updateAction);
+
+            const strategy = createStrategy();
+
+            await strategy.updateAddress(address, options);
+
+            expect(updateAction).toHaveBeenCalledWith(address, options);
+        });
+    });
+
+    describe('selectOption', () => {
+        it('selects shipping option', async () => {
+            const method = getFlatRateOption();
+            const options = {};
+            const updateAction = jest.fn();
+
+            jest.spyOn(consignmentActionCreator, 'selectShippingOption').mockImplementation(
+                updateAction,
+            );
+
+            const strategy = createStrategy();
+
+            await strategy.selectOption(method.id, options);
+
+            expect(consignmentActionCreator.selectShippingOption).toHaveBeenCalledWith(
+                method.id,
+                options,
+            );
+            expect(updateAction).toHaveBeenCalledWith(method.id, options);
+        });
+    });
+
+    describe('deinitialize', () => {
+        it('deinitialize shilling strategy', async () => {
+            jest.spyOn(store, 'getState').mockReturnValue('storeState');
+
+            const strategy = createStrategy();
+
+            expect(await strategy.deinitialize()).toBe('storeState');
+        });
+    });
+
+    describe('initialize', () => {
+        it('throws an error if no method Id in options', async () => {
+            const strategy = createStrategy();
+            const response = strategy.initialize(
+                {} as BraintreeAcceleratedCheckoutInitializeOptions,
+            );
+
+            return expect(response).rejects.toThrow(InvalidArgumentError);
+        });
+
+        it('should not run authentication flow if OTP was already shown', async () => {
+            const loadPaymentMethodMock = jest.fn();
+
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(
+                loadPaymentMethodMock,
+            );
+            jest.spyOn(
+                store.getState().paymentProviderCustomer,
+                'getPaymentProviderCustomer',
+            ).mockReturnValue({
+                authenticationState: 'anyState',
+            });
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(loadPaymentMethodMock).not.toHaveBeenCalled();
+        });
+
+        it('should not run authentication flow if PayPal session id is different', async () => {
+            const loadPaymentMethodMock = jest.fn();
+
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(
+                loadPaymentMethodMock,
+            );
+            jest.spyOn(
+                store.getState().paymentProviderCustomer,
+                'getPaymentProviderCustomer',
+            ).mockReturnValue(undefined);
+            jest.spyOn(BrowserStorage.prototype, 'getItem').mockReturnValue('123');
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(loadPaymentMethodMock).not.toHaveBeenCalled();
+        });
+
+        it('should run authentication flow', async () => {
+            const loadPaymentMethodMock = jest.fn();
+
+            jest.spyOn(paymentMethodActionCreator, 'loadPaymentMethod').mockImplementation(
+                loadPaymentMethodMock,
+            );
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(loadPaymentMethodMock).toHaveBeenCalledWith(BRAINTREE_AXO_METHOD_ID);
+        });
+
+        it('skip authentication if clientToken does not exist', async () => {
+            const getBraintreeConnectMock = jest.fn();
+
+            jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeConnect').mockImplementation(
+                getBraintreeConnectMock,
+            );
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
+                initializationData: {},
+            });
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(getBraintreeConnectMock).not.toHaveBeenCalled();
+        });
+
+        it('skip authentication if initializationData does not exist', async () => {
+            const getBraintreeConnectMock = jest.fn();
+
+            jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeConnect').mockImplementation(
+                getBraintreeConnectMock,
+            );
+            jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue({
+                clientToken: 'clientToken',
+            });
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(getBraintreeConnectMock).not.toHaveBeenCalled();
+        });
+
+        it('skip authentication if customerContextId does not exist', async () => {
+            const lookupCustomerByEmailMock = () => ({ customerContextId: undefined });
+            const triggerAuthenticationFlowMock = jest.fn();
+
+            jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeConnect').mockReturnValue({
+                braintreeConnect: {
+                    identity: {
+                        lookupCustomerByEmail: lookupCustomerByEmailMock,
+                        triggerAuthenticationFlow: triggerAuthenticationFlowMock,
+                    },
+                },
+            });
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(triggerAuthenticationFlowMock).not.toHaveBeenCalled();
+        });
+
+        it('skip authentication if customerContextId does not exist', async () => {
+            const triggerAuthenticationFlowMock = jest.fn();
+
+            jest.spyOn(braintreeIntegrationServiceMock, 'getBraintreeConnect').mockReturnValue({
+                braintreeConnect: {
+                    identity: {
+                        lookupCustomerByEmail: () => ({ customerContextId: undefined }),
+                        triggerAuthenticationFlow: triggerAuthenticationFlowMock,
+                    },
+                },
+            });
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(triggerAuthenticationFlowMock).not.toHaveBeenCalled();
+        });
+
+        it('update billing address for digital product', async () => {
+            const updatePaymentProviderCustomerMock = jest.fn();
+            const updateBillingAddressMock = jest.fn();
+            const updateShippingAddressMock = jest.fn();
+
+            jest.spyOn(
+                paymentProviderCustomerActionCreator,
+                'updatePaymentProviderCustomer',
+            ).mockImplementation(updatePaymentProviderCustomerMock);
+            jest.spyOn(billingAddressActionCreator, 'updateAddress').mockImplementation(
+                updateBillingAddressMock,
+            );
+            jest.spyOn(consignmentActionCreator, 'updateAddress').mockImplementation(
+                updateShippingAddressMock,
+            );
+            jest.spyOn(store.getState().cart, 'getCartOrThrow').mockReturnValue({
+                ...getCart(),
+                lineItems: {
+                    ...getCart().lineItems,
+                    physicalItems: [],
+                },
+            });
+
+            const strategy = createStrategy();
+
+            await strategy.initialize(defaultOptions);
+
+            expect(updatePaymentProviderCustomerMock).toHaveBeenCalledWith({
+                authenticationState: 'authenticationState',
+                addresses: [mappedAddress],
+                instruments: [],
+            });
+            expect(updateBillingAddressMock).toHaveBeenCalledWith({
+                ...mappedAddress,
+                id: '123',
+            });
+            expect(updateShippingAddressMock).not.toHaveBeenCalled();
+        });
+    });
+
+    it('update billing and shipping address for physical items', async () => {
+        const updatePaymentProviderCustomerMock = jest.fn();
+        const updateBillingAddressMock = jest.fn();
+        const updateShippingAddressMock = jest.fn();
+
+        jest.spyOn(
+            paymentProviderCustomerActionCreator,
+            'updatePaymentProviderCustomer',
+        ).mockImplementation(updatePaymentProviderCustomerMock);
+        jest.spyOn(billingAddressActionCreator, 'updateAddress').mockImplementation(
+            updateBillingAddressMock,
+        );
+        jest.spyOn(consignmentActionCreator, 'updateAddress').mockImplementation(
+            updateShippingAddressMock,
+        );
+
+        const strategy = createStrategy();
+
+        await strategy.initialize(defaultOptions);
+
+        expect(updatePaymentProviderCustomerMock).toHaveBeenCalledWith({
+            authenticationState: 'authenticationState',
+            addresses: [mappedAddress],
+            instruments: [],
+        });
+        expect(updateBillingAddressMock).toHaveBeenCalledWith({
+            ...mappedAddress,
+            id: '123',
+        });
+        expect(updateShippingAddressMock).toHaveBeenCalledWith(mappedAddress);
+    });
+});

--- a/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.ts
@@ -1,0 +1,221 @@
+import {
+    BraintreeConnectAddress,
+    BraintreeConnectVaultedInstrument,
+    BraintreeIntegrationService,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
+
+import { AddressRequestBody } from '../../../address';
+import { BillingAddressActionCreator } from '../../../billing';
+import { CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
+import {
+    InvalidArgumentError,
+    MissingDataError,
+    MissingDataErrorType,
+} from '../../../common/error/errors';
+import { CustomerAddress } from '../../../customer';
+import { Country } from '../../../geography';
+import { PaymentMethodActionCreator } from '../../../payment';
+import { PaymentProviderCustomerActionCreator } from '../../../payment-provider-customer';
+import { CardInstrument } from '../../../payment/instrument';
+import { UntrustedShippingCardVerificationType } from '../../../payment/instrument/instrument';
+import ConsignmentActionCreator from '../../consignment-action-creator';
+import { ShippingRequestOptions } from '../../shipping-request-options';
+import ShippingStrategy from '../shipping-strategy';
+
+import BraintreeAcceleratedCheckoutInitializeOptions from './braintree-accelerated-checkout-initialize-options';
+
+export default class BraintreeAcceleratedCheckoutShippingStrategy implements ShippingStrategy {
+    private _browserStorage: BrowserStorage;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _billingAddressActionCreator: BillingAddressActionCreator,
+        private _consignmentActionCreator: ConsignmentActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator,
+        private _braintreeIntegrationService: BraintreeIntegrationService,
+    ) {
+        this._browserStorage = new BrowserStorage('paypalConnect');
+    }
+
+    updateAddress(
+        address: AddressRequestBody,
+        options?: ShippingRequestOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(this._consignmentActionCreator.updateAddress(address, options));
+    }
+
+    selectOption(
+        optionId: string,
+        options?: ShippingRequestOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        return this._store.dispatch(
+            this._consignmentActionCreator.selectShippingOption(optionId, options),
+        );
+    }
+
+    deinitialize(): Promise<InternalCheckoutSelectors> {
+        return Promise.resolve(this._store.getState());
+    }
+
+    async initialize(
+        options: BraintreeAcceleratedCheckoutInitializeOptions,
+    ): Promise<InternalCheckoutSelectors> {
+        const { methodId } = options || {};
+
+        if (!methodId) {
+            throw new InvalidArgumentError(
+                'Unable to proceed because "methodId" argument is not provided.',
+            );
+        }
+
+        if (!this._shouldRunAuthenticationFlow()) {
+            return Promise.resolve(this._store.getState());
+        }
+
+        try {
+            await this._store.dispatch(
+                this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+            );
+            await this._runAuthenticationFlowOrThrow(methodId);
+        } catch (error) {
+            // Info: we should not throw any error here to avoid
+            // customer stuck on shipping step due to the payment provider
+            // custom flow
+        }
+
+        return Promise.resolve(this._store.getState());
+    }
+
+    private _shouldRunAuthenticationFlow(): boolean {
+        const state = this._store.getState();
+        const cartId = state.cart.getCart()?.id;
+        const payPalConnectSessionId = this._browserStorage.getItem('sessionId');
+        const paymentProviderCustomer = state.paymentProviderCustomer.getPaymentProviderCustomer();
+
+        return !paymentProviderCustomer?.authenticationState && payPalConnectSessionId === cartId;
+    }
+
+    private async _runAuthenticationFlowOrThrow(methodId: string): Promise<void> {
+        const state = this._store.getState();
+        const cart = state.cart.getCartOrThrow();
+        const countries = state.countries.getCountries() || [];
+        const customer = state.customer.getCustomer();
+        const billingAddress = state.billingAddress.getBillingAddress();
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const { clientToken, initializationData } = paymentMethod;
+
+        if (!clientToken || !initializationData) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        this._braintreeIntegrationService.initialize(clientToken, initializationData);
+
+        const braintreeConnect = await this._braintreeIntegrationService.getBraintreeConnect(
+            cart?.id,
+        );
+
+        const customerEmail = customer?.email || billingAddress?.email;
+
+        if (!customerEmail) {
+            return;
+        }
+
+        const { lookupCustomerByEmail, triggerAuthenticationFlow } = braintreeConnect.identity;
+
+        const { customerContextId } = await lookupCustomerByEmail(customerEmail);
+
+        if (!customerContextId) {
+            return;
+        }
+
+        const { authenticationState, profileData } = await triggerAuthenticationFlow(
+            customerContextId,
+        );
+
+        const addresses = this._mapPayPalToBcAddress(profileData.addresses, countries) || [];
+        const instruments = this._mapPayPalToBcInstrument(methodId, profileData.cards) || [];
+
+        await this._store.dispatch(
+            this._paymentProviderCustomerActionCreator.updatePaymentProviderCustomer({
+                authenticationState,
+                addresses,
+                instruments,
+            }),
+        );
+
+        if (addresses.length > 0) {
+            await this._store.dispatch(
+                this._billingAddressActionCreator.updateAddress({
+                    ...addresses[0],
+                    id: String(addresses[0].id),
+                }),
+            );
+        }
+
+        if (addresses.length > 0 && cart.lineItems.physicalItems.length > 0) {
+            await this._store.dispatch(this._consignmentActionCreator.updateAddress(addresses[0]));
+        }
+    }
+
+    private _getCountryNameByCountryCode(countryCode: string, countries: Country[]): string {
+        const matchedCountry = countries.find((country) => country.code === countryCode);
+
+        return matchedCountry?.name || '';
+    }
+
+    private _mapPayPalToBcAddress(
+        addresses: BraintreeConnectAddress[],
+        countries: Country[],
+    ): CustomerAddress[] | undefined {
+        return addresses.map((address) => ({
+            id: Number(address.id),
+            type: 'paypal-address',
+            firstName: address.firstName || '',
+            lastName: address.lastName || '',
+            company: address.company || '',
+            address1: address.streetAddress,
+            address2: address.extendedAddress || '',
+            city: address.locality,
+            stateOrProvince: address.region,
+            stateOrProvinceCode: address.region,
+            country: this._getCountryNameByCountryCode(address.countryCodeAlpha2, countries),
+            countryCode: address.countryCodeAlpha2,
+            postalCode: address.postalCode,
+            phone: '',
+            customFields: [],
+        }));
+    }
+
+    private _mapPayPalToBcInstrument(
+        methodId: string,
+        instruments?: BraintreeConnectVaultedInstrument[],
+    ): CardInstrument[] | undefined {
+        if (!instruments) {
+            return;
+        }
+
+        return instruments.map((instrument) => {
+            const { id, paymentSource } = instrument;
+            const { brand, expiry, lastDigits } = paymentSource.card;
+
+            const [expiryYear, expiryMonth] = expiry.split('-');
+
+            return {
+                bigpayToken: id,
+                brand,
+                defaultInstrument: false,
+                expiryMonth,
+                expiryYear,
+                iin: '',
+                last4: lastDigits,
+                method: methodId,
+                provider: methodId,
+                trustedShippingAddress: false,
+                untrustedShippingCardVerificationMode: UntrustedShippingCardVerificationType.CVV,
+                type: 'card',
+            };
+        });
+    }
+}

--- a/packages/core/src/shipping/strategies/braintree/index.ts
+++ b/packages/core/src/shipping/strategies/braintree/index.ts
@@ -1,0 +1,2 @@
+export { default as BraintreeAcceleratedCheckoutInitializeOptions } from './braintree-accelerated-checkout-initialize-options';
+export { default as BraintreeAcceleratedCheckoutShippingStrategy } from './braintree-accelerated-checkout-shipping-strategy';


### PR DESCRIPTION
## What?
Create shipping strategy for Braintree Accelerated checkout

## Why?
To check logged in user and show OTP modal for PayPal Connect users

## Testing / Proof
Unit test and manually tested

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/dfb0a7d0-8186-4744-bccc-f8a41b765652



@bigcommerce/team-checkout @bigcommerce/team-payments
