### PR TITLE
fix(payment): PAYPAL-3360 fixed a mistake in codeowners file due BT analytics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,7 +62,7 @@
 
 ## PayPal team
 
-/packages/core/src/analytics/src/braintree-connect-tracker
+/packages/core/src/analytics/braintree-connect-tracker
 /packages/core/src/checkout-buttons/strategies/braintree @bigcommerce/team-paypal
 /packages/core/src/checkout-buttons/strategies/paypal @bigcommerce/team-paypal
 /packages/core/src/customer/strategies/braintree @bigcommerce/team-paypal


### PR DESCRIPTION
## What?
Fixed a mistake in codeowners file due BT analytics

## Why?
To be able to update braintree connect tracker as a codeowner

## Testing / Proof
-
