### PR TITLE
fix(payment): PAYPAL-3061 prefill full phone number in BT AXO instead of slicing country code num

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.ts
@@ -123,10 +123,7 @@ export default class BraintreeAcceleratedCheckoutPaymentStrategy implements Paym
             fields: {
                 ...(phone && {
                     phoneNumber: {
-                        // Info: we should remove first character of the phone number
-                        // for PayPal Connect Phase 1, because this feature will
-                        // be available for US stores only
-                        prefill: phone.slice(1),
+                        prefill: phone,
                     },
                 }),
             },


### PR DESCRIPTION
## What?
Prefill full phone number in BT AXO instead of slicing country code num

## Why?
we should pass full phone number to the BT AXO CC form, because PayPal will remove hardcoded country code from their implementation.

## Testing / Proof
Unit tests
Manual tests
