### PR TITLE
feat(payment): PI-889 Add cart ID to stripe upe payment submit

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.spec.ts
@@ -407,6 +407,7 @@ describe('StripeUPEPaymentStrategy', () => {
                         methodId: 'card',
                         paymentData: {
                             formattedPayload: {
+                                cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                                 bigpay_token: {
                                     token: 'token',
                                 },
@@ -618,6 +619,7 @@ describe('StripeUPEPaymentStrategy', () => {
                                 methodId: 'card',
                                 paymentData: expect.objectContaining({
                                     formattedPayload: expect.objectContaining({
+                                        cart_id: 'b20deef40f9699e48671bbc3fef6ca44dc80e3c7',
                                         confirm: false,
                                         credit_card_token: {
                                             token: 'myToken',

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -235,13 +235,15 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
     }
 
     private async _executeWithAPM(methodId: string): Promise<InternalCheckoutSelectors> {
-        const paymentMethod = this._store
-            .getState()
-            .paymentMethods.getPaymentMethodOrThrow(methodId);
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const cartId = state.cart.getCart()?.id;
+
         const paymentPayload = {
             methodId,
             paymentData: {
                 formattedPayload: {
+                    cart_id: cartId,
                     credit_card_token: { token: paymentMethod.clientToken },
                     vault_payment_instrument: false,
                     confirm: false,
@@ -264,14 +266,15 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         shouldSaveInstrument: boolean,
         shouldSetAsDefaultInstrument: boolean,
     ): Promise<InternalCheckoutSelectors> {
-        const paymentMethod = this._store
-            .getState()
-            .paymentMethods.getPaymentMethodOrThrow(methodId);
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const cartId = state.cart.getCart()?.id;
 
         const paymentPayload = {
             methodId,
             paymentData: {
                 formattedPayload: {
+                    cart_id: cartId,
                     credit_card_token: { token: paymentMethod.clientToken },
                     vault_payment_instrument: shouldSaveInstrument,
                     confirm: false,
@@ -319,15 +322,16 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
         token: string,
         shouldSetAsDefaultInstrument: boolean,
     ): Promise<InternalCheckoutSelectors> {
-        const paymentMethod = this._store
-            .getState()
-            .paymentMethods.getPaymentMethodOrThrow(methodId);
+        const state = this._store.getState();
+        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        const cartId = state.cart.getCart()?.id;
 
         try {
             const paymentPayload = {
                 methodId,
                 paymentData: {
                     formattedPayload: {
+                        cart_id: cartId,
                         bigpay_token: { token },
                         confirm: false,
                         client_token: paymentMethod.clientToken,
@@ -505,10 +509,12 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                     throw new RequestError();
                 }
 
+                const cartId = this._store.getState().cart.getCart()?.id;
                 const paymentPayload = {
                     methodId,
                     paymentData: {
                         formattedPayload: {
+                            cart_id: cartId,
                             credit_card_token: {
                                 token: catchedConfirmError ? token : result?.paymentIntent?.id,
                             },
@@ -570,10 +576,12 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                 throw new RequestError();
             }
 
+            const cartId = this._store.getState().cart.getCart()?.id;
             const paymentPayload = {
                 methodId,
                 paymentData: {
                     formattedPayload: {
+                        cart_id: cartId,
                         credit_card_token: {
                             token: catchedConfirmError ? clientSecret : result?.paymentIntent?.id,
                         },


### PR DESCRIPTION
## What?
Add Cart ID property to Stripe UPE payment submit request

## Why?
Need this data to fix duplication of Stripe payment intents on BigPay side

## Testing / Proof
<img width="1280" alt="Screenshot 2023-10-10 at 10 25 58" src="https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/e5b2d504-e81c-4056-a2a8-dd07a05a041a">


@bigcommerce/team-checkout @bigcommerce/team-payments
