### PR TITLE
feat(payment): PAYPAL-00 hotfix ratepay date of birth field data

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.ts
@@ -189,12 +189,14 @@ export default class PaypalCommerceRatepayPaymentStrategy implements PaymentStra
     }
 
     private normalizeDate(date: BirthDate) {
-        const formattedDate =
-            date.getDate() < 10 ? `0${date.getDate()}` : date.getDate().toString();
-        const formattedMonth =
-            date.getMonth() < 10 ? `0${date.getMonth() + 1}` : date.getMonth().toString();
+        const formattedDate = this.formatDate(date.getDate());
+        const formattedMonth = this.formatDate(date.getMonth() + 1);
 
         return `${date.getFullYear()}-${formattedMonth}-${formattedDate}`;
+    }
+
+    private formatDate(date: number): string {
+        return `${date < 10 ? 0 : ''}${date}`;
     }
 
     private onPaymentSubmission(isPaymentSubmitting: boolean) {


### PR DESCRIPTION
## What?
Fixed date of birth ratepay field processing

## Why?
To send correct data

## Testing / Proof
**Before:**
<img width="836" alt="Screenshot 2023-10-23 at 15 36 00" src="https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/a133a0fb-38b8-440b-9d59-af59175433ca">

**After:**
<img width="651" alt="Screenshot 2023-10-23 at 19 36 44" src="https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/97e69e19-a300-422d-94b7-fb96a0fa6e92">


@bigcommerce/team-checkout @bigcommerce/team-payments
