### PR TITLE
feat(payment): PI-1076 add 3ds support for storing cards in square v2

### DIFF
--- a/packages/core/src/payment/instrument/supported-payment-instruments.ts
+++ b/packages/core/src/payment/instrument/supported-payment-instruments.ts
@@ -145,6 +145,10 @@ const supportedInstruments: SupportedInstruments = {
         provider: 'worldpayaccess',
         method: 'credit_card',
     },
+    squarev2: {
+        provider: 'squarev2',
+        method: 'credit_card',
+    },
 };
 
 export default supportedInstruments;

--- a/packages/squarev2-integration/src/squarev2-payment-processor.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-processor.spec.ts
@@ -10,7 +10,7 @@ import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment
 import { getSquareV2MockFunctions } from './mocks/squarev2-web-payments-sdk.mock';
 import SquareV2PaymentProcessor from './squarev2-payment-processor';
 import SquareV2ScriptLoader from './squarev2-script-loader';
-import { Square } from './types';
+import { Square, SquareIntent } from './types';
 
 describe('SquareV2PaymentProcessor', () => {
     let squareV2ScriptLoader: SquareV2ScriptLoader;
@@ -240,7 +240,7 @@ describe('SquareV2PaymentProcessor', () => {
                 intent: 'CHARGE',
             };
 
-            const nonce = await processor.verifyBuyer('cnon:zzz', 'CHARGE');
+            const nonce = await processor.verifyBuyer('cnon:zzz', SquareIntent.CHARGE);
 
             expect(nonce).toBe('verf:yyy');
             expect(squareV2MockFunctions.verifyBuyer).toHaveBeenCalledWith(
@@ -252,7 +252,7 @@ describe('SquareV2PaymentProcessor', () => {
         it('should fail if _payments has not yet been initialized', async () => {
             await processor.deinitialize();
 
-            const nonce = processor.verifyBuyer('cnon:zzz', 'CHARGE');
+            const nonce = processor.verifyBuyer('cnon:zzz', SquareIntent.CHARGE);
 
             await expect(nonce).rejects.toThrow(NotInitializedError);
         });

--- a/packages/squarev2-integration/src/squarev2-payment-processor.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-processor.spec.ts
@@ -240,7 +240,7 @@ describe('SquareV2PaymentProcessor', () => {
                 intent: 'CHARGE',
             };
 
-            const nonce = await processor.verifyBuyer('cnon:zzz');
+            const nonce = await processor.verifyBuyer('cnon:zzz', 'CHARGE');
 
             expect(nonce).toBe('verf:yyy');
             expect(squareV2MockFunctions.verifyBuyer).toHaveBeenCalledWith(
@@ -252,7 +252,7 @@ describe('SquareV2PaymentProcessor', () => {
         it('should fail if _payments has not yet been initialized', async () => {
             await processor.deinitialize();
 
-            const nonce = processor.verifyBuyer('cnon:zzz');
+            const nonce = processor.verifyBuyer('cnon:zzz', 'CHARGE');
 
             await expect(nonce).rejects.toThrow(NotInitializedError);
         });

--- a/packages/squarev2-integration/src/squarev2-payment-processor.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-processor.ts
@@ -20,6 +20,7 @@ import {
     ChargeVerifyBuyerDetails,
     Payments,
     SqEvent,
+    StoreVerifyBuyerDetails,
 } from './types';
 
 export interface SquareV2PaymentProcessorOptions {
@@ -106,21 +107,8 @@ export default class SquareV2PaymentProcessor {
         return result.token;
     }
 
-    async verifyBuyer(token: string): Promise<string> {
-        const { getCheckoutOrThrow, getBillingAddressOrThrow } =
-            this._paymentIntegrationService.getState();
-        const { outstandingBalance, cart } = getCheckoutOrThrow();
-
-        const details: ChargeVerifyBuyerDetails = {
-            amount: outstandingBalance.toString(),
-            billingContact: this._mapToSquareBillingContact(getBillingAddressOrThrow()),
-            currencyCode: cart.currency.code,
-            intent: 'CHARGE',
-        };
-
-        const response = await this._getPayments().verifyBuyer(token, details);
-
-        return response ? response.token : '';
+    async verifyBuyer(token: string, intent: 'CHARGE' | 'STORE'): Promise<string> {
+        return intent === 'CHARGE' ? this._chargeVerifyBuyer(token) : this._storeVerifyBuyer(token);
     }
 
     private _getPayments(): Payments {
@@ -196,5 +184,35 @@ export default class SquareV2PaymentProcessor {
             email,
             phone,
         };
+    }
+
+    private async _chargeVerifyBuyer(token: string): Promise<string> {
+        const { getCheckoutOrThrow, getBillingAddressOrThrow } =
+            this._paymentIntegrationService.getState();
+        const { outstandingBalance, cart } = getCheckoutOrThrow();
+
+        const details: ChargeVerifyBuyerDetails = {
+            amount: outstandingBalance.toString(),
+            billingContact: this._mapToSquareBillingContact(getBillingAddressOrThrow()),
+            currencyCode: cart.currency.code,
+            intent: 'CHARGE',
+        };
+
+        const response = await this._getPayments().verifyBuyer(token, details);
+
+        return response ? response.token : '';
+    }
+
+    private async _storeVerifyBuyer(token: string): Promise<string> {
+        const { getBillingAddressOrThrow } = this._paymentIntegrationService.getState();
+
+        const details: StoreVerifyBuyerDetails = {
+            billingContact: this._mapToSquareBillingContact(getBillingAddressOrThrow()),
+            intent: 'STORE',
+        };
+
+        const response = await this._getPayments().verifyBuyer(token, details);
+
+        return response ? response.token : '';
     }
 }

--- a/packages/squarev2-integration/src/squarev2-payment-processor.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-processor.ts
@@ -20,6 +20,7 @@ import {
     ChargeVerifyBuyerDetails,
     Payments,
     SqEvent,
+    SquareIntent,
     StoreVerifyBuyerDetails,
 } from './types';
 
@@ -107,8 +108,10 @@ export default class SquareV2PaymentProcessor {
         return result.token;
     }
 
-    async verifyBuyer(token: string, intent: 'CHARGE' | 'STORE'): Promise<string> {
-        return intent === 'CHARGE' ? this._chargeVerifyBuyer(token) : this._storeVerifyBuyer(token);
+    async verifyBuyer(token: string, intent: SquareIntent): Promise<string> {
+        return intent === SquareIntent.CHARGE
+            ? this._chargeVerifyBuyer(token)
+            : this._storeVerifyBuyer(token);
     }
 
     private _getPayments(): Payments {
@@ -195,7 +198,7 @@ export default class SquareV2PaymentProcessor {
             amount: outstandingBalance.toString(),
             billingContact: this._mapToSquareBillingContact(getBillingAddressOrThrow()),
             currencyCode: cart.currency.code,
-            intent: 'CHARGE',
+            intent: SquareIntent.CHARGE,
         };
 
         const response = await this._getPayments().verifyBuyer(token, details);
@@ -208,7 +211,7 @@ export default class SquareV2PaymentProcessor {
 
         const details: StoreVerifyBuyerDetails = {
             billingContact: this._mapToSquareBillingContact(getBillingAddressOrThrow()),
-            intent: 'STORE',
+            intent: SquareIntent.STORE,
         };
 
         const response = await this._getPayments().verifyBuyer(token, details);

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -275,6 +275,49 @@ describe('SquareV2PaymentStrategy', () => {
                 );
             });
         });
+
+        describe('when using a stored card', () => {
+            beforeEach(async () => {
+                payload = {
+                    ...getOrderRequestBody(),
+                    payment: {
+                        methodId: 'squarev2',
+                        paymentData: {
+                            instrumentId: 'bigpaytoken',
+                        },
+                    },
+                };
+
+                await strategy.initialize(options);
+            });
+
+            it('should not tokenize the card', async () => {
+                await strategy.execute(payload);
+
+                expect(processor.tokenize).not.toHaveBeenCalled();
+            });
+
+            it('should submit the payment', async () => {
+                const expectedPayment = {
+                    methodId: 'squarev2',
+                    paymentData: {
+                        formattedPayload: {
+                            bigpay_token: {
+                                token: 'bigpaytoken',
+                            },
+                            vault_payment_instrument: false,
+                            set_as_default_stored_instrument: false,
+                        },
+                    },
+                };
+
+                await strategy.execute(payload);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenCalledWith(
+                    expectedPayment,
+                );
+            });
+        });
     });
 
     describe('#finalize', () => {

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -150,7 +150,7 @@ describe('SquareV2PaymentStrategy', () => {
 
             await strategy.execute(payload);
 
-            expect(processor.verifyBuyer).toHaveBeenCalledWith('cnon:xxx');
+            expect(processor.verifyBuyer).toHaveBeenCalledWith('cnon:xxx', 'CHARGE');
         });
 
         it('should submit the order', async () => {

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -19,6 +19,7 @@ import { getSquareV2 } from './mocks/squarev2-method.mock';
 import SquareV2PaymentProcessor from './squarev2-payment-processor';
 import SquareV2PaymentStrategy from './squarev2-payment-strategy';
 import SquareV2ScriptLoader from './squarev2-script-loader';
+import { SquareIntent } from './types';
 
 describe('SquareV2PaymentStrategy', () => {
     let paymentIntegrationService: PaymentIntegrationService;
@@ -150,7 +151,7 @@ describe('SquareV2PaymentStrategy', () => {
 
             await strategy.execute(payload);
 
-            expect(processor.verifyBuyer).toHaveBeenCalledWith('cnon:xxx', 'CHARGE');
+            expect(processor.verifyBuyer).toHaveBeenCalledWith('cnon:xxx', SquareIntent.CHARGE);
         });
 
         it('should submit the order', async () => {
@@ -240,8 +241,8 @@ describe('SquareV2PaymentStrategy', () => {
 
                 await strategy.execute(payload);
 
-                expect(processor.verifyBuyer).toHaveBeenCalledWith('cnon:xxx', 'CHARGE');
-                expect(processor.verifyBuyer).toHaveBeenCalledWith('cnon:xxx', 'STORE');
+                expect(processor.verifyBuyer).toHaveBeenCalledWith('cnon:xxx', SquareIntent.CHARGE);
+                expect(processor.verifyBuyer).toHaveBeenCalledWith('cnon:xxx', SquareIntent.STORE);
             });
 
             it('should submit the payment with verification tokens', async () => {

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -13,7 +13,7 @@ import {
 
 import { WithSquareV2PaymentInitializeOptions } from './squarev2-payment-initialize-options';
 import SquareV2PaymentProcessor from './squarev2-payment-processor';
-import { SquarePaymentMethodInitializationData } from './types';
+import { SquareIntent, SquarePaymentMethodInitializationData } from './types';
 
 export default class SquareV2PaymentStrategy implements PaymentStrategy {
     constructor(
@@ -92,16 +92,22 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
                 nonce = JSON.stringify({
                     nonce,
                     store_card_nonce: storeCardNonce,
-                    token: await this._squareV2PaymentProcessor.verifyBuyer(nonce, 'CHARGE'),
+                    token: await this._squareV2PaymentProcessor.verifyBuyer(
+                        nonce,
+                        SquareIntent.CHARGE,
+                    ),
                     store_card_token: await this._squareV2PaymentProcessor.verifyBuyer(
                         storeCardNonce,
-                        'STORE',
+                        SquareIntent.STORE,
                     ),
                 });
             } else {
                 nonce = JSON.stringify({
                     nonce,
-                    token: await this._squareV2PaymentProcessor.verifyBuyer(nonce, 'CHARGE'),
+                    token: await this._squareV2PaymentProcessor.verifyBuyer(
+                        nonce,
+                        SquareIntent.CHARGE,
+                    ),
                 });
             }
         }

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -1,6 +1,7 @@
 import {
     InvalidArgumentError,
     isHostedInstrumentLike,
+    isVaultedInstrument,
     OrderFinalizationNotRequiredError,
     OrderRequestBody,
     PaymentArgumentInvalidError,
@@ -55,15 +56,6 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
             throw new PaymentArgumentInvalidError(['payment']);
         }
 
-        let nonce = await this._squareV2PaymentProcessor.tokenize();
-
-        if (this._shouldVerify()) {
-            nonce = JSON.stringify({
-                nonce,
-                token: await this._squareV2PaymentProcessor.verifyBuyer(nonce),
-            });
-        }
-
         const paymentData = payment.paymentData;
 
         const { shouldSaveInstrument, shouldSetAsDefaultInstrument } = isHostedInstrumentLike(
@@ -73,6 +65,47 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
             : { shouldSaveInstrument: false, shouldSetAsDefaultInstrument: false };
 
         await this._paymentIntegrationService.submitOrder();
+
+        if (paymentData && isVaultedInstrument(paymentData)) {
+            await this._paymentIntegrationService.submitPayment({
+                ...payment,
+                paymentData: {
+                    formattedPayload: {
+                        bigpay_token: {
+                            token: paymentData.instrumentId,
+                        },
+                        vault_payment_instrument: shouldSaveInstrument || false,
+                        set_as_default_stored_instrument: shouldSetAsDefaultInstrument || false,
+                    },
+                },
+            });
+
+            return;
+        }
+
+        let nonce = await this._squareV2PaymentProcessor.tokenize();
+
+        if (this._shouldVerify()) {
+            if (shouldSaveInstrument) {
+                const storeCardNonce = await this._squareV2PaymentProcessor.tokenize();
+
+                nonce = JSON.stringify({
+                    nonce,
+                    store_card_nonce: storeCardNonce,
+                    token: await this._squareV2PaymentProcessor.verifyBuyer(nonce, 'CHARGE'),
+                    store_card_token: await this._squareV2PaymentProcessor.verifyBuyer(
+                        storeCardNonce,
+                        'STORE',
+                    ),
+                });
+            } else {
+                nonce = JSON.stringify({
+                    nonce,
+                    token: await this._squareV2PaymentProcessor.verifyBuyer(nonce, 'CHARGE'),
+                });
+            }
+        }
+
         await this._paymentIntegrationService.submitPayment({
             ...payment,
             paymentData: {

--- a/packages/squarev2-integration/src/types.ts
+++ b/packages/squarev2-integration/src/types.ts
@@ -4,3 +4,8 @@ export interface SquarePaymentMethodInitializationData {
     applicationId: string;
     locationId?: string;
 }
+
+export enum SquareIntent {
+    CHARGE = 'CHARGE',
+    STORE = 'STORE',
+}


### PR DESCRIPTION
## What?
Added new tokens to `submitPayment` payload when storing new credit card.

## Why?
To enable storing credit cards with 3ds feature.
BE part: https://github.com/bigcommerce/bigpay/pull/7697

## Testing / Proof
Unit + manual tests.

@bigcommerce/team-checkout @bigcommerce/team-payments
