### PR TITLE
feat(payment): PAYPAL-3229 added onClick callback for GooglePay customer strategies

### DIFF
--- a/packages/core/src/customer/strategies/googlepay/googlepay-adyenv2-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-adyenv2-customer-strategy.spec.ts
@@ -291,5 +291,15 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
         });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepayadyenv2?.onClick).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-authorizenet-customer-strategy.spec.ts
@@ -297,5 +297,15 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
         });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepayauthorizenet?.onClick).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-bnz-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-bnz-customer-strategy.spec.ts
@@ -256,6 +256,7 @@ describe('GooglePayCustomerStrategy', () => {
                 methodId: 'googlepaybnz',
                 googlepaybnz: {
                     container: 'googlePayCheckoutButton',
+                    onClick: jest.fn(),
                 },
             };
 
@@ -294,6 +295,16 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.displayWallet).toHaveBeenCalled();
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepaybnz?.onClick).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-braintree-customer-strategy.spec.ts
@@ -301,5 +301,15 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
         });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepaybraintree?.onClick).toHaveBeenCalled();
+        });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-checkoutcom-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-checkoutcom-customer-strategy.spec.ts
@@ -265,6 +265,7 @@ describe('GooglePayCustomerStrategy', () => {
                 methodId: 'googlepaycheckoutcom',
                 googlepaycheckoutcom: {
                     container: 'googlePayCheckoutButton',
+                    onClick: jest.fn(),
                 },
             };
 
@@ -303,6 +304,16 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.displayWallet).toHaveBeenCalled();
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepaycheckoutcom?.onClick).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-customer-initialize-options.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-customer-initialize-options.ts
@@ -22,4 +22,9 @@ export default interface GooglePayCustomerInitializeOptions {
      *  short: Google Pay payment button without the "Buy with" text.
      */
     buttonType?: ButtonType;
+
+    /**
+     * Callback that gets called on google pay button click
+     */
+    onClick?(): void;
 }

--- a/packages/core/src/customer/strategies/googlepay/googlepay-customer-mock.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-customer-mock.ts
@@ -26,7 +26,12 @@ export function getAdyenV2CustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayAdyenV2 = { googlepayadyenv2: { ...container } };
+    const googlepayAdyenV2 = {
+        googlepayadyenv2: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayAdyenV2WithInvalidContainer = { googlepayadyenv2: { ...invalidContainer } };
 
     switch (mode) {
@@ -55,7 +60,12 @@ export function getAdyenV3CustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayAdyenV3 = { googlepayadyenv3: { ...container } };
+    const googlepayAdyenV3 = {
+        googlepayadyenv3: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayAdyenV3WithInvalidContainer = { googlepayadyenv3: { ...invalidContainer } };
 
     switch (mode) {
@@ -84,7 +94,12 @@ export function getAuthNetCustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayAuthNet = { googlepayauthorizenet: { ...container } };
+    const googlepayAuthNet = {
+        googlepayauthorizenet: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayAuthNetWithInvalidContainer = { googlepayauthorizenet: { ...invalidContainer } };
 
     switch (mode) {
@@ -107,7 +122,12 @@ export function getBNZCustomerInitializeOptions(mode: Mode = Mode.Full): Custome
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayBNZ = { googlepaybnz: { ...container } };
+    const googlepayBNZ = {
+        googlepaybnz: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayBNZWithInvalidContainer = { googlepaybnz: { ...invalidContainer } };
 
     switch (mode) {
@@ -132,7 +152,12 @@ export function getBraintreeCustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayBraintree = { googlepaybraintree: { ...container } };
+    const googlepayBraintree = {
+        googlepaybraintree: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayBraintreeWithInvalidContainer = { googlepaybraintree: { ...invalidContainer } };
 
     switch (mode) {
@@ -161,7 +186,12 @@ export function getCheckoutcomCustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayCheckoutcom = { googlepaycheckoutcom: { ...container } };
+    const googlepayCheckoutcom = {
+        googlepaycheckoutcom: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayCheckoutcomWithInvalidContainer = {
         googlepaycheckoutcom: { ...invalidContainer },
     };
@@ -188,7 +218,12 @@ export function getCybersourceV2CustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayCybersourceV2 = { googlepaycybersourcev2: { ...container } };
+    const googlepayCybersourceV2 = {
+        googlepaycybersourcev2: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayCyberSourceV2WithInvalidContainer = {
         googlepaycybersourcev2: { ...invalidContainer },
     };
@@ -215,7 +250,12 @@ export function getOrbitalCustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayOrbital = { googlepayorbital: { ...container } };
+    const googlepayOrbital = {
+        googlepayorbital: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayOrbitalWithInvalidContainer = { googlepayorbital: { ...invalidContainer } };
 
     switch (mode) {
@@ -240,7 +280,12 @@ export function getStripeCustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayStripe = { googlepaystripe: { ...container } };
+    const googlepayStripe = {
+        googlepaystripe: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayStripeWithInvalidContainer = { googlepaystripe: { ...invalidContainer } };
 
     switch (mode) {
@@ -269,7 +314,12 @@ export function getStripeUPECustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayStripeUPE = { googlepaystripeupe: { ...container } };
+    const googlepayStripeUPE = {
+        googlepaystripeupe: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayStripeUPEWithInvalidContainer = { googlepaystripeupe: { ...invalidContainer } };
 
     switch (mode) {
@@ -298,7 +348,12 @@ export function getWorldpayAccessCustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const googlepayWorldpayAccess = { googlepayworldpayaccess: { ...container } };
+    const googlepayWorldpayAccess = {
+        googlepayworldpayaccess: {
+            ...container,
+            onClick: jest.fn(),
+        },
+    };
     const googlepayWorldpayAccessWithInvalidContainer = {
         googlepayworldpayaccess: { ...invalidContainer },
     };

--- a/packages/core/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-customer-strategy.ts
@@ -24,6 +24,7 @@ import { default as MethodType } from './googlepay-customer-method-type';
 
 export default class GooglePayCustomerStrategy implements CustomerStrategy {
     private _walletButton?: HTMLElement;
+    private _onClick?: () => void;
 
     constructor(
         private _store: CheckoutStore,
@@ -40,6 +41,8 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         if (!methodId) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
+
+        this._onClick = googlePayOptions.onClick;
 
         this._googlePayPaymentProcessor.updateShouldThrowInvalidError(false);
 
@@ -178,6 +181,10 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
     @bind
     private async _handleWalletButtonClick(event: Event): Promise<void> {
         event.preventDefault();
+
+        if (this._onClick && typeof this._onClick === 'function') {
+            this._onClick();
+        }
 
         const cart = this._store.getState().cart.getCartOrThrow();
         const hasPhysicalItems = getShippableItemsCount(cart) > 0;

--- a/packages/core/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-cybersourcev2-customer-strategy.spec.ts
@@ -265,6 +265,7 @@ describe('GooglePayCustomerStrategy', () => {
                 methodId: 'googlepaycybersourcev2',
                 googlepaycybersourcev2: {
                     container: 'googlePayCheckoutButton',
+                    onClick: jest.fn(),
                 },
             };
 
@@ -303,6 +304,16 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.displayWallet).toHaveBeenCalled();
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepaycybersourcev2?.onClick).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-orbital-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-orbital-customer-strategy.spec.ts
@@ -263,6 +263,7 @@ describe('GooglePayCustomerStrategy', () => {
                 methodId: 'googlepayorbital',
                 googlepayorbital: {
                     container: 'googlePayCheckoutButton',
+                    onClick: jest.fn(),
                 },
             };
 
@@ -301,6 +302,16 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.displayWallet).toHaveBeenCalled();
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepayorbital?.onClick).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-stripe-customer-strategy.spec.ts
@@ -260,6 +260,7 @@ describe('GooglePayCustomerStrategy', () => {
                 methodId: 'googlepaystripe',
                 googlepaystripe: {
                     container: 'googlePayCheckoutButton',
+                    onClick: jest.fn(),
                 },
             };
 
@@ -298,6 +299,16 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.displayWallet).toHaveBeenCalled();
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepaystripe?.onClick).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-stripe-upe-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-stripe-upe-customer-strategy.spec.ts
@@ -263,6 +263,7 @@ describe('GooglePayCustomerStrategy', () => {
                 methodId: 'googlepaystripeupe',
                 googlepaystripeupe: {
                     container: 'googlePayCheckoutButton',
+                    onClick: jest.fn(),
                 },
             };
 
@@ -301,6 +302,16 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.displayWallet).toHaveBeenCalled();
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepaystripeupe?.onClick).toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/customer/strategies/googlepay/googlepay-worldpayaccess-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/googlepay/googlepay-worldpayaccess-customer-strategy.spec.ts
@@ -265,6 +265,7 @@ describe('GooglePayCustomerStrategy', () => {
                 methodId: 'googlepayworldpayaccess',
                 googlepayworldpayaccess: {
                     container: 'googlePayCheckoutButton',
+                    onClick: jest.fn(),
                 },
             };
 
@@ -303,6 +304,16 @@ describe('GooglePayCustomerStrategy', () => {
             expect(paymentProcessor.displayWallet).toHaveBeenCalled();
             expect(paymentProcessor.handleSuccess).toHaveBeenCalledWith(googlePaymentDataMock);
             expect(paymentProcessor.updateShippingAddress).not.toHaveBeenCalled();
+        });
+
+        it('triggers onClick callback on wallet button click', async () => {
+            await strategy.initialize(customerInitializeOptions);
+
+            walletButton.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(customerInitializeOptions.googlepayworldpayaccess?.onClick).toHaveBeenCalled();
         });
     });
 });

--- a/packages/google-pay-integration/src/google-pay-customer-initialize-options.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-initialize-options.ts
@@ -37,6 +37,11 @@ export default interface GooglePayCustomerInitializeOptions {
      * @param error - The error object describing the failure.
      */
     onError?(error: Error): void;
+
+    /**
+     * Callback that get called on wallet button click
+     */
+    onClick?(): void;
 }
 
 /**

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.spec.ts
@@ -17,7 +17,7 @@ import GooglePayCustomerStrategy from './google-pay-customer-strategy';
 import GooglePayPaymentProcessor from './google-pay-payment-processor';
 import GooglePayScriptLoader from './google-pay-script-loader';
 import { getGeneric } from './mocks/google-pay-payment-method.mock';
-import { GooglePayInitializationData } from './types';
+import { GooglePayButtonOptions, GooglePayInitializationData } from './types';
 
 describe('GooglePayCustomerStrategy', () => {
     const CONTAINER_ID = 'my_awesome_google_pay_button_container';
@@ -54,6 +54,7 @@ describe('GooglePayCustomerStrategy', () => {
             methodId: 'googlepayworldpayaccess',
             googlepayworldpayaccess: {
                 container: CONTAINER_ID,
+                onClick: jest.fn(),
             },
         };
     });
@@ -202,6 +203,29 @@ describe('GooglePayCustomerStrategy', () => {
             await strategy.deinitialize();
 
             expect(button.remove).toHaveBeenCalled();
+        });
+    });
+
+    describe('#handleClick', () => {
+        it('triggers onClick callback on wallet button click', async () => {
+            jest.spyOn(processor, 'addPaymentButton').mockImplementation(
+                (
+                    _: string,
+                    buttonOptions: Omit<GooglePayButtonOptions, 'allowedPaymentMethods'>,
+                ) => {
+                    button.onclick = buttonOptions.onClick;
+
+                    return button;
+                },
+            );
+
+            await strategy.initialize(options);
+
+            button.click();
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(options.googlepayworldpayaccess?.onClick).toHaveBeenCalled();
         });
     });
 });

--- a/packages/google-pay-integration/src/google-pay-customer-strategy.ts
+++ b/packages/google-pay-integration/src/google-pay-customer-strategy.ts
@@ -100,6 +100,7 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
         container,
         buttonColor,
         buttonType,
+        onClick,
         onError,
     }: GooglePayCustomerInitializeOptions): void {
         this._paymentButton =
@@ -107,15 +108,20 @@ export default class GooglePayCustomerStrategy implements CustomerStrategy {
             this._googlePayPaymentProcessor.addPaymentButton(container, {
                 buttonColor: buttonColor ?? 'default',
                 buttonType: buttonType ?? 'plain',
-                onClick: this._handleClick(onError),
+                onClick: this._handleClick(onError, onClick),
             });
     }
 
     private _handleClick(
         onError: GooglePayCustomerInitializeOptions['onError'],
+        onClick: GooglePayCustomerInitializeOptions['onClick'],
     ): (event: MouseEvent) => unknown {
         return async (event: MouseEvent) => {
             event.preventDefault();
+
+            if (onClick && typeof onClick === 'function') {
+                onClick();
+            }
 
             // TODO: Dispatch Widget Actions
             try {


### PR DESCRIPTION
## What?
Added onClick callback for GooglePay customer strategies

## Why?
To be able to track GooglePay wallet button click event for buttons implemented in customer strategy

## Testing / Proof
Unit tests
Manual tests
