### PR TITLE
feat(payment): PI-567 Amazon Pay Button needs to be changed to one with microtext

### DIFF
--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -16,7 +16,6 @@ import {
     AmazonPayV2Button,
     AmazonPayV2ButtonColor,
     AmazonPayV2ButtonConfig,
-    AmazonPayV2ButtonDesign,
     AmazonPayV2ButtonParameters,
     AmazonPayV2ButtonRenderingOptions,
     AmazonPayV2ChangeActionType,
@@ -131,10 +130,6 @@ export default class AmazonPayV2PaymentProcessor {
 
         const { id: parentContainerId } = container.appendChild(this._getButtonParentContainer());
 
-        if (options) {
-            options.design = AmazonPayV2ButtonDesign.C0001;
-        }
-
         const amazonPayV2ButtonOptions =
             options ??
             this._getAmazonPayV2ButtonOptions(
@@ -230,7 +225,6 @@ export default class AmazonPayV2PaymentProcessor {
             checkoutLanguage,
             placement,
             buttonColor,
-            design: AmazonPayV2ButtonDesign.C0001,
         };
 
         if (this._isBuyNowFlow) {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -4,7 +4,6 @@ import { getAmazonPayV2 } from '../../payment-methods.mock';
 import {
     AmazonPayV2ButtonColor,
     AmazonPayV2ButtonConfig,
-    AmazonPayV2ButtonDesign,
     AmazonPayV2ButtonParameters,
     AmazonPayV2CheckoutLanguage,
     AmazonPayV2LedgerCurrency,
@@ -59,7 +58,6 @@ export function getAmazonPayV2Ph4ButtonParamsMock(): AmazonPayV2ButtonParameters
             payloadJSON: 'payload',
             signature: 'xxxx',
         },
-        design: AmazonPayV2ButtonDesign.C0001,
     };
 }
 
@@ -71,7 +69,6 @@ export function getAmazonPayBaseButtonParamsMock(): AmazonPayV2ButtonConfig {
         placement: AmazonPayV2Placement.Checkout,
         buttonColor: AmazonPayV2ButtonColor.Gold,
         sandbox: true,
-        design: AmazonPayV2ButtonDesign.C0001,
     };
 }
 
@@ -89,6 +86,5 @@ export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParameters {
         placement: AmazonPayV2Placement.Checkout,
         productType: AmazonPayV2PayOptions.PayAndShip,
         sandbox: true,
-        design: AmazonPayV2ButtonDesign.C0001,
     };
 }


### PR DESCRIPTION
## What?
The incorrect Amazon Pay button was added to the platform. It needs to be switched to the button with microtext across all BC’s surfaces (PDP, cart page, checkout page etc). 

## Why?
Per Amazon team, button with microtext performs better conversion rates.

## Testing / Proof

Before:
Amazon Pay button without microtext:

![image](https://github.com/bigcommerce/checkout-sdk-js/assets/130754705/19b06b5c-2845-4389-98bf-f583fc6535e2)
 

Expected result:
Amazon Pay button with microtext is displayed across all BC surfaces (PDP, cart page, checkout page etc)

![image](https://github.com/bigcommerce/checkout-sdk-js/assets/130754705/b8b4c7a0-074a-4bc9-92dd-a79185c94534)
