### PR TITLE
chore(common): PAYPAL-000 updated pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,3 @@
 
 ## Testing / Proof
 ...
-
-@bigcommerce/team-checkout @bigcommerce/team-payments


### PR DESCRIPTION
## What?
Updated pull request template

## Why?
Because github are tagging codeowners, so it is not necessary to tag checkout and core payments team if the changes related to paypal or integration teams code

## Testing / Proof
There is nothing to test
