### PR TITLE
feat(payment): PAYPAL-2932 add PayPal billing addresses

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -232,6 +232,86 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
             );
         });
 
+        it('successfully authenticate customer with PP Connect and different shipping and bulling addresses', async () => {
+            const defaultProfileData = getBraintreeConnectProfileDataMock();
+            const profileData = getBraintreeConnectProfileDataMock();
+
+            profileData.cards[0].paymentSource.card.billingAddress = {
+                ...defaultProfileData.cards[0].paymentSource.card.billingAddress,
+                firstName: 'Mr.',
+                lastName: 'Smith',
+            };
+
+            jest.spyOn(braintreeConnectMock.identity, 'triggerAuthenticationFlow').mockReturnValue({
+                authenticationState: BraintreeConnectAuthenticationState.SUCCEEDED,
+                profileData,
+            });
+
+            const updatePaymentProviderCustomerPayload = {
+                authenticationState: BraintreeConnectAuthenticationState.SUCCEEDED,
+                addresses: [
+                    {
+                        id: 123123,
+                        type: 'paypal-address',
+                        firstName: 'John',
+                        lastName: 'Doe',
+                        company: '',
+                        address1: 'Hello World Address',
+                        address2: '',
+                        city: 'Bellingham',
+                        stateOrProvince: 'WA',
+                        stateOrProvinceCode: 'WA',
+                        country: 'United States',
+                        countryCode: 'US',
+                        postalCode: '98225',
+                        phone: '',
+                        customFields: [],
+                    },
+                    {
+                        id: 321,
+                        type: 'paypal-address',
+                        firstName: 'Mr.',
+                        lastName: 'Smith',
+                        company: '',
+                        address1: 'Hello World Address',
+                        address2: '',
+                        city: 'Bellingham',
+                        stateOrProvince: 'WA',
+                        stateOrProvinceCode: 'WA',
+                        country: 'United States',
+                        countryCode: 'US',
+                        postalCode: '98225',
+                        phone: '',
+                        customFields: [],
+                    },
+                ],
+                instruments: [
+                    {
+                        bigpayToken: 'pp-vaulted-instrument-id',
+                        brand: 'VISA',
+                        defaultInstrument: false,
+                        expiryMonth: undefined,
+                        expiryYear: '02/2037',
+                        iin: '',
+                        last4: '1111',
+                        method: 'braintreeacceleratedcheckout',
+                        provider: 'braintreeacceleratedcheckout',
+                        trustedShippingAddress: false,
+                        type: 'card',
+                    },
+                ],
+            };
+
+            await subject.initializeBraintreeConnectOrThrow(methodId);
+            await subject.runPayPalConnectAuthenticationFlowOrThrow();
+
+            expect(browserStorage.setItem).toHaveBeenCalledWith('sessionId', cart.id);
+            expect(braintreeConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
+            expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith(
+                updatePaymentProviderCustomerPayload,
+            );
+        });
+
         it('does not authenticate customer if the authentication was canceled or failed', async () => {
             jest.spyOn(braintreeConnectMock.identity, 'triggerAuthenticationFlow').mockReturnValue({
                 authenticationState: BraintreeConnectAuthenticationState.CANCELED,
@@ -254,12 +334,12 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
             );
         });
 
-        it('preselects billing address with first paypal connect address', async () => {
+        it('preselects billing address with first paypal connect billing address', async () => {
             await subject.initializeBraintreeConnectOrThrow(methodId);
             await subject.runPayPalConnectAuthenticationFlowOrThrow();
 
             expect(paymentIntegrationService.updateBillingAddress).toHaveBeenCalledWith({
-                id: 123123,
+                id: 321,
                 type: 'paypal-address',
                 firstName: 'John',
                 lastName: 'Doe',

--- a/packages/braintree-utils/src/braintree.ts
+++ b/packages/braintree-utils/src/braintree.ts
@@ -594,6 +594,10 @@ export interface BraintreeConnectProfileData {
     connectCustomerId: string;
     addresses: BraintreeConnectAddress[];
     cards: BraintreeConnectVaultedInstrument[];
+    name: {
+        given_name: string;
+        surname: string;
+    };
 }
 
 export interface BraintreeConnectAddress {

--- a/packages/braintree-utils/src/index.ts
+++ b/packages/braintree-utils/src/index.ts
@@ -15,6 +15,7 @@ export {
     BraintreeConnectVaultedInstrument,
     BraintreeConnectCardComponentOptions,
     BraintreeConnectCardComponent,
+    BraintreeConnectProfileData,
     onPaymentStartData,
     StartPaymentError,
     LocalPaymentsPayload,

--- a/packages/braintree-utils/src/mocks/braintree.mock.ts
+++ b/packages/braintree-utils/src/mocks/braintree.mock.ts
@@ -49,6 +49,7 @@ export function getBraintreeConnectProfileDataMock(): BraintreeConnectProfileDat
                         expiry: '02/2037',
                         lastDigits: '1111',
                         billingAddress: {
+                            id: '321',
                             company: undefined,
                             extendedAddress: undefined,
                             firstName: undefined,
@@ -65,6 +66,10 @@ export function getBraintreeConnectProfileDataMock(): BraintreeConnectProfileDat
                 },
             },
         ],
+        name: {
+            given_name: 'John',
+            surname: 'Doe',
+        },
     };
 }
 


### PR DESCRIPTION
## What?
Preset billing address fields from PP card info

## Why?
To setup correct billing address for preset payment instrument

## Testing / Proof
Manually tested and unit test

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/2c14a897-b3e7-412a-bb33-4a5759a6ccf7



@bigcommerce/team-checkout @bigcommerce/team-payments
