### PR TITLE
feat(payment): PAYPAL-3280 added inputDateFormat for date input

### DIFF
--- a/packages/core/src/form/form-field.ts
+++ b/packages/core/src/form/form-field.ts
@@ -32,6 +32,7 @@ export default interface FormField {
     secret?: boolean;
     min?: string | number;
     max?: string | number;
+    inputDateFormat?: string;
     options?: FormFieldOptions;
     requirements?: CustomerPasswordRequirements;
 }

--- a/packages/payment-integration-api/src/form/form-fields.ts
+++ b/packages/payment-integration-api/src/form/form-fields.ts
@@ -32,6 +32,7 @@ export default interface FormField {
     secret?: boolean;
     min?: string | number;
     max?: string | number;
+    inputDateFormat?: string;
     options?: FormFieldOptions;
     requirements?: CustomerPasswordRequirements;
 }


### PR DESCRIPTION
## What?

Added `inputDateFormat` for date input 

## Why?

To be able to set appropriate date format for Date Picker

@bigcommerce/team-checkout @bigcommerce/team-payments
