### PR TITLE
fix(payment): CHECKOUT-7901 added a condition to load PPCP payment methods only if they are not exist in checkout state

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.spec.ts
@@ -24,6 +24,7 @@ import {
 import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import {
     PayPalCommerceButtonsOptions,
+    PayPalCommerceHostWindow,
     PayPalSDK,
     StyleButtonColor,
 } from '../paypal-commerce-types';
@@ -175,6 +176,12 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
         );
     });
 
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PayPalCommerceHostWindow).paypal;
+    });
+
     it('creates an interface of the PayPal Commerce Credit (PayLater) customer strategy', () => {
         expect(strategy).toBeInstanceOf(PayPalCommerceCreditCustomerStrategy);
     });
@@ -236,6 +243,16 @@ describe('PayPalCommerceCreditCustomerStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
+        });
+
+        it('does not load paypalcommercecredit payment method if payment method is already exists', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockReturnValue(
+                paymentMethod,
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
         });
 
         it('loads paypal sdk with provided method id', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-customer-strategy.ts
@@ -66,7 +66,13 @@ export default class PayPalCommerceCreditCustomerStrategy implements CustomerStr
 
         this.onError = paypalcommercecredit.onError || noop;
 
-        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethod(methodId);
+
+        if (!paymentMethod) {
+            await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        }
+
         await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
 
         this.renderButton(methodId, paypalcommercecredit);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.spec.ts
@@ -187,12 +187,22 @@ describe('PayPalCommerceVenmoCustomerStrategy', () => {
             }
         });
 
-        it('loads paypalcommerce venmo payment method', async () => {
+        it('loads paypalcommercevenmo payment method', async () => {
             await strategy.initialize(initializationOptions);
 
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
                 defaultMethodId,
             );
+        });
+
+        it('does not load paypalcommercevenmo payment method if payment method is already exists', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockReturnValue(
+                paymentMethod,
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
         });
 
         it('loads paypal sdk with provided method id', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-customer-strategy.ts
@@ -55,7 +55,13 @@ export default class PayPalCommerceVenmoCustomerStrategy implements CustomerStra
             );
         }
 
-        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethod(methodId);
+
+        if (!paymentMethod) {
+            await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        }
+
         await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
 
         this.renderButton(methodId, paypalcommercevenmo);

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.spec.ts
@@ -24,6 +24,7 @@ import {
 import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
 import {
     PayPalCommerceButtonsOptions,
+    PayPalCommerceHostWindow,
     PayPalSDK,
     StyleButtonColor,
 } from '../paypal-commerce-types';
@@ -171,6 +172,12 @@ describe('PayPalCommerceCustomerStrategy', () => {
         );
     });
 
+    afterEach(() => {
+        jest.clearAllMocks();
+
+        delete (window as PayPalCommerceHostWindow).paypal;
+    });
+
     it('creates an interface of the PayPalCommerce customer strategy', () => {
         expect(strategy).toBeInstanceOf(PayPalCommerceCustomerStrategy);
     });
@@ -233,6 +240,16 @@ describe('PayPalCommerceCustomerStrategy', () => {
             await strategy.initialize(initializationOptions);
 
             expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
+        });
+
+        it('does not load paypalcommerce payment method if payment method is already exists', async () => {
+            jest.spyOn(paymentIntegrationService.getState(), 'getPaymentMethod').mockReturnValue(
+                paymentMethod,
+            );
+
+            await strategy.initialize(initializationOptions);
+
+            expect(paymentIntegrationService.loadPaymentMethod).not.toHaveBeenCalled();
         });
 
         it('loads paypal sdk with provided method id', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-customer-strategy.ts
@@ -66,7 +66,13 @@ export default class PayPalCommerceCustomerStrategy implements CustomerStrategy 
 
         this.onError = paypalcommerce.onError || noop;
 
-        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        const state = this.paymentIntegrationService.getState();
+        const paymentMethod = state.getPaymentMethod(methodId);
+
+        if (!paymentMethod) {
+            await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        }
+
         await this.paypalCommerceIntegrationService.loadPayPalSdk(methodId);
 
         this.renderButton(methodId, paypalcommerce);


### PR DESCRIPTION
## What?
Added a condition to load PPCP payment methods only if they are not exist in checkout state

## Why?
There is no need to make extra load for payment method in customer strategy, because it loads in parallel on checkout-js side.

## Parent PR
checkout-sdk: https://github.com/bigcommerce/checkout-sdk-js/pull/2258 

## Testing / Proof
Unit tests
CI tests
Manual tests