### PR TITLE
fix(payment): PAYPAL-3660 updated Braintree AXO events trigger order

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-customer-strategy.ts
@@ -70,12 +70,19 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
             );
         }
 
-        if (await this.shouldRunAuthenticationFlow()) {
-            await this.braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow();
-        }
+        if (this.isAcceleratedCheckoutEnabled) {
+            const shouldRunAuthenticationFlow = await this.shouldRunAuthenticationFlow();
 
-        if (checkoutPaymentMethodExecuted && typeof checkoutPaymentMethodExecuted === 'function') {
-            checkoutPaymentMethodExecuted();
+            if (
+                checkoutPaymentMethodExecuted &&
+                typeof checkoutPaymentMethodExecuted === 'function'
+            ) {
+                checkoutPaymentMethodExecuted();
+            }
+
+            if (shouldRunAuthenticationFlow) {
+                await this.braintreeAcceleratedCheckoutUtils.runPayPalConnectAuthenticationFlowOrThrow();
+            }
         }
 
         continueWithCheckoutCallback();
@@ -84,10 +91,6 @@ export default class BraintreeAcceleratedCheckoutCustomerStrategy implements Cus
     // TODO: remove this method after A/B testing finished
     private async shouldRunAuthenticationFlow(): Promise<boolean> {
         const primaryMethodId = 'braintreeacceleratedcheckout';
-
-        if (!this.isAcceleratedCheckoutEnabled) {
-            return false;
-        }
 
         try {
             // Info: we should load payment method each time to detect if the user

--- a/packages/core/src/analytics/braintree-connect-tracker/braintree-connect-tracker-service.ts
+++ b/packages/core/src/analytics/braintree-connect-tracker/braintree-connect-tracker-service.ts
@@ -1,4 +1,5 @@
 export default interface BraintreeConnectTrackerService {
+    // TODO: remove this method when this method will be removed from checkout-js part
     trackStepViewed(step: string): void;
     customerPaymentMethodExecuted(): void;
     paymentComplete(): void;

--- a/packages/core/src/analytics/braintree-connect-tracker/braintree-connect-tracker.spec.ts
+++ b/packages/core/src/analytics/braintree-connect-tracker/braintree-connect-tracker.spec.ts
@@ -73,35 +73,6 @@ describe('BraintreeConnectTracker', () => {
         });
     });
 
-    describe('trackStepViewed', () => {
-        it('does not trigger anything if braintreeConnect is not provided', () => {
-            delete braintreeConnectWindow.braintreeConnect;
-
-            braintreeConnectTracker.trackStepViewed('shipping');
-
-            expect(braintreeConnectMock.events.emailSubmitted).not.toHaveBeenCalled();
-        });
-
-        it('does not trigger any event on customer step', () => {
-            braintreeConnectTracker.trackStepViewed('customer');
-
-            expect(braintreeConnectMock.events.emailSubmitted).not.toHaveBeenCalled();
-        });
-
-        it('does not trigger any emailSubmitted event if it was called before', () => {
-            braintreeConnectTracker.customerPaymentMethodExecuted();
-            braintreeConnectTracker.trackStepViewed('shipping');
-
-            expect(braintreeConnectMock.events.emailSubmitted).toHaveBeenCalledTimes(1);
-        });
-
-        it('trigger emailSubmitted event', () => {
-            braintreeConnectTracker.trackStepViewed('payment');
-
-            expect(braintreeConnectMock.events.emailSubmitted).toHaveBeenCalled();
-        });
-    });
-
     describe('paymentComplete', () => {
         it('does not trigger anything if braintreeConnect is not provided', () => {
             delete braintreeConnectWindow.braintreeConnect;
@@ -111,18 +82,9 @@ describe('BraintreeConnectTracker', () => {
             expect(braintreeConnectMock.events.emailSubmitted).not.toHaveBeenCalled();
         });
 
-        it('triggers emailSubmitted and orderPlaced if emailSubmitted was not triggered before', () => {
+        it('triggers orderPlaced', () => {
             braintreeConnectTracker.paymentComplete();
 
-            expect(braintreeConnectMock.events.emailSubmitted).toHaveBeenCalled();
-            expect(braintreeConnectMock.events.orderPlaced).toHaveBeenCalled();
-        });
-
-        it('triggers only orderPlaced', () => {
-            braintreeConnectTracker.customerPaymentMethodExecuted();
-            braintreeConnectTracker.paymentComplete();
-
-            expect(braintreeConnectMock.events.emailSubmitted).toHaveBeenCalledTimes(1); // due to customerPaymentMethodExecuted method call
             expect(braintreeConnectMock.events.orderPlaced).toHaveBeenCalled();
         });
     });
@@ -272,16 +234,6 @@ describe('BraintreeConnectTracker', () => {
                 ...emailSubmitEventOptions,
                 apm_list: 'braintree,braintreeacceleratedcheckout',
                 apm_shown: '1',
-            });
-        });
-
-        it('calls emailSubmitted callback with preselected email', () => {
-            // Info: lets imagine that customer comes back from cart edit page and lands strait to shipping step
-            braintreeConnectTracker.trackStepViewed('shipping');
-
-            expect(braintreeConnectMock.events.emailSubmitted).toHaveBeenCalledWith({
-                ...emailSubmitEventOptions,
-                user_email_saved: true,
             });
         });
     });

--- a/packages/core/src/payment/create-payment-strategy-registry.ts
+++ b/packages/core/src/payment/create-payment-strategy-registry.ts
@@ -6,6 +6,11 @@ import {
     getStylesheetLoader,
 } from '@bigcommerce/script-loader';
 
+import {
+    BraintreeIntegrationService,
+    BraintreeScriptLoader,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
+
 import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import {
     CheckoutActionCreator,
@@ -320,6 +325,10 @@ export default function createPaymentStrategyRegistry(
                 paymentActionCreator,
                 paymentMethodActionCreator,
                 braintreePaymentProcessor,
+                new BraintreeIntegrationService(
+                    new BraintreeScriptLoader(getScriptLoader(), window),
+                    window,
+                ),
             ),
     );
 


### PR DESCRIPTION
## What?
- updated Braintree AXO events trigger order;
- added an ability to trigger Braintree Connect event for A/b control group;

## Why?
Due to updated requirements from PayPal side

## Testing / Proof
Unit tests
Manual tests by BC PayPal team
Manual tests by PayPal team
