### PR TITLE
feat(payment): PI-633 add vaulted instrument data to square v2 payment strategy

### DIFF
--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -162,7 +162,13 @@ describe('SquareV2PaymentStrategy', () => {
         it('should submit the payment', async () => {
             const expectedPayment = {
                 methodId: 'squarev2',
-                paymentData: { nonce: 'cnon:xxx' },
+                paymentData: {
+                    nonce: 'cnon:xxx',
+                    formattedPayload: {
+                        vault_payment_instrument: false,
+                        set_as_default_stored_instrument: false,
+                    },
+                },
             };
 
             await strategy.execute(payload);
@@ -175,6 +181,10 @@ describe('SquareV2PaymentStrategy', () => {
                 methodId: 'squarev2',
                 paymentData: {
                     nonce: '{"nonce":"cnon:xxx","token":"verf:yyy"}',
+                    formattedPayload: {
+                        vault_payment_instrument: false,
+                        set_as_default_stored_instrument: false,
+                    },
                 },
             };
             const storeConfigMock = getConfig().storeConfig;

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -163,8 +163,10 @@ describe('SquareV2PaymentStrategy', () => {
             const expectedPayment = {
                 methodId: 'squarev2',
                 paymentData: {
-                    nonce: 'cnon:xxx',
                     formattedPayload: {
+                        credit_card_token: {
+                            token: 'cnon:xxx',
+                        },
                         vault_payment_instrument: false,
                         set_as_default_stored_instrument: false,
                     },
@@ -180,8 +182,10 @@ describe('SquareV2PaymentStrategy', () => {
             const expectedPayment = {
                 methodId: 'squarev2',
                 paymentData: {
-                    nonce: '{"nonce":"cnon:xxx","token":"verf:yyy"}',
                     formattedPayload: {
+                        credit_card_token: {
+                            token: '{"nonce":"cnon:xxx","token":"verf:yyy"}',
+                        },
                         vault_payment_instrument: false,
                         set_as_default_stored_instrument: false,
                     },

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -76,8 +76,10 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
         await this._paymentIntegrationService.submitPayment({
             ...payment,
             paymentData: {
-                nonce,
                 formattedPayload: {
+                    credit_card_token: {
+                        token: nonce,
+                    },
                     vault_payment_instrument: shouldSaveInstrument || false,
                     set_as_default_stored_instrument: shouldSetAsDefaultInstrument || false,
                 },

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -1,5 +1,6 @@
 import {
     InvalidArgumentError,
+    isHostedInstrumentLike,
     OrderFinalizationNotRequiredError,
     OrderRequestBody,
     PaymentArgumentInvalidError,
@@ -63,10 +64,24 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
             });
         }
 
+        const paymentData = payment.paymentData;
+
+        const { shouldSaveInstrument, shouldSetAsDefaultInstrument } = isHostedInstrumentLike(
+            paymentData,
+        )
+            ? paymentData
+            : { shouldSaveInstrument: false, shouldSetAsDefaultInstrument: false };
+
         await this._paymentIntegrationService.submitOrder();
         await this._paymentIntegrationService.submitPayment({
             ...payment,
-            paymentData: { nonce },
+            paymentData: {
+                nonce,
+                formattedPayload: {
+                    vault_payment_instrument: shouldSaveInstrument || false,
+                    set_as_default_stored_instrument: shouldSetAsDefaultInstrument || false,
+                },
+            },
         });
     }
 


### PR DESCRIPTION
## What?
Added `vault_payment_instrument` and `set_as_default_stored_instrument` to `submitPayment` payload in Square v2 payment strategy.

## Why?
[PI-633](https://bigcommercecloud.atlassian.net/browse/PI-633)
As a part of stored credit cards implementation for Square v2.

## Testing / Proof
manual + unit tests

<img width="1512" alt="Screenshot 2023-10-23 at 15 33 23" src="https://github.com/bigcommerce/checkout-sdk-js/assets/138816572/792f77f8-8f69-4456-a593-5e8fe91f7156">

@bigcommerce/team-checkout @bigcommerce/team-payments


[PI-633]: https://bigcommercecloud.atlassian.net/browse/PI-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ