### PR TITLE
feat(payment): PAYPAL-3056 GP Braintree customer strategy

### DIFF
--- a/packages/core/src/customer/create-customer-strategy-registry.ts
+++ b/packages/core/src/customer/create-customer-strategy-registry.ts
@@ -22,7 +22,6 @@ import {
     GooglePayAdyenV3Initializer,
     GooglePayAuthorizeNetInitializer,
     GooglePayBNZInitializer,
-    GooglePayBraintreeInitializer,
     GooglePayCheckoutcomInitializer,
     GooglePayCybersourceV2Initializer,
     GooglePayOrbitalInitializer,
@@ -207,20 +206,6 @@ export default function createCustomerStrategyRegistry(
                 store,
                 remoteCheckoutActionCreator,
                 createGooglePayPaymentProcessor(store, new GooglePayBNZInitializer()),
-                formPoster,
-            ),
-    );
-
-    registry.register(
-        'googlepaybraintree',
-        () =>
-            new GooglePayCustomerStrategy(
-                store,
-                remoteCheckoutActionCreator,
-                createGooglePayPaymentProcessor(
-                    store,
-                    new GooglePayBraintreeInitializer(store, braintreeSDKCreator),
-                ),
                 formPoster,
             ),
     );

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-braintree-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-braintree-customer-strategy.spec.ts
@@ -1,0 +1,20 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+
+import createGooglePayBraintreeCustomerStrategy from './create-google-pay-braintree-customer-strategy';
+
+describe('createGooglePayBraintreeCustomerStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('instantiates google pay braintree customer strategy', () => {
+        const strategy = createGooglePayBraintreeCustomerStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(GooglePayCustomerStrategy);
+    });
+});

--- a/packages/google-pay-integration/src/factories/customer/create-google-pay-braintree-customer-strategy.ts
+++ b/packages/google-pay-integration/src/factories/customer/create-google-pay-braintree-customer-strategy.ts
@@ -1,0 +1,44 @@
+import { createFormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender } from '@bigcommerce/request-sender';
+import { getScriptLoader } from '@bigcommerce/script-loader';
+
+import {
+    BraintreeHostWindow,
+    BraintreeIntegrationService,
+    BraintreeScriptLoader,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+import {
+    CustomerStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import GooglePayBraintreeGateway from '../../gateways/google-pay-braintree-gateway';
+import GooglePayCustomerStrategy from '../../google-pay-customer-strategy';
+import GooglePayPaymentProcessor from '../../google-pay-payment-processor';
+import createGooglePayScriptLoader from '../create-google-pay-script-loader';
+
+const createGooglePayBraintreePaymentStrategy: CustomerStrategyFactory<
+    GooglePayCustomerStrategy
+> = (paymentIntegrationService) => {
+    const requestSender = createRequestSender();
+
+    const braintreeHostWindow: BraintreeHostWindow = window;
+    const braintreeIntegrationService = new BraintreeIntegrationService(
+        new BraintreeScriptLoader(getScriptLoader(), braintreeHostWindow),
+        braintreeHostWindow,
+    );
+
+    return new GooglePayCustomerStrategy(
+        paymentIntegrationService,
+        new GooglePayPaymentProcessor(
+            createGooglePayScriptLoader(),
+            new GooglePayBraintreeGateway(paymentIntegrationService, braintreeIntegrationService),
+            requestSender,
+            createFormPoster(),
+        ),
+    );
+};
+
+export default toResolvableModule(createGooglePayBraintreePaymentStrategy, [
+    { id: 'googlepaybraintree' },
+]);

--- a/packages/google-pay-integration/src/index.ts
+++ b/packages/google-pay-integration/src/index.ts
@@ -17,3 +17,4 @@ export { default as createGooglePayOrbitalCustomerStrategy } from './factories/c
 export { default as createGooglePayStripeCustomerStrategy } from './factories/customer/create-google-pay-stripe-customer-strategy';
 export { default as createGooglePayStripeUpeCustomerStrategy } from './factories/customer/create-google-pay-stripeupe-customer-strategy';
 export { default as createGooglePayWorldpayAccessCustomerStrategy } from './factories/customer/create-google-pay-worldpayaccess-customer-strategy';
+export { default as createGooglePayBraintreeCustomerStrategy } from './factories/customer/create-google-pay-braintree-customer-strategy';


### PR DESCRIPTION
## What?

Move googlepay-braintree from core to google-pay-integration package

## Why?

To separate the logic of integrations

## Testing / Proof

https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/e7d2bc2a-3bfc-48d3-9b0b-24f9f8f20f72

@bigcommerce/team-checkout @bigcommerce/team-payments
