### PR TITLE
feat(payment): PI-1318 TDBank add  browser info

### DIFF
--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
@@ -207,6 +207,16 @@ describe('TDOnlineMartPaymentStrategy', () => {
                         methodId: 'tdonlinemart',
                         paymentData: expect.objectContaining({
                             instrumentId: 'testInstrumentId',
+                            /* eslint-disable @typescript-eslint/naming-convention */
+                            browser_info: expect.objectContaining({
+                                color_depth: expect.any(Number),
+                                java_enabled: expect.any(Boolean),
+                                language: expect.any(String),
+                                screen_height: expect.any(Number),
+                                screen_width: expect.any(Number),
+                                time_zone: expect.any(String),
+                            }),
+                            /* eslint-enable @typescript-eslint/naming-convention */
                         }),
                     }),
                 );
@@ -236,6 +246,16 @@ describe('TDOnlineMartPaymentStrategy', () => {
                         paymentData: expect.objectContaining({
                             instrumentId: 'testInstrumentId',
                             shouldSetAsDefaultInstrument: true,
+                            /* eslint-disable @typescript-eslint/naming-convention */
+                            browser_info: expect.objectContaining({
+                                color_depth: expect.any(Number),
+                                java_enabled: expect.any(Boolean),
+                                language: expect.any(String),
+                                screen_height: expect.any(Number),
+                                screen_width: expect.any(Number),
+                                time_zone: expect.any(String),
+                            }),
+                            /* eslint-enable @typescript-eslint/naming-convention */
                         }),
                     }),
                 );

--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.ts
@@ -1,6 +1,7 @@
 import { FormPoster } from '@bigcommerce/form-poster';
 
 import {
+    getBrowserInfo,
     InvalidArgumentError,
     isHostedInstrumentLike,
     isVaultedInstrument,
@@ -23,6 +24,7 @@ import { isTdOnlineMartAdditionalAction } from './isTdOnlineMartAdditionalAction
 import {
     FieldType,
     TDCustomCheckoutSDK,
+    TdOnlineMartBrowserInfo,
     TdOnlineMartElement,
     TdOnlineMartThreeDSErrorBody,
 } from './td-online-mart';
@@ -93,6 +95,11 @@ export default class TDOnlineMartPaymentStrategy implements PaymentStrategy {
 
         const { shouldSaveInstrument = false, shouldSetAsDefaultInstrument = false } =
             isHostedInstrumentLike(paymentData) ? paymentData : {};
+        const commonPaymentData = {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            browser_info: this.getTDBrowserInfo(),
+            shouldSetAsDefaultInstrument,
+        };
 
         let paymentToken;
 
@@ -104,8 +111,8 @@ export default class TDOnlineMartPaymentStrategy implements PaymentStrategy {
             return {
                 methodId,
                 paymentData: {
+                    ...commonPaymentData,
                     instrumentId: paymentData.instrumentId,
-                    shouldSetAsDefaultInstrument,
                 },
             };
         }
@@ -119,12 +126,23 @@ export default class TDOnlineMartPaymentStrategy implements PaymentStrategy {
         return {
             methodId,
             paymentData: {
+                ...commonPaymentData,
                 nonce: paymentToken,
                 shouldSaveInstrument,
-                shouldSetAsDefaultInstrument,
             },
         };
     }
+
+    /* eslint-disable @typescript-eslint/naming-convention */
+    private getTDBrowserInfo(): TdOnlineMartBrowserInfo {
+        const { time_zone_offset, ...defaultBrowserInfo } = getBrowserInfo();
+
+        return {
+            ...defaultBrowserInfo,
+            time_zone: time_zone_offset,
+        };
+    }
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     private mountHostedFields(methodId: string): void {
         const options = this.getHostedFieldsOptions();

--- a/packages/td-bank-integration/src/td-online-mart.ts
+++ b/packages/td-bank-integration/src/td-online-mart.ts
@@ -1,4 +1,4 @@
-import { RequestError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { BrowserInfo, RequestError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 export interface TdOnlineMartHostWindow extends Window {
     customcheckout?(): TDCustomCheckoutSDK;
@@ -84,3 +84,9 @@ interface CssStyles {
     paddingRight?: string;
     paddingBottom?: string;
 }
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export interface TdOnlineMartBrowserInfo extends Omit<BrowserInfo, 'time_zone_offset'> {
+    time_zone: string;
+}
+/* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
## What?
Add browser info to payments request payload

## Why?
Need this info for 3DS flow on TD Bank side

## Testing / Proof
unity tests and manually tested
<img width="1254" alt="Screenshot 2024-01-03 at 17 42 32" src="https://github.com/bigcommerce/checkout-sdk-js/assets/9430298/1fe20bdb-84c8-4e41-8c77-6f64443f21be">


@bigcommerce/team-checkout @bigcommerce/team-payments
