### PR TITLE
feat(payment): PI-921 Amazon Pay Button needs to be changed to one wi…

### DIFF
--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -16,6 +16,7 @@ import {
     AmazonPayV2Button,
     AmazonPayV2ButtonColor,
     AmazonPayV2ButtonConfig,
+    AmazonPayV2ButtonDesign,
     AmazonPayV2ButtonParameters,
     AmazonPayV2ButtonRenderingOptions,
     AmazonPayV2ChangeActionType,
@@ -130,6 +131,10 @@ export default class AmazonPayV2PaymentProcessor {
 
         const { id: parentContainerId } = container.appendChild(this._getButtonParentContainer());
 
+        if (options) {
+            options.design = AmazonPayV2ButtonDesign.C0001;
+        }
+
         const amazonPayV2ButtonOptions =
             options ??
             this._getAmazonPayV2ButtonOptions(
@@ -225,6 +230,7 @@ export default class AmazonPayV2PaymentProcessor {
             checkoutLanguage,
             placement,
             buttonColor,
+            design: AmazonPayV2ButtonDesign.C0001,
         };
 
         if (this._isBuyNowFlow) {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.mock.ts
@@ -4,6 +4,7 @@ import { getAmazonPayV2 } from '../../payment-methods.mock';
 import {
     AmazonPayV2ButtonColor,
     AmazonPayV2ButtonConfig,
+    AmazonPayV2ButtonDesign,
     AmazonPayV2ButtonParameters,
     AmazonPayV2CheckoutLanguage,
     AmazonPayV2LedgerCurrency,
@@ -58,6 +59,7 @@ export function getAmazonPayV2Ph4ButtonParamsMock(): AmazonPayV2ButtonParameters
             payloadJSON: 'payload',
             signature: 'xxxx',
         },
+        design: AmazonPayV2ButtonDesign.C0001,
     };
 }
 
@@ -69,6 +71,7 @@ export function getAmazonPayBaseButtonParamsMock(): AmazonPayV2ButtonConfig {
         placement: AmazonPayV2Placement.Checkout,
         buttonColor: AmazonPayV2ButtonColor.Gold,
         sandbox: true,
+        design: AmazonPayV2ButtonDesign.C0001,
     };
 }
 
@@ -86,5 +89,6 @@ export function getAmazonPayV2ButtonParamsMock(): AmazonPayV2ButtonParameters {
         placement: AmazonPayV2Placement.Checkout,
         productType: AmazonPayV2PayOptions.PayAndShip,
         sandbox: true,
+        design: AmazonPayV2ButtonDesign.C0001,
     };
 }


### PR DESCRIPTION
…th WITHOUT microtext

## What?
Changing AmazonPay button design to one WITHOUT microtext.

## Why?
There was decision made to come back to AmazonPay button design WITHOUT microtext.

## Testing / Proof
...

@bigcommerce/team-checkout @bigcommerce/team-payments
