### PR TITLE
fix(payment): PAYPAL-000 fixed eslint warnings in paypal-commerce-integration package

### DIFF
--- a/packages/paypal-commerce-integration/src/mocks/index.ts
+++ b/packages/paypal-commerce-integration/src/mocks/index.ts
@@ -2,5 +2,6 @@ export { default as getBillingAddressFromOrderDetails } from './get-billing-addr
 export { default as getPayPalCommerceIntegrationServiceMock } from './get-paypal-commerce-integration-service-mock.mock';
 export { default as getPayPalCommerceOrderDetails } from './get-paypal-commerce-order-details.mock';
 export { default as getPayPalCommercePaymentMethod } from './get-paypal-commerce-payment-method.mock';
+export { default as getPayPalCommerceRatePayPaymentMethod } from './get-paypal-commerce-ratepay-payment-method.mock';
 export { default as getPayPalSDKMock } from './get-paypal-sdk.mock';
 export { default as getShippingAddressFromOrderDetails } from './get-shipping-address-from-order-details.mock';

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
@@ -205,23 +205,6 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
             }
         });
 
-        it('logs a warning message if options.paypalcommerce was not provided instead of options.paypalcommercealternativemethods', async () => {
-            const warnLogSpy = jest.spyOn(console, 'warn');
-
-            const options = {
-                methodId: defaultMethodId,
-                gatewayId: defaultGatewayId,
-                paypalcommerce: {
-                    container: defaultContainerId,
-                    apmFieldsContainer: defaultApmFieldsContainerId,
-                },
-            } as PaymentInitializeOptions;
-
-            await strategy.initialize(options);
-
-            expect(warnLogSpy).toHaveBeenCalled();
-        });
-
         it('does not continues strategy initialization if order id is available in initializationData', async () => {
             paymentMethod.initializationData.orderId = '1';
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -49,12 +49,6 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
         } = options;
         const paypalOptions = paypalcommercealternativemethods || paypalcommerce;
 
-        if (paypalcommerce) {
-            console.warn(
-                'The "options.paypalcommerce" option is deprecated for this strategy, please use "options.paypalcommercealternativemethods" instead',
-            );
-        }
-
         if (!methodId) {
             throw new InvalidArgumentError(
                 'Unable to initialize payment because "options.methodId" argument is not provided.',

--- a/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-credit/paypal-commerce-credit-payment-strategy.ts
@@ -49,12 +49,6 @@ export default class PayPalCommerceCreditPaymentStrategy implements PaymentStrat
             );
         }
 
-        if (paypalcommerce) {
-            console.warn(
-                'The "options.paypalcommerce" option is deprecated for this strategy, please use "options.paypalcommercevenmo" instead',
-            );
-        }
-
         if (!paypalOptions) {
             throw new InvalidArgumentError(
                 `Unable to initialize payment because "options.paypalcommerce" argument is not provided.`,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/create-paypal-commerce-ratepay-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/create-paypal-commerce-ratepay-payment-strategy.ts
@@ -4,6 +4,7 @@ import {
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import createPayPalCommerceIntegrationService from '../create-paypal-commerce-integration-service';
+
 import PaypalCommerceRatepayPaymentStrategy from './paypal-commerce-ratepay-payment-strategy';
 
 const createPaypalCommerceRatepayPaymentStrategy: PaymentStrategyFactory<

--- a/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-ratepay/paypal-commerce-ratepay-payment-strategy.spec.ts
@@ -7,15 +7,18 @@ import {
     PaymentIntegrationService,
     PaymentMethod,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
-import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
-
-import { PayPalCommerceHostWindow, PayPalSDK } from '../paypal-commerce-types';
-import PaypalCommerceRatepayPaymentStrategy from './paypal-commerce-ratepay-payment-strategy';
-import { getPayPalCommerceIntegrationServiceMock, getPayPalSDKMock } from '../mocks';
 import { PaymentIntegrationServiceMock } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
+
+import {
+    getPayPalCommerceIntegrationServiceMock,
+    getPayPalCommerceRatePayPaymentMethod,
+    getPayPalSDKMock,
+} from '../mocks';
+import PayPalCommerceIntegrationService from '../paypal-commerce-integration-service';
+import { PayPalCommerceHostWindow, PayPalSDK } from '../paypal-commerce-types';
+
 import { PaypalCommerceRatePay } from './paypal-commerce-ratepay-initialize-options';
-import getPayPalCommerceRatePayPaymentMethod from '../mocks/get-paypal-commerce-ratepay-payment-method.mock';
+import PaypalCommerceRatepayPaymentStrategy from './paypal-commerce-ratepay-payment-strategy';
 
 describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
     let billingAddress: BillingAddress;
@@ -173,6 +176,7 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
 
         it('throws error if merchantId is not provided', async () => {
             paymentMethod.initializationData.merchantId = '';
+
             const options = {
                 methodId: 'ratepay',
                 gatewayId: 'paypalcommercealternativemethods',
@@ -203,6 +207,7 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
 
         it('add another needed fraudNet script', async () => {
             await strategy.initialize(initializationOptions);
+
             const script = document.querySelector('script[src="https://c.paypal.com/da/r/fb.js"]');
 
             expect(script).toBeDefined();
@@ -212,6 +217,7 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
     describe('#renderLegalText', () => {
         it('throws error if legalTextContainerElement is not found', async () => {
             jest.spyOn(document, 'getElementById').mockImplementation(() => null);
+
             try {
                 await strategy.initialize(initializationOptions);
             } catch (error) {
@@ -221,6 +227,7 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
 
         it('renders legal text', async () => {
             await strategy.initialize(initializationOptions);
+
             const source = document.getElementsByTagName('html')[0].innerHTML;
             const legalText = source.search(
                 'By clicking on the button, you agree to the terms of payment and performance of a risk check from the payment partner, Ratepay. You also agree to PayPal’s privacy statement. If your request to purchase upon invoice is accepted, the purchase price claim will be assigned to Ratepay, and you may only pay Ratepay, not the merchant.',
@@ -241,6 +248,7 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
 
         it('throws an error if orderId is not defined', async () => {
             jest.spyOn(paypalCommerceIntegrationService, 'createOrder').mockReturnValue(undefined);
+
             const payload = {
                 payment: {
                     methodId: 'ratepay',
@@ -341,13 +349,16 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
             jest.spyOn(paypalCommerceIntegrationService, 'getOrderStatus').mockReturnValue(
                 'POLLING_ERROR',
             );
+
             const payload = {
                 payment: {
                     methodId: 'ratepay',
                     gatewayId: 'paypalcommercealternativemethods',
                 },
             };
+
             jest.spyOn(global, 'clearTimeout');
+
             try {
                 await strategy.initialize(initializationOptions);
                 await strategy.execute(payload);
@@ -371,6 +382,7 @@ describe('PayPalCommerceAlternativeMethodRatePayPaymentStrategy', () => {
                     gatewayId: 'paypalcommercealternativemethods',
                 },
             };
+
             jest.spyOn(paypalCommerceIntegrationService, 'getOrderStatus').mockReturnValue(
                 'POLLING_STOP',
             );

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.spec.ts
@@ -161,21 +161,6 @@ describe('PayPalCommerceVenmoPaymentStrategy', () => {
             }
         });
 
-        it('logs a warning message if options.paypalcommerce was not provided instead of options.paypalcommercealternativemethods', async () => {
-            const warnLogSpy = jest.spyOn(console, 'warn');
-
-            const options = {
-                methodId: defaultMethodId,
-                paypalcommerce: {
-                    container: defaultContainerId,
-                },
-            } as PaymentInitializeOptions;
-
-            await strategy.initialize(options);
-
-            expect(warnLogSpy).toHaveBeenCalled();
-        });
-
         it('throws error if options.paypalcommercevenmo is not provided', async () => {
             const options = {
                 methodId: defaultMethodId,

--- a/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-venmo/paypal-commerce-venmo-payment-strategy.ts
@@ -49,12 +49,6 @@ export default class PayPalCommerceVenmoPaymentStrategy implements PaymentStrate
             );
         }
 
-        if (paypalcommerce) {
-            console.warn(
-                'The "options.paypalcommerce" option is deprecated for this strategy, please use "options.paypalcommercevenmo" instead',
-            );
-        }
-
         if (!paypalOptions) {
             throw new InvalidArgumentError(
                 `Unable to initialize payment because "options.paypalcommercevenmo" argument is not provided.`,


### PR DESCRIPTION
## What?
Fixed eslint warnings in paypal-commerce-integration package.
Also removed unnecessary console.warn - we don't need them anymore

## Why?
To keep code as clean as possible

## Testing / Proof
Unit tests
Link command run

Before:
<img width="746" alt="Screenshot 2024-01-02 at 17 19 41" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/b6c0cb29-3ca9-4a61-9e34-53e4e3e3d79a">

After:
<img width="720" alt="Screenshot 2024-01-02 at 17 19 24" src="https://github.com/bigcommerce/checkout-sdk-js/assets/25133454/52085f20-800c-43d8-9531-49a83141df4b">