### PR TITLE
fix(payment): PAYPAL-3190 updated implementation to avoid trigger OTP if the shopper canceled PayPal Connect OTP window

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
@@ -184,6 +184,21 @@ describe('BraintreeAcceleratedCheckoutPaymentStrategy', () => {
             ).not.toHaveBeenCalled();
         });
 
+        it('should not authenticate user if OTP was canceled before', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentProviderCustomerOrThrow',
+            ).mockReturnValue({
+                authenticationState: BraintreeConnectAuthenticationState.CANCELED,
+            });
+
+            await strategy.initialize(defaultInitializationOptions);
+
+            expect(
+                braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow,
+            ).not.toHaveBeenCalled();
+        });
+
         it('should not authenticate user the user logged in before checkout page', async () => {
             jest.spyOn(
                 paymentIntegrationService.getState(),

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.ts
@@ -1,5 +1,6 @@
 import {
     BraintreeConnectAddress,
+    BraintreeConnectAuthenticationState,
     BraintreeConnectCardComponent,
     BraintreeConnectCardComponentOptions,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
@@ -244,6 +245,13 @@ export default class BraintreeAcceleratedCheckoutPaymentStrategy implements Paym
         const paymentProviderCustomer = state.getPaymentProviderCustomer();
 
         const paypalConnectSessionId = this.browserStorage.getItem('sessionId');
+
+        if (
+            paymentProviderCustomer?.authenticationState ===
+            BraintreeConnectAuthenticationState.CANCELED
+        ) {
+            return false;
+        }
 
         return !paymentProviderCustomer?.authenticationState && paypalConnectSessionId === cart.id;
     }

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-utils.spec.ts
@@ -328,7 +328,7 @@ describe('BraintreeAcceleratedCheckoutUtils', () => {
             await subject.initializeBraintreeConnectOrThrow(methodId);
             await subject.runPayPalConnectAuthenticationFlowOrThrow();
 
-            expect(browserStorage.setItem).toHaveBeenCalledWith('sessionId', cart.id);
+            expect(browserStorage.removeItem).toHaveBeenCalledWith('sessionId');
             expect(braintreeConnectMock.identity.triggerAuthenticationFlow).toHaveBeenCalled();
             expect(paymentIntegrationService.updatePaymentProviderCustomer).toHaveBeenCalledWith(
                 updatePaymentProviderCustomerPayload,


### PR DESCRIPTION
## What?
Connect OTP window should not be shown for the shopper anymore in the same cart session until he will click on continue button in customer step

## Why?
Connect OTP window re-appeared at the shipping/billing step when shopper initially closed it at the customer step of the checkout

## Testing / Proof
Unit tests
Manual tests


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/2aa189e0-3d99-404f-8cbc-00b36bc598f0


