### PR TITLE
feat(payment): PI-1318 TDBank add  browser info

### DIFF
--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.spec.ts
@@ -214,7 +214,7 @@ describe('TDOnlineMartPaymentStrategy', () => {
                                 language: expect.any(String),
                                 screen_height: expect.any(Number),
                                 screen_width: expect.any(Number),
-                                time_zone: expect.any(String),
+                                time_zone_offset: expect.any(String),
                             }),
                             /* eslint-enable @typescript-eslint/naming-convention */
                         }),
@@ -253,7 +253,7 @@ describe('TDOnlineMartPaymentStrategy', () => {
                                 language: expect.any(String),
                                 screen_height: expect.any(Number),
                                 screen_width: expect.any(Number),
-                                time_zone: expect.any(String),
+                                time_zone_offset: expect.any(String),
                             }),
                             /* eslint-enable @typescript-eslint/naming-convention */
                         }),

--- a/packages/td-bank-integration/src/td-online-mart-payment-strategy.ts
+++ b/packages/td-bank-integration/src/td-online-mart-payment-strategy.ts
@@ -24,7 +24,6 @@ import { isTdOnlineMartAdditionalAction } from './isTdOnlineMartAdditionalAction
 import {
     FieldType,
     TDCustomCheckoutSDK,
-    TdOnlineMartBrowserInfo,
     TdOnlineMartElement,
     TdOnlineMartThreeDSErrorBody,
 } from './td-online-mart';
@@ -97,7 +96,7 @@ export default class TDOnlineMartPaymentStrategy implements PaymentStrategy {
             isHostedInstrumentLike(paymentData) ? paymentData : {};
         const commonPaymentData = {
             // eslint-disable-next-line @typescript-eslint/naming-convention
-            browser_info: this.getTDBrowserInfo(),
+            browser_info: getBrowserInfo(),
             shouldSetAsDefaultInstrument,
         };
 
@@ -132,17 +131,6 @@ export default class TDOnlineMartPaymentStrategy implements PaymentStrategy {
             },
         };
     }
-
-    /* eslint-disable @typescript-eslint/naming-convention */
-    private getTDBrowserInfo(): TdOnlineMartBrowserInfo {
-        const { time_zone_offset, ...defaultBrowserInfo } = getBrowserInfo();
-
-        return {
-            ...defaultBrowserInfo,
-            time_zone: time_zone_offset,
-        };
-    }
-    /* eslint-enable @typescript-eslint/naming-convention */
 
     private mountHostedFields(methodId: string): void {
         const options = this.getHostedFieldsOptions();

--- a/packages/td-bank-integration/src/td-online-mart.ts
+++ b/packages/td-bank-integration/src/td-online-mart.ts
@@ -1,4 +1,4 @@
-import { BrowserInfo, RequestError } from '@bigcommerce/checkout-sdk/payment-integration-api';
+import { RequestError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 export interface TdOnlineMartHostWindow extends Window {
     customcheckout?(): TDCustomCheckoutSDK;
@@ -84,9 +84,3 @@ interface CssStyles {
     paddingRight?: string;
     paddingBottom?: string;
 }
-
-/* eslint-disable @typescript-eslint/naming-convention */
-export interface TdOnlineMartBrowserInfo extends Omit<BrowserInfo, 'time_zone_offset'> {
-    time_zone: string;
-}
-/* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
## What?
Change `time_zone` to `time_zone_offset` for TD bank 3DS browser information

## Why?
Because of difference between BigPay properties mapping and TD bank documentation

## Testing / Proof
unit test

@bigcommerce/team-checkout @bigcommerce/team-payments
