### PR TITLE
fix(payment): PAYPAL-3090 updated all paypal buttons on checkout page to have the same default button height

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import {
     CustomerInitializeOptions,
+    DefaultCheckoutButtonHeight,
     InvalidArgumentError,
     MissingDataError,
     PaymentIntegrationService,
@@ -279,7 +280,7 @@ describe('BraintreePaypalCustomerStrategy', () => {
                 commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYPAL,
                 style: {
-                    height: 40,
+                    height: DefaultCheckoutButtonHeight,
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
@@ -303,7 +304,7 @@ describe('BraintreePaypalCustomerStrategy', () => {
                 commit: false,
                 fundingSource: paypalSdkMock.FUNDING.PAYPAL,
                 style: {
-                    height: 40,
+                    height: DefaultCheckoutButtonHeight,
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -15,6 +15,7 @@ import {
     CustomerCredentials,
     CustomerInitializeOptions,
     CustomerStrategy,
+    DefaultCheckoutButtonHeight,
     ExecutePaymentMethodCheckoutOptions,
     InvalidArgumentError,
     MissingDataError,
@@ -128,7 +129,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
         containerId: string,
         methodId: string,
         testMode: boolean,
-        buttonHeight = 40,
+        buttonHeight = DefaultCheckoutButtonHeight,
     ): void {
         const { paypal } = this.braintreeHostWindow;
         const fundingSource = paypal?.FUNDING.PAYPAL;

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
@@ -5,6 +5,8 @@ import { createScriptLoader, getScriptLoader } from '@bigcommerce/script-loader'
 import { EventEmitter } from 'events';
 import { Observable, of } from 'rxjs';
 
+import { DefaultCheckoutButtonHeight } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import {
     CheckoutActionCreator,
     CheckoutRequestSender,
@@ -330,7 +332,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 onApprove: expect.any(Function),
                 style: {
-                    height: 40,
+                    height: DefaultCheckoutButtonHeight,
                     color: PaypalButtonStyleColorOption.GOLD,
                 },
             });
@@ -387,7 +389,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 onApprove: expect.any(Function),
                 style: {
-                    height: 40,
+                    height: DefaultCheckoutButtonHeight,
                     color: PaypalButtonStyleColorOption.GOLD,
                 },
             });
@@ -401,7 +403,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,
                 onApprove: expect.any(Function),
                 style: {
-                    height: 40,
+                    height: DefaultCheckoutButtonHeight,
                     label: 'credit',
                     color: PaypalButtonStyleColorOption.GOLD,
                 },

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -1,5 +1,7 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 
+import { DefaultCheckoutButtonHeight } from '@bigcommerce/checkout-sdk/payment-integration-api';
+
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import mapToLegacyBillingAddress from '../../../checkout-buttons/strategies/braintree/map-to-legacy-billing-address';
 import mapToLegacyShippingAddress from '../../../checkout-buttons/strategies/braintree/map-to-legacy-shipping-address';
@@ -47,7 +49,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
 
     async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { braintreepaypalcredit, methodId } = options;
-        const { container, buttonHeight = 40 } = braintreepaypalcredit || {};
+        const { container, buttonHeight } = braintreepaypalcredit || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -138,7 +140,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         braintreepaypalcredit: BraintreePaypalCreditCustomerInitializeOptions,
         methodId: string,
         testMode: boolean,
-        buttonHeight: number,
+        buttonHeight = DefaultCheckoutButtonHeight,
     ): void {
         const { container } = braintreepaypalcredit;
         const { paypal } = this._window;

--- a/packages/payment-integration-api/src/checkout-buttons/default-checkout-button-height.ts
+++ b/packages/payment-integration-api/src/checkout-buttons/default-checkout-button-height.ts
@@ -1,0 +1,3 @@
+const DefaultCheckoutButtonHeight = 36;
+
+export default DefaultCheckoutButtonHeight;

--- a/packages/payment-integration-api/src/checkout-buttons/index.ts
+++ b/packages/payment-integration-api/src/checkout-buttons/index.ts
@@ -2,3 +2,4 @@ export { default as CheckoutButtonInitializeOptions } from './checkout-button-in
 export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
 export { default as CheckoutButtonStrategyFactory } from './checkout-button-strategy-factory';
 export { default as CheckoutButtonStrategyResolveId } from './checkout-button-strategy-resolve-id';
+export { default as DefaultCheckoutButtonHeight } from './default-checkout-button-height';

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -5,6 +5,7 @@ export {
     CheckoutButtonStrategyFactory,
     CheckoutButtonStrategyResolveId,
     CheckoutButtonInitializeOptions,
+    DefaultCheckoutButtonHeight,
 } from './checkout-buttons';
 export {
     BuyNowCartRequestBody,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 
 import {
     CustomerInitializeOptions,
+    DefaultCheckoutButtonHeight,
     InvalidArgumentError,
     PaymentIntegrationService,
     PaymentMethod,
@@ -219,7 +220,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYLATER,
                 style: {
-                    height: 36,
+                    height: DefaultCheckoutButtonHeight,
                     color: StyleButtonColor.silver,
                     label: 'checkout',
                 },
@@ -245,7 +246,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYLATER,
                 style: {
-                    height: 36,
+                    height: DefaultCheckoutButtonHeight,
                     color: StyleButtonColor.silver,
                     label: 'checkout',
                 },
@@ -286,7 +287,7 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.CREDIT,
                 style: {
-                    height: 36,
+                    height: DefaultCheckoutButtonHeight,
                     color: StyleButtonColor.silver,
                     label: 'checkout',
                 },

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -4,6 +4,7 @@ import {
     CustomerCredentials,
     CustomerInitializeOptions,
     CustomerStrategy,
+    DefaultCheckoutButtonHeight,
     ExecutePaymentMethodCheckoutOptions,
     InvalidArgumentError,
     MissingDataError,
@@ -122,7 +123,7 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
                     fundingSource,
                     style: this.paypalCommerceIntegrationService.getValidButtonStyle({
                         ...checkoutTopButtonStyles,
-                        height: 36,
+                        height: DefaultCheckoutButtonHeight,
                     }),
                     ...defaultCallbacks,
                     ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 
 import {
     CustomerInitializeOptions,
+    DefaultCheckoutButtonHeight,
     InvalidArgumentError,
     PaymentIntegrationService,
     PaymentMethod,
@@ -182,7 +183,7 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
                 fundingSource: paypalSdk.FUNDING.VENMO,
                 style: {
                     color: 'silver',
-                    height: 36,
+                    height: DefaultCheckoutButtonHeight,
                     label: 'checkout',
                 },
                 createOrder: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
@@ -2,6 +2,7 @@ import {
     CustomerCredentials,
     CustomerInitializeOptions,
     CustomerStrategy,
+    DefaultCheckoutButtonHeight,
     ExecutePaymentMethodCheckoutOptions,
     InvalidArgumentError,
     PaymentIntegrationService,
@@ -82,7 +83,7 @@ export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStra
             fundingSource: paypalSdk.FUNDING.VENMO,
             style: this.paypalCommerceIntegrationService.getValidButtonStyle({
                 ...checkoutTopButtonStyles,
-                height: 36,
+                height: DefaultCheckoutButtonHeight,
             }),
             createOrder: () =>
                 this.paypalCommerceIntegrationService.createOrder('paypalcommercevenmo'),

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 
 import {
     CustomerInitializeOptions,
+    DefaultCheckoutButtonHeight,
     InvalidArgumentError,
     PaymentIntegrationService,
     PaymentMethod,
@@ -217,7 +218,11 @@ describe('PayPalCommerceCustomerStrategy', () => {
 
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: { height: 36, color: StyleButtonColor.silver, label: 'checkout' },
+                style: {
+                    height: DefaultCheckoutButtonHeight,
+                    color: StyleButtonColor.silver,
+                    label: 'checkout',
+                },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
             });
@@ -239,7 +244,11 @@ describe('PayPalCommerceCustomerStrategy', () => {
 
             expect(paypalSdk.Buttons).toHaveBeenCalledWith({
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
-                style: { height: 36, color: StyleButtonColor.silver, label: 'checkout' },
+                style: {
+                    height: DefaultCheckoutButtonHeight,
+                    color: StyleButtonColor.silver,
+                    label: 'checkout',
+                },
                 createOrder: expect.any(Function),
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -4,6 +4,7 @@ import {
     CustomerCredentials,
     CustomerInitializeOptions,
     CustomerStrategy,
+    DefaultCheckoutButtonHeight,
     ExecutePaymentMethodCheckoutOptions,
     InvalidArgumentError,
     MissingDataError,
@@ -120,7 +121,7 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
             fundingSource: paypalSdk.FUNDING.PAYPAL,
             style: this.paypalCommerceIntegrationService.getValidButtonStyle({
                 ...checkoutTopButtonStyles,
-                height: 36,
+                height: DefaultCheckoutButtonHeight,
             }),
             ...defaultCallbacks,
             ...(isHostedCheckoutEnabled && hostedCheckoutCallbacks),


### PR DESCRIPTION
## What?
Updated all PayPal buttons on checkout page to have the same default button height

## Why?
We have different buttons height for different providers like google pay, paypal commerce, braintree, apple pay buttons and etc. We should make all buttons with the same height to reduce styling mismatch.

## Testing / Proof
Unit tests
