### PR TITLE
feat(payment): PAYPAL-3098 added sessionId to local storage even for unrecognised guest users for Gary flow Braintree AXO

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -168,7 +168,7 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
             await subject.initializeBraintreeConnectOrThrow(methodId);
             await subject.runPayPalConnectAuthenticationFlowOrThrow();
 
-            expect(browserStorage.removeItem).toHaveBeenCalledWith('sessionId');
+            expect(browserStorage.setItem).toHaveBeenCalledWith('sessionId', cart.id);
             expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith({
                 authenticationState: BraintreeConnectAuthenticationState.UNRECOGNIZED,
                 addresses: [],

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.ts
@@ -107,9 +107,9 @@ export default class BraintreeAcceleratedCheckoutUtils {
 
             const { customerContextId } = await lookupCustomerByEmail(customerEmail);
 
-            if (!customerContextId) {
-                this.browserStorage.removeItem('sessionId');
+            this.browserStorage.setItem('sessionId', cart.id);
 
+            if (!customerContextId) {
                 // Info: we should clean up previous experience with default data and related authenticationState
                 await this.paymentIntegrationService.updatePaymentProviderCustomer({
                     authenticationState: BraintreeConnectAuthenticationState.UNRECOGNIZED,
@@ -134,8 +134,6 @@ export default class BraintreeAcceleratedCheckoutUtils {
                 shippingAddresses,
                 billingAddresses,
             );
-
-            this.browserStorage.setItem('sessionId', cart.id);
 
             await this.paymentIntegrationService.updatePaymentProviderCustomer({
                 authenticationState,


### PR DESCRIPTION
## What?
Added sessionId to local storage even for unrecognised guest users for Gary flow Braintree AXO

## Why?
To call `lookup` method for each cases when the user probably might use PayPal Connect. This fix fixes the behaviour with Braintree PayPal Connect Credit Card form for guest users who leave and return to the checkout page after passing customer step.

## Testing / Proof
Unit tests
Manual tests

Before:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/0e93b646-cbf2-4f2b-907b-9ef45b417efa


After:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/6e16f6df-0aac-43b6-9999-fb0747be156e

