### PR TITLE
fix(payment): PI-924 Add additional  message while waiting confirmation from Stripe

### DIFF
--- a/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/stripe-upe/stripe-upe-payment-strategy.ts
@@ -496,9 +496,17 @@ export default class StripeUPEPaymentStrategy implements PaymentStrategy {
                     shouldSetAsDefaultInstrument,
                 );
 
-                return this._store.dispatch(
-                    this._paymentActionCreator.submitPayment(paymentPayload),
-                );
+                try {
+                    return await this._store.dispatch(
+                        this._paymentActionCreator.submitPayment(paymentPayload),
+                    );
+                } catch (error) {
+                    // INFO: for case if payment was successfully confirmed on Stripe side but on BC side something go wrong, request failed and order status hasn't changed yet
+                    // For shopper we need to show additional message that BC is waiting for stripe confirmation, to prevent additional payment creation
+                    throw new PaymentMethodFailedError(
+                        "We've received your order and are processing your payment. Once the payment is verified, your order will be completed. We will send you an email when it's completed. Please note, this process may take a few minutes depending on the processing times of your chosen method.",
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## What?
Add error message for cases when Stripe has confirmed payment but on BC side something go wrong, additional payment request failed and order status has not changed yet.

## Why?
To show to shoppers that payment was accepted, but they should wait while BC will receive confirmation from stripe. To prevent unnecessary payment retries from shopper and to prevent double charging.

## Testing / Proof


https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/be187e6d-4107-4dcb-b294-54bd7bcd00c3





@bigcommerce/team-checkout @bigcommerce/team-payments
