### PR TITLE
feat(payment): PAYPAL-3229 added onClick callback to ApplePayCustomerStrategy

### DIFF
--- a/packages/apple-pay-integration/src/apple-pay-customer-initialize-options.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-initialize-options.ts
@@ -33,6 +33,11 @@ export default interface ApplePayCustomerInitializeOptions {
      * @param error - The error object describing the failure.
      */
     onError?(error?: Error): void;
+
+    /**
+     * A callback that gets called when wallet button clicked
+     */
+    onClick?(): void;
 }
 
 export interface WithApplePayCustomerInitializeOptions {

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.spec.ts
@@ -221,6 +221,31 @@ describe('ApplePayCustomerStrategy', () => {
             }
         });
 
+        it('triggers onClick callback provided through initialization options', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getCartOrThrow').mockReturnValue(
+                getCart(),
+            );
+
+            const customerInitializeOptions = getApplePayCustomerInitializationOptions();
+
+            await strategy.initialize(customerInitializeOptions);
+
+            if (customerInitializeOptions.applepay) {
+                jest.spyOn(customerInitializeOptions.applepay, 'onClick');
+
+                const buttonContainer = document.getElementById(
+                    customerInitializeOptions.applepay.container,
+                );
+                const button = buttonContainer?.firstChild as HTMLElement;
+
+                if (button) {
+                    button.click();
+
+                    expect(customerInitializeOptions.applepay.onClick).toHaveBeenCalled();
+                }
+            }
+        });
+
         it('throws error if merchant validation fails', async () => {
             jest.spyOn(requestSender, 'post').mockRejectedValue(false);
 

--- a/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
+++ b/packages/apple-pay-integration/src/apple-pay-customer-strategy.ts
@@ -42,6 +42,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
     private _applePayButton?: HTMLElement;
     private _onAuthorizeCallback = noop;
     private _onError = noop;
+    private _onClick = noop;
     private _subTotalLabel: string = DefaultLabels.Subtotal;
     private _shippingLabel: string = DefaultLabels.Shipping;
 
@@ -68,6 +69,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
             shippingLabel,
             subtotalLabel,
             onError = noop,
+            onClick = noop,
             onPaymentAuthorize,
         } = applepay;
 
@@ -75,6 +77,7 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
         this._subTotalLabel = subtotalLabel || DefaultLabels.Subtotal;
         this._onAuthorizeCallback = onPaymentAuthorize;
         this._onError = onError;
+        this._onClick = onClick;
 
         let state = this._paymentIntegrationService.getState();
 
@@ -135,6 +138,8 @@ export default class ApplePayCustomerStrategy implements CustomerStrategy {
 
     private _handleWalletButtonClick(event: Event) {
         event.preventDefault();
+
+        this._onClick();
 
         const state = this._paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();

--- a/packages/apple-pay-integration/src/mocks/apple-pay-wallet-button-mock.ts
+++ b/packages/apple-pay-integration/src/mocks/apple-pay-wallet-button-mock.ts
@@ -12,6 +12,7 @@ export function getApplePayCustomerInitializationOptions(): CustomerInitializeOp
             subtotalLabel: 'Subtotal',
             onPaymentAuthorize: jest.fn(),
             onError: jest.fn(),
+            onClick: jest.fn(),
         },
     };
 }


### PR DESCRIPTION
## What?
Added onClick callback to ApplePayCustomerStrategy

## Why?
To be able to track Apple Pay wallet button click event

## Testing / Proof
Unit tests
Manual tests


https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/47c6f326-c4ba-48b3-8554-7fdb0f2176a5


