### PR TITLE
fix(payment): PI-758 check if Stripe container exists before mount

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -184,6 +184,10 @@ describe('StripeUPEPaymentStrategy', () => {
             storeCreditActionCreator,
             billingAddressActionCreator,
         );
+
+        const mockElement = document.createElement('div');
+
+        jest.spyOn(document, 'getElementById').mockReturnValue(mockElement);
     });
 
     describe('#initialize()', () => {
@@ -326,6 +330,25 @@ describe('StripeUPEPaymentStrategy', () => {
 
                 await expect(strategy.initialize(options)).resolves.toBe(store.getState());
                 expect(mount).not.toHaveBeenCalled();
+            });
+
+            it('fails mounting a stripe payment element if container not exist', async () => {
+                const mountMock = jest.fn();
+                const { getElement } = stripeUPEJsMock.elements(elementsOptions);
+                const createMock = jest.fn().mockReturnValue({ mount: mountMock });
+
+                jest.spyOn(document, 'getElementById').mockReturnValue(null);
+
+                stripeUPEJsMock.elements = jest
+                    .fn()
+                    .mockReturnValue({ create: createMock, getElement });
+
+                jest.spyOn(stripeScriptLoader, 'getStripeClient').mockReturnValue(
+                    Promise.resolve(stripeUPEJsMock),
+                );
+
+                await expect(strategy.initialize(options)).resolves.toBe(store.getState());
+                expect(mountMock).not.toHaveBeenCalled();
             });
         });
     });

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -58,7 +58,6 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
     private _stripeElements?: StripeElements;
     private _isMounted = false;
     private _unsubscribe?: () => void;
-    private _isDeinitialize?: boolean;
 
     constructor(
         private _store: CheckoutStore,
@@ -82,8 +81,6 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                 'Unable to initialize payment because "gatewayId" argument is not provided.',
             );
         }
-
-        this._isDeinitialize = false;
 
         this._loadStripeElement(stripeupe, gatewayId, methodId).catch((error) =>
             stripeupe.onError?.(error),
@@ -113,8 +110,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                         stripeupe.onError?.(error);
                     } else if (!this._isMounted) {
                         await this._stripeElements?.fetchUpdates();
-                        payment.mount(`#${stripeupe.containerId}`);
-                        this._isMounted = true;
+                        this._mountElement(payment, stripeupe.containerId);
                     }
                 }
             },
@@ -219,7 +215,6 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
 
         this._stripeElements?.getElement(StripeElementType.PAYMENT)?.unmount();
         this._isMounted = false;
-        this._isDeinitialize = true;
 
         return Promise.resolve(this._store.getState());
     }
@@ -436,16 +431,7 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                 },
             });
 
-        try {
-            stripeElement.mount(`#${containerId}`);
-            this._isMounted = true;
-        } catch (error) {
-            if (!this._isDeinitialize) {
-                throw new InvalidArgumentError(
-                    'Unable to mount Stripe component without valid container ID.',
-                );
-            }
-        }
+        this._mountElement(stripeElement, containerId);
 
         stripeElement.on('ready', () => {
             render();
@@ -660,5 +646,14 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
             stripePublishableKey,
             stripeConnectedAccount,
         );
+    }
+
+    private _mountElement(stripeElement: StripeElement, containerId: string): void {
+        if (!document.getElementById(containerId)) {
+            return;
+        }
+
+        stripeElement.mount(`#${containerId}`);
+        this._isMounted = true;
     }
 }


### PR DESCRIPTION
## What?
Check if container exists before mounting payment fields inside.

## Why?
Because of error when payment provider was switched before current provider had been loaded

## Testing / Proof

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/18ed0b4f-a2d6-42e0-bb4f-e90fa558ecb6



@bigcommerce/team-checkout @bigcommerce/team-payments
