### PR TITLE
feat(payment): PAYPAL-2913 provided customer device data on any place order for BT AXO

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
@@ -302,6 +302,7 @@ describe('BraintreeAcceleratedCheckoutPaymentStrategy', () => {
             expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
                 methodId: 'braintreeacceleratedcheckout',
                 paymentData: {
+                    deviceSessionId,
                     shouldSaveInstrument: false,
                     shouldSetAsDefaultInstrument: false,
                     nonce: 'nonce',
@@ -317,6 +318,7 @@ describe('BraintreeAcceleratedCheckoutPaymentStrategy', () => {
             expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith({
                 methodId: 'braintreeacceleratedcheckout',
                 paymentData: {
+                    deviceSessionId,
                     shouldSaveInstrument: false,
                     shouldSetAsDefaultInstrument: false,
                     nonce: 'nonce',

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.ts
@@ -193,6 +193,8 @@ export default class BraintreeAcceleratedCheckoutPaymentStrategy implements Paym
         // Info: shipping can be unavailable for carts with digital items
         const shippingAddress = state.getShippingAddress();
 
+        const deviceSessionId = await this.braintreeAcceleratedCheckoutUtils.getDeviceSessionId();
+
         const { shouldSaveInstrument = false, shouldSetAsDefaultInstrument = false } =
             isHostedInstrumentLike(paymentData) ? paymentData : {};
 
@@ -210,6 +212,7 @@ export default class BraintreeAcceleratedCheckoutPaymentStrategy implements Paym
             methodId,
             paymentData: {
                 ...paymentData,
+                deviceSessionId,
                 shouldSaveInstrument,
                 shouldSetAsDefaultInstrument,
                 nonce,


### PR DESCRIPTION
## What?
Provided customer device data on any place order for BT AXO

## Why?
To give PayPal an ability to match transaction with the right customer on their end. Otherwise we have some unexpected behaviour while working with BT AXO.

## Testing / Proof
Unit tests
Manual tests

<img width="691" alt="Screenshot 2023-09-01 at 11 16 58" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/1b0b39dc-b33c-40a4-9d98-346b1c5d5475">

