### PR TITLE
feat(payment): PAYPAL-3416 updated WithPayPalConnectInstrument interface with an optional order_id

### DIFF
--- a/packages/payment-integration-api/src/payment/payment.ts
+++ b/packages/payment-integration-api/src/payment/payment.ts
@@ -101,6 +101,7 @@ export interface WithMollieIssuerInstrument {
 
 export interface WithPayPalConnectInstrument {
     paypal_connect_token: {
+        order_id?: string;
         token: string;
     };
 }


### PR DESCRIPTION
## What?
Updated WithPayPalConnectInstrument interface with an optional order_id

## Why?
To be able to pass order id in payment payload for successful place order with PPCP AXO payment method

## Testing / Proof
Unit tests
Manual tests
CI