### PR TITLE
fix(payment): PAYPAL-2936 updated PayPal Commerce shipping callbacks with onShippingChanged

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.spec.ts
@@ -222,20 +222,12 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                     }
                 });
 
-                eventEmitter.on('onShippingAddressChange', () => {
-                    if (options.onShippingAddressChange) {
-                        options.onShippingAddressChange({
-                            orderId: paypalOrderId,
-                            shippingAddress: paypalShippingAddressPayloadMock,
-                        });
-                    }
-                });
-
-                eventEmitter.on('onShippingOptionsChange', () => {
-                    if (options.onShippingOptionsChange) {
-                        options.onShippingOptionsChange({
-                            orderId: paypalOrderId,
-                            selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
+                eventEmitter.on('onShippingChange', () => {
+                    if (options.onShippingChange) {
+                        options.onShippingChange({
+                            orderID: paypalOrderId,
+                            shipping_address: paypalShippingAddressPayloadMock,
+                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
                         });
                     }
                 });
@@ -435,8 +427,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
                 fundingSource: paypalSdk.FUNDING.PAYLATER,
                 style: paypalCommerceCreditOptions.style,
                 createOrder: expect.any(Function),
-                onShippingAddressChange: expect.any(Function),
-                onShippingOptionsChange: expect.any(Function),
+                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });
@@ -673,7 +664,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         });
     });
 
-    describe('#onShippingAddressChange button callback', () => {
+    describe('#onShippingChange button callback', () => {
         beforeEach(() => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
@@ -710,7 +701,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingAddressChange');
+            eventEmitter.emit('onShippingChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -721,7 +712,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
         it('selects shipping option after address update', async () => {
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingAddressChange');
+            eventEmitter.emit('onShippingChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -742,47 +733,7 @@ describe('PayPalCommerceCreditButtonStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingAddressChange');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paypalCommerceIntegrationService.updateOrder).toHaveBeenCalled();
-        });
-    });
-
-    describe('#onShippingOptionsChange button callback', () => {
-        beforeEach(() => {
-            const paymentMethodWithShippingOptionsFeature = {
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isHostedCheckoutEnabled: true,
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
-        });
-
-        it('selects shipping option', async () => {
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onShippingOptionsChange');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paypalCommerceIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
-            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
-                getShippingOption().id,
-            );
-        });
-
-        it('updates PayPal order', async () => {
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onShippingOptionsChange');
+            eventEmitter.emit('onShippingChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-button-strategy.ts
@@ -14,8 +14,7 @@ import {
     PayPalBuyNowInitializeOptions,
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
-    ShippingAddressChangeCallbackPayload,
-    ShippingOptionChangeCallbackPayload,
+    ShippingChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditButtonInitializeOptions, {
@@ -122,10 +121,7 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         };
 
         const hostedCheckoutCallbacks = {
-            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                this.onShippingAddressChange(data),
-            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                this.onShippingOptionsChange(data),
+            onShippingChange: (data: ShippingChangeCallbackPayload) => this.onShippingChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -214,39 +210,22 @@ export default class PayPalCommerceCreditButtonStrategy implements CheckoutButto
         }
     }
 
-    private async onShippingAddressChange(
-        data: ShippingAddressChangeCallbackPayload,
-    ): Promise<void> {
+    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.country_code,
-            postalCode: data.shippingAddress.postal_code,
-            stateOrProvinceCode: data.shippingAddress.state,
+            city: data.shipping_address.city,
+            countryCode: data.shipping_address.country_code,
+            postalCode: data.shipping_address.postal_code,
+            stateOrProvinceCode: data.shipping_address.state,
         });
 
         try {
-            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
-            // on this stage we don't have access to valid customer's address accept shipping data
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);
 
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+                data.selected_shipping_option?.id,
+            );
 
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            throw new Error(error);
-        }
-    }
-
-    private async onShippingOptionsChange(
-        data: ShippingOptionChangeCallbackPayload,
-    ): Promise<void> {
-        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-            data.selectedShippingOption.id,
-        );
-
-        try {
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -19,8 +19,7 @@ import {
     ApproveCallbackPayload,
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
-    ShippingAddressChangeCallbackPayload,
-    ShippingOptionChangeCallbackPayload,
+    ShippingChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCreditCustomerInitializeOptions, {
@@ -113,10 +112,7 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         };
 
         const hostedCheckoutCallbacks = {
-            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                this.onShippingAddressChange(data),
-            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                this.onShippingOptionsChange(data),
+            onShippingChange: (data: ShippingChangeCallbackPayload) => this.onShippingChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -192,43 +188,26 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         }
     }
 
-    private async onShippingAddressChange(
-        data: ShippingAddressChangeCallbackPayload,
-    ): Promise<void> {
+    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.country_code,
-            postalCode: data.shippingAddress.postal_code,
-            stateOrProvinceCode: data.shippingAddress.state,
+            city: data.shipping_address.city,
+            countryCode: data.shipping_address.country_code,
+            postalCode: data.shipping_address.postal_code,
+            stateOrProvinceCode: data.shipping_address.state,
         });
 
         try {
-            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
-            // on this stage we don't have access to valid customer's address except shipping data
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);
 
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+                data.selected_shipping_option?.id,
+            );
 
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {
-            this.handleError(error);
-        }
-    }
-
-    private async onShippingOptionsChange(
-        data: ShippingOptionChangeCallbackPayload,
-    ): Promise<void> {
-        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-            data.selectedShippingOption.id,
-        );
-
-        try {
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            this.handleError(error);
+            throw new Error(error);
         }
     }
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -277,8 +277,7 @@ export interface PayPalCommerceButtonsOptions {
     onClick?(data: ClickCallbackPayload, actions: ClickCallbackActions): Promise<void> | void;
     onError?(error: Error): void;
     onCancel?(): void;
-    onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;
-    onShippingOptionsChange?(data: ShippingOptionChangeCallbackPayload): Promise<void>;
+    onShippingChange?(data: ShippingChangeCallbackPayload): Promise<void>;
 }
 
 export interface ClickCallbackPayload {
@@ -290,9 +289,10 @@ export interface ClickCallbackActions {
     resolve(): void;
 }
 
-export interface ShippingAddressChangeCallbackPayload {
-    orderId: string;
-    shippingAddress: PayPalAddress;
+export interface ShippingChangeCallbackPayload {
+    orderID: string;
+    shipping_address: PayPalAddress;
+    selected_shipping_option: PayPalSelectedShippingOption;
 }
 
 export interface PayPalAddress {
@@ -300,11 +300,6 @@ export interface PayPalAddress {
     country_code: string;
     postal_code: string;
     state: string;
-}
-
-export interface ShippingOptionChangeCallbackPayload {
-    orderId: string;
-    selectedShippingOption: PayPalSelectedShippingOption;
 }
 
 export interface PayPalSelectedShippingOption {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.spec.ts
@@ -215,20 +215,12 @@ describe('PayPalCommerceButtonStrategy', () => {
                     }
                 });
 
-                eventEmitter.on('onShippingAddressChange', () => {
-                    if (options.onShippingAddressChange) {
-                        options.onShippingAddressChange({
-                            orderId: paypalOrderId,
-                            shippingAddress: paypalShippingAddressPayloadMock,
-                        });
-                    }
-                });
-
-                eventEmitter.on('onShippingOptionsChange', () => {
-                    if (options.onShippingOptionsChange) {
-                        options.onShippingOptionsChange({
-                            orderId: paypalOrderId,
-                            selectedShippingOption: paypalSelectedShippingOptionPayloadMock,
+                eventEmitter.on('onShippingChange', () => {
+                    if (options.onShippingChange) {
+                        options.onShippingChange({
+                            orderID: paypalOrderId,
+                            shipping_address: paypalShippingAddressPayloadMock,
+                            selected_shipping_option: paypalSelectedShippingOptionPayloadMock,
                         });
                     }
                 });
@@ -406,8 +398,7 @@ describe('PayPalCommerceButtonStrategy', () => {
                 fundingSource: paypalSdk.FUNDING.PAYPAL,
                 style: paypalCommerceOptions.style,
                 createOrder: expect.any(Function),
-                onShippingAddressChange: expect.any(Function),
-                onShippingOptionsChange: expect.any(Function),
+                onShippingChange: expect.any(Function),
                 onApprove: expect.any(Function),
             });
         });
@@ -644,7 +635,7 @@ describe('PayPalCommerceButtonStrategy', () => {
         });
     });
 
-    describe('#onShippingAddressChange button callback', () => {
+    describe('#onShippingChange button callback', () => {
         beforeEach(() => {
             const paymentMethodWithShippingOptionsFeature = {
                 ...paymentMethod,
@@ -681,7 +672,7 @@ describe('PayPalCommerceButtonStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingAddressChange');
+            eventEmitter.emit('onShippingChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -692,7 +683,7 @@ describe('PayPalCommerceButtonStrategy', () => {
         it('selects shipping option after address update', async () => {
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingAddressChange');
+            eventEmitter.emit('onShippingChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 
@@ -713,47 +704,7 @@ describe('PayPalCommerceButtonStrategy', () => {
 
             await strategy.initialize(initializationOptions);
 
-            eventEmitter.emit('onShippingAddressChange');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paypalCommerceIntegrationService.updateOrder).toHaveBeenCalled();
-        });
-    });
-
-    describe('#onShippingOptionsChange button callback', () => {
-        beforeEach(() => {
-            const paymentMethodWithShippingOptionsFeature = {
-                ...paymentMethod,
-                initializationData: {
-                    ...paymentMethod.initializationData,
-                    isHostedCheckoutEnabled: true,
-                },
-            };
-
-            jest.spyOn(
-                paymentIntegrationService.getState(),
-                'getPaymentMethodOrThrow',
-            ).mockReturnValue(paymentMethodWithShippingOptionsFeature);
-        });
-
-        it('selects shipping option', async () => {
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onShippingOptionsChange');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(paypalCommerceIntegrationService.getShippingOptionOrThrow).toHaveBeenCalled();
-            expect(paymentIntegrationService.selectShippingOption).toHaveBeenCalledWith(
-                getShippingOption().id,
-            );
-        });
-
-        it('updates PayPal order', async () => {
-            await strategy.initialize(initializationOptions);
-
-            eventEmitter.emit('onShippingOptionsChange');
+            eventEmitter.emit('onShippingChange');
 
             await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-button-strategy.ts
@@ -14,8 +14,7 @@ import {
     PayPalBuyNowInitializeOptions,
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
-    ShippingAddressChangeCallbackPayload,
-    ShippingOptionChangeCallbackPayload,
+    ShippingChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceButtonInitializeOptions, {
@@ -115,10 +114,7 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         };
 
         const hostedCheckoutCallbacks = {
-            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                this.onShippingAddressChange(data),
-            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                this.onShippingOptionsChange(data),
+            onShippingChange: (data: ShippingChangeCallbackPayload) => this.onShippingChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -197,39 +193,22 @@ export default class PayPalCommerceButtonStrategy implements CheckoutButtonStrat
         }
     }
 
-    private async onShippingAddressChange(
-        data: ShippingAddressChangeCallbackPayload,
-    ): Promise<void> {
+    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.country_code,
-            postalCode: data.shippingAddress.postal_code,
-            stateOrProvinceCode: data.shippingAddress.state,
+            city: data.shipping_address.city,
+            countryCode: data.shipping_address.country_code,
+            postalCode: data.shipping_address.postal_code,
+            stateOrProvinceCode: data.shipping_address.state,
         });
 
         try {
-            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
-            // on this stage we don't have access to valid customer's address accept shipping data
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);
 
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+                data.selected_shipping_option?.id,
+            );
 
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            throw new Error(error);
-        }
-    }
-
-    private async onShippingOptionsChange(
-        data: ShippingOptionChangeCallbackPayload,
-    ): Promise<void> {
-        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-            data.selectedShippingOption.id,
-        );
-
-        try {
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -19,8 +19,7 @@ import {
     ApproveCallbackPayload,
     PayPalCommerceButtonsOptions,
     PayPalCommerceInitializationData,
-    ShippingAddressChangeCallbackPayload,
-    ShippingOptionChangeCallbackPayload,
+    ShippingChangeCallbackPayload,
 } from '../paypal-commerce-types';
 
 import PayPalCommerceCustomerInitializeOptions, {
@@ -116,10 +115,7 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         };
 
         const hostedCheckoutCallbacks = {
-            onShippingAddressChange: (data: ShippingAddressChangeCallbackPayload) =>
-                this.onShippingAddressChange(data),
-            onShippingOptionsChange: (data: ShippingOptionChangeCallbackPayload) =>
-                this.onShippingOptionsChange(data),
+            onShippingChange: (data: ShippingChangeCallbackPayload) => this.onShippingChange(data),
             onApprove: (data: ApproveCallbackPayload, actions: ApproveCallbackActions) =>
                 this.onHostedCheckoutApprove(data, actions, methodId, onComplete),
         };
@@ -185,43 +181,26 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         }
     }
 
-    private async onShippingAddressChange(
-        data: ShippingAddressChangeCallbackPayload,
-    ): Promise<void> {
+    private async onShippingChange(data: ShippingChangeCallbackPayload): Promise<void> {
         const address = this.paypalCommerceIntegrationService.getAddress({
-            city: data.shippingAddress.city,
-            countryCode: data.shippingAddress.country_code,
-            postalCode: data.shippingAddress.postal_code,
-            stateOrProvinceCode: data.shippingAddress.state,
+            city: data.shipping_address.city,
+            countryCode: data.shipping_address.country_code,
+            postalCode: data.shipping_address.postal_code,
+            stateOrProvinceCode: data.shipping_address.state,
         });
 
         try {
-            // Info: we use the same address to fill billing and shipping addresses to have valid quota on BE for order updating process
-            // on this stage we don't have access to valid customer's address except shipping data
             await this.paymentIntegrationService.updateBillingAddress(address);
             await this.paymentIntegrationService.updateShippingAddress(address);
 
-            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow();
+            const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
+                data.selected_shipping_option?.id,
+            );
 
             await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
             await this.paypalCommerceIntegrationService.updateOrder();
         } catch (error) {
-            this.handleError(error);
-        }
-    }
-
-    private async onShippingOptionsChange(
-        data: ShippingOptionChangeCallbackPayload,
-    ): Promise<void> {
-        const shippingOption = this.paypalCommerceIntegrationService.getShippingOptionOrThrow(
-            data.selectedShippingOption.id,
-        );
-
-        try {
-            await this.paymentIntegrationService.selectShippingOption(shippingOption.id);
-            await this.paypalCommerceIntegrationService.updateOrder();
-        } catch (error) {
-            this.handleError(error);
+            throw new Error(error);
         }
     }
 


### PR DESCRIPTION
## What?
Updated `onShippingAddressChange` and `onShippingOptionChange` callbacks to `onShippingChange` in different PayPal Commerce strategies.

## Why?
PayPal Commerce Skip Checkout feature does not work properly for shoppers. This issue happens because several shipping callbacks was deprecated on PayPal side due to closing another project. Therefore we should come back to PayPal's documentation and make it works as it was before that project.

## Testing / Proof
Unit tests
Manual tests
