### PR TITLE
fix(payment): PAYPAL-3367 removed error throw from onCancel callback for PayPal AMP payment strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -157,7 +157,7 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
             style: this.paypalCommerceIntegrationService.getValidButtonStyle(buttonStyle),
             createOrder: () => this.onCreateOrder(paypalOptions),
             onApprove: (data) => this.handleApprove(data, submitForm),
-            onCancel: () => this.handleFailure(new Error('Payment was canceled.'), onError),
+            onCancel: () => this.toggleLoadingIndicator(false),
             onError: (error) => this.handleFailure(error, onError),
         };
 


### PR DESCRIPTION
## What?
Removed error throw from onCancel callback for PayPal AMP payment strategy

## Why?
To reduce customers confusion about the error on APM popup close

## Testing / Proof
Unit tests
