### PR TITLE
feat(payment): PI-845 Add PaymentProviderAuthentication state

### DIFF
--- a/packages/core/src/checkout/checkout-store-state.ts
+++ b/packages/core/src/checkout/checkout-store-state.ts
@@ -10,6 +10,7 @@ import { CountryState } from '../geography';
 import { OrderState } from '../order';
 import { OrderBillingAddressState } from '../order-billing-address';
 import { PaymentMethodState, PaymentState, PaymentStrategyState } from '../payment';
+import { PaymentProviderAuthenticationState } from '../payment-provider-authentication';
 import { PaymentProviderCustomerState } from '../payment-provider-customer';
 import { InstrumentState } from '../payment/instrument';
 import { RemoteCheckoutState } from '../remote-checkout';
@@ -44,6 +45,7 @@ export default interface CheckoutStoreState {
     orderBillingAddress: OrderBillingAddressState;
     payment: PaymentState;
     paymentMethods: PaymentMethodState;
+    paymentProviderAuthentication: PaymentProviderAuthenticationState;
     paymentProviderCustomer: PaymentProviderCustomerState;
     paymentStrategies: PaymentStrategyState;
     pickupOptions: PickupOptionState;

--- a/packages/core/src/checkout/checkouts.mock.ts
+++ b/packages/core/src/checkout/checkouts.mock.ts
@@ -130,6 +130,7 @@ export function getCheckoutStoreState(): CheckoutStoreState {
         orderBillingAddress: getOrderBillingAddressState(),
         payment: getPaymentState(),
         paymentMethods: getPaymentMethodsState(),
+        paymentProviderAuthentication: { data: {} },
         paymentProviderCustomer: { data: {} },
         paymentStrategies: { data: {}, errors: {}, statuses: {} },
         pickupOptions: getPickupOptionsState(),

--- a/packages/core/src/checkout/create-checkout-store-reducer.ts
+++ b/packages/core/src/checkout/create-checkout-store-reducer.ts
@@ -12,6 +12,7 @@ import { countryReducer } from '../geography';
 import { orderReducer } from '../order';
 import { orderBillingAddressReducer } from '../order-billing-address';
 import { paymentMethodReducer, paymentReducer, paymentStrategyReducer } from '../payment';
+import { paymentProviderAuthenticationReducer } from '../payment-provider-authentication';
 import { paymentProviderCustomerReducer } from '../payment-provider-customer';
 import { instrumentReducer } from '../payment/instrument';
 import { remoteCheckoutReducer } from '../remote-checkout';
@@ -50,6 +51,7 @@ export default function createCheckoutStoreReducer(): Reducer<CheckoutStoreState
         paymentMethods: paymentMethodReducer,
         paymentStrategies: paymentStrategyReducer,
         pickupOptions: pickupOptionReducer,
+        paymentProviderAuthentication: paymentProviderAuthenticationReducer,
         paymentProviderCustomer: paymentProviderCustomerReducer,
         remoteCheckout: remoteCheckoutReducer,
         shippingCountries: shippingCountryReducer,

--- a/packages/core/src/checkout/create-internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/create-internal-checkout-selectors.ts
@@ -15,6 +15,7 @@ import {
     createPaymentSelectorFactory,
     createPaymentStrategySelectorFactory,
 } from '../payment';
+import { createPaymentProviderAuthenticationSelectorFactory } from '../payment-provider-authentication';
 import { createPaymentProviderCustomerSelectorFactory } from '../payment-provider-customer';
 import { createInstrumentSelectorFactory } from '../payment/instrument';
 import { createRemoteCheckoutSelectorFactory } from '../remote-checkout';
@@ -54,6 +55,8 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
     const createPaymentMethodSelector = createPaymentMethodSelectorFactory();
     const createPaymentStrategySelector = createPaymentStrategySelectorFactory();
     const createPickupOptionSelector = createPickupOptionSelectorFactory();
+    const createPaymentProviderAuthenticationSelector =
+        createPaymentProviderAuthenticationSelectorFactory();
     const createPaymentProviderCustomerSelector = createPaymentProviderCustomerSelectorFactory();
     const createRemoteCheckoutSelector = createRemoteCheckoutSelectorFactory();
     const createShippingAddressSelector = createShippingAddressSelectorFactory();
@@ -83,6 +86,9 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
         const instruments = createInstrumentSelector(state.instruments);
         const orderBillingAddress = createOrderBillingAddressSelector(state.orderBillingAddress);
         const paymentMethods = createPaymentMethodSelector(state.paymentMethods);
+        const paymentProviderAuthentication = createPaymentProviderAuthenticationSelector(
+            state.paymentProviderAuthentication,
+        );
         const paymentProviderCustomer = createPaymentProviderCustomerSelector(
             state.paymentProviderCustomer,
         );
@@ -130,6 +136,7 @@ export function createInternalCheckoutSelectorsFactory(): InternalCheckoutSelect
             orderBillingAddress,
             payment,
             paymentMethods,
+            paymentProviderAuthentication,
             paymentProviderCustomer,
             paymentStrategies,
             pickupOptions,

--- a/packages/core/src/checkout/internal-checkout-selectors.ts
+++ b/packages/core/src/checkout/internal-checkout-selectors.ts
@@ -10,6 +10,7 @@ import { CountrySelector } from '../geography';
 import { OrderSelector } from '../order';
 import OrderBillingAddressSelector from '../order-billing-address/order-billing-address-selector';
 import { PaymentMethodSelector, PaymentSelector, PaymentStrategySelector } from '../payment';
+import { PaymentProviderAuthenticationSelector } from '../payment-provider-authentication';
 import { PaymentProviderCustomerSelector } from '../payment-provider-customer';
 import { InstrumentSelector } from '../payment/instrument';
 import { RemoteCheckoutSelector } from '../remote-checkout';
@@ -46,6 +47,7 @@ export default interface InternalCheckoutSelectors {
     payment: PaymentSelector;
     paymentMethods: PaymentMethodSelector;
     paymentStrategies: PaymentStrategySelector;
+    paymentProviderAuthentication: PaymentProviderAuthenticationSelector;
     paymentProviderCustomer: PaymentProviderCustomerSelector;
     pickupOptions: PickupOptionSelector;
     remoteCheckout: RemoteCheckoutSelector;

--- a/packages/core/src/common/error/errors/missing-data-error.ts
+++ b/packages/core/src/common/error/errors/missing-data-error.ts
@@ -14,6 +14,7 @@ export enum MissingDataErrorType {
     MissingPaymentId,
     MissingPaymentInstrument,
     MissingPaymentMethod,
+    MissingPaymentProviderAuthentication,
     MissingPaymentProviderCustomer,
     MissingPaymentRedirectUrl,
     MissingPaymentStatus,
@@ -70,6 +71,9 @@ function getErrorMessage(type: MissingDataErrorType): string {
 
         case MissingDataErrorType.MissingPaymentMethod:
             return 'Unable to proceed because payment method data is unavailable or not properly configured.';
+
+        case MissingDataErrorType.MissingPaymentProviderAuthentication:
+            return 'Unable to proceed because payment provider authentication is unavailable.';
 
         case MissingDataErrorType.MissingPaymentProviderCustomer:
             return 'Unable to proceed because payment provider customer is unavailable.';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
     PaymentMethodActionCreator,
     PaymentMethod,
 } from './payment';
+export { PaymentProviderAuthentication } from './payment-provider-authentication';
 export {
     BraintreeAcceleratedCheckoutCustomer,
     PaymentProviderCustomer,

--- a/packages/core/src/payment-integration/create-payment-integration-selectors.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-selectors.ts
@@ -25,6 +25,10 @@ export default function createPaymentIntegrationSelectors({
         isPaymentDataRequired,
     },
     paymentMethods: { getPaymentMethod, getPaymentMethodOrThrow },
+    paymentProviderAuthentication: {
+        getPaymentProviderAuthentication,
+        getPaymentProviderAuthenticationOrThrow,
+    },
     paymentProviderCustomer: { getPaymentProviderCustomer, getPaymentProviderCustomerOrThrow },
     paymentStrategies: { isInitialized: isPaymentMethodInitialized },
     shippingAddress: {
@@ -65,6 +69,8 @@ export default function createPaymentIntegrationSelectors({
         getPaymentRedirectUrlOrThrow,
         getPaymentMethod: clone(getPaymentMethod),
         getPaymentMethodOrThrow: clone(getPaymentMethodOrThrow),
+        getPaymentProviderAuthentication: clone(getPaymentProviderAuthentication),
+        getPaymentProviderAuthenticationOrThrow: clone(getPaymentProviderAuthenticationOrThrow),
         getPaymentProviderCustomer: clone(getPaymentProviderCustomer),
         getPaymentProviderCustomerOrThrow: clone(getPaymentProviderCustomerOrThrow),
         getShippingAddress: clone(getShippingAddress),

--- a/packages/core/src/payment-integration/create-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/create-payment-integration-service.ts
@@ -24,6 +24,7 @@ import {
     PaymentRequestSender,
     PaymentRequestTransformer,
 } from '../payment';
+import { PaymentProviderAuthenticationActionCreator } from '../payment-provider-authentication';
 import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
 import {
     ConsignmentActionCreator,
@@ -113,6 +114,9 @@ export default function createPaymentIntegrationService(
 
     const cartRequestSender = new CartRequestSender(requestSender);
 
+    const paymentProviderAuthenticationActionCreator =
+        new PaymentProviderAuthenticationActionCreator();
+
     const paymentProviderCustomerActionCreator = new PaymentProviderCustomerActionCreator();
 
     const shippingCountryActionCreator = new ShippingCountryActionCreator(
@@ -133,6 +137,7 @@ export default function createPaymentIntegrationService(
         cartRequestSender,
         storeCreditActionCreator,
         spamProtectionActionCreator,
+        paymentProviderAuthenticationActionCreator,
         paymentProviderCustomerActionCreator,
         shippingCountryActionCreator,
     );

--- a/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.spec.ts
@@ -23,6 +23,7 @@ import { CustomerActionCreator } from '../customer';
 import { HostedForm, HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator } from '../order';
 import { getOrder } from '../order/orders.mock';
+import { PaymentProviderAuthenticationActionCreator } from '../payment-provider-authentication';
 import { PaymentProviderCustomerActionCreator } from '../payment-provider-customer';
 import PaymentActionCreator from '../payment/payment-action-creator';
 import PaymentMethodActionCreator from '../payment/payment-method-action-creator';
@@ -72,6 +73,7 @@ describe('DefaultPaymentIntegrationService', () => {
     let customerActionCreator: Pick<CustomerActionCreator, 'signInCustomer' | 'signOutCustomer'>;
     let cartRequestSender: CartRequestSender;
     let storeCreditActionCreator: Pick<StoreCreditActionCreator, 'applyStoreCredit'>;
+    let paymentProviderAuthenticationActionCreator: PaymentProviderAuthenticationActionCreator;
     let paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator;
     let shippingCountryActionCreator: Pick<ShippingCountryActionCreator, 'loadCountries'>;
 
@@ -156,6 +158,12 @@ describe('DefaultPaymentIntegrationService', () => {
             ),
         };
 
+        paymentProviderAuthenticationActionCreator = {
+            updatePaymentProviderAuthentication: jest.fn(
+                async () => () => createAction('UPDATE_PAYMENT_PROVIDER_AUTHENTICATION'),
+            ),
+        };
+
         paymentProviderCustomerActionCreator = {
             updatePaymentProviderCustomer: jest.fn(
                 async () => () => createAction('UPDATE_PAYMENT_PROVIDER_CUSTOMER'),
@@ -182,6 +190,7 @@ describe('DefaultPaymentIntegrationService', () => {
             cartRequestSender,
             storeCreditActionCreator as StoreCreditActionCreator,
             spamProtectionActionCreator as SpamProtectionActionCreator,
+            paymentProviderAuthenticationActionCreator,
             paymentProviderCustomerActionCreator,
             shippingCountryActionCreator as ShippingCountryActionCreator,
         );

--- a/packages/core/src/payment-integration/default-payment-integration-service.ts
+++ b/packages/core/src/payment-integration/default-payment-integration-service.ts
@@ -21,6 +21,10 @@ import { CustomerActionCreator, CustomerCredentials } from '../customer';
 import { HostedFormFactory } from '../hosted-form';
 import { OrderActionCreator } from '../order';
 import {
+    PaymentProviderAuthentication,
+    PaymentProviderAuthenticationActionCreator,
+} from '../payment-provider-authentication';
+import {
     PaymentProviderCustomer,
     PaymentProviderCustomerActionCreator,
 } from '../payment-provider-customer';
@@ -49,6 +53,7 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
         private _cartRequestSender: CartRequestSender,
         private _storeCreditActionCreator: StoreCreditActionCreator,
         private _spamProtectionActionCreator: SpamProtectionActionCreator,
+        private _paymentProviderAuthenticationActionCreator: PaymentProviderAuthenticationActionCreator,
         private _paymentProviderCustomerActionCreator: PaymentProviderCustomerActionCreator,
         private _shippingCountryActionCreator: ShippingCountryActionCreator,
     ) {
@@ -216,6 +221,18 @@ export default class DefaultPaymentIntegrationService implements PaymentIntegrat
 
     async loadCurrentOrder(options?: RequestOptions): Promise<PaymentIntegrationSelectors> {
         await this._store.dispatch(this._orderActionCreator.loadCurrentOrder(options));
+
+        return this._storeProjection.getState();
+    }
+
+    async updatePaymentProviderAuthentication(
+        paymentProviderAuthentication: PaymentProviderAuthentication,
+    ): Promise<PaymentIntegrationSelectors> {
+        await this._store.dispatch(
+            this._paymentProviderAuthenticationActionCreator.updatePaymentProviderAuthentication(
+                paymentProviderAuthentication,
+            ),
+        );
 
         return this._storeProjection.getState();
     }

--- a/packages/core/src/payment-provider-authentication/index.ts
+++ b/packages/core/src/payment-provider-authentication/index.ts
@@ -1,0 +1,17 @@
+export { PaymentProviderAuthentication } from './payment-provider-authentication';
+export {
+    PaymentProviderAuthenticationType,
+    PaymentProviderAuthenticationAction,
+    UpdatePaymentProviderAuthenticationAction,
+} from './payment-provider-authentication-actions';
+export { default as PaymentProviderAuthenticationActionCreator } from './payment-provider-authentication-actions-creator';
+export { default as paymentProviderAuthenticationReducer } from './payment-provider-authentication-reducer';
+export {
+    default as PaymentProviderAuthenticationSelector,
+    createPaymentProviderAuthenticationSelectorFactory,
+    PaymentProviderAuthenticationSelectorFactory,
+} from './payment-provider-authentication-selector';
+export {
+    default as PaymentProviderAuthenticationState,
+    DEFAULT_STATE,
+} from './payment-provider-authentication-state';

--- a/packages/core/src/payment-provider-authentication/payment-provider-authentication-actions-creator.ts
+++ b/packages/core/src/payment-provider-authentication/payment-provider-authentication-actions-creator.ts
@@ -1,0 +1,21 @@
+import { createAction } from '@bigcommerce/data-store';
+import { Observable, of } from 'rxjs';
+
+import { PaymentProviderAuthentication } from './payment-provider-authentication';
+import {
+    PaymentProviderAuthenticationAction,
+    PaymentProviderAuthenticationType,
+} from './payment-provider-authentication-actions';
+
+export default class PaymentProviderAuthenticationActionCreator {
+    updatePaymentProviderAuthentication(
+        providerAuthenticationData: PaymentProviderAuthentication,
+    ): Observable<PaymentProviderAuthenticationAction> {
+        return of(
+            createAction(
+                PaymentProviderAuthenticationType.UpdatePaymentProviderAuthentication,
+                providerAuthenticationData,
+            ),
+        );
+    }
+}

--- a/packages/core/src/payment-provider-authentication/payment-provider-authentication-actions.ts
+++ b/packages/core/src/payment-provider-authentication/payment-provider-authentication-actions.ts
@@ -1,0 +1,11 @@
+import { Action } from '@bigcommerce/data-store';
+
+export enum PaymentProviderAuthenticationType {
+    UpdatePaymentProviderAuthentication = 'UPDATE_PAYMENT_PROVIDER_AUTHENTICATION',
+}
+
+export type PaymentProviderAuthenticationAction = UpdatePaymentProviderAuthenticationAction;
+
+export interface UpdatePaymentProviderAuthenticationAction extends Action {
+    type: PaymentProviderAuthenticationType.UpdatePaymentProviderAuthentication;
+}

--- a/packages/core/src/payment-provider-authentication/payment-provider-authentication-reducer.ts
+++ b/packages/core/src/payment-provider-authentication/payment-provider-authentication-reducer.ts
@@ -1,0 +1,38 @@
+import { combineReducers } from '@bigcommerce/data-store';
+
+import { objectMerge } from '../common/utility';
+
+import { PaymentProviderAuthentication } from './payment-provider-authentication';
+import {
+    PaymentProviderAuthenticationType,
+    UpdatePaymentProviderAuthenticationAction,
+} from './payment-provider-authentication-actions';
+import PaymentProviderAuthenticationState, {
+    DEFAULT_STATE,
+} from './payment-provider-authentication-state';
+
+type ReducerActionType = UpdatePaymentProviderAuthenticationAction;
+
+export default function paymentProviderAuthenticationReducer(
+    state: PaymentProviderAuthenticationState = DEFAULT_STATE,
+    action: ReducerActionType,
+): PaymentProviderAuthenticationState {
+    const reducer = combineReducers<PaymentProviderAuthenticationState, ReducerActionType>({
+        data: dataReducer,
+    });
+
+    return reducer(state, action);
+}
+
+function dataReducer(
+    data: PaymentProviderAuthentication = DEFAULT_STATE.data,
+    action: ReducerActionType,
+): PaymentProviderAuthentication {
+    switch (action.type) {
+        case PaymentProviderAuthenticationType.UpdatePaymentProviderAuthentication:
+            return objectMerge(data, action.payload);
+
+        default:
+            return data;
+    }
+}

--- a/packages/core/src/payment-provider-authentication/payment-provider-authentication-selector.ts
+++ b/packages/core/src/payment-provider-authentication/payment-provider-authentication-selector.ts
@@ -1,0 +1,49 @@
+import { memoizeOne } from '@bigcommerce/memoize';
+
+import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
+import { createSelector } from '../common/selector';
+import { guard } from '../common/utility';
+
+import { PaymentProviderAuthentication } from './payment-provider-authentication';
+import PaymentProviderAuthenticationState, {
+    DEFAULT_STATE,
+} from './payment-provider-authentication-state';
+
+export default interface PaymentProviderAuthenticationSelector {
+    getPaymentProviderAuthentication(): PaymentProviderAuthentication | undefined;
+    getPaymentProviderAuthenticationOrThrow(): PaymentProviderAuthentication;
+}
+
+export type PaymentProviderAuthenticationSelectorFactory = (
+    state: PaymentProviderAuthenticationState,
+) => PaymentProviderAuthenticationSelector;
+
+export function createPaymentProviderAuthenticationSelectorFactory(): PaymentProviderAuthenticationSelectorFactory {
+    const getPaymentProviderAuthentication = createSelector(
+        (state: PaymentProviderAuthenticationState) => state.data,
+        (data) => () => data,
+    );
+
+    const getPaymentProviderAuthenticationOrThrow = createSelector(
+        getPaymentProviderAuthentication,
+        (getPaymentProviderAuthentication) => () => {
+            return guard(
+                getPaymentProviderAuthentication(),
+                () =>
+                    new MissingDataError(MissingDataErrorType.MissingPaymentProviderAuthentication),
+            );
+        },
+    );
+
+    return memoizeOne(
+        (
+            state: PaymentProviderAuthenticationState = DEFAULT_STATE,
+        ): PaymentProviderAuthenticationSelector => {
+            return {
+                getPaymentProviderAuthentication: getPaymentProviderAuthentication(state),
+                getPaymentProviderAuthenticationOrThrow:
+                    getPaymentProviderAuthenticationOrThrow(state),
+            };
+        },
+    );
+}

--- a/packages/core/src/payment-provider-authentication/payment-provider-authentication-state.ts
+++ b/packages/core/src/payment-provider-authentication/payment-provider-authentication-state.ts
@@ -1,0 +1,9 @@
+import { PaymentProviderAuthentication } from './payment-provider-authentication';
+
+export default interface PaymentProviderAuthenticationState {
+    data: PaymentProviderAuthentication;
+}
+
+export const DEFAULT_STATE = {
+    data: {},
+};

--- a/packages/core/src/payment-provider-authentication/payment-provider-authentication-state.ts
+++ b/packages/core/src/payment-provider-authentication/payment-provider-authentication-state.ts
@@ -5,5 +5,7 @@ export default interface PaymentProviderAuthenticationState {
 }
 
 export const DEFAULT_STATE = {
-    data: {},
+    data: {
+        isAuthenticated: false,
+    },
 };

--- a/packages/core/src/payment-provider-authentication/payment-provider-authentication.ts
+++ b/packages/core/src/payment-provider-authentication/payment-provider-authentication.ts
@@ -1,0 +1,3 @@
+export interface PaymentProviderAuthentication {
+    isAuthenticated?: boolean;
+}

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -138,6 +138,7 @@ export {
 } from './payment';
 export { default as PaymentIntegrationSelectors } from './payment-integration-selectors';
 export { default as PaymentIntegrationService } from './payment-integration-service';
+export { PaymentProviderAuthentication } from './payment-provider-authentication';
 export {
     BraintreeAcceleratedCheckoutCustomer,
     PaymentProviderCustomer,

--- a/packages/payment-integration-api/src/payment-integration-selectors.ts
+++ b/packages/payment-integration-api/src/payment-integration-selectors.ts
@@ -5,6 +5,7 @@ import { StoreConfig } from './config';
 import { Customer } from './customer';
 import { Country } from './geography';
 import { Order } from './order';
+import { PaymentProviderAuthentication } from './payment-provider-authentication';
 import { PaymentProviderCustomer } from './payment-provider-customer';
 import { CardInstrument } from './payment/instrument';
 import PaymentMethod from './payment/payment-method';
@@ -57,6 +58,9 @@ export default interface PaymentIntegrationSelectors {
         gatewayId?: string,
     ): PaymentMethod<T> | undefined;
     getPaymentMethodOrThrow<T = unknown>(methodId: string, gatewayId?: string): PaymentMethod<T>;
+
+    getPaymentProviderAuthentication(): PaymentProviderAuthentication | undefined;
+    getPaymentProviderAuthenticationOrThrow(): PaymentProviderAuthentication;
 
     getPaymentProviderCustomer(): PaymentProviderCustomer | undefined;
     getPaymentProviderCustomerOrThrow(): PaymentProviderCustomer;

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -5,6 +5,7 @@ import { HostedForm, HostedFormOptions } from './hosted-form';
 import { OrderRequestBody } from './order';
 import { InitializeOffsitePaymentConfig, Payment } from './payment';
 import PaymentIntegrationSelectors from './payment-integration-selectors';
+import { PaymentProviderAuthentication } from './payment-provider-authentication';
 import { PaymentProviderCustomer } from './payment-provider-customer';
 import { ShippingAddressRequestBody } from './shipping';
 import { RequestOptions } from './util-types';
@@ -74,6 +75,10 @@ export default interface PaymentIntegrationService {
     ): Promise<PaymentIntegrationSelectors>;
 
     createBuyNowCart(body: BuyNowCartRequestBody, options?: RequestOptions): Promise<Cart>;
+
+    updatePaymentProviderAuthentication(
+        paymentProviderAuthentication: PaymentProviderAuthentication,
+    ): Promise<PaymentIntegrationSelectors>;
 
     updatePaymentProviderCustomer(
         paymentProviderCustomer: PaymentProviderCustomer,

--- a/packages/payment-integration-api/src/payment-provider-authentication/index.ts
+++ b/packages/payment-integration-api/src/payment-provider-authentication/index.ts
@@ -1,0 +1,1 @@
+export { PaymentProviderAuthentication } from './payment-provider-authentication';

--- a/packages/payment-integration-api/src/payment-provider-authentication/payment-provider-authentication.ts
+++ b/packages/payment-integration-api/src/payment-provider-authentication/payment-provider-authentication.ts
@@ -1,0 +1,3 @@
+export interface PaymentProviderAuthentication {
+    isAuthenticated?: boolean;
+}

--- a/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
+++ b/packages/payment-integrations-test-utils/src/test-utils/payment-integration-service.mock.ts
@@ -62,6 +62,7 @@ const signOutCustomer = jest.fn();
 const selectShippingOption = jest.fn();
 const applyStoreCredit = jest.fn();
 const verifyCheckoutSpamProtection = jest.fn();
+const updatePaymentProviderAuthentication = jest.fn();
 const updatePaymentProviderCustomer = jest.fn();
 
 const PaymentIntegrationServiceMock = jest
@@ -88,6 +89,7 @@ const PaymentIntegrationServiceMock = jest
             selectShippingOption,
             applyStoreCredit,
             verifyCheckoutSpamProtection,
+            updatePaymentProviderAuthentication,
             updatePaymentProviderCustomer,
         };
     });


### PR DESCRIPTION
## What?
Added PaymentProviderAuthentication state

## Why?
To be able to save provider authentication data and use those data in separate strategies.

## Testing / Proof
Manutal testing
Unit tests
![Zrzut ekranu 2023-09-27 o 09 16 32](https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/d9ab46b3-14ca-4dba-8d76-56d7a66c456d)


@bigcommerce/team-checkout @bigcommerce/team-payments
