### PR TITLE
feat(payment): PAYPAL-3229 added onClick callback for each PayPalCommerce customer strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-initialize-options.ts
@@ -16,6 +16,11 @@ export default interface PayPalCommerceCreditCustomerInitializeOptions {
      * A callback that gets called when payment complete on paypal side.
      */
     onComplete?(): void;
+
+    /**
+     * A callback that gets called when paypal button clicked.
+     */
+    onClick?(): void;
 }
 
 export interface WithPayPalCommerceCreditCustomerInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -48,13 +48,19 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
 
         if (!paypalcommercecredit) {
             throw new InvalidArgumentError(
-                `Unable to initialize payment because "paypalcommercecredit" argument is not provided.`,
+                'Unable to initialize payment because "options.paypalcommercecredit" argument is not provided.',
             );
         }
 
         if (!paypalcommercecredit.container) {
             throw new InvalidArgumentError(
-                `Unable to initialize payment because "paypalcommercecredit.container" argument is not provided.`,
+                'Unable to initialize payment because "options.paypalcommercecredit.container" argument is not provided.',
+            );
+        }
+
+        if (paypalcommercecredit.onClick && typeof paypalcommercecredit.onClick !== 'function') {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.paypalcommercecredit.onClick" argument is not a function.',
             );
         }
 
@@ -88,7 +94,7 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
         methodId: string,
         paypalCommerceCredit: PayPalCommerceCreditCustomerInitializeOptions,
     ): void {
-        const { container, onComplete } = paypalCommerceCredit;
+        const { container, onComplete, onClick } = paypalCommerceCredit;
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
@@ -103,6 +109,7 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
                 this.paypalCommerceIntegrationService.createOrder('paypalcommercecredit'),
             onApprove: ({ orderID }: ApproveCallbackPayload) =>
                 this.paypalCommerceIntegrationService.tokenizePayment(methodId, orderID),
+            ...(onClick && { onClick: () => onClick() }),
         };
 
         const hostedCheckoutCallbacks = {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -274,7 +274,7 @@ export interface PayPalCommerceButtonsOptions {
         actions: ApproveCallbackActions,
     ): Promise<boolean | void> | void;
     onComplete?(data: CompleteCallbackDataPayload): Promise<void>;
-    onClick?(data: ClickCallbackPayload, actions: ClickCallbackActions): Promise<void>;
+    onClick?(data: ClickCallbackPayload, actions: ClickCallbackActions): Promise<void> | void;
     onError?(error: Error): void;
     onCancel?(): void;
     onShippingAddressChange?(data: ShippingAddressChangeCallbackPayload): Promise<void>;

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-initialize-options.ts
@@ -11,6 +11,11 @@ export default interface PayPalCommerceVenmoCustomerInitializeOptions {
      * @param error - The error object describing the failure.
      */
     onError?(error?: Error): void;
+
+    /**
+     * A callback that gets called when paypal button clicked.
+     */
+    onClick?(): void;
 }
 
 export interface WithPayPalCommerceVenmoCustomerInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
@@ -39,6 +39,7 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
 
     const paypalCommerceVenmoOptions: PayPalCommerceVenmoCustomerInitializeOptions = {
         container: defaultButtonContainerId,
+        onClick: jest.fn(),
         onError: jest.fn(),
     };
 
@@ -93,6 +94,18 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
                                 order: {
                                     get: jest.fn(),
                                 },
+                            },
+                        );
+                    }
+                });
+
+                eventEmitter.on('onClick', () => {
+                    if (options.onClick) {
+                        options.onClick(
+                            { fundingSource: 'venmo' },
+                            {
+                                resolve: jest.fn(),
+                                reject: jest.fn(),
                             },
                         );
                     }
@@ -158,6 +171,22 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
             }
         });
 
+        it('throws an error if paypalcommercevenmo.onClick is provided but it is not a function', async () => {
+            const options = {
+                methodId: defaultMethodId,
+                paypalcommercevenmo: {
+                    container: 'container',
+                    onClick: 'test',
+                },
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
         it('loads paypalcommerce venmo payment method', async () => {
             await strategy.initialize(initializationOptions);
 
@@ -188,6 +217,7 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
             });
         });
 
@@ -259,6 +289,18 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
                 defaultMethodId,
                 paypalOrderId,
             );
+        });
+    });
+
+    describe('#onClick button callback', () => {
+        it('triggers onClick option by clicking on the button', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceVenmoOptions.onClick).toHaveBeenCalled();
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-initialize-options.ts
@@ -20,6 +20,11 @@ export default interface PayPalCommerceCustomerInitializeOptions {
      * A callback that gets called when payment complete on paypal side.
      */
     onComplete?(): void;
+
+    /**
+     * A callback that gets called when paypal button clicked.
+     */
+    onClick?(): void;
 }
 
 export interface WithPayPalCommerceCustomerInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -45,6 +45,7 @@ describe('PayPalCommerceCustomerStrategy', () => {
 
     const paypalCommerceOptions: PayPalCommerceCustomerInitializeOptions = {
         container: defaultContainerId,
+        onClick: jest.fn(),
         onComplete: jest.fn(),
     };
 
@@ -113,6 +114,18 @@ describe('PayPalCommerceCustomerStrategy', () => {
                                 order: {
                                     get: jest.fn(),
                                 },
+                            },
+                        );
+                    }
+                });
+
+                eventEmitter.on('onClick', () => {
+                    if (options.onClick) {
+                        options.onClick(
+                            { fundingSource: 'paypal' },
+                            {
+                                resolve: jest.fn(),
+                                reject: jest.fn(),
                             },
                         );
                     }
@@ -199,6 +212,23 @@ describe('PayPalCommerceCustomerStrategy', () => {
             }
         });
 
+        it('throws an error if paypalcommerce.onClick is provided but it is not a function', async () => {
+            const options = {
+                methodId,
+                paypalcommerce: {
+                    container: 'container',
+                    onClick: 'test',
+                    onComplete: jest.fn(),
+                },
+            } as CustomerInitializeOptions;
+
+            try {
+                await strategy.initialize(options);
+            } catch (error) {
+                expect(error).toBeInstanceOf(InvalidArgumentError);
+            }
+        });
+
         it('loads paypalcommerce payment method', async () => {
             await strategy.initialize(initializationOptions);
 
@@ -225,6 +255,7 @@ describe('PayPalCommerceCustomerStrategy', () => {
                 },
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
             });
         });
 
@@ -253,6 +284,7 @@ describe('PayPalCommerceCustomerStrategy', () => {
                 onShippingAddressChange: expect.any(Function),
                 onShippingOptionsChange: expect.any(Function),
                 onApprove: expect.any(Function),
+                onClick: expect.any(Function),
             });
         });
 
@@ -452,6 +484,18 @@ describe('PayPalCommerceCustomerStrategy', () => {
                     approveDataOrderId,
                 );
             });
+        });
+    });
+
+    describe('#onClick button callback', () => {
+        it('triggers onClick option by clicking on the button', async () => {
+            await strategy.initialize(initializationOptions);
+
+            eventEmitter.emit('onClick');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(paypalCommerceOptions.onClick).toHaveBeenCalled();
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -48,13 +48,19 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
 
         if (!paypalcommerce) {
             throw new InvalidArgumentError(
-                `Unable to initialize payment because "options.paypalcommerce" argument is not provided.`,
+                'Unable to initialize payment because "options.paypalcommerce" argument is not provided.',
             );
         }
 
         if (!paypalcommerce.container) {
             throw new InvalidArgumentError(
-                `Unable to initialize payment because "options.paypalcommerce.container" argument is not provided.`,
+                'Unable to initialize payment because "options.paypalcommerce.container" argument is not provided.',
+            );
+        }
+
+        if (paypalcommerce.onClick && typeof paypalcommerce.onClick !== 'function') {
+            throw new InvalidArgumentError(
+                'Unable to initialize payment because "options.paypalcommerce.onClick" argument is not a function.',
             );
         }
 
@@ -92,7 +98,7 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
         methodId: string,
         paypalcommerce: PayPalCommerceCustomerInitializeOptions,
     ): void {
-        const { container, onComplete } = paypalcommerce;
+        const { container, onClick, onComplete } = paypalcommerce;
 
         const paypalSdk = this.paypalCommerceIntegrationService.getPayPalSdkOrThrow();
         const state = this.paymentIntegrationService.getState();
@@ -106,6 +112,7 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
             createOrder: () => this.paypalCommerceIntegrationService.createOrder('paypalcommerce'),
             onApprove: ({ orderID }: ApproveCallbackPayload) =>
                 this.paypalCommerceIntegrationService.tokenizePayment(methodId, orderID),
+            ...(onClick && { onClick: () => onClick() }),
         };
 
         const hostedCheckoutCallbacks = {


### PR DESCRIPTION
## What?
Added onClick callback for each PayPalCommerce customer strategy

## Why?
To be able to track wallet button click event for buttons implemented in PPCP customer strategies

## Testing / Proof
Unit tests
