### PR TITLE
feat(payment): PAYPAL-3337 PPCP GooglePay setGatewayIdentifier added

### DIFF
--- a/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
+++ b/packages/google-pay-integration/src/gateways/google-pay-gateway.ts
@@ -236,6 +236,10 @@ export default class GooglePayGateway {
         return this._gatewayIdentifier;
     }
 
+    protected setGatewayIdentifier(gateway?: string) {
+        this._gatewayIdentifier = gateway || this.getGatewayIdentifier();
+    }
+
     private _isShippingAddressRequired(): boolean {
         const { getCartOrThrow, getStoreConfig, getShippingAddress } =
             this._paymentIntegrationService.getState();

--- a/packages/google-pay-integration/src/google-pay-paypal-commerce/google-pay-paypal-commerce-gateway.spec.ts
+++ b/packages/google-pay-integration/src/google-pay-paypal-commerce/google-pay-paypal-commerce-gateway.spec.ts
@@ -26,6 +26,7 @@ describe('GooglePayPayPalCommerceGateway', () => {
                 {
                     tokenizationSpecification: {
                         parameters: {
+                            gateway: 'paypalsb',
                             gatewayMerchantId: 'ID',
                         },
                     },
@@ -67,6 +68,62 @@ describe('GooglePayPayPalCommerceGateway', () => {
 
     describe('#getPaymentGatewayParameters', () => {
         it('should return payment gateway parameters', async () => {
+            const expectedParams = {
+                gateway: 'paypalsb',
+                gatewayMerchantId: 'ID',
+            };
+
+            const googlePayPaymentMethod = getPayPalCommerce();
+
+            isGooglePayPaypalCommercePaymentMethod(googlePayPaymentMethod);
+
+            await gateway.initialize(() => googlePayPaymentMethod);
+
+            expect(gateway.getPaymentGatewayParameters()).toStrictEqual(expectedParams);
+        });
+
+        it('should return payment gateway parameters in production mode', async () => {
+            jest.spyOn(scriptLoader, 'getGooglePayConfigOrThrow').mockResolvedValue({
+                allowedPaymentMethods: [
+                    {
+                        tokenizationSpecification: {
+                            parameters: {
+                                gateway: 'paypalppcp',
+                                gatewayMerchantId: 'ID',
+                            },
+                        },
+                    },
+                ],
+            });
+
+            const expectedParams = {
+                gateway: 'paypalppcp',
+                gatewayMerchantId: 'ID',
+            };
+
+            const googlePayPaymentMethod = getPayPalCommerce();
+
+            isGooglePayPaypalCommercePaymentMethod(googlePayPaymentMethod);
+
+            await gateway.initialize(() => googlePayPaymentMethod);
+
+            expect(gateway.getPaymentGatewayParameters()).toStrictEqual(expectedParams);
+        });
+
+        it('should return default payment gateway name', async () => {
+            jest.spyOn(scriptLoader, 'getGooglePayConfigOrThrow').mockResolvedValue({
+                allowedPaymentMethods: [
+                    {
+                        tokenizationSpecification: {
+                            parameters: {
+                                gateway: undefined,
+                                gatewayMerchantId: 'ID',
+                            },
+                        },
+                    },
+                ],
+            });
+
             const expectedParams = {
                 gateway: 'paypalsb',
                 gatewayMerchantId: 'ID',

--- a/packages/google-pay-integration/src/google-pay-paypal-commerce/google-pay-paypal-commerce-gateway.ts
+++ b/packages/google-pay-integration/src/google-pay-paypal-commerce/google-pay-paypal-commerce-gateway.ts
@@ -54,6 +54,12 @@ export default class GooglePayPaypalCommerceGateway extends GooglePayGateway {
         await this.paypalCommerceScriptLoader.getPayPalSDK(paymentMethod, currency);
 
         this.googlepayConfig = await this.paypalCommerceScriptLoader.getGooglePayConfigOrThrow();
+
+        const { allowedPaymentMethods } = this.googlepayConfig;
+
+        this.setGatewayIdentifier(
+            allowedPaymentMethods[0]?.tokenizationSpecification?.parameters?.gateway,
+        );
     }
 
     getPaymentGatewayParameters(): GooglePayPayPalCommerceGatewayParameters {


### PR DESCRIPTION
## What?
We need to add dynamic gateway name from PPCP api: `allowedPaymentMethods[0].tokenizationSpecification.parameters.gateway`. 

## Why?
Because now it works only in sandbox mode because of hardcoded `paypalsb` name.

## Testing / Proof
All tests have been passed
@bigcommerce/team-checkout @bigcommerce/team-payments
