### PR TITLE
fix(payment): PAYPAL-000 fixed the issue with braintree initialization in apple pay payment strategy

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
@@ -279,6 +279,8 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
             ApplePayGatewayType.BRAINTREE,
         );
 
+        const storeConfig = state.getStoreConfigOrThrow();
+
         const braintreePaymentMethod: PaymentMethod = state.getPaymentMethodOrThrow(
             ApplePayGatewayType.BRAINTREE,
         );
@@ -289,7 +291,7 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
 
         this._braintreeIntegrationService.initialize(
             braintreePaymentMethod.clientToken,
-            braintreePaymentMethod.initializationData,
+            storeConfig,
         );
     }
 }


### PR DESCRIPTION
## What?
Fixed the issue with braintree initialization in apple pay payment strategy

## Why?
There was an issue with apple pay braintree initialization due to the async merge of two different PRs in the same time

## Testing / Proof
Unit tests
