### PR TITLE
fix(payment): PAYPAL-3124 PPCP loading indicator keeps after submit

### DIFF
--- a/packages/paypal-commerce-integration/src/mocks/get-paypal-sdk.mock.ts
+++ b/packages/paypal-commerce-integration/src/mocks/get-paypal-sdk.mock.ts
@@ -27,7 +27,7 @@ export default function getPayPalSDKMock(): PayPalSDK {
             render: jest.fn(),
         },
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
+        // @ts-ignore
         Legal: () => ({
             render: jest.fn(),
         }),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/create-paypal-commerce-alternative-methods-payment-strategy.ts
@@ -5,6 +5,7 @@ import {
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import createPayPalCommerceIntegrationService from '../create-paypal-commerce-integration-service';
+import { LOADING_INDICATOR_STYLES } from '../paypal-commerce-constants';
 
 import PayPalCommerceAlternativeMethodsPaymentStrategy from './paypal-commerce-alternative-methods-payment-strategy';
 
@@ -14,7 +15,9 @@ const createPayPalCommerceAlternativeMethodsPaymentStrategy: PaymentStrategyFact
     new PayPalCommerceAlternativeMethodsPaymentStrategy(
         paymentIntegrationService,
         createPayPalCommerceIntegrationService(paymentIntegrationService),
-        new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
+        new LoadingIndicator({
+            containerStyles: LOADING_INDICATOR_STYLES,
+        }),
     );
 
 export default toResolvableModule(createPayPalCommerceAlternativeMethodsPaymentStrategy, [

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
@@ -357,7 +357,7 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
             expect(submitFormMock).toHaveBeenCalled();
         });
 
-        it('hides loading indicator after form submit', async () => {
+        it('does not hide loading indicator after form submit', async () => {
             const submitFormMock = jest.fn();
 
             await strategy.initialize({
@@ -373,7 +373,7 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(submitFormMock).toHaveBeenCalled();
-            expect(loadingIndicator.hide).toHaveBeenCalled();
+            expect(loadingIndicator.hide).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -199,7 +199,6 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
         this.orderId = orderID;
 
         submitForm();
-        this.toggleLoadingIndicator(false);
     }
 
     private handleFailure(

--- a/packages/paypal-commerce-integration/src/paypal-commerce-constants.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-constants.ts
@@ -1,0 +1,4 @@
+export const LOADING_INDICATOR_STYLES = {
+    'background-color': 'rgba(0, 0, 0, 0.4)',
+    'z-index': '1000',
+};

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/create-paypal-commerce-credit-payment-strategy.ts
@@ -5,6 +5,7 @@ import {
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import createPayPalCommerceIntegrationService from '../create-paypal-commerce-integration-service';
+import { LOADING_INDICATOR_STYLES } from '../paypal-commerce-constants';
 
 import PayPalCommerceCreditPaymentStrategy from './paypal-commerce-credit-payment-strategy';
 
@@ -14,7 +15,9 @@ const createPayPalCommerceCreditPaymentStrategy: PaymentStrategyFactory<
     new PayPalCommerceCreditPaymentStrategy(
         paymentIntegrationService,
         createPayPalCommerceIntegrationService(paymentIntegrationService),
-        new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
+        new LoadingIndicator({
+            containerStyles: LOADING_INDICATOR_STYLES,
+        }),
     );
 
 export default toResolvableModule(createPayPalCommerceCreditPaymentStrategy, [

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.spec.ts
@@ -328,7 +328,7 @@ describe('PayPalCommerceCreditPaymentStrategy', () => {
             expect(submitFormMock).toHaveBeenCalled();
         });
 
-        it('hides loading indicator after form submit', async () => {
+        it("doesn't hide loading indicator after form submit", async () => {
             const submitFormMock = jest.fn();
 
             await strategy.initialize({
@@ -344,7 +344,7 @@ describe('PayPalCommerceCreditPaymentStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(submitFormMock).toHaveBeenCalled();
-            expect(loadingIndicator.hide).toHaveBeenCalled();
+            expect(loadingIndicator.hide).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
@@ -196,7 +196,6 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
         this.orderId = orderID;
 
         submitForm();
-        this.toggleLoadingIndicator(false);
     }
 
     private handleError(

--- a/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-integration-service.spec.ts
@@ -587,6 +587,7 @@ describe('PayPalCommerceIntegrationService', () => {
             paypalButtonElement.id = paypalCommerceButtonContainerId;
 
             document.body.appendChild(paypalButtonElement);
+
             const element = document.getElementById(paypalCommerceButtonContainerId);
 
             expect(element).toBeDefined();
@@ -594,6 +595,7 @@ describe('PayPalCommerceIntegrationService', () => {
             subject.removeElement(paypalCommerceButtonContainerId);
 
             const computedStyle = getComputedStyle(element as Element);
+
             expect(computedStyle.getPropertyValue('display')).toBe('none');
         });
     });

--- a/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/create-paypal-commerce-payment-strategy.ts
@@ -5,6 +5,7 @@ import {
 import { LoadingIndicator } from '@bigcommerce/checkout-sdk/ui';
 
 import createPayPalCommerceIntegrationService from '../create-paypal-commerce-integration-service';
+import { LOADING_INDICATOR_STYLES } from '../paypal-commerce-constants';
 
 import PayPalCommercePaymentStrategy from './paypal-commerce-payment-strategy';
 
@@ -14,7 +15,9 @@ const createPayPalCommercePaymentStrategy: PaymentStrategyFactory<PayPalCommerce
     new PayPalCommercePaymentStrategy(
         paymentIntegrationService,
         createPayPalCommerceIntegrationService(paymentIntegrationService),
-        new LoadingIndicator({ styles: { backgroundColor: 'black' } }),
+        new LoadingIndicator({
+            containerStyles: LOADING_INDICATOR_STYLES,
+        }),
     );
 
 export default toResolvableModule(createPayPalCommercePaymentStrategy, [{ id: 'paypalcommerce' }]);

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.spec.ts
@@ -287,7 +287,7 @@ describe('PayPalCommercePaymentStrategy', () => {
             expect(submitFormMock).toHaveBeenCalled();
         });
 
-        it('hides loading indicator after form submit', async () => {
+        it("doesn't hide loading indicator after form submit", async () => {
             const submitFormMock = jest.fn();
 
             await strategy.initialize({
@@ -303,7 +303,7 @@ describe('PayPalCommercePaymentStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(submitFormMock).toHaveBeenCalled();
-            expect(loadingIndicator.hide).toHaveBeenCalled();
+            expect(loadingIndicator.hide).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-strategy.ts
@@ -168,7 +168,6 @@ export default class PayPalCommercePaymentStrategy implements PaymentStrategy {
         this.orderId = orderID;
 
         submitForm();
-        this.toggleLoadingIndicator(false);
     }
 
     private handleError(

--- a/packages/ui/src/loading-indicator/loading-indicator-styles.ts
+++ b/packages/ui/src/loading-indicator/loading-indicator-styles.ts
@@ -3,3 +3,7 @@ export interface LoadingIndicatorStyles {
     color?: string;
     backgroundColor?: string;
 }
+
+export interface LoadingIndicatorContainerStyles {
+    [key: string]: string;
+}

--- a/packages/ui/src/loading-indicator/loading-indicator.ts
+++ b/packages/ui/src/loading-indicator/loading-indicator.ts
@@ -1,4 +1,7 @@
-import { LoadingIndicatorStyles } from './loading-indicator-styles';
+import {
+    LoadingIndicatorContainerStyles,
+    LoadingIndicatorStyles,
+} from './loading-indicator-styles';
 
 const DEFAULT_STYLES: LoadingIndicatorStyles = {
     size: 70,
@@ -8,13 +11,20 @@ const DEFAULT_STYLES: LoadingIndicatorStyles = {
 
 const ROTATION_ANIMATION = 'embedded-checkout-loading-indicator-rotation';
 
+interface LoadingIndicatorOptions {
+    styles?: LoadingIndicatorStyles;
+    containerStyles?: LoadingIndicatorContainerStyles;
+}
+
 export default class LoadingIndicator {
     private container: HTMLElement;
     private indicator: HTMLElement;
     private styles: LoadingIndicatorStyles;
+    private containerStyles: LoadingIndicatorContainerStyles;
 
-    constructor(options?: { styles?: LoadingIndicatorStyles }) {
+    constructor(options?: LoadingIndicatorOptions) {
         this.styles = { ...DEFAULT_STYLES, ...(options && options.styles) };
+        this.containerStyles = { ...(options && options.containerStyles) };
 
         this.defineAnimation();
 
@@ -67,6 +77,8 @@ export default class LoadingIndicator {
         container.style.transition = 'all 250ms ease-out';
         container.style.opacity = '0';
 
+        this.setStyleAttribute(container, this.containerStyles);
+
         return container;
     }
 
@@ -89,6 +101,12 @@ export default class LoadingIndicator {
         indicator.style.animation = `${ROTATION_ANIMATION} 500ms infinite cubic-bezier(0.69, 0.31, 0.56, 0.83)`;
 
         return indicator;
+    }
+
+    private setStyleAttribute(element: HTMLElement, attrs: { [key: string]: string }): void {
+        Object.keys(attrs).forEach((k) => {
+            element.style.setProperty(k, attrs[k]);
+        });
     }
 
     private defineAnimation(): void {


### PR DESCRIPTION
## What?
PPCP Payment step loading indicator keeps after submitting payment.
Also added `setStyleAttribute` method to `LoadingIndicator` class.

## Why?
Because we don't have any indicators after submitting payment which might be a bad user experience. 

## Testing / Proof
https://github.com/bigcommerce/checkout-sdk-js/assets/130665807/1d1cd74a-2ec5-47a8-b2cf-4da4fd9bc229


@bigcommerce/team-checkout @bigcommerce/team-payments
