### PR TITLE
Revert "feat(payment): PAYPAL-3229 added onClick callback to AmazonPay customer strategy (#2271)"

### DIFF
--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-initialize-options.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-initialize-options.ts
@@ -16,7 +16,6 @@
  *     methodId: 'amazonpay',
  *     amazonpay: {
  *         container: 'signInButton',
- *         onClick: () => console.log('AmazonPay button clicked'),
  *     },
  * });
  * ```
@@ -26,9 +25,4 @@ export default interface AmazonPayV2CustomerInitializeOptions {
      * The ID of a container which the sign-in button should insert into.
      */
     container: string;
-
-    /**
-     * Callback that get called on wallet button click
-     */
-    onClick?(): void;
 }

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.spec.ts
@@ -102,7 +102,6 @@ describe('AmazonPayV2CustomerStrategy', () => {
                 containerId: 'amazonpayCheckoutButton',
                 methodId: 'amazonpay',
                 placement: AmazonPayV2Placement.Checkout,
-                onClick: customerInitializeOptions.amazonpay?.onClick,
             });
         });
 
@@ -121,17 +120,6 @@ describe('AmazonPayV2CustomerStrategy', () => {
                 customerInitializeOptions = getAmazonPayV2CustomerInitializeOptions(
                     Mode.Incomplete,
                 );
-
-                const initialize = strategy.initialize(customerInitializeOptions);
-
-                await expect(initialize).rejects.toThrow(InvalidArgumentError);
-            });
-
-            test('if onClick is not a function', async () => {
-                customerInitializeOptions = {
-                    ...getAmazonPayV2CustomerInitializeOptions(Mode.UndefinedMethodId),
-                    onClick: 'test',
-                };
 
                 const initialize = strategy.initialize(customerInitializeOptions);
 

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer-strategy.ts
@@ -32,12 +32,6 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
             );
         }
 
-        if (amazonpay.onClick && typeof amazonpay.onClick !== 'function') {
-            throw new InvalidArgumentError(
-                'Unable to proceed because "options.amazonpay.onClick" argument is not a function.',
-            );
-        }
-
         let state = this._store.getState();
         let paymentMethod: PaymentMethod<any>;
 
@@ -57,7 +51,6 @@ export default class AmazonPayV2CustomerStrategy implements CustomerStrategy {
             containerId: amazonpay.container,
             methodId,
             placement: AmazonPayV2Placement.Checkout,
-            ...(amazonpay.onClick && { onClick: amazonpay.onClick }),
         });
 
         return this._store.getState();

--- a/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer.mock.ts
+++ b/packages/core/src/customer/strategies/amazon-pay-v2/amazon-pay-v2-customer.mock.ts
@@ -14,12 +14,7 @@ export function getAmazonPayV2CustomerInitializeOptions(
     const undefinedMethodId = { methodId: undefined };
     const container = { container: 'amazonpayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
-    const amazonPayV2 = {
-        amazonpay: {
-            ...container,
-            onClick: jest.fn(),
-        },
-    };
+    const amazonPayV2 = { amazonpay: { ...container } };
     const amazonPayV2WithInvalidContainer = { amazonpay: { ...invalidContainer } };
 
     switch (mode) {

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.spec.ts
@@ -155,20 +155,6 @@ describe('AmazonPayV2PaymentProcessor', () => {
             );
         });
 
-        it('onClick is called to define custom actions', async () => {
-            await processor.initialize(amazonPayV2Mock);
-
-            const onClickCallback = jest.fn();
-
-            processor.createButton(containerId, amazonPayV2ButtonParams, onClickCallback);
-
-            const amazonPayV2Button: AmazonPayV2Button = (
-                amazonPayV2SDKMock.Pay.renderButton as jest.Mock
-            ).mock.results[0].value;
-
-            expect(amazonPayV2Button.onClick).toHaveBeenCalledTimes(1);
-        });
-
         it('throws an error when amazonPayV2SDK is not initialized', () => {
             const createButton = () => processor.createButton(containerId, amazonPayV2ButtonParams);
 

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts
@@ -64,23 +64,11 @@ export default class AmazonPayV2PaymentProcessor {
         });
     }
 
-    createButton(
-        containerId: string,
-        options: AmazonPayV2ButtonParameters,
-        onClick?: () => void,
-    ): void {
+    createButton(containerId: string, options: AmazonPayV2ButtonParameters): void {
         this._amazonPayV2Button = this._getAmazonPayV2SDK().Pay.renderButton(
             `#${containerId}`,
             options,
         );
-
-        // onClick callback is a function provided through initializationOptions to the strategy
-        // P.S.: related to customer strategy
-        if (onClick && typeof onClick === 'function') {
-            this._amazonPayV2Button.onClick(() => {
-                onClick();
-            });
-        }
     }
 
     prepareCheckout(createCheckoutSessionConfig: Required<AmazonPayV2CheckoutSessionConfig>) {
@@ -132,7 +120,6 @@ export default class AmazonPayV2PaymentProcessor {
         methodId,
         options,
         placement,
-        onClick,
     }: AmazonPayV2ButtonRenderingOptions): HTMLDivElement {
         const container = document.querySelector<HTMLElement>(`#${containerId}`);
 
@@ -158,7 +145,7 @@ export default class AmazonPayV2PaymentProcessor {
                 buttonColor,
             );
 
-        this.createButton(parentContainerId, amazonPayV2ButtonOptions, onClick);
+        this.createButton(parentContainerId, amazonPayV2ButtonOptions);
 
         return this._getButtonParentContainer();
     }

--- a/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
+++ b/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2.ts
@@ -256,5 +256,4 @@ export interface AmazonPayV2ButtonRenderingOptions {
     buttonColor?: AmazonPayV2ButtonColor;
     options?: AmazonPayV2ButtonParameters;
     placement: AmazonPayV2Placement;
-    onClick?(): void;
 }


### PR DESCRIPTION
This reverts commit 2a4e0ec52b76cba5b5b4c0680778cfd8fff82164.

## What?
This reverts commit https://github.com/bigcommerce/checkout-sdk-js/commit/2a4e0ec52b76cba5b5b4c0680778cfd8fff82164. 
Due to the https://github.com/bigcommerce/checkout-sdk-js/issues/2310

## Why?
To fix this issue fast we need to revert commit. For adding working onClick handler on the customer step button need deeper and more time consuming refactoring 

Implementation should be similar to the https://github.com/bigcommerce/checkout-sdk-js/blob/master/packages/core/src/payment/strategies/amazon-pay-v2/amazon-pay-v2-payment-processor.ts#L104

[Amazon Docs](https://developer.amazon.com/docs/amazon-pay-checkout/amazon-pay-script.html?environmentSpecificKeys=true#render-the-amazon-pay-button)

## Testing / Proof
Tested manully/units

@bigcommerce/team-checkout @bigcommerce/team-payments
