### PR TITLE
fix(embedded-checkout): ISSUE-2189 Update Iframe property in embedded checkout to allow apple pay

### DIFF
--- a/packages/core/src/embedded-checkout/resizable-iframe-creator.ts
+++ b/packages/core/src/embedded-checkout/resizable-iframe-creator.ts
@@ -25,6 +25,7 @@ export default class ResizableIframeCreator {
         iframe.style.display = 'none';
         iframe.style.width = '100%';
         iframe.allowPaymentRequest = true;
+        iframe.allow = 'payment';
 
         container.appendChild(iframe);
 


### PR DESCRIPTION
Solution is instead of using iframe.allowPaymentRequest = true use allow="payment" in following file checkout-sdk-js/packages/core/src/embedded-checkout/resizable-iframe-creator.ts (line no. 27)

I have not removed  iframe.allowPaymentRequest = true for now. I have just added iframe.allow = payment as new line.

## What?
Apple Safari has given 17 release and now it supports apple pay. 

But in embedded checkout we need to pass allow="payment" as attribute in iframe. Right now the attribute is iframe.allowPaymentRequest = true. allowPaymentRequest attribute is deprecated and now It's allow="payment"

## Why?
To support apple pay using embedded checkout on Safari browser.
![embedded-checkout-code](https://github.com/bigcommerce/checkout-sdk-js/assets/128696510/5b8a57f0-3580-46e3-9257-20752ca666ee)

