### PR TITLE
feat(payment): PI-429 [Adyen] Improve FE validation for APMs on checkout

### DIFF
--- a/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.spec.ts
@@ -325,6 +325,37 @@ describe('AdyenV2PaymentStrategy', () => {
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(0);
             });
 
+            it('throws an error when a card field is empty', async () => {
+                const adyenInvalidPaymentComponent = {
+                    mount: jest.fn(),
+                    unmount: jest.fn(),
+                    componentRef: {
+                        showValidation: jest.fn(),
+                    },
+                    state: {
+                        data: { 'sepa.ownerName': '' },
+                    },
+                    props: {
+                        type: 'card',
+                    },
+                };
+
+                jest.spyOn(adyenCheckout, 'create').mockReturnValueOnce(
+                    adyenInvalidPaymentComponent,
+                );
+
+                await strategy.initialize(options);
+
+                await expect(strategy.execute(getOrderRequestBody())).rejects.toThrow(
+                    PaymentInvalidFormError,
+                );
+                expect(
+                    adyenInvalidPaymentComponent.componentRef.showValidation,
+                ).toHaveBeenCalledTimes(1);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(0);
+            });
+
             it('calls submitPayment when paying with vaulted instrument', async () => {
                 jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
                     submitPaymentAction,

--- a/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.ts
+++ b/packages/adyen-integration/src/adyenv2/adyenv2-payment-strategy.ts
@@ -387,6 +387,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
                         .getState()
                         .getBillingAddress();
                     const { prefillCardHolderName } = paymentMethod.initializationData;
+
                     paymentComponent = adyenClient.create(paymentMethod.method, {
                         ...adyenv2.options,
                         onChange: (componentState) => this._updateComponentState(componentState),
@@ -496,6 +497,7 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
         const cardComponent = adyenv2.hasVaultedInstruments
             ? this._cardVerificationComponent
             : this._paymentComponent;
+        const isEmptyString = (value: string) => value.toString().trim().length === 0;
 
         if (!cardComponent?.componentRef?.showValidation || !cardComponent.state) {
             return;
@@ -509,7 +511,8 @@ export default class AdyenV2PaymentStrategy implements PaymentStrategy {
          */
         if (
             Object.keys(cardComponent.state).length === 0 ||
-            (!cardComponent.state.isValid && !cardComponent.state.issuer)
+            (!cardComponent.state.isValid && !cardComponent.state.issuer) ||
+            Object.values(cardComponent.state.data).some(isEmptyString)
         ) {
             throw new PaymentInvalidFormError(this._mapCardErrors(cardComponent.state.errors));
         }

--- a/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
+++ b/packages/adyen-integration/src/adyenv3/adyenv3-payment-strategy.spec.ts
@@ -236,6 +236,35 @@ describe('AdyenV3PaymentStrategy', () => {
                 expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(0);
             });
 
+            it('throws an error when card field is empty', async () => {
+                const adyenInvalidPaymentComponent = {
+                    mount: jest.fn(),
+                    unmount: jest.fn(),
+                    componentRef: {
+                        showValidation: jest.fn(),
+                    },
+                    state: {
+                        data: { 'sepa.ownerName': '' },
+                    },
+                    props: {
+                        type: 'card',
+                    },
+                };
+
+                jest.spyOn(adyenCheckout, 'create').mockReturnValue(adyenInvalidPaymentComponent);
+
+                await strategy.initialize(options);
+
+                await expect(strategy.execute(getOrderRequestBody())).rejects.toThrow(
+                    PaymentInvalidFormError,
+                );
+                expect(
+                    adyenInvalidPaymentComponent.componentRef.showValidation,
+                ).toHaveBeenCalledTimes(1);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledTimes(0);
+            });
+
             it('calls submitPayment when paying with vaulted instrument', async () => {
                 jest.spyOn(paymentIntegrationService, 'submitPayment').mockReturnValueOnce(
                     submitPaymentAction,


### PR DESCRIPTION
## What?
FE validation of Blik and SEPA Direct Debit APM’s allow to trigger /payment request when empty strings are provided, so I added a check for empty values.

## Testing / Proof
before:
![image](https://github.com/bigcommerce/checkout-sdk-js/assets/130754705/bb783078-5943-400e-9dd6-fdcc56f7e6a7)

now:
<img width="1506" alt="Screenshot 2023-11-22 at 13 16 34" src="https://github.com/bigcommerce/checkout-sdk-js/assets/130754705/fa8152be-f052-438c-a2c8-7d41e0e8c380">
