### PR TITLE
refactor(payment): PAYPAL-3164 updated paypal sdk script loading in a new way

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-payment-strategy.ts
@@ -82,7 +82,7 @@ export default class PayPalCommerceCreditCardsPaymentStrategy implements Payment
         this.isCreditCardForm = isCreditCardFormFields(form.fields);
 
         await this.paymentIntegrationService.loadPaymentMethod(methodId);
-        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
+        await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId, undefined, true, true);
 
         await this.renderFields(form);
     }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit-card/paypal-commerce-credit-cards-strategy.spec.ts
@@ -168,7 +168,12 @@ describe('PayPalCommerceCreditCardsPaymentStrategy', () => {
         it('loads paypal sdk', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(methodId);
+            expect(paypalCommerceIntegrationService.loadPayPalSdk).toHaveBeenCalledWith(
+                methodId,
+                undefined,
+                true,
+                true,
+            );
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
@@ -91,11 +91,12 @@ describe('PayPalCommerceIntegrationService', () => {
 
     describe('#loadPayPalSdk', () => {
         it('loads paypal sdk', async () => {
-            const output = await subject.loadPayPalSdk(defaultMethodId, undefined, false);
+            const output = await subject.loadPayPalSdk(defaultMethodId, undefined, false, false);
 
             expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
                 paymentMethod,
                 cart.currency.code,
+                false,
                 false,
             );
             expect(output).toBe(paypalSdk);
@@ -107,11 +108,13 @@ describe('PayPalCommerceIntegrationService', () => {
                 defaultMethodId,
                 providedCurrencyCode,
                 false,
+                false,
             );
 
             expect(paypalCommerceScriptLoader.getPayPalSDK).toHaveBeenCalledWith(
                 paymentMethod,
                 providedCurrencyCode,
+                false,
                 false,
             );
             expect(output).toBe(paypalSdk);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.ts
@@ -49,6 +49,7 @@ export default class PayPalCommerceIntegrationService {
         methodId: string,
         providedCurrencyCode?: string,
         initializesOnCheckoutPage?: boolean,
+        forceLoad?: boolean,
     ): Promise<PayPalSDK> {
         const state = this.paymentIntegrationService.getState();
         const currencyCode = providedCurrencyCode || state.getCartOrThrow().currency.code;
@@ -59,6 +60,7 @@ export default class PayPalCommerceIntegrationService {
             paymentMethod,
             currencyCode,
             initializesOnCheckoutPage,
+            forceLoad,
         );
 
         return this.paypalSdk;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-script-loader.ts
@@ -15,8 +15,6 @@ import {
     PayPalSDK,
 } from './paypal-commerce-types';
 
-const PAYPAL_SDK_VERSION = '5.0.5';
-
 export default class PayPalCommerceScriptLoader {
     private window: PayPalCommerceHostWindow;
 
@@ -28,30 +26,35 @@ export default class PayPalCommerceScriptLoader {
         paymentMethod: PaymentMethod<PayPalCommerceInitializationData>,
         currencyCode: string,
         initializesOnCheckoutPage?: boolean,
+        forceLoad?: boolean,
     ): Promise<PayPalSDK> {
-        return this.loadPayPalSDK(
-            this.getPayPalSdkScriptConfigOrThrow(
-                paymentMethod,
-                currencyCode,
-                initializesOnCheckoutPage,
-            ),
+        const paypalSdkScriptConfig = this.getPayPalSdkScriptConfigOrThrow(
+            paymentMethod,
+            currencyCode,
+            initializesOnCheckoutPage,
         );
+
+        return this.loadPayPalSDK(paypalSdkScriptConfig, forceLoad);
     }
 
     private async loadPayPalSDK(
         paypalSdkScriptConfig: PayPalCommerceScriptParams,
+        forceLoad = false,
     ): Promise<PayPalSDK> {
-        if (!this.window.paypalLoadScript) {
-            const scriptSrc = `https://unpkg.com/@paypal/paypal-js@${PAYPAL_SDK_VERSION}/dist/iife/paypal-js.min.js`;
+        if (!this.window.paypal || forceLoad) {
+            const options = this.transformConfig<PayPalCommerceScriptParams['options']>(
+                paypalSdkScriptConfig.options,
+            );
+            const attributes = this.transformConfig<PayPalCommerceScriptParams['attributes']>(
+                paypalSdkScriptConfig.attributes,
+            );
 
-            await this.scriptLoader.loadScript(scriptSrc, { async: true, attributes: {} });
+            const paypalSdkUrl = 'https://www.paypal.com/sdk/js';
+            const scriptQuery = new URLSearchParams(options).toString();
+            const scriptSrc = `${paypalSdkUrl}?${scriptQuery}`;
 
-            if (!this.window.paypalLoadScript) {
-                throw new PaymentMethodClientUnavailableError();
-            }
+            await this.scriptLoader.loadScript(scriptSrc, { async: true, attributes });
         }
-
-        await this.window.paypalLoadScript(paypalSdkScriptConfig);
 
         if (!this.window.paypal) {
             throw new PaymentMethodClientUnavailableError();
@@ -118,17 +121,47 @@ export default class PayPalCommerceScriptLoader {
         ];
 
         return {
-            'client-id': clientId,
-            'data-partner-attribution-id': attributionId,
-            'data-client-token': clientToken,
-            'merchant-id': merchantId,
-            'enable-funding': enableFunding.length > 0 ? enableFunding : undefined,
-            'disable-funding': disableFunding.length > 0 ? disableFunding : undefined,
-            commit,
-            components: ['buttons', 'hosted-fields', 'messages', 'payment-fields', 'legal'],
-            currency: currencyCode,
-            intent,
-            ...(isDeveloperModeApplicable && { 'buyer-country': buyerCountry }),
+            options: {
+                'client-id': clientId,
+                'merchant-id': merchantId,
+                'enable-funding': enableFunding.length > 0 ? enableFunding : undefined,
+                'disable-funding': disableFunding.length > 0 ? disableFunding : undefined,
+                commit,
+                components: ['buttons', 'hosted-fields', 'messages', 'payment-fields', 'legal'],
+                currency: currencyCode,
+                intent,
+                ...(isDeveloperModeApplicable && { 'buyer-country': buyerCountry }),
+            },
+            attributes: {
+                'data-partner-attribution-id': attributionId,
+                'data-client-token': clientToken,
+            },
         };
+    }
+
+    private transformConfig<T extends Record<string, unknown>>(config: T): Record<string, string> {
+        let transformedConfig = {};
+
+        const keys = Object.keys(config) as Array<keyof T>;
+
+        keys.forEach((key) => {
+            const value = config[key];
+
+            if (
+                value === undefined ||
+                value === null ||
+                value === '' ||
+                (Array.isArray(value) && value.length === 0)
+            ) {
+                return;
+            }
+
+            transformedConfig = {
+                ...transformedConfig,
+                [key]: Array.isArray(value) ? value.join(',') : value,
+            };
+        });
+
+        return transformedConfig;
     }
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -57,17 +57,21 @@ export interface BirthDate {
 }
 
 export interface PayPalCommerceScriptParams {
-    'client-id'?: string;
-    'merchant-id'?: string;
-    'buyer-country'?: string;
-    'disable-funding'?: FundingType;
-    'enable-funding'?: EnableFundingType;
-    'data-client-token'?: string;
-    'data-partner-attribution-id'?: string;
-    currency?: string;
-    commit?: boolean;
-    intent?: PayPalCommerceIntent;
-    components?: ComponentsScriptType;
+    options: {
+        'client-id'?: string;
+        'merchant-id'?: string;
+        'buyer-country'?: string;
+        'disable-funding'?: FundingType;
+        'enable-funding'?: EnableFundingType;
+        currency?: string;
+        commit?: boolean;
+        intent?: PayPalCommerceIntent;
+        components?: ComponentsScriptType;
+    };
+    attributes: {
+        'data-client-token'?: string;
+        'data-partner-attribution-id'?: string;
+    };
 }
 
 export enum PayPalCommerceIntent {


### PR DESCRIPTION
## What?
We changed a way how we load paypal sdk script to try to avoid zoid issues that occur due to the multiple script loading with different configurations.

## Why?
Prev implementation had extra step with loading paypal script from CDN that we used to trigger paypal sdk script loading process. So the reason why we update that is to reduce amount of steps to get paypal sdk working properly, plus it might reduce amount of time spent on wallet buttons rendering process.

## Testing / Proof
Unit tests
Manual tests
QA regression