### PR TITLE
fix(payment): PAYPAL-2877 captured device info for Braintree GooglePay

### DIFF
--- a/packages/braintree-utils/src/index.ts
+++ b/packages/braintree-utils/src/index.ts
@@ -37,6 +37,7 @@ export {
     getPaypalCheckoutMock,
     getPayPalCheckoutCreatorMock,
     getBraintreeLocalPaymentMock,
+    getDeviceDataMock,
 } from './mocks/braintree.mock';
 
 export { BRAINTREE_SDK_STABLE_VERSION, BRAINTREE_SDK_ALPHA_VERSION } from './sdk-verison';

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -190,6 +190,12 @@ export default class BraintreeSDKCreator {
         return this._visaCheckout;
     }
 
+    async getSessionId(): Promise<string | undefined> {
+        const { deviceData } = await this.getDataCollector();
+
+        return deviceData;
+    }
+
     getGooglePaymentComponent(): Promise<GooglePayBraintreeSDK> {
         if (!this._googlePay) {
             this._googlePay = Promise.all([

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -4,6 +4,8 @@ import { createScriptLoader, getStylesheetLoader } from '@bigcommerce/script-loa
 import { noop } from 'lodash';
 import { of } from 'rxjs';
 
+import { getDeviceDataMock } from '@bigcommerce/checkout-sdk/braintree-utils';
+
 import { getCartState } from '../../../cart/carts.mock';
 import {
     CheckoutActionCreator,
@@ -198,6 +200,7 @@ describe('GooglePayPaymentStrategy', () => {
         jest.spyOn(braintreeSDKCreator, 'initialize').mockImplementationOnce(
             initializeBraintreeSDK,
         );
+        jest.spyOn(braintreeSDKCreator, 'getSessionId').mockResolvedValue(getDeviceDataMock());
         jest.spyOn(braintreeSDKCreator, 'get3DS').mockResolvedValue({ verifyCard });
         jest.spyOn(orderActionCreator, 'submitOrder').mockReturnValue(
             Promise.resolve(store.getState()),
@@ -506,6 +509,7 @@ describe('GooglePayPaymentStrategy', () => {
                         },
                         method: 'googlepaybraintree',
                         nonce: 'newNonce',
+                        deviceSessionId: getDeviceDataMock(),
                     },
                 });
             });
@@ -743,6 +747,7 @@ describe('GooglePayPaymentStrategy', () => {
                         nonce: 'verificationNonce',
                         method: 'googlepaybraintree',
                         cardInformation: 'card_info',
+                        deviceSessionId: getDeviceDataMock(),
                     },
                 });
             });

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -170,11 +170,17 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
                 );
             }
 
+            const deviceSessionId =
+                methodId === PaymentStrategyType.BRAINTREE_GOOGLE_PAY
+                    ? await this._braintreeSDKCreator?.getSessionId()
+                    : undefined;
+
             const newPayment = {
                 ...payment,
                 paymentData: {
                     ...payment.paymentData,
                     nonce: verification?.nonce || payment.paymentData.nonce,
+                    deviceSessionId,
                 },
             };
 


### PR DESCRIPTION
## What?

Added deviceSessionId to the payment payload for the GooglePay payment strategy

## Why?

Braintree Fraud Protection requires deviceData to work correctly.
To do this we need to pass deviceSessionId and make sure that the device data captured in the transaction journal.

## Testing / Proof

<img width="552" alt="Screenshot 2023-08-30 at 13 23 39" src="https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/bdac221a-9ee1-41e0-8966-620ad894d539">

Verified for the next GP strategies: payment, customer and button

@bigcommerce/team-checkout @bigcommerce/team-payments
