### PR TITLE
feat(payment): PAYPAL-3300 Added onClick and onInit options to handle validation process with mandatory terms and conditions

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-initialize-options.ts
@@ -1,4 +1,4 @@
-import { PayPalCommerceFieldsStyleOptions } from '../paypal-commerce-types';
+import { InitCallbackActions, PayPalCommerceFieldsStyleOptions } from '../paypal-commerce-types';
 
 /**
  * A set of options that are required to initialize the PayPal Commerce payment
@@ -114,6 +114,12 @@ export default interface PayPalCommerceAlternativeMethodsPaymentOptions {
      * when buyer approved PayPal account.
      */
     submitForm(): void;
+
+    /**
+     * A callback that gets called
+     * when Smart Payment Button is initialized.
+     */
+    onInitButton(actions: InitCallbackActions): Promise<void>;
 }
 
 export interface WithPayPalCommerceAlternativeMethodsPaymentInitializeOptions {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
@@ -113,6 +113,18 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
                     }
                 });
 
+                eventEmitter.on('onInit', () => {
+                    if (options.onInit) {
+                        options.onInit(
+                            { correlationID: defaultMethodId },
+                            {
+                                disable: jest.fn(),
+                                enable: jest.fn(),
+                            },
+                        );
+                    }
+                });
+
                 eventEmitter.on('onClick', () => {
                     if (options.onClick) {
                         options.onClick(
@@ -233,6 +245,7 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
                     height: 55,
                     label: 'pay',
                 },
+                onInit: expect.any(Function),
                 onClick: expect.any(Function),
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
@@ -319,6 +332,27 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
             await new Promise((resolve) => process.nextTick(resolve));
 
             expect(onValidateMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onInit button callback', () => {
+        it('calls validation callback with provided params', async () => {
+            const onInitButtonMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                methodId: NonInstantAlternativePaymentMethods.OXXO,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    onInitButton: onInitButtonMock,
+                },
+            });
+
+            eventEmitter.emit('onInit');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(onInitButtonMock).toHaveBeenCalled();
         });
     });
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.spec.ts
@@ -233,6 +233,7 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
                     height: 55,
                     label: 'pay',
                 },
+                onClick: expect.any(Function),
                 createOrder: expect.any(Function),
                 onApprove: expect.any(Function),
                 onCancel: expect.any(Function),
@@ -279,27 +280,6 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
                 'paypalcommercealternativemethodscheckout',
             );
         });
-    });
-
-    describe('#onClick button callback', () => {
-        it('does not initialize polling mechanism for non instant payment methods before validation', async () => {
-            const submitFormMock = jest.fn();
-
-            await strategy.initialize({
-                ...initializationOptions,
-                methodId: NonInstantAlternativePaymentMethods.OXXO,
-                paypalcommercealternativemethods: {
-                    ...paypalCommerceAlternativeMethodsOptions,
-                    submitForm: submitFormMock,
-                },
-            });
-
-            eventEmitter.emit('onClick');
-
-            await new Promise((resolve) => process.nextTick(resolve));
-
-            expect(submitFormMock).not.toHaveBeenCalled();
-        });
 
         it('calls validation callback with provided params', async () => {
             const onValidateMock = jest.fn();
@@ -314,6 +294,27 @@ describe('PayPalCommerceAlternativeMethodsPaymentStrategy', () => {
             });
 
             eventEmitter.emit('createOrder');
+
+            await new Promise((resolve) => process.nextTick(resolve));
+
+            expect(onValidateMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('#onClick button callback', () => {
+        it('calls validation callback with provided params', async () => {
+            const onValidateMock = jest.fn();
+
+            await strategy.initialize({
+                ...initializationOptions,
+                methodId: NonInstantAlternativePaymentMethods.OXXO,
+                paypalcommercealternativemethods: {
+                    ...paypalCommerceAlternativeMethodsOptions,
+                    onValidate: onValidateMock,
+                },
+            });
+
+            eventEmitter.emit('onClick');
 
             await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -149,12 +149,13 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
         const buttonOptions: PayPalCommerceButtonsOptions = {
             fundingSource: methodId,
             style: this.paypalCommerceIntegrationService.getValidButtonStyle(buttonStyle),
-            onClick: async (_, actions) =>
-                paypalOptions.onValidate(actions.resolve, actions.reject),
+            onInit: (_, actions) => paypalOptions.onInitButton(actions),
             createOrder: () => this.onCreateOrder(paypalOptions),
             onApprove: (data) => this.handleApprove(data, submitForm),
             onCancel: () => this.toggleLoadingIndicator(false),
             onError: (error) => this.handleFailure(error, onError),
+            onClick: async (_, actions) =>
+                paypalOptions.onValidate(actions.resolve, actions.reject),
         };
 
         this.paypalButton = paypalSdk.Buttons(buttonOptions);

--- a/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-alternative-methods/paypal-commerce-alternative-methods-payment-strategy.ts
@@ -149,6 +149,8 @@ export default class PayPalCommerceAlternativeMethodsPaymentStrategy implements 
         const buttonOptions: PayPalCommerceButtonsOptions = {
             fundingSource: methodId,
             style: this.paypalCommerceIntegrationService.getValidButtonStyle(buttonStyle),
+            onClick: async (_, actions) =>
+                paypalOptions.onValidate(actions.resolve, actions.reject),
             createOrder: () => this.onCreateOrder(paypalOptions),
             onApprove: (data) => this.handleApprove(data, submitForm),
             onCancel: () => this.toggleLoadingIndicator(false),

--- a/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-types.ts
@@ -279,6 +279,7 @@ export interface PayPalCommerceButtonsOptions {
         data: ApproveCallbackPayload,
         actions: ApproveCallbackActions,
     ): Promise<boolean | void> | void;
+    onInit?(data: InitCallbackPayload, actions: InitCallbackActions): Promise<void>;
     onComplete?(data: CompleteCallbackDataPayload): Promise<void>;
     onClick?(data: ClickCallbackPayload, actions: ClickCallbackActions): Promise<void> | void;
     onError?(error: Error): void;
@@ -293,6 +294,15 @@ export interface ClickCallbackPayload {
 export interface ClickCallbackActions {
     reject(): void;
     resolve(): void;
+}
+
+export interface InitCallbackPayload {
+    correlationID: string;
+}
+
+export interface InitCallbackActions {
+    disable(): void;
+    enable(): void;
 }
 
 export interface ShippingChangeCallbackPayload {


### PR DESCRIPTION
## What?

Added `onClick` and `onInit` options to handle validation process

## Why?

To validate a form with mandatory fields, as for the checkbox "Terms and Conditions"

@bigcommerce/team-payments
