### PR TITLE
feat(payment): PAYPAL-3439 added restart flow for PPCP

### DIFF
--- a/packages/paypal-commerce-integration/.eslintrc.json
+++ b/packages/paypal-commerce-integration/.eslintrc.json
@@ -29,7 +29,8 @@
                 "@typescript-eslint/no-floating-promises": "off",
                 "jest/valid-expect": "off",
                 "@typescript-eslint/no-unnecessary-condition": "off",
-                "@typescript-eslint/no-unsafe-call": "off"
+                "@typescript-eslint/no-unsafe-call": "off",
+                "@typescript-eslint/no-throw-literal": "off"
             }
         },
         {

--- a/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-initialize-options.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce/paypal-commerce-payment-initialize-options.ts
@@ -51,7 +51,7 @@ export default interface PayPalCommercePaymentInitializeOptions {
     /**
      * A callback for displaying error popup. This callback requires error object as parameter.
      */
-    onError?(error: Error): void;
+    onError?(error: unknown): void;
 
     /**
      * A callback right before render Smart Payment Button that gets called when

--- a/packages/paypal-commerce-utils/src/index.ts
+++ b/packages/paypal-commerce-utils/src/index.ts
@@ -17,3 +17,5 @@ export { default as PayPalCommerceSdk } from './paypal-commerce-sdk';
  */
 export { default as createPayPalCommerceAcceleratedCheckoutUtils } from './create-paypal-commerce-accelerated-checkout-utils';
 export { default as PayPalCommerceAcceleratedCheckoutUtils } from './paypal-commerce-accelerated-checkout-utils';
+
+export { default as isPaypalCommerceProviderError } from './utils/is-paypal-commerce-provider-error';

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-provider-error.spec.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-provider-error.spec.ts
@@ -1,0 +1,45 @@
+import isPaypalCommerceProviderError from './is-paypal-commerce-provider-error';
+
+describe('isPaypalCommerceProviderError', () => {
+    it('returns true if error paypalcommerce provider related', () => {
+        const providerError = {
+            status: 'error',
+            three_ds_result: {
+                acs_url: null,
+                payer_auth_request: null,
+                merchant_data: null,
+                callback_url: null,
+            },
+            errors: [
+                {
+                    code: 'invalid_request_error',
+                    message:
+                        'Were experiencing difficulty processing your transaction. Please contact us or try again later.',
+                },
+                {
+                    code: 'transaction_rejected',
+                    message: 'Payment was declined. Please try again.',
+                    provider_error: {
+                        code: 'INSTRUMENT_DECLINED',
+                    },
+                },
+            ],
+        };
+
+        expect(isPaypalCommerceProviderError(providerError)).toBe(true);
+    });
+
+    it('returns false if error not paypalcommerce provider related', () => {
+        const notProviderError = {
+            status: 'error',
+            three_ds_result: {
+                acs_url: null,
+                payer_auth_request: null,
+                merchant_data: null,
+                callback_url: null,
+            },
+        };
+
+        expect(isPaypalCommerceProviderError(notProviderError)).toBe(false);
+    });
+});

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-provider-error.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-provider-error.ts
@@ -1,0 +1,22 @@
+export interface ProviderError extends Error {
+    errors?: ErrorElement[];
+    status?: string;
+    three_ds_result?: {
+        acs_url: unknown;
+        payer_auth_request: unknown;
+        merchant_data: unknown;
+        callback_url: unknown;
+    };
+}
+
+export interface ErrorElement {
+    code: string;
+    message: string;
+    provider_error?: {
+        code: string;
+    };
+}
+
+export default function isPaypalCommerceProviderError(error: unknown): error is ProviderError {
+    return typeof error === 'object' && error !== null && 'errors' in error;
+}


### PR DESCRIPTION
## What?
Added restart flow for PPCP

## Why?
To avoid `INSTRUMENT_DECLINED` error

## Testing / Proof


https://github.com/bigcommerce/checkout-sdk-js/assets/56301104/bb8c385c-19a5-456f-a442-b97c8df6af54



@bigcommerce/team-checkout @bigcommerce/team-payments
