### PR TITLE
fix(payment): PAYPAL-2928 fixed the issue with braintree buttons rendering on PDP page

### DIFF
--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.spec.ts
@@ -272,7 +272,7 @@ describe('BraintreePaypalButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                store.getState().config.getStoreConfigOrThrow(),
+                store.getState().config.getStoreConfig(),
             );
         });
 
@@ -284,7 +284,7 @@ describe('BraintreePaypalButtonStrategy', () => {
 
             expect(braintreeSDKCreator.initialize).toHaveBeenCalledWith(
                 paymentMethodMock.clientToken,
-                store.getState().config.getStoreConfigOrThrow(),
+                store.getState().config.getStoreConfig(),
             );
             expect(braintreeSDKCreator.getPaypalCheckout).toHaveBeenCalled();
         });

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-button-strategy.ts
@@ -87,7 +87,9 @@ export default class BraintreePaypalButtonStrategy implements CheckoutButtonStra
             currencyCode = state.cart.getCartOrThrow().currency.code;
         }
 
-        const storeConfig = state.config.getStoreConfigOrThrow();
+        // Info: does not use getStoreConfigOrThrow, because storeConfig is not available if
+        // cart is empty, so it causes issues on Product Details Page
+        const storeConfig = state.config.getStoreConfig();
         const { clientToken, initializationData } = paymentMethod;
 
         if (!clientToken || !initializationData) {

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-paypal-credit-button-strategy.ts
@@ -90,7 +90,9 @@ export default class BraintreePaypalCreditButtonStrategy implements CheckoutButt
             currencyCode = state.cart.getCartOrThrow().currency.code;
         }
 
-        const storeConfig = state.config.getStoreConfigOrThrow();
+        // Info: does not use getStoreConfigOrThrow, because storeConfig is not available if
+        // cart is empty, so it causes issues on Product Details Page
+        const storeConfig = state.config.getStoreConfig();
         const { clientToken, initializationData } = paymentMethod;
 
         if (!clientToken || !initializationData) {

--- a/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
+++ b/packages/core/src/checkout-buttons/strategies/braintree/braintree-venmo-button-strategy.ts
@@ -70,7 +70,9 @@ export default class BraintreeVenmoButtonStrategy implements CheckoutButtonStrat
         const state = await this._store.dispatch(
             this._paymentMethodActionCreator.loadPaymentMethod(methodId),
         );
-        const storeConfig = state.config.getStoreConfigOrThrow();
+        // Info: does not use getStoreConfigOrThrow, because storeConfig is not available if
+        // cart is empty, so it causes issues on Product Details Page
+        const storeConfig = state.config.getStoreConfig();
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         const { clientToken, initializationData } = paymentMethod;
 

--- a/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-script-loader.ts
@@ -31,10 +31,10 @@ export default class BraintreeScriptLoader {
 
     // TODO: this method is needed only for braintree AXO
     // So can be removed after Beta stage
-    initialize(storeConfig: StoreConfig) {
-        const features = storeConfig.checkoutSettings.features;
+    initialize(storeConfig?: StoreConfig) {
+        const features = storeConfig?.checkoutSettings?.features;
         const shouldUseBraintreeAlphaVersion =
-            features['PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree'];
+            features && features['PROJECT-5505.PayPal_Accelerated_Checkout_v2_for_Braintree'];
 
         this.braintreeSdkVersion = shouldUseBraintreeAlphaVersion
             ? BRAINTREE_SDK_ALPHA_VERSION

--- a/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-sdk-creator.ts
@@ -43,7 +43,7 @@ export default class BraintreeSDKCreator {
         this._window = window;
     }
 
-    initialize(clientToken: string, storeConfig: StoreConfig) {
+    initialize(clientToken: string, storeConfig?: StoreConfig) {
         this._clientToken = clientToken;
         this._braintreeScriptLoader.initialize(storeConfig);
     }

--- a/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -28,7 +28,7 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
         paymentMethod: PaymentMethod,
         hasShippingAddress: boolean,
     ): Promise<GooglePayPaymentDataRequestV2> {
-        const storeConfig = this._store.getState().config.getStoreConfigOrThrow();
+        const storeConfig = this._store.getState().config.getStoreConfig();
         const { clientToken } = paymentMethod;
 
         if (!clientToken) {


### PR DESCRIPTION
## What?
Fixed the issue with braintree buttons rendering on PDP page.

## Why?
There was a problem with getting `storeConfig` to get access to feature flags. Therefore we should change `getStoreConfigOrThrow` to more calm `getStoreConfig` to get store config if it's available. It does not brake anything, because the reason why we need storeConfig is to understand whenever to load Braintree Alpha version for PayPal Connect that used only on Checkout Page.

## Testing / Proof
Unit tests
Manual tests

Before: 
There are console errors and the braintree buttons failed to render
<img width="1512" alt="Screenshot 2023-09-19 at 16 56 33" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/9c4b1326-cb19-4943-8117-9c1b150b0e38">

After:
There are no console errors and the braintree buttons rendered sucessfuly
<img width="1512" alt="Screenshot 2023-09-19 at 17 46 33" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/3a43ce2b-e041-4c03-a2ec-9510882ee94d">


