### PR TITLE
refactor(payment): PAYPAL-2923 covered Braintree AXO sandbox switcher with test mode condition

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -138,7 +138,10 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
                 paymentMethod.clientToken,
                 storeConfig,
             );
-            expect(braintreeIntegrationService.getBraintreeConnect).toHaveBeenCalledWith(cart.id);
+            expect(braintreeIntegrationService.getBraintreeConnect).toHaveBeenCalledWith(
+                cart.id,
+                false,
+            );
         });
     });
 

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -42,7 +42,7 @@ export default class BraintreeAcceleratedCheckoutUtils {
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCart();
         const storeConfig = state.getStoreConfigOrThrow();
-        const { clientToken, initializationData } =
+        const { clientToken, config, initializationData } =
             state.getPaymentMethodOrThrow<BraintreeInitializationData>(methodId);
 
         if (!clientToken || !initializationData) {
@@ -54,6 +54,7 @@ export default class BraintreeAcceleratedCheckoutUtils {
         this.braintreeIntegrationService.initialize(clientToken, storeConfig);
         this.braintreeConnect = await this.braintreeIntegrationService.getBraintreeConnect(
             cart?.id,
+            config.testMode,
         );
     }
 

--- a/packages/braintree-utils/src/braintree-integration-service.spec.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.spec.ts
@@ -94,6 +94,8 @@ describe('BraintreeIntegrationService', () => {
     afterEach(() => {
         jest.resetAllMocks();
         jest.restoreAllMocks();
+
+        localStorage.clear();
     });
 
     describe('#initialize()', () => {
@@ -173,6 +175,26 @@ describe('BraintreeIntegrationService', () => {
             });
 
             expect(result).toEqual(braintreeConnectMock);
+        });
+
+        it('sets axo to sandbox mode if test mode is enabled', async () => {
+            jest.spyOn(Storage.prototype, 'setItem').mockImplementation(jest.fn);
+
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
+
+            await braintreeIntegrationService.getBraintreeConnect('asd123', true);
+
+            expect(window.localStorage.setItem).toHaveBeenCalledWith('axoEnv', 'sandbox');
+        });
+
+        it('does not switch axo to sandbox mode if test mode is disabled', async () => {
+            jest.spyOn(Storage.prototype, 'setItem').mockImplementation(jest.fn);
+
+            braintreeIntegrationService.initialize(clientToken, storeConfigWithFeaturesOn);
+
+            await braintreeIntegrationService.getBraintreeConnect('asd123', false);
+
+            expect(window.localStorage.setItem).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/braintree-utils/src/braintree-integration-service.ts
+++ b/packages/braintree-utils/src/braintree-integration-service.ts
@@ -49,9 +49,10 @@ export default class BraintreeIntegrationService {
         this.braintreeScriptLoader.initialize(storeConfig);
     }
 
-    async getBraintreeConnect(cardId?: string) {
-        // TODO: should be removed after PayPal prepare stable Braintree SDK version with AXO implementation
-        window.localStorage.setItem('axoEnv', 'sandbox');
+    async getBraintreeConnect(cardId?: string, isTestModeEnabled?: boolean) {
+        if (isTestModeEnabled) {
+            window.localStorage.setItem('axoEnv', 'sandbox');
+        }
 
         if (!this.braintreeHostWindow.braintreeConnect) {
             const clientToken = this.getClientTokenOrThrow();


### PR DESCRIPTION
## What?
Covered Braintree AXO sandbox switcher with test mode condition

## Why?
We should prevent to enable PayPal Connect sandbox mode on production

## Testing / Proof
Unit tests
Manual tests