### PR TITLE
fix(payment): PI-924 Add loader while waiting order confirmation from Stripe

### DIFF
--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -6,6 +6,8 @@ import {
     getStylesheetLoader,
 } from '@bigcommerce/script-loader';
 
+import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
+
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import {
     CheckoutActionCreator,
@@ -819,6 +821,7 @@ export default function createPaymentStrategyRegistry(
                 new StripeUPEScriptLoader(scriptLoader),
                 storeCreditActionCreator,
                 billingAddressActionCreator,
+                new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
             ),
     );
 

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-initialize-options.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-initialize-options.ts
@@ -27,6 +27,11 @@ export default interface StripeUPEPaymentInitializeOptions {
     containerId: string;
 
     /**
+     * The location to insert the preloader while waiting for Stripe confirmation.
+     */
+    loaderContainerId?: string;
+
+    /**
      * Checkout styles from store theme
      */
     style?: {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
@@ -51,6 +51,7 @@ export function getStripeUPEInitializeOptionsMock(
         gatewayId,
         stripeupe: {
             containerId: `stripe-${stripePaymentMethodType}-component-field`,
+            loaderContainerId: 'loaderContainerId',
             style,
             render: jest.fn(),
         },


### PR DESCRIPTION
## What?
Add polling mechanism to wait while Stripe will confirm order by webhook

## Why?
Polling mechanism is needed in case when payment was successfully confirmed by Stripe.confirmPayment request on FE side, but has some delay to confirm payment on BE side, and BC order status mismatch with Stripe order status.
In this case the second payment request returns an error and we need to add some delay to wait confirmation by webhook on BE side and wait while BC order status will be changed.

PR for checkout-js: [https://github.com/bigcommerce/checkout-js/pull/1564](https://github.com/bigcommerce/checkout-js/pull/1564)

## Testing / Proof
Orders status updates immediately.

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/add170ab-8947-4f92-a291-4352226838d8

Order confirmed by Stripe but has some delay to be updated on BC side

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/030e2b39-c2ea-4e77-bdef-b7a0c270111e

Order was confirmed by Stripe but BC order status wasn't change.

https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/d687e414-ce28-4f69-8e53-2b3c8115317e



@bigcommerce/team-checkout @bigcommerce/team-payments
