### PR TITLE
feat(payment): PI-977 Move stripe confirmPayment to BE

### DIFF
--- a/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer.mock.ts
+++ b/packages/core/src/customer/strategies/stripe-upe/stripe-upe-customer.mock.ts
@@ -16,6 +16,8 @@ export function getCustomerStripeUPEJsMock(returnElement?: StripeElement): Strip
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
         retrievePaymentIntent: jest.fn(),
+        handleNextAction: jest.fn(),
+        createPaymentMethod: jest.fn(),
     };
 }
 

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-script-loader.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-script-loader.ts
@@ -46,6 +46,7 @@ export default class StripeUPEScriptLoader {
 
         if (!stripeElements) {
             stripeElements = stripeClient.elements(options);
+            stripeElements.paymentMethodCreation = options.paymentMethodCreation;
 
             Object.assign(this._window, { bcStripeElements: stripeElements });
         } else {

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.mock.ts
@@ -16,10 +16,13 @@ export function getStripeUPEJsMock(): StripeUPEClient {
             getElement: jest.fn().mockReturnValue(null),
             update: jest.fn(),
             fetchUpdates: jest.fn(),
+            submit: jest.fn(() => Promise.resolve({})),
         })),
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
         retrievePaymentIntent: jest.fn(),
+        handleNextAction: jest.fn(),
+        createPaymentMethod: jest.fn(),
     };
 }
 
@@ -35,10 +38,13 @@ export function getFailingStripeUPEJsMock(): StripeUPEClient {
             getElement: jest.fn().mockReturnValue(null),
             update: jest.fn(),
             fetchUpdates: jest.fn(),
+            submit: jest.fn(() => Promise.resolve({})),
         })),
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
         retrievePaymentIntent: jest.fn(),
+        handleNextAction: jest.fn(),
+        createPaymentMethod: jest.fn(),
     };
 }
 

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -150,7 +150,9 @@ export interface StripeUPEConfirmParams {
      * @recommended
      */
     return_url?: string;
+    payment_method?: string;
     payment_method_data?: PaymentMethodDataOptions;
+    is_backend_confirmation_supported?: boolean;
 }
 
 /**
@@ -276,6 +278,12 @@ export interface StripeElements {
     fetchUpdates(): void;
 
     submit(): Promise<{ error: StripeError }>;
+
+    /**
+     * Custom parameter to save initialization option for stripe payment method creation between different steps
+     * For Stripe Link flow Stripe payment method can't be created manually.
+     */
+    paymentMethodCreation?: string;
 }
 
 /**
@@ -448,3 +456,5 @@ export enum StripeUPEPaymentIntentStatus {
     SUCCEEDED = 'succeeded',
     CANCELED = 'canceled',
 }
+
+export const MANUAL_STRIPE_PAYMENT_METHOD_CREATION = 'manual';

--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe.ts
@@ -274,6 +274,8 @@ export interface StripeElements {
      * https://stripe.com/docs/js/elements_object/fetch_updates
      */
     fetchUpdates(): void;
+
+    submit(): Promise<{ error: StripeError }>;
 }
 
 /**
@@ -333,6 +335,8 @@ export interface StripeElementsOptions {
      * The layout of each Element stays consistent, but you can modify colors, fonts, borders, padding, and more.
      */
     appearance?: StripeUPEAppearanceOptions;
+
+    paymentMethodCreation?: string;
 }
 
 export interface StripeUpdateElementsOptions {
@@ -349,6 +353,15 @@ export interface StripeUpdateElementsOptions {
      * The layout of each Element stays consistent, but you can modify colors, fonts, borders, padding, and more.
      */
     appearance?: StripeUPEAppearanceOptions;
+}
+
+interface StripeCreatePaymentMethodOptions {
+    elements: StripeElements;
+    params?: PaymentMethodDataOptions;
+}
+
+interface StripePaymentMethod extends PaymentMethodDataOptions {
+    id: string;
 }
 
 export interface StripeUPEClient {
@@ -370,12 +383,25 @@ export interface StripeUPEClient {
     retrievePaymentIntent(clientSecret: string): Promise<StripeUpeResult>;
 
     /**
+     * For finalizing payments on the server flow to finish confirmation of a PaymentIntent with the requires_action status. It will throw an error if the PaymentIntent has a different status.
+     */
+    handleNextAction(options: { clientSecret: string }): Promise<StripeUpeResult>;
+
+    /**
+     * Convert payment information collected by elements into a PaymentMethod object that you safely pass to your server to use in an API call.
+     */
+    createPaymentMethod(options: StripeCreatePaymentMethodOptions): Promise<{
+        error: StripeError;
+        paymentMethod: StripePaymentMethod;
+    }>;
+
+    /**
      * Create an `Elements` instance, which manages a group of elements.
      */
     elements(options: StripeElementsOptions): StripeElements;
 }
 
-interface StripeUpeResult {
+export interface StripeUpeResult {
     paymentIntent?: PaymentIntent;
     error?: StripeError;
 }

--- a/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
+++ b/packages/core/src/shipping/strategies/stripe-upe/stripe-upe-shipping.mock.ts
@@ -17,6 +17,8 @@ export function getShippingStripeUPEJsMock(): StripeUPEClient {
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
         retrievePaymentIntent: jest.fn(),
+        handleNextAction: jest.fn(),
+        createPaymentMethod: jest.fn(),
     };
 }
 
@@ -31,6 +33,8 @@ export function getShippingStripeUPEJsOnMock(returnElement?: StripeElement): Str
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
         retrievePaymentIntent: jest.fn(),
+        handleNextAction: jest.fn(),
+        createPaymentMethod: jest.fn(),
     };
 }
 
@@ -55,6 +59,8 @@ export function getShippingStripeUPEJsMockWithAnElementCreated(): StripeUPEClien
         confirmPayment: jest.fn(),
         confirmCardPayment: jest.fn(),
         retrievePaymentIntent: jest.fn(),
+        handleNextAction: jest.fn(),
+        createPaymentMethod: jest.fn(),
     };
 }
 


### PR DESCRIPTION
## What?
Add new flow for cards with 3DS confirmation

## Why?
To move payment confirmation flow to BackEnd side.

## Testing / Proof
Unit tests and manually tested

@bigcommerce/team-checkout @bigcommerce/team-payments
