### PR TITLE
fix(payment): PAYPAL-2986 trigger 3DS for Braintree when the HostedForm feature turned off

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.spec.ts
@@ -301,16 +301,6 @@ describe('BraintreeCreditCardPaymentStrategy', () => {
         });
 
         describe('non hosted form behaviour', () => {
-            it('does not touch the card if it is going to be saved in the vault (shouldSaveInstrument: true)', async () => {
-                const payload = merge({}, orderRequestBody, {
-                    payment: { paymentData: { shouldSaveInstrument: true } },
-                });
-
-                await braintreeCreditCardPaymentStrategy.execute(payload, options);
-
-                expect(paymentActionCreator.submitPayment).toHaveBeenCalledWith(payload.payment);
-            });
-
             it('passes on optional flags to save and to make default', async () => {
                 const payload = merge({}, orderRequestBody, {
                     payment: {

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -10,12 +10,7 @@ import { OrderFinalizationNotRequiredError } from '../../../order/errors';
 import { PaymentArgumentInvalidError } from '../../errors';
 import { isHostedInstrumentLike, PaymentMethod } from '../../index';
 import isVaultedInstrument from '../../is-vaulted-instrument';
-import {
-    CreditCardInstrument,
-    NonceInstrument,
-    PaymentInstrument,
-    PaymentInstrumentMeta,
-} from '../../payment';
+import { PaymentInstrument, PaymentInstrumentMeta } from '../../payment';
 import PaymentActionCreator from '../../payment-action-creator';
 import PaymentMethodActionCreator from '../../payment-method-action-creator';
 import { PaymentInitializeOptions, PaymentRequestOptions } from '../../payment-request-options';
@@ -140,7 +135,7 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
         const { paymentData } = payment;
         const commonPaymentData = { deviceSessionId: this._deviceSessionId };
 
-        if (this._isSubmittingWithStoredCard(payment) || this._isStoringNewCard(payment)) {
+        if (this._isSubmittingWithStoredCard(payment)) {
             return {
                 ...commonPaymentData,
                 ...paymentData,
@@ -260,13 +255,6 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
 
     private _isSubmittingWithStoredCard(payment: OrderPaymentRequestBody): boolean {
         return !!(payment.paymentData && isVaultedInstrument(payment.paymentData));
-    }
-
-    private _isStoringNewCard(payment: OrderPaymentRequestBody): boolean {
-        return !!(
-            payment.paymentData &&
-            (payment.paymentData as CreditCardInstrument | NonceInstrument).shouldSaveInstrument
-        );
     }
 
     private _shouldPerform3DSVerification(payment: OrderPaymentRequestBody): boolean {


### PR DESCRIPTION
## What?
Removed the logic that stops trigger 3DS for Braintree nonHostedForm СС for transactions when the customer saves the instrument for future usage.

## Why?
Some merchants had an issue with triggering 3DS for cases when the customer wants to place an order and save the card data for future usages. Therefore there was an error during placing order, because 3DS verification is not passed for current transaction.

## Testing / Proof
Unit tests
Manual tests

Before:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/2fd82db6-24d6-4802-9d5d-dd33287a629f


After:

https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/e8cb6fd5-4f5c-4c9a-a9fa-7328583927b8


