### PR TITLE
fix(checkout): DATA-11638 Fix payloads for Segment events

### DIFF
--- a/packages/core/src/analytics/analytics-step-tracker.spec.ts
+++ b/packages/core/src/analytics/analytics-step-tracker.spec.ts
@@ -155,7 +155,7 @@ describe('AnalyticsStepTracker', () => {
                 expect.objectContaining({
                     products: [
                         {
-                            product_id: 103,
+                            product_id: '103',
                             sku: 'CLC',
                             name: 'Canvas Laundry Cart',
                             price: 190,
@@ -166,7 +166,7 @@ describe('AnalyticsStepTracker', () => {
                             variant: 'n:v',
                         },
                         {
-                            product_id: 104,
+                            product_id: '104',
                             sku: 'CLX',
                             name: 'Digital Book',
                             price: 200,
@@ -230,7 +230,7 @@ describe('AnalyticsStepTracker', () => {
                 expect(analytics.track).toHaveBeenCalledWith(
                     'Order Completed',
                     expect.objectContaining({
-                        orderId: 295,
+                        order_id: '295',
                     }),
                 );
             });
@@ -304,7 +304,7 @@ describe('AnalyticsStepTracker', () => {
                     expect.objectContaining({
                         products: [
                             {
-                                product_id: 103,
+                                product_id: '103',
                                 sku: 'CLC',
                                 name: 'Canvas Laundry Cart',
                                 price: 190,
@@ -585,7 +585,7 @@ describe('AnalyticsStepTracker', () => {
                 analyticsStepTracker.trackStepCompleted('payment');
             });
 
-            it('sends an empty shippingMethod property when neither paymentMethod nor shippingMethod are specified', () => {
+            it('sends an empty shipping_method property when neither payment_method nor shipping_method are specified', () => {
                 expect(analytics.track).toHaveBeenCalledWith(
                     COMPLETED_EVENT_NAME,
                     buildCompletedPayload(AnalyticStepId.PAYMENT),
@@ -608,11 +608,11 @@ describe('AnalyticsStepTracker', () => {
                 analyticsStepTracker.trackStepCompleted('payment');
             });
 
-            it('sends the shippingMethod and payment data', () => {
+            it('sends the shipping_method and payment data', () => {
                 expect(analytics.track).toHaveBeenCalledWith(COMPLETED_EVENT_NAME, {
                     step: AnalyticStepId.PAYMENT,
-                    shippingMethod: 'Flat Rate',
-                    paymentMethod: 'Authorizenet',
+                    shipping_method: 'Flat Rate',
+                    payment_method: 'Authorizenet',
                     currency: 'JPY',
                 });
             });
@@ -624,7 +624,7 @@ describe('AnalyticsStepTracker', () => {
                 expect(analytics.track).toHaveBeenCalledTimes(0);
             });
 
-            it('sends step complete event again if different shippingMethod method is selected', () => {
+            it('sends step complete event again if different shipping_method is selected', () => {
                 jest.spyOn(
                     checkoutService.getState().data,
                     'getSelectedShippingOption',
@@ -643,7 +643,7 @@ describe('AnalyticsStepTracker', () => {
 
                 expect(analytics.track).toHaveBeenLastCalledWith(COMPLETED_EVENT_NAME, {
                     step: AnalyticStepId.SHIPPING,
-                    shippingMethod: 'foo',
+                    shipping_method: 'foo',
                     currency: 'JPY',
                 });
             });
@@ -651,6 +651,6 @@ describe('AnalyticsStepTracker', () => {
     });
 
     function buildCompletedPayload(step: AnalyticStepId) {
-        return { step, shippingMethod: ' ', currency: 'JPY' };
+        return { step, shipping_method: ' ', currency: 'JPY' };
     }
 });


### PR DESCRIPTION
## What? [DATA-11638](https://bigcommercecloud.atlassian.net/browse/DATA-11638)
- Make `product_id` field a string for `Checkout Started` and `Order Completed` events
- Rename `orderId` field to `order_id` for `Order Completed` event
- Make `order_id` field a string  for `Order Completed` event
- Rename `shippingMethod` field to `shipping_method` for `Checkout Step Completed` event
- Rename `paymentMethod` field to `payment_method` for `Checkout Step Completed` event
- Do not populate `brand` field if brand is missing for a product
- Assign default value `single-product-option` for the `variant` field in products payload in order to make it consistent with other events. [Related PR](https://github.com/bigcommerce/bigcommerce/pull/56279)
- Update unit tests

## Why?
There are several inconsistencies between payload we generate and Segment specification. So that we need to adjust the existing logic to make the payload consistent with the specifications.

## Testing / Proof
- Manually tested on dev store
- Unit tests

@bigcommerce/team-checkout @bigcommerce/team-payments


[DATA-11638]: https://bigcommercecloud.atlassian.net/browse/DATA-11638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ