### PR TITLE
chore(payment): BIG-0 Update @bigcommerce/bigpay-client from v5.26.0 to v5.26.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.504.0",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.26.0",
+        "@bigcommerce/bigpay-client": "^5.26.2",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1413,9 +1413,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.0.tgz",
-      "integrity": "sha512-fODAOJqa0fAnBG58BX4KkkI6nTCgv7vZ3TX5943Ce7+VzYcQbuAJf7CXx0TFagr/Myp2UAnlTfUQqdHxPvA2iw==",
+      "version": "5.26.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.2.tgz",
+      "integrity": "sha512-Gdzahix8fTpXVlyRVAviX/IV2DlmAqj5e7JDICAJ6uZXWCGHIbq3V8xZHk1+pVv6p7oZnb/b0pULupoUDvriUw==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -31447,9 +31447,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.0.tgz",
-      "integrity": "sha512-fODAOJqa0fAnBG58BX4KkkI6nTCgv7vZ3TX5943Ce7+VzYcQbuAJf7CXx0TFagr/Myp2UAnlTfUQqdHxPvA2iw==",
+      "version": "5.26.2",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.2.tgz",
+      "integrity": "sha512-Gdzahix8fTpXVlyRVAviX/IV2DlmAqj5e7JDICAJ6uZXWCGHIbq3V8xZHk1+pVv6p7oZnb/b0pULupoUDvriUw==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.26.0",
+    "@bigcommerce/bigpay-client": "^5.26.2",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Update @bigcommerce/bigpay-client from v5.26.0 to v5.26.2

Changelog: https://github.com/bigcommerce/bigpay-client-js/compare/v5.26.0...v5.26.2

That contains various dependabot PRs

## Why?
Keeping dependencies up to date

## Testing / Proof
CI

@bigcommerce/team-checkout @bigcommerce/team-payments