### PR TITLE
feat(payment): PAYPAL-3146 stop polling mechanism when corresponding status recieved

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.spec.ts
@@ -336,6 +336,25 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
 
             expect(paypalCommerceIntegrationService.getOrderStatus).toHaveBeenCalled();
         });
+
+        it('stop polling mechanism if corresponding status received', async () => {
+            jest.spyOn(paypalCommerceIntegrationService, 'getOrderStatus').mockReturnValue(
+                'POLLING_ERROR',
+            );
+            const payload = {
+                payment: {
+                    methodId: 'ratepay',
+                    gatewayId: 'paypalcommercealternativemethods',
+                },
+            };
+            jest.spyOn(global, 'clearTimeout');
+            try {
+                await strategy.initialize(initializationOptions);
+                await strategy.execute(payload);
+            } catch (e) {
+                expect(clearTimeout).toHaveBeenCalled();
+            }
+        });
     });
 
     describe('#deinitialize()', () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.ts
@@ -331,11 +331,16 @@ export default class PaypalCommerceRatepayPaymentStrategy implements PaymentStra
             );
 
             const isOrderApproved = orderStatus === PayPalOrderStatus.PollingStop;
+            const isPollingError = orderStatus === PayPalOrderStatus.PollingError;
 
             if (isOrderApproved) {
                 this.deinitializePollingMechanism();
 
                 return resolvePromise();
+            }
+
+            if (isPollingError) {
+                return rejectPromise();
             }
 
             if (!isOrderApproved && this.pollingTimer < MAX_POLLING_TIME) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -422,6 +422,7 @@ export enum PayPalOrderStatus {
     Created = 'CREATED',
     PayerActionRequired = 'PAYER_ACTION_REQUIRED',
     PollingStop = 'POLLING_STOP',
+    PollingError = 'POLLING_ERROR',
 }
 
 export interface PayPalOrderStatusData {


### PR DESCRIPTION
## What?
Stop polling mechanism when corresponding status recieved

## Why?
To cancel polling calls

## Testing / Proof
Tested on dev and integration environment

@bigcommerce/team-checkout @bigcommerce/team-payments
