### PR TITLE
feat(payment): PI-474 load bluesnap script ONLY if it wasn't loaded before

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-3ds.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-3ds.spec.ts
@@ -22,20 +22,12 @@ describe('BlueSnapDirectHostedForm', () => {
         scriptLoader = new BlueSnapDirectScriptLoader(createScriptLoader());
         jest.spyOn(scriptLoader, 'load').mockResolvedValue(blueSnapDirectSdkMock);
 
-        threeDSChallange = new BlueSnapDirect3ds(scriptLoader);
-    });
-
-    describe('#initialize', () => {
-        it('should initialize bluesnap library for 3ds challange successfully', async () => {
-            await threeDSChallange.initialize(false);
-
-            expect(scriptLoader.load).toHaveBeenCalledWith(false);
-        });
+        threeDSChallange = new BlueSnapDirect3ds();
     });
 
     describe('#initialize3ds', () => {
         it('should create hosted payment fields with 3DS enabled', async () => {
-            await threeDSChallange.initialize(false);
+            threeDSChallange.initialize(blueSnapDirectSdkMock);
             await threeDSChallange.initialize3ds('pfToken', previouslyUsedCardDataMock);
 
             expect(blueSnapDirectSdkMock.threeDsPaymentsSetup).toHaveBeenCalledWith(
@@ -48,7 +40,7 @@ describe('BlueSnapDirectHostedForm', () => {
         });
 
         it('should resolves with threeDSecureReferenceId value', async () => {
-            await threeDSChallange.initialize(false);
+            threeDSChallange.initialize(blueSnapDirectSdkMock);
 
             const result = await threeDSChallange.initialize3ds(
                 'pfToken',
@@ -63,8 +55,8 @@ describe('BlueSnapDirectHostedForm', () => {
             blueSnapDirectSdkMock = sdkMocks.sdk;
             jest.spyOn(scriptLoader, 'load').mockResolvedValue(blueSnapDirectSdkMock);
 
-            threeDSChallange = new BlueSnapDirect3ds(scriptLoader);
-            await threeDSChallange.initialize(false);
+            threeDSChallange = new BlueSnapDirect3ds();
+            threeDSChallange.initialize(blueSnapDirectSdkMock);
 
             await expect(
                 threeDSChallange.initialize3ds('pfToken', previouslyUsedCardDataMock),

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-3ds.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-3ds.ts
@@ -5,16 +5,13 @@ import {
     PaymentMethodInvalidError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import BlueSnapDirectScriptLoader from './bluesnap-direct-script-loader';
 import { BlueSnapDirectPreviouslyUsedCard, BlueSnapDirectSdk } from './types';
 
 export default class BlueSnapDirect3ds {
     private _blueSnapSdk?: BlueSnapDirectSdk;
 
-    constructor(private _scriptLoader: BlueSnapDirectScriptLoader) {}
-
-    async initialize(testMode = false): Promise<void> {
-        this._blueSnapSdk = await this._scriptLoader.load(testMode);
+    initialize(blueSnapSdk: BlueSnapDirectSdk) {
+        this._blueSnapSdk = blueSnapSdk;
     }
 
     async initialize3ds(

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-form.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-form.spec.ts
@@ -59,11 +59,7 @@ describe('BlueSnapDirectHostedForm', () => {
         jest.spyOn(hostedInputValidator, 'initializeValidationFields');
         jest.spyOn(hostedInputValidator, 'validate');
 
-        hostedForm = new BlueSnapDirectHostedForm(
-            scriptLoader,
-            nameOnCardInput,
-            hostedInputValidator,
-        );
+        hostedForm = new BlueSnapDirectHostedForm(nameOnCardInput, hostedInputValidator);
 
         optionsMocks = getBlueSnapPaymentInitializeOptionsMocks();
         ccOptionsMock = optionsMocks.ccOptions;
@@ -106,24 +102,22 @@ describe('BlueSnapDirectHostedForm', () => {
     });
 
     describe('#initialize', () => {
-        it('should initialize hosted form successfully', async () => {
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+        it('should initialize hosted form successfully', () => {
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
 
             expect(hostedInputValidator.initialize).toHaveBeenCalled();
-            expect(scriptLoader.load).toHaveBeenCalledWith(false);
         });
 
-        it('should initialize hosted form for stored card successfully', async () => {
-            await hostedForm.initialize(false, storedCCOptionsMock.form.fields);
+        it('should initialize hosted form for stored card successfully', () => {
+            hostedForm.initialize(blueSnapDirectSdkMock, storedCCOptionsMock.form.fields);
 
             expect(hostedInputValidator.initializeValidationFields).toHaveBeenCalled();
-            expect(scriptLoader.load).toHaveBeenCalledWith(false);
         });
     });
 
     describe('#attach', () => {
         it('should set custom BlueSnap attributes to the hosted fields containers', async () => {
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
             await hostedForm.attach('pfToken', ccOptionsMock);
 
             expect(ccCvvContainer.dataset.bluesnap).toBe(HostedFieldTagId.CardCode);
@@ -133,7 +127,7 @@ describe('BlueSnapDirectHostedForm', () => {
         });
 
         it('should set custom BlueSnap attributes to the stored card hosted fields containers', async () => {
-            await hostedForm.initialize(false, storedCCOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, storedCCOptionsMock.form.fields);
             await hostedForm.attach('pfToken', storedCCOptionsMock);
 
             expect(ccCvvContainer.dataset.bluesnap).toBe(HostedFieldTagId.CardCode);
@@ -169,7 +163,7 @@ describe('BlueSnapDirectHostedForm', () => {
                 '3DS': false,
             };
 
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
             await hostedForm.attach('pfToken', ccOptionsMock);
 
             expect(blueSnapDirectSdkMock.hostedPaymentFieldsCreate).toHaveBeenCalledWith(
@@ -183,7 +177,7 @@ describe('BlueSnapDirectHostedForm', () => {
         });
 
         it('should create hosted payment fields for stored cards without name input', async () => {
-            await hostedForm.initialize(true, storedCCOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, storedCCOptionsMock.form.fields);
             await hostedForm.attach('pfToken', storedCCOptionsMock);
 
             expect(nameOnCardInput.attach).not.toHaveBeenCalled();
@@ -192,7 +186,7 @@ describe('BlueSnapDirectHostedForm', () => {
         it('should create hosted payment fields with 3DS enabled', async () => {
             const expectedOptions = expect.objectContaining({ '3DS': true });
 
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
             await hostedForm.attach('pfToken', ccOptionsMock, true);
 
             expect(blueSnapDirectSdkMock.hostedPaymentFieldsCreate).toHaveBeenCalledWith(
@@ -215,7 +209,7 @@ describe('BlueSnapDirectHostedForm', () => {
                     onFocus?.(HostedFieldTagId.CardNumber);
                 };
 
-                await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
                 await hostedForm.attach('pfToken', ccOptionsMock);
                 triggerFocus();
 
@@ -233,7 +227,7 @@ describe('BlueSnapDirectHostedForm', () => {
                     onBlur?.(HostedFieldTagId.CardNumber);
                 };
 
-                await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
                 await hostedForm.attach('pfToken', ccOptionsMock);
                 triggerBlur();
 
@@ -251,7 +245,7 @@ describe('BlueSnapDirectHostedForm', () => {
                     onEnter?.(HostedFieldTagId.CardNumber);
                 };
 
-                await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
                 await hostedForm.attach('pfToken', ccOptionsMock);
                 triggerEnter();
 
@@ -269,7 +263,7 @@ describe('BlueSnapDirectHostedForm', () => {
                     onType?.(HostedFieldTagId.CardNumber, 'MASTERCARD', undefined);
                 };
 
-                await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
                 await hostedForm.attach('pfToken', ccOptionsMock);
                 triggerCardTypeChange();
 
@@ -293,7 +287,7 @@ describe('BlueSnapDirectHostedForm', () => {
                         );
                     };
 
-                    await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                    hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
                     await hostedForm.attach('pfToken', ccOptionsMock);
                     triggerError();
 
@@ -314,7 +308,7 @@ describe('BlueSnapDirectHostedForm', () => {
                         onValid?.(HostedFieldTagId.CardNumber);
                     };
 
-                    await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                    hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
                     await hostedForm.attach('pfToken', ccOptionsMock);
                     triggerValid();
 
@@ -341,7 +335,7 @@ describe('BlueSnapDirectHostedForm', () => {
                     return hostedForm.attach('pfToken', ccOptionsMock);
                 };
 
-                await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
 
                 await expect(attach()).rejects.toThrow(InvalidArgumentError);
             });
@@ -355,7 +349,7 @@ describe('BlueSnapDirectHostedForm', () => {
                     return hostedForm.attach('pfToken', ccOptionsMock);
                 };
 
-                await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
 
                 await expect(attach()).rejects.toThrow(InvalidArgumentError);
             });
@@ -374,7 +368,7 @@ describe('BlueSnapDirectHostedForm', () => {
                     );
                 };
 
-                await hostedForm.initialize(false, ccOptionsMock.form.fields);
+                hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
                 await hostedForm.attach('pfToken', ccOptionsMock);
 
                 expect(triggerError).toThrow(
@@ -399,7 +393,7 @@ describe('BlueSnapDirectHostedForm', () => {
             };
             const placeOrder = () => hostedForm.validate();
 
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
             await hostedForm.attach('pfToken', ccOptionsMock);
             pretendUserEntersValidData();
 
@@ -421,7 +415,7 @@ describe('BlueSnapDirectHostedForm', () => {
             };
             const placeOrder = () => hostedForm.validate();
 
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
             await hostedForm.attach('pfToken', ccOptionsMock);
             pretendUserForgetsFillCcName();
 
@@ -446,7 +440,7 @@ describe('BlueSnapDirectHostedForm', () => {
                 }
             };
 
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
             await hostedForm.attach('pfToken', ccOptionsMock);
 
             expect(getErrorDetails()).toStrictEqual(expectedErrors);
@@ -457,7 +451,7 @@ describe('BlueSnapDirectHostedForm', () => {
         it('should submit payment data successfully', async () => {
             const placeOrder = () => hostedForm.submit(undefined, true);
 
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
 
             await expect(placeOrder()).resolves.toStrictEqual({
                 ...sdkMocks.callbackResults,
@@ -468,7 +462,7 @@ describe('BlueSnapDirectHostedForm', () => {
         it('should submit payment data successfully without cardholder name', async () => {
             const placeOrder = () => hostedForm.submit(undefined, false);
 
-            await hostedForm.initialize(false, ccOptionsMock.form.fields);
+            hostedForm.initialize(blueSnapDirectSdkMock, ccOptionsMock.form.fields);
 
             await expect(placeOrder()).resolves.toStrictEqual({
                 ...sdkMocks.callbackResults,
@@ -479,13 +473,11 @@ describe('BlueSnapDirectHostedForm', () => {
             const initialize = () => {
                 const sdkWithErrors = getBlueSnapDirectSdkMock('0').sdk;
 
-                jest.spyOn(scriptLoader, 'load').mockResolvedValue(sdkWithErrors);
-
-                return hostedForm.initialize();
+                return hostedForm.initialize(sdkWithErrors);
             };
             const placeOrder = () => hostedForm.submit();
 
-            await initialize();
+            initialize();
 
             await expect(placeOrder()).rejects.toThrow(
                 'Submission failed with status: 0 and errors: [{"errorCode":"0","errorDescription":"unknown","eventType":"Server Error","tagId":"cvv"}]',
@@ -496,13 +488,11 @@ describe('BlueSnapDirectHostedForm', () => {
             const initialize = () => {
                 const sdkWithErrors = getBlueSnapDirectSdkMock('14101').sdk;
 
-                jest.spyOn(scriptLoader, 'load').mockResolvedValue(sdkWithErrors);
-
-                return hostedForm.initialize();
+                return hostedForm.initialize(sdkWithErrors);
             };
             const placeOrder = () => hostedForm.submit();
 
-            await initialize();
+            initialize();
 
             await expect(placeOrder()).rejects.toThrow('3D Secure authentication failed');
         });

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-form.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-hosted-form.ts
@@ -23,7 +23,6 @@ import {
 import { BlueSnapHostedFieldType } from './bluesnap-direct-constants';
 import BlueSnapHostedInputValidator from './bluesnap-direct-hosted-input-validator';
 import BluesnapDirectNameOnCardInput from './bluesnap-direct-name-on-card-input';
-import BlueSnapDirectScriptLoader from './bluesnap-direct-script-loader';
 import isValidationErrorDescription from './is-bluesnap-direct-input-validation-error-description';
 import isHostedCardFieldOptionsMap from './is-hosted-card-field-options-map';
 import isHostedStoredCardFieldOptionsMap from './is-hosted-stored-card-field-options-map';
@@ -49,13 +48,12 @@ export default class BlueSnapDirectHostedForm {
     private _onValidate: HostedFormOptions['onValidate'];
 
     constructor(
-        private _scriptLoader: BlueSnapDirectScriptLoader,
         private _nameOnCardInput: BluesnapDirectNameOnCardInput,
         private _hostedInputValidator: BlueSnapHostedInputValidator,
     ) {}
 
-    async initialize(testMode = false, fields?: HostedFieldOptionsMap): Promise<void> {
-        this._blueSnapSdk = await this._scriptLoader.load(testMode);
+    initialize(blueSnapSdk: BlueSnapDirectSdk, fields?: HostedFieldOptionsMap) {
+        this._blueSnapSdk = blueSnapSdk;
 
         if (!fields) {
             return;

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-script-loader.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-script-loader.spec.ts
@@ -24,6 +24,10 @@ describe('BlueSnapDirectScriptLoader', () => {
         });
     });
 
+    afterEach(() => {
+        delete bsWindow.bluesnap;
+    });
+
     describe('#load', () => {
         it('should load the Hosted Payment Fields SDK successfully', async () => {
             const sdk = await blueSnapDirectScriptLoader.load();
@@ -41,6 +45,13 @@ describe('BlueSnapDirectScriptLoader', () => {
             await blueSnapDirectScriptLoader.load(true);
 
             expect(scriptLoader.loadScript).toHaveBeenCalledWith(BlueSnapDirectSdkEnv.SANDBOX);
+        });
+
+        it('should skip to load SDK if SDK was previusly loaded', async () => {
+            bsWindow.bluesnap = blueSnapDirectSdkMock;
+            await blueSnapDirectScriptLoader.load();
+
+            expect(scriptLoader.loadScript).not.toHaveBeenCalled();
         });
 
         it('should fail to load the Hosted Payment Fields SDK', async () => {

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-script-loader.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-script-loader.ts
@@ -16,10 +16,15 @@ export default class BlueSnapDirectScriptLoader {
     ) {}
 
     async load(testMode = false): Promise<BlueSnapDirectSdk> {
+        if (this._window.bluesnap) {
+            return this._window.bluesnap;
+        }
+
         await this._scriptLoader.loadScript(
             testMode ? BlueSnapDirectSdkEnv.SANDBOX : BlueSnapDirectSdkEnv.PRODUCTION,
         );
 
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (!this._window.bluesnap) {
             throw new PaymentMethodClientUnavailableError();
         }

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-credit-card-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-credit-card-payment-strategy.ts
@@ -16,13 +16,13 @@ const createBlueSnapDirectCreditCardPaymentStrategy: PaymentStrategyFactory<
     BlueSnapDirectCreditCardPaymentStrategy
 > = (paymentIntegrationService) =>
     new BlueSnapDirectCreditCardPaymentStrategy(
+        new BlueSnapDirectScriptLoader(getScriptLoader()),
         paymentIntegrationService,
         new BlueSnapDirectHostedForm(
-            new BlueSnapDirectScriptLoader(getScriptLoader()),
             new BluesnapDirectNameOnCardInput(),
             new BlueSnapHostedInputValidator(),
         ),
-        new BlueSnapDirect3ds(new BlueSnapDirectScriptLoader(getScriptLoader())),
+        new BlueSnapDirect3ds(),
     );
 
 export default toResolvableModule(createBlueSnapDirectCreditCardPaymentStrategy, [


### PR DESCRIPTION
## What?
Fixed not working 3ds challenge for the stored card case when new card form was selected previously

## Why?
Due to the 3ds issue

## Testing / Proof

BEFORE FIX:
Order placed without 3ds challenge

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/84800dcf-2365-4840-9429-5ff84cd074fa

AFTER FIX:
Order placed with 3ds challenge

https://github.com/bigcommerce/checkout-sdk-js/assets/79574476/2cf43ce0-642f-4b4a-8eae-648c94417800


@bigcommerce/team-checkout @bigcommerce/team-payments
