### PR TITLE
fix(checkout): Prevent Vite From Creating Syntax Errors

### DIFF
--- a/packages/core/src/checkout/create-checkout-service.ts
+++ b/packages/core/src/checkout/create-checkout-service.ts
@@ -92,7 +92,7 @@ export default function createCheckoutService(options?: CheckoutServiceOptions):
 
     if (getEnvironment() !== 'production') {
         getDefaultLogger().warn(
-            'Note that the development build is not optimized. To create a production build, set process.env.NODE_ENV to `production`.',
+            'Note that the development build is not optimized. To create a production build, set process\u200b.env.NODE_ENV to `production`.',
         );
     }
 


### PR DESCRIPTION
## What?
This adds a[ zero-width space character](https://en.wikipedia.org/wiki/Zero-width_space) into the `process.env.NODE_ENV` warning text so that it is not statically replaced. This is how the [Vite documentation](https://vitejs.dev/guide/env-and-mode.html#production-replacement) recommends fixing this issue (see the first bullet point under "Production Replacement").

Fixes #2138 


## Why?
When using Vite, env variables like `process.env.NODE_ENV` are statically replaced, even inside of strings. This means that that instead of a well-formed warning string being produced, invalid Javascript is actually created.

![image](https://github.com/bigcommerce/checkout-sdk-js/assets/8477966/2b51449b-2f31-4d80-b455-4f57e3e268e8)

## Testing / Proof

https://stackblitz.com/edit/vitejs-vite-t7xh32?file=main.js

Baseline reproduction of the issue. If you use devtools you can see the relevant error being thrown and jumping into the source you'll see the malformed replacement as seen in the screenshot above.

@bigcommerce/team-checkout @bigcommerce/team-payments
