### PR TITLE
feat(payment): PAYPAL-3229 added checkoutPaymentMethodExecuted callback call to BraintreeAcceleratedCheckoutCustomerStrategy

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.spec.ts
@@ -27,6 +27,7 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
     const initializationOptions = { methodId };
     const executionOptions = {
         methodId,
+        checkoutPaymentMethodExecuted: jest.fn(),
         continueWithCheckoutCallback: jest.fn(),
     };
     const paymentMethod = {
@@ -137,13 +138,20 @@ describe('BraintreeAcceleratedCheckoutCustomerStrategy', () => {
             }
         });
 
-        it('authenticates user with PayPal Connect and calls continueWithCheckoutCallback', async () => {
+        it('authenticates user with PayPal Connect', async () => {
             await strategy.initialize({ methodId });
             await strategy.executePaymentMethodCheckout(executionOptions);
 
             expect(
                 braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow,
             ).toHaveBeenCalled();
+        });
+
+        it('calls checkoutPaymentMethodExecuted and continueWithCheckoutCallback after payment method execution', async () => {
+            await strategy.initialize({ methodId });
+            await strategy.executePaymentMethodCheckout(executionOptions);
+
+            expect(executionOptions.checkoutPaymentMethodExecuted).toHaveBeenCalled();
             expect(executionOptions.continueWithCheckoutCallback).toHaveBeenCalled();
         });
     });

--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
@@ -64,7 +64,8 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
     async executePaymentMethodCheckout(
         options?: ExecutePaymentMethodCheckoutOptions,
     ): Promise<void> {
-        const { continueWithCheckoutCallback, methodId } = options || {};
+        const { checkoutPaymentMethodExecuted, continueWithCheckoutCallback, methodId } =
+            options || {};
 
         if (typeof continueWithCheckoutCallback !== 'function') {
             throw new InvalidArgumentError(
@@ -74,6 +75,10 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
 
         if (await this.shouldRunAuthenticationFlow(methodId)) {
             await this.braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow();
+        }
+
+        if (checkoutPaymentMethodExecuted && typeof checkoutPaymentMethodExecuted === 'function') {
+            checkoutPaymentMethodExecuted();
         }
 
         continueWithCheckoutCallback();


### PR DESCRIPTION
## What?
Added checkoutPaymentMethodExecuted callback call to BraintreeAcceleratedCheckoutCustomerStrategy

## Why?
To be able to track when Braintree Accelerated Checkout calls execute method

## Testing / Proof
Unit tests
Manual tests
