### PR TITLE
feat(payment): PI-853 BluesnapDirect added Sepa payment strategy

### DIFF
--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-sepa-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-sepa-payment-strategy.spec.ts
@@ -1,0 +1,113 @@
+import {
+    OrderFinalizationNotRequiredError,
+    OrderRequestBody,
+    PaymentArgumentInvalidError,
+    PaymentIntegrationService,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BlueSnapDirectSepaPaymentStrategy from './bluesnap-direct-sepa-payment-strategy';
+
+describe('BlueSnapDirectSepaPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+    let strategy: BlueSnapDirectSepaPaymentStrategy;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+
+        strategy = new BlueSnapDirectSepaPaymentStrategy(paymentIntegrationService);
+    });
+
+    describe('#initialize()', () => {
+        it('initializes the strategy successfully', async () => {
+            const initialize = strategy.initialize();
+
+            await expect(initialize).resolves.toBeUndefined();
+        });
+    });
+
+    describe('#execute()', () => {
+        let payload: OrderRequestBody;
+
+        beforeEach(async () => {
+            payload = {
+                payment: {
+                    gatewayId: 'bluesnapdirect',
+                    methodId: 'sepa_direct_debit',
+                    paymentData: {
+                        iban: '223344556',
+                        firstName: 'John',
+                        lastName: 'Smith',
+                        shopperPermission: true,
+                    },
+                },
+            };
+
+            await strategy.initialize();
+        });
+
+        afterEach(() => {
+            (paymentIntegrationService.submitOrder as jest.Mock).mockClear();
+            (paymentIntegrationService.submitPayment as jest.Mock).mockClear();
+        });
+
+        it('executes the strategy successfully', async () => {
+            const execute = strategy.execute(payload);
+
+            await expect(execute).resolves.toBeUndefined();
+        });
+
+        it('should submit the order', async () => {
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitOrder).toHaveBeenCalled();
+        });
+
+        it('should submit the payment', async () => {
+            const expectedPayment = {
+                gatewayId: 'bluesnapdirect',
+                methodId: 'sepa_direct_debit',
+                paymentData: {
+                    formattedPayload: {
+                        sepa_direct_debit: {
+                            iban: '223344556',
+                            first_name: 'John',
+                            last_name: 'Smith',
+                            shopper_permission: true,
+                        },
+                    },
+                },
+            };
+
+            await strategy.execute(payload);
+
+            expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(expectedPayment);
+        });
+
+        describe('should fail if...', () => {
+            test('payload.payment is not en Sepa instrument', async () => {
+                const execute = () => strategy.execute({ ...payload, payment: undefined });
+
+                await expect(execute()).rejects.toThrow(PaymentArgumentInvalidError);
+                expect(paymentIntegrationService.submitOrder).not.toHaveBeenCalled();
+                expect(paymentIntegrationService.submitPayment).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('#finalize()', () => {
+        it('throws error to inform that order finalization is not required', async () => {
+            const finalize = strategy.finalize();
+
+            await expect(finalize).rejects.toThrow(OrderFinalizationNotRequiredError);
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        it('deinitializes the strategy successfully', async () => {
+            const deinitialize = strategy.deinitialize();
+
+            await expect(deinitialize).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/bluesnap-direct-integration/src/bluesnap-direct-sepa-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/bluesnap-direct-sepa-payment-strategy.ts
@@ -5,9 +5,9 @@ import {
     PaymentStrategy,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-import assertEcpInstrument from './is-bluesnap-direct-ecp-instrument';
+import assertSepaInstrument from './is-bluesnap-direct-sepa-instrument';
 
-export default class BlueSnapDirectEcpPaymentStrategy implements PaymentStrategy {
+export default class BlueSnapDirectSepaPaymentStrategy implements PaymentStrategy {
     constructor(private _paymentIntegrationService: PaymentIntegrationService) {}
 
     initialize(): Promise<void> {
@@ -15,18 +15,18 @@ export default class BlueSnapDirectEcpPaymentStrategy implements PaymentStrategy
     }
 
     async execute({ payment }: OrderRequestBody): Promise<void> {
-        assertEcpInstrument(payment?.paymentData);
+        assertSepaInstrument(payment?.paymentData);
 
         await this._paymentIntegrationService.submitOrder();
         await this._paymentIntegrationService.submitPayment({
             ...payment,
             paymentData: {
                 formattedPayload: {
-                    ecp: {
-                        account_number: payment.paymentData.accountNumber,
-                        account_type: payment.paymentData.accountType,
+                    sepa_direct_debit: {
+                        iban: payment.paymentData.iban,
+                        first_name: payment.paymentData.firstName,
+                        last_name: payment.paymentData.lastName,
                         shopper_permission: payment.paymentData.shopperPermission,
-                        routing_number: payment.paymentData.routingNumber,
                     },
                 },
             },

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-sepa-payment-strategy.spec.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-sepa-payment-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { PaymentIntegrationService } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import BlueSnapDirectSepaPaymentStrategy from './bluesnap-direct-sepa-payment-strategy';
+import createBlueSnapDirectSepaPaymentStrategy from './create-bluesnap-direct-sepa-payment-strategy';
+
+describe('createBlueSnapDirectSepaPaymentStrategy', () => {
+    let paymentIntegrationService: PaymentIntegrationService;
+
+    beforeEach(() => {
+        paymentIntegrationService = new PaymentIntegrationServiceMock();
+    });
+
+    it('initializes bluesnapdirect Sepa payment strategy', () => {
+        const strategy = createBlueSnapDirectSepaPaymentStrategy(paymentIntegrationService);
+
+        expect(strategy).toBeInstanceOf(BlueSnapDirectSepaPaymentStrategy);
+    });
+});

--- a/packages/bluesnap-direct-integration/src/create-bluesnap-direct-sepa-payment-strategy.ts
+++ b/packages/bluesnap-direct-integration/src/create-bluesnap-direct-sepa-payment-strategy.ts
@@ -1,0 +1,14 @@
+import {
+    PaymentStrategyFactory,
+    toResolvableModule,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+import BlueSnapDirectSepaPaymentStrategy from './bluesnap-direct-sepa-payment-strategy';
+
+const createBlueSnapDirectSepaPaymentStrategy: PaymentStrategyFactory<
+    BlueSnapDirectSepaPaymentStrategy
+> = (paymentIntegrationService) => new BlueSnapDirectSepaPaymentStrategy(paymentIntegrationService);
+
+export default toResolvableModule(createBlueSnapDirectSepaPaymentStrategy, [
+    { id: 'sepa_direct_debit', gateway: 'bluesnapdirect' },
+]);

--- a/packages/bluesnap-direct-integration/src/index.ts
+++ b/packages/bluesnap-direct-integration/src/index.ts
@@ -1,6 +1,7 @@
 export { default as createBlueSnapDirectCreditCardPaymentStrategy } from './create-bluesnap-direct-credit-card-payment-strategy';
 export { default as createBlueSnapDirectEcpPaymentStrategy } from './create-bluesnap-direct-ecp-payment-strategy';
 export { default as createBlueSnapDirectAPMPaymentStrategy } from './create-bluesnap-direct-apm-payment-strategy';
+export { default as createBlueSnapDirectSepaPaymentStrategy } from './create-bluesnap-direct-sepa-payment-strategy';
 export {
     BlueSnapDirectAPMInitializeOptions,
     WithBlueSnapDirectAPMPaymentInitializeOptions,

--- a/packages/bluesnap-direct-integration/src/is-bluesnap-direct-ecp-instrument.ts
+++ b/packages/bluesnap-direct-integration/src/is-bluesnap-direct-ecp-instrument.ts
@@ -1,28 +1,21 @@
 import {
-    BlueSnapDirectEcpInstrument,
-    OrderPaymentRequestBody,
+    EcpInstrument,
     PaymentArgumentInvalidError,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-function isBlueSnapDirectEcpInstrument(
-    data: OrderPaymentRequestBody['paymentData'],
-): data is BlueSnapDirectEcpInstrument {
-    if (data === undefined) {
-        return false;
-    }
-
-    return (
-        'accountNumber' in data &&
-        'accountType' in data &&
-        'shopperPermission' in data &&
-        'routingNumber' in data
+function isEcpInstrument(data: unknown): data is EcpInstrument {
+    return Boolean(
+        typeof data === 'object' &&
+            data !== null &&
+            'accountNumber' in data &&
+            'accountType' in data &&
+            'shopperPermission' in data &&
+            'routingNumber' in data,
     );
 }
 
-export default function assertBlueSnapDirectEcpInstrument(
-    data: OrderPaymentRequestBody['paymentData'],
-): asserts data is BlueSnapDirectEcpInstrument {
-    if (!isBlueSnapDirectEcpInstrument(data)) {
+export default function assertEcpInstrument(data: unknown): asserts data is EcpInstrument {
+    if (!isEcpInstrument(data)) {
         throw new PaymentArgumentInvalidError();
     }
 }

--- a/packages/bluesnap-direct-integration/src/is-bluesnap-direct-sepa-instrument.ts
+++ b/packages/bluesnap-direct-integration/src/is-bluesnap-direct-sepa-instrument.ts
@@ -1,0 +1,23 @@
+import {
+    PaymentArgumentInvalidError,
+    SepaInstrument,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+function isSepaInstrument(paymentData: unknown): paymentData is SepaInstrument {
+    return Boolean(
+        typeof paymentData === 'object' &&
+            paymentData !== null &&
+            'iban' in paymentData &&
+            'firstName' in paymentData &&
+            'lastName' in paymentData &&
+            'shopperPermission' in paymentData,
+    );
+}
+
+export default function assertSepaInstrument(
+    paymentData: unknown,
+): asserts paymentData is SepaInstrument {
+    if (!isSepaInstrument(paymentData)) {
+        throw new PaymentArgumentInvalidError();
+    }
+}

--- a/packages/core/src/order/order-request-body.ts
+++ b/packages/core/src/order/order-request-body.ts
@@ -1,5 +1,6 @@
 import {
-    BlueSnapDirectEcpInstrument,
+    EcpInstrument,
+    SepaInstrument,
     WithAccountCreation,
     WithBankAccountInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -40,13 +41,14 @@ export default interface OrderRequestBody {
 
 export type OrderPaymentInstrument =
     | WithBankAccountInstrument
+    | EcpInstrument
+    | SepaInstrument
     | CreditCardInstrument
     | HostedInstrument
     | HostedCreditCardInstrument
     | HostedVaultedInstrument
     | NonceInstrument
     | VaultedInstrument
-    | BlueSnapDirectEcpInstrument
     | (CreditCardInstrument & WithDocumentInstrument)
     | (CreditCardInstrument & WithCheckoutcomFawryInstrument)
     | (CreditCardInstrument & WithCheckoutcomSEPAInstrument)

--- a/packages/core/src/payment/payment.ts
+++ b/packages/core/src/payment/payment.ts
@@ -1,6 +1,8 @@
 import {
-    BlueSnapDirectEcpInstrument,
     BlueSnapDirectEcpPayload,
+    BlueSnapDirectSepaPayload,
+    EcpInstrument,
+    SepaInstrument,
     WithAccountCreation,
     WithBankAccountInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
@@ -18,7 +20,8 @@ export default interface Payment {
 }
 
 export type PaymentInstrument =
-    | BlueSnapDirectEcpInstrument
+    | EcpInstrument
+    | SepaInstrument
     | CreditCardInstrument
     | (CreditCardInstrument & WithHostedFormNonce)
     | (CreditCardInstrument & WithDocumentInstrument)
@@ -30,6 +33,7 @@ export type PaymentInstrument =
           | AdyenV2Instrument
           | AppleInstrument
           | BlueSnapDirectEcpPayload
+          | BlueSnapDirectSepaPayload
           | BoltInstrument
           | PaypalInstrument
           | FormattedHostedInstrument

--- a/packages/core/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-sepa-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/checkoutcom-custom/checkoutcom-sepa/checkoutcom-sepa-payment-strategy.ts
@@ -44,7 +44,8 @@ export default class CheckoutcomSEPAPaymentStrategy extends CheckoutcomCustomPay
         paymentData: PaymentInstrument,
     ): WithCheckoutcomSEPAInstrument {
         const formattedPayload: WithCheckoutcomSEPAInstrument = { iban: '', bic: '' };
-        const { iban, bic } = 'iban' in paymentData ? paymentData : formattedPayload;
+        const { iban, bic } =
+            'iban' in paymentData && 'bic' in paymentData ? paymentData : formattedPayload;
 
         if (methodId === CHECKOUTCOM_SEPA_PAYMENT_METHOD && document) {
             formattedPayload.iban = iban;

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -110,8 +110,10 @@ export {
     SubmitOrderAction,
 } from './order';
 export {
-    BlueSnapDirectEcpInstrument,
+    EcpInstrument,
     BlueSnapDirectEcpPayload,
+    SepaInstrument,
+    BlueSnapDirectSepaPayload,
     CardInstrument,
     CreditCardInstrument,
     WithBankAccountInstrument,

--- a/packages/payment-integration-api/src/order/order-request-body.ts
+++ b/packages/payment-integration-api/src/order/order-request-body.ts
@@ -1,10 +1,11 @@
 import {
-    BlueSnapDirectEcpInstrument,
     CreditCardInstrument,
+    EcpInstrument,
     HostedCreditCardInstrument,
     HostedInstrument,
     HostedVaultedInstrument,
     NonceInstrument,
+    SepaInstrument,
     VaultedInstrument,
     WithAccountCreation,
     WithBankAccountInstrument,
@@ -62,7 +63,8 @@ export interface OrderPaymentRequestBody {
         | HostedVaultedInstrument
         | NonceInstrument
         | VaultedInstrument
-        | BlueSnapDirectEcpInstrument
+        | EcpInstrument
+        | SepaInstrument
         | (CreditCardInstrument & WithDocumentInstrument)
         | (CreditCardInstrument & WithCheckoutcomFawryInstrument)
         | (CreditCardInstrument & WithCheckoutcomSEPAInstrument)

--- a/packages/payment-integration-api/src/payment/index.ts
+++ b/packages/payment-integration-api/src/payment/index.ts
@@ -3,8 +3,10 @@ export { AccountInstrument, CardInstrument } from './instrument';
 
 export {
     default as Payment,
-    BlueSnapDirectEcpInstrument,
+    EcpInstrument,
     BlueSnapDirectEcpPayload,
+    SepaInstrument,
+    BlueSnapDirectSepaPayload,
     CreditCardInstrument,
     WithBankAccountInstrument,
     WithCheckoutcomiDealInstrument,

--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -11,7 +11,8 @@ export default interface Payment {
 }
 
 export type PaymentInstrument =
-    | BlueSnapDirectEcpInstrument
+    | EcpInstrument
+    | SepaInstrument
     | CreditCardInstrument
     | (CreditCardInstrument & WithHostedFormNonce)
     | (CreditCardInstrument & WithDocumentInstrument)
@@ -24,6 +25,7 @@ export type PaymentInstrument =
           | AppleInstrument
           | BlueSnapDirectCreditCardInstrument
           | BlueSnapDirectEcpPayload
+          | BlueSnapDirectSepaPayload
           | BoltInstrument
           | PaypalInstrument
           | FormattedHostedInstrument
@@ -77,7 +79,7 @@ export interface WithBankAccountInstrument {
     accountNumber: string;
     routingNumber: string;
     ownershipType: 'Personal' | 'Business';
-    accountType: BankAccountType | BlueSnapDirectEcpAccountType;
+    accountType: BankAccountType | EcpAccountType;
     firstName?: string;
     lastName?: string;
     businessName?: string;
@@ -238,15 +240,15 @@ interface BlueSnapDirectCreditCardInstrument {
     };
 }
 
-type BlueSnapDirectEcpAccountType =
+type EcpAccountType =
     | 'CONSUMER_CHECKING'
     | 'CONSUMER_SAVINGS'
     | 'CORPORATE_CHECKING'
     | 'CORPORATE_SAVINGS';
 
-export interface BlueSnapDirectEcpInstrument {
+export interface EcpInstrument {
     accountNumber: string;
-    accountType: BankAccountType | BlueSnapDirectEcpAccountType;
+    accountType: BankAccountType | EcpAccountType;
     shopperPermission: boolean;
     routingNumber: string;
 }
@@ -254,9 +256,25 @@ export interface BlueSnapDirectEcpInstrument {
 export interface BlueSnapDirectEcpPayload {
     ecp: {
         account_number: string;
-        account_type: BlueSnapDirectEcpAccountType | BankAccountType;
+        account_type: EcpAccountType | BankAccountType;
         shopper_permission: boolean;
         routing_number: string;
+    };
+}
+
+export interface SepaInstrument {
+    firstName: string;
+    lastName: string;
+    iban: string;
+    shopperPermission: boolean;
+}
+
+export interface BlueSnapDirectSepaPayload {
+    sepa_direct_debit: {
+        first_name: string;
+        last_name: string;
+        shopper_permission: boolean;
+        iban: string;
     };
 }
 


### PR DESCRIPTION
## What?
 BluesnapDirect SEPA implemantation
https://github.com/bigcommerce/checkout-js/pull/1545
## Why?
Due the Bluesnap requirement

## Testing / Proof
![image](https://github.com/bigcommerce/checkout-js/assets/79574476/550e7c49-f245-47ff-b089-7740d9077908)


@bigcommerce/team-checkout @bigcommerce/team-payments
