### PR TITLE
feat(payment): PI-1309 generating a verification token for payment with stored cards in Square v2

### DIFF
--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -305,6 +305,9 @@ describe('SquareV2PaymentStrategy', () => {
                             bigpay_token: {
                                 token: 'bigpaytoken',
                             },
+                            credit_card_token: {
+                                token: 'verf:yyy',
+                            },
                             vault_payment_instrument: false,
                             set_as_default_stored_instrument: false,
                         },

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -331,9 +331,7 @@ describe('SquareV2PaymentStrategy', () => {
 
             it('should submit the payment with verification token', async () => {
                 const storeConfigMock = getConfig().storeConfig;
-                const squareCardsDataMock = [
-                    { bigpay_token: 'bigpaytoken', provider_card_token: 'ccof:yyy' },
-                ];
+                const squareCardsDataMock = [{ token: 'bigpaytoken', id: 'ccof:yyy' }];
 
                 storeConfigMock.checkoutSettings.features = {
                     'PROJECT-3828.add_3ds_support_on_squarev2': true,

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.spec.ts
@@ -350,7 +350,9 @@ describe('SquareV2PaymentStrategy', () => {
                 ).mockReturnValue({
                     ...getSquareV2(),
                     initializationData: {
-                        squareCardsData: squareCardsDataMock,
+                        providerData: {
+                            squareCardsData: squareCardsDataMock,
+                        },
                     },
                 });
 

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -74,18 +74,20 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
 
         if (paymentData && isVaultedInstrument(paymentData)) {
             if (this._shouldVerify()) {
+                const squareCardId = this._getSquareCardId(paymentData.instrumentId);
+
                 await this._paymentIntegrationService.submitPayment({
                     ...payment,
                     paymentData: {
                         formattedPayload: {
-                            bigpay_token: {
-                                token: paymentData.instrumentId,
-                            },
                             credit_card_token: {
-                                token: await this._squareV2PaymentProcessor.verifyBuyer(
-                                    this._getSquareCardId(paymentData.instrumentId),
-                                    SquareIntent.CHARGE,
-                                ),
+                                token: JSON.stringify({
+                                    card_id: squareCardId,
+                                    token: await this._squareV2PaymentProcessor.verifyBuyer(
+                                        squareCardId,
+                                        SquareIntent.CHARGE,
+                                    ),
+                                }),
                             },
                             vault_payment_instrument: shouldSaveInstrument || false,
                             set_as_default_stored_instrument: shouldSetAsDefaultInstrument || false,

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -176,9 +176,9 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
             if (squareCardsData) {
                 const cardData = squareCardsData
                     .reduce((acc, cur) => acc.concat(cur), [])
-                    .find((data) => data.bigpay_token === bigpayToken);
+                    .find((data) => data.token === bigpayToken);
 
-                return cardData?.provider_card_token || '';
+                return cardData?.id || '';
             }
         }
 

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -174,7 +174,9 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
             const { squareCardsData } = initializationData?.providerData || {};
 
             if (squareCardsData) {
-                const cardData = squareCardsData.find((data) => data.bigpay_token === bigpayToken);
+                const cardData = squareCardsData
+                    .reduce((acc, cur) => acc.concat(cur), [])
+                    .find((data) => data.bigpay_token === bigpayToken);
 
                 return cardData?.provider_card_token || '';
             }

--- a/packages/squarev2-integration/src/squarev2-payment-strategy.ts
+++ b/packages/squarev2-integration/src/squarev2-payment-strategy.ts
@@ -171,7 +171,7 @@ export default class SquareV2PaymentStrategy implements PaymentStrategy {
                 .getState()
                 .getPaymentMethodOrThrow<SquarePaymentMethodInitializationData>(this._methodId);
 
-            const { squareCardsData } = initializationData || {};
+            const { squareCardsData } = initializationData?.providerData || {};
 
             if (squareCardsData) {
                 const cardData = squareCardsData.find((data) => data.bigpay_token === bigpayToken);

--- a/packages/squarev2-integration/src/types.ts
+++ b/packages/squarev2-integration/src/types.ts
@@ -1,8 +1,8 @@
 export * from '@square/web-payments-sdk-types';
 
 interface SquareCardsData {
-    bigpay_token: string;
-    provider_card_token: string;
+    token: string;
+    id: string;
 }
 
 export interface SquarePaymentMethodInitializationData {

--- a/packages/squarev2-integration/src/types.ts
+++ b/packages/squarev2-integration/src/types.ts
@@ -9,6 +9,6 @@ export interface SquarePaymentMethodInitializationData {
     applicationId: string;
     locationId?: string;
     providerData?: {
-        squareCardsData: SquareCardsData[];
+        squareCardsData: SquareCardsData[][];
     };
 }

--- a/packages/squarev2-integration/src/types.ts
+++ b/packages/squarev2-integration/src/types.ts
@@ -1,6 +1,12 @@
 export * from '@square/web-payments-sdk-types';
 
+interface SquareCardsData {
+    bigpay_token: string;
+    provider_card_token: string;
+}
+
 export interface SquarePaymentMethodInitializationData {
     applicationId: string;
     locationId?: string;
+    squareCardsData?: SquareCardsData[];
 }

--- a/packages/squarev2-integration/src/types.ts
+++ b/packages/squarev2-integration/src/types.ts
@@ -8,5 +8,7 @@ interface SquareCardsData {
 export interface SquarePaymentMethodInitializationData {
     applicationId: string;
     locationId?: string;
-    squareCardsData?: SquareCardsData[];
+    providerData?: {
+        squareCardsData: SquareCardsData[];
+    };
 }


### PR DESCRIPTION
## What?
Add verification token to the `submitPayment` payload for stored cards with 3ds in Square v2.

## Why?
Verification token is needed for a payment to be successful.

BE part:
https://github.com/bigcommerce/bigpay/pull/7799
https://github.com/bigcommerce/bigcommerce/pull/56276

## Testing / Proof
Unit tests
Manual tests

@bigcommerce/team-checkout @bigcommerce/team-payments
