### PR TITLE
feat(payment): PAYPAL-2908 updated braintree sdk version

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -15,6 +15,7 @@ import {
 import {
     getBillingAddress,
     getCart,
+    getConfig,
     getCountries,
     getCustomer,
     PaymentIntegrationServiceMock,
@@ -37,8 +38,10 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
     const countries = getCountries();
     const customer = getCustomer();
     const billingAddress = getBillingAddress();
-    const methodId = 'braintreeacceleratedcheckout';
     const paymentMethod = getBraintreeAcceleratedCheckoutPaymentMethod();
+    const storeConfig = getConfig().storeConfig;
+
+    const methodId = 'braintreeacceleratedcheckout';
 
     beforeEach(() => {
         braintreeConnectMock = getConnectMock();
@@ -133,7 +136,7 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
 
             expect(braintreeIntegrationService.initialize).toHaveBeenCalledWith(
                 paymentMethod.clientToken,
-                paymentMethod.initializationData,
+                storeConfig,
             );
             expect(braintreeIntegrationService.getBraintreeConnect).toHaveBeenCalledWith(cart.id);
         });

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -41,6 +41,7 @@ export default class BraintreeAcceleratedCheckoutUtils {
     async initializeBraintreeConnectOrThrow(methodId: string) {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCart();
+        const storeConfig = state.getStoreConfigOrThrow();
         const { clientToken, initializationData } =
             state.getPaymentMethodOrThrow<BraintreeInitializationData>(methodId);
 
@@ -50,7 +51,7 @@ export default class BraintreeAcceleratedCheckoutUtils {
 
         this.methodId = methodId;
 
-        this.braintreeIntegrationService.initialize(clientToken, initializationData);
+        this.braintreeIntegrationService.initialize(clientToken, storeConfig);
         this.braintreeConnect = await this.braintreeIntegrationService.getBraintreeConnect(
             cart?.id,
         );

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.spec.ts
@@ -163,7 +163,7 @@ describe('BraintreeLocalMethodsPaymentStrategy', () => {
 
             expect(braintreeIntegrationService.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                paymentIntegrationService.getState().getStoreConfig(),
             );
         });
 

--- a/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-local-payment-methods/braintree-local-methods-payment-strategy.ts
@@ -68,6 +68,7 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
         await this.paymentIntegrationService.loadPaymentMethod(gatewayId);
 
         const state = this.paymentIntegrationService.getState();
+        const storeConfig = state.getStoreConfigOrThrow();
         const paymentMethod = state.getPaymentMethodOrThrow<BraintreeInitializationData>(gatewayId);
         const { clientToken, config, initializationData } = paymentMethod;
 
@@ -76,7 +77,7 @@ export default class BraintreeLocalMethodsPaymentStrategy implements PaymentStra
         }
 
         try {
-            this.braintreeIntegrationService.initialize(clientToken, initializationData);
+            this.braintreeIntegrationService.initialize(clientToken, storeConfig);
             await this.braintreeIntegrationService.loadBraintreeLocalMethods(
                 this.getLocalPaymentInstance.bind(this),
                 config.merchantId || '',

--- a/packages/braintree-integration/src/braintree-paypal-ach/braintree-paypal-ach-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal-ach/braintree-paypal-ach-payment-strategy.spec.ts
@@ -179,7 +179,7 @@ describe('BraintreePaypalAchPaymentStrategy', () => {
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
             expect(braintreeIntegrationService.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                paymentIntegrationService.getState().getStoreConfig(),
             );
             expect(braintreeIntegrationService.getUsBankAccount).toHaveBeenCalled();
         });

--- a/packages/braintree-integration/src/braintree-paypal-ach/braintree-paypal-ach-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal-ach/braintree-paypal-ach-payment-strategy.ts
@@ -55,7 +55,7 @@ export default class BraintreePaypalAchPaymentStrategy implements PaymentStrateg
         await this.paymentIntegrationService.loadPaymentMethod(options.methodId);
 
         const state = this.paymentIntegrationService.getState();
-
+        const storeConfig = state.getStoreConfigOrThrow();
         const paymentMethod = state.getPaymentMethodOrThrow<BraintreeInitializationData>(
             options.methodId,
         );
@@ -66,7 +66,7 @@ export default class BraintreePaypalAchPaymentStrategy implements PaymentStrateg
         }
 
         try {
-            this.braintreeIntegrationService.initialize(clientToken, initializationData);
+            this.braintreeIntegrationService.initialize(clientToken, storeConfig);
             this.usBankAccount = await this.braintreeIntegrationService.getUsBankAccount();
         } catch (error) {
             this.handleError(error);

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
@@ -228,7 +228,7 @@ describe('BraintreePaypalCustomerStrategy', () => {
 
             expect(braintreeIntegrationService.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                paymentIntegrationService.getState().getStoreConfig(),
             );
             expect(braintreeIntegrationService.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -64,6 +64,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
         await this.paymentIntegrationService.loadPaymentMethod(methodId);
 
         const state = this.paymentIntegrationService.getState();
+        const storeConfig = state.getStoreConfigOrThrow();
         const paymentMethod: PaymentMethod<BraintreeInitializationData> =
             state.getPaymentMethodOrThrow(methodId);
 
@@ -95,7 +96,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this.handleError(error, container, onError);
 
-        this.braintreeIntegrationService.initialize(clientToken, initializationData);
+        this.braintreeIntegrationService.initialize(clientToken, storeConfig);
         await this.braintreeIntegrationService.getPaypalCheckout(
             paypalCheckoutOptions,
             paypalCheckoutSuccessCallback,

--- a/packages/braintree-utils/src/braintree-integration-service.spec.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.spec.ts
@@ -1,7 +1,10 @@
 import { createScriptLoader, ScriptLoader } from '@bigcommerce/script-loader';
 
 import { NotInitializedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { getShippingAddress } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getConfig,
+    getShippingAddress,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import {
     BraintreeClient,
@@ -40,8 +43,18 @@ describe('BraintreeIntegrationService', () => {
     let loader: ScriptLoader;
 
     const clientToken = 'clientToken';
-    const initializationData = {
-        isAcceleratedCheckoutEnabled: false,
+
+    const storeConfig = getConfig().storeConfig;
+    const storeConfigWithFeaturesOn = {
+        ...storeConfig,
+        checkoutSettings: {
+            ...storeConfig.checkoutSettings,
+            features: {
+                ...storeConfig.checkoutSettings.features,
+                'PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree': true,
+                'PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing': true,
+            },
+        },
     };
 
     beforeEach(() => {
@@ -85,15 +98,17 @@ describe('BraintreeIntegrationService', () => {
 
     describe('#initialize()', () => {
         it('initializes braintree script loader with provided initialization data', () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
-            expect(braintreeScriptLoader.initialize).toHaveBeenCalledWith(initializationData);
+            expect(braintreeScriptLoader.initialize).toHaveBeenCalledWith(
+                storeConfigWithFeaturesOn,
+            );
         });
     });
 
     describe('#getClient()', () => {
         it('uses the right arguments to create the client', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             const client = await braintreeIntegrationService.getClient();
 
@@ -102,7 +117,7 @@ describe('BraintreeIntegrationService', () => {
         });
 
         it('always returns the same instance of the client', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             const client1 = await braintreeIntegrationService.getClient();
             const client2 = await braintreeIntegrationService.getClient();
@@ -123,7 +138,7 @@ describe('BraintreeIntegrationService', () => {
 
     describe('#getBraintreeConnect()', () => {
         it('throws an error if client token is not provided', async () => {
-            braintreeIntegrationService.initialize('', initializationData);
+            braintreeIntegrationService.initialize('', storeConfigWithFeaturesOn);
 
             try {
                 await braintreeIntegrationService.getBraintreeConnect();
@@ -133,7 +148,7 @@ describe('BraintreeIntegrationService', () => {
         });
 
         it('loads braintree connect and creates an instance of connect object', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             const result = await braintreeIntegrationService.getBraintreeConnect();
 
@@ -161,7 +176,7 @@ describe('BraintreeIntegrationService', () => {
             const onSuccess = jest.fn();
             const onError = jest.fn();
 
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             await braintreeIntegrationService.getPaypalCheckout({}, onSuccess, onError);
 
@@ -176,7 +191,7 @@ describe('BraintreeIntegrationService', () => {
             const onSuccess = jest.fn();
             const onError = jest.fn();
 
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             await braintreeIntegrationService.getPaypalCheckout({}, onSuccess, onError);
 
@@ -198,7 +213,7 @@ describe('BraintreeIntegrationService', () => {
                 () => newPaypalCheckoutCreatorMock,
             );
 
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             await braintreeIntegrationService.getPaypalCheckout({}, onSuccess, onError);
 
@@ -209,7 +224,7 @@ describe('BraintreeIntegrationService', () => {
 
     describe('#getDataCollector()', () => {
         it('uses the right parameters to instantiate a data collector', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             await braintreeIntegrationService.getDataCollector();
 
@@ -228,7 +243,7 @@ describe('BraintreeIntegrationService', () => {
         });
 
         it('always returns the same instance of the data collector', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             const dataCollector1 = await braintreeIntegrationService.getDataCollector();
             const dataCollector2 = await braintreeIntegrationService.getDataCollector();
@@ -239,7 +254,7 @@ describe('BraintreeIntegrationService', () => {
         });
 
         it('returns different data collector instance if it is used for PayPal', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             const dataCollector = await braintreeIntegrationService.getDataCollector();
             const paypalDataCollector = await braintreeIntegrationService.getDataCollector({
@@ -253,7 +268,7 @@ describe('BraintreeIntegrationService', () => {
         });
 
         it('returns the data collector information', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             const dataCollector = await braintreeIntegrationService.getDataCollector();
 
@@ -267,7 +282,7 @@ describe('BraintreeIntegrationService', () => {
                 Promise.reject({ code: 'DATA_COLLECTOR_KOUNT_NOT_ENABLED' }),
             );
 
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             await expect(braintreeIntegrationService.getDataCollector()).resolves.toEqual(
                 expect.objectContaining({ deviceData: undefined }),
@@ -279,7 +294,7 @@ describe('BraintreeIntegrationService', () => {
                 Promise.reject({ code: 'OTHER_RANDOM_ERROR' }),
             );
 
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             await expect(braintreeIntegrationService.getDataCollector()).rejects.toEqual({
                 code: 'OTHER_RANDOM_ERROR',
@@ -348,7 +363,7 @@ describe('BraintreeIntegrationService', () => {
 
     describe('#loadBraintreeLocalMethods()', () => {
         it('loads local payment methods', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             await braintreeIntegrationService.loadBraintreeLocalMethods(jest.fn(), '');
 
@@ -456,7 +471,7 @@ describe('BraintreeIntegrationService', () => {
         it('provides riskCorrelationId to data collector', async () => {
             const cartIdMock = 'cartId-asdasd';
 
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
             await braintreeIntegrationService.getSessionId(cartIdMock);
 
             expect(dataCollectorCreatorMock.create).toHaveBeenCalledWith({
@@ -469,7 +484,7 @@ describe('BraintreeIntegrationService', () => {
 
     describe('#teardown()', () => {
         it('calls teardown in all the dependencies', async () => {
-            braintreeIntegrationService.initialize(clientToken, initializationData);
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
 
             await braintreeIntegrationService.getDataCollector();
 

--- a/packages/braintree-utils/src/braintree-integration-service.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.ts
@@ -3,6 +3,7 @@ import {
     LegacyAddress,
     NotInitializedError,
     NotInitializedErrorType,
+    StoreConfig,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import {
@@ -14,7 +15,6 @@ import {
     BraintreeEnv,
     BraintreeError,
     BraintreeHostWindow,
-    BraintreeInitializationData,
     BraintreeModule,
     BraintreePaypalCheckout,
     BraintreePaypalSdkCreatorConfig,
@@ -44,9 +44,9 @@ export default class BraintreeIntegrationService {
         private braintreeHostWindow: BraintreeHostWindow,
     ) {}
 
-    initialize(clientToken: string, initializationData: BraintreeInitializationData) {
+    initialize(clientToken: string, storeConfig: StoreConfig) {
         this.clientToken = clientToken;
-        this.braintreeScriptLoader.initialize(initializationData);
+        this.braintreeScriptLoader.initialize(storeConfig);
     }
 
     async getBraintreeConnect(cardId?: string) {

--- a/packages/braintree-utils/src/braintree-script-loader.spec.ts
+++ b/packages/braintree-utils/src/braintree-script-loader.spec.ts
@@ -1,6 +1,7 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
 import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { getConfig } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import {
     BraintreeClientCreator,
@@ -26,8 +27,17 @@ describe('BraintreeScriptLoader', () => {
     let scriptLoader: ScriptLoader;
     let mockWindow: BraintreeHostWindow;
 
-    const braintreeInitializationData = {
-        isAcceleratedCheckoutEnabled: true,
+    const storeConfig = getConfig().storeConfig;
+    const storeConfigWithFeaturesOn = {
+        ...storeConfig,
+        checkoutSettings: {
+            ...storeConfig.checkoutSettings,
+            features: {
+                ...storeConfig.checkoutSettings.features,
+                'PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree': true,
+                'PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing': true,
+            },
+        },
     };
 
     beforeEach(() => {
@@ -62,7 +72,7 @@ describe('BraintreeScriptLoader', () => {
         it('loads the client with braintree sdk alpha version', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
 
-            braintreeScriptLoader.initialize(braintreeInitializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             const client = await braintreeScriptLoader.loadClient();
 
@@ -125,7 +135,7 @@ describe('BraintreeScriptLoader', () => {
         it('loads the connect with braintree sdk alpha version', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
 
-            braintreeScriptLoader.initialize(braintreeInitializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             const connect = await braintreeScriptLoader.loadConnect();
 
@@ -188,7 +198,7 @@ describe('BraintreeScriptLoader', () => {
         it('loads PayPal checkout with braintree sdk alpha version', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
 
-            braintreeScriptLoader.initialize(braintreeInitializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             const paypalCheckout = await braintreeScriptLoader.loadPaypalCheckout();
 
@@ -251,7 +261,7 @@ describe('BraintreeScriptLoader', () => {
         it('loads local payment methods with braintree sdk alpha version', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
 
-            braintreeScriptLoader.initialize(braintreeInitializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             await braintreeScriptLoader.loadBraintreeLocalMethods();
 
@@ -288,7 +298,7 @@ describe('BraintreeScriptLoader', () => {
         it('loads the data collector library with braintree sdk alpha version', async () => {
             const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader, mockWindow);
 
-            braintreeScriptLoader.initialize(braintreeInitializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             const dataCollector = await braintreeScriptLoader.loadDataCollector();
 

--- a/packages/braintree-utils/src/braintree-script-loader.ts
+++ b/packages/braintree-utils/src/braintree-script-loader.ts
@@ -1,6 +1,9 @@
 import { ScriptLoader } from '@bigcommerce/script-loader';
 
-import { PaymentMethodClientUnavailableError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    PaymentMethodClientUnavailableError,
+    StoreConfig,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import {
     BraintreeBankAccountCreator,
@@ -8,7 +11,6 @@ import {
     BraintreeConnectCreator,
     BraintreeDataCollectorCreator,
     BraintreeHostWindow,
-    BraintreeInitializationData,
     BraintreeLocalPaymentCreator,
     BraintreePaypalCheckoutCreator,
 } from './braintree';
@@ -24,8 +26,13 @@ export default class BraintreeScriptLoader {
 
     // TODO: this method is needed only for braintree AXO
     // So can be removed after Beta state
-    initialize({ isAcceleratedCheckoutEnabled }: BraintreeInitializationData) {
-        this.braintreeSdkVersion = isAcceleratedCheckoutEnabled
+    initialize(storeConfig: StoreConfig) {
+        const features = storeConfig.checkoutSettings.features;
+        const shouldUseBraintreeAlphaVersion =
+            features['PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree'] &&
+            features['PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing'];
+
+        this.braintreeSdkVersion = shouldUseBraintreeAlphaVersion
             ? BRAINTREE_SDK_ALPHA_VERSION
             : BRAINTREE_SDK_STABLE_VERSION;
     }

--- a/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/packages/core/src/checkout-buttons/create-checkout-button-registry.ts
@@ -169,7 +169,7 @@ export default function createCheckoutButtonRegistry(
                 checkoutActionCreator,
                 createGooglePayPaymentProcessor(
                     store,
-                    new GooglePayBraintreeInitializer(braintreeSdkCreator),
+                    new GooglePayBraintreeInitializer(store, braintreeSdkCreator),
                 ),
                 cartRequestSender,
             ),

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -272,7 +272,7 @@ describe('BraintreePaypalButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
         });
 
@@ -284,7 +284,7 @@ describe('BraintreePaypalButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
             expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -87,6 +87,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
             currencyCode = state.cart.getCartOrThrow().currency.code;
         }
 
+        const storeConfig = state.config.getStoreConfigOrThrow();
         const { clientToken, initializationData } = paymentMethod;
 
         if (!clientToken || !initializationData) {
@@ -113,7 +114,7 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this._handleError(error, containerId, messagingContainerId, onError);
 
-        this._braintreeSDKCreator.initialize(clientToken, initializationData);
+        this._braintreeSDKCreator.initialize(clientToken, storeConfig);
         await this._braintreeSDKCreator.getPaypalCheckout(
             paypalCheckoutOptions,
             paypalCheckoutSuccessCallback,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.spec.ts
@@ -286,7 +286,7 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
         });
 
@@ -298,7 +298,7 @@ describe('BraintreePaypalCreditButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
             expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -90,6 +90,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
             currencyCode = state.cart.getCartOrThrow().currency.code;
         }
 
+        const storeConfig = state.config.getStoreConfigOrThrow();
         const { clientToken, initializationData } = paymentMethod;
 
         if (!clientToken || !initializationData) {
@@ -113,7 +114,7 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this._handleError(error, containerId, braintreepaypalcredit.onError);
 
-        this._braintreeSDKCreator.initialize(clientToken, initializationData);
+        this._braintreeSDKCreator.initialize(clientToken, storeConfig);
         await this._braintreeSDKCreator.getPaypalCheckout(
             paypalCheckoutOptions,
             paypalCheckoutCallback,

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.spec.ts
@@ -211,7 +211,7 @@ describe('BraintreeVenmoButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
         });
 
@@ -225,7 +225,7 @@ describe('BraintreeVenmoButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
             expect(braintreeSDKCreator.getVenmoCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
@@ -70,6 +70,7 @@ export default class BraintreeVenmoButtonStrategy implements CheckoutButtonStrat
         const state = await this._store.dispatch(
             this._paymentMethodActionCreator.loadPaymentMethod(methodId),
         );
+        const storeConfig = state.config.getStoreConfigOrThrow();
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         const { clientToken, initializationData } = paymentMethod;
 
@@ -85,7 +86,7 @@ export default class BraintreeVenmoButtonStrategy implements CheckoutButtonStrat
 
         this._onError = braintreevenmo?.onError || this._handleError;
 
-        this._braintreeSDKCreator.initialize(clientToken, initializationData);
+        this._braintreeSDKCreator.initialize(clientToken, storeConfig);
         await this._braintreeSDKCreator.getVenmoCheckout(
             (braintreeVenmoCheckout) =>
                 this._handleInitializationVenmoSuccess(

--- a/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -83,6 +83,7 @@ describe('GooglePayCheckoutButtonStrategy', () => {
         paymentProcessor = createGooglePayPaymentProcessor(
             store,
             new GooglePayBraintreeInitializer(
+                store,
                 new BraintreeSDKCreator(new BraintreeScriptLoader(createScriptLoader())),
             ),
         );

--- a/packages/core/src/customer/create-customer-strategy-registry.ts
+++ b/packages/core/src/customer/create-customer-strategy-registry.ts
@@ -219,7 +219,7 @@ export default function createCustomerStrategyRegistry(
                 remoteCheckoutActionCreator,
                 createGooglePayPaymentProcessor(
                     store,
-                    new GooglePayBraintreeInitializer(braintreeSDKCreator),
+                    new GooglePayBraintreeInitializer(store, braintreeSDKCreator),
                 ),
                 formPoster,
             ),

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
@@ -285,7 +285,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
         });
 
@@ -297,7 +297,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
             expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -70,6 +70,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         const state = await this._store.dispatch(
             this._paymentMethodActionCreator.loadPaymentMethod(methodId),
         );
+        const storeConfig = state.config.getStoreConfigOrThrow();
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         const { clientToken, initializationData } = paymentMethod;
 
@@ -95,7 +96,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this._handleError(error, braintreepaypalcredit);
 
-        this._braintreeSDKCreator.initialize(clientToken, initializationData);
+        this._braintreeSDKCreator.initialize(clientToken, storeConfig);
         await this._braintreeSDKCreator.getPaypalCheckout(
             paypalCheckoutOptions,
             paypalCheckoutCallback,

--- a/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.spec.ts
@@ -180,7 +180,7 @@ describe('BraintreeVisaCheckoutCustomerStrategy', () => {
 
             expect(braintreeVisaCheckoutPaymentProcessor.initialize).toHaveBeenCalledWith(
                 'clientToken',
-                {},
+                store.getState().config.getStoreConfigOrThrow(),
                 {
                     collectShipping: true,
                     currencyCode: 'USD',

--- a/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-visacheckout-customer-strategy.ts
@@ -50,7 +50,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
             .dispatch(this._paymentMethodActionCreator.loadPaymentMethod(methodId))
             .then((state) => {
                 this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
-                const { clientToken, initializationData } = this._paymentMethod;
+                const { clientToken } = this._paymentMethod;
 
                 const checkout = state.checkout.getCheckout();
                 const storeConfig = state.config.getStoreConfig();
@@ -63,7 +63,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
                     throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
                 }
 
-                if (!clientToken || !initializationData) {
+                if (!clientToken) {
                     throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                 }
 
@@ -80,7 +80,7 @@ export default class BraintreeVisaCheckoutCustomerStrategy implements CustomerSt
                     this._visaCheckoutScriptLoader.load(this._paymentMethod.config.testMode),
                     this._braintreeVisaCheckoutPaymentProcessor.initialize(
                         clientToken,
-                        initializationData,
+                        storeConfig,
                         initOptions,
                     ),
                 ])

--- a/packages/core/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
@@ -67,6 +67,7 @@ describe('GooglePayCustomerStrategy', () => {
         paymentProcessor = createGooglePayPaymentProcessor(
             store,
             new GooglePayBraintreeInitializer(
+                store,
                 new BraintreeSDKCreator(new BraintreeScriptLoader(createScriptLoader())),
             ),
         );

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -343,6 +343,7 @@ export default function createPaymentStrategyRegistry(
                 createGooglePayPaymentProcessor(
                     store,
                     new GooglePayBraintreeInitializer(
+                        store,
                         new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
                     ),
                 ),

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -167,7 +167,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
 
             expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
                 options.braintree,
             );
             expect(braintreePaymentProcessorMock.initializeHostedForm).not.toHaveBeenCalled();
@@ -195,7 +195,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
 
             expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
                 options.braintree,
             );
             expect(braintreePaymentProcessorMock.initializeHostedForm).toHaveBeenCalledWith(

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -42,20 +42,18 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
             this._paymentMethodActionCreator.loadPaymentMethod(options.methodId),
         );
 
+        const storeConfig = state.config.getStoreConfigOrThrow();
+
         this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(options.methodId);
 
-        const { clientToken, initializationData } = this._paymentMethod;
+        const { clientToken } = this._paymentMethod;
 
-        if (!clientToken || !initializationData) {
+        if (!clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         try {
-            this._braintreePaymentProcessor.initialize(
-                clientToken,
-                initializationData,
-                options.braintree,
-            );
+            this._braintreePaymentProcessor.initialize(clientToken, storeConfig, options.braintree);
 
             if (
                 this._isHostedPaymentFormEnabled(options.methodId, options.gatewayId) &&

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.spec.ts
@@ -5,6 +5,7 @@ import { Overlay } from '@bigcommerce/checkout-sdk/ui';
 
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
 import { NotInitializedError } from '../../../common/error/errors';
+import { getConfig } from '../../../config/configs.mock';
 import { PaymentArgumentInvalidError, PaymentMethodCancelledError } from '../../errors';
 import { NonceInstrument } from '../../payment';
 
@@ -33,9 +34,7 @@ describe('BraintreePaymentProcessor', () => {
     let overlay: Overlay;
 
     const clientToken = 'clientToken';
-    const initializationData = {
-        isAcceleratedCheckoutEnabled: false,
-    };
+    const storeConfig = getConfig().storeConfig;
 
     beforeEach(() => {
         braintreeSDKCreator = {} as BraintreeSDKCreator;
@@ -63,12 +62,9 @@ describe('BraintreePaymentProcessor', () => {
                 overlay,
             );
 
-            braintreePaymentProcessor.initialize(clientToken, initializationData);
+            braintreePaymentProcessor.initialize(clientToken, storeConfig);
 
-            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
-                clientToken,
-                initializationData,
-            );
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(clientToken, storeConfig);
         });
     });
 
@@ -570,7 +566,7 @@ describe('BraintreePaymentProcessor', () => {
                 overlay,
             );
 
-            braintreePaymentProcessor.initialize(clientToken, initializationData, {
+            braintreePaymentProcessor.initialize(clientToken, storeConfig, {
                 threeDSecure: {
                     ...getThreeDSecureOptionsMock(),
                     addFrame: (_error, _iframe, cancel) => {
@@ -581,7 +577,7 @@ describe('BraintreePaymentProcessor', () => {
         });
 
         it('throws if no 3DS modal handler was supplied on initialization', () => {
-            braintreePaymentProcessor.initialize('clientToken', {});
+            braintreePaymentProcessor.initialize('clientToken', storeConfig);
 
             return expect(
                 braintreePaymentProcessor.challenge3DSVerification(

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -6,6 +6,7 @@ import { Overlay } from '@bigcommerce/checkout-sdk/ui';
 
 import { Address } from '../../../address';
 import { NotInitializedError, NotInitializedErrorType } from '../../../common/error/errors';
+import { StoreConfig } from '../../../config';
 import { OrderPaymentRequestBody } from '../../../order';
 import {
     PaymentArgumentInvalidError,
@@ -17,7 +18,6 @@ import { CreditCardInstrument, NonceInstrument } from '../../payment';
 
 import {
     BraintreeError,
-    BraintreeInitializationData,
     BraintreePaypal,
     BraintreePaypalCheckout,
     BraintreePaypalSdkCreatorConfig,
@@ -59,10 +59,10 @@ export default class BraintreePaymentProcessor {
 
     initialize(
         clientToken: string,
-        initializationData: BraintreeInitializationData,
+        storeConfig: StoreConfig,
         options?: BraintreePaymentInitializeOptions,
     ): void {
-        this._braintreeSDKCreator.initialize(clientToken, initializationData);
+        this._braintreeSDKCreator.initialize(clientToken, storeConfig);
         this._threeDSecureOptions = options?.threeDSecure;
     }
 

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -111,7 +111,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
 
             expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
                 options.braintree,
             );
         });

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -241,22 +241,21 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     private async _loadPaypalCheckoutInstance(
         braintreeOptions?: BraintreePaymentInitializeOptions,
     ) {
+        const state = this._store.getState();
+        const storeConfig = state.config.getStoreConfigOrThrow();
+
         const { clientToken, initializationData } = this._paymentMethod || {};
 
-        if (!clientToken || !initializationData) {
+        if (!clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        if (!initializationData.enableCheckoutPaywallBanner) {
+        if (!initializationData?.enableCheckoutPaywallBanner) {
             return Promise.resolve(this._store.getState());
         }
 
         try {
-            this._braintreePaymentProcessor.initialize(
-                clientToken,
-                initializationData,
-                braintreeOptions,
-            );
+            this._braintreePaymentProcessor.initialize(clientToken, storeConfig, braintreeOptions);
 
             const currencyCode = this._store.getState().cart.getCartOrThrow().currency.code;
 
@@ -310,6 +309,9 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
     private async _loadPaypal(
         braintreeOptions?: BraintreePaymentInitializeOptions,
     ): Promise<InternalCheckoutSelectors> {
+        const state = this._store.getState();
+        const storeConfig = state.config.getStoreConfigOrThrow();
+
         const { clientToken, initializationData } = this._paymentMethod || {};
 
         if (!clientToken || !initializationData) {
@@ -317,11 +319,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
         }
 
         try {
-            this._braintreePaymentProcessor.initialize(
-                clientToken,
-                initializationData,
-                braintreeOptions,
-            );
+            this._braintreePaymentProcessor.initialize(clientToken, storeConfig, braintreeOptions);
 
             await this._braintreePaymentProcessor.preloadPaypal();
         } catch (error) {

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 
 import { StandardError } from '../../../common/error/errors';
+import { getConfig } from '../../../config/configs.mock';
 
 import {
     BraintreeClientCreator,
@@ -33,8 +34,17 @@ describe('BraintreeScriptLoader', () => {
     let scriptLoader: ScriptLoader;
     let mockWindow: BraintreeHostWindow;
 
-    const initializationData = {
-        isAcceleratedCheckoutEnabled: true,
+    const storeConfig = getConfig().storeConfig;
+    const storeConfigWithFeaturesOn = {
+        ...storeConfig,
+        checkoutSettings: {
+            ...storeConfig.checkoutSettings,
+            features: {
+                ...storeConfig.checkoutSettings.features,
+                'PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree': true,
+                'PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing': true,
+            },
+        },
     };
 
     beforeEach(() => {
@@ -66,7 +76,7 @@ describe('BraintreeScriptLoader', () => {
         });
 
         it('loads the client with braintree sdk alpha version', async () => {
-            braintreeScriptLoader.initialize(initializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             await braintreeScriptLoader.loadClient();
 
@@ -105,7 +115,7 @@ describe('BraintreeScriptLoader', () => {
         });
 
         it('loads the ThreeDSecure library with braintree sdk alpha version', async () => {
-            braintreeScriptLoader.initialize(initializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             await braintreeScriptLoader.load3DS();
 
@@ -144,7 +154,7 @@ describe('BraintreeScriptLoader', () => {
         });
 
         it('loads the data collector library with braintree sdk alpha version', async () => {
-            braintreeScriptLoader.initialize(initializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             await braintreeScriptLoader.loadDataCollector();
 
@@ -183,7 +193,7 @@ describe('BraintreeScriptLoader', () => {
         });
 
         it('loads the VisaCheckout library with braintree sdk alpha version', async () => {
-            braintreeScriptLoader.initialize(initializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             await braintreeScriptLoader.loadVisaCheckout();
 
@@ -222,7 +232,7 @@ describe('BraintreeScriptLoader', () => {
         });
 
         it('loads the GooglePay library with braintree sdk alpha version', async () => {
-            braintreeScriptLoader.initialize(initializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             await braintreeScriptLoader.loadGooglePayment();
 
@@ -278,7 +288,7 @@ describe('BraintreeScriptLoader', () => {
         });
 
         it('loads hosted fields module with braintree sdk alpha version', async () => {
-            braintreeScriptLoader.initialize(initializationData);
+            braintreeScriptLoader.initialize(storeConfigWithFeaturesOn);
 
             await braintreeScriptLoader.loadHostedFields();
 

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -5,6 +5,7 @@ import {
     BRAINTREE_SDK_STABLE_VERSION,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 
+import { StoreConfig } from '../../../config';
 import { PaymentMethodClientUnavailableError } from '../../errors';
 import { GooglePayCreator } from '../googlepay';
 
@@ -13,7 +14,6 @@ import {
     BraintreeDataCollectorCreator,
     BraintreeHostedFieldsCreator,
     BraintreeHostWindow,
-    BraintreeInitializationData,
     BraintreePaypalCheckoutCreator,
     BraintreePaypalCreator,
     BraintreeThreeDSecureCreator,
@@ -31,8 +31,13 @@ export default class BraintreeScriptLoader {
 
     // TODO: this method is needed only for braintree AXO
     // So can be removed after Beta stage
-    initialize({ isAcceleratedCheckoutEnabled }: BraintreeInitializationData) {
-        this.braintreeSdkVersion = isAcceleratedCheckoutEnabled
+    initialize(storeConfig: StoreConfig) {
+        const features = storeConfig.checkoutSettings.features;
+        const shouldUseBraintreeAlphaVersion =
+            features['PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree'] &&
+            features['PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing'];
+
+        this.braintreeSdkVersion = shouldUseBraintreeAlphaVersion
             ? BRAINTREE_SDK_ALPHA_VERSION
             : BRAINTREE_SDK_STABLE_VERSION;
     }

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.spec.ts
@@ -1,4 +1,5 @@
 import { NotInitializedError } from '../../../common/error/errors';
+import { getConfig } from '../../../config/configs.mock';
 import { getGooglePayBraintreeMock } from '../googlepay/googlepay.mock';
 
 import {
@@ -29,6 +30,8 @@ describe('Braintree SDK Creator', () => {
     let clientMock: BraintreeClient;
     let clientCreatorMock: BraintreeModuleCreator<BraintreeClient>;
 
+    const storeConfig = getConfig().storeConfig;
+
     beforeEach(() => {
         clientMock = getClientMock();
         clientCreatorMock = getModuleCreatorMock(clientMock);
@@ -55,7 +58,7 @@ describe('Braintree SDK Creator', () => {
         it('uses the right arguments to create the client', async () => {
             const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
 
-            braintreeSDKCreator.initialize('clientToken', {});
+            braintreeSDKCreator.initialize('clientToken', storeConfig);
             await braintreeSDKCreator.getClient();
 
             expect(clientCreatorMock.create).toHaveBeenCalledWith({ authorization: 'clientToken' });
@@ -64,7 +67,7 @@ describe('Braintree SDK Creator', () => {
         it('returns a copy of the client', async () => {
             const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
 
-            braintreeSDKCreator.initialize('clientToken', {});
+            braintreeSDKCreator.initialize('clientToken', storeConfig);
 
             const client = await braintreeSDKCreator.getClient();
 
@@ -74,7 +77,7 @@ describe('Braintree SDK Creator', () => {
         it('always returns the same instance of the client', async () => {
             const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
 
-            braintreeSDKCreator.initialize('clientToken', {});
+            braintreeSDKCreator.initialize('clientToken', storeConfig);
 
             const client1 = await braintreeSDKCreator.getClient();
             const client2 = await braintreeSDKCreator.getClient();
@@ -375,7 +378,7 @@ describe('Braintree SDK Creator', () => {
                 Promise.resolve(hostedFieldsCreatorMock),
             );
 
-            braintreeSDKCreator.initialize('client_token', {});
+            braintreeSDKCreator.initialize('client_token', storeConfig);
 
             expect(await braintreeSDKCreator.createHostedFields({ fields: {} })).toEqual(
                 hostedFieldsMock,
@@ -388,7 +391,7 @@ describe('Braintree SDK Creator', () => {
             braintreeScriptLoader.loadClient = jest.fn(() => Promise.resolve(clientCreatorMock));
             braintreeScriptLoader.loadHostedFields = jest.fn(() => Promise.reject(error));
 
-            braintreeSDKCreator.initialize('client_token', {});
+            braintreeSDKCreator.initialize('client_token', storeConfig);
 
             try {
                 await braintreeSDKCreator.createHostedFields({ fields: {} });
@@ -428,7 +431,7 @@ describe('Braintree SDK Creator', () => {
                 .mockReturnValue(Promise.resolve(getModuleCreatorMock(braintreeVenmoCheckout)));
 
             braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
-            braintreeSDKCreator.initialize('clientToken', {});
+            braintreeSDKCreator.initialize('clientToken', storeConfig);
         });
 
         it('calls teardown in all the dependencies', async () => {

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -3,6 +3,7 @@ import {
     NotInitializedErrorType,
     UnsupportedBrowserError,
 } from '../../../common/error/errors';
+import { StoreConfig } from '../../../config';
 import { PaypalHostWindow } from '../paypal';
 
 import {
@@ -11,7 +12,6 @@ import {
     BraintreeError,
     BraintreeHostedFields,
     BraintreeHostedFieldsCreatorConfig,
-    BraintreeInitializationData,
     BraintreeModule,
     BraintreePaypal,
     BraintreePaypalCheckout,
@@ -43,9 +43,9 @@ export default class BraintreeSDKCreator {
         this._window = window;
     }
 
-    initialize(clientToken: string, initializationData: BraintreeInitializationData) {
+    initialize(clientToken: string, storeConfig: StoreConfig) {
         this._clientToken = clientToken;
-        this._braintreeScriptLoader.initialize(initializationData);
+        this._braintreeScriptLoader.initialize(storeConfig);
     }
 
     getClient(): Promise<BraintreeClient> {

--- a/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-venmo-payment-strategy.spec.ts
@@ -108,7 +108,7 @@ describe('BraintreeVenmoPaymentStrategy', () => {
 
             expect(braintreePaymentProcessorMock.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                paymentMethodMock.initializationData,
+                store.getState().config.getStoreConfigOrThrow(),
             );
             expect(braintreePaymentProcessorMock.getVenmoCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.spec.ts
@@ -3,6 +3,7 @@ import { createScriptLoader } from '@bigcommerce/script-loader';
 
 import { Address } from '../../../address';
 import { getBillingAddress } from '../../../billing/billing-addresses.mock';
+import { getConfig } from '../../../config/configs.mock';
 import { getShippingAddress } from '../../../shipping/shipping-addresses.mock';
 
 import { BraintreeVisaCheckout } from './braintree';
@@ -20,6 +21,8 @@ import {
 describe('BraintreeVisaCheckoutPaymentProcessor', () => {
     let braintreeSDKCreator: BraintreeSDKCreator;
     let requestSender: RequestSender;
+
+    const storeConfig = getConfig().storeConfig;
 
     beforeEach(() => {
         const braintreeScriptLoader = new BraintreeScriptLoader(createScriptLoader());
@@ -56,9 +59,9 @@ describe('BraintreeVisaCheckoutPaymentProcessor', () => {
 
         it('initializes the sdk creator with the client token', () => {
             braintreeSDKCreator.initialize = jest.fn();
-            visaCheckoutPaymentProcessor.initialize('clientToken', {}, {});
+            visaCheckoutPaymentProcessor.initialize('clientToken', storeConfig, {});
 
-            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith('clientToken', {});
+            expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith('clientToken', storeConfig);
         });
 
         it('maps the init options to the ones required by the braintree visacheckout module', async () => {
@@ -67,16 +70,12 @@ describe('BraintreeVisaCheckoutPaymentProcessor', () => {
                 requestSender,
             );
 
-            await visaCheckoutPaymentProcessor.initialize(
-                'clientToken',
-                {},
-                {
-                    locale: 'es_ES',
-                    collectShipping: true,
-                    subtotal: 15,
-                    currencyCode: '$',
-                },
-            );
+            await visaCheckoutPaymentProcessor.initialize('clientToken', storeConfig, {
+                locale: 'es_ES',
+                collectShipping: true,
+                subtotal: 15,
+                currencyCode: '$',
+            });
 
             expect(visaCheckoutMock.createInitOptions).toHaveBeenCalledWith({
                 paymentRequest: {

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-processor.ts
@@ -3,8 +3,9 @@ import { RequestSender } from '@bigcommerce/request-sender';
 import { Address, LegacyAddress } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { SDK_VERSION_HEADERS } from '../../../common/http-request';
+import { StoreConfig } from '../../../config';
 
-import { BraintreeDataCollector, BraintreeInitializationData } from './braintree';
+import { BraintreeDataCollector } from './braintree';
 import BraintreeSDKCreator from './braintree-sdk-creator';
 import {
     VisaCheckoutAddress,
@@ -21,10 +22,10 @@ export default class BraintreeVisaCheckoutPaymentProcessor {
 
     initialize(
         clientToken: string,
-        initializationData: BraintreeInitializationData,
+        storeConfig: StoreConfig,
         options: VisaCheckoutInitializeOptions,
     ): Promise<VisaCheckoutInitOptions> {
-        this._braintreeSDKCreator.initialize(clientToken, initializationData);
+        this._braintreeSDKCreator.initialize(clientToken, storeConfig);
 
         return this._braintreeSDKCreator.getVisaCheckout().then((visaCheckout) =>
             visaCheckout.createInitOptions({

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.spec.ts
@@ -189,7 +189,7 @@ describe('BraintreeVisaCheckoutPaymentStrategy', () => {
 
             expect(braintreeVisaCheckoutPaymentProcessor.initialize).toHaveBeenCalledWith(
                 'clientToken',
-                {},
+                store.getState().config.getStoreConfigOrThrow(),
                 {
                     collectShipping: false,
                     currencyCode: 'USD',

--- a/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-visacheckout-payment-strategy.ts
@@ -60,9 +60,9 @@ export default class BraintreeVisaCheckoutPaymentStrategy implements PaymentStra
                     throw new MissingDataError(MissingDataErrorType.MissingCheckoutConfig);
                 }
 
-                const { clientToken, config, initializationData } = this._paymentMethod || {};
+                const { clientToken, config } = this._paymentMethod || {};
 
-                if (!clientToken || !initializationData) {
+                if (!clientToken) {
                     throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
                 }
 
@@ -79,7 +79,7 @@ export default class BraintreeVisaCheckoutPaymentStrategy implements PaymentStra
                     this._visaCheckoutScriptLoader.load(config?.testMode),
                     this._braintreeVisaCheckoutPaymentProcessor.initialize(
                         clientToken,
-                        initializationData,
+                        storeConfig,
                         initOptions,
                     ),
                 ]).then(([visaCheckout, visaInitOptions]) => {

--- a/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.spec.ts
@@ -1,5 +1,7 @@
 import { createScriptLoader } from '@bigcommerce/script-loader';
 
+import { CheckoutStore, createCheckoutStore } from '../../../checkout';
+import { getCheckoutStoreState } from '../../../checkout/checkouts.mock';
 import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import PaymentMethod from '../../payment-method';
 import { BraintreeScriptLoader, BraintreeSDKCreator, GooglePayBraintreeSDK } from '../braintree';
@@ -17,13 +19,15 @@ describe('GooglePayBraintreeInitializer', () => {
     let braintreeSDKCreator: BraintreeSDKCreator;
     let googlePayInitializer: GooglePayBraintreeInitializer;
     let googlePayMock: GooglePayBraintreeSDK;
+    let store: CheckoutStore;
 
     beforeEach(() => {
+        store = createCheckoutStore(getCheckoutStoreState());
         googlePayMock = getGooglePayBraintreeMock();
         braintreeSDKCreator = new BraintreeSDKCreator(
             new BraintreeScriptLoader(createScriptLoader()),
         );
-        googlePayInitializer = new GooglePayBraintreeInitializer(braintreeSDKCreator);
+        googlePayInitializer = new GooglePayBraintreeInitializer(store, braintreeSDKCreator);
         braintreeSDKCreator.initialize = jest.fn();
         braintreeSDKCreator.getGooglePaymentComponent = jest.fn(() =>
             Promise.resolve(googlePayMock),

--- a/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -1,6 +1,6 @@
 import { round } from 'lodash';
 
-import { Checkout } from '../../../checkout';
+import { Checkout, CheckoutStore } from '../../../checkout';
 import { MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
 import PaymentMethod from '../../payment-method';
 import { BraintreeSDKCreator, GooglePayBraintreeSDK } from '../braintree';
@@ -21,20 +21,21 @@ import {
 export default class GooglePayBraintreeInitializer implements GooglePayInitializer {
     private _googlePaymentInstance!: GooglePayBraintreeSDK;
 
-    constructor(private _braintreeSDKCreator: BraintreeSDKCreator) {}
+    constructor(private _store: CheckoutStore, private _braintreeSDKCreator: BraintreeSDKCreator) {}
 
     initialize(
         checkout: Checkout | undefined,
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
-        const { clientToken, initializationData } = paymentMethod;
+        const storeConfig = this._store.getState().config.getStoreConfigOrThrow();
+        const { clientToken } = paymentMethod;
 
-        if (!clientToken || !initializationData) {
+        if (!clientToken) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        this._braintreeSDKCreator.initialize(clientToken, initializationData);
+        this._braintreeSDKCreator.initialize(clientToken, storeConfig);
 
         return this._braintreeSDKCreator
             .getGooglePaymentComponent()

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.spec.ts
@@ -74,6 +74,7 @@ describe('GooglePayPaymentProcessor', () => {
         );
         googlePayScriptLoader = new GooglePayScriptLoader(scriptLoader);
         googlePayInitializer = new GooglePayBraintreeInitializer(
+            store,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
         );
         requestSender = createRequestSender();

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.spec.ts
@@ -21,7 +21,7 @@ import {
 } from '../../../common/error/errors';
 import { getResponse } from '../../../common/http-request/responses.mock';
 import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
-import { getConfigState } from '../../../config/configs.mock';
+import { getConfig, getConfigState } from '../../../config/configs.mock';
 import { getCustomerState } from '../../../customer/customers.mock';
 import { FormFieldsActionCreator, FormFieldsRequestSender } from '../../../form';
 import { OrderActionCreator } from '../../../order';
@@ -145,7 +145,7 @@ describe('GooglePayPaymentStrategy', () => {
 
         googlePayPaymentProcessor = createGooglePayPaymentProcessor(
             store,
-            new GooglePayBraintreeInitializer(braintreeSDKCreator),
+            new GooglePayBraintreeInitializer(store, braintreeSDKCreator),
         );
         googlePayAdyenV2PaymentProcessor = new GooglePayAdyenV2PaymentProcessor(
             store,
@@ -165,12 +165,14 @@ describe('GooglePayPaymentStrategy', () => {
             initializationData,
         };
         const order = getOrder();
+        const storeConfig = getConfig().storeConfig;
 
         jest.spyOn(store, 'dispatch');
         jest.spyOn(store.getState().order, 'getOrderOrThrow').mockReturnValue(order);
         jest.spyOn(store.getState().paymentMethods, 'getPaymentMethodOrThrow').mockReturnValue(
             googlePaymentMethodData,
         );
+        jest.spyOn(store.getState().config, 'getStoreConfigOrThrow').mockReturnValue(storeConfig);
         jest.spyOn(walletButton, 'removeEventListener');
         jest.spyOn(requestSender, 'post').mockReturnValue(Promise.resolve());
         jest.spyOn(checkoutActionCreator, 'loadCurrentCheckout').mockReturnValue(Promise.resolve());
@@ -347,7 +349,7 @@ describe('GooglePayPaymentStrategy', () => {
 
                 expect(initializeBraintreeSDK).toHaveBeenCalledWith(
                     'clienttoken',
-                    updatedPaymentMethod.initializationData,
+                    getConfig().storeConfig,
                 );
             });
 

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -61,6 +61,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         const state = await this._store.dispatch(
             this._paymentMethodActionCreator.loadPaymentMethod(methodId),
         );
+        const storeConfig = state.config.getStoreConfigOrThrow();
 
         this._paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         this._is3dsEnabled =
@@ -77,10 +78,7 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
             this._paymentMethod.clientToken &&
             this._paymentMethod.initializationData
         ) {
-            this._braintreeSDKCreator.initialize(
-                this._paymentMethod.clientToken,
-                this._paymentMethod.initializationData,
-            );
+            this._braintreeSDKCreator.initialize(this._paymentMethod.clientToken, storeConfig);
         }
 
         await this._googlePayPaymentProcessor.initialize(methodId);


### PR DESCRIPTION
## What?
Updated braintree sdk version in all places where Braintree SDK is in use

## Why?
To avoid issues with Braintree SDK version inconsistency between different Braintree integrations

## Testing / Proof
Unit tests
Manual tests

We can see that all versions are the same on the screenshot:
<img width="1512" alt="Screenshot 2023-09-04 at 10 18 51" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/3916dbc3-8a57-4da5-be45-33297296bb11">

