### PR TITLE
feat(payment): PAYPAL-3229 added onClick callback for all Braintree customer strategies

### DIFF
--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-options.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-options.ts
@@ -15,6 +15,11 @@ export default interface BraintreePaypalCustomerInitializeOptions {
      * @param error - The error object describing the failure.
      */
     onError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * A callback that gets called when wallet button clicked
+     */
+    onClick?(): void;
 }
 
 export interface WithBraintreePaypalCustomerInitializeOptions {

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.spec.ts
@@ -32,7 +32,9 @@ import {
 
 import { getPaypalSDKMock } from '../mocks/paypal.mock';
 
-import BraintreePaypalCustomerInitializeOptions from './braintree-paypal-customer-options';
+import BraintreePaypalCustomerInitializeOptions, {
+    WithBraintreePaypalCustomerInitializeOptions,
+} from './braintree-paypal-customer-options';
 import BraintreePaypalCustomerStrategy from './braintree-paypal-customer-strategy';
 
 describe('BraintreePaypalCustomerStrategy', () => {
@@ -53,10 +55,12 @@ describe('BraintreePaypalCustomerStrategy', () => {
 
     const braintreePaypalOptions: BraintreePaypalCustomerInitializeOptions = {
         container: defaultButtonContainerId,
+        onClick: jest.fn(),
         onError: jest.fn(),
     };
 
-    const initializationOptions: CustomerInitializeOptions = {
+    const initializationOptions: CustomerInitializeOptions &
+        WithBraintreePaypalCustomerInitializeOptions = {
         methodId: 'braintreepaypal',
         braintreepaypal: braintreePaypalOptions,
     };
@@ -136,6 +140,12 @@ describe('BraintreePaypalCustomerStrategy', () => {
             eventEmitter.on('approve', () => {
                 if (typeof options.onApprove === 'function') {
                     options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {});
+                }
+            });
+
+            eventEmitter.on('click', () => {
+                if (typeof options.onClick === 'function') {
+                    options.onClick();
                 }
             });
 
@@ -287,6 +297,7 @@ describe('BraintreePaypalCustomerStrategy', () => {
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
             });
             expect(renderMock).not.toHaveBeenCalled();
         });
@@ -311,6 +322,7 @@ describe('BraintreePaypalCustomerStrategy', () => {
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
             });
         });
 
@@ -332,6 +344,7 @@ describe('BraintreePaypalCustomerStrategy', () => {
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
             });
         });
 

--- a/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-paypal/braintree-paypal-customer-strategy.ts
@@ -1,4 +1,5 @@
 import { FormPoster } from '@bigcommerce/form-poster';
+import { noop } from 'lodash';
 
 import {
     BraintreeError,
@@ -42,7 +43,7 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
         options: CustomerInitializeOptions & WithBraintreePaypalCustomerInitializeOptions,
     ): Promise<void> {
         const { braintreepaypal, methodId } = options;
-        const { container, buttonHeight, onError } = braintreepaypal || {};
+        const { container, onError } = braintreepaypal || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -93,10 +94,8 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
             this.renderPayPalButton(
                 braintreePaypalCheckout,
                 braintreepaypal,
-                container,
                 methodId,
                 Boolean(config.testMode),
-                buttonHeight,
             );
         };
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
@@ -131,11 +130,15 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
     private renderPayPalButton(
         braintreePaypalCheckout: BraintreePaypalCheckout,
         braintreepaypal: BraintreePaypalCustomerInitializeOptions,
-        containerId: string,
         methodId: string,
         testMode: boolean,
-        buttonHeight = DefaultCheckoutButtonHeight,
     ): void {
+        const {
+            container,
+            buttonHeight = DefaultCheckoutButtonHeight,
+            onClick = noop,
+        } = braintreepaypal;
+
         const { paypal } = this.braintreeHostWindow;
         const fundingSource = paypal?.FUNDING.PAYPAL;
 
@@ -156,13 +159,14 @@ export default class BraintreePaypalCustomerStrategy implements CustomerStrategy
                         methodId,
                         braintreepaypal,
                     ),
+                onClick,
             });
 
             if (paypalButtonRender.isEligible()) {
-                paypalButtonRender.render(`#${containerId}`);
+                paypalButtonRender.render(`#${container}`);
             }
         } else {
-            this.braintreeIntegrationService.removeElement(containerId);
+            this.braintreeIntegrationService.removeElement(container);
         }
     }
 

--- a/packages/braintree-utils/src/paypal.ts
+++ b/packages/braintree-utils/src/paypal.ts
@@ -88,6 +88,7 @@ export interface PaypalButtonOptions {
     onAuthorize?(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
     createOrder?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
     onApprove?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<unknown>;
+    onClick?(): void;
 }
 
 export interface PaypalStyleOptions {

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-options.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-options.ts
@@ -15,4 +15,9 @@ export default interface BraintreePaypalCreditCustomerInitializeOptions {
      * @param error - The error object describing the failure.
      */
     onError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * A callback that gets called when wallet button clicked
+     */
+    onClick?(): void;
 }

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.spec.ts
@@ -84,6 +84,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
 
     const braintreePaypalCreditOptions: BraintreePaypalCreditCustomerInitializeOptions = {
         container: defaultButtonContainerId,
+        onClick: jest.fn(),
         onError: jest.fn(),
     };
 
@@ -184,6 +185,12 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             eventEmitter.on('approve', () => {
                 if (options.onApprove) {
                     options.onApprove({ payerId: 'PAYER_ID' }).catch(() => {});
+                }
+            });
+
+            eventEmitter.on('click', () => {
+                if (options.onClick) {
+                    options.onClick();
                 }
             });
 
@@ -331,6 +338,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
                 style: {
                     height: DefaultCheckoutButtonHeight,
                     color: PaypalButtonStyleColorOption.GOLD,
@@ -366,6 +374,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
                 style: {
                     height: 100,
                     color: PaypalButtonStyleColorOption.GOLD,
@@ -388,6 +397,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.PAYLATER,
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
                 style: {
                     height: DefaultCheckoutButtonHeight,
                     color: PaypalButtonStyleColorOption.GOLD,
@@ -402,6 +412,7 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
                 env: 'sandbox',
                 fundingSource: paypalSdkMock.FUNDING.CREDIT,
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
                 style: {
                     height: DefaultCheckoutButtonHeight,
                     label: 'credit',
@@ -540,6 +551,16 @@ describe('BraintreePaypalCreditCustomerStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(braintreePaypalCreditOptions.onError).toHaveBeenCalledWith(expectedError);
+        });
+
+        it('triggers click callback when onClick paypal callback get called', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('click');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(braintreePaypalCreditOptions.onClick).toHaveBeenCalled();
         });
     });
 

--- a/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/braintree/braintree-paypal-credit-customer-strategy.ts
@@ -1,3 +1,4 @@
+import { noop } from 'lodash';
 import { FormPoster } from '@bigcommerce/form-poster';
 
 import {
@@ -52,7 +53,6 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
 
     async initialize(options: CustomerInitializeOptions): Promise<InternalCheckoutSelectors> {
         const { braintreepaypalcredit, methodId } = options;
-        const { container, buttonHeight } = braintreepaypalcredit || {};
 
         if (!methodId) {
             throw new InvalidArgumentError(
@@ -66,9 +66,9 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
             );
         }
 
-        if (!container) {
+        if (!braintreepaypalcredit.container) {
             throw new InvalidArgumentError(
-                `Unable to initialize payment because "braintreepaypalcredit.container" argument is not provided.`,
+                `Unable to initialize payment because "options.braintreepaypalcredit.container" argument is not provided.`,
             );
         }
 
@@ -104,7 +104,6 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
                 braintreepaypalcredit,
                 methodId,
                 Boolean(paymentMethod.config.testMode),
-                buttonHeight,
             );
         const paypalCheckoutErrorCallback = (error: BraintreeError) =>
             this._handleError(error, braintreepaypalcredit);
@@ -151,9 +150,12 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
         braintreepaypalcredit: BraintreePaypalCreditCustomerInitializeOptions,
         methodId: string,
         testMode: boolean,
-        buttonHeight = DefaultCheckoutButtonHeight,
     ): void {
-        const { container } = braintreepaypalcredit;
+        const {
+            container,
+            buttonHeight = DefaultCheckoutButtonHeight,
+            onClick = noop,
+        } = braintreepaypalcredit;
         const { paypal } = this._window;
 
         let hasRenderedSmartButton = false;
@@ -190,6 +192,7 @@ export default class BraintreePaypalCreditCustomerStrategy implements CustomerSt
                                 braintreepaypalcredit,
                                 methodId,
                             ),
+                        onClick,
                     });
 
                     if (paypalButtonRender.isEligible()) {

--- a/packages/core/src/payment/strategies/paypal/paypal-sdk.ts
+++ b/packages/core/src/payment/strategies/paypal/paypal-sdk.ts
@@ -50,6 +50,7 @@ export interface PaypalButtonOptions {
     onAuthorize?(data: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
     createOrder?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
     onApprove?(data?: PaypalAuthorizeData, actions?: PaypalActions): Promise<any>;
+    onClick?(): void;
 }
 
 export interface PaypalClientToken {


### PR DESCRIPTION
## What?
Added onClick callback for all Braintree customer strategies

## Why?
To be able to track wallet button click event for buttons implemented in customer strategies

## Testing / Proof
Unit tests
Manual tests
