### PR TITLE
refactor(payment): PAYPAL-3466 covered paypal connect paymentProviderCustomer checkout state object with type guards

### DIFF
--- a/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
+++ b/packages/braintree-integration/src/braintree-accelerated-checkout/braintree-accelerated-checkout-payment-strategy.spec.ts
@@ -362,6 +362,7 @@ describe('BraintreeAcceleratedCheckoutPaymentStrategy', () => {
                 'getPaymentProviderCustomerOrThrow',
             ).mockImplementation(() => ({
                 authenticationState: 'succeeded',
+                addresses: [],
                 instruments: [
                     {
                         brand: 'visa',

--- a/packages/braintree-integration/src/map-to-braintree-shipping-address-override.spec.ts
+++ b/packages/braintree-integration/src/map-to-braintree-shipping-address-override.spec.ts
@@ -1,6 +1,6 @@
+import { getBraintreeAddress } from '@bigcommerce/checkout-sdk/braintree-utils';
 import { getShippingAddress } from '@bigcommerce/checkout-sdk/payment-integrations-test-utils';
 
-import { getBraintreeAddress } from '@bigcommerce/checkout-sdk/braintree-utils';
 import mapToBraintreeShippingAddressOverride from './map-to-braintree-shipping-address-override';
 
 describe('mapToBraintreeAddress()', () => {

--- a/packages/braintree-integration/src/map-to-braintree-shipping-address-override.ts
+++ b/packages/braintree-integration/src/map-to-braintree-shipping-address-override.ts
@@ -1,6 +1,5 @@
-import { Address } from '@bigcommerce/checkout-sdk/payment-integration-api';
-
 import { BraintreeShippingAddressOverride } from '@bigcommerce/checkout-sdk/braintree-utils';
+import { Address } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 export default function mapToBraintreeShippingAddressOverride(
     address: Address,

--- a/packages/braintree-utils/src/index.ts
+++ b/packages/braintree-utils/src/index.ts
@@ -1,4 +1,6 @@
 export * from './braintree';
+export * from './utils';
+
 export {
     PaypalSDK,
     PaypalButtonOptions,
@@ -27,6 +29,5 @@ export {
     getBraintreeAddress,
     getBraintreePaypal,
 } from './mocks/braintree.mock';
-export { getValidBraintreeConnectStyles, isBraintreeConnectWindow } from './utils';
 export { getPaypalMock } from './mocks/paypal.mock';
 export { BRAINTREE_SDK_STABLE_VERSION, BRAINTREE_SDK_ALPHA_VERSION } from './sdk-verison';

--- a/packages/braintree-utils/src/utils/index.ts
+++ b/packages/braintree-utils/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { default as getValidBraintreeConnectStyles } from './get-valid-braintree-connect-styles';
 export { default as isBraintreeConnectWindow } from './is-braintree-connect-window';
+export { default as isBraintreeAcceleratedCheckoutCustomer } from './is-braintree-accelerated-checkout-customer';

--- a/packages/braintree-utils/src/utils/is-braintree-accelerated-checkout-customer.spec.ts
+++ b/packages/braintree-utils/src/utils/is-braintree-accelerated-checkout-customer.spec.ts
@@ -1,0 +1,21 @@
+import isBraintreeAcceleratedCheckoutCustomer from './is-braintree-accelerated-checkout-customer';
+
+describe('isBraintreeAcceleratedCheckoutCustomer', () => {
+    it('returns true if payment provider customer is Braintree related', () => {
+        const paymentProviderCustomer = {
+            authenticationState: 'success',
+            addresses: [],
+            instruments: [],
+        };
+
+        expect(isBraintreeAcceleratedCheckoutCustomer(paymentProviderCustomer)).toBe(true);
+    });
+
+    it('returns false if payment provider customer is not Braintree related', () => {
+        const paymentProviderCustomer = {
+            stripeLinkAuthenticationState: true,
+        };
+
+        expect(isBraintreeAcceleratedCheckoutCustomer(paymentProviderCustomer)).toBe(false);
+    });
+});

--- a/packages/braintree-utils/src/utils/is-braintree-accelerated-checkout-customer.ts
+++ b/packages/braintree-utils/src/utils/is-braintree-accelerated-checkout-customer.ts
@@ -1,0 +1,16 @@
+import {
+    BraintreeAcceleratedCheckoutCustomer,
+    PaymentProviderCustomer,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default function isBraintreeAcceleratedCheckoutCustomer(
+    customer?: PaymentProviderCustomer,
+): customer is BraintreeAcceleratedCheckoutCustomer {
+    if (!customer) {
+        return false;
+    }
+
+    return (
+        'authenticationState' in customer || 'addresses' in customer || 'instruments' in customer
+    );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,10 +23,7 @@ export {
     PaymentMethodActionCreator,
     PaymentMethod,
 } from './payment';
-export {
-    BraintreeAcceleratedCheckoutCustomer,
-    PaymentProviderCustomer,
-} from './payment-provider-customer';
+export { PaymentProviderCustomer } from './payment-provider-customer';
 export { getPayment } from './payment/payments.mock';
 export { CardInstrument } from './payment/instrument';
 export {

--- a/packages/core/src/payment-provider-customer/index.ts
+++ b/packages/core/src/payment-provider-customer/index.ts
@@ -1,7 +1,4 @@
-export {
-    PaymentProviderCustomer,
-    BraintreeAcceleratedCheckoutCustomer,
-} from './payment-provider-customer';
+export { PaymentProviderCustomer } from './payment-provider-customer';
 export {
     PaymentProviderCustomerType,
     PaymentProviderCustomerAction,

--- a/packages/core/src/payment-provider-customer/payment-provider-customer-selector.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer-selector.ts
@@ -4,8 +4,8 @@ import { MissingDataError, MissingDataErrorType } from '../common/error/errors';
 import { createSelector } from '../common/selector';
 import { guard } from '../common/utility';
 
-import PaymentProviderCustomerState, { DEFAULT_STATE } from './payment-provider-customer-state';
 import { PaymentProviderCustomer } from './payment-provider-customer';
+import PaymentProviderCustomerState, { DEFAULT_STATE } from './payment-provider-customer-state';
 
 export default interface PaymentProviderCustomerSelector {
     getPaymentProviderCustomer(): PaymentProviderCustomer | undefined;

--- a/packages/core/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/core/src/payment-provider-customer/payment-provider-customer.ts
@@ -1,10 +1,3 @@
-import { CustomerAddress } from '../customer';
-import { CardInstrument } from '../payment/instrument/instrument';
+import { PaymentProviderCustomer } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
-export type PaymentProviderCustomer = BraintreeAcceleratedCheckoutCustomer;
-
-export interface BraintreeAcceleratedCheckoutCustomer {
-    authenticationState?: string;
-    addresses?: CustomerAddress[];
-    instruments?: CardInstrument[];
-}
+export { PaymentProviderCustomer };

--- a/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
+++ b/packages/core/src/payment/strategies/braintree/braintree-credit-card-payment-strategy.ts
@@ -1,6 +1,9 @@
 import { some } from 'lodash';
 
-import { BraintreeIntegrationService } from '@bigcommerce/checkout-sdk/braintree-utils';
+import {
+    BraintreeIntegrationService,
+    isBraintreeAcceleratedCheckoutCustomer,
+} from '@bigcommerce/checkout-sdk/braintree-utils';
 import { PaymentMethodFailedError } from '@bigcommerce/checkout-sdk/payment-integration-api';
 
 import { Address } from '../../../address';
@@ -271,10 +274,17 @@ export default class BraintreeCreditCardPaymentStrategy implements PaymentStrate
     private _shouldInitializeBraintreeConnect() {
         const state = this._store.getState();
         const paymentProviderCustomer = state.paymentProviderCustomer.getPaymentProviderCustomer();
+        const braintreePaymentProviderCustomer = isBraintreeAcceleratedCheckoutCustomer(
+            paymentProviderCustomer,
+        )
+            ? paymentProviderCustomer
+            : {};
         const isAcceleratedCheckoutEnabled =
             this._paymentMethod?.initializationData.isAcceleratedCheckoutEnabled;
 
-        return isAcceleratedCheckoutEnabled && !paymentProviderCustomer?.authenticationState;
+        return (
+            isAcceleratedCheckoutEnabled && !braintreePaymentProviderCustomer?.authenticationState
+        );
     }
 
     // TODO: remove this part when BT AXO A/B testing will be finished

--- a/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.ts
+++ b/packages/core/src/shipping/strategies/braintree/braintree-accelerated-checkout-shipping-strategy.ts
@@ -8,6 +8,7 @@ import {
     BraintreeConnectStylesOption,
     BraintreeConnectVaultedInstrument,
     BraintreeIntegrationService,
+    isBraintreeAcceleratedCheckoutCustomer,
 } from '@bigcommerce/checkout-sdk/braintree-utils';
 import { BrowserStorage } from '@bigcommerce/checkout-sdk/storage';
 
@@ -99,15 +100,23 @@ export default class BraintreeAcceleratedCheckoutShippingStrategy implements Shi
         const cartId = state.cart.getCart()?.id;
         const paypalConnectSessionId = this._browserStorage.getItem('sessionId');
         const paymentProviderCustomer = state.paymentProviderCustomer.getPaymentProviderCustomer();
+        const braintreePaymentProviderCustomer = isBraintreeAcceleratedCheckoutCustomer(
+            paymentProviderCustomer,
+        )
+            ? paymentProviderCustomer
+            : {};
 
         if (
-            paymentProviderCustomer?.authenticationState ===
+            braintreePaymentProviderCustomer?.authenticationState ===
             BraintreeConnectAuthenticationState.CANCELED
         ) {
             return false;
         }
 
-        return !paymentProviderCustomer?.authenticationState && paypalConnectSessionId === cartId;
+        return (
+            !braintreePaymentProviderCustomer?.authenticationState &&
+            paypalConnectSessionId === cartId
+        );
     }
 
     private async _runAuthenticationFlowOrThrow(

--- a/packages/payment-integration-api/src/index.ts
+++ b/packages/payment-integration-api/src/index.ts
@@ -149,6 +149,8 @@ export { default as PaymentIntegrationService } from './payment-integration-serv
 export {
     BraintreeAcceleratedCheckoutCustomer,
     PaymentProviderCustomer,
+    PayPalCommerceAcceleratedCheckoutCustomer,
+    StripeAcceleratedCheckoutCustomer,
 } from './payment-provider-customer';
 export {
     Consignment,

--- a/packages/payment-integration-api/src/payment-provider-customer/index.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/index.ts
@@ -1,5 +1,6 @@
 export {
     BraintreeAcceleratedCheckoutCustomer,
-    PayPalCommerceAcceleratedCheckoutCustomer,
     PaymentProviderCustomer,
+    PayPalCommerceAcceleratedCheckoutCustomer,
+    StripeAcceleratedCheckoutCustomer,
 } from './payment-provider-customer';

--- a/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
+++ b/packages/payment-integration-api/src/payment-provider-customer/payment-provider-customer.ts
@@ -4,7 +4,8 @@ import { CardInstrument } from '../payment';
 
 export type PaymentProviderCustomer =
     | BraintreeAcceleratedCheckoutCustomer
-    | PayPalCommerceAcceleratedCheckoutCustomer;
+    | PayPalCommerceAcceleratedCheckoutCustomer
+    | StripeAcceleratedCheckoutCustomer;
 
 export interface BraintreeAcceleratedCheckoutCustomer {
     authenticationState?: string;
@@ -16,4 +17,8 @@ export interface PayPalCommerceAcceleratedCheckoutCustomer {
     authenticationState?: string;
     addresses?: AddressRequestBody[];
     instruments?: CardInstrument[];
+}
+
+export interface StripeAcceleratedCheckoutCustomer {
+    stripeLinkAuthenticationState?: boolean;
 }

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-payment-strategy.ts
@@ -16,6 +16,7 @@ import {
     VaultedInstrument,
 } from '@bigcommerce/checkout-sdk/payment-integration-api';
 import {
+    isPayPalCommerceAcceleratedCheckoutCustomer,
     PayPalCommerceAcceleratedCheckoutUtils,
     PayPalCommerceConnectAuthenticationState,
     PayPalCommerceConnectCardComponentMethods,
@@ -155,18 +156,26 @@ export default class PayPalCommerceAcceleratedCheckoutPaymentStrategy implements
         const state = this.paymentIntegrationService.getState();
         const cart = state.getCartOrThrow();
         const paymentProviderCustomer = state.getPaymentProviderCustomer();
+        const paypalCommercePaymentProviderCustomer = isPayPalCommerceAcceleratedCheckoutCustomer(
+            paymentProviderCustomer,
+        )
+            ? paymentProviderCustomer
+            : {};
 
         const paypalConnectSessionId =
             this.paypalCommerceAcceleratedCheckoutUtils.getStorageSessionId();
 
         if (
-            paymentProviderCustomer?.authenticationState ===
+            paypalCommercePaymentProviderCustomer?.authenticationState ===
             PayPalCommerceConnectAuthenticationState.CANCELED
         ) {
             return false;
         }
 
-        return !paymentProviderCustomer?.authenticationState && paypalConnectSessionId === cart.id;
+        return (
+            !paypalCommercePaymentProviderCustomer?.authenticationState &&
+            paypalConnectSessionId === cart.id
+        );
     }
 
     private async runPayPalConnectAuthenticationFlowOrThrow(methodId: string): Promise<void> {

--- a/packages/paypal-commerce-utils/src/index.ts
+++ b/packages/paypal-commerce-utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './paypal-commerce-types';
 export * from './mocks';
+export * from './utils';
 
 /**
  *

--- a/packages/paypal-commerce-utils/src/utils/index.ts
+++ b/packages/paypal-commerce-utils/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as isPayPalCommerceAcceleratedCheckoutCustomer } from './is-paypal-commerce-accelerated-checkout-customer';

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-accelerated-checkout-customer.spec.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-accelerated-checkout-customer.spec.ts
@@ -1,0 +1,21 @@
+import isPayPalCommerceAcceleratedCheckoutCustomer from './is-paypal-commerce-accelerated-checkout-customer';
+
+describe('isPayPalCommerceAcceleratedCheckoutCustomer', () => {
+    it('returns true if payment provider customer is PayPalCommerce related', () => {
+        const paymentProviderCustomer = {
+            authenticationState: 'success',
+            addresses: [],
+            instruments: [],
+        };
+
+        expect(isPayPalCommerceAcceleratedCheckoutCustomer(paymentProviderCustomer)).toBe(true);
+    });
+
+    it('returns false if payment provider customer is not PayPalCommerce related', () => {
+        const paymentProviderCustomer = {
+            stripeLinkAuthenticationState: true,
+        };
+
+        expect(isPayPalCommerceAcceleratedCheckoutCustomer(paymentProviderCustomer)).toBe(false);
+    });
+});

--- a/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-accelerated-checkout-customer.ts
+++ b/packages/paypal-commerce-utils/src/utils/is-paypal-commerce-accelerated-checkout-customer.ts
@@ -1,0 +1,16 @@
+import {
+    PaymentProviderCustomer,
+    PayPalCommerceAcceleratedCheckoutCustomer,
+} from '@bigcommerce/checkout-sdk/payment-integration-api';
+
+export default function isPayPalCommerceAcceleratedCheckoutCustomer(
+    customer?: PaymentProviderCustomer,
+): customer is PayPalCommerceAcceleratedCheckoutCustomer {
+    if (!customer) {
+        return false;
+    }
+
+    return (
+        'authenticationState' in customer || 'addresses' in customer || 'instruments' in customer
+    );
+}


### PR DESCRIPTION
## What?
Covered PayPal Connect `paymentProviderCustomer` checkout state object with type guards

## Why?
To avoid any build errors when new paymentProviderCustomer type added

## Testing / Proof
Unit tests
CI