### PR TITLE
feat(payment): PAYPAL-3133 messaging logo type to be set to 'inline' for checkout paywall page

### DIFF
--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.spec.ts
@@ -182,7 +182,7 @@ describe('BraintreePaypalPaymentStrategy', () => {
                 style: {
                     layout: 'text',
                     logo: {
-                        type: 'none',
+                        type: 'inline',
                     },
                 },
             });

--- a/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-paypal-payment-strategy.ts
@@ -298,7 +298,7 @@ export default class BraintreePaypalPaymentStrategy implements PaymentStrategy {
                     style: {
                         layout: 'text',
                         logo: {
-                            type: 'none',
+                            type: 'inline',
                         },
                     },
                 })


### PR DESCRIPTION
## What?

Logo type changed

## Testing / Proof

<img width="693" alt="Screenshot 2023-10-25 at 11 13 44" src="https://github.com/bigcommerce/checkout-sdk-js/assets/99336044/9450a1db-ed05-4145-9039-ce588051a72e">


@bigcommerce/team-checkout @bigcommerce/team-payments
