### PR TITLE
fix(payment): PAYPAL-2908 removed unnecessary 2770 experiment because we dont need it here anymore (Braintree SDK)

### DIFF
--- a/packages/braintree-utils/src/braintree-script-loader.spec.ts
+++ b/packages/braintree-utils/src/braintree-script-loader.spec.ts
@@ -35,7 +35,6 @@ describe('BraintreeScriptLoader', () => {
             features: {
                 ...storeConfig.checkoutSettings.features,
                 'PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree': true,
-                'PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing': true,
             },
         },
     };

--- a/packages/braintree-utils/src/braintree-script-loader.ts
+++ b/packages/braintree-utils/src/braintree-script-loader.ts
@@ -29,8 +29,7 @@ export default class BraintreeScriptLoader {
     initialize(storeConfig: StoreConfig) {
         const features = storeConfig.checkoutSettings.features;
         const shouldUseBraintreeAlphaVersion =
-            features['PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree'] &&
-            features['PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing'];
+            features['PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree'];
 
         this.braintreeSdkVersion = shouldUseBraintreeAlphaVersion
             ? BRAINTREE_SDK_ALPHA_VERSION

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.spec.ts
@@ -42,7 +42,6 @@ describe('BraintreeScriptLoader', () => {
             features: {
                 ...storeConfig.checkoutSettings.features,
                 'PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree': true,
-                'PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing': true,
             },
         },
     };

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -34,8 +34,7 @@ export default class BraintreeScriptLoader {
     initialize(storeConfig: StoreConfig) {
         const features = storeConfig.checkoutSettings.features;
         const shouldUseBraintreeAlphaVersion =
-            features['PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree'] &&
-            features['PAYPAL-2770.PayPal_Accelerated_checkout_ab_testing'];
+            features['PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree'];
 
         this.braintreeSdkVersion = shouldUseBraintreeAlphaVersion
             ? BRAINTREE_SDK_ALPHA_VERSION


### PR DESCRIPTION
## What?
Removed unnecessary 2770 experiment because we dont need it here anymore (Braintree SDK)

## Why?
2770 is a dynamic ab testing experiment, so we don't need to relay on it to set Braintree SDK version

## Testing / Proof
Unit tests
Manual tests