### PR TITLE
fix(payment): PAYPAL-1752 added validation for braintree credit card form

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -64,6 +64,7 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
             Promise.resolve(true),
         );
         braintreePaymentProcessorMock.deinitializeHostedForm = jest.fn(() => Promise.resolve());
+        braintreePaymentProcessorMock.validateHostedForm = jest.fn();
         braintreePaymentProcessorMock.tokenizeCard = jest.fn(() =>
             Promise.resolve({ nonce: 'my_tokenized_card' }),
         );

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -83,19 +83,14 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
             throw new PaymentArgumentInvalidError(['payment']);
         }
 
-        const state = await this._store.dispatch(
-            this._orderActionCreator.submitOrder(order, options),
-        );
+        if (this._isHostedFormInitialized) {
+            this._braintreePaymentProcessor.validateHostedForm();
+        }
 
         const {
             billingAddress: { getBillingAddressOrThrow },
             order: { getOrderOrThrow },
-            payment: { isPaymentDataRequired },
-        } = state;
-
-        if (!isPaymentDataRequired(order.useStoreCredit)) {
-            return state;
-        }
+        } = await this._store.dispatch(this._orderActionCreator.submitOrder(order, options));
 
         const billingAddress = getBillingAddressOrThrow();
         const orderAmount = getOrderOrThrow().orderAmount;

--- a/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-payment-processor.ts
@@ -175,6 +175,10 @@ export default class BraintreePaymentProcessor {
         return this._braintreeHostedForm.initialize(options);
     }
 
+    validateHostedForm() {
+        return this._braintreeHostedForm.validate();
+    }
+
     isInitializedHostedForm(): boolean {
         return this._braintreeHostedForm.isInitialized();
     }

--- a/packages/core/src/payment/strategies/braintree/braintree.mock.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.mock.ts
@@ -85,6 +85,7 @@ export function getVenmoCheckoutMock(): BraintreeVenmoCheckout {
 
 export function getHostedFieldsMock(): BraintreeHostedFields {
     return {
+        getState: jest.fn(),
         teardown: jest.fn(() => Promise.resolve()),
         tokenize: jest.fn(() => Promise.resolve(getTokenizePayload())),
         on: jest.fn(),

--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -243,6 +243,7 @@ export type BraintreeHostedFieldsCreator = BraintreeModuleCreator<
 >;
 
 export interface BraintreeHostedFields {
+    getState(): BraintreeHostedFieldsState;
     teardown(): Promise<void>;
     tokenize(
         options?: BraintreeHostedFieldsTokenizeOptions,


### PR DESCRIPTION
## What?
Added validation for braintree credit card form before placing order

## Why?
To avoid placing order before form validation that causes some problems with order creation on place order action after form was filled with valid data.

## Testing / Proof
Unit tests
Manual tests

You can see that there is no order creation request in the network tab after attempt to place order:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/bfb7d1fd-7c6b-4ec8-a8a0-4f1211417958


