### PR TITLE
feat(payment): PI-804 Make an ability to use deleteConsignment action…

### DIFF
--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -58,7 +58,7 @@ describe('DefaultPaymentIntegrationService', () => {
     let billingAddressActionCreator: Pick<BillingAddressActionCreator, 'updateAddress'>;
     let consignmentActionCreator: Pick<
         ConsignmentActionCreator,
-        'updateAddress' | 'selectShippingOption'
+        'updateAddress' | 'selectShippingOption' | 'deleteConsignment'
     >;
     let paymentMethodActionCreator: Pick<PaymentMethodActionCreator, 'loadPaymentMethod'>;
     let paymentActionCreator: Pick<
@@ -125,6 +125,7 @@ describe('DefaultPaymentIntegrationService', () => {
         consignmentActionCreator = {
             updateAddress: jest.fn(async () => () => createAction('UPDATE_CONSIGNMENT_ADDRESS')),
             selectShippingOption: jest.fn(async () => () => createAction('UPDATE_SHIPPING_OPTION')),
+            deleteConsignment: jest.fn(async () => () => createAction('DELETE_CONSIGNMENT')),
         };
 
         paymentMethodActionCreator = {
@@ -445,6 +446,18 @@ describe('DefaultPaymentIntegrationService', () => {
             expect(shippingCountryActionCreator.loadCountries).toHaveBeenCalled();
             expect(store.dispatch).toHaveBeenCalledWith(
                 shippingCountryActionCreator.loadCountries(),
+            );
+            expect(output).toEqual(paymentIntegrationSelectors);
+        });
+    });
+
+    describe('#deleteConsignment', () => {
+        it('delete consignment', async () => {
+            const output = await subject.deleteConsignment('ID');
+
+            expect(consignmentActionCreator.deleteConsignment).toHaveBeenCalled();
+            expect(store.dispatch).toHaveBeenCalledWith(
+                consignmentActionCreator.deleteConsignment('ID'),
             );
             expect(output).toEqual(paymentIntegrationSelectors);
         });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -237,4 +237,15 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
 
         return this._storeProjection.getState();
     }
+
+    async deleteConsignment(
+        consignmentId: string,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._consignmentActionCreator.deleteConsignment(consignmentId, options),
+        );
+
+        return this._storeProjection.getState();
+    }
 }

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -12,6 +12,11 @@ import { RequestOptions } from './util-types';
 export default interface PaymentIntegrationService {
     createHostedForm(host: string, options: HostedFormOptions): HostedForm;
 
+    deleteConsignment(
+        consignmentId: string,
+        options?: RequestOptions,
+    ): Promise<PaymentIntegrationSelectors>;
+
     subscribe(
         subscriber: (state: PaymentIntegrationSelectors) => void,
         ...filters: Array<(state: PaymentIntegrationSelectors) => unknown>


### PR DESCRIPTION
… from core package in integration checkout-sdk packages

## What?
Add `deleteConsignment` to `PaymentIntegrationService`

## Why?
To get ability to use `consignmentActionCreator.deleteConsignment` from `PaymentIntegrationService`

## Testing / Proof
<img width="353" alt="Zrzut ekranu 2023-09-11 o 11 22 41" src="https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/4615aa27-5df3-44d8-bf4e-2cdda29de34b">


@bigcommerce/team-checkout @bigcommerce/team-payments
