### PR TITLE
feat(checkout): CHECKOUT-7648 Add isExpressPrivacyPolicy

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -109,6 +109,7 @@ export interface CheckoutSettings {
     isAnalyticsEnabled: boolean;
     isCardVaultingEnabled: boolean;
     isCouponCodeCollapsed: boolean;
+    isExpressPrivacyPolicy: boolean;
     isSignInEmailEnabled: boolean;
     isPaymentRequestEnabled: boolean;
     isPaymentRequestCanMakePaymentEnabled: boolean;

--- a/packages/core/src/config/configs.mock.ts
+++ b/packages/core/src/config/configs.mock.ts
@@ -34,6 +34,7 @@ export function getConfig(): Config {
                 isAccountCreationEnabled: true,
                 isAnalyticsEnabled: false,
                 isCardVaultingEnabled: true,
+                isExpressPrivacyPolicy: false,
                 isStorefrontSpamProtectionEnabled: false,
                 isSignInEmailEnabled: false,
                 isPaymentRequestEnabled: false,

--- a/packages/payment-integration-api/src/config/config.ts
+++ b/packages/payment-integration-api/src/config/config.ts
@@ -108,6 +108,7 @@ export interface CheckoutSettings {
     isAnalyticsEnabled: boolean;
     isCardVaultingEnabled: boolean;
     isCouponCodeCollapsed: boolean;
+    isExpressPrivacyPolicy: boolean;
     isSignInEmailEnabled: boolean;
     isPaymentRequestEnabled: boolean;
     isPaymentRequestCanMakePaymentEnabled: boolean;

--- a/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/config.mock.ts
@@ -31,6 +31,7 @@ export default function getConfig(): Config {
                 isAccountCreationEnabled: true,
                 isAnalyticsEnabled: false,
                 isCardVaultingEnabled: true,
+                isExpressPrivacyPolicy: false,
                 isStorefrontSpamProtectionEnabled: false,
                 isSignInEmailEnabled: false,
                 isPaymentRequestEnabled: false,


### PR DESCRIPTION
## What?
Add `isExpressPrivacyPolicy` to `checkoutSettings`.

## Why?
`checkout-js` can utilize this to display and obtain consent for the privacy policy.

## Depends on
https://github.com/bigcommerce/bigcommerce/pull/54381

## Testing / Proof
- CI checks.
