### PR TITLE
feat(payment): PAYPAL-2987 checkout page crashing fixed

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
@@ -584,12 +584,14 @@ describe('PayPalCommerceIntegrationService', () => {
             paypalButtonElement.id = paypalCommerceButtonContainerId;
 
             document.body.appendChild(paypalButtonElement);
+            const element = document.getElementById(paypalCommerceButtonContainerId);
 
-            expect(document.getElementById(paypalCommerceButtonContainerId)).toBeDefined();
+            expect(element).toBeDefined();
 
             subject.removeElement(paypalCommerceButtonContainerId);
 
-            expect(document.getElementById(paypalCommerceButtonContainerId)).toBeNull();
+            const computedStyle = getComputedStyle(element as Element);
+            expect(computedStyle.getPropertyValue('display')).toBe('none');
         });
     });
 });

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -310,7 +310,8 @@ export default class PayPalCommerceIntegrationService {
         const element = elementId && document.getElementById(elementId);
 
         if (element) {
-            element.remove();
+            // For now this is a temporary solution, further removeElement method will be removed
+            element.style.display = 'none';
         }
     }
 }


### PR DESCRIPTION
## What?
Checkout page crashing fixed

## Why?
Because sometimes an error and blank page appears when proceeding past Billing/Shipping step.

## Testing / Proof
All tests have been passed
