### PR TITLE
chore(payment): PAYPAL-000 extended codeowners file with team-integrations and team-paypal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,73 @@
+## Checkout team
+
 * @bigcommerce/team-checkout
-/packages/adyen-integration @bigcommerce/kyiv-payments-team
 /packages/apple-pay @bigcommerce/team-checkout
-/packages/bolt-integration @bigcommerce/kyiv-payments-team
-/packages/braintree-integration @bigcommerce/kyiv-payments-team
-/packages/braintree-utils @bigcommerce/kyiv-payments-team
 /packages/core @bigcommerce/team-checkout
-/packages/mollie-integration @bigcommerce/kyiv-payments-team
 /packages/payment-integration @bigcommerce/team-checkout
 /packages/payment-integration-test-utils @bigcommerce/team-checkout
-/packages/paypal-commerce-integration @bigcommerce/kyiv-payments-team
-/packages/stripe-integration @bigcommerce/kyiv-payments-team
-/packages/squarev2-integration @bigcommerce/apex-leads
-/packages/paypal-express-integration @bigcommerce/kyiv-payments-team
-/packages/bluesnap-direct-integration @bigcommerce/kyiv-payments-team
-/packages/google-pay-integration @bigcommerce/apex-leads
+
+
+## Payment integrations team
+
+# Core
+/packages/core/src/checkout-buttons/strategies/amazon-pay-v2 @bigcommerce/payment-integrations-team
+/packages/core/src/checkout-buttons/strategies/braintree @bigcommerce/payment-integrations-team
+/packages/core/src/checkout-buttons/strategies/googlepay @bigcommerce/payment-integrations-team
+/packages/core/src/checkout-buttons/strategies/masterpass @bigcommerce/payment-integrations-team
+/packages/core/src/checkout-buttons/strategies/paypal @bigcommerce/payment-integrations-team
+/packages/core/src/customer/strategies/amazon-pay-v2 @bigcommerce/payment-integrations-team
+/packages/core/src/customer/strategies/braintree @bigcommerce/payment-integrations-team
+/packages/core/src/customer/strategies/chasepay @bigcommerce/payment-integrations-team
+/packages/core/src/customer/strategies/googlepay @bigcommerce/payment-integrations-team
+/packages/core/src/customer/strategies/masterpass @bigcommerce/payment-integrations-team
+/packages/core/src/customer/strategies/square @bigcommerce/payment-integrations-team
+/packages/core/src/customer/strategies/stripe-upe @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/adyenv2 @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/adyenv3 @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/affirm @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/afterpay @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/amazon-pay-v2 @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/barclays @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/bluesnapv2 @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/bnz @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/braintree @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/cardinal @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/cba-mpgs @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/chasepay @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/checkoutcom @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/checkoutcom-custom @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/clearpay @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/converge @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/cybersource @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/cybersourcev2 @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/digitalriver @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/googlepay @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/humm @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/klarna @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/klarnav2 @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/masterpass @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/moneris @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/opy @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/paypal @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/ppsdk @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/quadpay @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/sage-pay @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/square @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/stripe-upe @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/stripev3 @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/wepay @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/worldpayaccess @bigcommerce/payment-integrations-team
+/packages/core/src/payment/strategies/zip @bigcommerce/payment-integrations-team
+
+# Packages
+/packages/adyen-integration @bigcommerce/payment-integrations-team
+/packages/bluesnap-direct-integration @bigcommerce/payment-integrations-team
+/packages/bolt-integration @bigcommerce/payment-integrations-team
+/packages/braintree-integration @bigcommerce/payment-integrations-team
+/packages/braintree-utils @bigcommerce/payment-integrations-team
+/packages/google-pay-integration @bigcommerce/payment-integrations-team
+/packages/mollie-integration @bigcommerce/payment-integrations-team
+/packages/paypal-express-integration @bigcommerce/payment-integrations-team
+/packages/paypal-commerce-integration @bigcommerce/payment-integrations-team
+/packages/squarev2-integration @bigcommerce/payment-integrations-team
+/packages/stripe-integration @bigcommerce/payment-integrations-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,73 +1,81 @@
 ## Checkout team
 
 * @bigcommerce/team-checkout
-/packages/apple-pay @bigcommerce/team-checkout
 /packages/core @bigcommerce/team-checkout
 /packages/payment-integration @bigcommerce/team-checkout
 /packages/payment-integration-test-utils @bigcommerce/team-checkout
 
 
-## Payment integrations team
+## Integrations team
 
-# Core
-/packages/core/src/checkout-buttons/strategies/amazon-pay-v2 @bigcommerce/payment-integrations-team
-/packages/core/src/checkout-buttons/strategies/braintree @bigcommerce/payment-integrations-team
-/packages/core/src/checkout-buttons/strategies/googlepay @bigcommerce/payment-integrations-team
-/packages/core/src/checkout-buttons/strategies/masterpass @bigcommerce/payment-integrations-team
-/packages/core/src/checkout-buttons/strategies/paypal @bigcommerce/payment-integrations-team
-/packages/core/src/customer/strategies/amazon-pay-v2 @bigcommerce/payment-integrations-team
-/packages/core/src/customer/strategies/braintree @bigcommerce/payment-integrations-team
-/packages/core/src/customer/strategies/chasepay @bigcommerce/payment-integrations-team
-/packages/core/src/customer/strategies/googlepay @bigcommerce/payment-integrations-team
-/packages/core/src/customer/strategies/masterpass @bigcommerce/payment-integrations-team
-/packages/core/src/customer/strategies/square @bigcommerce/payment-integrations-team
-/packages/core/src/customer/strategies/stripe-upe @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/adyenv2 @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/adyenv3 @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/affirm @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/afterpay @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/amazon-pay-v2 @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/barclays @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/bluesnapv2 @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/bnz @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/braintree @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/cardinal @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/cba-mpgs @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/chasepay @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/checkoutcom @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/checkoutcom-custom @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/clearpay @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/converge @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/cybersource @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/cybersourcev2 @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/digitalriver @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/googlepay @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/humm @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/klarna @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/klarnav2 @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/masterpass @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/moneris @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/opy @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/paypal @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/ppsdk @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/quadpay @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/sage-pay @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/square @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/stripe-upe @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/stripev3 @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/wepay @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/worldpayaccess @bigcommerce/payment-integrations-team
-/packages/core/src/payment/strategies/zip @bigcommerce/payment-integrations-team
+/packages/core/src/checkout-buttons/strategies/amazon-pay-v2 @bigcommerce/team-integrations
+/packages/core/src/checkout-buttons/strategies/masterpass @bigcommerce/team-integrations
+/packages/core/src/customer/strategies/amazon-pay-v2 @bigcommerce/team-integrations
+/packages/core/src/customer/strategies/chasepay @bigcommerce/team-integrations
+/packages/core/src/customer/strategies/masterpass @bigcommerce/team-integrations
+/packages/core/src/customer/strategies/square @bigcommerce/team-integrations
+/packages/core/src/customer/strategies/stripe-upe @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/adyenv2 @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/adyenv3 @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/affirm @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/afterpay @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/amazon-pay-v2 @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/barclays @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/bluesnapv2 @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/bnz @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/cardinal @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/cba-mpgs @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/chasepay @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/checkoutcom @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/checkoutcom-custom @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/clearpay @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/converge @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/cybersource @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/cybersourcev2 @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/digitalriver @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/humm @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/klarna @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/klarnav2 @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/masterpass @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/moneris @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/opy @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/ppsdk @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/quadpay @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/sage-pay @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/square @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/stripe-upe @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/stripev3 @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/wepay @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/worldpayaccess @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/zip @bigcommerce/team-integrations
 
-# Packages
-/packages/adyen-integration @bigcommerce/payment-integrations-team
-/packages/bluesnap-direct-integration @bigcommerce/payment-integrations-team
-/packages/bolt-integration @bigcommerce/payment-integrations-team
-/packages/braintree-integration @bigcommerce/payment-integrations-team
-/packages/braintree-utils @bigcommerce/payment-integrations-team
-/packages/google-pay-integration @bigcommerce/payment-integrations-team
-/packages/mollie-integration @bigcommerce/payment-integrations-team
-/packages/paypal-express-integration @bigcommerce/payment-integrations-team
-/packages/paypal-commerce-integration @bigcommerce/payment-integrations-team
-/packages/squarev2-integration @bigcommerce/payment-integrations-team
-/packages/stripe-integration @bigcommerce/payment-integrations-team
+/packages/adyen-integration @bigcommerce/team-integrations
+/packages/bluesnap-direct-integration @bigcommerce/team-integrations
+/packages/bolt-integration @bigcommerce/team-integrations
+/packages/mollie-integration @bigcommerce/team-integrations
+/packages/squarev2-integration @bigcommerce/team-integrations
+/packages/stripe-integration @bigcommerce/team-integrations
+
+
+## PayPal team
+
+/packages/core/src/checkout-buttons/strategies/braintree @bigcommerce/team-integrations
+/packages/core/src/checkout-buttons/strategies/paypal @bigcommerce/team-integrations
+/packages/core/src/customer/strategies/braintree @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/braintree @bigcommerce/team-integrations
+/packages/core/src/payment/strategies/paypal @bigcommerce/team-integrations
+
+/packages/braintree-integration @bigcommerce/team-integrations
+/packages/braintree-utils @bigcommerce/team-integrations
+/packages/paypal-express-integration @bigcommerce/team-integrations
+/packages/paypal-commerce-integration @bigcommerce/team-integrations
+
+
+## Shared
+
+/packages/core/src/checkout-buttons/strategies/googlepay @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
+/packages/core/src/customer/strategies/googlepay @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
+/packages/core/src/payment/strategies/googlepay @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
+
+/packages/apple-pay @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal
+/packages/google-pay-integration @bigcommerce/team-checkout @bigcommerce/team-integrations @bigcommerce/team-paypal


### PR DESCRIPTION
## What?
Extended codeowners file with `team-integrations` and `team-paypal` ownership

## Why?
To make `team-integrations` and `team-paypal` able to work with integrations as owners