### PR TITLE
feat(payment): PI-1021 [TD Bank][FE] Vaulted instruments implementation on Checkout 

### DIFF
--- a/packages/td-bank-integration/.eslintrc.json
+++ b/packages/td-bank-integration/.eslintrc.json
@@ -5,7 +5,8 @@
         {
             "files": ["*.spec.ts", "*.spec.tsx"],
             "rules": {
-                "@typescript-eslint/no-unsafe-call": "off"
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/no-unsafe-assignment": "off"
             }
         }
     ]

--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
@@ -157,6 +157,68 @@ describe('TDOnlineMartPaymentStrategy', () => {
 
             expect(paymentIntegrationService.submitPayment).not.toHaveBeenCalled();
         });
+
+        describe('with Vaulted Instruments', () => {
+            it('call submitPayment with instrument id', async () => {
+                payload = {
+                    payment: {
+                        methodId: 'tdonlinemart',
+                        paymentData: {
+                            instrumentId:
+                                'f73bdf6d8f466f6332f3daca2c5815f20c859cb7f19b9d1f340e4f2a7e18ddce',
+                        },
+                    },
+                };
+
+                await tdOnlineMartPaymentStrategy.initialize(
+                    tdOnlineMartClientScriptInitializationOptions,
+                );
+
+                await tdOnlineMartPaymentStrategy.execute(payload);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                    1,
+                    expect.objectContaining({
+                        methodId: 'tdonlinemart',
+                        paymentData: expect.objectContaining({
+                            instrumentId:
+                                'f73bdf6d8f466f6332f3daca2c5815f20c859cb7f19b9d1f340e4f2a7e18ddce',
+                        }),
+                    }),
+                );
+            });
+
+            it('call submitPayment with instrumentId and shouldSetAsDefaultInstrument id if customer want to save instrument', async () => {
+                payload = {
+                    payment: {
+                        methodId: 'tdonlinemart',
+                        paymentData: {
+                            instrumentId:
+                                'f73bdf6d8f466f6332f3daca2c5815f20c859cb7f19b9d1f340e4f2a7e18ddce',
+                            shouldSetAsDefaultInstrument: true,
+                        },
+                    },
+                };
+
+                await tdOnlineMartPaymentStrategy.initialize(
+                    tdOnlineMartClientScriptInitializationOptions,
+                );
+
+                await tdOnlineMartPaymentStrategy.execute(payload);
+
+                expect(paymentIntegrationService.submitPayment).toHaveBeenNthCalledWith(
+                    1,
+                    expect.objectContaining({
+                        methodId: 'tdonlinemart',
+                        paymentData: expect.objectContaining({
+                            instrumentId:
+                                'f73bdf6d8f466f6332f3daca2c5815f20c859cb7f19b9d1f340e4f2a7e18ddce',
+                            shouldSetAsDefaultInstrument: true,
+                        }),
+                    }),
+                );
+            });
+        });
     });
 
     describe('deinitialize', () => {

--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
@@ -164,8 +164,7 @@ describe('TDOnlineMartPaymentStrategy', () => {
                     payment: {
                         methodId: 'tdonlinemart',
                         paymentData: {
-                            instrumentId:
-                                'f73bdf6d8f466f6332f3daca2c5815f20c859cb7f19b9d1f340e4f2a7e18ddce',
+                            instrumentId: 'testInstrumentId',
                         },
                     },
                 };
@@ -181,8 +180,7 @@ describe('TDOnlineMartPaymentStrategy', () => {
                     expect.objectContaining({
                         methodId: 'tdonlinemart',
                         paymentData: expect.objectContaining({
-                            instrumentId:
-                                'f73bdf6d8f466f6332f3daca2c5815f20c859cb7f19b9d1f340e4f2a7e18ddce',
+                            instrumentId: 'testInstrumentId',
                         }),
                     }),
                 );
@@ -193,8 +191,7 @@ describe('TDOnlineMartPaymentStrategy', () => {
                     payment: {
                         methodId: 'tdonlinemart',
                         paymentData: {
-                            instrumentId:
-                                'f73bdf6d8f466f6332f3daca2c5815f20c859cb7f19b9d1f340e4f2a7e18ddce',
+                            instrumentId: 'testInstrumentId',
                             shouldSetAsDefaultInstrument: true,
                         },
                     },
@@ -211,8 +208,7 @@ describe('TDOnlineMartPaymentStrategy', () => {
                     expect.objectContaining({
                         methodId: 'tdonlinemart',
                         paymentData: expect.objectContaining({
-                            instrumentId:
-                                'f73bdf6d8f466f6332f3daca2c5815f20c859cb7f19b9d1f340e4f2a7e18ddce',
+                            instrumentId: 'testInstrumentId',
                             shouldSetAsDefaultInstrument: true,
                         }),
                     }),


### PR DESCRIPTION
## What?
Added vaulted credit cards support in checkout page. 

## Why?
Due to work with TD Bank integration.

## Testing / Proof
Manually tested
<img width="1460" alt="Zrzut ekranu 2023-12-19 o 12 17 15" src="https://github.com/bigcommerce/checkout-sdk-js/assets/130039975/c1c9c1d1-32d9-4316-a42d-a7bdb1154026">

@bigcommerce/team-checkout @bigcommerce/team-payments
