### PR TITLE
chore(payment): PAYPAL-3445 bump bigpay-client-js to v5.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.513.0",
       "license": "MIT",
       "dependencies": {
-        "@bigcommerce/bigpay-client": "^5.26.2",
+        "@bigcommerce/bigpay-client": "^5.27.0",
         "@bigcommerce/data-store": "^1.0.1",
         "@bigcommerce/form-poster": "^1.4.0",
         "@bigcommerce/memoize": "^1.0.0",
@@ -1413,9 +1413,9 @@
       "dev": true
     },
     "node_modules/@bigcommerce/bigpay-client": {
-      "version": "5.26.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.2.tgz",
-      "integrity": "sha512-Gdzahix8fTpXVlyRVAviX/IV2DlmAqj5e7JDICAJ6uZXWCGHIbq3V8xZHk1+pVv6p7oZnb/b0pULupoUDvriUw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.27.0.tgz",
+      "integrity": "sha512-yBMEzTavay+wHTgIfu6gt9efD/z7Bqxe0iYCQeM561PwwF/5v+vAaLS2Y8kasD9m9IszMy98rBBFMzhGBiMhNA==",
       "dependencies": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",
@@ -31447,9 +31447,9 @@
       "dev": true
     },
     "@bigcommerce/bigpay-client": {
-      "version": "5.26.2",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.26.2.tgz",
-      "integrity": "sha512-Gdzahix8fTpXVlyRVAviX/IV2DlmAqj5e7JDICAJ6uZXWCGHIbq3V8xZHk1+pVv6p7oZnb/b0pULupoUDvriUw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/bigpay-client/-/bigpay-client-5.27.0.tgz",
+      "integrity": "sha512-yBMEzTavay+wHTgIfu6gt9efD/z7Bqxe0iYCQeM561PwwF/5v+vAaLS2Y8kasD9m9IszMy98rBBFMzhGBiMhNA==",
       "requires": {
         "@bigcommerce/form-poster": "^1.4.0",
         "babel-jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "addFileAttribute": "true"
   },
   "dependencies": {
-    "@bigcommerce/bigpay-client": "^5.26.2",
+    "@bigcommerce/bigpay-client": "^5.27.0",
     "@bigcommerce/data-store": "^1.0.1",
     "@bigcommerce/form-poster": "^1.4.0",
     "@bigcommerce/memoize": "^1.0.0",


### PR DESCRIPTION
## What?
Bump bigpay-client-js to v5.27.0

## Why?
As part of PPCP AXO develompment

## Sibling PR
bigpay-client-js: https://github.com/bigcommerce/bigpay-client-js/pull/279

## Testing / Proof
Manual tests
CI
