### PR TITLE
feat(payment): PI-846 Quickly selecting different payment methods on …

### DIFF
--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -64,6 +64,10 @@ describe('AdyenV3PaymentStrategy', () => {
         paymentIntegrationService = new PaymentIntegrationServiceMock();
 
         strategy = new AdyenV3PaymentStrategy(paymentIntegrationService, adyenV3ScriptLoader);
+
+        const mockElement = document.createElement('div');
+
+        jest.spyOn(document, 'getElementById').mockReturnValue(mockElement);
     });
 
     describe('#Initializes & Executes', () => {
@@ -149,6 +153,16 @@ describe('AdyenV3PaymentStrategy', () => {
                 cardVerificationComponent = getFailingComponent();
 
                 await expect(strategy.initialize(options)).rejects.toThrow(NotInitializedError);
+            });
+
+            it('fails mounting payment element if container not exist', () => {
+                const adyenClient = getAdyenClient();
+                const adyenComponent = adyenClient.create('scheme', {});
+
+                jest.spyOn(document, 'getElementById').mockReturnValue(null);
+
+                expect(strategy.initialize(options));
+                expect(adyenComponent.mount).not.toHaveBeenCalled();
             });
         });
 

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.ts
@@ -309,7 +309,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                 );
             }
 
-            additionalActionComponent.mount(`#${containerId}`);
+            this._mountElement(additionalActionComponent, containerId);
 
             if (onLoad) {
                 onLoad(() => {
@@ -377,7 +377,10 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
                 });
 
                 try {
-                    cardVerificationComponent.mount(`#${adyenv3.cardVerificationContainerId}`);
+                    this._mountElement(
+                        cardVerificationComponent,
+                        adyenv3.cardVerificationContainerId,
+                    );
                 } catch (error) {
                     reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
                 }
@@ -410,7 +413,7 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
             });
 
             try {
-                paymentComponent.mount(`#${adyenv3.containerId}`);
+                this._mountElement(paymentComponent, adyenv3.containerId);
             } catch (error) {
                 reject(new NotInitializedError(NotInitializedErrorType.PaymentNotInitialized));
             }
@@ -481,5 +484,13 @@ export default class Adyenv3PaymentStrategy implements PaymentStrategy {
         });
 
         return errors;
+    }
+
+    private _mountElement(adyenComponent: AdyenComponent, containerId: string): void {
+        if (!document.getElementById(containerId)) {
+            return;
+        }
+
+        adyenComponent.mount(`#${containerId}`);
     }
 }


### PR DESCRIPTION
…Payment step of Checkout sometimes results in error

## What?
Check if container exists before mounting payment fields inside.

## Why?
Quickly selecting different payment methods on Payment step of Checkout sometimes results in an error.

## Testing / Proof
I was not able to reproduce the bug on dev or int store. Fix must be tested on merchant store.

@bigcommerce/team-checkout @bigcommerce/team-payments
