### PR TITLE
feat(payment): PI-1148 Hide card holder name from hosted fields form

### DIFF
--- a/packages/core/src/payment/payment-method-config.ts
+++ b/packages/core/src/payment/payment-method-config.ts
@@ -14,5 +14,6 @@ export default interface PaymentMethodConfig {
     redirectUrl?: string;
     requireCustomerCode?: boolean;
     returnUrl?: string;
+    showCardHolderName?: boolean;
     testMode?: boolean;
 }


### PR DESCRIPTION
## What?
Add new option to provider config to control visibility of card holder name field

## Why?
This option will be used in checkout-js PR:
[https://github.com/bigcommerce/checkout-js/pull/1609](https://github.com/bigcommerce/checkout-js/pull/1609)

@bigcommerce/team-checkout @bigcommerce/team-payments
