### PR TITLE
feat(payment): PAYPAL-3409 updated PaymentProviderCustomer with PPCP AXO related interface

### DIFF
--- a/packages/payment-integration-api/src/payment-provider-customer/index.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/index.ts
@@ -1,4 +1,5 @@
 export {
     BraintreeAcceleratedCheckoutCustomer,
+    PayPalCommerceAcceleratedCheckoutCustomer,
     PaymentProviderCustomer,
 } from './payment-provider-customer';

--- a/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,10 +1,19 @@
+import { AddressRequestBody } from '../address';
 import { CustomerAddress } from '../customer';
 import { CardInstrument } from '../payment';
 
-export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
+export type PaymentProviderCustomer =
+    | BraintreeAcceleratedCheckoutCustomer
+    | PayPalCommerceAcceleratedCheckoutCustomer;
 
 export interface BraintreeAcceleratedCheckoutCustomer {
     authenticationState?: string;
     addresses?: CustomerAddress[];
+    instruments?: CardInstrument[];
+}
+
+export interface PayPalCommerceAcceleratedCheckoutCustomer {
+    authenticationState?: string;
+    addresses?: AddressRequestBody[];
     instruments?: CardInstrument[];
 }


### PR DESCRIPTION
## What?
Updated PaymentProviderCustomer with PPCP AXO related interface

## Why?
To be able to save PayPalCommerce related PaymentProviderCustomer data into checkout state

## Testing / Proof
Unit tests
Ci tests
Manual test in separate PR with the feature, that uses this interface