### PR TITLE
feat(payment): PAYPAL-3470 Update paypal-commerce-sdk configuration to use PayLater Messages separately

### DIFF
--- a/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
@@ -8,12 +8,7 @@ import {
 
 import { getPayPalAxoSdk, getPayPalCommerceAcceleratedCheckoutPaymentMethod } from './mocks';
 import PayPalCommerceSdk from './paypal-commerce-sdk';
-import {
-    PayPalAxoSdk,
-    PayPalCommerceHostWindow,
-    PayPalCommerceSdkNamespaces,
-    PayPalMessagesSdk,
-} from './paypal-commerce-types';
+import { PayPalAxoSdk, PayPalCommerceHostWindow, PayPalMessagesSdk } from './paypal-commerce-types';
 
 describe('PayPalCommerceSdk', () => {
     let loader: ScriptLoader;
@@ -71,7 +66,7 @@ describe('PayPalCommerceSdk', () => {
                     async: true,
                     attributes: {
                         'data-client-metadata-id': 'sandbox',
-                        'data-namespace': PayPalCommerceSdkNamespaces.PaypalAxo,
+                        'data-namespace': 'paypalAxo',
                         'data-partner-attribution-id': '1123JLKJASD12',
                         'data-user-id-token': 'asdcvY7XFSQasd',
                     },
@@ -117,11 +112,11 @@ describe('PayPalCommerceSdk', () => {
             await subject.getPayPalMessages(paymentMethod, 'USD');
 
             expect(loader.loadScript).toHaveBeenCalledWith(
-                'https://www.paypal.com/sdk/js?client-id=abc&merchant-id=JTS4DY7XFSQZE&commit=true&components=messages&currency=USD&intent=capture',
+                'https://www.paypal.com/sdk/js?client-id=abc&merchant-id=JTS4DY7XFSQZE&components=messages&currency=USD',
                 {
                     async: true,
                     attributes: {
-                        'data-namespace': PayPalCommerceSdkNamespaces.PaypalMessages,
+                        'data-namespace': 'paypalMessages',
                         'data-partner-attribution-id': '1123JLKJASD12',
                         'data-user-id-token': 'asdcvY7XFSQasd',
                     },

--- a/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-sdk.spec.ts
@@ -8,13 +8,21 @@ import {
 
 import { getPayPalAxoSdk, getPayPalCommerceAcceleratedCheckoutPaymentMethod } from './mocks';
 import PayPalCommerceSdk from './paypal-commerce-sdk';
-import { PayPalAxoSdk, PayPalCommerceHostWindow } from './paypal-commerce-types';
+import {
+    PayPalAxoSdk,
+    PayPalCommerceHostWindow,
+    PayPalCommerceSdkNamespaces,
+    PayPalMessagesSdk,
+} from './paypal-commerce-types';
 
 describe('PayPalCommerceSdk', () => {
     let loader: ScriptLoader;
     let paymentMethod: PaymentMethod;
     let paypalAxoSdk: PayPalAxoSdk;
     let subject: PayPalCommerceSdk;
+    const paypalMessagesSdk: PayPalMessagesSdk = {
+        Messages: jest.fn(),
+    };
 
     beforeEach(() => {
         loader = createScriptLoader();
@@ -24,6 +32,7 @@ describe('PayPalCommerceSdk', () => {
 
         jest.spyOn(loader, 'loadScript').mockImplementation(() => {
             (window as PayPalCommerceHostWindow).paypalAxo = paypalAxoSdk;
+            (window as PayPalCommerceHostWindow).paypalMessages = paypalMessagesSdk;
 
             return Promise.resolve();
         });
@@ -31,6 +40,7 @@ describe('PayPalCommerceSdk', () => {
 
     afterEach(() => {
         (window as PayPalCommerceHostWindow).paypalAxo = undefined;
+        (window as PayPalCommerceHostWindow).paypalMessages = undefined;
 
         jest.clearAllMocks();
     });
@@ -61,7 +71,7 @@ describe('PayPalCommerceSdk', () => {
                     async: true,
                     attributes: {
                         'data-client-metadata-id': 'sandbox',
-                        'data-namespace': 'paypalAxo',
+                        'data-namespace': PayPalCommerceSdkNamespaces.PaypalAxo,
                         'data-partner-attribution-id': '1123JLKJASD12',
                         'data-user-id-token': 'asdcvY7XFSQasd',
                     },
@@ -83,6 +93,56 @@ describe('PayPalCommerceSdk', () => {
             const result = await subject.getPayPalAxo(paymentMethod, 'USD');
 
             expect(result).toEqual(paypalAxoSdk);
+        });
+    });
+
+    describe('#getPayLaterMessages()', () => {
+        it('throws an error if clientId is not defined in payment method while getting configuration for PayPal Sdk', async () => {
+            const mockPaymentMethod = {
+                ...paymentMethod,
+                initializationData: {
+                    ...paymentMethod.initializationData,
+                    clientId: undefined,
+                },
+            };
+
+            try {
+                await subject.getPayPalMessages(mockPaymentMethod, 'USD');
+            } catch (error: unknown) {
+                expect(error).toBeInstanceOf(MissingDataError);
+            }
+        });
+
+        it('loads PayLater Messages sdk script', async () => {
+            await subject.getPayPalMessages(paymentMethod, 'USD');
+
+            expect(loader.loadScript).toHaveBeenCalledWith(
+                'https://www.paypal.com/sdk/js?client-id=abc&merchant-id=JTS4DY7XFSQZE&commit=true&components=messages&currency=USD&intent=capture',
+                {
+                    async: true,
+                    attributes: {
+                        'data-namespace': PayPalCommerceSdkNamespaces.PaypalMessages,
+                        'data-partner-attribution-id': '1123JLKJASD12',
+                        'data-user-id-token': 'asdcvY7XFSQasd',
+                    },
+                },
+            );
+        });
+
+        it('throws an error if there was an issue with loading paylater messages sdk', async () => {
+            jest.spyOn(loader, 'loadScript').mockImplementation(jest.fn());
+
+            try {
+                await subject.getPayPalMessages(paymentMethod, 'USD');
+            } catch (error: unknown) {
+                expect(error).toBeInstanceOf(PaymentMethodClientUnavailableError);
+            }
+        });
+
+        it('returns PayPal Messages Sdk', async () => {
+            const result = await subject.getPayPalMessages(paymentMethod, 'USD');
+
+            expect(result).toEqual(paypalMessagesSdk);
         });
     });
 });

--- a/packages/paypal-commerce-utils/src/paypal-commerce-sdk.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-sdk.ts
@@ -11,7 +11,6 @@ import {
     PayPalAxoSdk,
     PayPalCommerceHostWindow,
     PayPalCommerceInitializationData,
-    PayPalCommerceSdkNamespaces,
     PayPalMessagesSdk,
     PayPalSdkConfig,
 } from './paypal-commerce-types';
@@ -35,10 +34,10 @@ export default class PayPalCommerceSdk {
             );
 
             await this.loadPayPalSdk(paypalSdkConnectConfig);
-        }
 
-        if (!this.window.paypalAxo) {
-            throw new PaymentMethodClientUnavailableError();
+            if (!this.window.paypalAxo) {
+                throw new PaymentMethodClientUnavailableError();
+            }
         }
 
         return this.window.paypalAxo;
@@ -55,10 +54,10 @@ export default class PayPalCommerceSdk {
             );
 
             await this.loadPayPalSdk(paypalSdkMessagesConfig);
-        }
 
-        if (!this.window.paypalMessages) {
-            throw new PaymentMethodClientUnavailableError();
+            if (!this.window.paypalMessages) {
+                throw new PaymentMethodClientUnavailableError();
+            }
         }
 
         return this.window.paypalMessages;
@@ -112,7 +111,7 @@ export default class PayPalCommerceSdk {
             },
             attributes: {
                 'data-client-metadata-id': 'sandbox', // TODO: should be updated when paypal will be ready for production
-                'data-namespace': PayPalCommerceSdkNamespaces.PaypalAxo,
+                'data-namespace': 'paypalAxo',
                 'data-partner-attribution-id': attributionId,
                 'data-user-id-token': clientToken,
             },
@@ -129,19 +128,17 @@ export default class PayPalCommerceSdk {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
-        const { intent, clientId, merchantId, attributionId } = initializationData;
+        const { clientId, merchantId, attributionId } = initializationData;
 
         return {
             options: {
                 'client-id': clientId,
                 'merchant-id': merchantId,
-                commit: true,
                 components: ['messages'],
                 currency: currencyCode,
-                intent,
             },
             attributes: {
-                'data-namespace': PayPalCommerceSdkNamespaces.PaypalMessages,
+                'data-namespace': 'paypalMessages',
                 'data-partner-attribution-id': attributionId,
                 'data-user-id-token': clientToken,
             },

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -39,25 +39,14 @@ export interface PayPalCommerceInitializationData {
 
 /**
  *
- * PayPal Commerce Sdk Namespaces
- *
- */
-export enum PayPalCommerceSdkNamespaces {
-    PaypalAxo = 'paypalAxo',
-    PaypalMessages = 'paypalMessages',
-    PaypalConnect = 'paypalConnect',
-}
-
-/**
- *
  * PayPalCommerceHostWindow contains different
  * PayPal Sdk instances for different purposes
  *
  */
 export interface PayPalCommerceHostWindow extends Window {
-    [PayPalCommerceSdkNamespaces.PaypalAxo]?: PayPalAxoSdk;
-    [PayPalCommerceSdkNamespaces.PaypalConnect]?: PayPalCommerceConnect;
-    [PayPalCommerceSdkNamespaces.PaypalMessages]?: PayPalMessagesSdk;
+    paypalAxo?: PayPalAxoSdk;
+    paypalConnect?: PayPalCommerceConnect;
+    paypalMessages?: PayPalMessagesSdk;
 }
 
 /**

--- a/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
+++ b/packages/paypal-commerce-utils/src/paypal-commerce-types.ts
@@ -39,13 +39,25 @@ export interface PayPalCommerceInitializationData {
 
 /**
  *
+ * PayPal Commerce Sdk Namespaces
+ *
+ */
+export enum PayPalCommerceSdkNamespaces {
+    PaypalAxo = 'paypalAxo',
+    PaypalMessages = 'paypalMessages',
+    PaypalConnect = 'paypalConnect',
+}
+
+/**
+ *
  * PayPalCommerceHostWindow contains different
  * PayPal Sdk instances for different purposes
  *
  */
 export interface PayPalCommerceHostWindow extends Window {
-    paypalAxo?: PayPalAxoSdk;
-    paypalConnect?: PayPalCommerceConnect;
+    [PayPalCommerceSdkNamespaces.PaypalAxo]?: PayPalAxoSdk;
+    [PayPalCommerceSdkNamespaces.PaypalConnect]?: PayPalCommerceConnect;
+    [PayPalCommerceSdkNamespaces.PaypalMessages]?: PayPalMessagesSdk;
 }
 
 /**
@@ -76,7 +88,7 @@ export enum PayPalCommerceIntent {
     CAPTURE = 'capture',
 }
 
-export type PayPalSdkComponents = Array<'connect'>;
+export type PayPalSdkComponents = Array<'connect' | 'messages'>;
 
 /**
  *
@@ -85,6 +97,32 @@ export type PayPalSdkComponents = Array<'connect'>;
  */
 export interface PayPalAxoSdk {
     Connect(): Promise<PayPalCommerceConnect>;
+}
+
+export interface PayPalMessagesSdk {
+    Messages(options: MessagingOptions): MessagingRender;
+}
+
+/**
+ *
+ * PayLater Messages related types
+ *
+ */
+export interface MessagingRender {
+    render(container: string): void;
+}
+
+export interface MessagesStyleOptions {
+    layout?: 'text' | 'flex';
+    logo?: {
+        type: 'none' | 'inline' | 'primary';
+    };
+}
+
+export interface MessagingOptions {
+    amount: number;
+    placement: string;
+    style?: MessagesStyleOptions;
 }
 
 /**


### PR DESCRIPTION
## What?

Update paypal-commerce-sdk configuration

## Why?

To use PayLater Messages separately

## Testing / Proof

Manual

@bigcommerce/team-checkout @bigcommerce/team-payments
