### PR TITLE
Revert "fix(payment): PAYPAL-000 fixed the issue with braintree initialization in apple pay payment strategy"

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-payment-strategy.ts
@@ -279,8 +279,6 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
             ApplePayGatewayType.BRAINTREE,
         );
 
-        const storeConfig = state.getStoreConfigOrThrow();
-
         const braintreePaymentMethod: PaymentMethod = state.getPaymentMethodOrThrow(
             ApplePayGatewayType.BRAINTREE,
         );
@@ -291,7 +289,7 @@ export default class ApplePayPaymentStrategy implements PaymentStrategy {
 
         this._braintreeIntegrationService.initialize(
             braintreePaymentMethod.clientToken,
-            storeConfig,
+            braintreePaymentMethod.initializationData,
         );
     }
 }


### PR DESCRIPTION
Reverts bigcommerce/checkout-sdk-js#2161

Due to the issue with apple pay e2e tests in checkout js project