### PR TITLE
feat(payment): PI-811 Make an ability to use stripeLinkAuthenticatedA…

### DIFF
--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -462,4 +462,17 @@ describe('DefaultPaymentIntegrationService', () => {
             expect(output).toEqual(paymentIntegrationSelectors);
         });
     });
+
+    describe('#stripeLinkAuthenticatedAction', () => {
+        it('authenticate stripe link action', async () => {
+            jest.spyOn(store, 'dispatch');
+
+            await subject.stripeLinkAuthenticatedAction(false);
+
+            expect(store.dispatch).toHaveBeenCalledWith({
+                type: 'STRIPE_LINK_AUTHENTICATED',
+                payload: false,
+            });
+        });
+    });
 });

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -1,3 +1,5 @@
+import { createAction } from '@bigcommerce/data-store';
+
 import {
     BillingAddressRequestBody,
     BuyNowCartRequestBody,
@@ -17,7 +19,7 @@ import { BillingAddressActionCreator } from '../billing';
 import { CartRequestSender } from '../cart';
 import { CheckoutActionCreator, CheckoutStore } from '../checkout';
 import { DataStoreProjection } from '../common/data-store';
-import { CustomerActionCreator, CustomerCredentials } from '../customer';
+import { CustomerActionCreator, CustomerActionType, CustomerCredentials } from '../customer';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator } from '../order';
 import {
@@ -244,6 +246,16 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
     ): Promise<PaymentIntegrationSelectors> {
         await this._store.dispatch(
             this._consignmentActionCreator.deleteConsignment(consignmentId, options),
+        );
+
+        return this._storeProjection.getState();
+    }
+
+    async stripeLinkAuthenticatedAction(
+        authenticated: boolean | undefined,
+    ): Promise<PaymentIntegrationSelectors> {
+        this._store.dispatch(
+            createAction(CustomerActionType.StripeLinkAuthenticated, authenticated),
         );
 
         return this._storeProjection.getState();

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -53,6 +53,10 @@ export default interface PaymentIntegrationService {
         options?: RequestOptions,
     ): Promise<PaymentIntegrationSelectors>;
 
+    stripeLinkAuthenticatedAction(
+        authenticated: boolean | undefined,
+    ): Promise<PaymentIntegrationSelectors>;
+
     verifyCheckoutSpamProtection(): Promise<PaymentIntegrationSelectors>;
 
     updateBillingAddress(payload: BillingAddressRequestBody): Promise<PaymentIntegrationSelectors>;


### PR DESCRIPTION
…ction in integration checkout-sdk packages

## What?
Add `stripeLinkAuthenticatedA` to `PaymentIntegrationService`

## Why?
To get ability to use `stripeLinkAuthenticatedA` from `PaymentIntegrationService`.
This method was added during work on moving StripeUPE customer strategy to package. Place in code where stripeLinkAuthenticated method was needed: 
![Zrzut ekranu 2023-09-13 o 10 14 20](https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/02c19209-def0-4941-a429-65d0efa50c20)


## Testing / Proof
![Zrzut ekranu 2023-09-13 o 08 33 48](https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/ba69be86-a816-43b7-8048-51e2b2756689)


@bigcommerce/team-checkout @bigcommerce/team-payments
