### PR TITLE
feat(payment): CHECKOUT-7901 Add method to load button payment method config in parallel

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -76,11 +76,14 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         this._onAuthorizeCallback = onPaymentAuthorize;
         this._onError = onError;
 
-        await this._paymentIntegrationService.loadPaymentMethod(methodId);
+        let state = this._paymentIntegrationService.getState();
 
-        const state = this._paymentIntegrationService.getState();
-
-        this._paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        try {
+            this._paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        } catch (_e) {
+            state = await this._paymentIntegrationService.loadPaymentMethod(methodId);
+            this._paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        }
 
         await this._paymentIntegrationService.verifyCheckoutSpamProtection();
 

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
@@ -25,7 +25,10 @@ import {
     PaymentIntegrationService,
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+import {
+    getConfig,
+    PaymentIntegrationServiceMock,
+} from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
 import { getPaypalSDKMock } from '../mocks/paypal.mock';
 
@@ -343,6 +346,18 @@ describe('BraintreePaypalCustomerStrategy', () => {
         });
 
         it('loads checkout details when customer is ready to pay', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockImplementation(() => {
+                throw new Error();
+            });
+
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValueOnce({
+                getPaymentMethodOrThrow: jest.fn().mockReturnValue(paymentMethodMock),
+                getStoreConfigOrThrow: jest.fn().mockReturnValue(getConfig().storeConfig),
+                getCartOrThrow: jest.fn().mockReturnValue({ currency: { code: 'AUD' } }),
+            });
             await strategy.initialize(initializationOptions);
 
             eventEmitter.emit('createOrder');

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -62,7 +62,11 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
             );
         }
 
+        console.log('going to init: SDK load method', methodId);
+
         await this.paymentIntegrationService.loadPaymentMethod(methodId);
+
+        console.log('going to init: SDK load method finished', methodId);
 
         const state = this.paymentIntegrationService.getState();
         const storeConfig = state.getStoreConfigOrThrow();

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -64,14 +64,20 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
 
         console.log('going to init: SDK load method', methodId);
 
+        let state = this.paymentIntegrationService.getState();
         // await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        let paymentMethod: PaymentMethod<BraintreeInitializationData>;
+
+        try {
+            paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        } catch (_e) {
+            state = await this.paymentIntegrationService.loadPaymentMethod(methodId);
+            paymentMethod = state.getPaymentMethodOrThrow(methodId);
+        }
 
         console.log('going to init: SDK load method finishe', methodId);
 
-        const state = this.paymentIntegrationService.getState();
         const storeConfig = state.getStoreConfigOrThrow();
-        const paymentMethod: PaymentMethod<BraintreeInitializationData> =
-            state.getPaymentMethodOrThrow(methodId);
 
         const { clientToken, config, initializationData } = paymentMethod;
 

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -62,10 +62,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
             );
         }
 
-        console.log('going to init: SDK load method', methodId);
-
         let state = this.paymentIntegrationService.getState();
-        // await this.paymentIntegrationService.loadPaymentMethod(methodId);
         let paymentMethod: PaymentMethod<BraintreeInitializationData>;
 
         try {
@@ -74,8 +71,6 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
             state = await this.paymentIntegrationService.loadPaymentMethod(methodId);
             paymentMethod = state.getPaymentMethodOrThrow(methodId);
         }
-
-        console.log('going to init: SDK load method finishe', methodId);
 
         const storeConfig = state.getStoreConfigOrThrow();
 

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -64,9 +64,9 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
 
         console.log('going to init: SDK load method', methodId);
 
-        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        // await this.paymentIntegrationService.loadPaymentMethod(methodId);
 
-        console.log('going to init: SDK load method finished', methodId);
+        console.log('going to init: SDK load method finishe', methodId);
 
         const state = this.paymentIntegrationService.getState();
         const storeConfig = state.getStoreConfigOrThrow();

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -366,6 +366,25 @@ export default class CheckoutService {
         return this._dispatch(action, { queueId: 'paymentMethods' });
     }
 
+    /**
+     * Loads a list of payment methods for given ids.
+     *
+     *
+     * Once the method is executed successfully, you can call
+     * `CheckoutStoreSelector#getPaymentMethods` to retrieve the list of payment
+     * methods.
+     *
+     * ```js
+     * const state = service.loadPaymentMethodsById(['applepay']);
+     *
+     * console.log(state.data.getPaymentMethodOrThrow('applepay'));
+     * ```
+     *
+     * @param methodIds - The identifier for the payment methods to load.
+     * @param options - Options for loading the payment methods that are
+     * available to the current customer.
+     * @returns A promise that resolves to the current state.
+     */
     loadPaymentMethodByIds(
         methodIds: string[],
         options?: RequestOptions,

--- a/packages/core/src/checkout/checkout-service.ts
+++ b/packages/core/src/checkout/checkout-service.ts
@@ -366,6 +366,15 @@ export default class CheckoutService {
         return this._dispatch(action, { queueId: 'paymentMethods' });
     }
 
+    loadPaymentMethodByIds(
+        methodIds: string[],
+        options?: RequestOptions,
+    ): Promise<CheckoutSelectors> {
+        const action = this._paymentMethodActionCreator.loadPaymentMethodsById(methodIds, options);
+
+        return this._dispatch(action, { queueId: 'paymentMethods' });
+    }
+
     /**
      * Loads a payment method by an id.
      *

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -69,13 +69,15 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
             );
         }
 
-        console.log('going to init: SDK load method', methodId);
+        console.log('going to init: SDK load method', methodId, this._paymentMethodActionCreator);
 
         const state = await this._store.dispatch(
-            this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+            this._paymentMethodActionCreator.loadPaymentMethod(methodId, { useCache: true }),
         );
 
         console.log('going to init: SDK load method finished', methodId);
+
+        // const state = this._store.getState();
 
         const storeConfig = state.config.getStoreConfigOrThrow();
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -69,9 +69,14 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
             );
         }
 
+        console.log('going to init: SDK load method', methodId);
+
         const state = await this._store.dispatch(
             this._paymentMethodActionCreator.loadPaymentMethod(methodId),
         );
+
+        console.log('going to init: SDK load method finished', methodId);
+
         const storeConfig = state.config.getStoreConfigOrThrow();
         const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         const { clientToken, initializationData } = paymentMethod;

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -1,6 +1,9 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 
-import { DefaultCheckoutButtonHeight } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import {
+    DefaultCheckoutButtonHeight,
+    PaymentMethod,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { CheckoutActionCreator, CheckoutStore, InternalCheckoutSelectors } from '../../../checkout';
 import mapToLegacyBillingAddress from '../../../checkout-buttons/strategies/braintree/map-to-legacy-billing-address';
@@ -69,18 +72,19 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
             );
         }
 
-        console.log('going to init: SDK load method', methodId, this._paymentMethodActionCreator);
+        let state = this._store.getState();
+        let paymentMethod: PaymentMethod<any>;
 
-        const state = await this._store.dispatch(
-            this._paymentMethodActionCreator.loadPaymentMethod(methodId, { useCache: true }),
-        );
-
-        console.log('going to init: SDK load method finished', methodId);
-
-        // const state = this._store.getState();
+        try {
+            paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        } catch (_e) {
+            state = await this._store.dispatch(
+                this._paymentMethodActionCreator.loadPaymentMethod(methodId),
+            );
+            paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
+        }
 
         const storeConfig = state.config.getStoreConfigOrThrow();
-        const paymentMethod = state.paymentMethods.getPaymentMethodOrThrow(methodId);
         const { clientToken, initializationData } = paymentMethod;
 
         if (!clientToken || !initializationData) {

--- a/packages/core/src/payment/payment-method-action-creator.spec.ts
+++ b/packages/core/src/payment/payment-method-action-creator.spec.ts
@@ -244,7 +244,7 @@ describe('PaymentMethodActionCreator', () => {
             ]);
         });
 
-        it('emits error actions if unable to load payment method', async () => {
+        it('if call fails no methods are returned', async () => {
             jest.spyOn(paymentMethodRequestSender, 'loadPaymentMethod').mockReturnValue(
                 Promise.reject(errorResponse),
             );
@@ -257,13 +257,11 @@ describe('PaymentMethodActionCreator', () => {
                 .pipe(catchError(errorHandler), toArray())
                 .toPromise();
 
-            expect(errorHandler).toHaveBeenCalled();
             expect(actions).toEqual([
                 { type: PaymentMethodActionType.LoadPaymentMethodsRequested },
                 {
-                    type: PaymentMethodActionType.LoadPaymentMethodsFailed,
-                    payload: errorResponse,
-                    error: true,
+                    type: PaymentMethodActionType.LoadPaymentMethodsSucceeded,
+                    payload: [],
                 },
             ]);
         });

--- a/packages/core/src/payment/payment-method-action-creator.ts
+++ b/packages/core/src/payment/payment-method-action-creator.ts
@@ -9,7 +9,6 @@ import { RequestOptions } from '../common/http-request';
 import {
     LoadPaymentMethodAction,
     LoadPaymentMethodsAction,
-    LoadPaymentMethodsByIdsAction,
     PaymentMethodActionType,
 } from './payment-method-actions';
 import PaymentMethodRequestSender from './payment-method-request-sender';
@@ -25,17 +24,14 @@ export default class PaymentMethodActionCreator {
     loadPaymentMethodsById(
         methodIds: string[],
         options?: RequestOptions,
-    ): ThunkAction<LoadPaymentMethodsByIdsAction, InternalCheckoutSelectors> {
+    ): ThunkAction<LoadPaymentMethodsAction, InternalCheckoutSelectors> {
         return (store) =>
-            new Observable((observer: Observer<LoadPaymentMethodsByIdsAction>) => {
+            new Observable((observer: Observer<LoadPaymentMethodsAction>) => {
                 const state = store.getState();
                 const cartId = state.cart.getCart()?.id;
                 const params = cartId ? { ...options?.params, cartId } : { ...options?.params };
 
-                observer.next(
-                    createAction(PaymentMethodActionType.LoadPaymentMethodsByIdsRequested),
-                );
-
+                observer.next(createAction(PaymentMethodActionType.LoadPaymentMethodsRequested));
                 Promise.all(
                     methodIds.map(async (id) => {
                         const response = await this._requestSender.loadPaymentMethod(id, {
@@ -49,7 +45,7 @@ export default class PaymentMethodActionCreator {
                     .then((response) => {
                         observer.next(
                             createAction(
-                                PaymentMethodActionType.LoadPaymentMethodsByIdsSucceeded,
+                                PaymentMethodActionType.LoadPaymentMethodsSucceeded,
                                 response,
                             ),
                         );
@@ -58,7 +54,7 @@ export default class PaymentMethodActionCreator {
                     .catch((response) => {
                         observer.error(
                             createErrorAction(
-                                PaymentMethodActionType.LoadPaymentMethodsByIdsFailed,
+                                PaymentMethodActionType.LoadPaymentMethodsFailed,
                                 response,
                             ),
                         );

--- a/packages/core/src/payment/payment-method-actions.ts
+++ b/packages/core/src/payment/payment-method-actions.ts
@@ -11,10 +11,6 @@ export enum PaymentMethodActionType {
     LoadPaymentMethodsRequested = 'LOAD_PAYMENT_METHODS_REQUESTED',
     LoadPaymentMethodsSucceeded = 'LOAD_PAYMENT_METHODS_SUCCEEDED',
     LoadPaymentMethodsFailed = 'LOAD_PAYMENT_METHODS_FAILED',
-
-    LoadPaymentMethodsByIdsRequested = 'LOAD_PAYMENT_METHODS_BY_IDS_REQUESTED',
-    LoadPaymentMethodsByIdsSucceeded = 'LOAD_PAYMENT_METHODS_BY_IDS_SUCCEEDED',
-    LoadPaymentMethodsByIdsFailed = 'LOAD_PAYMENT_METHODS_BY_IDS_FAILED',
 }
 
 export type PaymentMethodAction = LoadPaymentMethodAction | LoadPaymentMethodsAction;
@@ -28,11 +24,6 @@ export type LoadPaymentMethodsAction =
     | LoadPaymentMethodsRequestedAction
     | LoadPaymentMethodsSucceededAction
     | LoadPaymentMethodsFailedAction;
-
-export type LoadPaymentMethodsByIdsAction =
-    | LoadPaymentMethodsByIdsRequestedAction
-    | LoadPaymentMethodsByIdsSucceededAction
-    | LoadPaymentMethodsByIdsFailedAction;
 
 export interface LoadPaymentMethodRequestedAction extends Action {
     type: PaymentMethodActionType.LoadPaymentMethodRequested;
@@ -57,17 +48,4 @@ export interface LoadPaymentMethodsSucceededAction
 
 export interface LoadPaymentMethodsFailedAction extends Action<Error> {
     type: PaymentMethodActionType.LoadPaymentMethodsFailed;
-}
-
-export interface LoadPaymentMethodsByIdsRequestedAction extends Action {
-    type: PaymentMethodActionType.LoadPaymentMethodsByIdsRequested;
-}
-
-export interface LoadPaymentMethodsByIdsSucceededAction
-    extends Action<PaymentMethod[], PaymentMethodMeta> {
-    type: PaymentMethodActionType.LoadPaymentMethodsByIdsSucceeded;
-}
-
-export interface LoadPaymentMethodsByIdsFailedAction extends Action<Error> {
-    type: PaymentMethodActionType.LoadPaymentMethodsByIdsFailed;
 }

--- a/packages/core/src/payment/payment-method-actions.ts
+++ b/packages/core/src/payment/payment-method-actions.ts
@@ -11,6 +11,10 @@ export enum PaymentMethodActionType {
     LoadPaymentMethodsRequested = 'LOAD_PAYMENT_METHODS_REQUESTED',
     LoadPaymentMethodsSucceeded = 'LOAD_PAYMENT_METHODS_SUCCEEDED',
     LoadPaymentMethodsFailed = 'LOAD_PAYMENT_METHODS_FAILED',
+
+    LoadPaymentMethodsByIdsRequested = 'LOAD_PAYMENT_METHODS_BY_IDS_REQUESTED',
+    LoadPaymentMethodsByIdsSucceeded = 'LOAD_PAYMENT_METHODS_BY_IDS_SUCCEEDED',
+    LoadPaymentMethodsByIdsFailed = 'LOAD_PAYMENT_METHODS_BY_IDS_FAILED',
 }
 
 export type PaymentMethodAction = LoadPaymentMethodAction | LoadPaymentMethodsAction;
@@ -24,6 +28,11 @@ export type LoadPaymentMethodsAction =
     | LoadPaymentMethodsRequestedAction
     | LoadPaymentMethodsSucceededAction
     | LoadPaymentMethodsFailedAction;
+
+export type LoadPaymentMethodsByIdsAction =
+    | LoadPaymentMethodsByIdsRequestedAction
+    | LoadPaymentMethodsByIdsSucceededAction
+    | LoadPaymentMethodsByIdsFailedAction;
 
 export interface LoadPaymentMethodRequestedAction extends Action {
     type: PaymentMethodActionType.LoadPaymentMethodRequested;
@@ -48,4 +57,17 @@ export interface LoadPaymentMethodsSucceededAction
 
 export interface LoadPaymentMethodsFailedAction extends Action<Error> {
     type: PaymentMethodActionType.LoadPaymentMethodsFailed;
+}
+
+export interface LoadPaymentMethodsByIdsRequestedAction extends Action {
+    type: PaymentMethodActionType.LoadPaymentMethodsByIdsRequested;
+}
+
+export interface LoadPaymentMethodsByIdsSucceededAction
+    extends Action<PaymentMethod[], PaymentMethodMeta> {
+    type: PaymentMethodActionType.LoadPaymentMethodsByIdsSucceeded;
+}
+
+export interface LoadPaymentMethodsByIdsFailedAction extends Action<Error> {
+    type: PaymentMethodActionType.LoadPaymentMethodsByIdsFailed;
 }

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
@@ -66,6 +66,17 @@ describe('GooglePayCustomerStrategy', () => {
         });
 
         it('should call loadPaymentMethod', async () => {
+            jest.spyOn(
+                paymentIntegrationService.getState(),
+                'getPaymentMethodOrThrow',
+            ).mockImplementation(() => {
+                throw new Error();
+            });
+
+            jest.spyOn(paymentIntegrationService, 'loadPaymentMethod').mockResolvedValueOnce({
+                getPaymentMethodOrThrow: jest.fn().mockReturnValue(getGeneric()),
+            });
+
             await strategy.initialize(options);
 
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(

--- a/packages/payment-integration-api/src/payment-integration-service.ts
+++ b/packages/payment-integration-api/src/payment-integration-service.ts
@@ -34,7 +34,7 @@ export default interface PaymentIntegrationService {
 
     loadPaymentMethod(
         methodId: string,
-        options?: RequestOptions,
+        options?: RequestOptions & { useCache?: boolean },
     ): Promise<PaymentIntegrationSelectors>;
 
     loadCurrentOrder(options?: RequestOptions): Promise<PaymentIntegrationSelectors>;


### PR DESCRIPTION
## What?
- Add method to load button payment method config in parallel
- Refactor exisiting payment strategies to leverage pre-fetched configs

## Why?
Right now we have method to fetch button payment method config one at a time in sequence, which are blocking and cause a delay in rendering the buttons. 

Add a method to fetch button configs in parallel so buttons can be rendered quicker.

## Testing / Proof
- CI
- Manual
 
@bigcommerce/team-checkout @bigcommerce/team-payments
