### PR TITLE
feat(payment): PAYPAL-2926 Unable to place order via GooglePay with 3D secure 

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree.ts
@@ -221,6 +221,7 @@ export interface BraintreeGooglePayThreeDSecure {
 export interface BraintreeGooglePayThreeDSecureOptions {
     nonce: string;
     amount: number;
+    bin: string;
     showLoader?: boolean;
     onLookupComplete(data: BraintreeThreeDSecureVerificationData, next: () => void): void;
 }
@@ -408,7 +409,7 @@ export interface BraintreeThreeDSecureCreatorConfig extends BraintreeModuleCreat
 export interface BraintreeThreeDSecureOptions {
     nonce: string;
     amount: number;
-    bin?: string;
+    bin: string;
     challengeRequested: boolean;
     showLoader?: boolean;
     addFrame(error: Error | undefined, iframe: HTMLIFrameElement): void;

--- a/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-braintree-initializer.ts
@@ -66,6 +66,7 @@ export default class GooglePayBraintreeInitializer implements GooglePayInitializ
                 cardType: payload.details.cardType,
                 lastFour: payload.details.lastFour,
                 lastTwo: payload.details.lastTwo,
+                bin: payload.details.bin,
             },
             binData: payload.binData,
         });

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -202,10 +202,15 @@ export default class GooglePayPaymentProcessor {
             });
     }
 
-    private _getCardInformation(cardInformation: { cardType: string; lastFour: string }) {
+    private _getCardInformation(cardInformation: {
+        cardType: string;
+        lastFour: string;
+        bin?: string;
+    }) {
         return {
             type: cardInformation.cardType,
             number: cardInformation.lastFour,
+            ...(cardInformation?.bin ? { bin: cardInformation?.bin } : {}),
         };
     }
 

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-processor.ts
@@ -19,6 +19,7 @@ import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import {
     ButtonColor,
     ButtonType,
+    CardInformation,
     EnvironmentType,
     GooglePayAddress,
     GooglePayClient,
@@ -202,11 +203,7 @@ export default class GooglePayPaymentProcessor {
             });
     }
 
-    private _getCardInformation(cardInformation: {
-        cardType: string;
-        lastFour: string;
-        bin?: string;
-    }) {
+    private _getCardInformation(cardInformation: CardInformation) {
         return {
             type: cardInformation.cardType,
             number: cardInformation.lastFour,

--- a/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay-payment-strategy.ts
@@ -200,14 +200,19 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         payment: PaymentMethodData,
     ): Promise<GooglePayVerifyPayload> {
         if (methodId === PaymentStrategyType.BRAINTREE_GOOGLE_PAY) {
-            const { nonce } = payment.paymentData;
+            const { nonce, cardInformation } = payment.paymentData;
             const threeDSecure = await this._braintreeSDKCreator?.get3DS();
 
             if (!nonce || !threeDSecure) {
                 throw new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized);
             }
 
-            return this._braintreePresent3DSChallenge(threeDSecure, amount, nonce);
+            return this._braintreePresent3DSChallenge(
+                threeDSecure,
+                amount,
+                nonce,
+                cardInformation?.bin,
+            );
         }
     }
 
@@ -215,11 +220,13 @@ export default class GooglePayPaymentStrategy implements PaymentStrategy {
         threeDSecure: BraintreeGooglePayThreeDSecure,
         amount: number,
         nonce: string,
+        bin: string,
     ): Promise<BraintreeVerifyPayload> {
         const verification = new CancellablePromise(
             threeDSecure.verifyCard({
                 amount,
                 nonce,
+                bin,
                 onLookupComplete: (_data, next) => {
                     next();
                 },

--- a/packages/core/src/payment/strategies/googlepay/googlepay.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay.ts
@@ -89,6 +89,7 @@ export interface TokenizePayload {
         cardType: string;
         lastFour: string;
         lastTwo?: string;
+        bin?: string;
     };
     description?: string;
     type: TokenizeType;
@@ -152,6 +153,7 @@ export interface PaymentMethodData {
         cardInformation: {
             type: string;
             number: string;
+            bin: string;
         };
     };
 }

--- a/packages/core/src/payment/strategies/googlepay/googlepay.ts
+++ b/packages/core/src/payment/strategies/googlepay/googlepay.ts
@@ -82,15 +82,17 @@ export interface GooglePayHostWindow extends Window {
     google?: GooglePaySDK;
 }
 
+export interface CardInformation {
+    cardType: string;
+    lastFour: string;
+    lastTwo?: string;
+    bin?: string;
+}
+
 export interface TokenizePayload {
     nonce: string;
     tokenFormat?: string;
-    details: {
-        cardType: string;
-        lastFour: string;
-        lastTwo?: string;
-        bin?: string;
-    };
+    details: CardInformation;
     description?: string;
     type: TokenizeType;
     binData?: {


### PR DESCRIPTION
## What?

Fix an issue with 3DSecure

## Why?

3DSecure doesn't work without the `bin` parameter

## Testing / Proof

Example with payment strategy:

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/94cfe710-0667-4ba2-baea-6bdf1018fb99

Tested for client and button strategy

@bigcommerce/team-checkout @bigcommerce/team-payments
