### PR TITLE
feat(payment): PI-633 add square v2 to supported payment instruments

### DIFF
--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -145,6 +145,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'worldpayaccess',
         method: 'credit_card',
     },
+    squarev2: {
+        provider: 'squarev2',
+        method: 'credit_card',
+    },
 };
 
 export default supportedInstruments;


### PR DESCRIPTION
## What?
Added square v2 to supported payment instruments. Updated `submitPayment` payload for paying with stored card.

## Why?
As a part of Square v2 stored credit cards functionality.

## Testing / Proof
Unit tests + manual tests.

@bigcommerce/team-checkout @bigcommerce/team-payments
