### PR TITLE
fix(payment): PAYPAL-3466 load paypalcommerce payment method in initialization method of PPCP AXO customer strategy

### DIFF
--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.spec.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.spec.ts
@@ -147,7 +147,6 @@ describe('PayPalCommerceAcceleratedCheckoutCustomerStrategy', () => {
 
         const state = paymentIntegrationService.getState();
 
-        // jest.spyOn(paymentIntegrationService, 'getState');
         jest.spyOn(paymentIntegrationService, 'loadPaymentMethod');
         jest.spyOn(paymentIntegrationService, 'updatePaymentProviderCustomer');
         jest.spyOn(paymentIntegrationService, 'updateBillingAddress');
@@ -196,10 +195,12 @@ describe('PayPalCommerceAcceleratedCheckoutCustomerStrategy', () => {
             }
         });
 
-        it('loads paypal accelerated checkout payment method', async () => {
+        it('loads paypal commerce payment method', async () => {
             await strategy.initialize(initializationOptions);
 
-            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(methodId);
+            expect(paymentIntegrationService.loadPaymentMethod).toHaveBeenCalledWith(
+                'paypalcommerce',
+            );
         });
 
         it('do nothing if accelerated checkout feature is disabled', async () => {

--- a/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.ts
+++ b/packages/paypal-commerce-integration/src/paypal-commerce-accelerated-checkout/paypal-commerce-accelerated-checkout-customer-strategy.ts
@@ -39,13 +39,19 @@ export default class PayPalCommerceAcceleratedCheckoutCustomerStrategy implement
             );
         }
 
-        await this.paymentIntegrationService.loadPaymentMethod(methodId);
+        // TODO: remove when A/B testing finished
+        // Info: parent method id should be used in current initialization method
+        // to avoid getting error after loading payment method which is not available
+        // for a control group customers
+        const parentMethodId = 'paypalcommerce';
 
-        if (this.isAcceleratedCheckoutFeatureEnabled(methodId)) {
+        await this.paymentIntegrationService.loadPaymentMethod(parentMethodId);
+
+        if (this.isAcceleratedCheckoutFeatureEnabled(parentMethodId)) {
             const state = this.paymentIntegrationService.getState();
             const currency = state.getCartOrThrow().currency.code;
             const paymentMethod =
-                state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(methodId);
+                state.getPaymentMethodOrThrow<PayPalCommerceInitializationData>(parentMethodId);
 
             this.paypalConnectStyles = paypalcommerceacceleratedcheckout?.styles;
 


### PR DESCRIPTION
## What?
Load paypalcommerce payment method in initialization method of PPCP AXO customer strategy

## Why?
To avoid getting error on load payment method with  paypalcommerceacceleratedcheckout method id when the payment method is not available on BE side

## Testing / Proof
Unit tests
